### PR TITLE
fix veteran service memeber name validation

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -200,10 +200,6 @@ const formConfig = {
                         errors.addError(
                           'First character must be a letter with no leading space.',
                         );
-                      } else {
-                        errors.addError(
-                          'Please enter a valid entry. Acceptable entries are letters, spaces and apostrophes.',
-                        );
                       }
                     } else if (!isValidName(field)) {
                       errors.addError(
@@ -224,10 +220,6 @@ const formConfig = {
                         );
                       } else if (field.length > 20) {
                         errors.addError('Must be 20 characters or less');
-                      } else {
-                        errors.addError(
-                          'Please enter a valid entry. Acceptable entries are letters, spaces and apostrophes.',
-                        );
                       }
                     } else if (!isValidName(field)) {
                       errors.addError(
@@ -255,10 +247,6 @@ const formConfig = {
                       ) {
                         errors.addError(
                           'First character must be a letter with no leading space.',
-                        );
-                      } else {
-                        errors.addError(
-                          'Please enter a valid entry. Acceptable entries are letters, spaces, dashes and apostrophes.',
                         );
                       }
                     } else if (!isValidName(field)) {

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -191,7 +191,7 @@ const formConfig = {
                 ...fullNameUI.first,
                 'ui:validations': [
                   (errors, field) => {
-                    if (!isValidName(field)) {
+                    if (isValidName(field)) {
                       if (field.length === 0) {
                         errors.addError('Please enter your first name');
                       } else if (field.length > 20) {
@@ -213,7 +213,7 @@ const formConfig = {
                 ...fullNameUI.middle,
                 'ui:validations': [
                   (errors, field) => {
-                    if (!isValidName(field)) {
+                    if (isValidName(field)) {
                       if (field[0] === ' ' || field[0] === "'") {
                         errors.addError(
                           'First character must be a letter with no leading space.',
@@ -233,11 +233,13 @@ const formConfig = {
                 ...fullNameUI.last,
                 'ui:validations': [
                   (errors, field) => {
-                    if (!isValidLastName(field)) {
+                    if (isValidLastName(field)) {
                       if (field.length === 0) {
                         errors.addError('Please enter your last name');
-                      } else if (field.length > 20) {
-                        errors.addError('Must be 20 characters or less');
+                      } else if (field.length < 2) {
+                        errors.addError('Must be 2 characters or more');
+                      } else if (field.length > 26) {
+                        errors.addError('Must be 26 characters or less');
                       } else if (
                         field[0] === ' ' ||
                         field[0] === "'" ||

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -205,6 +205,10 @@ const formConfig = {
                           'Please enter a valid entry. Acceptable entries are letters, spaces and apostrophes.',
                         );
                       }
+                    } else if (!isValidName(field)) {
+                      errors.addError(
+                        'Please enter a valid entry. Acceptable entries are letters, spaces and apostrophes.',
+                      );
                     }
                   },
                 ],
@@ -225,6 +229,10 @@ const formConfig = {
                           'Please enter a valid entry. Acceptable entries are letters, spaces and apostrophes.',
                         );
                       }
+                    } else if (!isValidName(field)) {
+                      errors.addError(
+                        'Please enter a valid entry. Acceptable entries are letters, spaces and apostrophes.',
+                      );
                     }
                   },
                 ],
@@ -253,6 +261,10 @@ const formConfig = {
                           'Please enter a valid entry. Acceptable entries are letters, spaces, dashes and apostrophes.',
                         );
                       }
+                    } else if (!isValidName(field)) {
+                      errors.addError(
+                        'Please enter a valid entry. Acceptable entries are letters, spaces, dashes and apostrophes.',
+                      );
                     }
                   },
                 ],


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fix name validations for service members to meet requirements
