### PR TITLE
Add Referral Task Card component

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
@@ -28,7 +28,9 @@ import CernerAlert from '../../../components/CernerAlert';
 // import CernerTransitionAlert from '../../../components/CernerTransitionAlert';
 // import { selectPatientFacilities } from '~/platform/user/cerner-dsot/selectors';
 import ReferralAppLink from '../../../referral-appointments/components/ReferralAppLink';
+import ReferralTaskCard from '../../../referral-appointments/components/ReferralTaskCard';
 import { setFormCurrentPage } from '../../../referral-appointments/redux/actions';
+import { createReferral } from '../../../referral-appointments/utils/referrals';
 
 function renderWarningNotification() {
   return (props, childContent) => {
@@ -50,6 +52,7 @@ export default function AppointmentsPage() {
   const dispatch = useDispatch();
   const [hasTypeChanged, setHasTypeChanged] = useState(false);
   let [pageTitle] = useState('VA online scheduling');
+  const [referral, setReferral] = useState();
 
   const featureCCDirectScheduling = useSelector(state =>
     selectFeatureCCDirectScheduling(state),
@@ -64,6 +67,23 @@ export default function AppointmentsPage() {
   // const featureBookingExclusion = useSelector(state =>
   //   selectFeatureBookingExclusion(state),
   // );
+
+  useEffect(
+    () => {
+      if (!featureCCDirectScheduling || !location?.search) {
+        return;
+      }
+      const params = new URLSearchParams(location.search);
+      const id = params.get('id');
+      if (!id) {
+        return;
+      }
+      // TODO: Get referral data from redux
+      const referralFromId = createReferral(new Date().toISOString(), id);
+      setReferral(referralFromId);
+    },
+    [location, featureCCDirectScheduling],
+  );
 
   useEffect(
     () => {
@@ -164,6 +184,7 @@ export default function AppointmentsPage() {
           <ReferralAppLink linkText="Review and manage your appointment notifications" />
         </div>
       )}
+      {featureCCDirectScheduling && <ReferralTaskCard data={referral} />}
       {featureCCDirectScheduling && (
         <div
           className={classNames(

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
@@ -541,6 +541,61 @@ describe('VAOS Page: AppointmentsPage', () => {
 
       expect(screen.queryByRole('link', { name: /Pending \(1\)/ })).not.to
         .exist;
+
+      // Then it should not display the referral task card
+      expect(await screen.queryByTestId('referral-task-card')).not.to.exist;
+    });
+
+    describe('when a referral UUID is passed', () => {
+      it('should display the referral task card', async () => {
+        // Given the veteran lands on the VAOS homepage with with a UUID passed
+        const appointment = getVAOSRequestMock();
+        appointment.id = '1';
+        appointment.attributes = {
+          id: '1',
+          kind: 'clinic',
+          locationId: '983',
+          requestedPeriods: [{}],
+          serviceType: 'primaryCare',
+          status: 'proposed',
+        };
+
+        mockVAOSAppointmentsFetch({
+          start: moment()
+            .subtract(1, 'month')
+            .format('YYYY-MM-DD'),
+          end: moment()
+            .add(395, 'days')
+            .format('YYYY-MM-DD'),
+          statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+          requests: [appointment],
+        });
+        mockVAOSAppointmentsFetch({
+          start: moment()
+            .subtract(120, 'days')
+            .format('YYYY-MM-DD'),
+          end: moment().format('YYYY-MM-DD'),
+          statuses: ['proposed', 'cancelled'],
+          requests: [appointment],
+        });
+        // Given the veteran lands on the VAOS homepage with a UUID passed
+        // When the page displays
+        const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
+          initialState: defaultState,
+          path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c68',
+        });
+
+        await screen.findByRole('heading', { name: 'Appointments' });
+
+        expect(await screen.findByTestId('review-requests-and-referrals')).to
+          .exist;
+
+        expect(screen.queryByRole('link', { name: /Pending \(1\)/ })).not.to
+          .exist;
+
+        // Then it should display the referral task card
+        expect(await screen.findByTestId('referral-task-card')).to.exist;
+      });
     });
   });
 });

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCard.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCard.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import pluralize from 'pluralize';
+import { format, isAfter } from 'date-fns';
+
+export default function ReferralTaskCard({ data }) {
+  if (!data) {
+    return null;
+  }
+
+  const { numberOfAppointments, ReferralExpirationDate, UUID } = data;
+
+  const expirationDate = new Date(ReferralExpirationDate);
+  const isPastExpirationDate = isAfter(new Date(), expirationDate);
+
+  if (isPastExpirationDate) {
+    return null;
+  }
+
+  return (
+    <va-card
+      class={classNames('vads-u-margin-y--3')}
+      data-testid="referral-task-card"
+    >
+      <h4 className="vads-u-margin--0">
+        Schedule your physical therapy appointment
+      </h4>
+      <p>
+        {`We’ve approved your referral for ${numberOfAppointments} ${pluralize(
+          'appointment',
+          numberOfAppointments,
+        )} with a community care provider. You must schedule all appointments for this referral by ${format(
+          expirationDate,
+          'PP',
+        )}.`}
+      </p>
+      <va-link-action
+        text="Go to your referral details to start scheduling"
+        type="secondary"
+        href={`/my-health/appointments/schedule-referral/${UUID}`}
+        data-testid={`referral-task-card-schedule-referral-${UUID}`}
+      />
+    </va-card>
+  );
+}
+
+ReferralTaskCard.propTypes = {
+  /** Referral data */
+  data: PropTypes.object,
+};

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCard.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCard.jsx
@@ -3,8 +3,16 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import { format, isAfter } from 'date-fns';
+import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+
+import { selectCurrentPage } from '../redux/selectors';
+import { routeToNextReferralPage } from '../flow';
 
 export default function ReferralTaskCard({ data }) {
+  const currentPage = useSelector(selectCurrentPage);
+  const history = useHistory();
+
   if (!data) {
     return null;
   }
@@ -38,8 +46,10 @@ export default function ReferralTaskCard({ data }) {
       <va-link-action
         text="Go to your referral details to start scheduling"
         type="secondary"
-        href={`/my-health/appointments/schedule-referral/${UUID}`}
         data-testid={`referral-task-card-schedule-referral-${UUID}`}
+        onClick={() => {
+          routeToNextReferralPage(history, currentPage, UUID);
+        }}
       />
     </va-card>
   );

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import ReferralTaskCard from './ReferralTaskCard';
+import { createReferral } from '../utils/referrals';
+
+describe('VAOS Component: ReferralTaskCard', () => {
+  let sandbox;
+  let clock;
+  const now = new Date('2024-09-09T00:00:00Z');
+
+  beforeEach(() => {
+    // Set a fixed date for all tests
+    sandbox = sinon.sandbox.create();
+    clock = sinon.useFakeTimers({
+      now,
+      toFake: ['Date'],
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    clock.restore();
+  });
+
+  const uuid = 'add2f0f4-a1ea-4dea-a504-a54ab57c68';
+  const referralData = createReferral('2024-09-06T00:00:00Z', uuid);
+
+  it('should not display referral task card with defaults', () => {
+    const screen = render(<ReferralTaskCard />);
+    expect(screen.queryByRole('heading')).not.to.exist;
+  });
+
+  it('should display referral task card', () => {
+    const screen = render(<ReferralTaskCard data={referralData} />);
+    expect(
+      screen.getByRole('heading', {
+        level: 4,
+        name: 'Schedule your physical therapy appointment',
+      }),
+    ).to.exist;
+    expect(
+      screen.getByText(
+        'We’ve approved your referral for 1 appointment with a community care provider. You must schedule all appointments for this referral by Mar 4, 2025.',
+      ),
+    ).to.exist;
+    expect(screen.queryByTestId(`referral-task-card-schedule-referral-${uuid}`))
+      .to.exist;
+  });
+
+  it('should display referral task card when there are multiple appointments', () => {
+    const referral = {
+      ...referralData,
+      numberOfAppointments: 3,
+    };
+    const screen = render(<ReferralTaskCard data={referral} />);
+    expect(
+      screen.getByRole('heading', {
+        name: 'Schedule your physical therapy appointment',
+      }),
+    ).to.exist;
+    expect(
+      screen.getByText(
+        'We’ve approved your referral for 3 appointments with a community care provider. You must schedule all appointments for this referral by Mar 4, 2025.',
+      ),
+    ).to.exist;
+    expect(screen.queryByTestId(`referral-task-card-schedule-referral-${uuid}`))
+      .to.exist;
+  });
+
+  it('should not display a referral task card when the referral has expired', () => {
+    const referral = {
+      ...referralData,
+      ReferralExpirationDate: '2024-09-08',
+    };
+    const screen = render(<ReferralTaskCard data={referral} />);
+    expect(screen.queryByRole('heading')).not.to.exist;
+  });
+});

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
 import { format } from 'date-fns';
 import ReferralTaskCard from './ReferralTaskCard';
 import { createReferral } from '../utils/referrals';
+import {
+  createTestStore,
+  renderWithStoreAndRouter,
+} from '../../tests/mocks/setup';
 
 describe('VAOS Component: ReferralTaskCard', () => {
   let sandbox;
@@ -34,12 +37,18 @@ describe('VAOS Component: ReferralTaskCard', () => {
   );
 
   it('should not display referral task card with defaults', () => {
-    const screen = render(<ReferralTaskCard />);
+    const store = createTestStore();
+    const screen = renderWithStoreAndRouter(<ReferralTaskCard />, { store });
     expect(screen.queryByRole('heading')).not.to.exist;
   });
 
   it('should display referral task card', () => {
-    const screen = render(<ReferralTaskCard data={referralData} />);
+    const store = createTestStore();
+
+    const screen = renderWithStoreAndRouter(
+      <ReferralTaskCard data={referralData} />,
+      { store },
+    );
     expect(
       screen.getByRole('heading', {
         level: 4,
@@ -56,11 +65,15 @@ describe('VAOS Component: ReferralTaskCard', () => {
   });
 
   it('should display referral task card when there are multiple appointments', () => {
+    const store = createTestStore();
     const referral = {
       ...referralData,
       numberOfAppointments: 3,
     };
-    const screen = render(<ReferralTaskCard data={referral} />);
+    const screen = renderWithStoreAndRouter(
+      <ReferralTaskCard data={referral} />,
+      { store },
+    );
     expect(
       screen.getByRole('heading', {
         name: 'Schedule your physical therapy appointment',
@@ -76,11 +89,15 @@ describe('VAOS Component: ReferralTaskCard', () => {
   });
 
   it('should not display a referral task card when the referral has expired', () => {
+    const store = createTestStore();
     const referral = {
       ...referralData,
       ReferralExpirationDate: '2024-09-08',
     };
-    const screen = render(<ReferralTaskCard data={referral} />);
+    const screen = renderWithStoreAndRouter(
+      <ReferralTaskCard data={referral} />,
+      { store },
+    );
     expect(screen.queryByRole('heading')).not.to.exist;
   });
 });

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { format } from 'date-fns';
 import ReferralTaskCard from './ReferralTaskCard';
 import { createReferral } from '../utils/referrals';
 
@@ -26,6 +27,11 @@ describe('VAOS Component: ReferralTaskCard', () => {
 
   const uuid = 'add2f0f4-a1ea-4dea-a504-a54ab57c68';
   const referralData = createReferral('2024-09-06T00:00:00Z', uuid);
+  referralData.ReferralExpirationDate = '2025-03-04';
+  const expectedDateFormated = format(
+    new Date(referralData.ReferralExpirationDate),
+    'PP',
+  );
 
   it('should not display referral task card with defaults', () => {
     const screen = render(<ReferralTaskCard />);
@@ -42,7 +48,7 @@ describe('VAOS Component: ReferralTaskCard', () => {
     ).to.exist;
     expect(
       screen.getByText(
-        'We’ve approved your referral for 1 appointment with a community care provider. You must schedule all appointments for this referral by Mar 4, 2025.',
+        `We’ve approved your referral for 1 appointment with a community care provider. You must schedule all appointments for this referral by ${expectedDateFormated}.`,
       ),
     ).to.exist;
     expect(screen.queryByTestId(`referral-task-card-schedule-referral-${uuid}`))
@@ -62,7 +68,7 @@ describe('VAOS Component: ReferralTaskCard', () => {
     ).to.exist;
     expect(
       screen.getByText(
-        'We’ve approved your referral for 3 appointments with a community care provider. You must schedule all appointments for this referral by Mar 4, 2025.',
+        `We’ve approved your referral for 3 appointments with a community care provider. You must schedule all appointments for this referral by ${expectedDateFormated}.`,
       ),
     ).to.exist;
     expect(screen.queryByTestId(`referral-task-card-schedule-referral-${uuid}`))


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Adds a `Referral Task Card` component that only shows when a feature flag is on and UUID is passed to the main appointments page ex: `/appointments/?id=add2f0f4-a1ea-4dea-a504-a54ab57c68`

## Related issue(s)

department-of-veterans-affairs/va.gov-team#95265

## Testing done

- Unit tests for component logic
- Added tests for main appointments page
- In order to test this the feature `vaOnlineSchedulingCCDirectScheduling` must be enabled and a id supplied such as `/my-health/appointments/?id=add2f0f4-a1ea-4dea-a504-a54ab57c68`
- Pass in referral object and ensure the component renders as expected
- Pass in expired referral object and ensure the card does not show

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![Screen Shot 2024-11-13 at 23 18 44](https://github.com/user-attachments/assets/937e1de6-d029-4772-a873-c003cbfec250)|![Screen Shot 2024-11-13 at 22 58 54](https://github.com/user-attachments/assets/e168241e-f97d-4098-81be-749dea391306)|
| Desktop | ![Screenshot 2024-11-13 at 23-18-38 Appointments Veterans Affairs](https://github.com/user-attachments/assets/11aea383-6040-473e-96c3-be865444430e)| ![Screenshot 2024-11-13 at 22-59-45 Appointments Veterans Affairs](https://github.com/user-attachments/assets/bbf1e93b-1796-4b29-8db0-a7fe878847ca) |

## What areas of the site does it impact?

- Appointments list feature in VAOS

## Acceptance criteria

 - [X] Create component for displaying referral as task card
 - [X] component takes referral object as prop
 ~~- [ ] fetch referral from redux by UUID~~
 - [X] conditionally show if UUID passed and feature is on
 - [X] show date in `Month DD, YYYY` format
 - [X] add unit tests

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

- Data pulled from Redux will be done in separate ticket
