### PR TITLE
add alert to payment history page

### DIFF
--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -21,6 +21,7 @@ import {
   filterReturnPayments,
   reformatReturnPaymentDates,
   reformatPaymentDates,
+  alertMessage,
 } from './helpers';
 import Payments from './payments/Payments';
 
@@ -77,6 +78,7 @@ class ViewPaymentsLists extends Component {
           fields={paymentsReceivedFields}
           data={reformattedPayments}
           textContent={paymentsReceivedContent}
+          alertMessage={alertMessage}
         />
       );
     } else {

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -164,13 +164,13 @@ export const alertMessage = (
   <va-alert close-btn-aria-label="Close notification" status="warning" visible>
     <h2 slot="headline">We’re working to improve what we display here</h2>
     <p className="vads-u-margin-y--0">
-      1. If you receive education benefits, we’ll be removing information about
+      If you receive education benefits, we’ll be removing information about
       payments we send directly to your school. After making this update, your
       list of payments will only include payments sent to you.
     </p>
     <p className="vads-u-margin-y--1">
-      2. Some education benefit payments may appear as "C&P Hardship" or
-      something similar. We’re working to fix this.
+      Some education benefit payments may appear as "C&P Hardship" or something
+      similar. We’re working to fix this.
     </p>
   </va-alert>
 );

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -159,3 +159,18 @@ export const reformatPaymentDates = payments => {
     };
   });
 };
+
+export const alertMessage = (
+  <va-alert close-btn-aria-label="Close notification" status="warning" visible>
+    <h2 slot="headline">We’re working to improve what we display here</h2>
+    <p className="vads-u-margin-y--0">
+      1. If you receive education benefits, we’ll be removing information about
+      payments we send directly to your school. After making this update, your
+      list of payments will only include payments sent to you.
+    </p>
+    <p className="vads-u-margin-y--1">
+      2. Some education benefit payments may appear as "C&P Hardship" or
+      something similar. We’re working to fix this.
+    </p>
+  </va-alert>
+);

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -162,7 +162,7 @@ export const reformatPaymentDates = payments => {
 
 export const alertMessage = (
   <va-alert close-btn-aria-label="Close notification" status="warning" visible>
-    <h2 slot="headline">We’re working to improve what we display here</h2>
+    <h3 slot="headline">We’re working to improve what we display here</h3>
     <p className="vads-u-margin-y--0">
       If you receive education benefits, we’ll be removing information about
       payments we send directly to your school. After making this update, your

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
@@ -90,6 +90,7 @@ const Payments = ({
 
 Payments.propTypes = {
   tableVersion: PropTypes.oneOf(['received', 'returned']).isRequired,
+  alertMessage: PropTypes.element,
   data: PropTypes.array,
   fields: PropTypes.array,
   textContent: PropTypes.element,

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
@@ -19,7 +19,13 @@ const getFromToNums = (page, total) => {
   return [from, to];
 };
 
-const Payments = ({ data, fields, tableVersion, textContent }) => {
+const Payments = ({
+  data,
+  fields,
+  tableVersion,
+  textContent,
+  alertMessage,
+}) => {
   const [currentData, setCurrentData] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   // Using `useRef` here to avoid triggering a rerender whenever these are
@@ -44,6 +50,7 @@ const Payments = ({ data, fields, tableVersion, textContent }) => {
     return (
       <>
         {textContent}
+        {alertMessage}
         <p className="vads-u-font-size--lg vads-u-font-family--serif">
           Displaying {from} - {to} of {data.length}
         </p>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add alert message on payment history page

## Related issue(s)

* [#95616](https://github.com/department-of-veterans-affairs/va.gov-team/issues/95616)
* [#99620](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96620) - Accessibility testing artifact

## Testing done

test locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        | 
![Screenshot 2024-11-06 at 3 34 38 PM](https://github.com/user-attachments/assets/b4d4ca1d-f8e3-43ed-af13-1c186b604206)|


## What areas of the site does it impact?

Payment history page

## Acceptance criteria
Add alert message to the Payment History page with the following content:
[Header] We're working to improve what we display here 

If you receive education benefits, we'll be removing information about payments we send directly to your school. After making this update, your list of payments will only include payments sent to you.

Some education benefit payments may appear as "C&P Hardship" or something similar. We're working to fix this.

Alert is styled per the [Figma file](https://www.figma.com/design/AMsEAbhbHtrahQTp6GzVkQ/Payment-History?node-id=2207-2710&t=RvOtpYigm4YAsMDF-4) provided. See screenshot below.
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
