### PR TITLE
MHV-64019: Filter issues from an Audit

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
@@ -50,7 +50,9 @@ const MedicationsList = props => {
   return (
     <>
       {/* clean after filter flag is removed */}
-      {!showFilterContent && <h2 className="sr-only no-print">List of Medications</h2>}
+      {!showFilterContent && (
+        <h2 className="sr-only no-print">List of Medications</h2>
+      )}
       <p
         className="rx-page-total-info vads-u-font-family--sans"
         data-testid="page-total-info"

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
@@ -8,6 +8,7 @@ import MedicationsListCard from './MedicationsListCard';
 import { rxListSortingOptions } from '../../util/constants';
 import PrescriptionPrintOnly from '../PrescriptionDetails/PrescriptionPrintOnly';
 import { fromToNumbs } from '../../util/helpers';
+import { selectFilterFlag } from '../../util/selectors';
 
 const MAX_PAGE_LIST_LENGTH = 6;
 const perPage = 20;
@@ -27,6 +28,7 @@ const MedicationsList = props => {
   const prescriptionId = useSelector(
     state => state.rx.prescriptions?.prescriptionDetails?.prescriptionId,
   );
+  const showFilterContent = useSelector(selectFilterFlag);
 
   const displaynumberOfPrescriptionsSelector =
     ".no-print [data-testid='page-total-info']";
@@ -47,7 +49,8 @@ const MedicationsList = props => {
 
   return (
     <>
-      <h2 className="sr-only no-print">List of Medications</h2>
+      {/* clean after filter flag is removed */}
+      {!showFilterContent && <h2 className="sr-only no-print">List of Medications</h2>}
       <p
         className="rx-page-total-info vads-u-font-family--sans"
         data-testid="page-total-info"

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
@@ -7,7 +7,7 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   filterOptions,
-  SESSION_SELECTED_FILTER_OPTION
+  SESSION_SELECTED_FILTER_OPTION,
 } from '../../util/constants';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
@@ -28,11 +28,11 @@ const MedicationsListFilter = props => {
       const isOpen = target.getAttribute('open');
       if (!isOpen) {
         setFilterOption(
-          sessionStorage.getItem(SESSION_SELECTED_FILTER_OPTION) || null
+          sessionStorage.getItem(SESSION_SELECTED_FILTER_OPTION) || null,
         );
       }
     }
-  }
+  };
 
   const filterOptionsArray = Object.keys(filterOptions);
   return (

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
@@ -6,6 +6,7 @@ import {
   VaButton,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { filterOptions } from '../../util/constants';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const MedicationsListFilter = props => {
   const { updateFilter, filterOption, setFilterOption } = props;
@@ -16,6 +17,7 @@ const MedicationsListFilter = props => {
 
   const handleFilterSubmit = () => {
     updateFilter(filterOption);
+    focusElement(document.getElementById('showingRx'));
   };
 
   const filterOptionsArray = Object.keys(filterOptions);
@@ -40,6 +42,7 @@ const MedicationsListFilter = props => {
           label="Select a filter"
           data-testid="filter-option"
           onVaValueChange={handleFilterOptionChange}
+          className="vads-u-margin-top--0"
         >
           {filterOptionsArray.map(option => (
             <VaRadioOption
@@ -53,7 +56,7 @@ const MedicationsListFilter = props => {
           ))}
         </VaRadio>
         <VaButton
-          className="vads-u-width--full filter-submit-btn"
+          className="vads-u-width--full tablet:vads-u-width--auto filter-submit-btn vads-u-margin-top--3"
           onClick={handleFilterSubmit}
           text="Filter"
           data-testid="filter-button"

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
@@ -5,7 +5,7 @@ import {
   VaRadioOption,
   VaButton,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { filterOptions } from '../../util/constants';
+import { filterOptions, SESSION_SELECTED_FILTER_OPTION } from '../../util/constants';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const MedicationsListFilter = props => {
@@ -20,6 +20,15 @@ const MedicationsListFilter = props => {
     focusElement(document.getElementById('showingRx'));
   };
 
+  const handleAccordionItemToggle = ({ target }) => {
+    if (target) {
+      const isOpen = target.getAttribute('open');
+      if (!isOpen) {
+        setFilterOption(sessionStorage.getItem(SESSION_SELECTED_FILTER_OPTION) || null);
+      }
+    }
+  }
+
   const filterOptionsArray = Object.keys(filterOptions);
   return (
     <va-accordion
@@ -27,6 +36,7 @@ const MedicationsListFilter = props => {
       open-single
       data-testid="filter-accordion"
       class="filter-accordion"
+      onAccordionItemToggled={handleAccordionItemToggle}
     >
       <va-accordion-item
         header="Filter list"

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
@@ -5,7 +5,10 @@ import {
   VaRadioOption,
   VaButton,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { filterOptions, SESSION_SELECTED_FILTER_OPTION } from '../../util/constants';
+import {
+  filterOptions,
+  SESSION_SELECTED_FILTER_OPTION
+} from '../../util/constants';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const MedicationsListFilter = props => {
@@ -24,7 +27,9 @@ const MedicationsListFilter = props => {
     if (target) {
       const isOpen = target.getAttribute('open');
       if (!isOpen) {
-        setFilterOption(sessionStorage.getItem(SESSION_SELECTED_FILTER_OPTION) || null);
+        setFilterOption(
+          sessionStorage.getItem(SESSION_SELECTED_FILTER_OPTION) || null
+        );
       }
     }
   }

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListSort.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListSort.jsx
@@ -9,7 +9,10 @@ import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { datadogRum } from '@datadog/browser-rum';
 import { rxListSortingOptions } from '../../util/constants';
-import { selectFilterFlag, selectRefillContentFlag } from '../../util/selectors';
+import {
+  selectFilterFlag,
+  selectRefillContentFlag
+} from '../../util/selectors';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 
 const MedicationsListSort = props => {

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListSort.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListSort.jsx
@@ -9,13 +9,14 @@ import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { datadogRum } from '@datadog/browser-rum';
 import { rxListSortingOptions } from '../../util/constants';
-import { selectRefillContentFlag } from '../../util/selectors';
+import { selectFilterFlag, selectRefillContentFlag } from '../../util/selectors';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 
 const MedicationsListSort = props => {
   const { value, sortRxList } = props;
   const history = useHistory();
   const showRefillContent = useSelector(selectRefillContentFlag);
+  const showFilterContent = useSelector(selectFilterFlag);
   const [sortListOption, setSortListOption] = useState(value);
 
   const rxSortingOptions = Object.keys(rxListSortingOptions);
@@ -33,7 +34,18 @@ const MedicationsListSort = props => {
           }
           value={sortListOption}
           onVaSelect={e => {
-            setSortListOption(e.detail.value);
+            // clean after filter flag is removed
+            if (showFilterContent) {
+              sortRxList(e.detail.value);
+              history.push(`/?page=1`);
+              waitForRenderThenFocus(
+                "[data-testid='page-total-info']",
+                document,
+                500,
+              );
+            } else {
+              setSortListOption(e.detail.value);
+            }
             const capitalizedOption = e.detail.value
               .replace(/([a-z])([A-Z])/g, '$1 $2')
               .split(' ')
@@ -54,29 +66,32 @@ const MedicationsListSort = props => {
           })}
         </VaSelect>
       </div>
-      <div className="sort-button">
-        <VaButton
-          data-dd-action-name={
-            dataDogActionNames.medicationsListPage.SORT_MEDICATIONS_BUTTON
-          }
-          uswds
-          className="va-button"
-          secondary={showRefillContent}
-          data-testid="sort-button"
-          text="Sort"
-          onClick={() => {
-            if (sortListOption) {
-              sortRxList(sortListOption);
-              history.push(`/?page=1`);
-              waitForRenderThenFocus(
-                "[data-testid='page-total-info']",
-                document,
-                500,
-              );
+      {/* clean after filter flag is removed */}
+      {!showFilterContent && (
+        <div className="sort-button">
+          <VaButton
+            data-dd-action-name={
+              dataDogActionNames.medicationsListPage.SORT_MEDICATIONS_BUTTON
             }
-          }}
-        />
-      </div>
+            uswds
+            className="va-button"
+            secondary={showRefillContent}
+            data-testid="sort-button"
+            text="Sort"
+            onClick={() => {
+              if (sortListOption) {
+                sortRxList(sortListOption);
+                history.push(`/?page=1`);
+                waitForRenderThenFocus(
+                  "[data-testid='page-total-info']",
+                  document,
+                  500,
+                );
+              }
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListSort.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListSort.jsx
@@ -11,7 +11,7 @@ import { datadogRum } from '@datadog/browser-rum';
 import { rxListSortingOptions } from '../../util/constants';
 import {
   selectFilterFlag,
-  selectRefillContentFlag
+  selectRefillContentFlag,
 } from '../../util/selectors';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-active-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-active-option-list-page.cypress.spec.js
@@ -20,6 +20,9 @@ describe('Medications List Page Active Filter Option', () => {
     listPage.verifyFilterButtonWhenAccordionExpanded();
     listPage.clickFilterRadioButtonOptionOnListPage('Active');
     listPage.clickFilterButtonOnAccordion();
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      'Showing 1 - 20 of 20 medications',
+    );
     listPage.verifyNameOfFirstRxOnMedicationsList('active');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-all-medications-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-all-medications-option-list-page.cypress.spec.js
@@ -20,6 +20,10 @@ describe('Medications List Page All Medications Filter', () => {
     );
     listPage.verifyFilterButtonWhenAccordionExpanded();
     listPage.clickFilterRadioButtonOptionOnListPage('All medications');
+    listPage.clickFilterButtonOnAccordion();
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      'Showing 1 - 20 of 20 medications',
+    );
     listPage.verifyNameOfFirstRxOnMedicationsList('all medications');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-collapsed-after-reload-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-collapsed-after-reload-list-page.cypress.spec.js
@@ -1,10 +1,9 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
-import { Data } from './utils/constants';
 
-describe('Medications List Page Active Filter Option', () => {
-  it('visits Medications List Page Filter Option Active', () => {
+describe('Medications List Page Filter Accordion Collapsed', () => {
+  it('visits Medications List Page Filter Accordion Collapsed after Reload', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
     const landingPage = new MedicationsLandingPage();
@@ -13,17 +12,12 @@ describe('Medications List Page Active Filter Option', () => {
     cy.injectAxe();
     cy.axeCheck('main');
     listPage.clickGotoMedicationsLink();
+    listPage.verifyLabelTextWhenFilterAccordionExpanded();
     listPage.clickfilterAccordionDropdownOnListPage();
-    listPage.verifyFilterOptionsOnListPage(
-      'Active',
-      'Active prescriptions and non-VA medications',
-    );
+    listPage.verifyFilterHeaderTextHasFocusafterExpanded();
     listPage.verifyFilterButtonWhenAccordionExpanded();
-    listPage.clickFilterRadioButtonOptionOnListPage('Active');
-    listPage.clickFilterButtonOnAccordion();
-    listPage.verifyFocusOnPaginationTextInformationOnListPage(
-      Data.PAGINATION_TEXT,
-    );
-    listPage.verifyNameOfFirstRxOnMedicationsList('active');
+    listPage.clickFilterRadioButtonOptionOnListPage('All medications');
+    cy.reload();
+    listPage.verifyFilterCollapsedOnListPage();
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-collapsed-when-nav-back-from-about-medications-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-collapsed-when-nav-back-from-about-medications-page.cypress.spec.js
@@ -1,13 +1,14 @@
 import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
-import { Data } from './utils/constants';
 
-describe('Medications List Page All Medications Filter', () => {
-  it('visits Medications List Page Filter Option All Medications', () => {
+describe('Medications List Page Filter Collapsed ', () => {
+  it('visits Medications List Page Filter collpased after navigating away and back', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
     const landingPage = new MedicationsLandingPage();
+    const detailsPage = new MedicationsDetailsPage();
     site.login();
     landingPage.visitLandingPageURL();
     cy.injectAxe();
@@ -21,10 +22,9 @@ describe('Medications List Page All Medications Filter', () => {
     );
     listPage.verifyFilterButtonWhenAccordionExpanded();
     listPage.clickFilterRadioButtonOptionOnListPage('All medications');
-    listPage.clickFilterButtonOnAccordion();
-    listPage.verifyFocusOnPaginationTextInformationOnListPage(
-      Data.PAGINATION_TEXT,
-    );
     listPage.verifyNameOfFirstRxOnMedicationsList('all medications');
+    detailsPage.clickMedicationsLandingPageBreadcrumbsOnListPage();
+    listPage.clickGotoMedicationsLink();
+    listPage.verifyFilterCollapsedOnListPage();
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-non-active-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-non-active-option-list-page.cypress.spec.js
@@ -1,6 +1,7 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
+import Data from './utils/constants';
 
 describe('Medications List Page Non-Active Filter Option', () => {
   it('visits Medications List Page Filter Option Non-Active', () => {
@@ -21,7 +22,7 @@ describe('Medications List Page Non-Active Filter Option', () => {
     listPage.clickFilterRadioButtonOptionOnListPage('Non-active');
     listPage.clickFilterButtonOnAccordion();
     listPage.verifyFocusOnPaginationTextInformationOnListPage(
-      'Showing 1 - 20 of 20 medications',
+      Data.PAGINATION_TEXT,
     );
     listPage.verifyNameOfFirstRxOnMedicationsList('non active');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-non-active-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-non-active-option-list-page.cypress.spec.js
@@ -1,7 +1,7 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
-import Data from './utils/constants';
+import { Data } from './utils/constants';
 
 describe('Medications List Page Non-Active Filter Option', () => {
   it('visits Medications List Page Filter Option Non-Active', () => {

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-non-active-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-non-active-option-list-page.cypress.spec.js
@@ -20,6 +20,9 @@ describe('Medications List Page Non-Active Filter Option', () => {
     listPage.verifyFilterButtonWhenAccordionExpanded();
     listPage.clickFilterRadioButtonOptionOnListPage('Non-active');
     listPage.clickFilterButtonOnAccordion();
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      'Showing 1 - 20 of 20 medications',
+    );
     listPage.verifyNameOfFirstRxOnMedicationsList('non active');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-recently-requested-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-recently-requested-option-list-page.cypress.spec.js
@@ -20,6 +20,9 @@ describe('Medications List Page Recently Requested Filter Option', () => {
     listPage.verifyFilterButtonWhenAccordionExpanded();
     listPage.clickFilterRadioButtonOptionOnListPage('Recently requested');
     listPage.clickFilterButtonOnAccordion();
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      'Showing 1 - 20 of 20 medications',
+    );
     listPage.verifyNameOfFirstRxOnMedicationsList('recently requested');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-recently-requested-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-recently-requested-option-list-page.cypress.spec.js
@@ -1,6 +1,7 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
+import { Data } from './utils/constants';
 
 describe('Medications List Page Recently Requested Filter Option', () => {
   it('visits Medications List Page Filter Option Recently Requested', () => {
@@ -21,7 +22,7 @@ describe('Medications List Page Recently Requested Filter Option', () => {
     listPage.clickFilterRadioButtonOptionOnListPage('Recently requested');
     listPage.clickFilterButtonOnAccordion();
     listPage.verifyFocusOnPaginationTextInformationOnListPage(
-      'Showing 1 - 20 of 20 medications',
+      Data.PAGINATION_TEXT,
     );
     listPage.verifyNameOfFirstRxOnMedicationsList('recently requested');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-renewal-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-renewal-option-list-page.cypress.spec.js
@@ -1,6 +1,7 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
+import { Data } from './utils/constants';
 
 describe('Medications List Page Renewal Filter Option', () => {
   it('visits Medications List Page Filter Option Renewal', () => {
@@ -23,7 +24,7 @@ describe('Medications List Page Renewal Filter Option', () => {
     );
     listPage.clickFilterButtonOnAccordion();
     listPage.verifyFocusOnPaginationTextInformationOnListPage(
-      'Showing 1 - 20 of 20 medications',
+      Data.PAGINATION_TEXT,
     );
     listPage.verifyNameOfFirstRxOnMedicationsList('renewal');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-renewal-option-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-renewal-option-list-page.cypress.spec.js
@@ -22,6 +22,9 @@ describe('Medications List Page Renewal Filter Option', () => {
       'Renewal needed before refill',
     );
     listPage.clickFilterButtonOnAccordion();
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      'Showing 1 - 20 of 20 medications',
+    );
     listPage.verifyNameOfFirstRxOnMedicationsList('renewal');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-sort-alphabetically-by-name-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-sort-alphabetically-by-name-list-page.cypress.spec.js
@@ -33,8 +33,11 @@ describe('Medications List Page Sort Alphabetically By Name', () => {
 
     site.verifyPaginationPrescriptionsDisplayed(1, 20, listLength);
     // site.loadVAPaginationNextPrescriptions(2, mockRxPageTwo);
-    listPage.selectSortDropDownOption('Alphabetically by name');
-    listPage.clickSortAlphabeticallyByName();
+    listPage.selectSortDropDownOption(
+      'Alphabetically by name',
+      'prescription_name&sort[]=dispensed_date',
+    );
+    listPage.loadRxAfterSortAlphabeticallyByName();
     listPage.verifyPaginationDisplayedforSortAlphabeticallyByName(
       1,
       20,

--- a/src/applications/mhv-medications/tests/e2e/medications-sort-default-prescriptions-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-sort-default-prescriptions-list-page.cypress.spec.js
@@ -36,8 +36,11 @@ describe('Medications List Page Sort Alphabetically By Status', () => {
     // site.loadVAPaginationPrescriptions(1, mockRxPageOne);
     site.verifyPaginationPrescriptionsDisplayed(1, 20, listLength);
     // site.loadVAPaginationNextPrescriptions(2, mockRxPageTwo);
-    listPage.selectSortDropDownOption('Alphabetically by status');
-    listPage.clickSortAlphabeticallyByStatus();
+    listPage.selectSortDropDownOption(
+      'Alphabetically by status',
+      'disp_status&sort[]=prescription_name&sort[]=dispensed_date',
+    );
+    listPage.loadRxDefaultSortAlphabeticallyByStatus();
     listPage.verifyPaginationDisplayedforSortAlphabeticallyByStatus(
       1,
       20,

--- a/src/applications/mhv-medications/tests/e2e/medications-sort-last-filled-first-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-sort-last-filled-first-list-page.cypress.spec.js
@@ -36,8 +36,11 @@ describe('Medications List Page Sort By Last Filled First', () => {
     // site.loadVAPaginationPrescriptions(1, mockRxPageOne);
     site.verifyPaginationPrescriptionsDisplayed(1, 20, listLength);
     // site.loadVAPaginationNextPrescriptions(2, mockRxPageTwo);
-    listPage.selectSortDropDownOption('Last filled first');
-    listPage.clickSortLastFilledFirst();
+    listPage.selectSortDropDownOption(
+      'Last filled first',
+      '-dispensed_date&sort[]=prescription_name',
+    );
+    listPage.loadRxAfterSortLastFilledFirst();
     listPage.verifyPaginationDisplayedforSortLastFilledFirst(1, 20, listLength);
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -775,6 +775,17 @@ class MedicationsListPage {
       .should('be.focused')
       .and('contain', text);
   };
+
+  verifyFilterCollapsedOnListPage = () => {
+    cy.get('[data-testid="filter-button"]')
+      .shadow()
+      .find('[type="button"]')
+      .should('not.exist');
+    cy.get('[data-testid="filter-option"]')
+      .shadow()
+      .find('[class="usa-legend"]', { force: true })
+      .should('not.exist');
+  };
 }
 
 export default MedicationsListPage;

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -463,13 +463,18 @@ class MedicationsListPage {
     );
   };
 
-  selectSortDropDownOption = text => {
+  selectSortDropDownOption = (text, intercept) => {
+    cy.intercept(
+      'GET',
+      `/my_health/v1/prescriptions?page=1&per_page=20&sort[]=${intercept}`,
+      prescriptions,
+    );
     cy.get('[data-testid="sort-dropdown"]')
       .find('#options')
       .select(text, { force: true });
   };
 
-  clickSortAlphabeticallyByStatus = () => {
+  loadRxDefaultSortAlphabeticallyByStatus = () => {
     cy.intercept(
       'GET',
       '/my_health/v1/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true',
@@ -480,8 +485,6 @@ class MedicationsListPage {
       '/my_health/v1/prescriptions?page=1&per_page=20&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date',
       prescriptions,
     );
-    cy.get('[data-testid="sort-button"]').should('be.visible');
-    cy.get('[data-testid="sort-button"]').click({ waitForAnimations: true });
   };
 
   verifyPaginationDisplayedforSortAlphabeticallyByStatus = (
@@ -495,7 +498,7 @@ class MedicationsListPage {
     );
   };
 
-  clickSortAlphabeticallyByName = () => {
+  loadRxAfterSortAlphabeticallyByName = () => {
     cy.intercept(
       'GET',
       '/my_health/v1/prescriptions?&sort[]=prescription_name&sort[]=dispensed_date&include_image=true',
@@ -508,8 +511,7 @@ class MedicationsListPage {
         return Cypress.Promise.delay(500).then(() => req.continue());
       },
     ).as('prescriptions');
-    cy.get('[data-testid="sort-button"]').should('be.visible');
-    cy.get('[data-testid="sort-button"]').click({ waitForAnimations: true });
+
     cy.get('[data-testid="loading-indicator"]').should('exist');
     cy.intercept(
       'GET',
@@ -531,7 +533,7 @@ class MedicationsListPage {
       );
   };
 
-  clickSortLastFilledFirst = () => {
+  loadRxAfterSortLastFilledFirst = () => {
     cy.intercept(
       'GET',
       '/my_health/v1/prescriptions?&sort[]=-dispensed_date&sort[]=prescription_name&include_image=true',
@@ -543,8 +545,7 @@ class MedicationsListPage {
         return Cypress.Promise.delay(500).then(() => req.continue());
       },
     ).as('prescriptions');
-    cy.get('[data-testid="sort-button"]').should('be.visible');
-    cy.get('[data-testid="sort-button"]').click({ waitForAnimations: true });
+
     cy.get('[data-testid="loading-indicator"]').should('exist');
     cy.intercept(
       'GET',

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -769,6 +769,12 @@ class MedicationsListPage {
   verifyAllMedicationsRadioButtonIsChecked = () => {
     cy.get(`input[type="radio"][value="All medications"]`).should('be.checked');
   };
+
+  verifyFocusOnPaginationTextInformationOnListPage = text => {
+    cy.get('[data-testid="page-total-info"]')
+      .should('be.focused')
+      .and('contain', text);
+  };
 }
 
 export default MedicationsListPage;

--- a/src/applications/mhv-medications/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-medications/tests/e2e/utils/constants.js
@@ -1,0 +1,3 @@
+export const Data = {
+  PAGINATION_TEXT: 'Showing 1 - 20 of 20 medications',
+};


### PR DESCRIPTION
## Summary

1. Layout updates + focus logic for `MedicationsListFilter`
2. Removed sr-only `h2` for `MedicationsList` (behind the feature flag)
3. Removed the Sort button and made sorting apply automatically on the dropdown value change for `MedicationsListSort` (behind the feature flag)

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-64019

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Remove 24 px spacing above select a filter
AC2: Add 24 px space above filter button
AC3: Filter button should be a fixed width on desktop (keep full width on mobile) - this should be a property of the button if you're using the correct VA component
AC4: If user does not click filter after selecting an option, it should not be saved if they leave and come back, collapse, or refresh the page
AC5: After filter button is clicked, the focus should land on the "Showing 1-20..." 
AC6: Remove the "Sort" button next to the sort dropdown.
AC7: We originally intended for the H2 to read "List of Medications," but RX now has a new visible H2 header. We should remove the SR-only text on RX.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
