### PR TITLE
VACMS-19516 Email signup form disable analytics

### DIFF
--- a/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
+++ b/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
@@ -84,6 +84,7 @@ const EmailSignup = () => {
           use-forms-pattern="single"
         />
         <va-button
+          disable-analytics
           class="vads-u-width--auto vads-u-margin-bottom--2 vads-u-margin-top--1p5"
           onClick={event => {
             event.preventDefault();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Disable web component analytics for the `va-button` in the email signup form on the homepage.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19516

## Testing done
Checked analytics when clicking the Sign up button. Only this custom event should appear:

```
{
  event: 'homepage-email-sign-up'
  button-click-label: 'Sign up'
}
```

## Screenshots
<img width="516" alt="Screenshot 2024-11-15 at 3 03 30 PM" src="https://github.com/user-attachments/assets/851c470e-e6fb-4d32-98c4-76a5b163b5b6">

## What areas of the site does it impact?

Homepage email signup form only.