### PR TITLE
Update back link text on request details page

### DIFF
--- a/src/applications/vaos/components/BackLink.jsx
+++ b/src/applications/vaos/components/BackLink.jsx
@@ -25,7 +25,7 @@ export default function BackLink({ appointment }) {
   if (isPendingAppointment) {
     status = 'pending';
     link = '/pending';
-    linkText = 'Back to request for appointments';
+    linkText = 'Back to pending appointments';
   } else if (isUpcomingAppointment) {
     status = 'upcoming';
     link = '/';

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
@@ -68,7 +68,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     fireEvent.click(detailLinks);
     expect(await screen.findByText('Request for appointment')).to.be.ok;
     const link = screen.container.querySelector(
-      'va-link[text="Back to request for appointments"]',
+      'va-link[text="Back to pending appointments"]',
     );
     userEvent.click(link);
     expect(screen.history.push.called).to.be.true;
@@ -322,7 +322,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
         .to.be.ok;
 
       const link = screen.container.querySelector(
-        'va-link[text="Back to request for appointments"]',
+        'va-link[text="Back to pending appointments"]',
       );
       fireEvent.click(link);
       expect(screen.history.push.called).to.be.true;
@@ -403,7 +403,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
       });
 
       const link = screen.container.querySelector(
-        'va-link[text="Back to request for appointments"]',
+        'va-link[text="Back to pending appointments"]',
       );
       fireEvent.click(link);
       await waitFor(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Change the back link text in request details page to "Back to pending appointments"

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#93129


## Testing done

unit test

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |     ![Screenshot 2024-10-23 at 10 40 59 AM](https://github.com/user-attachments/assets/6ce906c8-1b81-4404-a6b4-491e01b7ee29)  |  ![Screenshot 2024-10-23 at 1 32 28 PM](https://github.com/user-attachments/assets/248ea89a-8113-4d2a-a9e2-7bb45660d338)   |


## What areas of the site does it impact?

request appointment details page back link text

## Acceptance criteria

- [ ] Change the back link text in request details page to "Back to pending appointments"

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed


