### PR TITLE
Update check in message wording to 10 mins

### DIFF
--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -140,10 +140,10 @@ const CheckInConfirmation = props => {
         testID="multiple-appointments-confirm"
       >
         <div data-testid="confirmation-message">
-          <p>{staffMessage()}</p>
           <p data-testid="tell-staff-member">
             {t('tell-a-staff-member-if-you-wait')}
           </p>
+          <p>{staffMessage()}</p>
         </div>
         <h2>{t('your-appointments', { count: 1 })}</h2>
         <div

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -251,7 +251,7 @@
   "state-is-required": "State is required",
   "state-province-region-is-required": "State/Province/Region is required.",
   "stepchild": "Stepchild",
-  "tell-a-staff-member-if-you-wait": "Tell a staff member if you wait more than 15 minutes or if you haven’t been called back by your scheduled appointment time.",
+  "tell-a-staff-member-if-you-wait": "Tell a staff member if you wait more than 10 minutes or if you haven’t been called back by your scheduled appointment time.",
   "thank-you-for-checking-in": "Thank you for checking in.",
   "the-staff-can-call-you-back-anytime": "The staff can call you back anytime now that you’ve completed check-in.",
   "the-staff-can-call-you-back-anytime-see-staff": "The staff can call you back anytime now that you’ve completed check-in. See a staff member when you arrive in the waiting room.",

--- a/src/applications/check-in/locales/es/translation.json
+++ b/src/applications/check-in/locales/es/translation.json
@@ -283,7 +283,7 @@
   "state-province-region-is-required": "Se requiere un/una estado/provincia/región",
   "stepchild": "Hijastro o hijastra",
   "tagalog": "Tagalo",
-  "tell-a-staff-member-if-you-wait": "Dígale a un miembro del personal si espera más de 15 minutos o si no le han llamado a la hora de su cita programada.",
+  "tell-a-staff-member-if-you-wait": "Dígale a un miembro del personal si espera más de 10 minutos o si no le han llamado a la hora de su cita programada.",
   "thank-you-for-checking-in": "Gracias por completar el registro.",
   "the-link-selected-has-expired": "El enlace que seleccionó de nuestro mensaje de texto ya no es válido. Cuando sea el momento de registrarse para su próxima cita, le enviaremos un mensaje de texto.  O, si está en el centro, acuda al personal para registrarse y podrá revisar su información de contacto en ese momento.",
   "the-name": "El nombre",

--- a/src/applications/check-in/locales/tl/translation.json
+++ b/src/applications/check-in/locales/tl/translation.json
@@ -307,7 +307,7 @@
   "state-province-region-is-required": "Kailangan ang Estado/Probinsya/Rehiyon.",
   "stepchild": "Anak sa iba ng asawa",
   "tagalog": "Tagalog",
-  "tell-a-staff-member-if-you-wait": "Ipaalam sa miyembro ng staff kung naghintay ka ng mahigit 15 minuto o kung hindi ka pa tinatawag nang alinsunod sa iyong naka-iskedyul na oras ng appointment.",
+  "tell-a-staff-member-if-you-wait": "Ipaalam sa miyembro ng staff kung naghintay ka ng mahigit 10 minuto o kung hindi ka pa tinatawag nang alinsunod sa iyong naka-iskedyul na oras ng appointment.",
   "thank-you-for-checking-in": "Salamat sa pag-check in.",
   "the-link-selected-has-expired": "Ang link na pinili mo mula sa aming text message ay nag-expire na. Kapag oras na para mag-check in para sa iyong papalapit na appointment, magpapadala kami ng isa pang text. O kung ikaw ay nasa pasilidad, makita ang staff upang i-check in ka. Maaari mong i-review ang iyong impormasyon sa pakikipag-ugnayan sa oras na iyon.",
   "the-name": "Ang pangalan",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update `tell-a-staff-member-if-you-wait` key content to 10 minutes rather than 15
- Move staff message upon successful check in to go bellow the `tell-a-staff-member-if-you-wait` content

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#96034

## Testing done

- Run through check in flow and ensure the content after a successful check in is updated

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| 📱 |![Screen Shot 2024-11-15 at 10 24 40](https://github.com/user-attachments/assets/c2f4098a-b413-4f39-a2bb-03ebb8246323)|![Screen Shot 2024-11-15 at 10 13 01](https://github.com/user-attachments/assets/d62bbd81-6e42-4396-b0c0-2ceaa5f15baa)|
| 🖥️ |![Screenshot 2024-11-15 at 10-24-32 You’re checked in Veterans Affairs](https://github.com/user-attachments/assets/c2d2a698-0e5c-4253-9ccb-732144e8f469)|![Screenshot 2024-11-15 at 10-13-16 You’re checked in Veterans Affairs](https://github.com/user-attachments/assets/f375f288-5437-43bf-bec9-108aba892442)|

## What areas of the site does it impact?

- Check In

## Acceptance criteria
- [x] `tell-a-staff-member-if-you-wait` key is updated to 10 minutes rather than 15
- [x] Staff message is placed below the `tell-a-staff-member-if-you-wait` content

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
