### PR TITLE
[96361] Set PDF Generation rep and org ids correctly

### DIFF
--- a/src/applications/representative-appoint/utilities/pdfTransform.js
+++ b/src/applications/representative-appoint/utilities/pdfTransform.js
@@ -1,4 +1,4 @@
-import { isAttorneyOrClaimsAgent } from './helpers';
+import { getRepType } from './helpers';
 
 function consentLimitsTransform(formData) {
   const authorizeRecords = formData['view:authorizeRecordsCheckbox'] || {};
@@ -81,12 +81,23 @@ export function pdfTransform(formData) {
           email: applicantEmail || '',
         };
 
-  const representative = {
-    id: selectedRep?.id,
-  };
+  const repType = getRepType(selectedRep);
 
-  if (!isAttorneyOrClaimsAgent(formData)) {
-    representative.organizationId = formData.selectedAccreditedOrganizationId;
+  const representative = {};
+
+  if (repType !== 'Organization') {
+    representative.id = selectedRep?.id;
+  }
+
+  if (repType === 'Organization') {
+    representative.organizationId = selectedRep?.id;
+  } else if (repType === 'VSO Representative') {
+    if (formData?.selectedAccreditedOrganizationId) {
+      representative.organizationId = formData.selectedAccreditedOrganizationId;
+    } else {
+      representative.organizationId =
+        selectedRep?.attributes?.accreditedOrganizations?.data[0]?.id;
+    }
   }
 
   return {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr changes the representative id and organization id pdf generation payload attributes to correctly handle the single org rep and only org appointment use cases.

## Related issue(s)

- [96361](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96361)

## Testing done

- Went through the flow locally for all rep type combinations and was able to get to the pdf download page

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)