### PR TITLE
Handle old claimant address

### DIFF
--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -46,6 +46,7 @@ import additionalEvidence from './chapters/05-additional-information/additionalE
 
 import { submit } from '../utils/helpers';
 import manifest from '../manifest.json';
+import migrations from '../migrations';
 
 const {
   fullName,
@@ -73,8 +74,8 @@ const formConfig = {
       saved: 'Your burial benefits application has been saved.',
     },
   },
-  version: 0,
-  migrations: [],
+  version: 1,
+  migrations,
   prefillEnabled: true,
   downtime: {
     dependencies: [externalServices.icmhs],

--- a/src/applications/burials-ez/migrations.js
+++ b/src/applications/burials-ez/migrations.js
@@ -1,5 +1,6 @@
 export default [
   // 0 -> 1, move user back to address page if country code is bad
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/95950
   ({ formData, metadata }) => {
     let newMetadata = metadata;
 

--- a/src/applications/burials-ez/migrations.js
+++ b/src/applications/burials-ez/migrations.js
@@ -1,0 +1,15 @@
+export default [
+  // 0 -> 1, move user back to address page if country code is bad
+  ({ formData, metadata }) => {
+    let newMetadata = metadata;
+
+    if (formData?.claimantAddress?.country?.length !== 3) {
+      newMetadata = {
+        ...metadata,
+        returnUrl: '/claimant-information/mailing-address',
+      };
+    }
+
+    return { formData, metadata: newMetadata };
+  },
+];

--- a/src/applications/burials-ez/tests/migrations.unit.spec.js
+++ b/src/applications/burials-ez/tests/migrations.unit.spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+
+import migrations from '../migrations';
+
+describe('Burials migrations', () => {
+  it('should set url to claimant address if invalid country code', () => {
+    const { formData, metadata } = migrations[0]({
+      formData: {
+        claimantAddress: {
+          country: 'US',
+        },
+      },
+      metadata: {
+        returnUrl: 'asdf',
+      },
+    });
+
+    expect(metadata.returnUrl).to.equal(
+      '/claimant-information/mailing-address',
+    );
+    expect(formData).to.be.an('object');
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

We updated the claimant address schema for Burials to match the vets-website schema for the address component. In the process, the required country code changed from requiring two-digit codes to three-digit codes, resulting in validation errors for some returning in-progress forms. This PR adds a migration to return those users to the address entry page to update their country code. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95950

## Testing done

- Visit Burials and fill in the form. Don't submit.
- In the network tab, note the in-progress form id. In the Rails console, update that IPF to be version 0 and have a claimant_address.country_code of 'US'. 
- Reload the Burials form and select continue in-progress form. You should be taken to the address page, and the country code should be blank. 

## What areas of the site does it impact?

Burials

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
