### PR TITLE
Mailing address form updates - use url query strings, move edit form, adjust headings, use web component pattern, other fixes

### DIFF
--- a/src/applications/_mock-form-ae-design-patterns/mocks/endpoints/in-progress-forms/22-1990.js
+++ b/src/applications/_mock-form-ae-design-patterns/mocks/endpoints/in-progress-forms/22-1990.js
@@ -20,6 +20,7 @@ const responses = {
           state: 'CO',
           country: 'USA',
           postalCode: '80521',
+          isMilitary: false,
         },
         toursOfDuty: [
           {

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/components/SaveInProgressInfo.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/components/SaveInProgressInfo.jsx
@@ -64,9 +64,9 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
         data-testid="ezr-login-alert"
         uswds
       >
-        <h3 slot="headline">
+        <h2 className="vads-u-font-size--h3" slot="headline">
           Sign in now to save time and save your work in progress
-        </h3>
+        </h2>
         <p>Here&rsquo;s how signing in now helps you:</p>
         <ul>
           <li>

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
@@ -72,7 +72,7 @@ const formConfig = {
       'Please sign in again to resume your application for education benefits.',
   },
   dev: {
-    showNavLinks: true,
+    showNavLinks: environment?.isLocalhost(),
   },
   prefillEnabled: true,
   prefillTransformer,
@@ -136,7 +136,7 @@ const formConfig = {
       },
     },
     personalInformation: {
-      title: 'Personal information',
+      title: 'Contact information',
       pages: {
         otherContactInfo: {
           hideNavButtons: true,

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
@@ -237,14 +237,13 @@ const formConfig = {
           CustomPage: MailingAddressEdit,
           CustomPageReview: null,
           uiSchema: {
-            ...descriptionUI(<PrefillAlert slim />, { hideOnReview: true }),
-            veteranAddress: addressUI(),
+            veteranAddress: addressUI({ omit: ['street3'] }),
           },
           schema: {
             type: 'object',
             properties: {
               'view:pageTitle': blankSchema,
-              veteranAddress: addressSchema(),
+              veteranAddress: addressSchema({ omit: ['street3'] }),
             },
           },
         },

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
@@ -36,6 +36,7 @@ import {
 } from '../pages/ApplicantInformation';
 import ReviewPage from '../pages/ReviewPage';
 import { EditNavigationWithRouter } from '../components/EditNavigation';
+import { ContactInfoEditReroute } from '../pages/ContactInfoEditReroute';
 
 const {
   date,
@@ -69,6 +70,9 @@ const formConfig = {
     notFound: 'Please start over to apply for education benefits.',
     noAuth:
       'Please sign in again to resume your application for education benefits.',
+  },
+  dev: {
+    showNavLinks: true,
   },
   prefillEnabled: true,
   prefillTransformer,
@@ -173,7 +177,6 @@ const formConfig = {
                 hideOnReview: true, // We're using the `ReveiwDescription`, so don't show this page
                 forceDivWrapper: true, // It's all info and links, so we don't need a fieldset or legend
               },
-              'ui:reviewId': 'other-contact-information',
               'ui:title': '',
               'ui:description': '',
               'ui:widget': props => {
@@ -209,33 +212,16 @@ const formConfig = {
         },
         contactInformation: merge({}, contactInformationPage(fullSchema1990)),
         contactInformationEdit: {
-          hideNavButtons: true,
-          title: 'Edit mailing address',
+          title: 'Edit contact information',
           taskListHide: true,
-          path: 'personal-information/edit-mailing-address',
+          path: 'personal-information/edit-veteran-address',
+          CustomPage: ContactInfoEditReroute,
+          CustomPageReview: null,
           uiSchema: {
             ...descriptionUI(PrefillAlert, { hideOnReview: true }),
             veteranAddress: addressFormDefinition.uiSchema(
               'Edit mailing address',
             ),
-            'view:editNavigation': {
-              'ui:options': {
-                hideOnReview: true, // We're using the `ReveiwDescription`, so don't show this page
-                forceDivWrapper: true, // It's all info and links, so we don't need a fieldset or legend
-              },
-              'ui:reviewId': 'veteranAddress',
-              'ui:title': '',
-              'ui:description': '',
-              'ui:widget': props => {
-                return (
-                  <EditNavigationWithRouter
-                    {...props}
-                    fields={['email', 'homePhone', 'mobilePhone']}
-                    returnPath="/personal-information"
-                  />
-                );
-              },
-            },
           },
           schema: {
             type: 'object',
@@ -245,15 +231,9 @@ const formConfig = {
                 fullSchema1990,
                 true,
               ),
-              'view:editNavigation': {
-                type: 'string',
-              },
             },
-            required: ['email'],
           },
-          scrollAndFocusTarget,
           depends: () => false,
-          review: null,
         },
       },
     },

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/config/form.js
@@ -8,6 +8,8 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import { scrollAndFocusTarget } from 'applications/_mock-form-ae-design-patterns/utils/focus';
 import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
 import {
+  addressSchema,
+  addressUI,
   descriptionUI,
   emailSchema,
   emailUI,
@@ -15,7 +17,6 @@ import {
   phoneUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import * as addressFormDefinition from 'platform/forms-system/src/js/definitions/address';
 import { PrefillAlert } from 'applications/_mock-form-ae-design-patterns/shared/components/alerts/PrefillAlert';
 import PreSubmitInfo from '../pages/PreSubmitInfo';
 import contactInformationPage from '../pages/contactInformation';
@@ -36,7 +37,7 @@ import {
 } from '../pages/ApplicantInformation';
 import ReviewPage from '../pages/ReviewPage';
 import { EditNavigationWithRouter } from '../components/EditNavigation';
-import { ContactInfoEditReroute } from '../pages/ContactInfoEditReroute';
+import { MailingAddressEdit } from '../pages/MailingAddressEdit';
 
 const {
   date,
@@ -211,30 +212,6 @@ const formConfig = {
           review: null,
         },
         contactInformation: merge({}, contactInformationPage(fullSchema1990)),
-        contactInformationEdit: {
-          title: 'Edit contact information',
-          taskListHide: true,
-          path: 'personal-information/edit-veteran-address',
-          CustomPage: ContactInfoEditReroute,
-          CustomPageReview: null,
-          uiSchema: {
-            ...descriptionUI(PrefillAlert, { hideOnReview: true }),
-            veteranAddress: addressFormDefinition.uiSchema(
-              'Edit mailing address',
-            ),
-          },
-          schema: {
-            type: 'object',
-            properties: {
-              'view:pageTitle': blankSchema,
-              veteranAddress: addressFormDefinition.schema(
-                fullSchema1990,
-                true,
-              ),
-            },
-          },
-          depends: () => false,
-        },
       },
     },
     review: {
@@ -253,6 +230,23 @@ const formConfig = {
             properties: {},
           },
           scrollAndFocusTarget,
+        },
+        contactInformationEdit: {
+          title: 'Edit contact information',
+          path: 'personal-information/edit-veteran-address',
+          CustomPage: MailingAddressEdit,
+          CustomPageReview: null,
+          uiSchema: {
+            ...descriptionUI(<PrefillAlert slim />, { hideOnReview: true }),
+            veteranAddress: addressUI(),
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              'view:pageTitle': blankSchema,
+              veteranAddress: addressSchema(),
+            },
+          },
         },
       },
     },

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/containers/IntroductionPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/containers/IntroductionPage.jsx
@@ -37,15 +37,15 @@ export class IntroductionPage extends React.Component {
         <p>Equal to VA Form 22-1990 (Application for VA Education Benefits).</p>
         <div className="subway-map">
           <SaveInProgressInfo {...sipProps} route={route} />
-          <h4>Follow the steps below to apply for education benefits.</h4>
+          <h3>Follow the steps below to apply for education benefits.</h3>
           <div className="process schemaform-process">
             <ol>
               <li className="process-step list-one">
                 <div>
-                  <h5>Prepare</h5>
+                  <h4>Prepare</h4>
                 </div>
                 <div>
-                  <h6>To fill out this application, you’ll need your:</h6>
+                  <h5>To fill out this application, you’ll need your:</h5>
                 </div>
                 <ul>
                   <li>Social Security number (required)</li>
@@ -68,7 +68,7 @@ export class IntroductionPage extends React.Component {
                   </a>
                   .
                 </p>
-                <h6>Learn about educational programs</h6>
+                <h5>Learn about educational programs</h5>
                 <p>
                   See what benefits you’ll get at the school you want to attend.{' '}
                   <a href="/education/gi-bill-comparison-tool/">
@@ -79,7 +79,7 @@ export class IntroductionPage extends React.Component {
               </li>
               <li className="process-step list-two">
                 <div>
-                  <h5>Apply</h5>
+                  <h4>Apply</h4>
                 </div>
                 <p>Complete this education benefits form.</p>
                 <p>
@@ -89,7 +89,7 @@ export class IntroductionPage extends React.Component {
               </li>
               <li className="process-step list-three">
                 <div>
-                  <h5>VA review</h5>
+                  <h4>VA review</h4>
                 </div>
                 <p>
                   We usually process claims within 30 days. We’ll let you know
@@ -105,7 +105,7 @@ export class IntroductionPage extends React.Component {
               </li>
               <li className="process-step list-four">
                 <div>
-                  <h5>Decision</h5>
+                  <h4>Decision</h4>
                 </div>
                 <p>
                   You’ll get a Certificate of Eligibility (COE), or award

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/containers/IntroductionPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/containers/IntroductionPage.jsx
@@ -5,25 +5,12 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { connect } from 'react-redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import {
-  WIZARD_STATUS,
-  WIZARD_STATUS_NOT_STARTED,
-} from 'applications/static-pages/wizard';
 import SaveInProgressInfo from '../components/SaveInProgressInfo';
 
 export class IntroductionPage extends React.Component {
-  state = {
-    status: sessionStorage.getItem(WIZARD_STATUS) || WIZARD_STATUS_NOT_STARTED,
-  };
-
   componentDidMount() {
     focusElement('.va-nav-breadcrumbs-list');
   }
-
-  setWizardStatus = value => {
-    sessionStorage.setItem(WIZARD_STATUS, value);
-    this.setState({ status: value });
-  };
 
   render() {
     const { route, showWizard } = this.props;

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ApplicantInformation.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ApplicantInformation.jsx
@@ -5,9 +5,27 @@ import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import { InfoSection } from '../../../../shared/components/InfoSection';
 import { maskSSN } from '../../../../utils/helpers/general';
-import { APP_URLS } from '../../../../utils/constants';
 import { genderLabels } from '../utils/labels';
 import { isOnReviewPage } from '../utils/reviewPage';
+
+const AdditionalInfoContent = () => {
+  return (
+    <div>
+      <p className="vads-u-margin-top--0">
+        To protect your personal information, we don’t allow online changes to
+        your name, date of birth, or Social Security number. If you need to
+        change this information, call Veterans Benefits Assistance at{' '}
+        <va-telephone contact="8008271000" />. We’re here Monday through Friday,
+        between 8:00 a.m. and 9:00 p.m. ET.
+      </p>
+
+      <va-link
+        text="Find instructions for how to change your legal name"
+        href="/resources/how-to-change-your-legal-name-on-file-with-va/"
+      />
+    </div>
+  );
+};
 
 export const ApplicantInformationBase = ({
   veteranFullName,
@@ -22,6 +40,14 @@ export const ApplicantInformationBase = ({
     veteranDateOfBirth && format(parseISO(veteranDateOfBirth), 'MMMM dd, yyyy');
   return (
     <InfoSection title={title} titleLevel={3}>
+      {isReviewPage && (
+        <va-additional-info
+          trigger="Why isn't this information editable here?"
+          class="vads-u-margin-y--2"
+        >
+          <AdditionalInfoContent />
+        </va-additional-info>
+      )}
       <InfoSection.InfoBlock
         label="First name"
         value={veteranFullName?.first}
@@ -81,23 +107,13 @@ export const ApplicantInformation = ({
         gender={gender}
       />
 
-      <p>
-        <strong>Note:</strong> To protect your personal information, we don’t
-        allow online changes to your name, date of birth, or Social Security
-        number. If you need to change this information for your health benefits,
-        call your VA health facility.{' '}
-        <va-link
-          href={APP_URLS.facilities}
-          text="Find your VA health facility"
-        />
-      </p>
-      <p>
-        If you want to update your contact information for other VA benefits,
-        you can do that from your profile.{' '}
-      </p>
-      <div className="vads-u-margin-bottom--3">
-        <va-link href="/profile" text="Go to your profile" external />
-      </div>
+      <va-additional-info
+        trigger="How to change this information"
+        class="vads-u-margin-bottom--5"
+      >
+        <AdditionalInfoContent />
+      </va-additional-info>
+
       {contentBeforeButtons}
       <FormNavButtons goBack={goBack} goForward={goForward} />
       {contentAfterButtons}

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ContactInfoEditReroute.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ContactInfoEditReroute.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { SchemaForm, setData } from 'platform/forms-system/exportsFile';
+import { useDispatch } from 'react-redux';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { withRouter } from 'react-router';
+
+export const ContactInfoEditBase = props => {
+  const dispatch = useDispatch();
+
+  const { location } = props;
+  const fromReviewPage = location?.query?.review;
+
+  const setFormData = data => {
+    dispatch(setData(data));
+  };
+
+  const { schema, uiSchema, data, goBack, goToPath } = props;
+  const handlers = {
+    onInput: inputData => {
+      setFormData(inputData);
+    },
+    onSubmit: () => {
+      if (fromReviewPage) {
+        goToPath(
+          '/2/task-orange/review-then-submit?updatedSection=veteranAddress&success=true',
+        );
+        return;
+      }
+      goBack();
+    },
+    onCancel: () => {
+      goBack();
+    },
+  };
+  return (
+    <SchemaForm
+      addNameAttribute
+      // `name` and `title` are required by SchemaForm, but are only used
+      // internally by the SchemaForm component
+      name="Contact Info Form"
+      title="Contact Info Form"
+      schema={schema}
+      data={data}
+      uiSchema={uiSchema}
+      onChange={handlers.onInput}
+      onSubmit={handlers.onSubmit}
+    >
+      <VaButton text="Save" submit="prevent" />
+      <VaButton text="Cancel" onClick={handlers.onCancel} secondary />
+    </SchemaForm>
+  );
+};
+
+export const ContactInfoEditReroute = withRouter(ContactInfoEditBase);

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/MailingAddressEdit.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/MailingAddressEdit.jsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { withRouter } from 'react-router';
 
-export const ContactInfoEditBase = props => {
+export const MailingAddressEditBase = props => {
   const dispatch = useDispatch();
 
   const { location } = props;
@@ -51,4 +51,4 @@ export const ContactInfoEditBase = props => {
   );
 };
 
-export const ContactInfoEditReroute = withRouter(ContactInfoEditBase);
+export const MailingAddressEdit = withRouter(MailingAddressEditBase);

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/MailingAddressEdit.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/MailingAddressEdit.jsx
@@ -3,6 +3,7 @@ import { SchemaForm, setData } from 'platform/forms-system/exportsFile';
 import { useDispatch } from 'react-redux';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
 
 export const MailingAddressEditBase = props => {
   const dispatch = useDispatch();
@@ -65,6 +66,15 @@ export const MailingAddressEditBase = props => {
       </div>
     </>
   );
+};
+
+MailingAddressEditBase.propTypes = {
+  data: PropTypes.object.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  schema: PropTypes.object.isRequired,
+  uiSchema: PropTypes.object.isRequired,
+  location: PropTypes.object,
 };
 
 export const MailingAddressEdit = withRouter(MailingAddressEditBase);

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/MailingAddressEdit.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/MailingAddressEdit.jsx
@@ -33,21 +33,37 @@ export const MailingAddressEditBase = props => {
     },
   };
   return (
-    <SchemaForm
-      addNameAttribute
-      // `name` and `title` are required by SchemaForm, but are only used
-      // internally by the SchemaForm component
-      name="Contact Info Form"
-      title="Contact Info Form"
-      schema={schema}
-      data={data}
-      uiSchema={uiSchema}
-      onChange={handlers.onInput}
-      onSubmit={handlers.onSubmit}
-    >
-      <VaButton text="Save" submit="prevent" />
-      <VaButton text="Cancel" onClick={handlers.onCancel} secondary />
-    </SchemaForm>
+    <>
+      <va-alert status="info" slim class="vads-u-margin-y--3">
+        <p className="vads-u-margin--0">
+          <strong>Note:</strong> We’ve prefilled some of your information. If
+          you need to make changes, you can edit on this screen. Your changes
+          won’t affect your VA.gov profile.
+        </p>
+      </va-alert>
+      <h3 className="vads-u-margin-bottom--4">Edit mailing address</h3>
+      <SchemaForm
+        addNameAttribute
+        // `name` and `title` are required by SchemaForm, but are only used
+        // internally by the SchemaForm component
+        name="Contact Info Form"
+        title="Contact Info Form"
+        schema={schema}
+        data={data}
+        uiSchema={uiSchema}
+        onChange={handlers.onInput}
+        onSubmit={handlers.onSubmit}
+      >
+        <VaButton text="Save" submit="prevent" />
+        <VaButton text="Cancel" onClick={handlers.onCancel} secondary />
+      </SchemaForm>
+      <div className="vads-u-margin-y--4">
+        <va-link
+          text="Finish this application later"
+          href="/mock-form-ae-design-patterns/2/task-orange"
+        />
+      </div>
+    </>
   );
 };
 

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/PersonalInformation.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/PersonalInformation.jsx
@@ -12,7 +12,7 @@ import { InfoSection } from '../../../../shared/components/InfoSection';
 const getLinkFactory = (rootUrl, review = false) => {
   return id => {
     const url = `${rootUrl}personal-information/${id}`;
-    return review ? `${url}?review` : url;
+    return review ? `${url}?review=true` : url;
   };
 };
 
@@ -70,6 +70,7 @@ export const PersonalInformationContact = ({
           <InfoSection.SubHeading
             text="Communication method"
             editLink={getLink('edit-contact-preference')}
+            level={4}
           />
           <InfoSection.InfoBlock
             label="How should we contact you if we have questions about your application?"
@@ -81,6 +82,7 @@ export const PersonalInformationContact = ({
             editLink={getLink('edit-veteran-address')}
             id="veteranAddress"
             name="veteranAddress"
+            level={4}
           />
           {success &&
             updatedSection === 'veteranAddress' && (
@@ -106,6 +108,7 @@ export const PersonalInformationContact = ({
             editLink={getLink('edit-other-contact-information')}
             id="otherContactInformation"
             name="otherContactInformation"
+            level={4}
           />
 
           {success &&

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/PersonalInformation.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/PersonalInformation.jsx
@@ -35,20 +35,19 @@ export const PersonalInformationContact = ({
 }) => {
   const config = useContext(PatternConfigContext);
 
-  const reviewId = location?.state?.reviewId;
-  const success = location?.state?.success;
+  const updatedSection = location?.query?.updatedSection;
+  const success = location?.query?.success;
 
   useEffect(
     () => {
-      if (reviewId) {
+      if (updatedSection) {
         setTimeout(() => {
-          waitForRenderThenFocus(`#${reviewId}`);
-          scrollToElement(reviewId);
-          window.history.replaceState({}, '');
+          waitForRenderThenFocus(`#${updatedSection}`);
+          scrollToElement(updatedSection);
         }, 100);
       }
     },
-    [reviewId],
+    [updatedSection],
   );
 
   const { homePhone, mobilePhone, email } = data;
@@ -79,12 +78,12 @@ export const PersonalInformationContact = ({
 
           <InfoSection.SubHeading
             text="Address"
-            editLink={getLink('edit-mailing-address')}
+            editLink={getLink('edit-veteran-address')}
             id="veteranAddress"
             name="veteranAddress"
           />
           {success &&
-            reviewId === 'veteranAddress' && (
+            updatedSection === 'veteranAddress' && (
               <SaveSuccessAlert updatedText="Address information" />
             )}
           <InfoSection.InfoBlock
@@ -102,11 +101,12 @@ export const PersonalInformationContact = ({
           <InfoSection.SubHeading
             text="Other contact information"
             editLink={getLink('edit-other-contact-information')}
-            id="other-contact-information"
+            id="otherContactInformation"
+            name="otherContactInformation"
           />
 
           {success &&
-            reviewId === 'other-contact-information' && (
+            updatedSection === 'otherContactInformation' && (
               <SaveSuccessAlert updatedText="Other contact information" />
             )}
           <InfoSection.InfoBlock label="Email address" value={email} />

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/PersonalInformation.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/PersonalInformation.jsx
@@ -68,16 +68,16 @@ export const PersonalInformationContact = ({
       <div className="vads-u-margin-top--4">
         <InfoSection>
           <InfoSection.SubHeading
-            text="Contact information"
+            text="Communication method"
             editLink={getLink('edit-contact-preference')}
           />
           <InfoSection.InfoBlock
             label="How should we contact you if we have questions about your application?"
-            value="email"
+            value="Email"
           />
 
           <InfoSection.SubHeading
-            text="Address"
+            text="Mailing address"
             editLink={getLink('edit-veteran-address')}
             id="veteranAddress"
             name="veteranAddress"
@@ -96,7 +96,10 @@ export const PersonalInformationContact = ({
           />
           <InfoSection.InfoBlock label="City" value={address?.city} />
           <InfoSection.InfoBlock label="State" value={address?.state} />
-          <InfoSection.InfoBlock label="Zip code" value={address?.postalCode} />
+          <InfoSection.InfoBlock
+            label="Postal code"
+            value={address?.postalCode}
+          />
 
           <InfoSection.SubHeading
             text="Other contact information"

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 import { Link, withRouter } from 'react-router';
 import PropTypes from 'prop-types';
-import { VaPrivacyAgreement } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaButtonPair,
+  VaPrivacyAgreement,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { setupPages } from '../utils/reviewPage';
 import { formConfigForOrangeTask } from '../config/form';
@@ -32,6 +35,9 @@ const ReviewPage = props => {
         props.goToPath('/confirmation');
       }
     },
+    onBack: () => {
+      props.goBack();
+    },
   };
 
   return (
@@ -46,12 +52,12 @@ const ReviewPage = props => {
           return (
             <div key={index}>
               <div className={chapterClasses}>
-                <h2
+                <h3
                   id={index}
                   className="vads-u-margin--0 vads-u-font-size--h3"
                 >
                   {title}
-                </h2>
+                </h3>
               </div>
 
               {getChapterPagesFromChapterIndex(index).map(page => {
@@ -84,7 +90,13 @@ const ReviewPage = props => {
         <Link to="review-then-submit2">Finish this application later</Link>
       </p>
       {/* {props.contentBeforeButtons} */}
-      <va-button onClick={handlers.onSubmit} text="Submit" uswds />
+      <VaButtonPair
+        class="vads-u-margin-top--2"
+        continue
+        onPrimaryClick={handlers.onSubmit}
+        onSecondaryClick={handlers.onBack}
+        uswds
+      />
       {/* {props.contentAfterButtons} */}
     </article>
   );
@@ -97,6 +109,7 @@ ReviewPage.propTypes = {
   goBack: PropTypes.func,
   goForward: PropTypes.func,
   goToPath: PropTypes.func,
+  location: PropTypes.object,
   name: PropTypes.string,
   pagePerItemIndex: PropTypes.number,
   schema: PropTypes.shape({}),

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
@@ -10,6 +10,7 @@ import { setupPages } from '../utils/reviewPage';
 import { formConfigForOrangeTask } from '../config/form';
 
 const ReviewPage = props => {
+  const { location } = props;
   const [privacyCheckbox, setPrivacyCheckbox] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
@@ -60,7 +61,9 @@ const ReviewPage = props => {
               </div>
 
               {getChapterPagesFromChapterIndex(index).map(page => {
-                const depends = page.depends ? page.depends(props.data) : true;
+                const depends = page.depends
+                  ? page.depends({ ...props.data, location })
+                  : true;
                 return page.review && depends
                   ? Object.entries(page.review(props)).map(([label, value]) => (
                       <div className="page-value" key={label}>

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
@@ -7,6 +7,7 @@ import { setupPages } from '../utils/reviewPage';
 import { formConfigForOrangeTask } from '../config/form';
 
 const ReviewPage = props => {
+  const { location } = props;
   const [privacyCheckbox, setPrivacyCheckbox] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
@@ -45,13 +46,18 @@ const ReviewPage = props => {
           return (
             <div key={index}>
               <div className={chapterClasses}>
-                <h2 id={index} className="vads-u-margin--0">
+                <h2
+                  id={index}
+                  className="vads-u-margin--0 vads-u-font-size--h3"
+                >
                   {title}
                 </h2>
               </div>
 
               {getChapterPagesFromChapterIndex(index).map(page => {
-                const depends = page.depends ? page.depends(props.data) : true;
+                const depends = page.depends
+                  ? page.depends({ ...props.data, location })
+                  : true;
                 return page.review && depends
                   ? Object.entries(page.review(props)).map(([label, value]) => (
                       <div className="page-value" key={label}>

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/ReviewPage.jsx
@@ -10,7 +10,6 @@ import { setupPages } from '../utils/reviewPage';
 import { formConfigForOrangeTask } from '../config/form';
 
 const ReviewPage = props => {
-  const { location } = props;
   const [privacyCheckbox, setPrivacyCheckbox] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
@@ -61,9 +60,7 @@ const ReviewPage = props => {
               </div>
 
               {getChapterPagesFromChapterIndex(index).map(page => {
-                const depends = page.depends
-                  ? page.depends({ ...props.data, location })
-                  : true;
+                const depends = page.depends ? page.depends(props.data) : true;
                 return page.review && depends
                   ? Object.entries(page.review(props)).map(([label, value]) => (
                       <div className="page-value" key={label}>

--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/contactInformation.js
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskOrange/pages/contactInformation.js
@@ -22,5 +22,12 @@ export default function createContactInformationPage() {
         return <PersonalInformationContactReview {...props} />;
       })(),
     }),
+    depends: args => {
+      // on the review page we want to show this page
+      // so passing in location to check if we are on the review page
+      const pathname = args?.location?.pathname;
+      const shouldShow = pathname?.includes?.('review');
+      return !!shouldShow;
+    },
   };
 }

--- a/src/applications/_mock-form-ae-design-patterns/shared/components/InfoSection.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/shared/components/InfoSection.jsx
@@ -31,7 +31,7 @@ const SubHeading = ({
   const H = `h${level || 3}`;
   return (
     <div className="vads-u-display--flex vads-u-justify-content--space-between vads-u-align-items--center vads-u-border-bottom--1px vads-u-margin-bottom--2">
-      <H className="vads-u-margin--0" id={id} tabindex="-1" name={name}>
+      <H className="vads-u-margin--0" id={id} tabIndex="-1" name={name}>
         {text}
       </H>
       {editLink && (
@@ -75,7 +75,7 @@ InfoBlock.propTypes = {
 
 export const InfoSection = ({ title, children, titleLevel }) => (
   <section className="vads-u-margin-bottom--4">
-    {title && <Heading text={title} level={titleLevel} tabindex="-1" />}
+    {title && <Heading text={title} level={titleLevel} tabIndex="-1" />}
     <div className="vads-u-margin--0">{children}</div>
   </section>
 );

--- a/src/applications/_mock-form-ae-design-patterns/tests/e2e/pattern2/taskOrange.cypress.spec.js
+++ b/src/applications/_mock-form-ae-design-patterns/tests/e2e/pattern2/taskOrange.cypress.spec.js
@@ -80,11 +80,9 @@ describe('Prefill pattern - Orange Task', () => {
 
     cy.findByRole('button', { name: /continue/i }).click();
 
-    // cy.wait('@mockSip');
-
-    // check prefilled contact info page
-    cy.url().should('contain', '/personal-information/contact-information');
-    cy.findByText('Address').should('exist');
+    // check prefilled review page
+    cy.url().should('contain', '/review-then-submit');
+    cy.findByText('Mailing address').should('exist');
     cy.findByText('1234 Fake St.').should('exist');
     cy.findByText('Fort Collins').should('exist');
     cy.findByText('CO').should('exist');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added the usage of query strings to represent section being edited and if the editing originated from the review page. Since we are using regular links, it didn't work too well to wire up additional session storage event listeners to the link clicks and set up cleanup of the session storage on page visit.
- Use the web component 'pattern' for the address form itself. This presented an interesting bug. If I used the 'depends' property to hide the form form the usual form page flow, then for some reason the state and city sections of the form broke and didn't display correctly. This resulted in me having to move the address editing page to after the new review page, that way it wouldn't be shown in the usual form flow, but could still be navigated to from the review page and would not require the 'depends' property.
  - This is somewhat of a compromise in getting the form to work, because now the 'stepper' on the top of the page does not match the design, but I will see if the VFF team may be able to address the bug and then we could move it back if possible, otherwise we may just have to live with the difference. 
- Used the Schema form component to render the form and related schema/uiSchema from the form config, and that way we could pass in the submit and cancel buttons.
- Fixed some heading levels
- Adjusted depends logic for contact info page to display using location check
- Added dev links to localhost version, so that it is easier to navigate the form while working through code changes

## Related issue(s)

- https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/175

## Testing done

- Updated e2e test for orange pattern

## Screenshots

![screencapture-localhost-3001-mock-form-ae-design-patterns-2-task-orange-personal-information-edit-veteran-address-2024-10-29-08_01_56](https://github.com/user-attachments/assets/904433b0-3aeb-44f8-a2e8-77ad21bce0d9)


## What areas of the site does it impact?

Auth patterns mock form

## Acceptance criteria

- Edit address form works from review page, updates address and shows success alert

### Quality Assurance & Testing

To test, spool up the mock server and frontend locally

- You should be able to navigate through the 2 pages of the form and then edit the address from the review page. The success alert should be shown on saving address, and the page should be scrolling to the address section on the review page.

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
