### PR TITLE
Address feedback for Direct Schedule headers

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
@@ -81,6 +81,7 @@ export default function ClinicChoicePage() {
               level={2}
             />
           </div>
+          <br />
         </>
       )}
       <SchemaForm

--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.unit.spec.js
@@ -58,7 +58,7 @@ describe('VAOS Page: ClinicChoicePage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983', 'primaryCare', { facilityData });
 
     const screen = renderWithStoreAndRouter(<ClinicChoicePage />, {
@@ -124,7 +124,7 @@ describe('VAOS Page: ClinicChoicePage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '211'); // amputation
+    await setTypeOfCare(store, /amputation care/i);
     await setVAFacility(store, '983', 'amputation', { facilityData });
 
     const screen = renderWithStoreAndRouter(<ClinicChoicePage />, {
@@ -184,7 +184,7 @@ describe('VAOS Page: ClinicChoicePage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '211'); // amputation
+    await setTypeOfCare(store, /amputation care/i);
     await setVAFacility(store, '983', 'amputation', { facilityData });
 
     const screen = renderWithStoreAndRouter(<ClinicChoicePage />, {
@@ -265,7 +265,7 @@ describe('VAOS Page: ClinicChoicePage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
 
     let screen = renderWithStoreAndRouter(<ClinicChoicePage />, {
@@ -326,7 +326,7 @@ describe('VAOS Page: ClinicChoicePage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '211'); // amputation
+    await setTypeOfCare(store, /amputation care/i);
     await setVAFacility(store, '983', 'amputation', { facilityData });
 
     // When the page is displayed

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.js
@@ -88,7 +88,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   it('should display list of providers when choose a provider clicked', async () => {
     // Given the CC iteration flag is on
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -132,7 +132,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(
@@ -192,7 +192,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(
@@ -255,7 +255,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(
@@ -351,7 +351,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(
@@ -428,7 +428,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     // Belgrade is the 2nd of three options so the expectation is
@@ -501,7 +501,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     // Belgrade is the 2nd of three options so the expectation is
@@ -533,7 +533,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   it('should display an error message when lookup fails', async () => {
     // Given the CC iteration flag is on
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.js
@@ -95,7 +95,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   });
   it('should display closest city question when user has multiple supported sites', async () => {
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -157,7 +157,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
   it('should display list of providers when choose a provider clicked', async () => {
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -231,7 +231,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
   it('should display Select provider when remove provider clicked', async () => {
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -296,7 +296,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     // Facility 983 is the 2nd of three options so the expectation is
@@ -339,7 +339,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
   it('should display an error when choose a provider clicked and provider fetch error', async () => {
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
@@ -377,7 +377,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
   it('should display an alert when no providers are available', async () => {
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
@@ -432,7 +432,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       // true,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(
@@ -485,7 +485,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(
@@ -538,7 +538,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(
@@ -601,7 +601,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       careType: 'Podiatry',
     });
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     let screen = renderWithStoreAndRouter(
@@ -637,7 +637,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       ),
       CC_PROVIDERS_DATA,
     );
-    await setTypeOfCare(store, 'tbd-podiatry'); // podiatry
+    await setTypeOfCare(store, /podiatry/i);
 
     screen = renderWithStoreAndRouter(<CommunityCareProviderSelectionPage />, {
       store,
@@ -665,7 +665,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       CC_PROVIDERS_DATA,
     );
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, 'communityCare');
 
     const screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.js
@@ -133,7 +133,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);
@@ -202,7 +202,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, moment());
@@ -284,7 +284,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);
@@ -456,7 +456,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);
@@ -580,7 +580,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);
@@ -649,7 +649,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
       ],
     });
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
 
@@ -693,7 +693,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
       },
     });
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
 
@@ -732,7 +732,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '502'); // mental health
+    await setTypeOfCare(store, /mental health/i);
     await setVAFacility(store, '983', 'outpatientMentalHealth');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);
@@ -763,7 +763,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);
@@ -825,7 +825,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);
@@ -931,7 +931,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
 
     const store = createTestStore(initialState);
 
-    await setTypeOfCare(store, '323'); // primary care
+    await setTypeOfCare(store, /primary care/i);
     await setVAFacility(store, '983');
     await setClinic(store, '983_308');
     await setPreferredDate(store, preferredDate);

--- a/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.unit.spec.js
@@ -30,7 +30,7 @@ describe('VAOS Page: TypeOfAudiologyCarePage', () => {
   beforeEach(() => mockFetch());
   it('should show page and validation', async () => {
     const store = createTestStore(initialState);
-    await setTypeOfCare(store, '203'); // audiology
+    await setTypeOfCare(store, /audiology/i);
 
     const screen = renderWithStoreAndRouter(
       <Route component={TypeOfAudiologyCarePage} />,

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -92,6 +92,7 @@ export default function TypeOfCarePage() {
       typeOfCareId: {
         'ui:widget': 'radio',
         'ui:options': {
+          classNames: 'vads-u-margin-top--neg2',
           hideLabelText: true,
         },
       },

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -103,7 +103,7 @@ export default function TypeOfCarePage() {
     <div className="vaos-form__radio-field">
       <h1 className="vads-u-font-size--h2">
         {pageTitle}
-        <span className="schemaform-required-span vaos-calendar__page_header vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal">
+        <span className="schemaform-required-span vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal">
           (*Required)
         </span>
       </h1>

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router-dom';
 // eslint-disable-next-line import/no-unresolved
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import FormButtons from '../../../components/FormButtons';
 import PodiatryAppointmentUnavailableModal from './PodiatryAppointmentUnavailableModal';
@@ -91,13 +90,9 @@ export default function TypeOfCarePage() {
     },
     uiSchema: {
       typeOfCareId: {
-        'ui:title': pageTitle,
-        'ui:widget': 'radio', // Required
-        'ui:webComponentField': VaRadioField,
+        'ui:widget': 'radio',
         'ui:options': {
-          classNames: 'vads-u-margin-top--neg2',
-          showFieldLabel: false,
-          labelHeaderLevel: '1',
+          hideLabelText: true,
         },
       },
     },
@@ -106,6 +101,12 @@ export default function TypeOfCarePage() {
 
   return (
     <div className="vaos-form__radio-field">
+      <h1 className="vads-u-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vaos-calendar__page_header vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {showUpdateAddressAlert && (
         <UpdateAddressAlert
           onClickUpdateAddress={heading => {

--- a/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.unit.spec.js
@@ -48,7 +48,7 @@ describe('VAOS Page: TypeOfEyeCarePage', () => {
   });
   it('should show page and validation', async () => {
     const store = createTestStore(initialState);
-    const nextPage = await setTypeOfCare(store, 'EYE'); // eye care
+    const nextPage = await setTypeOfCare(store, /eye care/i);
     expect(nextPage).to.equal('/new-appointment/choose-eye-care');
 
     const screen = renderWithStoreAndRouter(
@@ -111,7 +111,7 @@ describe('VAOS Page: TypeOfEyeCarePage', () => {
     });
 
     const store = createTestStore(initialState);
-    const nextPage = await setTypeOfCare(store, 'EYE'); // eye care
+    const nextPage = await setTypeOfCare(store, /eye care/i);
     expect(nextPage).to.equal('/new-appointment/choose-eye-care');
 
     const screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.unit.spec.js
@@ -29,7 +29,7 @@ describe('VAOS Page: TypeOfSleepCarePage', () => {
   beforeEach(() => mockFetch());
   it('should show page and validation', async () => {
     const store = createTestStore(initialState);
-    const nextPage = await setTypeOfCare(store, 'SLEEP'); // sleep
+    const nextPage = await setTypeOfCare(store, /sleep/i);
     expect(nextPage).to.equal('/new-appointment/choose-sleep-care');
 
     const screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
@@ -91,7 +91,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '211'); // amputation
+      await setTypeOfCare(store, /amputation care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -131,7 +131,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '502'); // mental health
+      await setTypeOfCare(store, /mental health/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -167,7 +167,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -183,7 +183,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
 
     it('should show error message when checks fail', async () => {
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -271,7 +271,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
         ],
       });
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '125'); // social work
+      await setTypeOfCare(store, /social work/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -324,7 +324,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '211'); // amputation
+      await setTypeOfCare(store, /amputation care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -378,7 +378,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '211'); // amputation
+      await setTypeOfCare(store, /amputation care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -430,7 +430,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -474,7 +474,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '502'); // mental health
+      await setTypeOfCare(store, /mental health/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -512,7 +512,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -558,7 +558,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       );
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -602,7 +602,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       // And the facitility page is presented
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -656,7 +656,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '502'); // mental health
+      await setTypeOfCare(store, /mental health/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -711,7 +711,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
         ...initialState,
         featureToggles: {},
       });
-      await setTypeOfCare(store, '502'); // mental health
+      await setTypeOfCare(store, /mental health/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.unit.spec.js
@@ -119,7 +119,7 @@ describe('VAOS Page: VAFacilityPage', () => {
           },
         },
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -186,7 +186,7 @@ describe('VAOS Page: VAFacilityPage', () => {
         directPastVisits: true,
       });
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -247,7 +247,7 @@ describe('VAOS Page: VAFacilityPage', () => {
         directPastVisits: true,
       });
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       let screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -333,7 +333,7 @@ describe('VAOS Page: VAFacilityPage', () => {
         },
       };
       const store = createTestStore(state);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -406,7 +406,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       mockSchedulingConfigurations(configs);
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -429,7 +429,7 @@ describe('VAOS Page: VAFacilityPage', () => {
 
     it('should display an error message when facilities call fails', async () => {
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -512,7 +512,7 @@ describe('VAOS Page: VAFacilityPage', () => {
           },
         },
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
       });
@@ -599,7 +599,7 @@ describe('VAOS Page: VAFacilityPage', () => {
           },
         },
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
       });
@@ -675,7 +675,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       });
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       let screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -684,7 +684,7 @@ describe('VAOS Page: VAFacilityPage', () => {
 
       await cleanup();
 
-      await setTypeOfCare(store, 'EYE'); // eye care
+      await setTypeOfCare(store, /eye care/i);
       await setTypeOfEyeCare(store, /optometry/i);
 
       screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -725,7 +725,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       const store = createTestStore({
         ...initialState,
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -830,7 +830,7 @@ describe('VAOS Page: VAFacilityPage', () => {
           },
         },
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -904,7 +904,7 @@ describe('VAOS Page: VAFacilityPage', () => {
           },
         },
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -980,7 +980,7 @@ describe('VAOS Page: VAFacilityPage', () => {
           },
         },
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, { store });
       await screen.findAllByRole('radio');
@@ -1044,7 +1044,7 @@ describe('VAOS Page: VAFacilityPage', () => {
           },
         },
       });
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, { store });
       await screen.findAllByRole('radio');
@@ -1103,7 +1103,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       ]);
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const { baseElement, findByText, history } = renderWithStoreAndRouter(
         <VAFacilityPage />,
@@ -1177,7 +1177,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       ]);
 
       const store = createTestStore(initialState);
-      await setTypeOfCare(store, 'EYE'); // eye care
+      await setTypeOfCare(store, /eye care/i);
       await setTypeOfEyeCare(store, /optometry/i);
 
       let screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -1307,7 +1307,7 @@ describe('VAOS Page: VAFacilityPage', () => {
         },
       });
 
-      await setTypeOfCare(store, '323'); // primary care
+      await setTypeOfCare(store, /primary care/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -1446,7 +1446,7 @@ describe('VAOS Page: VAFacilityPage', () => {
         },
       });
 
-      await setTypeOfCare(store, '123'); // nutrition and food
+      await setTypeOfCare(store, /nutrition and food/i);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfCarePageObject.js
@@ -27,11 +27,10 @@ export class TypeOfCarePageObject extends PageObject {
   }
 
   selectTypeOfCare(label) {
-    cy.get('va-radio')
-      .shadow()
-      .get('va-radio-option')
-      .contains(label)
-      .click();
+    cy.findByLabelText(label)
+      .as('radio')
+      .focus();
+    cy.get('@radio').check();
 
     return this;
   }

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -166,23 +166,23 @@ export async function setTypeOfFacility(store, value) {
  * @export
  * @async
  * @param {ReduxStore} store The Redux store to use to render the page
- * @param {string} value The string value of the radio button to click on
+ * @param {string|RegExp} label The string or regex to pass to *ByText query to get
+ *   a radio button to click on
  * @returns {string} The url path that was routed to after clicking Continue
  */
-export async function setTypeOfCare(store, value) {
-  const screen = renderWithStoreAndRouter(<TypeOfCarePage />, { store });
-  await screen.findByText(/Continue/i);
+export async function setTypeOfCare(store, label) {
+  const { findByLabelText, getByText, history } = renderWithStoreAndRouter(
+    <TypeOfCarePage />,
+    { store },
+  );
 
-  const radioSelector = screen.container.querySelector('va-radio');
-  const changeEvent = new CustomEvent('selected', {
-    detail: { value },
-  });
-  radioSelector.__events.vaValueChange(changeEvent);
-  fireEvent.click(screen.getByText(/Continue/));
-  await waitFor(() => expect(screen.history.push.called).to.be.true);
+  const radioButton = await findByLabelText(label);
+  fireEvent.click(radioButton);
+  fireEvent.click(getByText(/Continue/));
+  await waitFor(() => expect(history.push.called).to.be.true);
   await cleanup();
 
-  return screen.history.push.firstCall.args[0];
+  return history.push.firstCall.args[0];
 }
 
 /**
@@ -445,7 +445,7 @@ export async function setCommunityCareFlow({
     careType: typeOfCare.cceType,
   });
 
-  await setTypeOfCare(store, typeOfCare.id);
+  await setTypeOfCare(store, new RegExp(typeOfCare.name));
   await setTypeOfFacility(store, 'communityCare');
 
   return store;

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.js
@@ -138,10 +138,13 @@ describe('VAOS Page: TypeOfCarePage', () => {
       ),
     ).to.not.exist;
 
-    fireEvent.click(await screen.findByLabelText(/primary care/i));
     fireEvent.click(screen.getByText(/Continue/));
+
+    expect(await screen.findByText('What type of care do you need?')).to.exist;
     expect(screen.history.push.called).to.not.be.true;
 
+    fireEvent.click(await screen.findByLabelText(/primary care/i));
+    fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal(
         '/new-appointment/va-facility-2',

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.js
@@ -59,13 +59,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       ...initialState,
     });
     const screen = renderWithStoreAndRouter(<TypeOfCarePage />, { store });
-    await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: '323' }, // primary care
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/primary care/i));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
@@ -92,13 +87,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       ...initialState,
     });
     const screen = renderWithStoreAndRouter(<TypeOfCarePage />, { store });
-    await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: '323' }, // primary care
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/primary care/i));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
@@ -116,18 +106,9 @@ describe('VAOS Page: TypeOfCarePage', () => {
       eligible: false,
     });
     const screen = renderWithStoreAndRouter(<TypeOfCarePage />, { store });
-    await screen.findByText(/Continue/i);
 
-    // Then the primary header should have focus
-    const radioSelector = screen.container.querySelector('va-radio');
-    expect(radioSelector).to.exist;
-    expect(radioSelector).to.have.attribute(
-      'label',
-      'What type of care do you need?',
-    );
-
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
-    expect(radioOptions).to.have.lengthOf(12);
+    expect(await screen.findByText('What type of care do you need?')).to.exist;
+    expect((await screen.findAllByRole('radio')).length).to.equal(12);
 
     // Verify alert is shown
     expect(
@@ -157,14 +138,10 @@ describe('VAOS Page: TypeOfCarePage', () => {
       ),
     ).to.not.exist;
 
+    fireEvent.click(await screen.findByLabelText(/primary care/i));
     fireEvent.click(screen.getByText(/Continue/));
     expect(screen.history.push.called).to.not.be.true;
 
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: '323' }, // primary care
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
-    fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal(
         '/new-appointment/va-facility-2',
@@ -181,13 +158,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       eligible: false,
     });
     let screen = renderWithStoreAndRouter(<TypeOfCarePage />, { store });
-    await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: '323' }, // primary care
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/primary care/i));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal(
@@ -200,9 +172,9 @@ describe('VAOS Page: TypeOfCarePage', () => {
       store,
     });
 
-    await waitFor(() => {
-      expect(radioSelector).to.have.attribute('value', '323'); // primary care
-    });
+    expect(await screen.findByLabelText(/primary care/i)).to.have.attribute(
+      'checked',
+    );
   });
 
   it('should show type of care page without podiatry when CC flag is off', async () => {
@@ -217,10 +189,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       <Route component={TypeOfCarePage} />,
       { store },
     );
-    await screen.findByText(/Continue/i);
 
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
-    expect(radioOptions).to.have.lengthOf(11);
+    expect((await screen.findAllByRole('radio')).length).to.equal(11);
   });
 
   it('should not allow users who are not CC eligible to use Podiatry', async () => {
@@ -232,13 +202,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       eligible: false,
     });
     const screen = renderWithStoreAndRouter(<TypeOfCarePage />, { store });
-    await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'tbd-podiatry' }, // podiatry
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/podiatry/i));
     fireEvent.click(screen.getByText(/Continue/));
     await screen.findByText(
       /not eligible to request a community care Podiatry appointment online at this time/i,
@@ -263,13 +228,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       <Route component={TypeOfCarePage} />,
       { store },
     );
-    await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'EYE' }, // eye care
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/eye care/i));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
@@ -284,13 +244,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       <Route component={TypeOfCarePage} />,
       { store },
     );
-    await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'SLEEP' }, // sleep
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/sleep/i));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
@@ -391,7 +346,7 @@ describe('VAOS Page: TypeOfCarePage', () => {
     screen = renderWithStoreAndRouter(<Route component={TypeOfCarePage} />, {
       store,
     });
-    await screen.findByText(/Continue/i);
+    await screen.findAllByRole('radio');
 
     expect(
       screen.queryByText(
@@ -451,13 +406,8 @@ describe('VAOS Page: TypeOfCarePage', () => {
       },
     });
     const screen = renderWithStoreAndRouter(<TypeOfCarePage />, { store });
-    await screen.findByText(/Continue/i);
-
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'covid' }, // covid vaccine
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    expect((await screen.findAllByRole('radio')).length).to.equal(12);
+    fireEvent.click(await screen.findByLabelText(/COVID-19 vaccine/i));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This UX PR addresses the feedback on https://github.com/department-of-veterans-affairs/va.gov-team/issues/95036
  - Refactor Type of Care page to allow the display of the address alert between the header and radio options
  - Update Clinic single choice page to add break between phone number and prompt
- Appointments (VAOS) team
- This work is no behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95036

## Testing done

- Tested locally to ensure the requested changes are made, see below for screenshots after the change. For before pictures, see the comments in the linked issue.
- Updated unit and e2e tests

## Screenshots

| Type of Care | Clinic Choice - Single |
| - | - |
| ![image](https://github.com/user-attachments/assets/056772ed-957e-4142-9379-cc2f2d3f036f) | ![image](https://github.com/user-attachments/assets/198db071-bfe3-4f0c-805f-00720b35d090) |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

