### PR TITLE
Conditions 600 Add to "Conditions First" List and Loop the Follow Up Questions

### DIFF
--- a/src/applications/user-testing/new-conditions/config/form.js
+++ b/src/applications/user-testing/new-conditions/config/form.js
@@ -1,14 +1,16 @@
+import React from 'react';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import CallVBACenter from 'platform/static-data/CallVBACenter';
-import React from 'react';
+
 import { SUBTITLE, TITLE } from '../constants';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import IntroductionPage from '../containers/IntroductionPage';
 import manifest from '../manifest.json';
-
 import chooseDemo from '../pages/chooseDemo';
 import conditionByConditionPages from '../pages/conditionByConditionPages';
 import conditionsFirstPages from '../pages/conditionsFirstPages';
+import followUp from '../pages/followUp';
+import followUpIntro from '../pages/followUpIntro';
 
 const FormFooter = () => (
   <div className="row vads-u-margin-bottom--2">
@@ -70,6 +72,8 @@ const formConfig = {
         chooseDemo,
         ...conditionByConditionPages,
         ...conditionsFirstPages,
+        followUpIntro,
+        followUp,
       },
     },
   },

--- a/src/applications/user-testing/new-conditions/config/form.js
+++ b/src/applications/user-testing/new-conditions/config/form.js
@@ -20,7 +20,7 @@ const FormFooter = () => (
           <div>
             <p className="help-talk">
               For help filling out this form, or if the form isn’t working
-              right, please <CallVBACenter />
+              right, <CallVBACenter />
             </p>
           </div>
         </div>
@@ -50,16 +50,16 @@ const formConfig = {
       inProgress:
         'Your disability compensation application (21-526EZ) is in progress.',
       expired:
-        'Your saved disability compensation application (21-526EZ) has expired. If you want to apply for disability compensation, please start a new application.',
+        'Your saved disability compensation application (21-526EZ) has expired. If you want to apply for disability compensation, start a new application.',
       saved: 'Your disability compensation application has been saved.',
     },
   },
   version: 0,
   prefillEnabled: true,
   savedFormMessages: {
-    notFound: 'Please start over to apply for disability compensation.',
+    notFound: 'Start over to apply for disability compensation.',
     noAuth:
-      'Please sign in again to continue your application for disability compensation.',
+      'Sign in again to continue your application for disability compensation.',
   },
   title: TITLE,
   subTitle: SUBTITLE,

--- a/src/applications/user-testing/new-conditions/constants.js
+++ b/src/applications/user-testing/new-conditions/constants.js
@@ -2,3 +2,4 @@ export const TITLE = 'Demo: File for disability compensation - New conditions';
 export const SUBTITLE = 'Demo of VA Form 21-526EZ';
 export const CONDITION_BY_CONDITION = 'ape';
 export const CONDITIONS_FIRST = 'elk';
+export const NULL_CONDITION_STRING = 'Unknown Condition';

--- a/src/applications/user-testing/new-conditions/containers/ConfirmationPage.jsx
+++ b/src/applications/user-testing/new-conditions/containers/ConfirmationPage.jsx
@@ -37,7 +37,7 @@ export const ConfirmationPage = () => {
       </va-alert>
 
       <p>We may contact you for more information or documents.</p>
-      <p className="screen-only">Please print this page for your records.</p>
+      <p className="screen-only">Print this page for your records.</p>
       <div className="inset">
         <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
           File for disability compensation Claim{' '}

--- a/src/applications/user-testing/new-conditions/content/newConditions.jsx
+++ b/src/applications/user-testing/new-conditions/content/newConditions.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { createItemName } from '../pages/conditionsFirstPages/utils';
+
 export const conditionInstructions = (
   <>
     <p>Add a condition below. You can add more conditions later.</p>
@@ -20,6 +22,12 @@ export const conditionInstructions = (
     </ul>
     <h4>Add a new condition</h4>
   </>
+);
+
+export const disabilityNameTitle = ({ formData }) => (
+  <legend className="schemaform-block-title schemaform-title-underline">
+    {createItemName(formData, true)}
+  </legend>
 );
 
 export const ServiceConnectedDisabilityDescription = () => (

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/cause.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/cause.js
@@ -7,7 +7,7 @@ import {
 import { ServiceConnectedDisabilityDescription } from '../../content/newConditions';
 import { createItemName } from './utils';
 
-const causeOptions = {
+export const causeOptions = {
   NEW:
     'My condition was caused by an injury or exposure during my military service.',
   SECONDARY:

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
@@ -5,14 +5,13 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import Autocomplete from '../../components/Autocomplete';
+import { NULL_CONDITION_STRING } from '../../constants';
 import { conditionOptions } from '../../content/conditionOptions';
 import { conditionInstructions } from '../../content/newConditions';
 import { arrayBuilderOptions, createTitle } from './utils';
 
 const missingConditionMessage =
   'Enter a condition, diagnosis, or short description of your symptoms';
-
-const NULL_CONDITION_STRING = 'Unknown Condition';
 
 const regexNonWord = /[^\w]/g;
 const sippableId = str =>

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/condition.js
@@ -5,14 +5,13 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import Autocomplete from '../../components/Autocomplete';
+import { NULL_CONDITION_STRING } from '../../constants';
 import { conditionOptions } from '../../content/conditionOptions';
 import { conditionInstructions } from '../../content/newConditions';
 import { arrayBuilderOptions, createTitle } from './utils';
 
 const missingConditionMessage =
   'Enter a condition, diagnosis, or short description of your symptoms';
-
-const NULL_CONDITION_STRING = 'Unknown Condition';
 
 const regexNonWord = /[^\w]/g;
 const sippableId = str =>

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
@@ -25,7 +25,7 @@ export const hasSideOfBody = (formData, index) => {
 };
 
 // Different than lodash _capitalize because does not make rest of string lowercase which would break acronyms
-const capitalizeFirstLetter = string => {
+export const capitalizeFirstLetter = string => {
   return string?.charAt(0).toUpperCase() + string?.slice(1);
 };
 

--- a/src/applications/user-testing/new-conditions/pages/followUp.js
+++ b/src/applications/user-testing/new-conditions/pages/followUp.js
@@ -1,0 +1,187 @@
+import {
+  radioSchema,
+  radioUI,
+  selectSchema,
+  selectUI,
+  textareaUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+import { CONDITIONS_FIRST } from '../constants';
+import { conditionOptions } from '../content/conditionOptions';
+import {
+  disabilityNameTitle,
+  ServiceConnectedDisabilityDescription,
+} from '../content/newConditions';
+import { causeOptions } from './conditionByConditionPages/cause';
+import { createItemName } from './conditionsFirstPages/utils';
+
+const getOtherConditions = (formData, currentIndex) => {
+  const otherNewConditions = formData?.conditionsFirst
+    ?.filter((_, index) => index !== currentIndex)
+    ?.map(item => createItemName(item));
+
+  return [...otherNewConditions];
+};
+
+const allCauses = ['NEW', 'SECONDARY', 'WORSENED', 'VA'];
+const causesWithoutSecondary = allCauses.filter(cause => cause !== 'SECONDARY');
+
+/** @type {PageSchema} */
+export default {
+  title: formData => createItemName(formData, true),
+  depends: formData => formData.demo === 'CONDITIONS_FIRST',
+  path: `new-conditions-${CONDITIONS_FIRST}-follow-up/:index`,
+  showPagePerItem: true,
+  arrayPath: 'conditionsFirst',
+  uiSchema: {
+    'ui:title': 'Conditions cause follow up',
+    conditionsFirst: {
+      items: {
+        'ui:title': disabilityNameTitle,
+        'ui:options': {
+          itemAriaLabel: data => `${data.condition} followup questions`,
+        },
+        cause: radioUI({
+          title: 'What caused your condition?',
+          labels: causeOptions,
+          options: {
+            updateSchema: (formData, _causeSchema, _causeUISchema, index) => ({
+              enum: getOtherConditions(formData, index).length
+                ? allCauses
+                : causesWithoutSecondary,
+            }),
+          },
+        }),
+        primaryDescription: textareaUI({
+          title:
+            'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing.',
+          required: (formData, index) =>
+            formData.conditionsFirst[index]?.cause === 'NEW',
+          charcount: true,
+          expandUnder: 'cause',
+          expandUnderCondition: 'NEW',
+        }),
+        'view:secondaryFollowUp': {
+          causedByCondition: selectUI({
+            title:
+              'Please choose the disability that caused the new disability you’re claiming here.',
+            required: (formData, index) =>
+              formData.conditionsFirst[index]?.cause === 'SECONDARY' &&
+              getOtherConditions(formData, index).length > 0,
+            updateSchema: (formData, _schema, _uiSchema, index) => {
+              return selectSchema(getOtherConditions(formData, index));
+            },
+          }),
+          causedByConditionDescription: textareaUI({
+            title:
+              'Please briefly describe how the disability you selected caused your new disability.',
+            required: (formData, index) =>
+              formData.conditionsFirst[index]?.cause === 'SECONDARY',
+            charcount: true,
+          }),
+          'ui:options': {
+            expandUnder: 'cause',
+            expandUnderCondition: 'SECONDARY',
+          },
+        },
+        'view:worsenedFollowUp': {
+          worsenedDescription: textareaUI({
+            title:
+              'Please briefly describe the injury or exposure during your military service that caused your existing disability to get worse.',
+            required: (formData, index) =>
+              formData.conditionsFirst[index]?.cause === 'WORSENED',
+            charcount: true,
+          }),
+          worsenedEffects: textareaUI({
+            title:
+              'Please tell us how the disability affected you before your service, and how it affects you now after your service.',
+            required: (formData, index) =>
+              formData.conditionsFirst[index]?.cause === 'WORSENED',
+            charcount: true,
+          }),
+          'ui:options': {
+            expandUnder: 'cause',
+            expandUnderCondition: 'WORSENED',
+          },
+        },
+        'view:vaFollowUp': {
+          vaMistreatmentDescription: textareaUI({
+            title:
+              'Please briefly describe the injury or event while you were under VA care that caused your disability.',
+            required: (formData, index) =>
+              formData.conditionsFirst[index]?.cause === 'VA',
+            charcount: true,
+          }),
+          vaMistreatmentLocation: textareaUI({
+            title: 'Please tell us where this happened.',
+            required: (formData, index) =>
+              formData.conditionsFirst[index]?.cause === 'VA',
+            charcount: true,
+          }),
+          'ui:options': {
+            expandUnder: 'cause',
+            expandUnderCondition: 'VA',
+          },
+        },
+        'view:serviceConnectedDisabilityDescription': {
+          'ui:description': ServiceConnectedDisabilityDescription,
+        },
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      conditionsFirst: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['cause'],
+          properties: {
+            cause: radioSchema(Object.keys(causeOptions)),
+            primaryDescription: {
+              type: 'string',
+              maxLength: 400,
+            },
+            'view:secondaryFollowUp': {
+              type: 'object',
+              properties: {
+                causedByCondition: selectSchema(conditionOptions),
+                causedByConditionDescription: {
+                  type: 'string',
+                  maxLength: 400,
+                },
+              },
+            },
+            'view:worsenedFollowUp': {
+              type: 'object',
+              properties: {
+                worsenedDescription: {
+                  type: 'string',
+                  maxLength: 50,
+                },
+                worsenedEffects: {
+                  type: 'string',
+                  maxLength: 350,
+                },
+              },
+            },
+            'view:vaFollowUp': {
+              type: 'object',
+              properties: {
+                vaMistreatmentDescription: {
+                  type: 'string',
+                  maxLength: 350,
+                },
+                vaMistreatmentLocation: {
+                  type: 'string',
+                  maxLength: 25,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/user-testing/new-conditions/pages/followUp.js
+++ b/src/applications/user-testing/new-conditions/pages/followUp.js
@@ -54,7 +54,7 @@ export default {
         }),
         primaryDescription: textareaUI({
           title:
-            'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing.',
+            'Briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing.',
           required: (formData, index) =>
             formData.conditionsFirst[index]?.cause === 'NEW',
           charcount: true,
@@ -64,7 +64,7 @@ export default {
         'view:secondaryFollowUp': {
           causedByCondition: selectUI({
             title:
-              'Please choose the disability that caused the new disability you’re claiming here.',
+              'Choose the service-connected disability that caused the new condition that you’re claiming here.',
             required: (formData, index) =>
               formData.conditionsFirst[index]?.cause === 'SECONDARY' &&
               getOtherConditions(formData, index).length > 0,
@@ -74,7 +74,7 @@ export default {
           }),
           causedByConditionDescription: textareaUI({
             title:
-              'Please briefly describe how the disability you selected caused your new disability.',
+              'Briefly describe how this disability caused your new condition.',
             required: (formData, index) =>
               formData.conditionsFirst[index]?.cause === 'SECONDARY',
             charcount: true,
@@ -87,14 +87,14 @@ export default {
         'view:worsenedFollowUp': {
           worsenedDescription: textareaUI({
             title:
-              'Please briefly describe the injury or exposure during your military service that caused your existing disability to get worse.',
+              'Briefly describe the injury or exposure during your military service that caused your existing disability to get worse.',
             required: (formData, index) =>
               formData.conditionsFirst[index]?.cause === 'WORSENED',
             charcount: true,
           }),
           worsenedEffects: textareaUI({
             title:
-              'Please tell us how the disability affected you before your service, and how it affects you now after your service.',
+              'Tell us how the disability affected you before your service, and how it affects you now after your service.',
             required: (formData, index) =>
               formData.conditionsFirst[index]?.cause === 'WORSENED',
             charcount: true,
@@ -107,13 +107,13 @@ export default {
         'view:vaFollowUp': {
           vaMistreatmentDescription: textareaUI({
             title:
-              'Please briefly describe the injury or event while you were under VA care that caused your disability.',
+              'Briefly describe the injury or event while you were under VA care that caused your disability.',
             required: (formData, index) =>
               formData.conditionsFirst[index]?.cause === 'VA',
             charcount: true,
           }),
           vaMistreatmentLocation: textareaUI({
-            title: 'Please tell us where this happened.',
+            title: 'Tell us where this happened.',
             required: (formData, index) =>
               formData.conditionsFirst[index]?.cause === 'VA',
             charcount: true,

--- a/src/applications/user-testing/new-conditions/pages/followUpIntro.js
+++ b/src/applications/user-testing/new-conditions/pages/followUpIntro.js
@@ -1,0 +1,19 @@
+import { descriptionUI } from 'platform/forms-system/src/js/web-component-patterns';
+
+import { CONDITIONS_FIRST } from '../constants';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Follow-up intro',
+  depends: formData => formData.demo === 'CONDITIONS_FIRST',
+  path: `new-conditions-${CONDITIONS_FIRST}-follow-up-intro`,
+  uiSchema: {
+    ...descriptionUI(
+      'Now we’re going to ask you some follow-up questions about each of your conditions. We’ll go through them one by one.',
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {},
+  },
+};

--- a/src/applications/user-testing/new-conditions/sass/new-conditions.scss
+++ b/src/applications/user-testing/new-conditions/sass/new-conditions.scss
@@ -1,10 +1,3 @@
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-process-list";
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-form-process";
-@import "../../../../platform/forms/sass/m-schemaform";
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-modal";
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-omb-info";
-@import "../../../../platform/forms/sass/m-form-confirmation";
-
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/functions";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-process-list";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-form-process";


### PR DESCRIPTION
## Summary

- On 11/7 it was also deemed necessary in addition to the list and loop that encompassed the new conditions, date, cause, and follow up questions (which was named the "Condition by Condition" approach), to have a list and loop that just encompassed new conditions and date and then leave the cause and follow-up as they currently are (named the "Conditions First" approach). 
- This PR adds the follow-up questions.
- Which team do you work for, does your team own the maintenance of this component? Conditions Team and Yes

## Related issue(s)

- [Engineering Multiple Responses Condition by Condition and Conditions First Multi Page Prototypes
#600](https://github.com/orgs/department-of-veterans-affairs/projects/873/views/2?pane=issue&itemId=79627396&issue=department-of-veterans-affairs%7Cvagov-claim-classification%7C600)