### PR TITLE
update privacy notice to include checkbox

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/components/PreSubmitInfo.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/components/PreSubmitInfo.jsx
@@ -1,23 +1,37 @@
 import React from 'react';
+import { VaPrivacyAgreement } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { connect } from 'react-redux';
+import { setPreSubmit as setPreSubmitAction } from 'platform/forms-system/src/js/actions';
 
-const CustomPreSubmitInfo = () => {
-  // Note text to be displayed with the privacy policy link
-  const noteText = (
-    <>
-      <strong>Note:</strong> According to federal law, there are criminal
-      penalties, including a fine and/or imprisonment for up to 5 years, for
-      withholding information or for providing incorrect information (See 18
-      U.S.C. 1001).{' '}
-      <a
-        href="https://www.va.gov/privacy-policy/"
-        target="_blank"
-        rel="noreferrer"
-        aria-label="Privacy policy, will open in new tab"
-      >
-        Learn more about our privacy policy
-      </a>
-    </>
+function PreSubmitNotice({ formData, showError, setPreSubmit }) {
+  const privacyAgreementAccepted = formData.privacyAgreementAccepted || false;
+
+  const privacyAgreement = (
+    <div>
+      <div>
+        <strong>Note:</strong> According to federal law, there are criminal
+        penalties, including a fine and/or imprisonment for up to 5 years, for
+        withholding information or for providing incorrect information. (See 18
+        U.S.C. 1001)
+      </div>
+      <VaPrivacyAgreement
+        name="privacyAgreementAccepted"
+        onVaChange={event =>
+          setPreSubmit('privacyAgreementAccepted', event.detail.checked)
+        }
+        showError={showError && !privacyAgreementAccepted}
+      />
+    </div>
   );
-  return <div className="vads-u-margin-bottom--1p5">{noteText}</div>;
+
+  return <>{privacyAgreement}</>;
+}
+
+const mapDispatchToProps = {
+  setPreSubmit: setPreSubmitAction,
 };
-export default CustomPreSubmitInfo;
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(PreSubmitNotice);

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -162,7 +162,7 @@ const formConfig = {
   footerContent: FormFooter,
   preSubmitInfo: {
     CustomComponent: CustomPreSubmitInfo,
-    required: false,
+    required: true,
     field: 'privacyAgreementAccepted',
   },
   chapters: {


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update presubmit info to have radio button acknowledging statement

## Screenshots

<img width="900" alt="Screenshot 2024-11-11 at 3 10 47 PM" src="https://github.com/user-attachments/assets/e1f47bd9-1177-4eab-aa48-589d286eec7a">

