### PR TITLE
Remove streamlined waiver asset update

### DIFF
--- a/src/applications/financial-status-report/components/monetary/CashInBank.jsx
+++ b/src/applications/financial-status-report/components/monetary/CashInBank.jsx
@@ -126,6 +126,7 @@ CashInBank.propTypes = {
   }),
   goBack: PropTypes.func,
   goForward: PropTypes.func,
+  goToPath: PropTypes.func,
   setFormData: PropTypes.func,
 };
 
@@ -162,9 +163,7 @@ const CashInBankReview = ({ data, goToPath }) => {
     //  cash on hand page since it's the head of the chapter
     const gmtDepends =
       (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
-      (gmtData?.isEligibleForStreamlined &&
-        gmtData?.incomeBelowOneFiftyGmt &&
-        data['view:streamlinedWaiverAssetUpdate']);
+      (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowOneFiftyGmt);
 
     if (gmtDepends || data['view:reviewPageNavigationToggle']) {
       return goToPath('/cash-on-hand');
@@ -212,7 +211,6 @@ CashInBankReview.propTypes = {
       isEligibleForStreamlined: PropTypes.bool,
       incomeBelowOneFiftyGmt: PropTypes.bool,
     }),
-    'view:streamlinedWaiverAssetUpdate': PropTypes.bool,
   }),
 };
 

--- a/src/applications/financial-status-report/components/monetary/CashOnHand.jsx
+++ b/src/applications/financial-status-report/components/monetary/CashOnHand.jsx
@@ -1,15 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { focusElement } from 'platform/utilities/ui';
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { setData } from 'platform/forms-system/src/js/actions';
 import { isValidCurrency } from '../../utils/validations';
-import { currency as currencyFormatter } from '../../utils/helpers';
-import { safeNumber } from '../../utils/calculateIncome';
 
-import ReviewPageHeader from '../shared/ReviewPageHeader';
 import ReviewPageNavigationAlert from '../alerts/ReviewPageNavigationAlert';
 
 const CASH_ON_HAND = 'Cash on hand (not in bank)';
