### PR TITLE
Removed unused feature flag for showing maxing rating.

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -53,7 +53,6 @@
   "dependencyVerification": "dependency_verification",
   "dgiRudisillHideBenefitsSelectionStep": "dgi_rudisill_hide_benefits_selection_step",
   "dhpConnectedDevicesFitbit": "dhp_connected_devices_fitbit",
-  "disability526MaximumRating": "disability_526_maximum_rating",
   "disability526ToxicExposure": "disability_526_toxic_exposure",
   "disability526NewConfirmationPage": "disability_526_new_confirmation_page",
   "disablityBenefitsBrowserMonitoringEnabled": "disablity_benefits_browser_monitoring_enabled",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removing flipper feature flag for test feature after deployment to 100% of users.
- I'm on the Employee Experience team; we work with the Disability Experience team which maintains Form 526.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/abd-vro/issues/3456
- Removes flag added by https://github.com/department-of-veterans-affairs/vets-website/pull/25287

## Testing done

- Old behavior: No longer uses the feature toggle
- New behavior: Still does not use the feature toggle


## Screenshots
None

## What areas of the site does it impact?
Removes unused feature toggle key value pair.

Previous use of feature toggle was used by Form 526EZ (rated disabilities screen)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable). **N/A**
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
