### PR TITLE
[21-10210] Make email address required depending on flow

### DIFF
--- a/src/applications/simple-forms/21-10210/pages/claimantContInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/claimantContInfo.js
@@ -56,6 +56,25 @@ export default {
         },
       },
     },
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        const { claimOwnership, claimantType } = formData;
+
+        if (
+          claimOwnership === CLAIM_OWNERSHIPS.SELF &&
+          claimantType === CLAIMANT_TYPES.NON_VETERAN
+        ) {
+          return {
+            ...formSchema,
+            required: ['claimantPhone', 'claimantEmail'],
+          };
+        }
+        return {
+          ...formSchema,
+          required: ['claimantPhone'],
+        };
+      },
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/21-10210/pages/vetContInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/vetContInfo.js
@@ -56,6 +56,22 @@ export default {
         },
       },
     },
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        const { claimOwnership, claimantType } = formData;
+
+        if (
+          claimOwnership === CLAIM_OWNERSHIPS.SELF &&
+          claimantType === CLAIMANT_TYPES.VETERAN
+        ) {
+          return { ...formSchema, required: ['veteranPhone', 'veteranEmail'] };
+        }
+        return {
+          ...formSchema,
+          required: ['veteranPhone'],
+        };
+      },
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/21-10210/pages/witnessContInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/witnessContInfo.js
@@ -32,7 +32,7 @@ export default {
   },
   schema: {
     type: 'object',
-    required: ['witnessPhone'],
+    required: ['witnessPhone', 'witnessEmail'],
     properties: {
       witnessPhone: formDefinitions.phone,
       witnessEmail: formDefinitions.pdfEmail,

--- a/src/applications/simple-forms/21-10210/tests/pages/claimantContInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/claimantContInfo.unit.spec.jsx
@@ -27,7 +27,7 @@ testNumberOfFields(
   mockData,
 );
 
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 2;
 testNumberOfErrorsOnSubmit(
   formConfig,
   schema,

--- a/src/applications/simple-forms/21-10210/tests/pages/vetContInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/vetContInfo.unit.spec.jsx
@@ -27,7 +27,7 @@ testNumberOfFields(
   mockData,
 );
 
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 2;
 testNumberOfErrorsOnSubmit(
   formConfig,
   schema,

--- a/src/applications/simple-forms/21-10210/tests/pages/witnessContInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/witnessContInfo.unit.spec.jsx
@@ -27,7 +27,7 @@ testNumberOfFields(
   mockData,
 );
 
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 2;
 testNumberOfErrorsOnSubmit(
   formConfig,
   schema,


### PR DESCRIPTION
## Summary
Form 21-10210 has a few different email fields throughout the form. Depending on flow, this field should sometimes be required. This pull request makes changes to require email for the person who needs to be notified for the form submission status.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1752

## Testing done
Updated unit tests for pages