### PR TITLE
Conditions 629 Autocomplete Move Focus into List

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -143,6 +143,12 @@ const Autocomplete = ({
     };
   }, []);
 
+  const handleFocus = () => {
+    if (value && results.length === 0) {
+      debouncedSearch(value);
+    }
+  };
+
   return (
     <div className="cc-autocomplete" ref={containerRef}>
       <VaTextInput
@@ -153,6 +159,7 @@ const Autocomplete = ({
         ref={inputRef}
         required
         value={value}
+        onFocus={handleFocus}
         onInput={e => handleInputChange(e.target.value)}
         onKeyDown={handleKeyDown}
       />

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -142,9 +142,9 @@ const Autocomplete = ({
         }
       };
 
-      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('mouseup', handleClickOutside);
       return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('mouseup', handleClickOutside);
       };
     },
     [closeList],

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import debounce from 'lodash/debounce';
@@ -52,12 +52,15 @@ const Autocomplete = ({
     }, debounceDelay),
   ).current;
 
-  const closeList = () => {
-    debouncedSearch.cancel();
-    debouncedSetAriaLiveText.cancel();
-    setResults([]);
-    setActiveIndex(null);
-  };
+  const closeList = useCallback(
+    () => {
+      debouncedSearch.cancel();
+      debouncedSetAriaLiveText.cancel();
+      setResults([]);
+      setActiveIndex(null);
+    },
+    [debouncedSearch, debouncedSetAriaLiveText],
+  );
 
   const handleInputChange = inputValue => {
     setValue(inputValue);
@@ -127,21 +130,24 @@ const Autocomplete = ({
     }
   };
 
-  useEffect(() => {
-    const handleClickOutside = event => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target)
-      ) {
-        closeList();
-      }
-    };
+  useEffect(
+    () => {
+      const handleClickOutside = event => {
+        if (
+          containerRef.current &&
+          !containerRef.current.contains(event.target)
+        ) {
+          closeList();
+        }
+      };
 
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    },
+    [closeList],
+  );
 
   const handleFocus = () => {
     if (value && results.length === 0) {

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -125,6 +125,8 @@ const Autocomplete = ({
       } else if (e.key === 'Escape') {
         closeList();
         focusOnInput();
+      } else if (e.key === 'Tab') {
+        closeList();
       } else {
         focusOnInput();
       }

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -144,9 +144,9 @@ const Autocomplete = ({
         }
       };
 
-      document.addEventListener('mouseup', handleClickOutside);
+      document.addEventListener('mousedown', handleClickOutside);
       return () => {
-        document.removeEventListener('mouseup', handleClickOutside);
+        document.removeEventListener('mousedown', handleClickOutside);
       };
     },
     [closeList],

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -124,6 +124,7 @@ const Autocomplete = ({
         selectResult(results[activeIndex]);
       } else if (e.key === 'Escape') {
         closeList();
+        focusOnInput();
       } else {
         focusOnInput();
       }

--- a/src/applications/disability-benefits/all-claims/tests/components/Autocomplete.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/Autocomplete.unit.spec.jsx
@@ -226,7 +226,7 @@ describe('Autocomplete Component', () => {
         expect(list).to.have.length(21);
       });
 
-      fireEvent.blur(input);
+      fireEvent.mouseDown(document);
 
       await waitFor(() => {
         list = queryByTestId('autocomplete-list');


### PR DESCRIPTION
## Summary
- This is behind a feature toggle so will not impact prod
- Changes:
  - Move Focus into List to try to solve the following:
    - NVDA/Firefox - the input value is read every time you navigate the dropdown options
    - JAWS/Chrome, Narrator/Edge - Cannot navigate through the dropdown options with UP + Down keys
  - Replace onBlur with eventListener that closes list only if click outside container and add tabIndex so that focus can go on list items. 
  - Ensure any key press other than arrow up/down, enter, or escape, brings focus back to input. 
  - Add focus onMouseEnter so that highlight and focus are always aligned. 
  - Remove search onFocus functionality since this was firing with stale data whenever focusOnInput ran. Need to determine how to add back this functionality.
  - Remove updating aria text when arrow since this is now coming from focus
- Which team do you work for, does your team own the maintenance of this component? Conditions Team and Yes

## Related issue(s)

- [Autocomplete Accessibility Review in Staging #629](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/629)