### PR TITLE
DR | Fix focus issue on array pages

### DIFF
--- a/src/applications/appeals/shared/tests/utils/focus.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/focus.unit.spec.js
@@ -5,89 +5,15 @@ import sinon from 'sinon';
 
 import { $ } from '~/platform/forms-system/src/js/utilities/ui';
 import * as focusUtils from '~/platform/utilities/ui/focus';
+import * as focusReview from 'platform/forms-system/src/js/utilities/ui/focus-review';
 
 import {
-  focusIssue,
   focusFileCard,
   focusAddAnotherButton,
   focusCancelButton,
-  focusRadioH3,
-  focusAlertH3,
-  focusToggledHeader,
-  focusH3,
   focusOnAlert,
+  focusH3AfterAlert,
 } from '../../utils/focus';
-import { LAST_ISSUE } from '../../constants';
-
-describe('focusIssue', () => {
-  afterEach(() => {
-    window.sessionStorage.removeItem(LAST_ISSUE);
-  });
-  const renderPage = () =>
-    render(
-      <div id="main">
-        <h3>Title</h3>
-        <ul>
-          <li id="issue-0">
-            <input />
-            <a href="#0" className="edit-issue-link">
-              Edit
-            </a>
-          </li>
-          <li id="issue-1">
-            <input />
-            <a href="#1" className="edit-issue-link">
-              Edit
-            </a>
-          </li>
-        </ul>
-        <a href="#new" className="add-new-issue">
-          Add
-        </a>
-      </div>,
-    );
-
-  it('should focus on header', async () => {
-    window.sessionStorage.removeItem(LAST_ISSUE);
-    const { container } = await renderPage();
-
-    await focusIssue(0, container);
-    await waitFor(() => {
-      const target = $('h3', container);
-      expect(document.activeElement).to.eq(target);
-    });
-  });
-  it('should focus on add new issue link', async () => {
-    window.sessionStorage.setItem(LAST_ISSUE, -1);
-    const { container } = await renderPage();
-
-    await focusIssue(0, container);
-    await waitFor(() => {
-      const target = $('.add-new-issue', container);
-      expect(document.activeElement).to.eq(target);
-    });
-  });
-  it('should focus on second input', async () => {
-    window.sessionStorage.setItem(LAST_ISSUE, '1,updated');
-    const { container } = await renderPage();
-
-    await focusIssue(0, container);
-    await waitFor(() => {
-      const target = $('#issue-1 input', container);
-      expect(document.activeElement).to.eq(target);
-    });
-  });
-  it('should focus on second edit link', async () => {
-    window.sessionStorage.setItem(LAST_ISSUE, '1,cancel');
-    const { container } = await renderPage();
-
-    await focusIssue(0, container);
-    await waitFor(() => {
-      const target = $('#issue-1 .edit-issue-link', container);
-      expect(document.activeElement).to.eq(target);
-    });
-  });
-});
 
 describe('focusFileCard', () => {
   let focusElementSpy;
@@ -300,84 +226,6 @@ describe('focusAddAnotherButton', () => {
   });
 });
 
