### PR TITLE
[96833] [96834] Enforce nonempty search and enforce rep selection

### DIFF
--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -196,6 +196,12 @@ const SelectAccreditedRepresentative = props => {
 
 SelectAccreditedRepresentative.propTypes = {
   fetchRepresentatives: PropTypes.func,
+  formData: PropTypes.object,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  goToPath: PropTypes.func,
+  loggedIn: PropTypes.bool,
+  setFormData: PropTypes.func,
 };
 
 const mapStateToProps = state => ({

--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -4,6 +4,7 @@ import { setData } from '~/platform/forms-system/src/js/actions';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import { scrollToFirstError } from 'platform/utilities/ui';
 import { fetchRepresentatives } from '../api/fetchRepresentatives';
 import { fetchRepStatus } from '../api/fetchRepStatus';
 import SearchResult from './SearchResult';
@@ -28,6 +29,9 @@ const SelectAccreditedRepresentative = props => {
   const currentSelectedRep = useRef(
     formData?.['view:representativeSearchResults'],
   );
+
+  const noSearchError =
+    'Enter the name of the accredited representative or VSO you’d like to appoint';
 
   const isReviewPage = useReviewPage();
 
@@ -54,12 +58,14 @@ const SelectAccreditedRepresentative = props => {
     }
   };
 
-  const handleGoForward = () => {
-    if (!formData['view:selectedRepresentative']) {
-      // set unselected rep error
-    }
-    if (isReviewPage) {
-      if (formData['view:selectedRepresentative'] === currentSelectedRep) {
+  const handleGoForward = ({ selectionMade = false }) => {
+    const selection = formData['view:selectedRepresentative'];
+
+    if (!selection && !selectionMade) {
+      setError('You must select an accredited representative');
+      scrollToFirstError({ focusOnAlertRole: true });
+    } else if (isReviewPage) {
+      if (selection === currentSelectedRep) {
         goToPath('/review-and-submit');
       } else {
         goToPath('/representative-contact?review=true');
@@ -72,10 +78,9 @@ const SelectAccreditedRepresentative = props => {
   const handleSearch = async () => {
     const query = formData['view:representativeQuery'];
 
-    if (!query.trim()) {
-      setError(
-        'Enter the name of the accredited representative or VSO you’d like to appoint',
-      );
+    if (query === undefined || !query.trim()) {
+      setError(noSearchError);
+      scrollToFirstError({ focusOnAlertRole: true });
       return;
     }
 
@@ -117,7 +122,12 @@ const SelectAccreditedRepresentative = props => {
         ...tempData,
       });
 
-      handleGoForward();
+      // similar to the tempData trick above with async state variables,
+      //  we need to trick our routing logic to know that a selection has
+      //  been made before that selection is reflected in formData.
+      //  Otherwise, one would have to double click the select
+      //  representative button to register that a selection was made.
+      handleGoForward({ selectionMade: true });
     }
   };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds validation on the search query to enforce the query string's existence
- This pr adds validation on rep selection to enforce a selection must occur

## Related issue(s)

- [96833](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96833)
- [96834](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96834)

## Testing done

- went through the flow with various rep types trying combinations of searching for a string/ searching without a string and trying to advance the flow without making a rep selection
  - did this with fresh app, in progress app, and from review page
  - did this for auth and unauth users

## Screenshots
### Before
https://github.com/user-attachments/assets/2097c526-1a61-4718-9044-987e39c5a777

### After
https://github.com/user-attachments/assets/96f22dbc-ad54-484b-b4f4-e947f494c7e4

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user