### PR TITLE
DBEX_59255 | Clean up aria-describedBy uses for the 526 Start wizard button

### DIFF
--- a/src/applications/disability-benefits/all-claims/subtask/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/all-claims/subtask/pages/file-claim-early.jsx
@@ -32,7 +32,6 @@ const FileClaimPage = () => (
             'button-click-label': 'File a disability claim online',
           });
         }}
-        aria-describedby="other_ways_to_file_526"
       >
         File a disability claim online
       </Link> */}

--- a/src/applications/disability-benefits/all-claims/subtask/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/all-claims/subtask/pages/file-claim.jsx
@@ -32,7 +32,6 @@ const FileClaimPage = () => (
             'button-click-label': 'File a disability claim online',
           });
         }}
-        aria-describedby="other_ways_to_file_526"
       >
         File a disability claim online
       </Link> */}

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -58,7 +58,6 @@ const FileBDDClaim = ({ getPageStateFromPageName, setWizardStatus }) => {
           {formStartButton({
             setWizardStatus,
             label,
-            ariaId: 'learn_about_bdd',
             eventReason: 'wizard completed, starting BDD flow',
           })}
         </>

--- a/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
@@ -21,7 +21,6 @@ const FileClaimPage = ({ setWizardStatus }) => {
       {formStartButton({
         setWizardStatus,
         label,
-        ariaId: 'other_ways_to_file_526',
         eventReason:
           'wizard completed, starting 526 flow (less than 90 days to discharge)',
       })}

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -21,7 +21,6 @@ const FileClaimPage = ({ setWizardStatus }) => {
       {formStartButton({
         setWizardStatus,
         label,
-        ariaId: 'other_ways_to_file_526',
         eventReason:
           'wizard completed, starting 526 disability compensation flow',
       })}

--- a/src/platform/forms/tests/sub-task/complex-subtask/pages/file-claim-early.jsx
+++ b/src/platform/forms/tests/sub-task/complex-subtask/pages/file-claim-early.jsx
@@ -32,7 +32,6 @@ const FileClaimPage = () => (
             'button-click-label': 'File a disability claim online',
           });
         }}
-        aria-describedby="other_ways_to_file_526"
       >
         File a disability claim online
       </Link> */}

--- a/src/platform/forms/tests/sub-task/complex-subtask/pages/file-claim.jsx
+++ b/src/platform/forms/tests/sub-task/complex-subtask/pages/file-claim.jsx
@@ -32,7 +32,6 @@ const FileClaimPage = () => (
             'button-click-label': 'File a disability claim online',
           });
         }}
-        aria-describedby="other_ways_to_file_526"
       >
         File a disability claim online
       </Link> */}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- `Aria-describedby` on the "File a disability claim online" and "File a BDD disability claim online" links was pointing to another link, which isn't the correct way to use the property. In this case `aria-describedby` wasn't needed at all. `aria-describedby` could still be [useful in the future](https://www.w3.org/WAI/GL/wiki/Using_aria-describedby_for_link_purpose_-_May_2014), so I didn't remove it fully from the [wizard file](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/disability-benefits/wizard/wizard-utils.js#L33), I only removed the `ariaId` that was being passed to `aria-describedby`, along with the old `aria-describedby` in the commented out code.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/59255

## Testing done
- Links inspected
- Subtask test file that used to reference the `aria-describedby` have been updated as well
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Regular start link  |   <img width="1424" alt="Screenshot 2024-11-03 at 2 34 26 PM" src="https://github.com/user-attachments/assets/2a2fa273-1039-4d00-85f8-5b5a39167c0a"> | <img width="1425" alt="Screenshot 2024-11-03 at 2 35 05 PM" src="https://github.com/user-attachments/assets/3819fbe7-db68-473e-9a2f-25ad1fcf0581"> |
| BDD start link |   <img width="1429" alt="Screenshot 2024-11-03 at 2 34 01 PM" src="https://github.com/user-attachments/assets/b8d73f53-63ac-4b32-9fff-da0f30bd15b0"> |  <img width="1423" alt="Screenshot 2024-11-03 at 2 36 15 PM" src="https://github.com/user-attachments/assets/4170e0aa-e7f0-4e32-a6e6-ac826146fc39"> |

## What areas of the site does it impact?

526 start page

## Acceptance criteria
- On the `disability/file-disability-claim-form-21-526ez/start` page answer the wizard to trigger the File a disability claim online link to show (see screenshots). 
- Inspect the link. It should not have `aria-describedby` in the element html.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
