### PR TITLE
add missing validations for 5490

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -972,6 +972,7 @@ const formConfig = {
                   ],
                 },
                 street2: {
+                  'ui:title': 'Street address line 2',
                   'ui:validations': [
                     (errors, field) => {
                       if (field?.length > 40) {
@@ -990,8 +991,8 @@ const formConfig = {
                         errors.addError('Please enter a valid city');
                       } else if (field?.length < 2) {
                         errors.addError('minimum of 2 characters');
-                      } else if (field?.length > 40) {
-                        errors.addError('maximum of 40 characters');
+                      } else if (field?.length > 20) {
+                        errors.addError('maximum of 20 characters');
                       }
                     },
                   ],
@@ -1013,24 +1014,44 @@ const formConfig = {
                   },
                 },
                 state: {
-                  'ui:title': 'State/County/Province',
+                  'ui:options': {
+                    replaceSchema: formData => {
+                      if (
+                        formData?.mailingAddressInput?.livesOnMilitaryBase ||
+                        formData?.mailingAddressInput?.address?.country ===
+                          'USA'
+                      ) {
+                        return {
+                          title: 'State',
+                          type: 'string',
+                        };
+                      }
+                      return {
+                        title: 'State/County/Province',
+                        type: 'string',
+                      };
+                    },
+                  },
                   'ui:required': formData =>
                     formData?.mailingAddressInput?.livesOnMilitaryBase ||
                     formData?.mailingAddressInput?.address?.country === 'USA',
                 },
                 postalCode: {
                   'ui:errorMessages': {
-                    required: 'Zip code must be 5 digits',
+                    required: 'This field is required.',
                   },
                   'ui:options': {
                     replaceSchema: formData => {
                       if (
+                        formData?.mailingAddressInput?.livesOnMilitaryBase ||
                         formData?.mailingAddressInput?.address?.country !==
-                        'USA'
+                          'USA'
                       ) {
                         return {
                           title: 'Postal Code',
                           type: 'string',
+                          maxLength: 10,
+                          minLength: 3,
                         };
                       }
 

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -971,6 +971,15 @@ const formConfig = {
                     },
                   ],
                 },
+                street2: {
+                  'ui:validations': [
+                    (errors, field) => {
+                      if (field?.length > 40) {
+                        errors.addError('maximum of 40 characters');
+                      }
+                    },
+                  ],
+                },
                 city: {
                   'ui:errorMessages': {
                     required: 'Please enter a valid city',
@@ -979,6 +988,10 @@ const formConfig = {
                     (errors, field) => {
                       if (isOnlyWhitespace(field)) {
                         errors.addError('Please enter a valid city');
+                      } else if (field?.length < 2) {
+                        errors.addError('minimum of 2 characters');
+                      } else if (field?.length > 40) {
+                        errors.addError('maximum of 40 characters');
                       }
                     },
                   ],

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.js
@@ -514,9 +514,17 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
       'input#root_mailingAddressInput_address_street',
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     );
+
+    fillData(
+      form,
+      'input#root_mailingAddressInput_address_street2',
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
     form.find('form').simulate('submit');
 
     expect(errorMessages.at(0).text()).to.include('maximum of 40 characters');
+    expect(errorMessages.at(1).text()).to.include('maximum of 40 characters');
+
     form.unmount();
   });
 

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.js
@@ -515,15 +515,8 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     );
 
-    fillData(
-      form,
-      'input#root_mailingAddressInput_address_street2',
-      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    );
     form.find('form').simulate('submit');
-
     expect(errorMessages.at(0).text()).to.include('maximum of 40 characters');
-    expect(errorMessages.at(1).text()).to.include('maximum of 40 characters');
 
     form.unmount();
   });


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add missing city and street 2 validations to 5490

