### PR TITLE
MHV-62515: Expand filter dropdown on list when navigating from refill page

### DIFF
--- a/src/applications/mhv-medications/components/RefillPrescriptions/RefillNotification.jsx
+++ b/src/applications/mhv-medications/components/RefillPrescriptions/RefillNotification.jsx
@@ -5,6 +5,10 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import { useSelector } from 'react-redux';
 import { dataDogActionNames } from '../../util/dataDogConstants';
 import { selectFilterFlag } from '../../util/selectors';
+import {
+  SESSION_SELECTED_FILTER_OPTION,
+  filterOptions,
+} from '../../util/constants';
 
 const RefillNotification = ({ refillStatus }) => {
   // Selectors
@@ -37,12 +41,22 @@ const RefillNotification = ({ refillStatus }) => {
     },
     [refillStatus, successfulMeds, failedMeds],
   );
+
+  const handleGoToMedicationsListOnSuccess = () => {
+    if (!sessionStorage.getItem(SESSION_SELECTED_FILTER_OPTION)) {
+      sessionStorage.setItem(
+        SESSION_SELECTED_FILTER_OPTION,
+        Object.values(filterOptions)[0].label,
+      );
+    }
+  };
+
   const isNotSubmitted =
     refillStatus === 'finished' &&
     successfulMeds?.length === 0 &&
     failedMeds?.length === 0;
   const isPartiallySubmitted = failedMeds?.length > 0;
-  const isSuccess = successfulMeds?.length > 0;
+  const isSuccess = true;
   return (
     <>
       <va-alert
@@ -144,6 +158,7 @@ const RefillNotification = ({ refillStatus }) => {
               dataDogActionNames.refillPage
                 .GO_TO_YOUR_MEDICATIONS_LIST_ACTION_LINK
             }
+            onClick={handleGoToMedicationsListOnSuccess}
           >
             Go to your medications list
           </Link>

--- a/src/applications/mhv-medications/components/RefillPrescriptions/RefillNotification.jsx
+++ b/src/applications/mhv-medications/components/RefillPrescriptions/RefillNotification.jsx
@@ -56,7 +56,7 @@ const RefillNotification = ({ refillStatus }) => {
     successfulMeds?.length === 0 &&
     failedMeds?.length === 0;
   const isPartiallySubmitted = failedMeds?.length > 0;
-  const isSuccess = true;
+  const isSuccess = successfulMeds?.length > 0;
   return (
     <>
       <va-alert

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-expanded-on-nav-from-refill-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-expanded-on-nav-from-refill-page.cypress.spec.js
@@ -1,0 +1,32 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsRefillPage from './pages/MedicationsRefillPage';
+import prescription from './fixtures/active-prescriptions-with-refills.json';
+import prescriptions from './fixtures/listOfPrescriptions.json';
+import successRequest from './fixtures/refill-success.json';
+import MedicationsListPage from './pages/MedicationsListPage';
+
+describe('Medications filter expanded on nav from refill page', () => {
+  it('visits medications list page expanded filter after refill success', () => {
+    const site = new MedicationsSite();
+    const refillPage = new MedicationsRefillPage();
+    const listPage = new MedicationsListPage();
+
+    site.login();
+    refillPage.loadRefillPage(prescriptions);
+    cy.injectAxe();
+    cy.axeCheck('main');
+    refillPage.verifyRefillPageTitle();
+    refillPage.clickPrescriptionRefillCheckboxForSuccessfulRequest(
+      prescription,
+    );
+    refillPage.clickRequestRefillButtonforSuccessfulRequests(
+      prescription.data.attributes.prescriptionId,
+      successRequest,
+    );
+    refillPage.verifyRefillRequestSuccessConfirmationMessage();
+    refillPage.clickMedicationsListPageLinkOnRefillSuccessAlertOnRefillsPage();
+    listPage.verifyLabelTextWhenFilterAccordionExpanded();
+    listPage.verifyAllMedicationsRadioButtonIsChecked();
+    listPage.verifyFilterButtonWhenAccordionExpanded();
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -764,6 +764,10 @@ class MedicationsListPage {
       '.landing-page-content > [data-testid="medication-list"] > :nth-child(1) > [data-testid="rx-card-info"] > [data-testid="medications-history-details-link"]',
     ).should('contain', rxName);
   };
+
+  verifyAllMedicationsRadioButtonIsChecked = () => {
+    cy.get(`input[type="radio"][value="All medications"]`).should('be.checked');
+  };
 }
 
 export default MedicationsListPage;


### PR DESCRIPTION
## Summary

Added a handler to set a default filter option (All Medications) to `sessionStorage` when user clicks "Go to your medications list" link on success alert on Refill page, so that filter dropdown gets expanded.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-62515

<img width="756" alt="image" src="https://github.com/user-attachments/assets/0be2798d-b609-4a4f-b7ae-376a887dc3aa">

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Put under filter feature flag 
AC2: Verify with UCD 
AC3: Verify with Accessibility
AC4: Expand filter dropdown on list when navigating from refill page

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
