### PR TITLE
add useAllFormData ui:option for ui:validations

### DIFF
--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -165,7 +165,7 @@ class SchemaForm extends React.Component {
   }
 
   validate(formData, errors) {
-    const { schema, uiSchema, appStateData } = this.props;
+    const { schema, uiSchema, appStateData, getFormData } = this.props;
     if (uiSchema) {
       uiSchemaValidate(
         errors,
@@ -175,6 +175,7 @@ class SchemaForm extends React.Component {
         '',
         null,
         appStateData,
+        getFormData,
       );
     }
     return errors;
@@ -227,7 +228,6 @@ class SchemaForm extends React.Component {
 }
 
 SchemaForm.propTypes = {
-  idSchema: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   schema: PropTypes.object.isRequired,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
@@ -239,8 +239,10 @@ SchemaForm.propTypes = {
   editModeOnReviewPage: PropTypes.bool,
   formContext: PropTypes.shape({}),
   formOptions: PropTypes.shape({}),
+  getFormData: PropTypes.func,
   hideTitle: PropTypes.bool,
-  pagePerItemIndex: PropTypes.number,
+  idSchema: PropTypes.object,
+  pagePerItemIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   reviewMode: PropTypes.bool,
   safeRenderCompletion: PropTypes.bool,
   onChange: PropTypes.func,

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -177,7 +177,15 @@ class FormPage extends React.Component {
     }
   };
 
-  formData = () => {
+  /**
+   * @param {Object} [options]
+   * @param {boolean} [options.all] If true, return the entire form data regardless of context
+   */
+  formData = ({ all } = {}) => {
+    if (all) {
+      return this.props.form.data;
+    }
+
     const { pageConfig } = this.props.route;
     // If it's a CustomPage, return the entire form data
     if (pageConfig.CustomPage && !pageConfig.customPageUsesPagePerItemData) {
@@ -340,6 +348,7 @@ class FormPage extends React.Component {
             uploadFile={this.props.uploadFile}
             schema={schema}
             uiSchema={uiSchema}
+            getFormData={this.formData}
             goBack={this.goBack}
             goForward={this.onSubmit}
             goToPath={this.goToPath}
@@ -374,6 +383,7 @@ class FormPage extends React.Component {
           uiSchema={uiSchema}
           pagePerItemIndex={params ? params.index : undefined}
           formContext={formContext}
+          getFormData={this.formData}
           trackingPrefix={this.props.form.trackingPrefix}
           uploadFile={this.props.uploadFile}
           onChange={this.onChange}

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
@@ -74,6 +74,7 @@ export default function ArrayBuilderItemPage({
         uiSchema={uiSchema}
         pagePerItemIndex={props.pagePerItemIndex}
         formContext={props.formContext}
+        getFormData={props.getFormData}
         trackingPrefix={props.trackingPrefix}
         onChange={onChange}
         onSubmit={onSubmit}
@@ -142,6 +143,7 @@ export default function ArrayBuilderItemPage({
     PageContentBeforeButtons: PropTypes.node,
     data: PropTypes.object,
     formContext: PropTypes.object,
+    getFormData: PropTypes.func,
     goBack: PropTypes.func,
     goToPath: PropTypes.func,
     onChange: PropTypes.func,

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -335,6 +335,7 @@
  * @property {boolean} [useVaCards] For arrays on a single page. If true, will use the `VaCard` component to wrap each item in the array. Has a white background with border instead of gray background.
  * @property {boolean} [reflectInputError] Whether or not to add usa-input--error as class if error message is outside of component.
  * @property {string} [reviewItemHeaderLevel] Optional level for the item-header on Review page - for arrays. Defaults to '5' for a <h5> header-tag.
+ * @property {boolean} [useAllFormData] `formData` will return all form data instead of just the current item in an array. Applicable to `ui:validations`. TODO other fields.
  * @property {boolean} [useDlWrap] On the review page, moves \<dl\> tag to immediately surrounding the \<dt\> field instead of using a \<div\>. \<dt\> fields should be wrapped in \<dl\> fields, so this fixes that a11y issue. Formats fields horizontally.
  * @property {'single' | 'multiple'} [useFormsPattern] Used if you want to define the formHeading and formDescription for the web component field, which can include JSX, so it can be read out by screen readers. Accepts 'single' for a single field on the page where the error will show on the entire block, or 'multiple' for multiple fields on the page where the error will show only on the field.
  * @property {boolean} [useHeaderStyling] Enables developer to implement and use alternate style classes for auto generated html elements such as in ObjectField or ArrayField


### PR DESCRIPTION
## Summary

- Allow `'ui:validations'` to access all form data by passing ui option `useAllFormData: true`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1440

## Testing done

unit, regression

## Screenshots

n/a

## What areas of the site does it impact?

new ui:option for devs to use
allows ui:validations to target all formData

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
