### PR TITLE
Profile | Fix contact info page focus & scroll

### DIFF
--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -190,13 +190,13 @@ const ContactInfo = ({
           scrollTo(
             onReviewPage
               ? `${contactInfoPageKey}ScrollElement`
-              : 'topScrollElement',
+              : `header-${lastEdited}`,
           );
           focusElement(onReviewPage ? `#${contactInfoPageKey}Header` : target);
         });
       }
     },
-    [editState, onReviewPage],
+    [contactInfoPageKey, editState, onReviewPage],
   );
 
   useEffect(
@@ -239,7 +239,10 @@ const ContactInfo = ({
   const contactSection = [
     keys.homePhone ? (
       <React.Fragment key="home">
-        <Headers className={`${headerClassNames} vads-u-margin-top--0p5`}>
+        <Headers
+          name="header-home-phone"
+          className={`${headerClassNames} vads-u-margin-top--0p5`}
+        >
           {content.homePhone}
         </Headers>
         {showSuccessAlert('home-phone', content.homePhone)}
@@ -262,7 +265,9 @@ const ContactInfo = ({
 
     keys.mobilePhone ? (
       <React.Fragment key="mobile">
-        <Headers className={headerClassNames}>{content.mobilePhone}</Headers>
+        <Headers name="header-mobile-phone" className={headerClassNames}>
+          {content.mobilePhone}
+        </Headers>
         {showSuccessAlert('mobile-phone', content.mobilePhone)}
         <span className="dd-privacy-hidden" data-dd-action-name="mobile phone">
           {renderTelephone(dataWrap[keys.mobilePhone])}
@@ -283,7 +288,9 @@ const ContactInfo = ({
 
     keys.email ? (
       <React.Fragment key="email">
-        <Headers className={headerClassNames}>{content.email}</Headers>
+        <Headers name="header-email" className={headerClassNames}>
+          {content.email}
+        </Headers>
         {showSuccessAlert('email', content.email)}
         <span className="dd-privacy-hidden" data-dd-action-name="email">
           {dataWrap[keys.email] || ''}
@@ -304,7 +311,9 @@ const ContactInfo = ({
 
     keys.address ? (
       <React.Fragment key="mailing">
-        <Headers className={headerClassNames}>{content.mailingAddress}</Headers>
+        <Headers name="header-address" className={headerClassNames}>
+          {content.mailingAddress}
+        </Headers>
         {showSuccessAlert('address', content.mailingAddress)}
         <AddressView data={dataWrap[keys.address]} />
         {loggedIn && (

--- a/src/platform/forms-system/src/js/definitions/profileContactInfo.js
+++ b/src/platform/forms-system/src/js/definitions/profileContactInfo.js
@@ -14,8 +14,10 @@ import {
   standardEmailSchema,
   profileAddressSchema,
   blankSchema,
+  getReturnState,
   clearReturnState,
 } from '../utilities/data/profile';
+import { scrollTo, focusElement } from '../../../../utilities/ui';
 
 /**
  * Profile settings
@@ -189,6 +191,13 @@ const profileContactInfo = ({
       onFormExit: formData => {
         clearReturnState();
         return formData;
+      },
+      // overide scroll & focus header
+      scrollAndFocusTarget: () => {
+        if (!getReturnState()) {
+          scrollTo('topContentElement');
+          focusElement('h3');
+        }
       },
     },
     // edit pages; only accessible via ContactInfo component links


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > If a form has `useCustomScrollAndFocus` set in the form config and it's using the platform profile component, focus management is overridden. After returning from editing or canceling any contact info field, focus moves to the edit button (upon canceling) or the success alert (upon successfully updating); but with a default `scrollAndFocusTarget` function, focus would then move to the page header. Optimally, we'd want to scroll to the last edited field's header to keep it in view on small screens, and keep the focus on the desired link or alert.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Added a page config `scrollAndFocusTarget` to the `profileContactInfo` definition to prevent the form default function from controlling focus.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/93251

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![profile-focus-before](https://github.com/user-attachments/assets/ce5ac39b-9cc8-4a3e-8168-6c6dfa849133) | ![profile-focus-after](https://github.com/user-attachments/assets/61890272-70ee-4065-9389-22acb809e6c4) |

## What areas of the site does it impact?

All forms that are using platform's profile contact info definition to add contact into editing within a form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
