### PR TITLE
95231 Fix `isMilitary` in address component displaying empty value on review page

### DIFF
--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -316,6 +316,9 @@ export function addressUI(options) {
           cachedPath = addressPath;
           const countryUI = _uiSchema;
           const addressFormData = get(addressPath, formData) ?? {};
+          /* Set isMilitary to either `true` or `undefined` (not `false`) so that
+          `hideEmptyValueInReview` works as expected. See docs: https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-about-schema-and-uischema#VAFormsLibrary-AboutschemaanduiSchema-ui:options */
+          addressFormData.isMilitary = addressFormData.isMilitary || undefined;
           const { isMilitary } = addressFormData;
           // 'inert' is the preferred solution for now
           // instead of disabled via DST guidance


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

The address `isMilitary` checkbox row still shows on review if it has been unchecked. This renders an empty row that should be hidden (per the existing configuration [here](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx#L278)).

### Problem
When on the review page, if a user checks the address component "I live on a military base" checkbox and clicks `update`, they see the expected review row with the checkbox selected. **However**, if they then uncheck the military base checkbox and click `update`, they will still see the review row, but now it is empty of data:

| |Initial Check|Unchecked (after initial check)|
|-|------|-----|
|Military checkbox|![correct](https://github.com/user-attachments/assets/f1838a99-4335-4eb0-bc5e-67df77c03c9b)|![incorrect](https://github.com/user-attachments/assets/84234141-6dc3-41d9-85d5-e6ea653d3546)|

Inside the address component currently, `hideEmptyValueInReview` is being set ([see this line](https://github.com/department-of-veterans-affairs/vets-website/blob/6b636dab849df90acb8828d17c88a176b3aceb31/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx#L278)) to hide the review row when there is no value. However, it only works if the property is `null`, `''`, or `undefined` per [this documentation](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-about-schema-and-uischema#VAFormsLibrary-AboutschemaanduiSchema-ui:options). Since unchecking the checkbox sets `isMilitary` to false, this causes `hideEmptyValueInReview` to be ignored and the empty row is shown:

| |`isMilitary` false after unchecking | Documentation of `hideEmptyValueInReview`|
|-|------|-----|
|Details|![Screenshot 2024-10-25 at 09 03 05](https://github.com/user-attachments/assets/4588583c-51ff-4fcc-ba51-daf0ab6b798a)|![Screenshot 2024-10-25 at 09 02 52](https://github.com/user-attachments/assets/0c55fee6-9aea-48c3-af1b-31c75921add6)|

### Fix
To fix the issue, I added logic in the address country `updateSchema` block that checks if `isMilitary` is true or false. If it's true, it does nothing. However, if it is `false` (i.e., user has unchecked the box), it sets it to `undefined`. This prevents the row from showing up in review and does not change the behavior otherwise:

|Video of fix in action|
|------|
|https://github.com/user-attachments/assets/1b40b366-d014-4cf1-b72a-6fc56dad50ab|

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95231

## Testing done

- Manual
- Verified existing unit and E2E tests run and pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After (no `isMilitary` row visible |
| ------- | ------ | ----- |
| Desktop |![incorrect](https://github.com/user-attachments/assets/7b0ca260-e62e-4f98-adb5-308d3aa9ba14)|![Screenshot 2024-10-25 at 11 35 38](https://github.com/user-attachments/assets/bdfca817-405a-4eef-a2f6-4c57ef738958)|

## What areas of the site does it impact?

Locations where the platform address component is used (no changes necessary in those locations).

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Is this an acceptable solution to this problem?