### PR TITLE
Cc/95263/provider mock

### DIFF
--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -1,8 +1,15 @@
+import { captureError } from '../../utils/error';
+import { getProviderById } from '../../services/referral';
+
 export const SET_FACILITY = 'SET_FACILITY';
 export const SET_APPOINTMENT_DETAILS = 'SET_APPOINTMENT_DETAILS';
 export const SET_SORT_PROVIDER_BY = 'SET_SORT_PROVIDER_BY';
 export const SET_SELECTED_PROVIDER = 'SET_SELECTED_PROVIDER';
 export const SET_FORM_CURRENT_PAGE = 'SET_FORM_CURRENT_PAGE';
+export const FETCH_PROVIDER_DETAILS = 'FETCH_PROVIDER_DETAILS';
+export const FETCH_PROVIDER_DETAILS_SUCCEEDED =
+  'FETCH_PROVIDER_DETAILS_SUCCEEDED';
+export const FETCH_PROVIDER_DETAILS_FAILED = 'FETCH_PROVIDER_DETAILS_FAILED';
 
 export function setFacility(facility) {
   return {
@@ -39,5 +46,27 @@ export function setFormCurrentPage(currentPage) {
   return {
     type: SET_FORM_CURRENT_PAGE,
     payload: currentPage,
+  };
+}
+
+export function fetchProviderDetails(id) {
+  return async dispatch => {
+    try {
+      dispatch({
+        type: FETCH_PROVIDER_DETAILS,
+      });
+      const providerDetails = await getProviderById(id);
+
+      dispatch({
+        type: FETCH_PROVIDER_DETAILS_SUCCEEDED,
+        data: providerDetails,
+      });
+      return providerDetails;
+    } catch (error) {
+      dispatch({
+        type: FETCH_PROVIDER_DETAILS_FAILED,
+      });
+      return captureError(error);
+    }
   };
 }

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -4,13 +4,18 @@ import {
   SET_SORT_PROVIDER_BY,
   SET_SELECTED_PROVIDER,
   SET_FORM_CURRENT_PAGE,
+  FETCH_PROVIDER_DETAILS,
+  FETCH_PROVIDER_DETAILS_FAILED,
+  FETCH_PROVIDER_DETAILS_SUCCEEDED,
 } from './actions';
+import { FETCH_STATUS } from '../../utils/constants';
 
 const initialState = {
   facility: null,
   sortProviderBy: '',
   selectedProvider: '',
   currentPage: null,
+  providerFetchStatus: FETCH_STATUS.notStarted,
 };
 
 function ccAppointmentReducer(state = initialState, action) {
@@ -40,6 +45,22 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         currentPage: action.payload,
+      };
+    case FETCH_PROVIDER_DETAILS:
+      return {
+        ...state,
+        providerFetchStatus: FETCH_STATUS.loading,
+      };
+    case FETCH_PROVIDER_DETAILS_SUCCEEDED:
+      return {
+        ...state,
+        providerFetchStatus: FETCH_STATUS.succeeded,
+        selectedProvider: action.data,
+      };
+    case FETCH_PROVIDER_DETAILS_FAILED:
+      return {
+        ...state,
+        providerFetchStatus: FETCH_STATUS.failed,
       };
     default:
       return state;

--- a/src/applications/vaos/referral-appointments/redux/selectors.js
+++ b/src/applications/vaos/referral-appointments/redux/selectors.js
@@ -2,3 +2,10 @@ export const selectCCAppointment = state => state.ccAppointment;
 export const selectProvider = state => state.referral.selectedProvider;
 export const selectProviderSortBy = state => state.referral.sortProviderBy;
 export const selectCurrentPage = state => state.referral.currentPage;
+
+export function getProviderInfo(state) {
+  return {
+    provider: state.referral.selectedProvider,
+    providerFetchStatus: state.referral.providerFetchStatus,
+  };
+}

--- a/src/applications/vaos/referral-appointments/temp-data/referral.js
+++ b/src/applications/vaos/referral-appointments/temp-data/referral.js
@@ -19,6 +19,7 @@ const getAvailableSlots = (number = 2) => {
 const referral = {
   id: 123456,
   providerName: 'Dr. Face',
+  provider: '111',
   typeOfCare: 'Dermatology',
   appointmentCount: 2,
   orgName: 'New Skin Technologies',

--- a/src/applications/vaos/referral-appointments/temp-data/referral.js
+++ b/src/applications/vaos/referral-appointments/temp-data/referral.js
@@ -19,7 +19,7 @@ const getAvailableSlots = (number = 2) => {
 const referral = {
   id: 123456,
   providerName: 'Dr. Face',
-  provider: '111',
+  provider: '3',
   typeOfCare: 'Dermatology',
   appointmentCount: 2,
   orgName: 'New Skin Technologies',

--- a/src/applications/vaos/referral-appointments/temp-data/referral.js
+++ b/src/applications/vaos/referral-appointments/temp-data/referral.js
@@ -19,7 +19,7 @@ const getAvailableSlots = (number = 2) => {
 const referral = {
   id: 123456,
   providerName: 'Dr. Face',
-  provider: '3',
+  provider: '111',
   typeOfCare: 'Dermatology',
   appointmentCount: 2,
   orgName: 'New Skin Technologies',

--- a/src/applications/vaos/referral-appointments/tests/utils/provider.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/utils/provider.unit.spec.js
@@ -1,0 +1,26 @@
+import { addDays, startOfDay, addHours } from 'date-fns';
+import { expect } from 'chai';
+
+const providerUtil = require('../../utils/provider');
+
+describe('VAOS provider generator', () => {
+  const tomorrow = addDays(startOfDay(new Date()), 1);
+  describe('createProviderDetails', () => {
+    const providerObjectTwoSlots = providerUtil.createProviderDetails(2);
+    const providerObjectNoSlots = providerUtil.createProviderDetails(0);
+    it('Creates a provider with specified number of slots', () => {
+      expect(providerObjectTwoSlots.slots.length).to.equal(2);
+    });
+    it('Creates slots for tomorrow an hour apart starting at 12', () => {
+      expect(providerObjectTwoSlots.slots[0].start).to.equal(
+        addHours(tomorrow, 12).toISOString(),
+      );
+      expect(providerObjectTwoSlots.slots[1].start).to.equal(
+        addHours(tomorrow, 13).toISOString(),
+      );
+    });
+    it('Creates empty slots array with 0', () => {
+      expect(providerObjectNoSlots.slots.length).to.equal(0);
+    });
+  });
+});

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-plusplus */
+const dateFns = require('date-fns');
+
+/**
+ * Creates a provider object with a configurable number of slots an hour apart.
+ *
+ * @param {Number} numberOfSlots How many slots to create
+ * @returns {Object} Provider object
+ */
+const getProviderDetails = numberOfSlots => {
+  const slots = [];
+  const tomorrow = dateFns.addDays(dateFns.startOfDay(new Date()), 1);
+  let hourFromNow = 1;
+  for (let i = 0; i < numberOfSlots; i++) {
+    const startTime = dateFns.addHours(tomorrow, hourFromNow);
+    slots.push({
+      end: dateFns.addMinutes(startTime, 30).toISOString(),
+      id: Math.floor(Math.random() * 90000) + 10000,
+      start: startTime.toISOString(),
+    });
+    hourFromNow++;
+  }
+  return {
+    providerName: 'Dr. Face',
+    typeOfCare: 'Dermatology',
+    orgName: 'New Skin Technologies',
+    orgAddress: {
+      street1: '111 Lori Ln.',
+      street2: '',
+      street3: '',
+      city: 'New York',
+      state: 'New York',
+      zip: '10016',
+    },
+    orgPhone: '555-867-5309',
+    driveTime: '7 minute drive',
+    driveDistance: '8 miles',
+    slots,
+    location: 'New skin technologies bldg 2',
+  };
+};
+
+module.exports = { getProviderDetails };

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -7,10 +7,10 @@ const dateFns = require('date-fns');
  * @param {Number} numberOfSlots How many slots to create
  * @returns {Object} Provider object
  */
-const getProviderDetails = numberOfSlots => {
+const createProviderDetails = numberOfSlots => {
   const slots = [];
   const tomorrow = dateFns.addDays(dateFns.startOfDay(new Date()), 1);
-  let hourFromNow = 1;
+  let hourFromNow = 12;
   for (let i = 0; i < numberOfSlots; i++) {
     const startTime = dateFns.addHours(tomorrow, hourFromNow);
     slots.push({
@@ -40,4 +40,4 @@ const getProviderDetails = numberOfSlots => {
   };
 };
 
-module.exports = { getProviderDetails };
+module.exports = { createProviderDetails };

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -669,6 +669,10 @@ const responses = {
     });
   },
   'GET /vaos/v2/epsApi/providerDetails/:providerId': (req, res) => {
+    // Provider 3 throws error
+    if (req.params.providerId === '3') {
+      return res.status(500).json({ error: true });
+    }
     return res.json({ data: providerUtils.createProviderDetails(5) });
   },
   'GET /v0/user': {

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -57,12 +57,8 @@ const specialtyGroups = require('./epsApi/specialtyGroups.json');
 const providerOrgs = require('./epsApi/providerOrganizations.json');
 const providerServices = require('./epsApi/providerServices.json');
 const providerSlots = require('./epsApi/providerServicesSlots.json');
-<<<<<<< HEAD
 const referralUtils = require('../../referral-appointments/utils/referrals');
-=======
-const referrals = require('./epsApi/referrals.json');
 const providerUtils = require('../../referral-appointments/utils/provider');
->>>>>>> 543cd95040 (added new mock for provider using generator.)
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
@@ -672,18 +668,8 @@ const responses = {
       data: getSlot.find(slot => slot?.id === req.params.slotId),
     });
   },
-  'GET /vaos/v2/epsApi/providerDetails': (req, res) => {
+  'GET /vaos/v2/epsApi/providerDetails/:providerId': (req, res) => {
     return res.json({ data: providerUtils.createProviderDetails(5) });
-  },
-  'GET /vaos/v2/epsApi/referrals': (req, res) => {
-    return res.json({ data: referrals });
-  },
-  'GET /vaos/v2/epsApi/referrals/:referralId': (req, res) => {
-    return res.json({
-      data: referrals.referrals.find(
-        referral => referral?.id === req.params.referralId,
-      ),
-    });
   },
   'GET /v0/user': {
     data: {

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -673,7 +673,7 @@ const responses = {
     });
   },
   'GET /vaos/v2/epsApi/providerDetails': (req, res) => {
-    return res.json({ data: providerUtils.getProviderDetails(5) });
+    return res.json({ data: providerUtils.createProviderDetails(5) });
   },
   'GET /vaos/v2/epsApi/referrals': (req, res) => {
     return res.json({ data: referrals });

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -57,7 +57,12 @@ const specialtyGroups = require('./epsApi/specialtyGroups.json');
 const providerOrgs = require('./epsApi/providerOrganizations.json');
 const providerServices = require('./epsApi/providerServices.json');
 const providerSlots = require('./epsApi/providerServicesSlots.json');
+<<<<<<< HEAD
 const referralUtils = require('../../referral-appointments/utils/referrals');
+=======
+const referrals = require('./epsApi/referrals.json');
+const providerUtils = require('../../referral-appointments/utils/provider');
+>>>>>>> 543cd95040 (added new mock for provider using generator.)
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
@@ -665,6 +670,19 @@ const responses = {
     ];
     return res.json({
       data: getSlot.find(slot => slot?.id === req.params.slotId),
+    });
+  },
+  'GET /vaos/v2/epsApi/providerDetails': (req, res) => {
+    return res.json({ data: providerUtils.getProviderDetails(5) });
+  },
+  'GET /vaos/v2/epsApi/referrals': (req, res) => {
+    return res.json({ data: referrals });
+  },
+  'GET /vaos/v2/epsApi/referrals/:referralId': (req, res) => {
+    return res.json({
+      data: referrals.referrals.find(
+        referral => referral?.id === req.params.referralId,
+      ),
     });
   },
   'GET /v0/user': {

--- a/src/applications/vaos/services/referral/index.js
+++ b/src/applications/vaos/services/referral/index.js
@@ -39,6 +39,6 @@ export async function getProviderById(providerId) {
     );
     return response.data;
   } catch (error) {
-    return null;
+    return error;
   }
 }

--- a/src/applications/vaos/services/referral/index.js
+++ b/src/applications/vaos/services/referral/index.js
@@ -30,15 +30,11 @@ export async function getPatientReferralById(referralId) {
 }
 
 export async function getProviderById(providerId) {
-  try {
-    const response = await apiRequestWithUrl(
-      `/vaos/v2/epsApi/providerDetails/${providerId}`,
-      {
-        method: 'GET',
-      },
-    );
-    return response.data;
-  } catch (error) {
-    return error;
-  }
+  const response = await apiRequestWithUrl(
+    `/vaos/v2/epsApi/providerDetails/${providerId}`,
+    {
+      method: 'GET',
+    },
+  );
+  return response.data;
 }

--- a/src/applications/vaos/services/referral/index.js
+++ b/src/applications/vaos/services/referral/index.js
@@ -28,3 +28,17 @@ export async function getPatientReferralById(referralId) {
     return null;
   }
 }
+
+export async function getProviderById(providerId) {
+  try {
+    const response = await apiRequestWithUrl(
+      `/vaos/v2/epsApi/providerDetails/${providerId}`,
+      {
+        method: 'GET',
+      },
+    );
+    return response.data;
+  } catch (error) {
+    return null;
+  }
+}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds a provider details generator, mock, and redux boiler plate. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#95263


## Testing done

 - unit test for generator util


## What areas of the site does it impact?

 - community care referral scheduling in VAOS

## Acceptance criteria
 - [ ] creates a mock that takes a providerId param and returns data
 - [ ] slots are generated dynamically into the future from the current date
 - [ ] Add provider API fetch to date picker page and store in redux
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


