### PR TITLE
Dependents 81254 | Remove spouse (refactored)

### DIFF
--- a/src/applications/disability-benefits/686c-674-v2/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
+++ b/src/applications/disability-benefits/686c-674-v2/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
@@ -2,6 +2,8 @@ import {
   titleUI,
   fullNameNoSuffixUI,
   fullNameNoSuffixSchema,
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 export const schema = {
@@ -11,6 +13,7 @@ export const schema = {
       type: 'object',
       properties: {
         fullName: fullNameNoSuffixSchema,
+        birthDate: currentOrPastDateSchema,
       },
     },
   },
@@ -21,6 +24,10 @@ export const uiSchema = {
     ...titleUI('Divorced spouse’s information'),
     fullName: {
       ...fullNameNoSuffixUI(title => `Former spouse’s ${title}`),
+    },
+    birthDate: {
+      ...currentOrPastDateUI('Former spouse’s date of birth'),
+      'ui:required': () => true,
     },
   },
 };

--- a/src/applications/disability-benefits/686c-674-v2/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartThree.js
+++ b/src/applications/disability-benefits/686c-674-v2/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartThree.js
@@ -1,0 +1,26 @@
+import {
+  titleUI,
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    reportDivorce: {
+      type: 'object',
+      properties: {
+        formerSpouseIncome: yesNoSchema,
+      },
+    },
+  },
+};
+
+export const uiSchema = {
+  reportDivorce: {
+    ...titleUI('Divorced spouse’s income'),
+    formerSpouseIncome: yesNoUI(
+      'Did this dependent earn an income in the last 365 days? Answer this question only if you are adding this dependent to your pension.',
+    ),
+  },
+};

--- a/src/applications/disability-benefits/686c-674-v2/config/chapters/report-divorce/index.js
+++ b/src/applications/disability-benefits/686c-674-v2/config/chapters/report-divorce/index.js
@@ -1,4 +1,9 @@
 import * as formerSpouseInformation from './former-spouse-information/formerSpouseInformation';
 import * as formerSpouseInformationPartTwo from './former-spouse-information/formerSpouseInformationPartTwo';
+import * as formerSpouseInformationPartThree from './former-spouse-information/formerSpouseInformationPartThree';
 
-export { formerSpouseInformation, formerSpouseInformationPartTwo };
+export {
+  formerSpouseInformation,
+  formerSpouseInformationPartTwo,
+  formerSpouseInformationPartThree,
+};

--- a/src/applications/disability-benefits/686c-674-v2/config/form.js
+++ b/src/applications/disability-benefits/686c-674-v2/config/form.js
@@ -17,6 +17,7 @@ import { customSubmit686 } from '../analytics/helpers';
 // Chapter imports
 import {
   formerSpouseInformation,
+  formerSpouseInformationPartThree,
   formerSpouseInformationPartTwo,
 } from './chapters/report-divorce';
 import {
@@ -831,6 +832,14 @@ export const formConfig = {
           path: 'report-a-divorce/divorce-information',
           uiSchema: formerSpouseInformationPartTwo.uiSchema,
           schema: formerSpouseInformationPartTwo.schema,
+        },
+        formerSpouseInformationPartThree: {
+          depends: formData =>
+            isChapterFieldRequired(formData, TASK_KEYS.reportDivorce),
+          title: 'Information needed to report a divorce',
+          path: 'report-a-divorce/former-spouse-income',
+          uiSchema: formerSpouseInformationPartThree.uiSchema,
+          schema: formerSpouseInformationPartThree.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/686c-674-v2/tests/config/chapters/report-divorce/formerSpouseInformation.unit.spec.js
+++ b/src/applications/disability-benefits/686c-674-v2/tests/config/chapters/report-divorce/formerSpouseInformation.unit.spec.js
@@ -42,6 +42,7 @@ describe('686 report divorce: Former spouse full name', () => {
     );
 
     expect($$('va-text-input', container).length).to.equal(3);
+    expect($$('va-memorable-date', container).length).to.equal(1);
   });
 });
 
