### PR TITLE
dbex/95149: add disability526NewConfirmationPage feature toggle

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Toggler } from 'platform/utilities/feature-toggles';
 
 import {
   focusElement,
@@ -29,22 +30,49 @@ export default class ConfirmationPage extends React.Component {
     setTimeout(() => focusElement('va-alert h2'), 100);
   }
 
+  // the legacy 526 confirmation page that has 3 states
+  LegacyConfirmationPage = props => {
+    switch (props.submissionStatus) {
+      case submissionStatuses.succeeded:
+        return successfulSubmitContent(props);
+      case submissionStatuses.retry:
+      case submissionStatuses.exhausted:
+      case submissionStatuses.apiFailure:
+        return retryableErrorContent(props);
+      default:
+        return submitErrorContent(props);
+    }
+  };
+
+  // the new 526 submission confirmation that has one state
+  ConfirmationPageContent = props => (
+    // TODO: #95241 implement new confirmation page
+    <>
+      <Toggler
+        toggleName={Toggler.TOGGLE_NAMES.disability526NewConfirmationPage}
+      >
+        <Toggler.Enabled>
+          <p
+            hidden
+            aria-hidden
+            id="new-confirmation-page"
+            className="vads-u-margin-top--0"
+          >
+            New confirmation page content goes in here
+          </p>
+        </Toggler.Enabled>
+      </Toggler>
+
+      {this.LegacyConfirmationPage(props)}
+    </>
+  );
+
   render() {
     // Reset everything
     sessionStorage.removeItem(WIZARD_STATUS);
     sessionStorage.removeItem(FORM_STATUS_BDD);
     sessionStorage.removeItem(SAVED_SEPARATION_DATE);
-
-    switch (this.props.submissionStatus) {
-      case submissionStatuses.succeeded:
-        return successfulSubmitContent(this.props);
-      case submissionStatuses.retry:
-      case submissionStatuses.exhausted:
-      case submissionStatuses.apiFailure:
-        return retryableErrorContent(this.props);
-      default:
-        return submitErrorContent(this.props);
-    }
+    return this.ConfirmationPageContent(this.props);
   }
 }
 

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -52,14 +52,12 @@ export default class ConfirmationPage extends React.Component {
         toggleName={Toggler.TOGGLE_NAMES.disability526NewConfirmationPage}
       >
         <Toggler.Enabled>
-          <p
+          <div
             hidden
             aria-hidden
             id="new-confirmation-page"
-            className="vads-u-margin-top--0"
-          >
-            New confirmation page content goes in here
-          </p>
+            data-testid="new-confirmation-page"
+          />
         </Toggler.Enabled>
       </Toggler>
 

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -7,11 +7,35 @@ import {
   mockMultipleApiRequests,
 } from 'platform/testing/unit/helpers';
 
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { submissionStatuses } from '../../constants';
 import {
   ConfirmationPoll,
   selectAllDisabilityNames,
 } from '../../components/ConfirmationPoll';
-import { submissionStatuses } from '../../constants';
+
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+
+const getData = ({
+  renderName = true,
+  suffix = 'Esq.',
+  disability526NewConfirmationPage = false,
+} = {}) => ({
+  user: {
+    profile: {
+      userFullName: renderName
+        ? { first: 'Foo', middle: 'Man', last: 'Choo', suffix }
+        : {},
+    },
+  },
+  featureToggles: {
+    loading: false,
+    disability526NewConfirmationPage,
+  },
+});
 
 const pendingResponse = {
   shouldResolve: true,
@@ -145,7 +169,9 @@ describe('ConfirmationPoll', () => {
     ]);
 
     const form = mount(
-      <ConfirmationPoll {...defaultProps} pollRate={10} delayFailure={20} />,
+      <Provider store={mockStore(getData())}>
+        <ConfirmationPoll {...defaultProps} pollRate={10} delayFailure={20} />
+      </Provider>,
     );
     setTimeout(() => {
       form.update();

--- a/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -218,8 +218,7 @@ describe('ConfirmationPage', () => {
       </Provider>,
     );
 
-    expect(tree.queryByText('New confirmation page content goes in here')).to
-      .exist;
+    expect(tree.queryByTestId('new-confirmation-page')).to.exist;
   });
 
   // new confirmation page toggle off
@@ -236,7 +235,6 @@ describe('ConfirmationPage', () => {
       </Provider>,
     );
 
-    expect(tree.queryByText('New confirmation page content goes in here')).to.be
-      .null;
+    expect(tree.queryByTestId('new-confirmation-page')).to.be.null;
   });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -54,6 +54,7 @@
   "dhpConnectedDevicesFitbit": "dhp_connected_devices_fitbit",
   "disability526MaximumRating": "disability_526_maximum_rating",
   "disability526ToxicExposure": "disability_526_toxic_exposure",
+  "disability526NewConfirmationPage": "disability_526_new_confirmation_page",
   "disablityBenefitsBrowserMonitoringEnabled": "disablity_benefits_browser_monitoring_enabled",
   "dischargeWizardFeatures": "discharge_wizard_features",
   "enrollmentVerification": "enrollment_verification",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- adds disability526NewConfirmationPage feature toggle

## Related issue(s)

- [#95149](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95149)

## Testing done

- before: regular, boring old confirmation page with nothing changed.
- after: with feature toggle disability526NewConfirmationPage on, there is now a hidden element, proving that the feature toggle is working! so exciting!
-- after getting the confirmation page, look for the hidden element with the id "new-confirmation-page" in the html of the page using the inspector

## Screenshots

No visual changes... yet.

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

Form 21-526EZ confirmation page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