@@ -24,12 +19,12 @@ const CashOnHand = ({
   setFormData,
 }) => {
   const headerRef = useRef(null);
-  const { assets, gmtData } = data;
+  const { assets } = data;
   const {
     reviewNavigation = false,
     'view:reviewPageNavigationToggle': showReviewNavigation,
   } = data;
-  const { cashOnHand, monetaryAssets = [] } = assets;
+  const { monetaryAssets = [] } = assets;
 
   useEffect(
     () => {
@@ -44,11 +39,7 @@ const CashOnHand = ({
     amount: '',
   };
 
-  const [cash, setCash] = useState(
-    data['view:streamlinedWaiverAssetUpdate']
-      ? cashOnHandTotal.amount
-      : cashOnHand,
-  );
+  const [cash, setCash] = useState(cashOnHandTotal?.amount);
   const ERR_MSG = 'Please enter a valid dollar amount';
   const [error, setError] = useState(null);
 
@@ -61,33 +52,17 @@ const CashOnHand = ({
       asset => asset.name !== CASH_ON_HAND,
     );
 
-    // New asset caclulation adds cash on hand to monetary assets array.
-    // secondary condition can be removed when feature flag is disabled
-    if (data['view:streamlinedWaiverAssetUpdate']) {
-      setFormData({
-        ...data,
-        assets: {
-          ...data.assets,
-          monetaryAssets: [
-            ...filteredMonetaryAssets,
-            { name: CASH_ON_HAND, amount: cash },
-          ],
-        },
-      });
-    } else {
-      // update form data & gmtIsShort
-      setFormData({
-        ...data,
-        assets: {
-          ...data.assets,
-          cashOnHand: cash,
-        },
-        gmtData: {
-          ...gmtData,
-          cashBelowGmt: safeNumber(cash) < gmtData?.assetThreshold,
-        },
-      });
-    }
+    setFormData({
+      ...data,
+      assets: {
+        ...data.assets,
+        monetaryAssets: [
+          ...filteredMonetaryAssets,
+          { name: CASH_ON_HAND, amount: cash },
+        ],
+      },
+    });
+
     return setError(null);
   };
 
@@ -161,12 +136,7 @@ CashOnHand.propTypes = {
   contentBeforeButtons: PropTypes.object,
   data: PropTypes.shape({
     assets: PropTypes.shape({
-      cashOnHand: PropTypes.string,
       monetaryAssets: PropTypes.array,
-    }),
-    'view:streamlinedWaiverAssetUpdate': PropTypes.bool,
-    gmtData: PropTypes.shape({
-      assetThreshold: PropTypes.number,
     }),
     reviewNavigation: PropTypes.bool,
     'view:reviewPageNavigationToggle': PropTypes.bool,
@@ -177,61 +147,4 @@ CashOnHand.propTypes = {
   setFormData: PropTypes.func,
 };
 
-// Cash on hand review component won't be necessary after feature flag is disabled
-//  because cash on hand will be added to monetary assets array
-const CashOnHandReview = ({ data, goToPath }) => {
-  const dispatch = useDispatch();
-  const {
-    assets,
-    'view:reviewPageNavigationToggle': showReviewNavigation,
-  } = data;
-  const { cashOnHand } = assets;
-
-  // set reviewNavigation to true to show the review page alert
-  const onReviewClick = () => {
-    dispatch(
-      setData({
-        ...data,
-        reviewNavigation: true,
-      }),
-    );
-    goToPath('/cash-on-hand');
-  };
-
-  return data['view:streamlinedWaiverAssetUpdate'] ? null : (
-    <>
-      {showReviewNavigation ? (
-        <ReviewPageHeader
-          title="household assets"
-          goToPath={() => onReviewClick()}
-        />
-      ) : null}
-      <div className="form-review-panel-page">
-        <div className="form-review-panel-page-header-row">
-          <h4 className="form-review-panel-page-header vads-u-font-size--h5">
-            Cash on hand
-          </h4>
-        </div>
-        <dl className="review">
-          <div className="review-row">
-            <dt>Available cash (not in a bank)</dt>
-            <dd>{currencyFormatter(cashOnHand)}</dd>
-          </div>
-        </dl>
-      </div>
-    </>
-  );
-};
-
-CashOnHandReview.propTypes = {
-  data: PropTypes.shape({
-    assets: PropTypes.shape({
-      cashOnHand: PropTypes.string,
-    }),
-    'view:streamlinedWaiverAssetUpdate': PropTypes.bool,
-    'view:reviewPageNavigationToggle': PropTypes.bool,
-  }),
-  goToPath: PropTypes.func,
-};
-
-export { CashOnHand, CashOnHandReview };
+export { CashOnHand };

--- a/src/applications/financial-status-report/components/monetary/MonetaryAssetsSummaryReview.jsx
+++ b/src/applications/financial-status-report/components/monetary/MonetaryAssetsSummaryReview.jsx
@@ -9,7 +9,6 @@ const MonetaryAssetsSummaryReview = ({ data, goToPath }) => {
   const dispatch = useDispatch();
   const {
     assets,
-    gmtData,
     'view:reviewPageNavigationToggle': showReviewNavigation,
   } = data;
   const { monetaryAssets = [] } = assets;
@@ -22,20 +21,7 @@ const MonetaryAssetsSummaryReview = ({ data, goToPath }) => {
         reviewNavigation: true,
       }),
     );
-
-    // if the user saw cash on hand/in bank, they should be routed to
-    //  cash on hand page since it's the head of the chapter
-
-    const gmtDepends =
-      (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
-      (gmtData?.isEligibleForStreamlined &&
-        gmtData?.incomeBelowOneFiftyGmt &&
-        data['view:streamlinedWaiverAssetUpdate']);
-
-    if (gmtDepends || showReviewNavigation) {
-      return goToPath('/cash-on-hand');
-    }
-    return goToPath('/monetary-asset-checklist');
+    return goToPath('/cash-on-hand');
   };
 
   return (
@@ -72,12 +58,6 @@ MonetaryAssetsSummaryReview.propTypes = {
     assets: PropTypes.shape({
       monetaryAssets: PropTypes.array,
     }),
-    gmtData: PropTypes.shape({
-      incomeBelowGmt: PropTypes.bool,
-      isEligibleForStreamlined: PropTypes.bool,
-      incomeBelowOneFiftyGmt: PropTypes.bool,
-    }),
-    'view:streamlinedWaiverAssetUpdate': PropTypes.bool,
     'view:reviewPageNavigationToggle': PropTypes.bool,
   }),
   goToPath: PropTypes.func,

--- a/src/applications/financial-status-report/components/monetary/MonetaryCheckList.jsx
+++ b/src/applications/financial-status-report/components/monetary/MonetaryCheckList.jsx
@@ -17,7 +17,6 @@ const MonetaryCheckList = ({
 }) => {
   const {
     assets,
-    gmtData,
     reviewNavigation = false,
     'view:reviewPageNavigationToggle': showReviewNavigation,
   } = data;
@@ -53,40 +52,8 @@ const MonetaryCheckList = ({
   const title = 'Your household assets';
   const prompt = 'Select any of these financial assets you have:';
 
-  // noCashList - remove cash in hand for original asset implementation
-  //  only used to protect save in progress for forms prior to streamlinedWaiverAssetUpdate
-  const noCashList = monetaryAssetList.filter(
-    asset => asset.toLowerCase() !== 'cash',
-  );
-
-  // noLiquidAssetsList - remove liquid assets for streamlinedWaiverAssetUpdate
-  //  this filter hides all the fields we collect in previous steps
-  const noLiquidAssetsList = noCashList.filter(
-    asset =>
-      asset.toLowerCase() !== 'checking accounts' &&
-      asset.toLowerCase() !== 'savings accounts',
-  );
-
-  const streamlinedList = data['view:streamlinedWaiverAssetUpdate']
-    ? noLiquidAssetsList
-    : noCashList;
-
-  // only filtering out these options for streamlined candidiates
-  const adjustForStreamlined =
-    (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
-    (data['view:streamlinedWaiverAssetUpdate'] &&
-      gmtData?.isEligibleForStreamlined &&
-      gmtData?.incomeBelowOneFiftyGmt);
-
-  const adjustedAssetList =
-    adjustForStreamlined || showReviewNavigation
-      ? streamlinedList
-      : monetaryAssetList;
-
-  // reviewDepends - only show/handle review alert and navigation if
-  //  feature flag is on, user is in review mode, and they have not seen the cash pages
-  const reviewDepends =
-    reviewNavigation && showReviewNavigation && !adjustForStreamlined;
+  // reviewDepends - only show/handle review alert and navigation
+  const reviewDepends = reviewNavigation && showReviewNavigation;
 
   const handleBackNavigation = () => {
     if (reviewDepends) {
@@ -118,7 +85,7 @@ const MonetaryCheckList = ({
         ) : null}
         <Checklist
           prompt={prompt}
-          options={adjustedAssetList}
+          options={monetaryAssetList}
           onChange={event => onChange(event)}
           isBoxChecked={isBoxChecked}
         />
@@ -141,16 +108,11 @@ MonetaryCheckList.propTypes = {
     assets: PropTypes.shape({
       monetaryAssets: PropTypes.array,
     }),
-    gmtData: PropTypes.shape({
-      incomeBelowGmt: PropTypes.bool,
-      isEligibleForStreamlined: PropTypes.bool,
-      incomeBelowOneFiftyGmt: PropTypes.bool,
-    }),
+
     reviewNavigation: PropTypes.bool,
     questions: PropTypes.shape({
       isMarried: PropTypes.bool,
     }),
-    'view:streamlinedWaiverAssetUpdate': PropTypes.bool,
     'view:reviewPageNavigationToggle': PropTypes.bool,
   }),
   goBack: PropTypes.func,

--- a/src/applications/financial-status-report/components/monetary/MonetaryInputList.jsx
+++ b/src/applications/financial-status-report/components/monetary/MonetaryInputList.jsx
@@ -4,7 +4,6 @@ import { setData } from 'platform/forms-system/src/js/actions';
 import PropTypes from 'prop-types';
 import InputList from '../shared/InputList';
 import { VALIDATION_LIMITS } from '../../constants';
-// import { safeNumber } from '../../utils/calculateIncome';
 
 const MonetaryInputList = props => {
   const { errorSchema, formContext } = props;
@@ -16,7 +15,6 @@ const MonetaryInputList = props => {
 
   const {
     assets: { monetaryAssets = [] },
-    gmtData,
   } = data;
 
   const onChange = ({ target }) => {
@@ -43,37 +41,12 @@ const MonetaryInputList = props => {
   const prompt =
     'How much are each of your financial assets worth? Include the total amounts for you and your spouse.';
 
-  // noCashList - remove cash in hand for original asset implementation
-  //  only used to protect save in progress for forms prior to streamlinedWaiverAssetUpdate
-  const noCashList = monetaryAssets.filter(
-    asset => asset?.name?.toLowerCase() !== 'cash',
-  );
-
-  // noLiquidAssetsList - remove liquid assets for streamlinedWaiverAssetUpdate
-  //  this filter hides all the newly populated fields we collect in previous steps
-  const noLiquidAssetsList = noCashList.filter(
+  // this filter hides all the newly populated fields we collect in previous steps
+  const adjustedAssetList = monetaryAssets.filter(
     asset =>
-      asset?.name?.toLowerCase() !== 'checking accounts' &&
-      asset?.name?.toLowerCase() !== 'savings accounts' &&
       asset?.name?.toLowerCase() !== 'cash on hand (not in bank)' &&
       asset?.name?.toLowerCase() !== 'cash in a bank (savings and checkings)',
   );
-
-  const streamlinedList = data['view:streamlinedWaiverAssetUpdate']
-    ? noLiquidAssetsList
-    : noCashList;
-
-  // only filtering out these options for streamlined candidiates
-  const adjustForStreamlined =
-    (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
-    (data['view:streamlinedWaiverAssetUpdate'] &&
-      gmtData?.isEligibleForStreamlined &&
-      gmtData?.incomeBelowOneFiftyGmt);
-
-  const adjustedAssetList =
-    adjustForStreamlined || data['view:reviewPageNavigationToggle']
-      ? streamlinedList
-      : monetaryAssets;
 
   return (
     <InputList
@@ -93,10 +66,6 @@ MonetaryInputList.propTypes = {
   errorSchema: PropTypes.shape({
     monetaryAssets: PropTypes.shape({
       __errors: PropTypes.array,
-    }),
-    gmtData: PropTypes.shape({
-      isEligibleForStreamlined: PropTypes.bool,
-      incomeBelowGmt: PropTypes.bool,
     }),
   }),
   formContext: PropTypes.shape({

--- a/src/applications/financial-status-report/components/otherAssets/OtherAssetsChecklist.jsx
+++ b/src/applications/financial-status-report/components/otherAssets/OtherAssetsChecklist.jsx
@@ -4,7 +4,6 @@ import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButto
 
 import { otherAssetOptions } from '../../constants/checkboxSelections';
 import Checklist from '../shared/CheckList';
-import { calculateLiquidAssets } from '../../utils/streamlinedDepends';
 
 const OtherAssetsChecklist = ({
   data,
@@ -17,34 +16,10 @@ const OtherAssetsChecklist = ({
 }) => {
   const {
     assets,
-    gmtData,
     reviewNavigation = false,
     'view:reviewPageNavigationToggle': showReviewNavigation,
   } = data;
   const { otherAssets = [] } = assets;
-
-  // Calculate total assets as necessary
-  // - Calculating these assets is only necessary in the long form version
-  const updateStreamlinedValues = () => {
-    if (
-      otherAssets?.length ||
-      !gmtData?.isEligibleForStreamlined ||
-      gmtData?.incomeBelowGmt
-    )
-      return;
-
-    // liquid assets are caluclated in cash in bank with this ff
-    if (data['view:streamlinedWaiverAssetUpdate']) return;
-
-    const calculatedAssets = calculateLiquidAssets(data);
-    setFormData({
-      ...data,
-      gmtData: {
-        ...gmtData,
-        assetsBelowGmt: calculatedAssets < gmtData?.assetThreshold,
-      },
-    });
-  };
 
   const onChange = ({ name, checked }) => {
     setFormData({
@@ -96,7 +71,7 @@ const OtherAssetsChecklist = ({
           {contentBeforeButtons}
           <FormNavButtons
             goBack={goBack}
-            goForward={updateStreamlinedValues}
+            goForward={goForward}
             submitToContinue
           />
           {contentAfterButtons}
@@ -113,15 +88,10 @@ OtherAssetsChecklist.propTypes = {
     assets: PropTypes.shape({
       otherAssets: PropTypes.array,
     }),
-    gmtData: PropTypes.shape({
-      assetThreshold: PropTypes.number,
-      incomeBelowGmt: PropTypes.bool,
-      isEligibleForStreamlined: PropTypes.bool,
-    }),
     questions: PropTypes.shape({
       isMarried: PropTypes.bool,
     }),
-    'view:streamlinedWaiverAssetUpdate': PropTypes.bool,
+    reviewNavigation: PropTypes.bool,
     'view:reviewPageNavigationToggle': PropTypes.bool,
   }),
   goBack: PropTypes.func,

--- a/src/applications/financial-status-report/components/otherAssets/OtherAssetsSummary.jsx
+++ b/src/applications/financial-status-report/components/otherAssets/OtherAssetsSummary.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 import {
@@ -12,7 +12,6 @@ import {
   firstLetterLowerCase,
   generateUniqueKey,
 } from '../../utils/helpers';
-import { calculateLiquidAssets } from '../../utils/streamlinedDepends';
 import ButtonGroup from '../shared/ButtonGroup';
 
 export const keyFieldsForOtherAssets = ['name', 'amount'];
@@ -27,7 +26,6 @@ const OtherAssetsSummary = ({
 }) => {
   const {
     assets,
-    gmtData,
     reviewNavigation = false,
     'view:reviewPageNavigationToggle': showReviewNavigation,
   } = data;
@@ -38,26 +36,6 @@ const OtherAssetsSummary = ({
     reviewNavigation && showReviewNavigation
       ? 'Continue to review page'
       : 'Continue';
-
-  useEffect(
-    () => {
-      if (!gmtData?.isEligibleForStreamlined) return;
-      // liquid assets are caluclated in cash in bank with this ff
-      if (data['view:streamlinedWaiverAssetUpdate']) return;
-
-      const calculatedAssets = calculateLiquidAssets(data);
-      setFormData({
-        ...data,
-        gmtData: {
-          ...gmtData,
-          assetsBelowGmt: calculatedAssets < gmtData?.assetThreshold,
-        },
-      });
-    },
-    // avoiding use of data since it changes so often
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [otherAssets, gmtData?.isEligibleForStreamlined, gmtData?.assetThreshold],
-  );
 
   const onDelete = deleteIndex => {
     setFormData({
@@ -200,13 +178,7 @@ OtherAssetsSummary.propTypes = {
     assets: PropTypes.shape({
       otherAssets: PropTypes.array,
     }),
-    gmtData: PropTypes.shape({
-      assetThreshold: PropTypes.number,
-      assetsBelowGmt: PropTypes.bool,
-      isEligibleForStreamlined: PropTypes.bool,
-    }),
     reviewNavigation: PropTypes.bool,
-    'view:streamlinedWaiverAssetUpdate': PropTypes.bool,
     'view:reviewPageNavigationToggle': PropTypes.bool,
   }),
   goForward: PropTypes.func,

--- a/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
+++ b/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
@@ -18,10 +18,7 @@ import EnhancedVehicleRecord from '../../components/otherAssets/EnhancedVehicleR
 import VehicleSummaryWidget from '../../components/otherAssets/VehicleSummaryWidget';
 import MonetaryAssetsSummaryReview from '../../components/monetary/MonetaryAssetsSummaryReview';
 import VehicleSummaryReview from '../../components/otherAssets/VehicleSummaryReview';
-import {
-  CashOnHand,
-  CashOnHandReview,
-} from '../../components/monetary/CashOnHand';
+import { CashOnHand } from '../../components/monetary/CashOnHand';
 import RecreationalVehiclesReview from '../../components/otherAssets/RecreationalVehcilesReview';
 import StreamlinedExplainer from '../../components/shared/StreamlinedExplainer';
 import { isStreamlinedShortForm } from '../../utils/streamlinedDepends';
@@ -42,17 +39,7 @@ export default {
         uiSchema: {},
         schema: { type: 'object', properties: {} },
         CustomPage: CashOnHand,
-        CustomPageReview: CashOnHandReview,
-        depends: formData => {
-          const { gmtData } = formData;
-          // Also show if the new asset update is true
-          const gmtDepends =
-            (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
-            (gmtData?.isEligibleForStreamlined &&
-              gmtData?.incomeBelowOneFiftyGmt &&
-              formData['view:streamlinedWaiverAssetUpdate']);
-          return gmtDepends || formData['view:reviewPageNavigationToggle'];
-        },
+        CustomPageReview: null,
       },
       cashInBank: {
         path: 'cash-in-bank',
@@ -61,15 +48,6 @@ export default {
         schema: { type: 'object', properties: {} },
         CustomPage: CashInBank,
         CustomPageReview: CashInBankReview,
-        depends: formData => {
-          const { gmtData } = formData;
-          // Only show if the new asset update is true
-          const gmtDepends =
-            gmtData?.isEligibleForStreamlined &&
-            gmtData?.incomeBelowOneFiftyGmt &&
-            formData['view:streamlinedWaiverAssetUpdate'];
-          return gmtDepends || formData['view:reviewPageNavigationToggle'];
-        },
       },
       streamlinedShortTransitionPage: {
         // Transition page - streamlined short form only

--- a/src/applications/financial-status-report/constants/checkboxSelections.js
+++ b/src/applications/financial-status-report/constants/checkboxSelections.js
@@ -12,9 +12,6 @@ export const otherIncome = [
 ];
 
 export const monetaryAssets = [
-  'Cash',
-  'Checking accounts',
-  'Savings accounts',
   'U.S. Savings Bonds',
   'Retirement accounts (401k, IRAs, 403b, TSP)',
   'Other stocks and bonds (not in your retirement accounts)',

--- a/src/applications/financial-status-report/mocks/development.js
+++ b/src/applications/financial-status-report/mocks/development.js
@@ -1,7 +1,7 @@
 // when USE_MOCK is true, the application will use the copay mock data below instead of live api data
 export const USE_COPAY_MOCK_DATA = false;
 // when USE_GEOGRAPHIC_MOCK_DATA is true, the application will use the geographic mock data below instead of live api data
-export const USE_GEOGRAPHIC_MOCK_DATA = false;
+export const USE_GEOGRAPHIC_MOCK_DATA = true;
 // this is the value that will be used for GMT calculations when USE_GEOGRAPHIC_MOCK_DATA is true
 export const MOCK_GMT_VALUE = 78300;
 // when USE_STAGING_DATA is true, the application will use the staging api instead of the production api or USE_GEOGRAPHIC_MOCK_DATA

--- a/src/applications/financial-status-report/mocks/development.js
+++ b/src/applications/financial-status-report/mocks/development.js
@@ -1,7 +1,7 @@
 // when USE_MOCK is true, the application will use the copay mock data below instead of live api data
 export const USE_COPAY_MOCK_DATA = false;
 // when USE_GEOGRAPHIC_MOCK_DATA is true, the application will use the geographic mock data below instead of live api data
-export const USE_GEOGRAPHIC_MOCK_DATA = true;
+export const USE_GEOGRAPHIC_MOCK_DATA = false;
 // this is the value that will be used for GMT calculations when USE_GEOGRAPHIC_MOCK_DATA is true
 export const MOCK_GMT_VALUE = 78300;
 // when USE_STAGING_DATA is true, the application will use the staging api instead of the production api or USE_GEOGRAPHIC_MOCK_DATA

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
@@ -314,18 +314,11 @@ const testConfig = createTestConfig(
       },
       'monetary-asset-checklist': ({ afterHook }) => {
         afterHook(() => {
-          cy.get('@testData').then(testData => {
-            const monetaryAssetChecklistLength = testData[
-              'view:streamlinedWaiverAssetUpdate'
-            ]
-              ? 5
-              : 8;
-            cy.get('va-checkbox')
-              .shadow()
-              .find('input[type=checkbox]')
-              .as('checklist')
-              .should('have.length', monetaryAssetChecklistLength);
-          });
+          cy.get('va-checkbox')
+            .shadow()
+            .find('input[type=checkbox]')
+            .as('checklist')
+            .should('have.length', 5);
 
           // Check specific checkboxes
           cy.get('va-checkbox')
@@ -350,33 +343,16 @@ const testConfig = createTestConfig(
           cy.get('va-text-input')
             .as('numberInputs')
             .should('have.length', 2);
-
-          // check testData to see if assets feature flag is true to udpate the length the checkbox should be
-          cy.get('@testData').then(testData => {
-            if (testData['view:streamlinedWaiverAssetUpdate']) {
-              cy.get('[id="U.S. Savings Bonds0"]')
-                .first()
-                .shadow()
-                .find('input')
-                .type('1000');
-              cy.get('[id="Retirement accounts (401k, IRAs, 403b, TSP)1"]')
-                .first()
-                .shadow()
-                .find('input')
-                .type('1500');
-            } else {
-              cy.get('#Cash0')
-                .first()
-                .shadow()
-                .find('input')
-                .type('1000');
-              cy.get('[id="Checking accounts1"]')
-                .first()
-                .shadow()
-                .find('input')
-                .type('1500');
-            }
-          });
+          cy.get('[id="U.S. Savings Bonds0"]')
+            .first()
+            .shadow()
+            .find('input')
+            .type('1000');
+          cy.get('[id="Retirement accounts (401k, IRAs, 403b, TSP)1"]')
+            .first()
+            .shadow()
+            .find('input')
+            .type('1500');
           cy.get('.usa-button-primary').click();
         });
       },


### PR DESCRIPTION
## Summary

Financial_status_report_streamlined_waiver_assets has been removed for some time now, it's safe to remove any remaining references to it via `streamlinedWaiverAssetUpdate`. The flag has been defaulted to true

Flag is defaulted to true in src/applications/financial-status-report/containers/App.jsx:155

https://github.com/department-of-veterans-affairs/vets-website/pull/28078
Feature flag clean up tickets:
[FSR] Deprecate unused enhanced feature flag [#94930](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/94930)
[FSR] Deprecate unused streamlinedwaiver feature flag [#94931](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/94931)
[FSR] Deprecate unused streamlinedWaiverAssetUpdate feature flag [#94932](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/94932) (this one)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#94932


## Testing done

- Manual Testing
- Verified unit and cypress tests pass as expected