-describe('focusRadioH3', () => {
-  const renderPage = (hasRadio = true) =>
-    render(
-      <div id="main">
-        {hasRadio ? (
-          <va-radio label-header-level="3" label="test">
-            <va-radio-option label="1" name="test" value="1" />
-            <va-radio-option label="2" name="test" value="2" />
-          </va-radio>
-        ) : (
-          <div className="nav-header">
-            <h2>test 2</h2>
-          </div>
-        )}
-      </div>,
-    );
-
-  it('should focus on H3', async () => {
-    // h3 is inside shadow DOM (not supported in RTL), so test by stubbing
-    // waitForRenderThenFocus
-    const focusSpy = sinon.spy(focusUtils, 'waitForRenderThenFocus');
-    await renderPage();
-
-    await focusRadioH3();
-    await waitFor(() => {
-      expect(focusSpy.args[0][0]).to.eq('h3');
-      focusSpy.restore();
-    });
-  });
-  it('should focus on H2', async () => {
-    const { container } = await renderPage(false);
-
-    await focusRadioH3();
-    await waitFor(() => {
-      const target = $('h2', container);
-      expect(document.activeElement).to.eq(target);
-    });
-  });
-});
-
-describe('focusAlertH3', () => {
-  const renderPage = () =>
-    render(
-      <div id="main">
-        <h3>test</h3>
-      </div>,
-    );
-
-  it('should focus on H3', async () => {
-    const { container } = await renderPage();
-
-    await focusAlertH3();
-    await waitFor(() => {
-      const target = $('h3', container);
-      expect(document.activeElement).to.eq(target);
-    });
-  });
-});
-
-describe('focusH3', () => {
-  const renderPage = () =>
-    render(
-      <div id="main">
-        <h3>test</h3>
-      </div>,
-    );
-
-  it('should focus on H3', async () => {
-    const { container } = await renderPage();
-
-    await focusH3();
-    await waitFor(() => {
-      const target = $('h3', container);
-      expect(document.activeElement).to.eq(target);
-    });
-  });
-});
-
 describe('focusOnAlert', () => {
   const renderPage = (hasErrorAlert = true) =>
     render(
@@ -413,42 +261,49 @@ describe('focusOnAlert', () => {
   });
 });
 
-describe('focusToggledHeader', () => {
-  const renderPage = (hasRadio = true) =>
+describe('focusH3AfterAlert', () => {
+  let focusElementSpy;
+  let focusReviewSpy;
+  beforeEach(() => {
+    focusElementSpy = sinon.stub(focusUtils, 'focusElement');
+    focusReviewSpy = sinon.stub(focusReview, 'focusReview');
+  });
+  afterEach(() => {
+    focusElementSpy.restore();
+    focusReviewSpy.restore();
+  });
+
+  const setup = () =>
     render(
       <div id="main">
-        {hasRadio ? (
-          <va-radio label-header-level="3" label="test">
-            <va-radio-option label="1" name="test" value="1" />
-            <va-radio-option label="2" name="test" value="2" />
-          </va-radio>
-        ) : (
-          <div className="nav-header">
-            <h3>test 2</h3>
-          </div>
-        )}
+        <div name="topContentElement" />
+        <div name="testScrollElement" />
+        <div>
+          <va-alert status="info" visible="false">
+            <h3 id="alert" slot="headline">
+              Alert header
+            </h3>
+          </va-alert>
+          <h3 id="header">Page header</h3>
+        </div>
       </div>,
     );
 
-  it('should focus on H3 inside va-radio', async () => {
-    global.sessionStorage.setItem('hlrUpdated', 'false');
-    const focusSpy = sinon.spy(focusUtils, 'waitForRenderThenFocus');
-    await renderPage();
+  it('should focus on h3 outside of va-alert on review page', async () => {
+    setup();
 
-    await focusToggledHeader();
+    await focusH3AfterAlert();
     await waitFor(() => {
-      expect(focusSpy.args[0][0]).to.eq('h3');
-      focusSpy.restore();
+      expect(focusElementSpy.args[0][0]).to.eq('h3#header');
     });
   });
-  it('should focus on H3', async () => {
-    global.sessionStorage.setItem('hlrUpdated', 'true');
-    const { container } = await renderPage(false);
 
-    await focusToggledHeader();
+  it('should focus on header on review page', async () => {
+    setup();
+
+    await focusH3AfterAlert(null, { name: 'test', onReviewPage: true });
     await waitFor(() => {
-      const target = $('h3', container);
-      expect(document.activeElement).to.eq(target);
+      expect(focusReviewSpy.args[0]).to.deep.equal(['test', true, true]);
     });
   });
 });

--- a/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.js
@@ -1,0 +1,234 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { $ } from '~/platform/forms-system/src/js/utilities/ui';
+import * as focusUtils from '~/platform/utilities/ui/focus';
+
+import {
+  focusH3,
+  focusRadioH3,
+  focusIssue,
+  focusAlertH3,
+  focusEvidence,
+  focusToggledHeader,
+} from '../../utils/focus';
+import { LAST_ISSUE } from '../../constants';
+
+describe('focusH3', () => {
+  const renderPage = () =>
+    render(
+      <div id="main">
+        <h3>test</h3>
+      </div>,
+    );
+
+  it('should focus on H3', async () => {
+    const { container } = await renderPage();
+
+    await focusH3(null, container);
+    await waitFor(() => {
+      const target = $('h3', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});
+
+describe('focusRadioH3', () => {
+  const renderPage = (hasRadio = true) =>
+    render(
+      <div id="main">
+        {hasRadio ? (
+          <va-radio label-header-level="3" label="test">
+            <va-radio-option label="1" name="test" value="1" />
+            <va-radio-option label="2" name="test" value="2" />
+          </va-radio>
+        ) : (
+          <div className="nav-header">
+            <h2>test 2</h2>
+          </div>
+        )}
+      </div>,
+    );
+
+  it('should focus on H3', async () => {
+    // h3 is inside shadow DOM (not supported in RTL), so test by stubbing
+    // waitForRenderThenFocus
+    const focusSpy = sinon.spy(focusUtils, 'waitForRenderThenFocus');
+    const { container } = await renderPage();
+
+    await focusRadioH3(null, container);
+    await waitFor(() => {
+      expect(focusSpy.args[0][0]).to.eq('h3');
+      focusSpy.restore();
+    });
+  });
+  it('should focus on H2', async () => {
+    const { container } = await renderPage(false);
+
+    await focusRadioH3(null, container);
+    await waitFor(() => {
+      const target = $('h2', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});
+
+describe('focusIssue', () => {
+  afterEach(() => {
+    window.sessionStorage.removeItem(LAST_ISSUE);
+  });
+  const renderPage = () =>
+    render(
+      <div id="main">
+        <h3>Title</h3>
+        <ul>
+          <li id="issue-0">
+            <input />
+            <a href="#0" className="edit-issue-link">
+              Edit
+            </a>
+          </li>
+          <li id="issue-1">
+            <input />
+            <a href="#1" className="edit-issue-link">
+              Edit
+            </a>
+          </li>
+        </ul>
+        <a href="#new" className="add-new-issue">
+          Add
+        </a>
+      </div>,
+    );
+
+  it('should focus on header', async () => {
+    window.sessionStorage.removeItem(LAST_ISSUE);
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('h3', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on add new issue link', async () => {
+    window.sessionStorage.setItem(LAST_ISSUE, -1);
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('.add-new-issue', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on second input', async () => {
+    window.sessionStorage.setItem(LAST_ISSUE, '1,updated');
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('#issue-1 input', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on second edit link', async () => {
+    window.sessionStorage.setItem(LAST_ISSUE, '1,cancel');
+    const { container } = await renderPage();
+
+    await focusIssue(0, container);
+    await waitFor(() => {
+      const target = $('#issue-1 .edit-issue-link', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});
+
+describe('focusAlertH3', () => {
+  const renderPage = () =>
+    render(
+      <div id="main">
+        <h3>test</h3>
+      </div>,
+    );
+
+  it('should focus on H3', async () => {
+    const { container } = await renderPage();
+
+    await focusAlertH3(null, container);
+    await waitFor(() => {
+      const target = $('h3', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});
+
+describe('focusEvidence', () => {
+  const renderPage = hasError =>
+    render(
+      <div id="main">
+        <h3>Title</h3>
+        {hasError ? <div error="true" /> : <div />}
+      </div>,
+    );
+
+  it('should focus on header', async () => {
+    const { container } = await renderPage();
+
+    await focusEvidence(null, container);
+    await waitFor(() => {
+      const target = $('h3', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should focus on error', async () => {
+    const { container } = await renderPage(true);
+
+    await focusEvidence(null, container);
+    await waitFor(() => {
+      const target = $('[error]', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});
+
+describe('focusToggledHeader', () => {
+  const renderPage = (hasRadio = true) =>
+    render(
+      <div id="main">
+        {hasRadio ? (
+          <va-radio label-header-level="3" label="test">
+            <va-radio-option label="1" name="test" value="1" />
+            <va-radio-option label="2" name="test" value="2" />
+          </va-radio>
+        ) : (
+          <div className="nav-header">
+            <h3>test 2</h3>
+          </div>
+        )}
+      </div>,
+    );
+
+  it('should focus on H3 inside va-radio', async () => {
+    global.sessionStorage.setItem('hlrUpdated', 'false');
+    const focusSpy = sinon.spy(focusUtils, 'waitForRenderThenFocus');
+    const { container } = await renderPage();
+
+    await focusToggledHeader(null, container);
+    await waitFor(() => {
+      expect(focusSpy.args[0][0]).to.eq('h3');
+      focusSpy.restore();
+    });
+  });
+  it('should focus on H3', async () => {
+    global.sessionStorage.setItem('hlrUpdated', 'true');
+    const { container } = await renderPage(false);
+
+    await focusToggledHeader(null, container);
+    await waitFor(() => {
+      const target = $('h3', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+});

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -12,7 +12,7 @@ import { $, $$ } from '~/platform/forms-system/src/js/utilities/ui';
 
 import { LAST_ISSUE } from '../constants';
 
-export const focusFirstError = (root = document) => {
+export const focusFirstError = (_index, root) => {
   const error = $('[error]', root);
   if (error) {
     scrollToFirstError({ focusOnAlertRole: true });
@@ -21,27 +21,26 @@ export const focusFirstError = (root = document) => {
   return false;
 };
 
-export const focusEvidence = (_index, root) => {
+export const focusEvidence = (index, root) => {
   setTimeout(() => {
-    if (!focusFirstError(root)) {
+    if (!focusFirstError(index, root)) {
       scrollTo('topContentElement');
       focusElement('#main h3', null, root);
     }
   });
 };
 
-export const focusH3AfterAlert = ({
-  name,
-  onReviewPage,
-  root = document,
-} = {}) => {
+export const focusH3AfterAlert = (
+  index,
+  { name, onReviewPage, root = document } = {},
+) => {
   if (name && onReviewPage) {
     focusReview(
       name, // name of scroll element
       true, // review accordion in edit mode
       true, // reviewEditFocusOnHeaders setting from form/config.js
     );
-  } else if (!focusFirstError(root)) {
+  } else if (!focusFirstError(index, root)) {
     scrollTo('topContentElement');
     focusElement('h3#header', null, root);
   }
@@ -140,21 +139,20 @@ export const focusRadioH3 = () => {
 };
 
 // Testing focus on role="alert" inside web components
-export const focusH3OrRadioError = () => {
+export const focusH3OrRadioError = (_index, root) => {
   scrollTo('topContentElement');
-  const radio = $('va-radio, va-checkbox-group');
+  const radio = $('va-radio, va-checkbox-group', root);
   const hasError = radio.getAttribute('error');
   const target = hasError ? '[role="alert"]' : 'h3';
-  const root = hasError ? radio.shadowRoot : document;
-  waitForRenderThenFocus(target, root);
+  waitForRenderThenFocus(target, hasError ? radio.shadowRoot : root);
 };
 
 // Temporary focus function for HLR homlessness question (page header is
 // dynamic); once 100% released, change homeless form config to use
 // `scrollAndFocusTarget: focusH3`
-export const focusToggledHeader = () => {
+export const focusToggledHeader = (_index, root) => {
   scrollTo('topContentElement');
-  const radio = $('va-radio');
+  const radio = $('va-radio', root);
   if ((sessionStorage.getItem('hlrUpdated') || 'false') === 'false' && radio) {
     waitForRenderThenFocus('h3', radio.shadowRoot);
   } else {
@@ -162,14 +160,14 @@ export const focusToggledHeader = () => {
   }
 };
 
-export const focusH3 = (root = document) => {
+export const focusH3 = (index, root) => {
   scrollTo('topContentElement');
-  if (!focusFirstError(root)) {
+  if (!focusFirstError(index, root)) {
     focusElement('#main h3');
   }
 };
 
-export const focusAlertH3 = (root = document) => {
+export const focusAlertH3 = (_index, root = document) => {
   scrollTo('topContentElement');
   const alert = $('va-alert[visible="true"]', root);
   // va-alert header is not in the shadow DOM, but still the content doesn't


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > When on an array page, the focus function called by `scrollAndFocusTarget` will pass in a page index parameter. This conflicts with how the functions are set up. The `focusH3` function expects a `root` parameter, which defaults to the `document`, to allow passing in the rendered container in unit tests. When an index is passed in, the focus `querySelector` is attempted on the index causing a JS error.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95199

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Split out focus functions specifically called by the `scrollAndFocusTarget` function because there are other internal focus functions that don't expect an index parameter. Splitting these up _should_ avoid confusion.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Higher-Level Review & Notice of Disagreement forms

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
