### PR TITLE
[SIMPLE_FORMS] fix: add form id to pdf download link copy

### DIFF
--- a/src/platform/forms-system/src/js/components/ConfirmationView/ConfirmationView.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/ConfirmationView.jsx
@@ -130,6 +130,7 @@ export const ConfirmationView = props => {
       <SavePdfDownload
         pdfUrl={pdfUrl}
         trackingPrefix={formConfig.trackingPrefix}
+        formId={formConfig.formId}
       />
       <ChapterSectionCollection formConfig={formConfig} />
       <PrintThisPage />
@@ -144,6 +145,7 @@ export const ConfirmationView = props => {
 
 ConfirmationView.propTypes = {
   formConfig: PropTypes.shape({
+    formId: PropTypes.string,
     trackingPrefix: PropTypes.string,
     chapters: PropTypes.object,
   }).isRequired,

--- a/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
@@ -280,6 +280,7 @@ export const SavePdfDownloadWithContext = ({ className }) => {
       pdfUrl={pdfUrl}
       trackingPrefix={formConfig.trackingPrefix}
       className={className}
+      formId={formConfig.formId}
     />
   );
 };

--- a/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/components.jsx
@@ -232,7 +232,12 @@ WhatsNextProcessListWithContext.propTypes = {
   item2Header: PropTypes.string,
 };
 
-export const SavePdfDownload = ({ pdfUrl, trackingPrefix, className }) => {
+export const SavePdfDownload = ({
+  pdfUrl,
+  trackingPrefix,
+  className,
+  formId,
+}) => {
   const onClick = () => {
     recordEvent({
       event: `${trackingPrefix}confirmation-pdf-download`,
@@ -254,7 +259,7 @@ export const SavePdfDownload = ({ pdfUrl, trackingPrefix, className }) => {
         filetype="PDF"
         href={pdfUrl}
         onClick={onClick}
-        text="Download a copy of your VA Form"
+        text={`Download a copy of your VA Form ${formId}`}
       />
     </div>
   ) : null;
@@ -262,6 +267,7 @@ export const SavePdfDownload = ({ pdfUrl, trackingPrefix, className }) => {
 
 SavePdfDownload.propTypes = {
   className: PropTypes.string,
+  formId: PropTypes.string,
   pdfUrl: PropTypes.string,
   trackingPrefix: PropTypes.string,
 };


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): YES
- This PR addresses a bug where the PDF download link on the confirmation page did not include the form number. The link currently reads "Download a copy of your VA Form (PDF)" instead of the expected "Download a copy of your VA Form 21-10210 (PDF)".
- To reproduce the bug, navigate to the confirmation page after submitting a form and observe the download link name.
- The solution involves updating the link text to include the specific form number, aligning it with the design specifications provided in the Figma designs. This change enhances clarity for users by providing them with the exact form number they are downloading.
- I work for the Veteran Facing Forms Development team, which is responsible for maintaining this component.

## Related issue(s)

- [[BUG] Form number missing from PDF download link name](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1813)
- No previous changes or bugs are applicable for this specific issue.
- No epic link is required as this is a standalone bug fix.

## Testing done

- [ ] New code is covered by unit tests
- Prior to this change, the download link did not include the form number, which could lead to confusion for users.
- To verify the changes, navigate to the confirmation page after form submission and check that the download link now reads "Download a copy of your VA Form 21-10210 (PDF)".
- I have added unit tests to ensure that the link text is generated correctly based on the form number.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-11-05 at 4 12 31 PM](https://github.com/user-attachments/assets/9c34a9a1-ce6e-4b5c-906a-7098e4a2618c)|![Screenshot 2024-11-05 at 4 06 40 PM](https://github.com/user-attachments/assets/c364708a-686a-4e19-ae13-ba39aaed9df0)|

## What areas of the site does it impact?

- This change impacts the confirmation page where users download their forms. The code touched primarily involves the rendering of the download link.

## Acceptance criteria

- [ ] I fixed unit tests and integration tests for the feature.
- [ ] No error nor warning in the console.
- [ ] Events are being sent to the appropriate logging solution.
- [ ] Documentation has been updated (link to documentation).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [ ] Feature/bug has a monitor built into Datadog (if applicable).
- [ ] If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected.
- [ ] I added a screenshot of the developed feature.

## Requested Feedback

*I would appreciate feedback on the clarity of the link text and whether it meets the design specifications. Additionally, any suggestions for improving the unit tests would be welcome.*