### PR TITLE
[94983] Update Appoint a Rep search to use original_entities api

### DIFF
--- a/src/applications/representative-appoint/api/generatePDF.js
+++ b/src/applications/representative-appoint/api/generatePDF.js
@@ -2,11 +2,7 @@ import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/a
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import manifest from '../manifest.json';
 
-export const generatePDF = transformedFormData => {
-  const isAttorneyOrClaimsAgent =
-    transformedFormData?.representative?.type === 'attorney' ||
-    transformedFormData?.representative?.type === 'claimsAgent';
-
+export const generatePDF = (transformedFormData, is2122a) => {
   const apiSettings = {
     mode: 'cors',
     method: 'POST',
@@ -23,9 +19,7 @@ export const generatePDF = transformedFormData => {
 
   const requestUrl = `${
     environment.API_URL
-  }/representation_management/v0/pdf_generator${
-    isAttorneyOrClaimsAgent ? '2122a' : '2122'
-  }`;
+  }/representation_management/v0/pdf_generator${is2122a ? '2122a' : '2122'}`;
 
   return new Promise((resolve, reject) => {
     apiRequest(requestUrl, apiSettings)

--- a/src/applications/representative-appoint/components/ContactAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/ContactAccreditedRepresentative.jsx
@@ -21,7 +21,9 @@ const ContactAccreditedRepresentative = props => {
 
   const orgSelectionRequired =
     !!representative &&
-    representative.attributes?.individualType === 'representative' &&
+    ['representative', 'veteran_service_officer'].includes(
+      representative.attributes?.individualType,
+    ) &&
     representative.attributes?.accreditedOrganizations?.data?.length > 1;
 
   const handleGoBack = () => {

--- a/src/applications/representative-appoint/constants/api.js
+++ b/src/applications/representative-appoint/constants/api.js
@@ -1,5 +1,7 @@
 export const REPRESENTATIVES_API =
-  '/representation_management/v0/accredited_entities_for_appoint';
+  '/representation_management/v0/original_entities';
+// use this endpoint when the GCLAWS API data is available in the accredited_x vets-api tables:
+// '/representation_management/v0/accredited_entities_for_appoint';
 
 export const NEXT_STEPS_EMAIL_API =
   '/representation_management/v0/next_steps_email';

--- a/src/applications/representative-appoint/tests/fixtures/data/test-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/test-data.json
@@ -7,7 +7,7 @@
   },
   "veteranSocialSecurityNumber": "333224444",
   "vaClaimsHistory": true,
-  "vaFileNumber": "12345678",
+  "vaFileNumber": "123456789",
   "veteranDateOfBirth": "1960-01-01",
   "serviceBranch": {
     "army": true,
@@ -17,7 +17,7 @@
     "from": "2003-03-02",
     "to": "2007-03-20"
   },
-  "serviceNumber": "123456",
+  "serviceNumber": "123456789",
   "serveUnderOtherNames": true,
   "previousNames": [
     {

--- a/src/applications/representative-appoint/tests/utilities/getFormNumber.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/utilities/getFormNumber.unit.spec.jsx
@@ -14,7 +14,7 @@ describe('getFormNumber', () => {
     expect(result).to.equal('21-22');
   });
 
-  it('should return "21-22" for justan organization representative', () => {
+  it('should return "21-22" for just an organization representative', () => {
     const mockFormData = {
       'view:selectedRepresentative': {
         type: 'organization',

--- a/src/applications/representative-appoint/utilities/helpers.js
+++ b/src/applications/representative-appoint/utilities/helpers.js
@@ -106,9 +106,11 @@ export const getFormSubtitle = formData => {
   if (entityType === 'organization') {
     return 'VA Form 21-22';
   }
-  if (entityType === 'individual') {
+  if (['representative', 'individual'].includes(entityType)) {
     const { individualType } = entity.attributes;
-    if (individualType === 'representative') {
+    if (
+      ['representative', 'veteran_service_officer'].includes(individualType)
+    ) {
       return 'VA Form 21-22';
     }
     return 'VA Form 21-22a';
@@ -126,9 +128,11 @@ export const getFormSubmitUrlSuffix = formData => {
   if (entityType === 'organization') {
     return '2122';
   }
-  if (entityType === 'individual') {
+  if (['representative', 'individual'].includes(entityType)) {
     const { individualType } = entity.attributes;
-    if (individualType === 'representative') {
+    if (
+      ['representative', 'veteran_service_officer'].includes(individualType)
+    ) {
       return '2122';
     }
     return '2122a';
@@ -168,7 +172,7 @@ export const getRepType = entity => {
     return 'Attorney';
   }
 
-  if (repType === 'claimsAgent' || repType === 'claims_agent') {
+  if (['claimsAgent', 'claims_agent', 'claim_agents'].includes(repType)) {
     return 'Claims Agent';
   }
 
@@ -181,8 +185,10 @@ export const getFormNumber = formData => {
 
   if (
     entityType === 'organization' ||
-    (entityType === 'individual' &&
-      entity.attributes.individualType === 'representative')
+    (['representative', 'individual'].includes(entityType) &&
+      ['representative', 'veteran_service_officer'].includes(
+        entity.attributes.individualType,
+      ))
   ) {
     return '21-22';
   }
@@ -211,10 +217,8 @@ export const isAttorneyOrClaimsAgent = formData => {
   const repType =
     formData['view:selectedRepresentative']?.attributes?.individualType;
 
-  return (
-    repType === 'attorney' ||
-    repType === 'claimsAgent' ||
-    repType === 'claims_agent'
+  return ['attorney', 'claimsAgent', 'claims_agent', 'claim_agents'].includes(
+    repType,
   );
 };
 
@@ -277,6 +281,10 @@ export const convertRepType = input => {
     attorney: 'Attorney',
     /* eslint-disable-next-line camelcase */
     claims_agent: 'Claims Agent',
+    /* eslint-disable-next-line camelcase */
+    claim_agents: 'Claims Agent',
+    /* eslint-disable-next-line camelcase */
+    veteran_service_officer: 'VSO',
   };
 
   return mapping[input] || input;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr updates the representative search to use the `original_entities` endpoint on vets-api
- This pr updates the representative type conditional logic to account for changes in values due to the endpoint switch

## Related issue(s)

- [94983](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94983)

## Testing done

- Tested Appoint flow locally with selecting all 5 types:
  - rep with 1 org
  - rep with many orgs
  - just an org
  - attorney
  - claim_agents 

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user