### PR TITLE
VACMS-19282 Redirect for Manila VA Clinic

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1543,5 +1543,10 @@
     "src": "/ROCHEYENNE",
     "dest": "/cheyenne-va-regional-benefit-office/",
     "catchAll": true
+  },
+  {
+    "domain": "www.visn21.va.gov",
+    "src": "/locations/manila.asp",
+    "dest": "/manila-va-clinic/"
   }
 ]


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
In support of the launch of the Manila VA Clinic page, we need to redirect https://www.visn21.va.gov/locations/manila.asp to https://www.va.gov/manila-va-clinic/.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19282