### PR TITLE
Fix Date of Birth Formatting Issue in Profile Information

### DIFF
--- a/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/personalInformationUtils.unit.spec.js
@@ -6,6 +6,7 @@ import {
   createBooleanSchemaPropertiesFromOptions,
   createUiTitlePropertiesFromOptions,
   formatIndividualLabel,
+  renderDOB,
 } from '@@vap-svc/util/personal-information/personalInformationUtils';
 
 describe('formatMultiSelectAndText utility', () => {
@@ -117,5 +118,25 @@ describe('formatIndividualLabel utility', () => {
     const output = 'test string here';
 
     expect(formatIndividualLabel(key, label)).to.equal(output);
+  });
+});
+
+describe('renderDOB utility', () => {
+  it('returns formatted date for a valid date string', () => {
+    const dob = '1986-05-06';
+    const expected = 'May 6, 1986';
+    expect(renderDOB(dob)).to.equal(expected);
+  });
+
+  it('returns NOT_SET_TEXT when dob is undefined, null, or an empty string', () => {
+    const NOT_SET_TEXT = 'This information is not available right now.';
+    let dob;
+    expect(renderDOB(dob)).to.equal(NOT_SET_TEXT);
+
+    dob = null;
+    expect(renderDOB(dob)).to.equal(NOT_SET_TEXT);
+
+    dob = '';
+    expect(renderDOB(dob)).to.equal(NOT_SET_TEXT);
   });
 });

--- a/src/platform/user/profile/vap-svc/util/personal-information/personalInformationUtils.js
+++ b/src/platform/user/profile/vap-svc/util/personal-information/personalInformationUtils.js
@@ -190,4 +190,4 @@ export const formatMultiSelectAndText = (data, fieldName) => {
 };
 
 export const renderDOB = dob =>
-  dob ? format(parseStringOrDate(dob), 'LL') : NOT_SET_TEXT;
+  dob ? format(parseStringOrDate(dob), 'MMMM d, yyyy') : NOT_SET_TEXT;


### PR DESCRIPTION
## Summary

This PR fixes an issue in the **Profile > Personal Information** section where the **Date of Birth** was only displaying the month. The issue started after `moment.js` was removed, which caused the `renderDOB` function to return only partial date information. This update ensures that the full date (month, day, year) is correctly displayed in the format `MMMM d, yyyy`.

### Changes

- Updated the `renderDOB` function to display the full date.
- Added unit tests to validate the correct date format and ensure the function handles various inputs (valid date, undefined, null, and empty string).

## Related Issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#96305

## Testing Done

- **Unit Tests:** Added tests for `renderDOB` to confirm that it returns the full date and handles invalid date inputs as expected.
- **Manual Testing:** Verified that the date of birth displays correctly in the Profile > Personal Information section.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |   ![Screenshot 2024-11-01 at 11 39 27 AM](https://github.com/user-attachments/assets/19c478c6-d3f1-4b49-891f-6af83fa009f8)|    ![Screenshot 2024-11-01 at 11 39 13 AM](https://github.com/user-attachments/assets/8a1952b8-9150-4794-8c6c-03ed496ef706)|



## What areas of the site does it impact?

- Profile > Personal Information

## Acceptance Criteria

1. Date of birth should display the full date (month, day, year) in `MMMM d, yyyy` format.
2. The function should return `NOT_SET_TEXT` for invalid date inputs.

## Quality Assurance & Testing

- [x] I updated unit tests for the `renderDOB` function.
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [x] Linting warnings have been addressed.
- [ ] Documentation has been updated ([link to documentation](#) *if necessary).
- [ ] Screenshot of the developed feature is added.
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed.

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution.
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable).

### Authentication

- [x] Did you log in to a local build and verify all authenticated routes work as expected with a test user?