### PR TITLE
Update mailing address in submission error alert for the Caregivers application

### DIFF
--- a/src/applications/caregivers/components/FormAlerts/SubmissionErrorAlert.jsx
+++ b/src/applications/caregivers/components/FormAlerts/SubmissionErrorAlert.jsx
@@ -31,10 +31,12 @@ const SubmissionErrorAlert = () => {
           <strong>
             Program of Comprehensive Assistance for Family Caregivers
           </strong>
-          <br />
-          Health Eligibility Center <br />
-          2957 Clairmont Road NE, Ste 200 <br />
-          Atlanta, GA 30329-1647 <br />
+          <br role="presentation" />
+          10-10CG Evidence Intake Center
+          <br role="presentation" />
+          PO Box 5154
+          <br role="presentation" />
+          Janesville, WI 53547-5154
         </p>
 
         <p>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the mailing address provided in the Submission Error alert in the Caregivers application. The address update reflects a change in the facility processing these applications.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#96238

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/5261af33-b7ad-4498-93ab-7fec2f85ec52) | ![Screenshot 2024-10-31 at 12 13 37](https://github.com/user-attachments/assets/4f8dff66-4d76-47ca-9589-2f8cf8e39eaf) |

## Acceptance criteria

 - Mailing address is accurate for the Veteran to submit applications via mail

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution