### PR TITLE
HLR | Use focusOnAlertRole option for focus management

### DIFF
--- a/src/applications/appeals/996/components/InformalConference.jsx
+++ b/src/applications/appeals/996/components/InformalConference.jsx
@@ -4,6 +4,7 @@ import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/
 import { Toggler } from 'platform/utilities/feature-toggles';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import recordEvent from 'platform/monitoring/record-event';
+import { scrollToFirstError } from 'platform/utilities/ui';
 
 import { showNewHlrContent } from '../utils/helpers';
 import { validateConferenceChoice } from '../validations';
@@ -69,6 +70,9 @@ export const InformalConference = ({
     );
     const errorMsg = error?.[0] || null;
     setHasError(errorMsg);
+    if (errorMsg) {
+      scrollToFirstError({ focusOnAlertRole: true });
+    }
     return errorMsg;
   };
 

--- a/src/applications/appeals/996/components/InformalConferenceContact.jsx
+++ b/src/applications/appeals/996/components/InformalConferenceContact.jsx
@@ -3,6 +3,7 @@ import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/
 
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import recordEvent from 'platform/monitoring/record-event';
+import { scrollToFirstError } from 'platform/utilities/ui';
 
 // import { showNewHlrContent } from '../utils/helpers';
 import { validateConferenceContactChoice } from '../validations';
@@ -48,6 +49,9 @@ export const InformalConferenceContact = ({
     );
     const errorMsg = error?.[0] || null;
     setHasError(errorMsg);
+    if (errorMsg) {
+      scrollToFirstError({ focusOnAlertRole: true });
+    }
     return errorMsg;
   };
 

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -129,6 +129,10 @@ const formConfig = {
   // Fix double headers (only show v3)
   v3SegmentedProgressBar: true,
 
+  formOptions: {
+    focusOnAlertRole: true,
+  },
+
   additionalRoutes: [
     {
       path: 'start',

--- a/src/applications/appeals/996/pages/addIssue.js
+++ b/src/applications/appeals/996/pages/addIssue.js
@@ -7,6 +7,9 @@ import { MAX_LENGTH, SELECTED } from '../../shared/constants';
 export default {
   // this uiSchema is completely ignored
   uiSchema: {
+    'ui:options': {
+      focusOnAlertRole: true,
+    },
     addIssue: {
       'ui:title': '',
       items: {

--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -8,8 +8,10 @@ import {
 import cloneDeep from '~/platform/utilities/data/cloneDeep';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { waitForRenderThenFocus } from '~/platform/utilities/ui';
-import { focusOnChange } from '~/platform/forms-system/src/js/utilities//ui';
-import { ERROR_ELEMENTS } from '~/platform/utilities/constants';
+import {
+  focusOnChange,
+  scrollToFirstError,
+} from '~/platform/forms-system/src/js/utilities//ui';
 
 import { DISAGREEMENT_TYPES, MAX_LENGTH } from '../constants';
 import {
@@ -55,6 +57,9 @@ const AreaOfDisagreement = ({
     const hasError = (disagreement.otherEntry?.length || 0) > max;
     setMaxLength(max);
     setInputErrorMessage(hasError ? errorMessages.maxOtherEntry(max) : null);
+    if (hasError) {
+      scrollToFirstError({ focusOnAlertRole: true });
+    }
     return hasError;
   };
 
@@ -63,6 +68,9 @@ const AreaOfDisagreement = ({
     setCheckboxErrorMessage(
       hasError ? errorMessages.missingDisagreement : null,
     );
+    if (hasError) {
+      scrollToFirstError({ focusOnAlertRole: true });
+    }
     return hasError;
   };
 
@@ -110,8 +118,7 @@ const AreaOfDisagreement = ({
         focusOnChange(scrollKey, 'va-button', 'button');
         updatePage(data);
       } else {
-        // replaces scrollToFirstError()
-        focusOnChange(scrollKey, ERROR_ELEMENTS.join(','));
+        scrollToFirstError({ focusOnAlertRole: true });
       }
     },
   };

--- a/src/applications/appeals/shared/components/SubTaskWrap.jsx
+++ b/src/applications/appeals/shared/components/SubTaskWrap.jsx
@@ -7,7 +7,7 @@ import GetFormHelp from '../content/GetFormHelp';
 const SubTaskWrap = ({ pages }) => (
   <>
     <div className="vads-u-margin-bottom--4">
-      <SubTask pages={pages} />
+      <SubTask pages={pages} focusOnAlertRole />
     </div>
     <va-need-help>
       <div slot="content">

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -31,7 +31,7 @@ export const focusIssue = (_index, root, value) => {
         focusElement('.edit-issue-link', null, card);
       }
     } else {
-      scrollTo('h3');
+      scrollTo('topContentElement');
       focusElement('h3');
     }
   });

--- a/src/applications/appeals/testing/hlr/config/form.js
+++ b/src/applications/appeals/testing/hlr/config/form.js
@@ -20,7 +20,7 @@ import contactInfo from '../pages/contactInformation';
 import contestableIssuesPage from '../pages/contestableIssues';
 import addIssue from '../pages/addIssue';
 import areaOfDisagreementFollowUp from '../pages/areaOfDisagreement';
-import AreaOfDisagreement from '../components/AreaOfDisagreement';
+import AreaOfDisagreement from '../../../shared/components/AreaOfDisagreement';
 import optIn from '../pages/optIn';
 import issueSummary from '../pages/issueSummary';
 import informalConference from '../pages/informalConference';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Updating Higher-Level Review (HLR) form to focus on errors within web components (WC). Currently, the focus management is broken, but it should be focusing on the entire WC. This causes screen readers to read out the WC content instead of reading out the error message (using `role="alert"`). This is still experimental, but will be added to our appeals apps for further accessibility evaluation before making this behavior globally to all apps.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/93251

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before (broken focus management) | After (focus on error inside web component) |
| ------- | ------ | ----- |
| Radio error focus | ![no focus changes](https://github.com/user-attachments/assets/1b77dd5f-12d9-4d2f-99d5-d21f18692715) | ![focus on error message & scroll to web component](https://github.com/user-attachments/assets/ff284c09-0d2a-4b41-82f3-9ab82ead660c) |

## What areas of the site does it impact?

HLR & HLR prototype

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
