### PR TITLE
Update spec coverage for insurance helpers in Health Care Application

### DIFF
--- a/src/applications/hca/config/chapters/insuranceInformation/general.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/general.js
@@ -11,7 +11,7 @@ import {
   TricarePolicyDescription,
 } from '../../../components/FormDescriptions';
 import { validatePolicyNumber } from '../../../utils/validation';
-import { getInsuranceAriaLabel } from '../../../utils/helpers';
+import { getInsuranceAriaLabel } from '../../../utils/helpers/insurance';
 import { emptyObjectSchema } from '../../../definitions';
 
 const { providers, isCoveredByHealthInsurance } = fullSchemaHca.properties;

--- a/src/applications/hca/tests/unit/utils/helpers/helpers.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/helpers.unit.spec.js
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
-
 import {
   transformAttachments,
-  getInsuranceAriaLabel,
   normalizeFullName,
   parseVeteranDob,
   getDataToSet,
@@ -59,41 +57,6 @@ describe('hca helpers', () => {
         };
         const transformedData = transformAttachments(inputData);
         expect(transformedData).to.deep.equal(expectedOutputData);
-      });
-    });
-  });
-
-  describe('when `getInsuranceAriaLabel` executes', () => {
-    describe('when the provider name is not provided', () => {
-      it('should return a generic label', () => {
-        const formData = {};
-        expect(getInsuranceAriaLabel(formData)).to.equal('insurance policy');
-      });
-    });
-
-    describe('when the provider name is provided', () => {
-      describe('when the policy number when provided', () => {
-        it('should return the provider name & policy number', () => {
-          const formData = {
-            insuranceName: 'Aetna',
-            insurancePolicyNumber: '005588',
-          };
-          expect(getInsuranceAriaLabel(formData)).to.equal(
-            'Aetna, Policy number 005588',
-          );
-        });
-      });
-
-      describe('when the group code when provided', () => {
-        it('should return the provider name & group code', () => {
-          const formData = {
-            insuranceName: 'Aetna',
-            insuranceGroupCode: '005588',
-          };
-          expect(getInsuranceAriaLabel(formData)).to.equal(
-            'Aetna, Group code 005588',
-          );
-        });
       });
     });
   });

--- a/src/applications/hca/tests/unit/utils/helpers/insurance.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/insurance.unit.spec.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { getInsuranceAriaLabel } from '../../../../utils/helpers/insurance';
+
+describe('hca `getInsuranceAriaLabel` method', () => {
+  it('should return a generic label when the provider name is not provided', () => {
+    const formData = {};
+    expect(getInsuranceAriaLabel(formData)).to.equal('insurance policy');
+  });
+
+  it('should return the provider name & policy number when the policy number when provided', () => {
+    const formData = {
+      insuranceName: 'Aetna',
+      insurancePolicyNumber: '005588',
+    };
+    expect(getInsuranceAriaLabel(formData)).to.equal(
+      'Aetna, Policy number 005588',
+    );
+  });
+
+  it('should return the provider name & group code when the group code when provided', () => {
+    const formData = {
+      insuranceName: 'Aetna',
+      insuranceGroupCode: '005588',
+    };
+    expect(getInsuranceAriaLabel(formData)).to.equal(
+      'Aetna, Group code 005588',
+    );
+  });
+});

--- a/src/applications/hca/tests/unit/utils/helpers/insurance.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/insurance.unit.spec.js
@@ -7,7 +7,7 @@ describe('hca `getInsuranceAriaLabel` method', () => {
     expect(getInsuranceAriaLabel(formData)).to.equal('insurance policy');
   });
 
-  it('should return the provider name & policy number when the policy number when provided', () => {
+  it('should return the provider name & policy number when the policy number is provided', () => {
     const formData = {
       insuranceName: 'Aetna',
       insurancePolicyNumber: '005588',
@@ -17,7 +17,7 @@ describe('hca `getInsuranceAriaLabel` method', () => {
     );
   });
 
-  it('should return the provider name & group code when the group code when provided', () => {
+  it('should return the provider name & group code when the group code is provided', () => {
     const formData = {
       insuranceName: 'Aetna',
       insuranceGroupCode: '005588',

--- a/src/applications/hca/utils/helpers/index.js
+++ b/src/applications/hca/utils/helpers/index.js
@@ -167,26 +167,6 @@ export function createLiteralMap(arrayToMap) {
 }
 
 /**
- * Helper that returns a descriptive aria label for the edit buttons on the
- * health insurance information page
- * @param {Object} formData - the current data object passed from the form
- * @returns {String} - the name of the provider and either the policy number
- * or group code.
- */
-export function getInsuranceAriaLabel(formData) {
-  const { insuranceName, insurancePolicyNumber, insuranceGroupCode } = formData;
-  const labels = {
-    policy: insurancePolicyNumber
-      ? `Policy number ${insurancePolicyNumber}`
-      : null,
-    group: insuranceGroupCode ? `Group code ${insuranceGroupCode}` : null,
-  };
-  return insuranceName
-    ? `${insuranceName}, ${labels.policy ?? labels.group}`
-    : 'insurance policy';
-}
-
-/**
  * Helper that builds a full name string based on provided input values
  * @param {Object} name - the object that stores all the available input values
  * @param {Boolean} outputMiddle - optional param to declare whether to output

--- a/src/applications/hca/utils/helpers/insurance.js
+++ b/src/applications/hca/utils/helpers/insurance.js
@@ -1,0 +1,19 @@
+/**
+ * Helper that returns a descriptive aria label for the edit buttons on the
+ * health insurance information page
+ * @param {Object} formData - the current data object passed from the form
+ * @returns {String} - the name of the provider and either the policy number
+ * or group code.
+ */
+export function getInsuranceAriaLabel(formData) {
+  const { insuranceName, insurancePolicyNumber, insuranceGroupCode } = formData;
+  const labels = {
+    policy: insurancePolicyNumber
+      ? `Policy number ${insurancePolicyNumber}`
+      : null,
+    group: insuranceGroupCode ? `Group code ${insuranceGroupCode}` : null,
+  };
+  return insuranceName
+    ? `${insuranceName}, ${labels.policy ?? labels.group}`
+    : 'insurance policy';
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR isolates the insurance helper methods into their own file and updates spec coverage for all methods. No updates were made to the methods themselves, just the spec coverage and what file they live in.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#60897

## Screenshots

![Screenshot 2024-11-15 at 14 11 45](https://github.com/user-attachments/assets/7c3deb2e-d794-4e24-ba64-ea6aa1324b80)

## Acceptance criteria

- Spec coverage meets or exceeds allowable coverage numbers

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution