### PR TITLE
MHV-62455 MR details pages: All subheadings must maintain a logical heading hierarchy

### DIFF
--- a/src/applications/mhv-medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
+++ b/src/applications/mhv-medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
@@ -142,14 +142,24 @@ ${record.summary}`;
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h3>
-        <p data-testid="note-record-location"> {record.location}</p>
+        <p
+          data-testid="note-record-location"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.location}
+        </p>
         {record.sortByField !== dischargeSummarySortFields.ADMISSION_DATE &&
           record.sortByField !== null && (
             <>
               <h3 className="vads-u-font-size--base vads-u-font-family--sans">
                 Date admitted
               </h3>
-              <p data-testid="note-admission-date">{record.admissionDate}</p>
+              <p
+                data-testid="note-admission-date"
+                className="vads-u-font-size--base vads-u-font-family--sans"
+              >
+                {record.admissionDate}
+              </p>
             </>
           )}
         {record.sortByField !== dischargeSummarySortFields.DISCHARGE_DATE && (
@@ -157,13 +167,23 @@ ${record.summary}`;
             <h3 className="vads-u-font-size--base vads-u-font-family--sans">
               Date discharged
             </h3>
-            <p data-testid="note-discharge-date">{record.dischargeDate}</p>
+            <p
+              data-testid="note-discharge-date"
+              className="vads-u-font-size--base vads-u-font-family--sans"
+            >
+              {record.dischargeDate}
+            </p>
           </>
         )}
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Discharged by
         </h3>
-        <p data-testid="note-discharged-by">{record.dischargedBy}</p>
+        <p
+          data-testid="note-discharged-by"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.dischargedBy}
+        </p>
       </div>
 
       <div className="test-results-container">

--- a/src/applications/mhv-medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
+++ b/src/applications/mhv-medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
@@ -139,51 +139,23 @@ ${record.summary}`;
 
       <div className="test-details-container max-80">
         <h2>Details</h2>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Location
-        </h3>
-        <p
-          data-testid="note-record-location"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.location}
-        </p>
+        <h3 className=" vads-u-font-family--sans">Location</h3>
+        <p data-testid="note-record-location"> {record.location}</p>
         {record.sortByField !== dischargeSummarySortFields.ADMISSION_DATE &&
           record.sortByField !== null && (
             <>
-              <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-                Date admitted
-              </h3>
-              <p
-                data-testid="note-admission-date"
-                className="vads-u-font-size--base vads-u-font-family--sans"
-              >
-                {record.admissionDate}
-              </p>
+              <h3 className=" vads-u-font-family--sans">Date admitted</h3>
+              <p data-testid="note-admission-date">{record.admissionDate}</p>
             </>
           )}
         {record.sortByField !== dischargeSummarySortFields.DISCHARGE_DATE && (
           <>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date discharged
-            </h3>
-            <p
-              data-testid="note-discharge-date"
-              className="vads-u-font-size--base vads-u-font-family--sans"
-            >
-              {record.dischargeDate}
-            </p>
+            <h3 className=" vads-u-font-family--sans">Date discharged</h3>
+            <p data-testid="note-discharge-date">{record.dischargeDate}</p>
           </>
         )}
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Discharged by
-        </h3>
-        <p
-          data-testid="note-discharged-by"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.dischargedBy}
-        </p>
+        <h3 className=" vads-u-font-family--sans">Discharged by</h3>
+        <p data-testid="note-discharged-by">{record.dischargedBy}</p>
       </div>
 
       <div className="test-results-container">

--- a/src/applications/mhv-medical-records/components/CareSummaries/ProgressNoteDetails.jsx
+++ b/src/applications/mhv-medical-records/components/CareSummaries/ProgressNoteDetails.jsx
@@ -120,19 +120,39 @@ ${record.note}`;
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h3>
-        <p data-testid="progress-location">{record.location}</p>
+        <p
+          data-testid="progress-location"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.location}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Written by
         </h3>
-        <p data-testid="note-record-written-by">{record.writtenBy}</p>
+        <p
+          data-testid="note-record-written-by"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.writtenBy}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Signed by
         </h3>
-        <p data-testid="note-record-signed-by">{record.signedBy}</p>
+        <p
+          data-testid="note-record-signed-by"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.signedBy}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Date signed
         </h3>
-        <p data-testid="progress-signed-date">{record.dateSigned}</p>
+        <p
+          data-testid="progress-signed-date"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.dateSigned}
+        </p>
       </div>
 
       <div className="test-results-container">

--- a/src/applications/mhv-medical-records/components/CareSummaries/ProgressNoteDetails.jsx
+++ b/src/applications/mhv-medical-records/components/CareSummaries/ProgressNoteDetails.jsx
@@ -117,42 +117,14 @@ ${record.note}`;
 
       <div className="test-details-container max-80">
         <h2>Details</h2>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Location
-        </h3>
-        <p
-          data-testid="progress-location"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.location}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Written by
-        </h3>
-        <p
-          data-testid="note-record-written-by"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.writtenBy}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Signed by
-        </h3>
-        <p
-          data-testid="note-record-signed-by"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.signedBy}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Date signed
-        </h3>
-        <p
-          data-testid="progress-signed-date"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.dateSigned}
-        </p>
+        <h3 className=" vads-u-font-family--sans">Location</h3>
+        <p data-testid="progress-location">{record.location}</p>
+        <h3 className=" vads-u-font-family--sans">Written by</h3>
+        <p data-testid="note-record-written-by">{record.writtenBy}</p>
+        <h3 className=" vads-u-font-family--sans">Signed by</h3>
+        <p data-testid="note-record-signed-by">{record.signedBy}</p>
+        <h3 className=" vads-u-font-family--sans">Date signed</h3>
+        <p data-testid="progress-signed-date">{record.dateSigned}</p>
       </div>
 
       <div className="test-results-container">

--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -138,19 +138,37 @@ Lab comments: ${entry.labComments}\n`,
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Type of test
         </h3>
-        <p data-testid="chem-hem-category">{record.category}</p>
+        <p
+          data-testid="chem-hem-category"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.category}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Site or sample tested
         </h3>
-        <p data-testid="chem-hem-sample-tested">{record.sampleTested}</p>
+        <p
+          data-testid="chem-hem-sample-tested"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.sampleTested}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Ordered by
         </h3>
-        <p data-testid="chem-hem-ordered-by">{record.orderedBy}</p>
+        <p
+          data-testid="chem-hem-ordered-by"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.orderedBy}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h3>
-        <p data-testid="chem-hem-collecting-location">
+        <p
+          data-testid="chem-hem-collecting-location"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
           {record.collectingLocation}
         </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">

--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -135,45 +135,17 @@ Lab comments: ${entry.labComments}\n`,
       {/*                   TEST DETAILS                          */}
       <div className="test-details-container max-80">
         <h2>Details about this test</h2>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Type of test
-        </h3>
-        <p
-          data-testid="chem-hem-category"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.category}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Site or sample tested
-        </h3>
-        <p
-          data-testid="chem-hem-sample-tested"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.sampleTested}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Ordered by
-        </h3>
-        <p
-          data-testid="chem-hem-ordered-by"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.orderedBy}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Location
-        </h3>
-        <p
-          data-testid="chem-hem-collecting-location"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
+        <h3 className=" vads-u-font-family--sans">Type of test</h3>
+        <p data-testid="chem-hem-category">{record.category}</p>
+        <h3 className=" vads-u-font-family--sans">Site or sample tested</h3>
+        <p data-testid="chem-hem-sample-tested">{record.sampleTested}</p>
+        <h3 className=" vads-u-font-family--sans">Ordered by</h3>
+        <p data-testid="chem-hem-ordered-by">{record.orderedBy}</p>
+        <h3 className=" vads-u-font-family--sans">Location</h3>
+        <p data-testid="chem-hem-collecting-location">
           {record.collectingLocation}
         </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Lab comments
-        </h3>
+        <h3 className=" vads-u-font-family--sans">Lab comments</h3>
         <ItemList list={record.comments} />
       </div>
       {/*         RESULTS CARDS            */}
@@ -186,7 +158,7 @@ Lab comments: ${entry.labComments}\n`,
             for your health. To ask a question now, send a secure message to
             your care team.
           </p>
-          <h4 className="vads-u-margin--0 vads-u-font-size--base vads-u-font-family--sans">
+          <h4 className="vads-u-margin--0 vads-u-font-family--sans">
             Standard range
           </h4>
           <p className="vads-u-margin-top--0">

--- a/src/applications/mhv-medical-records/components/LabsAndTests/EkgDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/EkgDetails.jsx
@@ -105,22 +105,12 @@ const EkgDetails = props => {
       <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
 
       <div className="test-details-container max-80">
-        <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-          Location
-        </h2>
-        <p
-          data-testid="ekg-record-facility"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
+        <h2 className=" vads-u-font-family--sans">Location</h2>
+        <p data-testid="ekg-record-facility">
           {record.facility || 'There is no facility reported at this time'}
         </p>
-        <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-          Results
-        </h2>
-        <p
-          data-testid="ekg-results"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
+        <h2 className=" vads-u-font-family--sans">Results</h2>
+        <p data-testid="ekg-results">
           Your EKG results aren’t available in this tool. To get your EKG
           results, you can request a copy of your complete medical record from
           your VA health facility.

--- a/src/applications/mhv-medical-records/components/LabsAndTests/EkgDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/EkgDetails.jsx
@@ -108,13 +108,19 @@ const EkgDetails = props => {
         <h2 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h2>
-        <p data-testid="ekg-record-facility">
+        <p
+          data-testid="ekg-record-facility"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
           {record.facility || 'There is no facility reported at this time'}
         </p>
         <h2 className="vads-u-font-size--base vads-u-font-family--sans">
           Results
         </h2>
-        <p data-testid="ekg-results">
+        <p
+          data-testid="ekg-results"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
           Your EKG results aren’t available in this tool. To get your EKG
           results, you can request a copy of your complete medical record from
           your VA health facility.

--- a/src/applications/mhv-medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -135,25 +135,48 @@ ${record.results}`;
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Site or sample tested
         </h3>
-        <p data-testid="microbio-sample-tested">{record.sampleTested}</p>
+        <p
+          data-testid="microbio-sample-tested"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.sampleTested}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Collection sample
         </h3>
-        <p data-testid="microbio-sample-from">{record.sampleFrom}</p>
+        <p
+          data-testid="microbio-sample-from"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.sampleFrom}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Ordered by
         </h3>
-        <p data-testid="microbio-ordered-by">{record.orderedBy}</p>
+        <p
+          data-testid="microbio-ordered-by"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.orderedBy}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h3>
-        <p data-testid="microbio-collecting-location">
+        <p
+          data-testid="microbio-collecting-location"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
           {record.collectingLocation}
         </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Date completed
         </h3>
-        <p data-testid="microbio-date-completed">{record.dateCompleted}</p>
+        <p
+          data-testid="microbio-date-completed"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.dateCompleted}
+        </p>
       </div>
 
       <div className="test-results-container">

--- a/src/applications/mhv-medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -126,63 +126,28 @@ ${record.results}`;
         <h2>Details about this test</h2>
         {record.labType && (
           <>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Lab type
-            </h3>
+            <h3 className=" vads-u-font-family--sans">Lab type</h3>
             <p data-testid="microbio-sample-tested">{record.labType}</p>
           </>
         )}
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Site or sample tested
-        </h3>
-        <p
-          data-testid="microbio-sample-tested"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.sampleTested}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Collection sample
-        </h3>
-        <p
-          data-testid="microbio-sample-from"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.sampleFrom}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Ordered by
-        </h3>
-        <p
-          data-testid="microbio-ordered-by"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.orderedBy}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Location
-        </h3>
-        <p
-          data-testid="microbio-collecting-location"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
+        <h3 className=" vads-u-font-family--sans">Site or sample tested</h3>
+        <p data-testid="microbio-sample-tested">{record.sampleTested}</p>
+        <h3 className=" vads-u-font-family--sans">Collection sample</h3>
+        <p data-testid="microbio-sample-from">{record.sampleFrom}</p>
+        <h3 className=" vads-u-font-family--sans">Ordered by</h3>
+        <p data-testid="microbio-ordered-by">{record.orderedBy}</p>
+        <h3 className=" vads-u-font-family--sans">Location</h3>
+        <p data-testid="microbio-collecting-location">
           {record.collectingLocation}
         </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Date completed
-        </h3>
-        <p
-          data-testid="microbio-date-completed"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.dateCompleted}
-        </p>
+        <h3 className=" vads-u-font-family--sans">Date completed</h3>
+        <p data-testid="microbio-date-completed">{record.dateCompleted}</p>
       </div>
 
       <div className="test-results-container">
         <h2>Results</h2>
         <InfoAlert fullState={fullState} />
-        <p className="vads-u-font-size--base monospace vads-u-line-height--3">
+        <p className=" monospace vads-u-line-height--3">
           {record.results}
         </p>{' '}
       </div>

--- a/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -117,15 +117,30 @@ ${record.results} \n`;
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Site or sample tested
         </h3>
-        <p data-testid="pathology-sample-tested">{record.sampleTested}</p>
+        <p
+          data-testid="pathology-sample-tested"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.sampleTested}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h3>
-        <p data-testid="pathology-location">{record.labLocation}</p>
+        <p
+          data-testid="pathology-location"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.labLocation}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Date completed
         </h3>
-        <p data-testid="date-completed">{record.date}</p>
+        <p
+          data-testid="date-completed"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.date}
+        </p>
       </div>
       <div className="test-results-container">
         <h2>Results</h2>

--- a/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -114,33 +114,12 @@ ${record.results} \n`;
 
       <div className="test-details-container max-80">
         <h2>Details about this test</h2>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Site or sample tested
-        </h3>
-        <p
-          data-testid="pathology-sample-tested"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.sampleTested}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Location
-        </h3>
-        <p
-          data-testid="pathology-location"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.labLocation}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Date completed
-        </h3>
-        <p
-          data-testid="date-completed"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.date}
-        </p>
+        <h3 className=" vads-u-font-family--sans">Site or sample tested</h3>
+        <p data-testid="pathology-sample-tested">{record.sampleTested}</p>
+        <h3 className=" vads-u-font-family--sans">Location</h3>
+        <p data-testid="pathology-location">{record.labLocation}</p>
+        <h3 className=" vads-u-font-family--sans">Date completed</h3>
+        <p data-testid="date-completed">{record.date}</p>
       </div>
       <div className="test-results-container">
         <h2>Results</h2>

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -112,58 +112,18 @@ ${record.results}`;
 
       <div className="test-details-container max-80">
         <h2>Details about this test</h2>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Reason for test
-        </h3>
-        <p
-          data-testid="radiology-reason"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.reason}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Clinical history
-        </h3>
-        <p
-          data-testid="radiology-clinical-history"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.clinicalHistory}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Ordered by
-        </h3>
-        <p
-          data-testid="radiology-ordered-by"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.orderedBy}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Location
-        </h3>
-        <p
-          data-testid="radiology-imaging-location"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.imagingLocation}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Imaging provider
-        </h3>
-        <p
-          data-testid="radiology-imaging-provider"
-          className="vads-u-font-size--base vads-u-font-family--sans"
-        >
-          {record.imagingProvider}
-        </p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans no-print">
-          Images
-        </h3>
-        <p
-          data-testid="radiology-image"
-          className="no-print vads-u-font-size--base vads-u-font-family--sans"
-        >
+        <h3 className=" vads-u-font-family--sans">Reason for test</h3>
+        <p data-testid="radiology-reason">{record.reason}</p>
+        <h3 className=" vads-u-font-family--sans">Clinical history</h3>
+        <p data-testid="radiology-clinical-history">{record.clinicalHistory}</p>
+        <h3 className=" vads-u-font-family--sans">Ordered by</h3>
+        <p data-testid="radiology-ordered-by">{record.orderedBy}</p>
+        <h3 className=" vads-u-font-family--sans">Location</h3>
+        <p data-testid="radiology-imaging-location">{record.imagingLocation}</p>
+        <h3 className=" vads-u-font-family--sans">Imaging provider</h3>
+        <p data-testid="radiology-imaging-provider">{record.imagingProvider}</p>
+        <h3 className=" vads-u-font-family--sans no-print">Images</h3>
+        <p data-testid="radiology-image" className="no-print">
           Images are not yet available in this new medical records tool. To get
           images, you’ll need to request them in the previous version of medical
           records on the My HealtheVet website.

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -115,27 +115,55 @@ ${record.results}`;
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Reason for test
         </h3>
-        <p data-testid="radiology-reason">{record.reason}</p>
+        <p
+          data-testid="radiology-reason"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.reason}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Clinical history
         </h3>
-        <p data-testid="radiology-clinical-history">{record.clinicalHistory}</p>
+        <p
+          data-testid="radiology-clinical-history"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.clinicalHistory}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Ordered by
         </h3>
-        <p data-testid="radiology-ordered-by">{record.orderedBy}</p>
+        <p
+          data-testid="radiology-ordered-by"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.orderedBy}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h3>
-        <p data-testid="radiology-imaging-location">{record.imagingLocation}</p>
+        <p
+          data-testid="radiology-imaging-location"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.imagingLocation}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Imaging provider
         </h3>
