### PR TITLE
Interstitial e2e

### DIFF
--- a/src/applications/sign-in-changes/containers/InterstitialChanges.jsx
+++ b/src/applications/sign-in-changes/containers/InterstitialChanges.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import {
+  VaAlert,
   VaLink,
   VaLoadingIndicator,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
@@ -14,6 +15,7 @@ export default function InterstitialChanges() {
 
   const [userEmails, setUserEmails] = useState({});
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     apiRequest('/user/credential_emails', {
@@ -26,7 +28,10 @@ export default function InterstitialChanges() {
         setUserEmails(data);
         setIsLoading(false);
       })
-      .catch(() => {});
+      .catch(() => {
+        setError(true);
+        setIsLoading(false);
+      });
   }, []);
 
   const showAccount = userEmails?.logingov || userEmails?.idme;
@@ -34,6 +39,15 @@ export default function InterstitialChanges() {
 
   if (isLoading) {
     return <VaLoadingIndicator />;
+  }
+  if (error) {
+    return (
+      <div>
+        <VaAlert status="error" closeable={false} showIcon uswds>
+          <h1 slot="headline">401: Not authorized</h1>
+        </VaAlert>
+      </div>
+    );
   }
 
   return (

--- a/src/applications/sign-in-changes/tests/sign-in-changes.cypress.spec.js
+++ b/src/applications/sign-in-changes/tests/sign-in-changes.cypress.spec.js
@@ -1,0 +1,123 @@
+describe('Interstitial Changes Page', () => {
+  const baseUrl = '/sign-in-changes-reminder';
+
+  const interceptCredentialEmails = (statusCode, body) => {
+    cy.intercept('GET', '/user/credential_emails', {
+      statusCode,
+      body,
+    });
+  };
+
+  const visitPage = () => {
+    cy.visit(baseUrl);
+  };
+
+  context('when user data is loading', () => {
+    beforeEach(() => {
+      interceptCredentialEmails(200, { logingov: 'user@logingov.com' });
+      cy.visit(baseUrl);
+    });
+
+    it('displays a loading indicator', () => {
+      cy.get('va-loading-indicator').should('be.visible');
+    });
+  });
+
+  context('when user is unauthorized', () => {
+    beforeEach(() => {
+      interceptCredentialEmails(401, {});
+      visitPage();
+    });
+
+    it('displays an unauthorized error message', () => {
+      cy.get('va-alert').should('have.attr', 'status', 'error');
+      cy.contains('401: Not authorized').should('be.visible');
+    });
+  });
+
+  context('when user has only a Login.gov account', () => {
+    beforeEach(() => {
+      interceptCredentialEmails(200, { logingov: 'user@logingov.com' });
+      visitPage();
+    });
+
+    it('displays the Login.gov account switch option', () => {
+      cy.get('#signin-changes-title').should('be.visible');
+      cy.contains(
+        'You’ll need to sign in with a different account after January 31, 2025',
+      ).should('be.visible');
+      cy.contains('Start using your Login.gov account now').should(
+        'be.visible',
+      );
+      cy.get('[data-testid="logingov"]').should('be.visible');
+    });
+  });
+
+  context('when user has only an ID.me account', () => {
+    beforeEach(() => {
+      interceptCredentialEmails(200, { idme: 'user@idme.com' });
+      visitPage();
+    });
+
+    it('displays the ID.me account switch option', () => {
+      cy.get('#signin-changes-title').should('be.visible');
+      cy.contains(
+        'You’ll need to sign in with a different account after January 31, 2025',
+      ).should('be.visible');
+      cy.contains('Start using your ID.me account now').should('be.visible');
+      cy.get('[data-testid="idme"]').should('be.visible');
+    });
+  });
+
+  context('when user has both Login.gov and ID.me accounts', () => {
+    beforeEach(() => {
+      interceptCredentialEmails(200, {
+        logingov: 'user@logingov.com',
+        idme: 'user@idme.com',
+      });
+      visitPage();
+    });
+
+    it('displays options to use either Login.gov or ID.me account', () => {
+      cy.contains('Start using your Login.gov or ID.me account now').should(
+        'be.visible',
+      );
+      cy.get('[data-testid="logingov"]').should('be.visible');
+      cy.get('[data-testid="idme"]').should('be.visible');
+    });
+  });
+
+  context('when user has no Login.gov or ID.me account', () => {
+    beforeEach(() => {
+      interceptCredentialEmails(200, {});
+      visitPage();
+    });
+
+    it('displays the create account option', () => {
+      cy.get('#signin-changes-title').should('be.visible');
+      cy.contains('Create a different account now').should('be.visible');
+      cy.contains('Learn about why we are making changes to sign in').should(
+        'be.visible',
+      );
+      cy.get('#button-div').within(() => {
+        cy.get('[data-testid="logingov"]').should('be.visible');
+        cy.get('[data-testid="idme"]').should('be.visible');
+      });
+    });
+  });
+
+  context('when user clicks on continue with My HealtheVet link', () => {
+    beforeEach(() => {
+      sessionStorage.setItem('RETURN_URL', '/return-path');
+      interceptCredentialEmails(200, {});
+      visitPage();
+    });
+
+    it('navigates to the return URL', () => {
+      cy.get('va-link')
+        .contains('Continue with your My HealtheVet account for now')
+        .click();
+      cy.url().should('include', '/return-path');
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add end to end testing using cypress for ```/sign-in-changes-reminder```

## Related issue(s)

[Jira Ticket]()

## What areas of the site does it impact?

```/sign-in-changes-reminder``` endpoint
```sign_in_changes_reminder``` feature toggle

## Acceptance criteria
- Test for loading spinner
- Test for page scenarios
  - user has Login.gov
  - user has IDme
  - user has both IDme & Login.gov
  - user has neither IDme or Login.gov
  - user is not authorized
- Test return url

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

