### PR TITLE
Conditions-567 | Add empty string validation for condition name

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -450,6 +450,11 @@ describe('526 All Claims validations', () => {
       validateDisabilityName(err, tooLong);
       expect(err.addError.calledOnce).to.be.true;
     });
+    it('should add an error when disability is an empty string', () => {
+      const err = { addError: sinon.spy() };
+      validateDisabilityName(err, '  ');
+      expect(err.addError.calledOnce).to.be.true;
+    });
     it('should add error when duplicate names are encountered', () => {
       const _ = null;
       const err = { addError: sinon.spy() };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -453,10 +453,12 @@ export const validateDisabilityName = (
     err.addError('This needs to be less than 256 characters');
   }
 
-  if (
+  const missingCondition =
     !fieldData ||
-    fieldData.toLowerCase() === NULL_CONDITION_STRING.toLowerCase()
-  ) {
+    fieldData.toLowerCase() === NULL_CONDITION_STRING.toLowerCase() ||
+    (fieldData.length > 0 && fieldData.trim() === '');
+
+  if (missingCondition) {
     err.addError(missingConditionMessage);
   }
 

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -454,9 +454,8 @@ export const validateDisabilityName = (
   }
 
   const missingCondition =
-    !fieldData ||
-    fieldData.toLowerCase() === NULL_CONDITION_STRING.toLowerCase() ||
-    (fieldData.length > 0 && fieldData.trim() === '');
+    !fieldData?.trim() ||
+    fieldData.toLowerCase() === NULL_CONDITION_STRING.toLowerCase();
 
   if (missingCondition) {
     err.addError(missingConditionMessage);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Currently on Conditions page of the 526 you can enter spaces "  " and successfully save the empty string as a condition.
- This PR adds a check for that to the `validateDisabilityName` validation. `validateDisabilityName` is only used on the Conditions page.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/567

## Testing done

- Added a test to `validateDisadbilityName` in the validations spec

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Before:  [Short video example](https://us02web.zoom.us/clips/share/QQRGDXuqH9CHUCmUq9mY8O5ZmtwBvao_wjzXdVRgucAbjfNnMXiUdh6YlNVSoKgb0aNee8mXXFOdS_33M-Uo0Nde.H-MNZ7_83QC8pPjU)

After: [Updated experience video](https://www.loom.com/share/c303a630a94a4c95975f3e878e832a36?sid=8f3158bc-9797-496a-9191-8351b65dd820)


## What areas of the site does it impact?

526 Conditions page

## Acceptance criteria
- Login & go to the 526 conditions page. `http://localhost:3001/disability/file-disability-claim-form-21-526ez/new-disabilities/add`
- In the conditions input hit the spacebar a couple of times.
- Click the save button
- You should not be able to save, and an error should show.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
