### PR TITLE
check if firstname is there on claimant info call

### DIFF
--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -109,7 +109,7 @@ export const App = ({
         getPersonalInfo(formData?.chosenBenefit);
       } else if (
         !formData[formFields.claimantId] &&
-        claimantInfo &&
+        claimantInfo?.firstName &&
         meb160630Automation
       ) {
         setFormData({


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- update check for firstName

