### PR TITLE
DBEX-95517 | Update scroll utilities to include prefers-reduced-motion settings

### DIFF
--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -120,11 +120,26 @@ export const scrollToElement = name => {
 };
 
 export function setGlobalScroll() {
-  window.Forms = window.Forms || {
-    scroll: {
-      duration: 500,
-      delay: 0,
-      smooth: true,
-    },
+  window.Forms = window.Forms || {};
+
+  // Set default scroll values if they don't exist
+  window.Forms.scroll = window.Forms.scroll || {
+    duration: 500,
+    delay: 0,
+    smooth: true,
   };
+
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)',
+  ).matches;
+
+  // If user prefers reduced motion, merge the settings
+  if (prefersReducedMotion) {
+    window.Forms.scroll = {
+      ...window.Forms.scroll,
+      duration: 0,
+      delay: 0,
+      smooth: false,
+    };
+  }
 }

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -10,6 +10,7 @@ import {
   focusElement,
   focusOnChange,
   getFocusableElements,
+  setGlobalScroll,
 } from '../../../src/js/utilities/ui';
 import { ReviewCollapsibleChapter } from '../../../src/js/review/ReviewCollapsibleChapter';
 
@@ -405,5 +406,82 @@ describe('getFocuableElements', () => {
     global.document = dom;
     const focusableElements = await getFocusableElements(dom);
     expect(focusableElements.length).to.eq(0);
+  });
+});
+
+describe('setGlobalScroll', () => {
+  beforeEach(() => {
+    // Reset window.Forms before each test
+    window.Forms = undefined;
+
+    // Clear the mock for matchMedia before each test
+    window.matchMedia = () => ({ matches: false });
+  });
+
+  it("should initialize window.Forms.scroll with default values if it doesn't exist", () => {
+    setGlobalScroll();
+
+    expect(window.Forms).to.exist;
+    expect(window.Forms.scroll).to.deep.equal({
+      duration: 500,
+      delay: 0,
+      smooth: true,
+    });
+  });
+
+  it('should not overwrite existing window.Forms.scroll values', () => {
+    window.Forms = {
+      scroll: {
+        duration: 1000,
+        delay: 100,
+        smooth: false,
+      },
+    };
+
+    setGlobalScroll();
+
+    expect(window.Forms.scroll).to.deep.equal({
+      duration: 1000,
+      delay: 100,
+      smooth: false,
+    });
+  });
+
+  it('should override default scroll values when user prefers reduced motion', () => {
+    // Simulate prefers-reduced-motion
+    window.matchMedia = () => ({
+      matches: true,
+    });
+
+    setGlobalScroll();
+
+    expect(window.Forms.scroll).to.deep.equal({
+      duration: 0,
+      delay: 0,
+      smooth: false,
+    });
+  });
+
+  it('should combine existing window.Forms.scroll values with reduced motion settings', () => {
+    window.Forms = {
+      scroll: {
+        duration: 1000,
+        delay: 100,
+        smooth: true,
+        offset: 30,
+      },
+    };
+    window.matchMedia = () => ({
+      matches: true,
+    });
+
+    setGlobalScroll();
+
+    expect(window.Forms.scroll).to.deep.equal({
+      duration: 0,
+      delay: 0,
+      smooth: false,
+      offset: 30,
+    });
   });
 });

--- a/src/platform/utilities/tests/ui/scroll.unit.spec.jsx
+++ b/src/platform/utilities/tests/ui/scroll.unit.spec.jsx
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import { $ } from '../../../forms-system/src/js/utilities/ui';
 import * as focusUtils from '../../ui/focus';
 
