### PR TITLE
mhv-64076 adjusted color of unread icon to red

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
@@ -90,7 +90,7 @@ const ThreadListItem = props => {
               <span
                 aria-hidden="true"
                 role="img"
-                className="unread-icon vads-u-margin-right--1 vads-u-color--primary-dark unread-bubble"
+                className="unread-icon vads-u-margin-right--1 unread-bubble"
                 data-testid="thread-list-unread-icon"
               />
             </span>

--- a/src/applications/mhv-secure-messaging/sass/secure-messaging.scss
+++ b/src/applications/mhv-secure-messaging/sass/secure-messaging.scss
@@ -340,7 +340,7 @@ va-loading-indicator {
 .unread-bubble {
   height: 12px;
   width: 12px;
-  background-color: var(--vads-color-primary);
+  background-color: var(--vads-color-secondary);
   border-radius: 50%;
 }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- changed the color of the unread message icon from blue to red to align with other VA unread icons
- the unread icon appears in 3 places on Va.gov Secure Messaging:
  - Inbox folder
  - inbox folder after messages have been filtered
  - message thread accordion header (for threads that have multiple messages)

## Related issue(s)

### [MHV-64076](https://jira.devops.va.gov/browse/MHV-64076) - Change dot indicator color for unread messages to red ###

> Change dot indicator color for unread messages to red. Use vads-color-secondary.
> 
> Slack thread: https://dsva.slack.com/archives/C05CD3ECB44/p1730232328841129
> 
> User Story:  As a SM user, I want to  be see the dot indicator color for unread messages in red, so that it is consistent with other products.
> 
> Feature Flag Y/N ? N 
> 
> DataDog Analytics  Y/N ? N 
> 
> Manual Testing Y/N ? Y - Rakesh
> 
> Automated Testing Y/N ?  
> 
> Accessibility Testing Y/N ? Y - Bobby
> 
> UCD Validation Y/N N/A
> 
> Acceptance Criteria:
> 
> AC1   The dot indicator color for unread messages will be red (vads-color-secondary)

## Testing done

- no new unit tests added or adjusted.  manual testing only

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |![Screenshot 2024-11-13 at 1 44 16 PM](https://github.com/user-attachments/assets/1a4b4dca-19f0-40d6-829d-09f36dfb93f8)|![Screenshot 2024-11-13 at 1 39 46 PM](https://github.com/user-attachments/assets/34e9f7e6-73eb-4c05-b485-2fde0179235a)|
| Desktop |![Screenshot 2024-11-13 at 1 44 30 PM](https://github.com/user-attachments/assets/bf22599b-3b86-4db6-8666-1d62c3c3012a)|![Screenshot 2024-11-13 at 1 44 41 PM](https://github.com/user-attachments/assets/53748b3f-20a4-4b4c-8f17-80cfa213310c)|
| Desktop |![Screenshot 2024-11-13 at 1 45 11 PM](https://github.com/user-attachments/assets/77e52b65-9887-49e8-8639-8b20030befd0)|![Screenshot 2024-11-13 at 1 44 54 PM](https://github.com/user-attachments/assets/cfbb30d5-ee98-41e7-a388-a640221c4e00)|

## What areas of the site does it impact?

va.gov - secure messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
