### PR TITLE
VACMS-19255 Remove Find Forms flipper for detail page modal

### DIFF
--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/index.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/index.js
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/browser';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { fetchFormsApi } from '../../api';
 import DownloadHandler from './DownloadHandler';
 
@@ -77,18 +75,13 @@ export async function onDownloadLinkClick(event, reduxStore) {
 }
 
 export default (reduxStore, widgetType) => {
-  const showFindFormsModal = state =>
-    toggleValues(state)[FEATURE_FLAG_NAMES.findFormsShowPDFModal];
+  const downloadLinks = document.querySelectorAll(
+    `[data-widget-type="${widgetType}"]`,
+  );
 
-  if (showFindFormsModal) {
-    const downloadLinks = document.querySelectorAll(
-      `[data-widget-type="${widgetType}"]`,
+  for (const downloadLink of [...downloadLinks]) {
+    downloadLink.addEventListener('click', e =>
+      onDownloadLinkClick(e, reduxStore),
     );
-
-    for (const downloadLink of [...downloadLinks]) {
-      downloadLink.addEventListener('click', e =>
-        onDownloadLinkClick(e, reduxStore),
-      );
-    }
   }
 };

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -75,7 +75,6 @@
   "financialStatusReportReviewPageNavigation": "financial_status_report_review_page_navigation",
   "findARepresentativeEnableFrontend": "find_a_representative_enable_frontend",
   "findARepresentativeFlagResultsEnabled": "find_a_representative_flag_results_enabled",
-  "findFormsShowPDFModal": "find_forms_show_pdf_modal",
   "form1010d": "form1010d",
   "form107959c": "form107959c",
   "form107959a": "form107959a",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
In https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18855, we re-added the download modal to form detail pages. This required implementing a feature toggle for the content-build changes and a feature toggle for the vets-api changes. This work is for removing the feature flipper used for the form detail page.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19255

## Testing done

- Regression testing for the form search results (nothing changed; this only changes the form detail pages)
- Tested the modal opening for a form detail page with one modal trigger
- Tested the modal opening for a form detail page with multiple modal triggers (e.g. has related forms)
- Tested the errors for when part of the data calls fail on the form detail page

## Screenshots

<details><summary>Regression check: form search results</summary>

<img width="939" alt="Screenshot 2024-10-28 at 4 36 48 PM" src="https://github.com/user-attachments/assets/6543dcc5-0c11-4209-9213-cb0ffd03e849">

</details>

<details><summary>Form detail page: modal opens for a single trigger (form 10-10m)</summary>

<img width="934" alt="Screenshot 2024-10-28 at 4 36 23 PM" src="https://github.com/user-attachments/assets/a3d17309-0487-488c-a0a0-e8d819328d08">

</details>

<details><summary>Form detail page: modal opens for multiple triggers (form 10-0003k & 10-0003k-2)</summary>

#### 10-7959C
<img width="938" alt="Screenshot 2024-10-28 at 4 35 55 PM" src="https://github.com/user-attachments/assets/2221552e-9787-4f18-a022-e860bff9563a">


#### 10-10d
<img width="936" alt="Screenshot 2024-10-28 at 4 36 04 PM" src="https://github.com/user-attachments/assets/b87ea14d-ea66-4c31-8d57-eb33d2f4b765">

</details>

<details><summary>Error banners when parts of the data calls don't work</summary>

#### Single trigger
<img width="936" alt="Screenshot 2024-10-28 at 4 39 49 PM" src="https://github.com/user-attachments/assets/ec1dcb67-e57a-4d3f-ba31-1862bcd86cbd">


#### Multiple triggers
<img width="937" alt="Screenshot 2024-10-28 at 4 40 01 PM" src="https://github.com/user-attachments/assets/b6928a20-de2c-460e-954a-0491dd397097">



</details>


## What areas of the site does it impact?

Form detail pages only.

## Acceptance criteria

- [x] Forms detail pages for forms with related forms (e.g. https://www.va.gov/find-forms/about-form-10-10ez) should still work as expected:
  - [x] Correct form download buttons appear for the primary form and the related forms
  - [x] When clicking on download buttons, the modal should appear with the correct download link
- [x] Forms detail pages for forms without related forms (e.g. https://www.va.gov/find-forms/about-form-10-10065/) should still work as expected:
  - [x] Correct form download buttons appear for the primary form and the related forms
  - [x] When clicking on download buttons, the modal should appear with the correct download link