### PR TITLE
[96237] Serve 21-22 and 21-22a pdf in Appoint a Rep flow

### DIFF
--- a/src/applications/representative-appoint/api/generatePDF.js
+++ b/src/applications/representative-appoint/api/generatePDF.js
@@ -1,8 +1,9 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import * as Sentry from '@sentry/browser';
 import manifest from '../manifest.json';
 
-export const generatePDF = (transformedFormData, is2122a) => {
+export const generatePDF = async (transformedFormData, is2122a) => {
   const apiSettings = {
     mode: 'cors',
     method: 'POST',
@@ -15,29 +16,24 @@ export const generatePDF = (transformedFormData, is2122a) => {
     body: JSON.stringify(transformedFormData),
   };
 
-  const startTime = new Date().getTime();
+  const formType = is2122a ? '2122a' : '2122';
 
   const requestUrl = `${
     environment.API_URL
-  }/representation_management/v0/pdf_generator${is2122a ? '2122a' : '2122'}`;
+  }/representation_management/v0/pdf_generator${formType}`;
 
-  return new Promise((resolve, reject) => {
-    apiRequest(requestUrl, apiSettings)
-      .then(response => {
-        if (response.error) {
-          throw Error(response.error);
-        }
-        return response;
-      })
-      .then(res => {
-        const endTime = new Date().getTime();
-        const resultTime = endTime - startTime;
-        res.meta = {
-          ...res.meta,
-          resultTime,
-        };
-        return res;
-      })
-      .then(data => resolve(data), error => reject(error));
-  });
+  try {
+    const response = await apiRequest(requestUrl, apiSettings);
+
+    const blob = await response.blob();
+    const downloadUrl = URL.createObjectURL(blob);
+
+    localStorage.setItem('pdfUrl', downloadUrl);
+  } catch (error) {
+    Sentry.captureException(
+      new Error(`${formType} PDF Generation Error: ${error}`),
+    );
+
+    throw error;
+  }
 };

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -69,8 +69,7 @@ const formConfig = {
   submit: async form => {
     const is2122a = isAttorneyOrClaimsAgent(form.data);
     const transformedFormData = pdfTransform(form.data);
-    const pdfResponse = await generatePDF(transformedFormData, is2122a);
-    localStorage.setItem('formPdf', pdfResponse);
+    await generatePDF(transformedFormData, is2122a);
 
     return Promise.resolve({ attributes: { confirmationNumber: '123123123' } });
   },

--- a/src/applications/representative-appoint/containers/ConfirmationPage.jsx
+++ b/src/applications/representative-appoint/containers/ConfirmationPage.jsx
@@ -22,9 +22,6 @@ export default function ConfirmationPage({ router }) {
       selectedEntity.type === 'organization' ? 'organization' : 'individual',
   };
   const handlers = {
-    onClickDownloadForm: e => {
-      e.preventDefault();
-    },
     onChangeSignedFormCheckbox: () => {
       setSignedForm(prevState => !prevState);
 
@@ -53,9 +50,10 @@ export default function ConfirmationPage({ router }) {
       <p>First, you’ll need to download your form.</p>
       <va-link
         download
-        href=""
+        filetype="PDF"
+        href={localStorage.getItem('pdfUrl')}
+        filename={`VA Form ${getFormNumber(formData)}`}
         label="Download your form"
-        onClick={handlers.onClickDownloadForm}
         text="Download your form"
       />
       <p className="vads-u-margin-top--4">


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr creates a blob url for the form pdf returned from vets-api on submission of the 21-22 and 21-22a form
- This pr allows for pdf to be downloaded on the confirmation page using the blob url

## Related issue(s)

- [96237](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96237)

## Testing done

- Tested by going through flow locally with:
  - attorney
  - rep with many orgs 

## What areas of the site does it impact?
Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)