-import { scrollToFirstError, scrollAndFocus } from '../../ui';
+import { getScrollOptions, scrollToFirstError, scrollAndFocus } from '../../ui';
 
 describe('scrollToFirstError', () => {
   let scrollSpy;
@@ -214,6 +214,85 @@ describe('scrollAndFocus', () => {
     waitFor(() => {
       expect(scrollSpy.notCalled).to.be.true;
       expect(focusSpy.notCalled).to.be.true;
+    });
+  });
+});
+
+describe('getScrollOptions', () => {
+  beforeEach(() => {
+    // Reset window.Forms before each test
+    window.Forms = undefined;
+
+    // Clear the mock for matchMedia before each test
+    window.matchMedia = () => ({ matches: false });
+  });
+
+  it('should return default scroll options if nothing else exists', () => {
+    const options = getScrollOptions();
+
+    expect(options).to.deep.equal({
+      duration: 500,
+      delay: 0,
+      smooth: true,
+    });
+  });
+
+  it('should return window.Forms.scroll option when it exists', () => {
+    window.Forms = {
+      scroll: {
+        duration: 1000,
+        delay: 100,
+        smooth: false,
+      },
+    };
+
+    const options = getScrollOptions();
+
+    expect(options).to.deep.equal({
+      duration: 1000,
+      delay: 100,
+      smooth: false,
+    });
+  });
+
+  it('should include additionalOptions when they exist', () => {
+    window.Forms = {
+      scroll: {
+        delay: 200,
+        duration: 1000,
+      },
+    };
+
+    const options = getScrollOptions({ offset: -100 });
+
+    expect(options).to.deep.equal({
+      delay: 200,
+      duration: 1000,
+      offset: -100,
+      smooth: true, // Default value since it's not overridden
+    });
+  });
+
+  it('should override all other scroll options when user prefers reduced motion', () => {
+    window.Forms = {
+      scroll: {
+        delay: 200,
+        duration: 1000,
+        smooth: true,
+      },
+    };
+    // Simulate prefers-reduced-motion
+    window.matchMedia = () => ({
+      matches: true,
+    });
+
+    const options = getScrollOptions({ delay: 5, offset: 20 });
+
+    expect(options).to.deep.equal({
+      duration: 0,
+      delay: 0,
+      offset: 20,
+      smooth: false,
     });
   });
 });

--- a/src/platform/utilities/ui/scroll.js
+++ b/src/platform/utilities/ui/scroll.js
@@ -8,14 +8,27 @@ const { scroller } = Scroll;
 // Allows smooth scrolling to be overridden by our E2E tests
 export function getScrollOptions(additionalOptions) {
   const globals = window.Forms || {};
+  const defaults = {
+    duration: 500,
+    delay: 0,
+    smooth: true,
+  };
   const reducedMotion = window?.matchMedia('(prefers-reduced-motion: reduce)')
     ?.matches;
-  const defaults = {
-    duration: reducedMotion ? 0 : 500,
-    delay: 0,
-    smooth: !reducedMotion,
+  const motionPreference = reducedMotion
+    ? {
+        duration: 0,
+        delay: 0,
+        smooth: false,
+      }
+    : {};
+
+  return {
+    ...defaults,
+    ...globals.scroll,
+    ...additionalOptions,
+    ...motionPreference,
   };
-  return { ...defaults, ...globals.scroll, ...additionalOptions };
 }
 
 export function scrollTo(elem, options = getScrollOptions()) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- For https://github.com/department-of-veterans-affairs/va.gov-team/issues/95517
- The default scroll settings include animation, which can make folks with vestibular disorders sick. This PR sets scroll settings for users who prefer reduced motion to `{delay: 0, duration: 0, smooth: false}`.
- We're setting the scroll behavior a variety of ways in this repo. `setGlobalScroll` updates `windows.Forms.scroll`. Most uses of the scroll reference `windows.Form.scroll` first as the default settings.  In some uses of the scroller we're not looking at `windows.Forms.scroll` but are calling `getScrollOptions`. So I updated those 2 places.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95517
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1604

## Testing done
- Tests were added checking that `prefers-reduced-motion` settings were added successfully to the scroll object, only overwriting the delay, duration and smooth properties.
- To test the behavior in the browser using the [Chrome DevTools simulator](https://developer.chrome.com/docs/devtools/rendering/emulate-css#emulate_css_media_feature_prefers-reduced-motion) or your local OS accessibility settings (ex: [Mac](https://support.apple.com/guide/mac-help/stop-or-reduce-onscreen-motion-mchlc03f57a1/mac) ), turn on "reduced motion" settings.
- Login and go to the 526 form. Click around the page and trigger the scroll by trying to edit an item but filling it out incorrectly, triggering an error to show on the page.
- Instead of a smooth scroll to the error, motion should be reduced and it should appear to "jump" straight to the error.

## Screenshots
[Short video ](https://www.loom.com/share/c588bdc8f013492b81fbf60fa77dcb38?sid=c46038b4-2bdc-48d1-9b7b-bdaf523f5b59)of the scroll behavior with prefers-reduced-motion on and off

## What areas of the site does it impact?

* Pages that reference the `window.Forms.scroll` or use `getScrollOptions`

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
