### PR TITLE
removed content below travel success message

### DIFF
--- a/src/applications/check-in/travel-claim/pages/complete/Complete.unit.spec.jsx
+++ b/src/applications/check-in/travel-claim/pages/complete/Complete.unit.spec.jsx
@@ -63,8 +63,6 @@ describe('Check-in experience', () => {
           </CheckInProvider>,
         );
         expect(getByTestId('header')).to.exist;
-        expect(getByTestId('travel-info-external-link')).to.exist;
-        expect(getByTestId('travel-complete-content')).to.exist;
       });
       it('calls travel API via hook', () => {
         sandbox.stub(v2, 'postTravelOnlyClaim').resolves({});

--- a/src/applications/check-in/travel-claim/pages/complete/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/complete/index.jsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { usePostTravelOnlyClaim } from '../../../hooks/usePostTravelOnlyClaim';
 import { useUpdateError } from '../../../hooks/useUpdateError';
 import Wrapper from '../../../components/layout/Wrapper';
-import ExternalLink from '../../../components/ExternalLink';
 import TravelClaimSuccessAlert from './TravelClaimSuccessAlert';
 
 const Complete = props => {
@@ -37,19 +36,6 @@ const Complete = props => {
         testID="travel-complete-page"
       >
         <TravelClaimSuccessAlert />
-        <div data-testid="travel-complete-content">
-          <p>{t('to-file-another-claim-for-different-date')}</p>
-        </div>
-        <ExternalLink
-          key="link"
-          href="https://www.va.gov/health-care/get-reimbursed-for-travel-pay/"
-          hrefLang="en"
-          eventId="travel-claim-info-clicked"
-          eventPrefix="nav"
-          dataTestId="travel-info-external-link"
-        >
-          {t('find-out-how-to-file--link')}
-        </ExternalLink>
       </Wrapper>
     </>
   );


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removes content below success message on complete page

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#93512

## Testing done
 - updated unit test
 - Visual

## Screenshots

![localhost_3001_my-health_appointment-travel-claim_complete (6)](https://github.com/user-attachments/assets/873cfd51-0b29-4102-bf8b-c01ca962ab79)

## What areas of the site does it impact?

Stand alone travel pay for OH appointments

## Acceptance criteria
 - [ ] Content below success message is gone
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