@@ -86,6 +87,29 @@ describe('686 report divorce: Former spouse information', () => {
     expect($$('va-memorable-date', container).length).to.equal(1);
     expect($$('va-checkbox', container).length).to.equal(1);
     expect($$('va-text-input', container).length).to.equal(2);
+    expect($$('va-radio', container).length).to.equal(1);
+    expect($$('va-radio-option', container).length).to.equal(2);
+  });
+});
+
+describe('686 report divorce: Former spouse income', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.reportDivorce.pages.formerSpouseInformationPartThree;
+
+  it('should render', () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={formData}
+        />
+      </Provider>,
+    );
+
     expect($$('va-radio', container).length).to.equal(1);
     expect($$('va-radio-option', container).length).to.equal(2);
   });

--- a/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/add-child-add-674.json
+++ b/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/add-child-add-674.json
@@ -113,7 +113,7 @@
     },
     "doesLiveWithSpouse": {},
     "view:additionalEvidenceDescription": {},
-    "reportDivorce": { "fullName": {}, "divorceLocation": {"outsideUsa": false, "location": {}} },
+    "reportDivorce": { "fullName": {}, "divorceLocation": {"outsideUsa": false, "location": {}}, "formerSpouseIncome": false },
     "childMarriage": { "fullName": {} },
     "childStoppedAttendingSchool": { "fullName": {} },
     "veteranInformation": {

--- a/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/add-child-report-divorce.json
+++ b/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/add-child-report-divorce.json
@@ -89,7 +89,9 @@
           "city": "Army Post Office"
         }
       },
-      "reasonMarriageEnded": "Divorce"
+      "reasonMarriageEnded": "Divorce",
+      "birthDate": "1991-05-04",
+      "formerSpouseIncome": false
     },
     "veteranInformation": {
       "fullName": {

--- a/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/ancilliary-flows.json
+++ b/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/ancilliary-flows.json
@@ -101,7 +101,7 @@
     "schoolInformation": { "address": {} },
     "currentTermDates": {},
     "programInformation": {},
-    "reportDivorce": { "fullName": {}, "divorceLocation": {"outsideUsa": false, "location": {}} },
+    "reportDivorce": { "fullName": {}, "divorceLocation": {"outsideUsa": false, "location": {}}, "formerSpouseIncome": false},
     "veteranInformation": {
       "fullName": { "first": "Greg", "middle": "A", "last": "Anderson" },
       "ssn": "796121200",

--- a/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/spouse-report-divorce.json
+++ b/src/applications/disability-benefits/686c-674-v2/tests/e2e/fixtures/spouse-report-divorce.json
@@ -117,6 +117,7 @@
         "last": "does"
       },
       "date": "1991-07-07",
+      "birthDate": "1991-05-04",
       "divorceLocation": {
         "outsideUsa": false,
         "location": {
@@ -125,7 +126,8 @@
         }
       },
       "reasonMarriageEnded": "Other",
-      "explanationOfOther": "Other reason"
+      "explanationOfOther": "Other reason",
+      "formerSpouseIncome": false
     },
     "veteranInformation": {
       "fullName": {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Separated questions out into several pages
- Added Array builder list and loop pattern
- Refactored using latest platform web-component patterns
- Updated unit and E2E tests
- Added updated copy

NOTE: The branch name has "array-builder" in it but this section does not contain an array

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/67456

## Testing done

- Manual
- Unit / E2E
- Axe



## What areas of the site does it impact?

- `/view-change-dependents/add-remove-form-21-686c-v2/`

All of this work is behind the flipper `va_dependents_v2` and will be incrementally rolled out

## Figma
- [Remove dependent who has died](https://www.figma.com/design/7W55oNwdVXvXOTI9SaFzQ7/686c-Add-or-Remove-Dependents?node-id=1207-18113&node-type=canvas&t=mafljlsGXQD55eZp-0)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
