### PR TITLE
[96835] [96855] Add org select requirement and show selection

### DIFF
--- a/src/applications/representative-appoint/components/SelectOrganization.jsx
+++ b/src/applications/representative-appoint/components/SelectOrganization.jsx
@@ -100,6 +100,9 @@ const SelectOrganization = props => {
 
 SelectOrganization.propTypes = {
   formData: PropTypes.object,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  goToPath: PropTypes.func,
   setFormData: PropTypes.func,
 };
 

--- a/src/applications/representative-appoint/components/SelectOrganization.jsx
+++ b/src/applications/representative-appoint/components/SelectOrganization.jsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import { scrollToFirstError } from 'platform/utilities/ui';
 import { useReviewPage } from '../hooks/useReviewPage';
 
 const SelectOrganization = props => {
   const { formData, setFormData, goBack, goForward, goToPath } = props;
+  const [error, setError] = useState(null);
   const organizations =
     formData['view:selectedRepresentative']?.attributes?.accreditedOrganizations
       ?.data;
@@ -26,7 +28,10 @@ const SelectOrganization = props => {
   };
 
   const handleGoForward = () => {
-    if (isReviewPage) {
+    if (!formData?.selectedAccreditedOrganizationId) {
+      setError('You must select an accredited organization');
+      scrollToFirstError({ focusOnAlertRole: true });
+    } else if (isReviewPage) {
       if (isReplacingRep) {
         goToPath('/representative-replace?review=true');
       } else {
@@ -65,7 +70,7 @@ const SelectOrganization = props => {
 
   const organizationList = (
     <VaRadio
-      error={null}
+      error={error}
       label="Which VSO do you want to appoint?"
       required
       onVaValueChange={handleRadioSelect}
@@ -76,6 +81,7 @@ const SelectOrganization = props => {
           name="organization"
           value={org.id}
           key={`${org.id}-${index}`}
+          checked={formData.selectedAccreditedOrganizationId === org.id}
         />
       ))}
     </VaRadio>

--- a/src/applications/representative-appoint/components/SelectOrganization.jsx
+++ b/src/applications/representative-appoint/components/SelectOrganization.jsx
@@ -61,6 +61,8 @@ const SelectOrganization = props => {
     const selectedOrgId = e.detail.value;
     const selectedOrg = organizations?.find(org => org.id === selectedOrgId);
 
+    setError(null);
+
     setFormData({
       ...formData,
       selectedAccreditedOrganizationId: selectedOrgId,


### PR DESCRIPTION
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds validation to organization selection to force users to select an option
- This pr adds the `checked` attribute to the radio buttons to show users their selection when navigating backwards

## Related issue(s)

- [96835](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96835)
- [96855](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96855)

## Testing done

- Went through flow locally with all rep types options as well as through the review page to confirm expected behavior

## Screenshots
### Before
https://github.com/user-attachments/assets/dac1bcac-aa70-4f38-9b4a-976023dc1115
### After
https://github.com/user-attachments/assets/6db0bcaf-35d6-4a7b-a5a0-99ae9e6d6ac2

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user