### PR TITLE
92030: Remove endpoint from README

### DIFF
--- a/src/applications/pensions/README.md
+++ b/src/applications/pensions/README.md
@@ -75,7 +75,6 @@ yarn generate-form-docs -- pensions
 Active toggle names:
 
 - `pension_form_enabled`: Enable the pension form
-- `pension_ipf_callbacks_endpoint`: Pension IPF VANotify notification callbacks endpoint
 - `pension_browser_monitoring_enabled`: Pension Datadog RUM monitoring
 - `pension_claim_submission_to_lighthouse`: Pension claim submission uses Lighthouse API
 


### PR DESCRIPTION
Remove any and all logic around this unused (and never used) feature.

## Summary

Remove the following:
-Remove reference in README

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92030