### PR TITLE
update edu wizard to send user to meb instead of legacy app

### DIFF
--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -71,6 +71,14 @@ class EducationWizard extends React.Component {
         }
         url = `/education/apply-for-education-benefits/application/${form}`;
         break;
+      case '1990':
+        if (this?.props.meb160630Automation) {
+          url = `/education/apply-for-benefits-form-22-1990`;
+          break;
+        }
+
+        url = `/education/apply-for-education-benefits/application/1990`;
+        break;
       case '5490':
         if (this?.props.meb160630Automation) {
           url = `/education/survivor-dependent-education-benefit-22-5490`;


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update edu wizard to send users to MEB instead of the legacy 1990 when feature flag is on

## Screenshots

<img width="1049" alt="Screenshot 2024-10-31 at 9 35 41 PM" src="https://github.com/user-attachments/assets/ac12f930-38ba-490f-836b-5975afcf6a42">

