### PR TITLE
MHV-64019: fixed a bug with filter selection reset on dropdown collapse

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
@@ -4,12 +4,14 @@ import {
   VaRadio,
   VaRadioOption,
   VaButton,
+  VaAccordion,
+  VaAccordionItem,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
   filterOptions,
   SESSION_SELECTED_FILTER_OPTION,
 } from '../../util/constants';
-import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const MedicationsListFilter = props => {
   const { updateFilter, filterOption, setFilterOption } = props;
@@ -26,7 +28,7 @@ const MedicationsListFilter = props => {
   const handleAccordionItemToggle = ({ target }) => {
     if (target) {
       const isOpen = target.getAttribute('open');
-      if (!isOpen) {
+      if (isOpen === 'false') {
         setFilterOption(
           sessionStorage.getItem(SESSION_SELECTED_FILTER_OPTION) || null,
         );
@@ -36,19 +38,21 @@ const MedicationsListFilter = props => {
 
   const filterOptionsArray = Object.keys(filterOptions);
   return (
-    <va-accordion
+    <VaAccordion
       bordered
       open-single
       data-testid="filter-accordion"
       class="filter-accordion"
       onAccordionItemToggled={handleAccordionItemToggle}
+      uswds
     >
-      <va-accordion-item
+      <VaAccordionItem
         header="Filter list"
         bordered="true"
         open={!!filterOption}
         id="filter"
         data-testid="rx-filter"
+        uswds
       >
         <span slot="icon">
           <va-icon aria-hidden="true" icon="filter_alt" />
@@ -76,8 +80,8 @@ const MedicationsListFilter = props => {
           text="Filter"
           data-testid="filter-button"
         />
-      </va-accordion-item>
-    </va-accordion>
+      </VaAccordionItem>
+    </VaAccordion>
   );
 };
 


### PR DESCRIPTION
This is a follow up fix for #32935

## Summary

1. Layout updates + focus logic for `MedicationsListFilter`
2. Removed sr-only `h2` for `MedicationsList` (behind the feature flag)
3. Removed the Sort button and made sorting apply automatically on the dropdown value change for `MedicationsListSort` (behind the feature flag)

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-64019

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Remove 24 px spacing above select a filter
AC2: Add 24 px space above filter button
AC3: Filter button should be a fixed width on desktop (keep full width on mobile) - this should be a property of the button if you're using the correct VA component
AC4: If user does not click filter after selecting an option, it should not be saved if they leave and come back, collapse, or refresh the page
AC5: After filter button is clicked, the focus should land on the "Showing 1-20..." 
AC6: Remove the "Sort" button next to the sort dropdown.
AC7: We originally intended for the H2 to read "List of Medications," but RX now has a new visible H2 header. We should remove the SR-only text on RX.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
