### PR TITLE
update education wizard to point to automated 5490 when flag is on

### DIFF
--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -15,6 +15,7 @@ import VARadioButton from '../utils/VaRadioButton';
 import {
   merge1995And5490Feature,
   showMebDgi40Feature,
+  meb160630Automation,
 } from '../selectors/educationWizard';
 
 const levels = [
@@ -71,6 +72,11 @@ class EducationWizard extends React.Component {
         url = `/education/apply-for-education-benefits/application/${form}`;
         break;
       case '5490':
+        if (this?.props.meb160630Automation) {
+          url = `/education/survivor-dependent-education-benefit-22-5490`;
+          break;
+        }
+
         url = `/family-and-caregiver-benefits/education-and-careers/apply-dea-fry-form-22-5490`;
         break;
       default:
@@ -485,6 +491,7 @@ class EducationWizard extends React.Component {
 const mapStateToProps = state => ({
   showMebDgi40Feature: showMebDgi40Feature(state),
   merge1995And5490Feature: merge1995And5490Feature(state),
+  meb160630Automation: meb160630Automation(state),
 });
 
 export default connect(mapStateToProps)(EducationWizard);

--- a/src/applications/edu-benefits/selectors/educationWizard.js
+++ b/src/applications/edu-benefits/selectors/educationWizard.js
@@ -28,3 +28,6 @@ export const showMebDgi40Feature = state =>
 
 export const merge1995And5490Feature = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.merge1995And5490];
+
+export const meb160630Automation = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.meb160630Automation];


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add link for automated 5490 form

