### PR TITLE
NOD | Use focusOnAlertRole option for focus management

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -109,6 +109,10 @@ const formConfig = {
   // Fix double headers (only show v3)
   v3SegmentedProgressBar: true,
 
+  formOptions: {
+    focusOnAlertRole: true,
+  },
+
   chapters: {
     infoPages: {
       title: 'Veteran Information',

--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -8,8 +8,10 @@ import {
 import cloneDeep from '~/platform/utilities/data/cloneDeep';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { waitForRenderThenFocus } from '~/platform/utilities/ui';
-import { focusOnChange } from '~/platform/forms-system/src/js/utilities//ui';
-import { ERROR_ELEMENTS } from '~/platform/utilities/constants';
+import {
+  focusOnChange,
+  scrollToFirstError,
+} from '~/platform/forms-system/src/js/utilities//ui';
 
 import { DISAGREEMENT_TYPES, MAX_LENGTH } from '../constants';
 import {
@@ -55,6 +57,9 @@ const AreaOfDisagreement = ({
     const hasError = (disagreement.otherEntry?.length || 0) > max;
     setMaxLength(max);
     setInputErrorMessage(hasError ? errorMessages.maxOtherEntry(max) : null);
+    if (hasError) {
+      scrollToFirstError({ focusOnAlertRole: true });
+    }
     return hasError;
   };
 
@@ -63,6 +68,9 @@ const AreaOfDisagreement = ({
     setCheckboxErrorMessage(
       hasError ? errorMessages.missingDisagreement : null,
     );
+    if (hasError) {
+      scrollToFirstError({ focusOnAlertRole: true });
+    }
     return hasError;
   };
 
@@ -110,8 +118,7 @@ const AreaOfDisagreement = ({
         focusOnChange(scrollKey, 'va-button', 'button');
         updatePage(data);
       } else {
-        // replaces scrollToFirstError()
-        focusOnChange(scrollKey, ERROR_ELEMENTS.join(','));
+        scrollToFirstError({ focusOnAlertRole: true });
       }
     },
   };

--- a/src/applications/appeals/shared/components/FileField.jsx
+++ b/src/applications/appeals/shared/components/FileField.jsx
@@ -14,7 +14,6 @@ import {
 
 import unset from '~/platform/utilities/data/unset';
 import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from '~/platform/forms-system/src/js/constants';
-import { ERROR_ELEMENTS } from '~/platform/utilities/constants';
 import {
   PasswordLabel,
   PasswordSuccess,
@@ -24,7 +23,11 @@ import {
 } from '~/platform/forms-system/src/js/utilities/file';
 import { usePreviousValue } from '~/platform/forms-system/src/js/helpers';
 
-import { focusAddAnotherButton, focusCancelButton } from '../utils/focus';
+import {
+  focusAddAnotherButton,
+  focusCancelButton,
+  focusFirstError,
+} from '../utils/focus';
 import {
   MISSING_PASSWORD_ERROR,
   INCORRECT_PASSWORD_ERROR,
@@ -132,6 +135,20 @@ const FileField = props => {
   const updateProgress = percent => {
     setProgress(percent);
   };
+
+  useEffect(
+    () => {
+      if (files.length === 0 && formContext.submitted) {
+        // scroll fieldset to top
+        scrollTo('topContentElement');
+        // focus on error text above upload button
+        setTimeout(() => {
+          focusElement('span.usa-input-error-message');
+        });
+      }
+    },
+    [formContext.submitted, files.length],
+  );
 
   useEffect(
     () => {
@@ -436,7 +453,7 @@ const FileField = props => {
                 } else if (retryButton) {
                   focusElement('button', {}, retryButton?.shadowRoot);
                 } else {
-                  focusElement(ERROR_ELEMENTS.join(','));
+                  focusFirstError();
                 }
               }, 250);
             } else if (showPasswordInput) {
@@ -669,6 +686,7 @@ FileField.propTypes = {
   formContext: PropTypes.shape({
     onReviewPage: PropTypes.bool,
     reviewMode: PropTypes.bool,
+    submitted: PropTypes.bool,
     trackingPrefix: PropTypes.string,
     uploadFile: PropTypes.func,
   }),

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -3,12 +3,47 @@ import {
   focusElement,
   focusByOrder,
   scrollTo,
+  scrollToFirstError,
   waitForRenderThenFocus,
   scrollAndFocus,
 } from '~/platform/utilities/ui';
+import { focusReview } from '~/platform/forms-system/src/js/utilities/ui/focus-review';
 import { $, $$ } from '~/platform/forms-system/src/js/utilities/ui';
 
 import { LAST_ISSUE } from '../constants';
+
+export const focusFirstError = (root = document) => {
+  const error = $('[error]', root);
+  if (error) {
+    scrollToFirstError({ focusOnAlertRole: true });
+    return true;
+  }
+  return false;
+};
+export const focusEvidence = (_index, root) => {
+  setTimeout(() => {
+    if (!focusFirstError(root)) {
+      scrollTo('topContentElement');
+      focusElement('#main h3', null, root);
+    }
+  });
+};
+export const focusH3AfterAlert = ({
+  name,
+  onReviewPage,
+  root = document,
+} = {}) => {
+  if (name && onReviewPage) {
+    focusReview(
+      name, // name of scroll element
+      true, // review accordion in edit mode
+      true, // reviewEditFocusOnHeaders setting from form/config.js
+    );
+  } else if (!focusFirstError(root)) {
+    scrollTo('topContentElement');
+    focusElement('h3#header', null, root);
+  }
+};
 
 export const focusIssue = (_index, root, value) => {
   setTimeout(() => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Updating Notice of Disagreement (NOD) form to focus on errors within web components (WC). Currently, the entire WC is focused causing screen readers to read out the WC content instead of reading out the error message (using `role="alert"`). This is still experimental, but will be added to our appeals apps for further accessibility evaluation before making this behavior globally to all apps.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/93251

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before (broken focus management) | After (focus on error inside web component) |
| ------- | ------ | ----- |
| Radio error focus | ![focus & scroll on entire web component](https://github.com/user-attachments/assets/2120a32d-c2df-49ce-9322-08fc5346b980) | ![nod-focus-after](https://github.com/user-attachments/assets/1df3a093-ff30-4538-8ddb-4e0617a87d75) |

## What areas of the site does it impact?

NOD

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
