### PR TITLE
Update sign-in  Alerts text

### DIFF
--- a/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.jsx
@@ -55,7 +55,7 @@ const AlertVerifyAndRegister = ({ cspId, recordEvent, testId }) => {
         </p>
         <p>
           <a href={learnHowToVerifyIdentityUrl}>
-            Learn how to verify your identity
+            Learn more about verifying your identity
           </a>
         </p>
       </div>

--- a/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.jsx
@@ -12,8 +12,15 @@ import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const AlertVerifyAndRegister = ({ cspId, recordEvent, testId }) => {
-  const headline = 'Verify and register your account to access My HealtheVet';
+  const headline = 'Verify your identity';
   const serviceProviderLabel = SERVICE_PROVIDERS[cspId].label;
+  const verifyIdentityUrl = {
+    [CSP_IDS.LOGIN_GOV]:
+      '/resources/how-to-verify-your-identity-for-your-logingov-account/',
+    [CSP_IDS.ID_ME]:
+      '/resources/how-to-verify-your-identity-for-your-idme-account/',
+  };
+  const learnHowToVerifyIdentityUrl = verifyIdentityUrl[cspId];
 
   useEffect(
     () => {
@@ -32,26 +39,23 @@ const AlertVerifyAndRegister = ({ cspId, recordEvent, testId }) => {
       <h2 slot="headline">{headline}</h2>
       <div>
         <p className="vads-u-margin-y--2">
-          We need you to verify your identity and register your account before
-          you can access My HealtheVet. These steps help us keep your health
-          information safe and prevent fraud and identity theft.
+          We need you to verify your identity for your
+          <strong> {serviceProviderLabel}</strong> account. This step helps us
+          protect all Veterans’ information and prevent scammers from stealing
+          your benefits.
         </p>
-        <ul>
-          <li>
-            Verify your identity for your {serviceProviderLabel} account. This
-            one-time process often takes about 10 minutes. You’ll need to
-            provide certain personal information and identification.
-          </li>
-          <li>
-            Then we’ll ask you to register with My HealtheVet by confirming your
-            personal information and relationship with VA health care. You’ll
-            need to register before you can access your messages, medications,
-            and medical records.
-          </li>
-        </ul>
+        <p>
+          This one-time process often takes about 10 minutes. You’ll need to
+          provide certain personal information and identification.
+        </p>
         <p>
           <a href="/verify" className="vads-c-action-link--green">
             Verify your identity with {serviceProviderLabel}
+          </a>
+        </p>
+        <p>
+          <a href={learnHowToVerifyIdentityUrl}>
+            Learn how to verify your identity
           </a>
         </p>
       </div>

--- a/src/applications/mhv-landing-page/mocks/api/user/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/user/index.js
@@ -109,6 +109,10 @@ const CSP_IDS = {
 const USER_MOCKS = Object.freeze({
   UNREGISTERED: generateUser({ vaPatient: false }),
   UNVERIFIED: generateUser({ loa: 1, vaPatient: false }),
+  LOGIN_GOV_UNVERIFIED: generateUser({
+    loa: 1,
+    serviceName: CSP_IDS.LOGIN_GOV,
+  }),
   DS_LOGON_UNVERIFIED: generateUser({ loa: 1, serviceName: CSP_IDS.DS_LOGON }),
   NO_MHV_ACCOUNT: generateUser({ mhvAccountState: 'NONE' }),
   MHV_BASIC_ACCOUNT: generateUser({ loa: 1, serviceName: CSP_IDS.MHV }),

--- a/src/applications/mhv-landing-page/tests/e2e/alerts/unverified.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/alerts/unverified.cypress.spec.js
@@ -5,8 +5,7 @@ import LandingPage from '../pages/LandingPage';
 const viewportSizes = ['va-top-desktop-1', 'va-top-mobile-1'];
 
 // ID.me is LandingPage.visitPage default for serviceProvider
-const verifyIdentityHeading =
-  'Verify and register your account to access My HealtheVet';
+const verifyIdentityHeading = 'Verify your identity';
 
 describe(appName, () => {
   describe('Display content based on identity verification', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Update the heading and body content in our access / sign-in alerts to match the finalized versions now available in VADS: 
- [Verify with ID.me](https://design.va.gov/components/alert/alert-sign-in/#verify-with-idme) and 
- [Verify with Login.gov](https://design.va.gov/components/alert/alert-sign-in/#verify-with-logingov))

Notes:
- Our current implementation uses action links, not buttons - these buttons are not yet built, so we need to leave the action links & only edit the body text content
- Our current implementation uses VSDS Alert component with the Warning icon, not the Lock icon - this is the default icon for VSDS Warning alert, so we will not change this icon
- Additional "Learn more about verifying your identity" links added at end of alerts:
  - [Login.gov](http://login.gov/) url: /resources/how-to-verify-your-identity-for-your-logingov-account/,
  - ID.me url: /resources/how-to-verify-your-identity-for-your-idme-account/

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/96243

## Testing done

- Verified the ID.me and Login.gov sign-in alerts are shown with the new content in local development:
Run `yarn mock-api --responses src/applications/mhv-landing-page/mocks/api/index.js`, and set users to:
  - USER_MOCKS.UNVERIFIED for ID.me sign-in, then
  - USER_MOCKS.LOGIN_GOV_UNVERIFIED for Login.gov sign-in

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile: ID.me |   <img width="296" alt="Screenshot 2024-11-14 at 9 18 38 AM" src="https://github.com/user-attachments/assets/3a4e41e5-2ecf-4c0b-ba55-4052e2583950">     |   <img width="293" alt="Screenshot 2024-11-14 at 10 26 57 AM" src="https://github.com/user-attachments/assets/ee716e53-def1-44b8-9356-c09aaf460c5a">    |
| Desktop: ID.me |    <img width="1013" alt="Screenshot 2024-11-14 at 9 19 15 AM" src="https://github.com/user-attachments/assets/4331633a-9c4a-4f8a-baf1-12cd7185a23f">    |   <img width="948" alt="Screenshot 2024-11-14 at 10 25 41 AM" src="https://github.com/user-attachments/assets/1cf26f94-487d-4e83-bb28-3a220469adf7">    |
| Mobile: Login.gov  |   <img width="296" alt="Screenshot 2024-11-14 at 9 16 41 AM" src="https://github.com/user-attachments/assets/edbe0aec-94ee-48b0-81b6-4ed5d3f9c540">     |   <img width="293" alt="Screenshot 2024-11-14 at 10 32 03 AM" src="https://github.com/user-attachments/assets/9c74d12d-4e7f-453c-aef0-a1824778344c">    |
| Desktop: Login.gov |   <img width="1012" alt="Screenshot 2024-11-14 at 9 15 56 AM" src="https://github.com/user-attachments/assets/237e1978-a78f-430e-b8f9-7cbd30d812f9">     |   <img width="952" alt="Screenshot 2024-11-14 at 10 32 54 AM" src="https://github.com/user-attachments/assets/dd3263c1-8112-4980-b268-00668f41908f">    |

## What areas of the site does it impact?

Only changes the alerts at `/my-health` path


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
