### PR TITLE
adds error handling to interstitial

### DIFF
--- a/src/applications/sign-in-changes/containers/InterstitialChanges.jsx
+++ b/src/applications/sign-in-changes/containers/InterstitialChanges.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import {
+  VaAlert,
   VaLink,
   VaLoadingIndicator,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
@@ -14,6 +15,7 @@ export default function InterstitialChanges() {
 
   const [userEmails, setUserEmails] = useState({});
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     apiRequest('/user/credential_emails', {
@@ -26,7 +28,10 @@ export default function InterstitialChanges() {
         setUserEmails(data);
         setIsLoading(false);
       })
-      .catch(() => {});
+      .catch(() => {
+        setError(true);
+        setIsLoading(false);
+      });
   }, []);
 
   const showAccount = userEmails?.logingov || userEmails?.idme;
@@ -34,6 +39,15 @@ export default function InterstitialChanges() {
 
   if (isLoading) {
     return <VaLoadingIndicator />;
+  }
+  if (error) {
+    return (
+      <div>
+        <VaAlert status="error" closeable={false} showIcon uswds>
+          <h1 slot="headline">401: Not authorized</h1>
+        </VaAlert>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Currently only users who are authenticated should get redirected to '/sign-in-changes-reminder'. However, if an unauthenticated user we're to somehow get directed to that endpoint, they would see a loading spinner indefinitely. To fix this issue, we are throwing the '401 not authorized' error on the API side. This ticket is to display that error on the front end to the user.

## Related issue(s)

[Jira Ticket](https://jira.devops.va.gov/browse/VI-754)

## Testing done

- unit tests passing

## Screenshots

<img width="969" alt="Screenshot 2024-11-12 at 1 32 34 PM" src="https://github.com/user-attachments/assets/b6aaa333-fc81-418d-971e-51ab2f50cad8">

## What areas of the site does it impact?

```/sign-in-changes-reminder```

## Acceptance criteria

- check if user is authenticated
- display VaAlert if user is un-authenticated
- update/add unit test coverage as needed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
