### PR TITLE
[21P-0847] Require email for notifications

### DIFF
--- a/src/applications/simple-forms/20-10206/pages/phoneEmail.js
+++ b/src/applications/simple-forms/20-10206/pages/phoneEmail.js
@@ -1,6 +1,6 @@
 import {
   emailSchema,
-  emailUI,
+  emailToSendNotificationsUI,
   phoneSchema,
   phoneUI,
   titleUI,
@@ -11,7 +11,7 @@ export default {
   uiSchema: {
     ...titleUI('Your phone and email address'),
     homePhone: phoneUI('Phone number'),
-    emailAddress: emailUI(),
+    emailAddress: emailToSendNotificationsUI,
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/21-0972/pages/preparerContactInformation.js
+++ b/src/applications/simple-forms/21-0972/pages/preparerContactInformation.js
@@ -1,6 +1,6 @@
 import {
   emailSchema,
-  emailUI,
+  emailToSendNotificationsUI,
   phoneUI,
   phoneSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -9,7 +9,7 @@ import {
 export default {
   uiSchema: {
     preparerPhone: phoneUI('Phone number'),
-    preparerEmail: emailUI('Email address'),
+    preparerEmail: emailToSendNotificationsUI,
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/21P-0847/pages/preparerContactInformation.js
+++ b/src/applications/simple-forms/21P-0847/pages/preparerContactInformation.js
@@ -1,6 +1,6 @@
 import {
   emailSchema,
-  emailUI,
+  emailToSendNotificationsUI,
   phoneUI,
   phoneSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -10,7 +10,7 @@ export default {
   uiSchema: {
     preparerHomePhone: phoneUI('Primary phone number'),
     preparerMobilePhone: phoneUI('Secondary phone number'),
-    preparerEmail: emailUI(),
+    preparerEmail: emailToSendNotificationsUI,
   },
   schema: {
     type: 'object',
@@ -19,6 +19,6 @@ export default {
       preparerMobilePhone: phoneSchema,
       preparerEmail: emailSchema,
     },
-    required: ['preparerHomePhone'],
+    required: ['preparerHomePhone', 'preparerEmail'],
   },
 };

--- a/src/applications/simple-forms/21P-0847/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/simple-forms/21P-0847/tests/e2e/fixtures/data/minimal-test.json
@@ -5,6 +5,7 @@
   },
   "preparerSsn": "222668888",
   "preparerHomePhone": "1234567890",
+  "preparerEmail": "arthur.c.preparer@email.com",
   "preparerAddress": {
     "street": "124 Main St",
     "city": "Anytown",

--- a/src/applications/simple-forms/21P-0847/tests/pages/preparerContactInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/preparerContactInformation.unit.spec.jsx
@@ -20,7 +20,7 @@ testNumberOfWebComponentFields(
   pageTitle,
 );
 
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 2;
 testNumberOfErrorsOnSubmitForWebComponents(
   formConfig,
   schema,

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/phoneAndEmailAddress.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/phoneAndEmailAddress.js
@@ -1,6 +1,6 @@
 import {
   emailSchema,
-  emailUI,
+  emailToSendNotificationsUI,
   phoneSchema,
   phoneUI,
   titleUI,
@@ -12,7 +12,7 @@ export default {
     ...titleUI('Phone and email address'),
     homePhone: phoneUI('Home phone number'),
     mobilePhone: phoneUI('Mobile phone number'),
-    emailAddress: emailUI(),
+    emailAddress: emailToSendNotificationsUI,
   },
   schema: {
     type: 'object',

--- a/src/platform/forms-system/src/js/web-component-patterns/emailPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/emailPattern.jsx
@@ -81,6 +81,12 @@ const emailUI = options => {
   };
 };
 
+const emailToSendNotificationsUI = emailUI({
+  title: 'Email',
+  hint:
+    'We’ll use this email address to send you notifications about your form submission',
+});
+
 /**
  * ```js
  * schema: {
@@ -93,4 +99,4 @@ const emailSchema = {
   maxLength: 256,
 };
 
-export { emailUI, emailSchema };
+export { emailUI, emailToSendNotificationsUI, emailSchema };


### PR DESCRIPTION
## Summary
This pull request updates form 21P-0847 to require email for the preparer. Additionally, a new pattern has been created for these required emails used for notifications. Right now, the pattern displays a hint and always has the text of "Email". Because of this new pattern, the other forms that were updated to require email have been changed to use the pattern.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1753

## Testing done
Updated unit and E2E tests for 21P-0847

## Screenshots
![image](https://github.com/user-attachments/assets/400f5182-40e1-43cf-bbf6-f13f2d256363)