-        <p data-testid="radiology-imaging-provider">{record.imagingProvider}</p>
+        <p
+          data-testid="radiology-imaging-provider"
+          className="vads-u-font-size--base vads-u-font-family--sans"
+        >
+          {record.imagingProvider}
+        </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans no-print">
           Images
         </h3>
-        <p data-testid="radiology-image" className="no-print">
+        <p
+          data-testid="radiology-image"
+          className="no-print vads-u-font-size--base vads-u-font-family--sans"
+        >
           Images are not yet available in this new medical records tool. To get
           images, you’ll need to request them in the previous version of medical
           records on the My HealtheVet website.

--- a/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/RecordList.jsx
@@ -70,7 +70,8 @@ const RecordList = props => {
 
   return (
     <div className="record-list vads-l-row vads-u-flex-direction--column">
-      <h2
+      <h2 className="sr-only">List of {type}</h2>
+      <p
         className="vads-u-line-height--4 vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--0 vads-u-font-weight--normal vads-u-padding-y--1 vads-u-margin-bottom--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light no-print"
         hidden={hidePagination}
         id="showingRecords"
@@ -80,7 +81,7 @@ const RecordList = props => {
             displayNums[1]
           } of ${totalEntries} records from newest to oldest`}
         </span>
-      </h2>
+      </p>
       <h2 className="vads-u-line-height--4 vads-u-font-size--base vads-u-font-family--sans vads-u-margin--0 vads-u-padding--0 vads-u-font-weight--normal vads-u-border-color--gray-light print-only">
         Showing {totalEntries} from newest to oldest
       </h2>

--- a/src/applications/mhv-medical-records/components/shared/ItemList.jsx
+++ b/src/applications/mhv-medical-records/components/shared/ItemList.jsx
@@ -16,7 +16,7 @@ const ItemList = props => {
           return (
             <li
               key={idx}
-              className="vads-u-margin-bottom--0"
+              className="vads-u-margin-bottom--0 vads-u-font-size--base vads-u-font-family--sans"
               data-dd-privacy="mask"
               data-testid="list-item-multiple"
             >

--- a/src/applications/mhv-medical-records/components/shared/ItemList.jsx
+++ b/src/applications/mhv-medical-records/components/shared/ItemList.jsx
@@ -16,7 +16,7 @@ const ItemList = props => {
           return (
             <li
               key={idx}
-              className="vads-u-margin-bottom--0 vads-u-font-size--base vads-u-font-family--sans"
+              className="vads-u-margin-bottom--0"
               data-dd-privacy="mask"
               data-testid="list-item-multiple"
             >

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -153,7 +153,6 @@ ${allergies.map(entry => generateAllergyListItemTxt(entry)).join('')}`;
     <div id="allergies">
       <PrintHeader />
       <h1 className="vads-u-margin--0">Allergies and reactions</h1>
-      <h2 className="sr-only">List of Allergies</h2>
       <p className="page-description">
         Review allergies, reactions, and side effects in your VA medical
         records. This includes medication side effects (also called adverse drug

--- a/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
@@ -156,48 +156,24 @@ Provider notes: ${allergy.notes} \n`;
             className="condition-details max-80 vads-u-margin-top--4"
             data-testid="allergy-reaction"
           >
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Signs and symptoms
-            </h2>
+            <h2 className=" vads-u-font-family--sans">Signs and symptoms</h2>
             <ItemList list={allergy.reaction} />
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Type of allergy
-            </h2>
-            <p
-              data-dd-privacy="mask"
-              data-testid="allergy-type"
-              className="vads-u-font-size--base vads-u-font-family--sans"
-            >
+            <h2 className=" vads-u-font-family--sans">Type of allergy</h2>
+            <p data-dd-privacy="mask" data-testid="allergy-type">
               {allergy.type}
             </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Location
-            </h2>
-            <p
-              data-dd-privacy="mask"
-              data-testid="allergy-location"
-              className="vads-u-font-size--base vads-u-font-family--sans"
-            >
+            <h2 className=" vads-u-font-family--sans">Location</h2>
+            <p data-dd-privacy="mask" data-testid="allergy-location">
               {allergy.location}
             </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+            <h2 className=" vads-u-font-family--sans">
               Observed or historical
             </h2>
-            <p
-              data-dd-privacy="mask"
-              data-testid="allergy-observed"
-              className="vads-u-font-size--base vads-u-font-family--sans"
-            >
+            <p data-dd-privacy="mask" data-testid="allergy-observed">
               {allergy.observedOrReported}
             </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Provider notes
-            </h2>
-            <p
-              data-dd-privacy="mask"
-              data-testid="allergy-notes"
-              className="vads-u-font-size--base vads-u-font-family--sans"
-            >
+            <h2 className=" vads-u-font-family--sans">Provider notes</h2>
+            <p data-dd-privacy="mask" data-testid="allergy-notes">
               {allergy.notes}
             </p>
           </div>

--- a/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
@@ -163,25 +163,41 @@ Provider notes: ${allergy.notes} \n`;
             <h2 className="vads-u-font-size--base vads-u-font-family--sans">
               Type of allergy
             </h2>
-            <p data-dd-privacy="mask" data-testid="allergy-type">
+            <p
+              data-dd-privacy="mask"
+              data-testid="allergy-type"
+              className="vads-u-font-size--base vads-u-font-family--sans"
+            >
               {allergy.type}
             </p>
             <h2 className="vads-u-font-size--base vads-u-font-family--sans">
               Location
             </h2>
-            <p data-dd-privacy="mask" data-testid="allergy-location">
+            <p
+              data-dd-privacy="mask"
+              data-testid="allergy-location"
+              className="vads-u-font-size--base vads-u-font-family--sans"
+            >
               {allergy.location}
             </p>
             <h2 className="vads-u-font-size--base vads-u-font-family--sans">
               Observed or historical
             </h2>
-            <p data-dd-privacy="mask" data-testid="allergy-observed">
+            <p
+              data-dd-privacy="mask"
+              data-testid="allergy-observed"
+              className="vads-u-font-size--base vads-u-font-family--sans"
+            >
               {allergy.observedOrReported}
             </p>
             <h2 className="vads-u-font-size--base vads-u-font-family--sans">
               Provider notes
             </h2>
-            <p data-dd-privacy="mask" data-testid="allergy-notes">
+            <p
+              data-dd-privacy="mask"
+              data-testid="allergy-notes"
+              className="vads-u-font-size--base vads-u-font-family--sans"
+            >
               {allergy.notes}
             </p>
           </div>

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -70,7 +70,6 @@ const CareSummariesAndNotes = () => {
       <h1 data-testid="care-summaries-and-notes" className="page-title">
         Care summaries and notes
       </h1>
-      <h2 className="sr-only">List of Care summaries and notes</h2>
       <p>
         Most care summaries and notes are available{' '}
         <span className="vads-u-font-weight--bold">36 hours</span> after

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -70,7 +70,7 @@ const CareSummariesAndNotes = () => {
       <h1 data-testid="care-summaries-and-notes" className="page-title">
         Care summaries and notes
       </h1>
-      <h2 className="sr-only">List of Vitals</h2>
+      <h2 className="sr-only">List of Care summaries and notes</h2>
       <p>
         Most care summaries and notes are available{' '}
         <span className="vads-u-font-weight--bold">36 hours</span> after

--- a/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
@@ -168,16 +168,24 @@ Provider Notes: ${processList(record.comments)}\n`;
             <h2 className="vads-u-font-size--base vads-u-font-family--sans">
               Provider
             </h2>
-            <p data-dd-privacy="mask" data-testid="condition-provider">
+            <p
+              className="vads-u-font-size--base vads-u-font-family--sans"
+              data-dd-privacy="mask"
+              data-testid="condition-provider"
+            >
               {record.provider}
             </p>
             <h2 className="vads-u-font-size--base vads-u-font-family--sans">
               Location
             </h2>
-            <p data-dd-privacy="mask" data-testid="condition-location">
+            <p
+              data-dd-privacy="mask"
+              data-testid="condition-location"
+              className="vads-u-font-size--base vads-u-font-family--sans"
+            >
               {record.facility || 'There is no facility reported at this time'}
             </p>
-            <h2 className="vads-u-margin-bottom--0 vads-u-font-family--sans">
+            <h2 className="vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--base">
               Provider notes
             </h2>
             <ItemList
@@ -190,6 +198,7 @@ Provider Notes: ${processList(record.comments)}\n`;
                   About the code in this condition name
                 </h2>
                 <p
+                  className="vads-u-font-size--base vads-u-font-family--sans"
                   data-dd-privacy="mask"
                   data-testid="about-the-condition-code"
                 >

--- a/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
@@ -165,27 +165,15 @@ Provider Notes: ${processList(record.comments)}\n`;
           <div className="vads-u-margin-y--4 vads-u-border-top--1px vads-u-border-color--gray-light" />
 
           <div className="condition-details max-80">
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Provider
-            </h2>
-            <p
-              className="vads-u-font-size--base vads-u-font-family--sans"
-              data-dd-privacy="mask"
-              data-testid="condition-provider"
-            >
+            <h2 className="vads-u-font-family--sans">Provider</h2>
+            <p data-dd-privacy="mask" data-testid="condition-provider">
               {record.provider}
             </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Location
-            </h2>
-            <p
-              data-dd-privacy="mask"
-              data-testid="condition-location"
-              className="vads-u-font-size--base vads-u-font-family--sans"
-            >
+            <h2 className="vads-u-font-family--sans">Location</h2>
+            <p data-dd-privacy="mask" data-testid="condition-location">
               {record.facility || 'There is no facility reported at this time'}
             </p>
-            <h2 className="vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--base">
+            <h2 className="vads-u-margin-bottom--0 vads-u-font-family--sans">
               Provider notes
             </h2>
             <ItemList
@@ -194,11 +182,10 @@ Provider Notes: ${processList(record.comments)}\n`;
             />
             {containsSctOrIcd(record.name) && (
               <>
-                <h2 className="vads-u-font-size--base vads-u-font-family--sans">
+                <h2 className="vads-u-font-family--sans">
                   About the code in this condition name
                 </h2>
                 <p
-                  className="vads-u-font-size--base vads-u-font-family--sans"
                   data-dd-privacy="mask"
                   data-testid="about-the-condition-code"
                 >

--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -63,7 +63,6 @@ const HealthConditions = () => {
       <h1 className="vads-u-margin--0" data-testid="health-conditions">
         Health conditions
       </h1>
-      <h2 className="sr-only">List of Health conditions</h2>
       <p className="vads-u-margin-top--1 vads-u-margin-bottom--3">
         Health condition records are available{' '}
         <span className="vads-u-font-weight--bold">36 hours</span> after your

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -65,7 +65,6 @@ const LabsAndTests = () => {
       <h1 className="page-title vads-u-margin-bottom--1">
         Lab and test results
       </h1>
-      <h2 className="sr-only">List of Lab and test results</h2>
 
       <p className="vads-u-margin-top--0 vads-u-margin-bottom--4">
         Most lab and test results are available{' '}

--- a/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
@@ -150,17 +150,17 @@ Location: ${record.location}\n`;
           <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
           <div className="vads-u-margin-y--4 vads-u-border-top--1px vads-u-border-color--gray-light" />
           <div>
-            <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-size--base vads-u-font-family--sans">
+            <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans">
               Location
             </h2>
             <p
-              className="vads-u-margin-top--0 vads-u-font-size--base vads-u-font-family--sans"
+              className="vads-u-margin-top--0"
               data-dd-privacy="mask"
               data-testid="vaccine-location"
             >
               {record.location}
             </p>
-            {/* <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
+            {/* <h2 className="vads-u-font-family--sans vads-u-margin-bottom--0">
               Reactions recorded by provider
             </h2>
             <ItemList list={record.reactions} /> */}

--- a/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
@@ -154,7 +154,7 @@ Location: ${record.location}\n`;
               Location
             </h2>
             <p
-              className="vads-u-margin-top--0"
+              className="vads-u-margin-top--0 vads-u-font-size--base vads-u-font-family--sans"
               data-dd-privacy="mask"
               data-testid="vaccine-location"
             >

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -148,7 +148,7 @@ ${vaccines.map(entry => generateVaccineListItemTxt(entry)).join('')}`;
     <div id="vaccines">
       <PrintHeader />
       <h1 className="vads-u-margin--0">Vaccines</h1>
-      <h2 className="sr-only">List of Vitals</h2>
+      <h2 className="sr-only">List of Vaccines</h2>
       <p>Review vaccines (immunizations) in your VA medical records.</p>
       <p className="vads-u-margin-bottom--4">
         For a list of your allergies and reactions (including any reactions to

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -148,7 +148,6 @@ ${vaccines.map(entry => generateVaccineListItemTxt(entry)).join('')}`;
     <div id="vaccines">
       <PrintHeader />
       <h1 className="vads-u-margin--0">Vaccines</h1>
-      <h2 className="sr-only">List of Vaccines</h2>
       <p>Review vaccines (immunizations) in your VA medical records.</p>
       <p className="vads-u-margin-bottom--4">
         For a list of your allergies and reactions (including any reactions to

--- a/src/applications/mhv-medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VitalDetails.jsx
@@ -304,7 +304,7 @@ Provider notes: ${vital.notes}\n\n`,
                 </h4>
                 <p
                   data-testid="vital-result"
-                  className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+                  className="vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-font-size--base vads-u-font-family--sans"
                   data-dd-privacy="mask"
                 >
                   {vital.measurement}
@@ -314,7 +314,7 @@ Provider notes: ${vital.notes}\n\n`,
                 </h4>
                 <p
                   data-testid="vital-location"
-                  className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+                  className="vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-font-size--base vads-u-font-family--sans"
                   data-dd-privacy="mask"
                 >
                   {vital.location}
@@ -324,7 +324,7 @@ Provider notes: ${vital.notes}\n\n`,
                 </h4>
                 <p
                   data-testid="vital-provider-note"
-                  className="vads-u-margin--0"
+                  className="vads-u-margin--0 vads-u-font-size--base vads-u-font-family--sans"
                   data-dd-privacy="mask"
                 >
                   {vital.notes}

--- a/src/applications/mhv-medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VitalDetails.jsx
@@ -299,32 +299,32 @@ Provider notes: ${vital.notes}\n\n`,
                 >
                   {vital.date}
                 </h3>
-                <h4 className="vads-u-font-size--base vads-u-margin--0 vads-u-font-family--sans">
+                <h4 className=" vads-u-margin--0 vads-u-font-family--sans">
                   Result
                 </h4>
                 <p
                   data-testid="vital-result"
-                  className="vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-font-size--base vads-u-font-family--sans"
+                  className="vads-u-margin-top--0 vads-u-margin-bottom--2"
                   data-dd-privacy="mask"
                 >
                   {vital.measurement}
                 </p>
-                <h4 className="vads-u-font-size--base vads-u-margin--0 vads-u-font-family--sans">
+                <h4 className=" vads-u-margin--0 vads-u-font-family--sans">
                   Location
                 </h4>
                 <p
                   data-testid="vital-location"
-                  className="vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-font-size--base vads-u-font-family--sans"
+                  className="vads-u-margin-top--0 vads-u-margin-bottom--2"
                   data-dd-privacy="mask"
                 >
                   {vital.location}
                 </p>
-                <h4 className="vads-u-font-size--base vads-u-margin--0 vads-u-font-family--sans">
+                <h4 className=" vads-u-margin--0 vads-u-font-family--sans">
                   Provider notes
                 </h4>
                 <p
                   data-testid="vital-provider-note"
-                  className="vads-u-margin--0 vads-u-font-size--base vads-u-font-family--sans"
+                  className="vads-u-margin--0"
                   data-dd-privacy="mask"
                 >
                   {vital.notes}

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -165,7 +165,6 @@ const Vitals = () => {
       <h1 data-testid="vitals" className="vads-u-margin--0">
         Vitals
       </h1>
-      <h2 className="sr-only">List of Vitals</h2>
       <p className="vads-u-margin-top--1 vads-u-margin-bottom--2">
         {`Vitals are basic health numbers your providers check at your
         appointments. ${vitals?.length === 0 ? 'Vitals include:' : ''}`}


### PR DESCRIPTION
## Summary

- Fixed the font size.
- Not a bug.
- Updated/added classNames to change the rendering of the "p" tags. 
- MHV Medical Records.

## Related issue(s)
### [MHV-62455](https://jira.devops.va.gov/browse/MHV-62455) - MR details pages: All subheadings must maintain a logical heading hierarchy ###

![Screenshot 2024-10-25 at 12 36 26 PM](https://github.com/user-attachments/assets/19237dca-5884-452a-a661-36533bd07f4a)

## Screenshots

![Screenshot 2024-10-25 at 12 38 27 PM](https://github.com/user-attachments/assets/d078cc60-b10f-48e7-bb42-7bbd09ebb93f)
![Screenshot 2024-10-25 at 12 39 18 PM](https://github.com/user-attachments/assets/0602111e-d5e4-4d8e-abdb-c89ed481a7a9)
![Screenshot 2024-10-25 at 12 40 18 PM](https://github.com/user-attachments/assets/b029532d-bc91-436b-8bed-f68743f29cac)

## Testing done

-  Manual testing.

## What areas of the site does it impact?
MHV Medical Records
