### PR TITLE
Add maintenance alert for Simple Forms

### DIFF
--- a/src/applications/simple-forms/20-10206/config/form.js
+++ b/src/applications/simple-forms/20-10206/config/form.js
@@ -1,5 +1,6 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import footerContent from 'platform/forms/components/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import getHelp from '../../shared/components/GetFormHelp';
 
 import manifest from '../manifest.json';
@@ -293,6 +294,9 @@ const formConfig = {
     appType: 'request',
     appAction: 'requesting your personal records',
     submitButtonText: 'Submit request',
+  },
+  downtime: {
+    dependencies: [externalServices.lighthouseBenefitsIntake],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/20-10206/containers/App.jsx
+++ b/src/applications/simple-forms/20-10206/containers/App.jsx
@@ -6,6 +6,10 @@ import { connect } from 'react-redux';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
 import { isLoggedIn, isLOA3 } from 'platform/user/selectors';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 
 import formConfig from '../config/form';
 
@@ -43,7 +47,12 @@ const App = props => {
 
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="personal records request system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 };

--- a/src/applications/simple-forms/20-10207/config/form.js
+++ b/src/applications/simple-forms/20-10207/config/form.js
@@ -1,6 +1,7 @@
 // we're not using JSON schema for this form
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import footerContent from 'platform/forms/components/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import getHelp from '../../shared/components/GetFormHelp';
 
 import manifest from '../manifest.json';
@@ -567,6 +568,9 @@ const formConfig = {
       checkboxLabel:
         'I confirm that the information above is correct and true to the best of my knowledge and belief.',
     },
+  },
+  downtime: {
+    dependencies: [externalServices.lighthouseBenefitsIntake],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/20-10207/containers/App.jsx
+++ b/src/applications/simple-forms/20-10207/containers/App.jsx
@@ -6,6 +6,10 @@ import { connect } from 'react-redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 import { WIP } from '../../shared/components/WIP';
 import { workInProgressContent } from '../config/constants';
@@ -26,7 +30,12 @@ function App({ location, children, showForm, isLoading }) {
 
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="priority processing request system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 }

--- a/src/applications/simple-forms/21-0845/config/form.js
+++ b/src/applications/simple-forms/21-0845/config/form.js
@@ -1,6 +1,7 @@
 // this form does NOT use JSON schema for its data model
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import footerContent from 'platform/forms/components/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 
 import manifest from '../manifest.json';
 import transformForSubmit from './submit-transformer';
@@ -333,6 +334,9 @@ const formConfig = {
         },
       },
     },
+  },
+  downtime: {
+    dependencies: [externalServices.lighthouseBenefitsIntake],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/21-0845/containers/App.jsx
+++ b/src/applications/simple-forms/21-0845/containers/App.jsx
@@ -4,12 +4,21 @@ import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="third-party authorization system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 }

--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import footerContent from '@department-of-veterans-affairs/platform-forms/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import {
@@ -310,6 +311,9 @@ const formConfig = {
         },
       },
     },
+  },
+  downtime: {
+    dependencies: [externalServices.lighthouseBenefitsIntake],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/21-0972/containers/App.jsx
+++ b/src/applications/simple-forms/21-0972/containers/App.jsx
@@ -4,12 +4,21 @@ import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="alternate signer system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 }

--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -1,5 +1,6 @@
 import environment from 'platform/utilities/environment';
 import footerContent from 'platform/forms/components/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import { scrollAndFocus } from 'platform/utilities/ui';
 
 import manifest from '../manifest.json';
@@ -416,6 +417,9 @@ const formConfig = {
         },
       },
     },
