### PR TITLE
remove unneded text from footer page

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/IntroductionPage.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/IntroductionPage.jsx
@@ -128,12 +128,6 @@ export const IntroductionPage = ({
             about 15 minutes.
           </p>
           <va-additional-info trigger="What happens after I apply?">
-            <p>
-              <strong>
-                You may be eligible for Fry Scholarship benefits if you’re the
-                child or surviving spouse of:
-              </strong>
-            </p>
             <ul className="vads-u-margin-bottom--0">
               <li>
                 {' '}


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove incorrect text
