### PR TITLE
fix delete modal not receiving focus

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ManageFolderButtons.jsx
+++ b/src/applications/mhv-secure-messaging/components/ManageFolderButtons.jsx
@@ -58,7 +58,7 @@ const ManageFolderButtons = props => {
   );
 
   const openDelModal = () => {
-    dispatch(closeAlert());
+    if (alertStatus) dispatch(closeAlert());
     if (threads.threadList.length > 0) {
       setIsEmptyWarning(true);
     } else {

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageCustomFolderPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageCustomFolderPage.js
@@ -75,7 +75,11 @@ class PatientMessageCustomFolderPage {
     cy.wait('@singleFolderThread');
   };
 
-  loadMessages = (folderName = this.folderName, folderId = this.folderId) => {
+  loadMessages = (
+    threadResponse = mockSingleThreadResponse,
+    folderName = this.folderName,
+    folderId = this.folderId,
+  ) => {
     cy.intercept(
       'GET',
       `${Paths.SM_API_BASE + Paths.FOLDERS}/${this.folderId}*`,
@@ -87,7 +91,7 @@ class PatientMessageCustomFolderPage {
     cy.intercept(
       'GET',
       `${Paths.SM_API_BASE + Paths.FOLDERS}/${folderId}/threads*`,
-      mockSingleThreadResponse,
+      threadResponse,
     ).as('customFolderThread');
 
     cy.get(`[data-testid=${folderName}]`).click();
@@ -282,6 +286,22 @@ class PatientMessageCustomFolderPage {
     cy.get(Locators.FOLDERS.FOLDER_REMOVE)
       .shadow()
       .find('[type="button"]')
+      .click();
+  };
+
+  deleteParticularCustomFolder = (folderId, updatedFoldersResponse) => {
+    cy.intercept('DELETE', `${Paths.SM_API_BASE}/folders/${folderId}`, {
+      statusCode: 204,
+    }).as('deletedFolderResponse');
+
+    cy.intercept(
+      'GET',
+      `${Paths.SM_API_BASE}/folders*`,
+      updatedFoldersResponse,
+    ).as('updatedFoldersList');
+
+    cy.get(Locators.ALERTS.REMOVE_THIS_FOLDER)
+      .find(`va-button[text*='remove']`)
       .click();
   };
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-custom-folder-delete.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-custom-folder-delete.cypress.spec.js
@@ -1,0 +1,65 @@
+import SecureMessagingSite from './sm_site/SecureMessagingSite';
+import PatientInboxPage from './pages/PatientInboxPage';
+import PatientMessageCustomFolderPage from './pages/PatientMessageCustomFolderPage';
+import { AXE_CONTEXT, Data, Locators } from './utils/constants';
+import FolderLoadPage from './pages/FolderLoadPage';
+import mockFolders from './fixtures/folder-response.json';
+
+describe('SM DELETE CUSTOM FOLDER', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+    FolderLoadPage.loadFolders();
+  });
+
+  it('remove non-empty folder', () => {
+    PatientMessageCustomFolderPage.loadMessages();
+    PatientMessageCustomFolderPage.tabAndPressToRemoveFolderButton();
+    PatientMessageCustomFolderPage.verifyEmptyFolderAlert();
+    PatientMessageCustomFolderPage.clickOnCloseIcon();
+    PatientMessageCustomFolderPage.verifyFocusOnRemoveFolderButton();
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('remove empty folder', () => {
+    const emptyThread = { data: [] };
+    const deletedFolder = mockFolders.data.filter(
+      el => el.attributes.name === `TESTAGAIN`,
+    )[0];
+
+    const newData = mockFolders.data.filter(
+      el => el.attributes.name !== `TESTAGAIN`,
+    );
+    const newMeta = {
+      ...mockFolders.meta,
+      pagination: { ...mockFolders.data.pagination, totalEntries: 5 },
+    };
+    const updatedFolderList = { data: newData, meta: newMeta };
+
+    PatientMessageCustomFolderPage.loadMessages(emptyThread);
+    PatientMessageCustomFolderPage.tabAndPressToRemoveFolderButton();
+
+    cy.get(Locators.BUTTONS.ALERT_CLOSE).should(`be.focused`);
+    cy.get(Locators.ALERTS.REMOVE_THIS_FOLDER)
+      .find(`va-button[text*='keep']`)
+      .click();
+    cy.get(Locators.BUTTONS.REMOVE_FOLDER).should(`be.focused`);
+
+    PatientMessageCustomFolderPage.tabAndPressToRemoveFolderButton();
+
+    PatientMessageCustomFolderPage.deleteParticularCustomFolder(
+      deletedFolder.attributes.folderId,
+      updatedFolderList,
+    );
+
+    cy.get(Locators.ALERTS.ALERT_TEXT)
+      .should(`be.visible`)
+      .and(`include.text`, Data.FOLDER_REMOVED_SUCCESSFULLY);
+
+    cy.get(`[data-testid=${deletedFolder.id}]`).should(`not.exist`);
+
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-custom-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-custom-folder.cypress.spec.js
@@ -4,7 +4,7 @@ import PatientMessageCustomFolderPage from './pages/PatientMessageCustomFolderPa
 import { AXE_CONTEXT } from './utils/constants';
 import FolderLoadPage from './pages/FolderLoadPage';
 
-describe('Secure Messaging Custom Folder AXE Check', () => {
+describe('SM CUSTOM FOLDER CONTENT', () => {
   beforeEach(() => {
     SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
@@ -21,15 +21,6 @@ describe('Secure Messaging Custom Folder AXE Check', () => {
 
   it('verify main buttons', () => {
     PatientMessageCustomFolderPage.verifyMainButtons();
-    cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT);
-  });
-
-  it('verify remove non-empty folder', () => {
-    PatientMessageCustomFolderPage.tabAndPressToRemoveFolderButton();
-    PatientMessageCustomFolderPage.verifyEmptyFolderAlert();
-    PatientMessageCustomFolderPage.clickOnCloseIcon();
-    PatientMessageCustomFolderPage.verifyFocusOnRemoveFolderButton();
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -210,6 +210,7 @@ export const Locators = {
     ALERT_TEXT: `[data-testid="alert-text"]`,
     ATTCH_VIRUS: `[data-testid="attachment-virus-alert"]`,
     VA_ALERT: `va-alert`,
+    REMOVE_THIS_FOLDER: `[data-testid="remove-this-folder"]`,
   },
   FIELDS: {
     RECIPIENT: '#select',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- bug: In a custom folder, clicking on the "remove folder" button opens a confirmation modal.  When that modal opened, the focus was reverting to the h1 of the page and not the modal close button.
- fix: add a check to only dispatch closeAlert() if there is an active alert.  Doing so prevents the alertStatus from being updated and triggering focus on the h1. (This is how the "edit folder name" button already works).

## Related issue(s)

### [MHV-60490](https://jira.devops.va.gov/browse/MHV-60490) - Incorrect focus after "delete custom folder" action ###

> Incorrect focus after "delete custom folder" action
> 
> ER: when user trying to delete custom folder modal alert will pop up and focus should stay on it
> 
> AR: focus stays on page header
> 
> UCD to clarify: which element of modal alert should be focused: close icon, alert text or one of action buttons?
> 
> Steps to reproduce:
> 
> navigate to custom folder page
> open custom folder
> click `Remove folder` btn
> 
> Feature Flag Y/N ? N
> 
> DataDog Analytics  Y/N ? N
> 
> Manual Testing Y/N ? 
> 
> Automated Testing Y/N ? Y-Fazil
> 
> Accessibility Testing Y/N ? Y-Bobby
> 
> UCD Validation Y/N N
> 
> Acceptance Criteria:
> 
> AC1 Focus is moved to modal after remove custom folder action

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

va.gov - secure messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
