### PR TITLE
Update payload for next steps request

### DIFF
--- a/src/applications/representative-appoint/containers/ConfirmationPage.jsx
+++ b/src/applications/representative-appoint/containers/ConfirmationPage.jsx
@@ -5,23 +5,18 @@ import PropTypes from 'prop-types';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import NeedHelp from '../components/NeedHelp';
 import sendNextStepsEmail from '../api/sendNextStepsEmail';
-import {
-  getEntityAddressAsString,
-  getRepType,
-  getFormNumber,
-  getFormName,
-} from '../utilities/helpers';
+import { getFormNumber, getFormName } from '../utilities/helpers';
 
 export default function ConfirmationPage({ router }) {
   const [signedForm, setSignedForm] = useState(false);
   const [signedFormError, setSignedFormError] = useState(false);
   const { data: formData } = useSelector(state => state.form);
   const selectedEntity = formData['view:selectedRepresentative'];
-  const emailAddress = formData.email;
+  const emailAddress = formData.applicantEmail || formData.veteranEmail;
   const firstName =
     formData.applicantName?.first || formData.veteranFullName.first;
-  const representativeName = selectedEntity?.name || selectedEntity?.fullName;
-
+  const entityType =
+    selectedEntity.type === 'organization' ? 'organization' : 'individual';
   const handlers = {
     onClickDownloadForm: e => {
       e.preventDefault();
@@ -37,9 +32,8 @@ export default function ConfirmationPage({ router }) {
           await sendNextStepsEmail({
             emailAddress,
             firstName,
-            representativeType: getRepType(selectedEntity),
-            representativeName,
-            representativeAddress: getEntityAddressAsString(formData),
+            entityType,
+            entityId: selectedEntity.id,
             formNumber: getFormNumber(formData),
             formName: getFormName(formData),
           });

--- a/src/applications/representative-appoint/containers/ConfirmationPage.jsx
+++ b/src/applications/representative-appoint/containers/ConfirmationPage.jsx
@@ -12,11 +12,15 @@ export default function ConfirmationPage({ router }) {
   const [signedFormError, setSignedFormError] = useState(false);
   const { data: formData } = useSelector(state => state.form);
   const selectedEntity = formData['view:selectedRepresentative'];
-  const emailAddress = formData.applicantEmail || formData.veteranEmail;
-  const firstName =
-    formData.applicantName?.first || formData.veteranFullName.first;
-  const entityType =
-    selectedEntity.type === 'organization' ? 'organization' : 'individual';
+  const sendNextStepsEmailPayload = {
+    formNumber: getFormNumber(formData),
+    formName: getFormName(formData),
+    firstName: formData.applicantName?.first || formData.veteranFullName.first,
+    emailAddress: formData.applicantEmail || formData.veteranEmail,
+    entityId: selectedEntity.id,
+    entityType:
+      selectedEntity.type === 'organization' ? 'organization' : 'individual',
+  };
   const handlers = {
     onClickDownloadForm: e => {
       e.preventDefault();
@@ -29,14 +33,7 @@ export default function ConfirmationPage({ router }) {
     onClickContinueButton: async () => {
       if (signedForm) {
         try {
-          await sendNextStepsEmail({
-            emailAddress,
-            firstName,
-            entityType,
-            entityId: selectedEntity.id,
-            formNumber: getFormNumber(formData),
-            formName: getFormName(formData),
-          });
+          await sendNextStepsEmail(sendNextStepsEmailPayload);
         } catch (error) {
           // Should we set an error state to display a message in the UI?
         }


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/96353

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
This PR removes the rep name, address, and type and adds the entity_type and entity_id to the payload sent to the next steps email endpoint.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96353

## Testing done
- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
NA

## What areas of the site does it impact?
Appoint a Rep, which is behind a feature flag.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
NA

## Requested Feedback
NA
