### PR TITLE
fix prefill issue on meb

### DIFF
--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -97,6 +97,7 @@ export const App = ({
           ...claimantInfo,
         });
       }
+
       if (
         (!fetchedPersonalInfo &&
           meb160630Automation &&
@@ -109,7 +110,7 @@ export const App = ({
         getPersonalInfo(formData?.chosenBenefit);
       } else if (
         !formData[formFields.claimantId] &&
-        claimantInfo?.firstName &&
+        claimantInfo?.claimantId &&
         meb160630Automation
       ) {
         setFormData({

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -308,7 +308,8 @@ export function prefillTransformerV1(pages, formData, metadata, state) {
   const newData = {
     ...formData,
     [formFields.formId]: state.data?.formData?.data?.id,
-    [formFields.claimantId]: claimant?.claimantId,
+    [formFields.claimantId]:
+      claimant?.claimantId === 0 ? 100 : claimant?.claimantId,
     [formFields.viewUserFullName]: {
       [formFields.userFullName]: {
         first: firstName || undefined,
@@ -437,7 +438,8 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
   const newData = {
     ...formData,
     [formFields.formId]: state.data?.formData?.data?.id,
-    [formFields.claimantId]: claimant?.claimantId,
+    [formFields.claimantId]:
+      claimant?.claimantId === 0 ? 100 : claimant?.claimantId,
     [formFields.viewUserFullName]: {
       [formFields.userFullName]: {
         first: firstName || undefined,
@@ -573,7 +575,8 @@ export function prefillTransformerV3(pages, formData, metadata, state) {
   const newData = {
     ...formData,
     [formFields.formId]: state.data?.formData?.data?.id,
-    [formFields.claimantId]: claimant?.claimantId,
+    [formFields.claimantId]:
+      claimant?.claimantId === 0 ? 100 : claimant?.claimantId,
     [formFields.viewUserFullName]: {
       [formFields.userFullName]: {
         first: firstName || undefined,

--- a/src/applications/my-education-benefits/utils/form-submit-transform.js
+++ b/src/applications/my-education-benefits/utils/form-submit-transform.js
@@ -359,7 +359,10 @@ export function createMilitaryClaimant(submissionForm) {
   );
   // Construct And Return the claimant object
   return {
-    claimantId: submissionForm[formFields.claimantId],
+    claimantId:
+      submissionForm[formFields.claimantId] === 100
+        ? ''
+        : submissionForm[formFields.claimantId],
     firstName: userFullName?.first,
     middleName: userFullName?.middle,
     lastName: userFullName?.last,


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fix prefill issue when claimantId is 0

