### PR TITLE
VACMS-19599: Fix bug for previous than 15 years and month function for results page

### DIFF
--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import moment from 'moment';
-import { differenceInYears } from 'date-fns';
 import * as options from 'platform/static-data/options-for-select';
 import {
   questionLabels,
@@ -278,7 +277,7 @@ export const determineBranchOfService = key =>
 
 // Determines if a previous discharge occurred more than 15 years ago.
 export const determineOldDischarge = (dischargeYear, dischargeMonth) =>
-  differenceInYears(new Date(), new Date(dischargeMonth, dischargeYear)) >= 15;
+  new Date() >= new Date(Number(dischargeYear) + 15, dischargeMonth);
 
 // Determines the label used on the review page to provide a full readable answer based on answers in the form.
 export const answerReviewLabel = (key, formValues) => {
@@ -358,9 +357,9 @@ export const determineBoardObj = (formResponses, noDRB) => {
   const intention =
     formResponses[SHORT_NAME_MAP.INTENTION] === RESPONSES.INTENTION_YES;
   const dischargeYear = formResponses[SHORT_NAME_MAP.DISCHARGE_YEAR];
-  const dischargeMonth = formResponses[SHORT_NAME_MAP.DISCHARGE_MONTH] || 0;
+  const dischargeMonth = formResponses[SHORT_NAME_MAP.DISCHARGE_MONTH] - 1 || 0;
 
-  const oldDischarge = determineOldDischarge(dischargeMonth, dischargeYear);
+  const oldDischarge = determineOldDischarge(dischargeYear, dischargeMonth);
 
   const failureToExhaust = [
     RESPONSES.FAILURE_TO_EXHAUST_BCMR_YES,
@@ -645,16 +644,14 @@ export const getBoardExplanation = formResponses => {
   const prevAppType = formResponses[SHORT_NAME_MAP.PREV_APPLICATION_TYPE];
   const prevAppYear = formResponses[SHORT_NAME_MAP.PREV_APPLICATION_YEAR];
   const dischargeYear = formResponses[SHORT_NAME_MAP.DISCHARGE_YEAR];
-  const dischargeMonth = formResponses[SHORT_NAME_MAP.DISCHARGE_MONTH] || 1;
-  const oldDischarge =
-    new Date().getFullYear() -
-      new Date(dischargeYear, dischargeMonth).getFullYear() >
-    15;
+  const dischargeMonth = formResponses[SHORT_NAME_MAP.DISCHARGE_MONTH] - 1 || 0;
+  const oldDischarge = determineOldDischarge(dischargeYear, dischargeMonth);
 
   const boardToSubmit = determineBoardObj(formResponses);
   const serviceBranch = determineBranchOfService(
     formResponses[SHORT_NAME_MAP.SERVICE_BRANCH],
   );
+
   const { abbr, name } = boardToSubmit;
 
   if (reason === RESPONSES.REASON_DD215_UPDATE_TO_DD214) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
There was a bug in the discharge year/month logic for displaying dynamic text on the results page. This PR fixes that bug and cleans up the logic.

## Related issue(s)
[#19599](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19599)

## Testing done
Tested flows that utilizes the dynamic content on the results page. Ensured there was no regression in testing. Example test case:
![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/user-attachments/assets/4204ee40-29db-4af9-ade9-7a158b7d1650)



## Screenshots
![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/user-attachments/assets/5a14565f-ed91-47c3-84a2-c2a2a4de88a1)

## What areas of the site does it impact?
DUW v2

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

