### PR TITLE
Updated Downtime Banner Content

### DIFF
--- a/src/platform/user/authentication/downtime.js
+++ b/src/platform/user/authentication/downtime.js
@@ -25,7 +25,7 @@ export const generateCSPBanner = ({ csp }) => {
     ? {
         headline: `You may have trouble signing in with some of your accounts`,
         status: 'warning',
-        message: `We’re sorry. We’re working to fix some problems with ID.me. If you’d like to sign in to VA.gov with your ID.me, DS Logon, or My HealtheVet accounts, please check back later.`,
+        message: `We’re sorry. We’re working to fix some problems with ID.me, but you can still sign in to VA.gov using your Login.gov account. If you’d like to sign in with your ID.me, DS Logon, or My HealtheVet accounts, please check back later.`,
       }
     : {
         headline: `You may have trouble signing in with ${

--- a/src/platform/user/tests/authentication/downtime.unit.spec.js
+++ b/src/platform/user/tests/authentication/downtime.unit.spec.js
@@ -2,40 +2,18 @@
 
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { SERVICE_PROVIDERS } from '../../authentication/constants';
 import * as downtimeUtils from '../../authentication/downtime';
 
 describe('generateCSPBanner', () => {
-  it('should return a specific banner message when csp is "idme"', () => {
-    const result = downtimeUtils.generateCSPBanner({
-      csp: 'idme',
-    });
-    expect(result).to.deep.equal({
-      headline: `You may have trouble signing in with some of your accounts`,
-      status: 'warning',
-      message: `We’re sorry. We’re working to fix some problems with ID.me. If you’d like to sign in to VA.gov with your ID.me, DS Logon, or My HealtheVet accounts, please check back later.`,
-    });
-  });
-
   // Array of CSPs to test
-  const csps = ['logingov', 'mhv', 'dslogon'];
+  const csps = ['logingov', 'idme', 'mhv', 'dslogon'];
 
   csps.forEach(csp => {
     it(`should return a correct banner message when csp is "${csp}"`, () => {
       const result = downtimeUtils.generateCSPBanner({
         csp,
       });
-      expect(result).to.deep.equal({
-        headline: `You may have trouble signing in with ${
-          SERVICE_PROVIDERS[csp].label
-        }`,
-        status: 'warning',
-        message: `We’re sorry. We’re working to fix some problems with our ${
-          SERVICE_PROVIDERS[csp].label
-        } sign in process. If you’d like to sign in to VA.gov with your ${
-          SERVICE_PROVIDERS[csp].label
-        } account, please check back later.`,
-      });
+      expect(result).to.deep.equal(downtimeUtils.DOWNTIME_BANNER_CONFIG[csp]);
     });
   });
 
@@ -57,9 +35,11 @@ describe('renderServiceDown', () => {
     const { container } = render(downtimeUtils.renderServiceDown('ssoe'));
     const alert = container.querySelector('va-alert');
     expect(alert).to.exist;
-    expect(alert.getAttribute('status')).to.equal('warning');
+    expect(alert.getAttribute('status')).to.equal(
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.ssoe.status,
+    );
     expect(alert.querySelector('h2').textContent).to.equal(
-      'Our sign in process isn’t working right now',
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.ssoe.headline,
     );
   });
 
@@ -69,9 +49,11 @@ describe('renderServiceDown', () => {
     );
     const alert = container.querySelector('va-alert');
     expect(alert).to.exist;
-    expect(alert.getAttribute('status')).to.equal('warning');
+    expect(alert.getAttribute('status')).to.equal(
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.mvi.status,
+    );
     expect(alert.querySelector('h2').textContent).to.equal(
-      'You may have trouble signing in or using some tools or services',
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.mvi.headline,
     );
   });
 
@@ -86,8 +68,10 @@ describe('renderServiceDown', () => {
     );
     const alert = container.querySelector('va-alert');
     expect(alert).to.exist;
-    expect(alert.getAttribute('status')).to.equal('info');
-    expect(alert.querySelector('h2').textContent).to.equal('Custom headline');
+    expect(alert.getAttribute('status')).to.equal(customService.status);
+    expect(alert.querySelector('h2').textContent).to.equal(
+      customService.headline,
+    );
   });
 });
 
@@ -100,9 +84,11 @@ describe('renderDowntimeBanner', () => {
     const { container } = render(downtimeUtils.renderDowntimeBanner(statuses));
     const alert = container.querySelector('va-alert');
     expect(alert).to.exist;
-    expect(alert.getAttribute('status')).to.equal('warning');
+    expect(alert.getAttribute('status')).to.equal(
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.multipleServices.status,
+    );
     expect(alert.querySelector('h2').textContent).to.equal(
-      'You may have trouble signing in or using some tools or services',
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.multipleServices.headline,
     );
   });
 
@@ -111,9 +97,11 @@ describe('renderDowntimeBanner', () => {
     const { container } = render(downtimeUtils.renderDowntimeBanner(statuses));
     const alert = container.querySelector('va-alert');
     expect(alert).to.exist;
-    expect(alert.getAttribute('status')).to.equal('warning');
+    expect(alert.getAttribute('status')).to.equal(
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.logingov.status,
+    );
     expect(alert.querySelector('h2').textContent).to.equal(
-      'You may have trouble signing in with Login.gov',
+      downtimeUtils.DOWNTIME_BANNER_CONFIG.logingov.headline,
     );
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updated `src/platform/user/authentication/downtime.js` to account for Login.gov still being available when ID.me is down.

## Related issue(s)

[Jira Ticket VI-567](https://jira.devops.va.gov/browse/VI-567)

## Testing done

- Unit tests for `downtime.js` were adjusted accordingly and run locally.
- Can be replicated by running `yarn test:unit src/platform/user/tests/authentication/downtime.unit.spec.js`.

## What areas of the site does it impact?

This only impacts `downtime.js`.

## Acceptance criteria

- [x] Update content when the ID.me service is down to render that Login.gov is still available (if it is).