+  },
+  downtime: {
+    dependencies: [externalServices.lighthouseBenefitsIntake],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/21-10210/containers/App.jsx
+++ b/src/applications/simple-forms/21-10210/containers/App.jsx
@@ -2,12 +2,21 @@ import React from 'react';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="lay or witness statement system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 }

--- a/src/applications/simple-forms/21-4142/config/form.js
+++ b/src/applications/simple-forms/21-4142/config/form.js
@@ -1,6 +1,7 @@
 import environment from 'platform/utilities/environment';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import footerContent from 'platform/forms/components/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import manifest from '../manifest.json';
 
 import IntroductionPage from '../containers/IntroductionPage';
@@ -240,6 +241,9 @@ const formConfig = {
         },
       },
     },
+  },
+  downtime: {
+    dependencies: [externalServices.lighthouseBenefitsIntake],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/21-4142/containers/App.jsx
+++ b/src/applications/simple-forms/21-4142/containers/App.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="medical information release system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 }

--- a/src/applications/simple-forms/21P-0847/config/form.js
+++ b/src/applications/simple-forms/21P-0847/config/form.js
@@ -1,4 +1,5 @@
 import footerContent from 'platform/forms/components/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import environment from 'platform/utilities/environment';
 
 import manifest from '../manifest.json';
@@ -157,6 +158,9 @@ const formConfig = {
         },
       },
     },
+  },
+  downtime: {
+    dependencies: [externalServices.lighthouseBenefitsIntake],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/21P-0847/containers/App.jsx
+++ b/src/applications/simple-forms/21P-0847/containers/App.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="substitute claimant request system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 }

--- a/src/applications/simple-forms/26-4555/config/form.js
+++ b/src/applications/simple-forms/26-4555/config/form.js
@@ -1,6 +1,6 @@
 import environment from 'platform/utilities/environment';
 import fullSchema from 'vets-json-schema/dist/26-4555-schema.json';
-
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import footerContent from 'platform/forms/components/FormFooter';
 import transformForSubmit from './submit-transformer';
 import prefillTransformer from './prefill-transformer';
@@ -182,6 +182,9 @@ const formConfig = {
         },
       },
     },
+  },
+  downtime: {
+    dependencies: [externalServices.sahsha],
   },
   footerContent,
   getHelp,

--- a/src/applications/simple-forms/26-4555/containers/App.jsx
+++ b/src/applications/simple-forms/26-4555/containers/App.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <DowntimeNotification
+        appTitle="Specially Adapted Housing or Special Home Adaptation Grant system"
+        dependencies={[externalServices.lighthouseBenefitsIntake]}
+      >
+        {children}
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 }

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -27,6 +27,10 @@ export default {
   idme: 'idme',
   // COE, Certificate of Eligibility form and LGY Eligibility Manager API
   coe: 'coe',
+  // Lighthouse Benefits Claims API
+  lighthouseBenefitsClaims: 'lighthouse_benefits_claims',
+  // Lighthouse Benefits Intake API
+  lighthouseBenefitsIntake: 'lighthouse_benefits_intake',
   // Login.gov, identity provider
   logingov: 'logingov',
   // Master Veteran Index (source of veteran profile info)
@@ -43,6 +47,8 @@ export default {
   mhvMeds: 'mhv_meds',
   // PEGA form ingestion for IVC CHAMPVA forms (10-10d, 10-7959x)
   pega: 'pega',
+  // SAHSHA API for form 26-4555
+  sahsha: 'sahsha',
   // Search.gov API
   search: 'search',
   // The Image Management System (education forms)


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR adds a maintenance alert to Simple Forms.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=83348489&issue=department-of-veterans-affairs%7Cva.gov-team-sensitive%7C2017

## Screenshots
Shortly before a maintenance window:
<img width="1330" alt="Screenshot 2024-11-01 at 10 49 31 AM" src="https://github.com/user-attachments/assets/f5b5c213-44e1-477f-9e2d-851ebb4469e7">

In a maintenance window:
<img width="1285" alt="Screenshot 2024-11-01 at 10 50 32 AM" src="https://github.com/user-attachments/assets/ca2ebc5b-6f9f-4851-9e88-08eee11af5ef">

## What areas of the site does it impact?

Only Simple Forms
