### PR TITLE
Allow for using a link or button instead of yes/no (array builder)

### DIFF
--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -356,6 +356,7 @@ class FormPage extends React.Component {
             onChange={this.onChange}
             onSubmit={this.onSubmit}
             setFormData={this.props.setData}
+            pageContentBeforeButtons={pageContentBeforeButtons}
             contentBeforeButtons={contentBeforeNavButtons}
             contentAfterButtons={contentAfterNavButtons}
             appStateData={appStateData}

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
@@ -92,6 +92,7 @@ export default function ArrayBuilderItemPage({
                 required={required}
               />
               {/* save-in-progress link, etc */}
+              {props.pageContentBeforeButtons}
               {props.contentBeforeButtons}
               <FormNavButtons
                 goBack={props.goBack}
@@ -140,7 +141,6 @@ export default function ArrayBuilderItemPage({
     appStateData: PropTypes.object,
     contentAfterButtons: PropTypes.node,
     contentBeforeButtons: PropTypes.node,
-    PageContentBeforeButtons: PropTypes.node,
     data: PropTypes.object,
     formContext: PropTypes.object,
     getFormData: PropTypes.func,
@@ -150,6 +150,7 @@ export default function ArrayBuilderItemPage({
     onContinue: PropTypes.func,
     onReviewPage: PropTypes.bool,
     onSubmit: PropTypes.func,
+    pageContentBeforeButtons: PropTypes.node,
     pagePerItemIndex: PropTypes.string,
     required: PropTypes.bool,
     setFormData: PropTypes.func,

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryNoSchemaFormPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryNoSchemaFormPage.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+
+// NoSchemaFormPage = No uiSchema or schema
+const ArrayBuilderSummaryNoSchemaFormPage = ({
+  addAnotherItemButtonClick,
+  arrayBuilderOptions,
+  arrayData,
+  customPageProps,
+  description,
+  hideAdd,
+  title,
+}) => {
+  function onSubmit(e) {
+    e.preventDefault();
+    customPageProps.onSubmit({ formData: customPageProps.data });
+  }
+
+  return (
+    <form className="vads-u-margin-y--2" onSubmit={onSubmit}>
+      {title}
+      {description}
+      {!hideAdd &&
+        arrayBuilderOptions.useLinkInsteadOfYesNo && (
+          <va-link-action
+            data-action="add"
+            text={arrayBuilderOptions.getText(
+              'summaryAddLinkText',
+              arrayData,
+              customPageProps.data,
+            )}
+            onClick={addAnotherItemButtonClick}
+            name={`${arrayBuilderOptions.nounPlural}AddLink`}
+          />
+        )}
+      {!hideAdd &&
+        arrayBuilderOptions.useButtonInsteadOfYesNo && (
+          <va-button
+            data-action="add"
+            text={arrayBuilderOptions.getText(
+              'summaryAddButtonText',
+              arrayData,
+              customPageProps.data,
+            )}
+            onClick={addAnotherItemButtonClick}
+            name={`${arrayBuilderOptions.nounPlural}AddButton`}
+            primary
+            uswds
+          />
+        )}
+      {customPageProps.pageContentBeforeButtons}
+      {customPageProps.contentBeforeButtons}
+      <FormNavButtons
+        goBack={customPageProps.goBack}
+        goForward={customPageProps.onContinue}
+        submitToContinue
+      />
+      {customPageProps.contentAfterButtons}
+    </form>
+  );
+};
+
+export default ArrayBuilderSummaryNoSchemaFormPage;
+
+ArrayBuilderSummaryNoSchemaFormPage.propTypes = {
+  addAnotherItemButtonClick: PropTypes.func,
+  arrayBuilderOptions: PropTypes.object,
+  arrayData: PropTypes.array,
+  customPageProps: PropTypes.shape({
+    onSubmit: PropTypes.func,
+    data: PropTypes.object,
+    pageContentBeforeButtons: PropTypes.node,
+    contentBeforeButtons: PropTypes.node,
+    goBack: PropTypes.func,
+    onContinue: PropTypes.func,
+    contentAfterButtons: PropTypes.node,
+  }),
+  description: PropTypes.node,
+  hideAdd: PropTypes.bool,
+  title: PropTypes.node,
+};

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -50,12 +50,15 @@ function filterEmptyItems(arrayData) {
 }
 
 function checkHasYesNoReviewError(reviewErrors, hasItemsKey) {
-  return reviewErrors?.errors?.some(obj => obj.name === hasItemsKey);
+  return (
+    hasItemsKey && reviewErrors?.errors?.some(obj => obj.name === hasItemsKey)
+  );
 }
 
 function getYesNoReviewErrorMessage(reviewErrors, hasItemsKey) {
   // use the same error message as the yes/no field
-  const error = reviewErrors?.errors?.find(obj => obj.name === hasItemsKey);
+  const error =
+    hasItemsKey && reviewErrors?.errors?.find(obj => obj.name === hasItemsKey);
   return error?.message;
 }
 
@@ -149,7 +152,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
         // We shouldn't persist the 'yes' answer after an item is entered/cancelled
         // We should ask the yes/no question again after an item is entered/cancelled
         // Since it is required, it shouldn't be left null/undefined
-        if (props.data[hasItemsKey]) {
+        if (props.data?.[hasItemsKey]) {
           props.setData({ ...props.data, [hasItemsKey]: undefined });
         }
       };
@@ -192,8 +195,8 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
           (uiSchema &&
             schema?.properties &&
             isMaxItemsReached &&
-            props.data[hasItemsKey] !== false) ||
-          (isReviewPage && props.data[hasItemsKey] == null)
+            props.data?.[hasItemsKey] !== false) ||
+          (isReviewPage && props.data?.[hasItemsKey] == null)
         ) {
           // 1. If the user has reached the max items, we want to make sure the
           //    yes/no field is set to false because it will be hidden yet required.
@@ -439,7 +442,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
 
     const hideAdd = maxItems && arrayData?.length >= maxItems;
 
-    if (schema?.properties && hideAdd) {
+    if (schema?.properties && hideAdd && newSchema.properties?.[hasItemsKey]) {
       newSchema = { ...schema };
       newSchema.properties[hasItemsKey]['ui:hidden'] = true;
     }

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ArrayBuilderSummaryReviewPage = ({
+  customPageProps,
+  arrayBuilderOptions,
+  arrayData,
+  addAnotherItemButtonClick,
+  updatedItemData,
+  Cards,
+  Title,
+  hideAdd,
+}) => {
+  return (
+    <>
+      {arrayData?.length ? (
+        <Title textType="summaryTitle" />
+      ) : (
+        <>
+          <div className="form-review-panel-page-header-row">
+            <h4
+              className="form-review-panel-page-header vads-u-font-size--h5"
+              data-title-for-noun-singular={`${
+                arrayBuilderOptions.nounSingular
+              }`}
+            >
+              {arrayBuilderOptions.getText(
+                'summaryTitle',
+                updatedItemData,
+                customPageProps.data,
+              )}
+            </h4>
+          </div>
+          <dl className="review">
+            <div className="review-row">
+              <dt>
+                {arrayBuilderOptions.getText(
+                  'yesNoBlankReviewQuestion',
+                  null,
+                  customPageProps.data,
+                )}
+              </dt>
+              <dd>
+                <span
+                  className="dd-privacy-hidden"
+                  data-dd-action-name="data value"
+                >
+                  No
+                </span>
+              </dd>
+            </div>
+          </dl>
+        </>
+      )}
+      {arrayBuilderOptions.getText(
+        'summaryDescription',
+        null,
+        customPageProps.data,
+      ) && (
+        <span className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-display--block">
+          {arrayBuilderOptions.getText(
+            'summaryDescription',
+            null,
+            customPageProps.data,
+          )}
+        </span>
+      )}
+      <Cards />
+      {!hideAdd && (
+        <div className="vads-u-margin-top--2">
+          <va-button
+            data-action="add"
+            text={arrayBuilderOptions.getText(
+              'reviewAddButtonText',
+              updatedItemData,
+              customPageProps.data,
+            )}
+            onClick={addAnotherItemButtonClick}
+            name={`${arrayBuilderOptions.nounPlural}AddButton`}
+            primary
+            uswds
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ArrayBuilderSummaryReviewPage;
+
+ArrayBuilderSummaryReviewPage.propTypes = {
+  Cards: PropTypes.func,
+  Title: PropTypes.func,
+  addAnotherItemButtonClick: PropTypes.func,
+  arrayBuilderOptions: PropTypes.object,
+  arrayData: PropTypes.array,
+  customPageProps: PropTypes.shape({
+    onSubmit: PropTypes.func,
+    data: PropTypes.object,
+    pageContentBeforeButtons: PropTypes.node,
+    contentBeforeButtons: PropTypes.node,
+    goBack: PropTypes.func,
+    onContinue: PropTypes.func,
+    contentAfterButtons: PropTypes.node,
+  }),
+  hideAdd: PropTypes.bool,
+  updatedItemData: PropTypes.object,
+};

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
@@ -72,7 +72,7 @@ const ArrayBuilderSummaryReviewPage = ({
             data-action="add"
             text={arrayBuilderOptions.getText(
               'reviewAddButtonText',
-              updatedItemData,
+              arrayData,
               customPageProps.data,
             )}
             onClick={addAnotherItemButtonClick}

--- a/src/platform/forms-system/src/js/patterns/array-builder/README.md
+++ b/src/platform/forms-system/src/js/patterns/array-builder/README.md
@@ -12,7 +12,7 @@ Array builder pattern features an intro page (for required flow), a yes/no quest
     - [Step 2. Create either "required" pages flow or "optional" pages flow](#step-2-create-either-required-pages-flow-or-optional-pages-flow)
     - [Example Pages "Required" Flow](#example-pages-required-flow)
     - [Example Pages "Optional" Flow](#example-pages-optional-flow)
-    - [Example with action link or button instead of yes/no question](#example-with-action-link-or-button-instead-of-yesno-question)
+    - [Example using action link (or button) instead of yes/no question](#example-using-action-link-or-button-instead-of-yesno-question)
     - [Example content at bottom of page](#example-content-at-bottom-of-page)
   - [Web Component Patterns](#web-component-patterns)
     - [Example `arrayBuilderYesNoUI` Text Overrides:](#example-arraybuilderyesnoui-text-overrides)
@@ -297,7 +297,7 @@ export const nounPluralReplaceMePages = arrayBuilderPages( options,
 );
 ```
 
-### Example with action link or button instead of yes/no question
+### Example using action link (or button) instead of yes/no question
 Use the [Optional flow](#example-pages-optional-flow) as a starting point, and make the following replacements:
 
 ```js
@@ -335,7 +335,9 @@ const options = {
 };
 ```
 
-If you use `useLinkInsteadOfYesNo` or `useButtonInsteadOfYesNo`, then `uiSchema` or `schema` will no longer be necessary to give to the `pageBuilder.summaryPage`, because there are no longer any form fields.
+If you want to use a button instead of a link, use `useButtonInsteadOfYesNo: true`.
+
+`uiSchema` or `schema` no longer be necessary if using a link or button.
 
 ### Example content at bottom of page
 If you want additional content below the link or button, you can use the `ContentBeforeButtons` prop at the `form/config` page level.

--- a/src/platform/forms-system/src/js/patterns/array-builder/README.md
+++ b/src/platform/forms-system/src/js/patterns/array-builder/README.md
@@ -301,13 +301,36 @@ export const nounPluralReplaceMePages = arrayBuilderPages( options,
 Use the [Optional flow](#example-pages-optional-flow) as a starting point, and make the following replacements:
 
 ```js
+const title = 'Events from your service';
+const description = (
+  <div>
+    <p>Lorem ipsum dolor sit amet.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do.</p>
+  </div>
+);
+
 /** @type {ArrayBuilderOptions} */
 const options = {
   ...
-  useLinkInsteadOfYesNo: true, // or useButtonInsteadOfYesNo: true,
+  useLinkInsteadOfYesNo: true,
+  required: false,
   text: {
-    ...
-    summaryAddLinkText: data => 'Custom text' // or summaryAddButtonText: data => 'Custom text', (optional)
+    getItemName: item => item.name,
+    summaryTitle: title,
+    summaryTitleWithoutItems: title,
+    summaryDescription: description,
+    summaryDescriptionWithoutItems: description,
+    summaryAddLinkText: (props) => {
+      return props.itemData?.length ? 'Add another event' : 'Add an event';
+    },
+    reviewAddButtonText: (props) => {
+      return props.itemData?.length ? 'Add another event' : 'Add an event';
+    },
+    yesNoBlankReviewQuestion: 'Did you have any events?', // No
+    cardDescription: item =>
+      `${formatReviewDate(item?.dateRange?.from)} - ${formatReviewDate(
+        item?.dateRange?.to,
+      )}`,
   },
 };
 ```

--- a/src/platform/forms-system/src/js/patterns/array-builder/README.md
+++ b/src/platform/forms-system/src/js/patterns/array-builder/README.md
@@ -12,6 +12,8 @@ Array builder pattern features an intro page (for required flow), a yes/no quest
     - [Step 2. Create either "required" pages flow or "optional" pages flow](#step-2-create-either-required-pages-flow-or-optional-pages-flow)
     - [Example Pages "Required" Flow](#example-pages-required-flow)
     - [Example Pages "Optional" Flow](#example-pages-optional-flow)
+    - [Example with action link or button instead of yes/no question](#example-with-action-link-or-button-instead-of-yesno-question)
+    - [Example content at bottom of page](#example-content-at-bottom-of-page)
   - [Web Component Patterns](#web-component-patterns)
     - [Example `arrayBuilderYesNoUI` Text Overrides:](#example-arraybuilderyesnoui-text-overrides)
   - [General Pattern Text Overrides](#general-pattern-text-overrides)
@@ -294,6 +296,43 @@ export const nounPluralReplaceMePages = arrayBuilderPages( options,
   }),
 );
 ```
+
+### Example with action link or button instead of yes/no question
+Use the [Optional flow](#example-pages-optional-flow) as a starting point, and make the following replacements:
+
+```js
+/** @type {ArrayBuilderOptions} */
+const options = {
+  ...
+  useLinkInsteadOfYesNo: true, // or useButtonInsteadOfYesNo: true,
+  text: {
+    ...
+    summaryAddLinkText: data => 'Custom text' // or summaryAddButtonText: data => 'Custom text', (optional)
+  },
+};
+```
+
+If you use `useLinkInsteadOfYesNo` or `useButtonInsteadOfYesNo`, then `uiSchema` or `schema` will no longer be necessary to give to the `pageBuilder.summaryPage`, because there are no longer any form fields.
+
+### Example content at bottom of page
+If you want additional content below the link or button, you can use the `ContentBeforeButtons` prop at the `form/config` page level.
+
+```js
+export const nounPluralReplaceMePages = arrayBuilderPages( options,
+  pageBuilder => ({
+    nounPluralReplaceMeSummary: pageBuilder.summaryPage({
+      ...
+      ContentBeforeButtons: () => (
+        <div>
+          <p>Content before "Finish your form later" link, and back/continue buttons</p>
+        </div>
+      ),
+    }),
+    ...
+  }),
+);
+```
+
 
 ## Web Component Patterns
 | Pattern | Description |

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -475,7 +475,7 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
     if (!pageConfig.uiSchema) {
       page.uiSchema = {};
     }
-    if (!pageConfig.schema) {
+    if (!pageConfig.schema || !Object.keys(pageConfig.schema).length) {
       page.schema = {
         type: 'object',
         properties: {},

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -52,7 +52,7 @@ function throwErrorNoOptionsOrCallbackFunction() {
 
 function throwMissingYesNoField() {
   throw new Error(
-    "arrayBuilderPages `pageBuilder.summaryPage()` must include a `uiSchema` that is using `arrayBuilderYesNoUI` pattern (class 'wc-pattern-array-builder-yes-no')",
+    'arrayBuilderPages `pageBuilder.summaryPage()` must either include a `uiSchema` that is using `arrayBuilderYesNoUI` pattern OR option `useLinkInsteadOfYesNo` or `useButtonInsteadOfYesNo` to array builder primary options.',
   );
 }
 
@@ -60,6 +60,35 @@ function throwMissingYesNoValidation() {
   throw new Error(
     "arrayBuilderPages `pageBuilder.summaryPage()` must include a `uiSchema` that is using `arrayBuilderYesNoUI` pattern instead of `yesNoUI` pattern, or a similar pattern including `yesNoUI` with `'ui:validations'`",
   );
+}
+
+function validateNoSchemaAssociatedWithLinkOrButton(
+  pageConfig,
+  useLinkInsteadOfYesNo,
+  useButtonInsteadOfYesNo,
+) {
+  if (useLinkInsteadOfYesNo || useButtonInsteadOfYesNo) {
+    const noSchemaProp = useLinkInsteadOfYesNo
+      ? 'useLinkInsteadOfYesNo'
+      : 'useButtonInsteadOfYesNo';
+
+    const error =
+      (pageConfig.schema?.properties &&
+        Object.keys(pageConfig.schema.properties).length) ||
+      (pageConfig.uiSchema && Object.keys(pageConfig.uiSchema).length);
+
+    if (error) {
+      const message = `
+        arrayBuilderPages \`pageBuilder.summaryPage()\` does not currently support
+        using \`uiSchema\` or \`schema\` properties when using option \`${noSchemaProp}\`.
+        Provide an empty object for \`uiSchema\` and \`schema\` properties or remove them.
+        For adding content, use \`text\` options \`summaryTitle\`, \`summaryTitleWithoutItems\`,
+        \`summaryDescription\`, \`summaryDescriptionWithoutItems\`, \`summaryAddButtonText\`,
+        \`summaryAddLinkText\`, as well as \`ContentBeforeButtons\` at the \`form/config\` page.
+      `.replace(/\s+/g, ' ');
+      throw new Error(message);
+    }
+  }
 }
 
 function throwIncorrectItemPath() {
@@ -99,7 +128,7 @@ function determineYesNoField(uiSchema) {
   if (uiSchema) {
     for (const key of Object.keys(uiSchema)) {
       if (
-        uiSchema[key]['ui:options'].classNames.includes(
+        uiSchema[key]?.['ui:options']?.classNames?.includes(
           'wc-pattern-array-builder-yes-no',
         )
       ) {
@@ -239,8 +268,11 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
     text: userText = {},
     reviewPath = 'review-and-submit',
     required: userRequired,
+    useLinkInsteadOfYesNo = false,
+    useButtonInsteadOfYesNo = false,
   } = options;
 
+  const usesYesNo = !useLinkInsteadOfYesNo && !useButtonInsteadOfYesNo;
   const getItemName = assignGetItemName(options);
 
   const getText = initGetText({
@@ -264,23 +296,31 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
     },
     summaryPage: pageConfig => {
       summaryPath = pageConfig.path;
-      try {
-        hasItemsKey = determineYesNoField(pageConfig.uiSchema);
-      } catch (e) {
-        throwMissingYesNoField();
+      if (usesYesNo) {
+        try {
+          hasItemsKey = determineYesNoField(pageConfig.uiSchema);
+        } catch (e) {
+          throwMissingYesNoField();
+        }
+        if (!hasItemsKey) {
+          throwMissingYesNoField();
+        }
+        if (!pageConfig.uiSchema?.[hasItemsKey]?.['ui:validations']?.[0]) {
+          throwMissingYesNoValidation();
+        }
       }
-      if (!hasItemsKey) {
-        throwMissingYesNoField();
-      }
-      if (!pageConfig.uiSchema?.[hasItemsKey]?.['ui:validations']?.[0]) {
-        throwMissingYesNoValidation();
-      }
+
+      validateNoSchemaAssociatedWithLinkOrButton(
+        pageConfig,
+        useLinkInsteadOfYesNo,
+        useButtonInsteadOfYesNo,
+      );
       validatePath(summaryPath);
       orderedPageTypes.push('summary');
       return pageConfig;
     },
     itemPage: pageConfig => {
-      if (!pageConfig?.path.includes('/:index')) {
+      if (!pageConfig?.path?.includes('/:index')) {
         throwIncorrectItemPath();
       }
       validatePath(pageConfig?.path);
@@ -332,7 +372,7 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
   const navForwardSummary = ({ formData, goPath, pageList }) => {
     const index = formData[arrayPath] ? formData[arrayPath].length : 0;
 
-    if (formData[hasItemsKey]) {
+    if (formData?.[hasItemsKey]) {
       const path = createArrayBuilderItemAddPath({
         path: firstItemPagePath,
         index,
@@ -396,7 +436,10 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
   };
 
   pageBuilder.summaryPage = pageConfig => {
-    const requiredOpts = ['title', 'path', 'uiSchema', 'schema'];
+    let requiredOpts = ['title', 'path'];
+    if (usesYesNo) {
+      requiredOpts = requiredOpts.concat(['uiSchema', 'schema']);
+    }
     verifyRequiredPropsPageConfig('summaryPage', requiredOpts, pageConfig);
 
     const summaryPageProps = {
@@ -410,9 +453,11 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
       nounPlural,
       nounSingular,
       required,
+      useLinkInsteadOfYesNo,
+      useButtonInsteadOfYesNo,
     };
 
-    return {
+    const page = {
       CustomPageReview: ArrayBuilderSummaryPage({
         isReviewPage: true,
         ...summaryPageProps,
@@ -426,6 +471,18 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
       onNavBack: onNavBackKeepUrlParams,
       ...pageConfig,
     };
+
+    if (!pageConfig.uiSchema) {
+      page.uiSchema = {};
+    }
+    if (!pageConfig.schema) {
+      page.schema = {
+        type: 'object',
+        properties: {},
+      };
+    }
+
+    return page;
   };
 
   pageBuilder.itemPage = pageConfig => {

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -68,6 +68,11 @@ function validateNoSchemaAssociatedWithLinkOrButton(
   useButtonInsteadOfYesNo,
 ) {
   if (useLinkInsteadOfYesNo || useButtonInsteadOfYesNo) {
+    if (useLinkInsteadOfYesNo && useButtonInsteadOfYesNo) {
+      throw new Error(
+        'arrayBuilderPages options cannot include both `useLinkInsteadOfYesNo` and `useButtonInsteadOfYesNo`.',
+      );
+    }
     const noSchemaProp = useLinkInsteadOfYesNo
       ? 'useLinkInsteadOfYesNo'
       : 'useButtonInsteadOfYesNo';

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilderText.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilderText.js
@@ -87,6 +87,8 @@ export const DEFAULT_ARRAY_BUILDER_TEXT = {
   },
   deleteYes: props => `Yes, delete this ${props.nounSingular}`,
   reviewAddButtonText: props => `Add another ${props.nounSingular}`,
+  summaryAddButtonText: props => `Add ${props.nounSingular}`,
+  summaryAddLinkText: props => `Add ${props.nounSingular}`,
   summaryTitle: props => `Review your ${props.nounPlural}`,
   yesNoBlankReviewQuestion: props =>
     `Do you have any ${props.nounPlural} to add?`,

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilder.unit.spec.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilder.unit.spec.js
@@ -208,6 +208,73 @@ describe('arrayBuilderPages required parameters and props tests', () => {
     }
   });
 
+  it('should not throw an error if uiSchema is not defined as long as we have a link or button', () => {
+    const options = {
+      ...validOptions,
+      useLinkInsteadOfYesNo: true,
+    };
+    try {
+      arrayBuilderPages(options, pageBuilder => ({
+        summaryPage: pageBuilder.summaryPage({
+          title: 'Employment history',
+          path: 'employers-summary',
+        }),
+        itemPage: pageBuilder.itemPage({
+          title: 'Name of employer',
+          path: 'employers/name/:index',
+          uiSchema: {},
+          schema: {},
+        }),
+      }));
+      expect(true).to.be.true;
+    } catch (e) {
+      expect(
+        'Error should not be thrown for missing uiSchema when using link',
+      ).to.eq(e.message);
+    }
+  });
+
+  it("it should throw an error if a user tries to use uiSchema properties but we aren't using it", () => {
+    const options = {
+      ...validOptions,
+      useLinkInsteadOfYesNo: true,
+    };
+    try {
+      arrayBuilderPages(options, pageBuilder => ({
+        summaryPage: pageBuilder.summaryPage({
+          title: 'Employment history',
+          path: 'employers-summary',
+          uiSchema: {
+            test: {
+              'ui:title': 'Hello',
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              test: {
+                type: 'string',
+              },
+            },
+          },
+        }),
+        itemPage: pageBuilder.itemPage({
+          title: 'Name of employer',
+          path: 'employers/name/:index',
+          uiSchema: {},
+          schema: {},
+        }),
+      }));
+      expect(
+        'Expected error to be thrown when using useLinkInsteadOfYesNo with uiSchema',
+      ).to.be.false;
+    } catch (e) {
+      expect(e.message).to.include(
+        'does not currently support using `uiSchema` or `schema` properties when using option `useLinkInsteadOfYesNo`',
+      );
+    }
+  });
+
   it('should throw an error if specific options are not provided', () => {
     try {
       arrayBuilderPages({}, pageBuilder => ({

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
@@ -106,6 +106,10 @@ describe('ArrayBuilderSummaryPage', () => {
     isReviewPage = false,
     reviewErrors,
     text,
+    uiSchema,
+    schema,
+    useButtonInsteadOfYesNo,
+    useLinkInsteadOfYesNo,
   }) {
     const setFormData = sinon.spy();
     const goToPath = sinon.spy();
@@ -127,21 +131,27 @@ describe('ArrayBuilderSummaryPage', () => {
     });
 
     const summaryPage = {
-      uiSchema: {
-        'view:hasOption': arrayBuilderYesNoUI({
-          arrayPath: 'employers',
-          nounSingular: 'employer',
-          required: false,
-          maxItems,
-        }),
-      },
-      schema: {
-        type: 'object',
-        properties: {
-          'view:hasOption': arrayBuilderYesNoSchema,
-        },
-        required: ['view:hasOption'],
-      },
+      uiSchema:
+        uiSchema !== undefined
+          ? uiSchema
+          : {
+              'view:hasOption': arrayBuilderYesNoUI({
+                arrayPath: 'employers',
+                nounSingular: 'employer',
+                required: false,
+                maxItems,
+              }),
+            },
+      schema:
+        schema !== undefined
+          ? schema
+          : {
+              type: 'object',
+              properties: {
+                'view:hasOption': arrayBuilderYesNoSchema,
+              },
+              required: ['view:hasOption'],
+            },
     };
 
     const CustomPage = ArrayBuilderSummaryPage({
@@ -157,6 +167,8 @@ describe('ArrayBuilderSummaryPage', () => {
       summaryRoute: '/summary',
       introRoute: '/intro',
       reviewRoute: '/review',
+      useButtonInsteadOfYesNo,
+      useLinkInsteadOfYesNo,
       getText,
     });
 
@@ -191,6 +203,8 @@ describe('ArrayBuilderSummaryPage', () => {
 
     expect(container.querySelector('va-radio')).to.exist;
     expect(container.querySelector('va-card')).to.not.exist;
+    expect(container.querySelector('.wc-pattern-array-builder-yes-no')).to
+      .exist;
   });
 
   it('should display appropriately with 1 items', () => {
@@ -384,5 +398,52 @@ describe('ArrayBuilderSummaryPage', () => {
     const description = $fieldset.querySelector('span');
     expect(description).to.exist;
     expect(description).to.include.text('Custom summary description');
+  });
+
+  it('should allow for showing a link instead of a yes no question', () => {
+    const { container } = setupArrayBuilderSummaryPage({
+      arrayData: [{ name: 'Test' }],
+      urlParams: '',
+      uiSchema: null,
+      schema: null,
+      useLinkInsteadOfYesNo: true,
+    });
+
+    expect(container.querySelector('va-link-action[name="employersAddLink"]'))
+      .to.exist;
+    expect(container.querySelector('va-button[name="employersAddButton"]')).to
+      .not.exist;
+    expect(container.querySelector('.wc-pattern-array-builder-yes-no')).to.not
+      .exist;
+  });
+
+  it('should allow for showing a button instead of a yes no question', () => {
+    const { container } = setupArrayBuilderSummaryPage({
+      arrayData: [{ name: 'Test' }],
+      urlParams: '',
+      uiSchema: null,
+      schema: null,
+      useButtonInsteadOfYesNo: true,
+    });
+
+    expect(container.querySelector('va-link-action[name="employersAddLink"]'))
+      .to.not.exist;
+    expect(container.querySelector('va-button[name="employersAddButton"]')).to
+      .exist;
+    expect(container.querySelector('.wc-pattern-array-builder-yes-no')).to.not
+      .exist;
+  });
+
+  it('should allow empty schema with a link', () => {
+    const { container } = setupArrayBuilderSummaryPage({
+      arrayData: [{ name: 'Test' }],
+      urlParams: '',
+      uiSchema: null,
+      schema: null,
+      useLinkInsteadOfYesNo: true,
+    });
+
+    expect(container.querySelector('va-link-action[name="employersAddLink"]'))
+      .to.exist;
   });
 });

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -429,6 +429,8 @@
  *   summaryTitleWithoutItems?: (props: ArrayBuilderTextProps) => string,
  *   summaryDescription?: (props: ArrayBuilderTextProps) => string,
  *   summaryDescriptionWithoutItems?: (props: ArrayBuilderTextProps) => string,
+ *   summaryAddLinkText?: (props: ArrayBuilderTextProps) => string,
+ *   summaryAddButtonText?: (props: ArrayBuilderTextProps) => string,
  *   yesNoBlankReviewQuestion?: (props: ArrayBuilderTextProps) => string,
  * }} ArrayBuilderText
  */
@@ -453,4 +455,6 @@
  * @property {boolean} required This determines the flow type of the array builder. Required starts with an intro page, optional starts with the yes/no question (summary page).
  * @property {string} [reviewPath] Defaults to `'review-and-submit'` if not provided.
  * @property {ArrayBuilderText} [text] Override any default text used in the array builder pattern
+ * @property {boolean} [useLinkInsteadOfYesNo]
+ * @property {boolean} [useButtonInsteadOfYesNo]
  */


### PR DESCRIPTION
## Summary

- Add options `useLinkInsteadOfYesNo` and `useButtonInsteadOfYesNo` for array builder

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1801

## Testing done

- Unit, browser, regression, tested as a consumer

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/005aaa54-95d6-4dc0-ae12-496786c7ef61)

After:
![image](https://github.com/user-attachments/assets/87e189b8-ec36-4e1c-9c31-1ccc12994a78)

## What areas of the site does it impact?

array builder options

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
