### PR TITLE
Conditions Fix error on searchTerm being undefined and focusOption being null

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -7,7 +7,7 @@ import { fullStringSimilaritySearch } from 'platform/forms-system/src/js/utiliti
 const COMBOBOX_LIST_MAX_HEIGHT = '440px';
 const defaultHighlightedIndex = -1;
 
-const getSelectionMessage = searchTerm => {
+const getSelectionMessage = (searchTerm = '') => {
   return searchTerm.trim() === '' ? '' : `${searchTerm} is selected.`;
 };
 
@@ -273,7 +273,7 @@ export class ComboBox extends React.Component {
 
   optionFocus(index) {
     const focusOption = document.getElementById(`option-${index}`);
-    focusOption.focus();
+    focusOption?.focus();
   }
 
   // Click handler for a list item


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Summarize the changes that have been made to the platform:
  - Added default argument to `getSelectionMessage` to prevent searchTerm from being undefined and therefore resulting in an error here `searchTerm.trim()`
  - Added optional chaining to `focusOption.focus()` to prevent error
- If bug, how to reproduce
  - Without these PR changes, just put the focus on the Enter your condition input to trigger the error on `searchTerm`
  - With just the searchTerm default argument addition, just put the focus on the Enter your condition input and then arrow down to trigger the error on `focusOption.focus()`
- Which team do you work for, does your team own the maintenance of this component? Conditions Team and Yes

## Testing done

- Describe the steps required to verify your changes are working as expected
  - Save a condition in the `Enter your condition` input
  - Test other normal user interactions for this page

## Screenshots
### Before
On input focus...
<img width="1048" alt="Screenshot 2024-11-07 at 1 17 35 PM" src="https://github.com/user-attachments/assets/387aa0ca-a3ed-45d2-aeba-1da82b1159a0">
On input focus with the above fixed then arrow down...
<img width="1042" alt="Screenshot 2024-11-07 at 1 18 43 PM" src="https://github.com/user-attachments/assets/a4194465-bc9a-4ebf-a5c6-f34094840b6e">

### After
<img width="1044" alt="Screenshot 2024-11-07 at 1 18 25 PM" src="https://github.com/user-attachments/assets/2e445949-1e34-4995-83bb-5d5cd4fb5293">
<img width="1060" alt="Screenshot 2024-11-07 at 1 19 27 PM" src="https://github.com/user-attachments/assets/6df85818-3a75-49f7-bd7c-c6216125e2a2">


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
