### PR TITLE
CST - Added changes to the claims status workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,6 +402,7 @@
     "nohoist": [
       "**/applications-check-in/i18next-resources-to-backend",
       "**/applications-check-in/react-i18next",
+      "**/applications-claims-status/@department-of-veterans-affairs/component-library",
       "**/applications-vaos/simple-guid",
       "**/applications-vaos/mocker-api",
       "**/platform-pdf/blob-stream",
@@ -439,6 +440,7 @@
       "**/platform-testing/sentry-testkit",
       "**/platform-testing/table",
       "**/platform-testing/winston"
+
     ]
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/src/applications/claims-status/package.json
+++ b/src/applications/claims-status/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@department-of-veterans-affairs/claims-status",
+    "name": "applications-claims-status",
     "version": "1.0.0",
     "description": "Dependencies for claims-status tool. Specifically, component library is pinned to 43.0.2 to ensure v1 of the file input component can still be used while the team works on migrating to mulitple file input. For now, please refrain from bumping the component library version in this dependeny list.",
     "scripts": {

--- a/src/applications/claims-status/package.json
+++ b/src/applications/claims-status/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "applications-claims-status",
-    "version": "1.0.0",
-    "description": "Dependencies for claims-status tool. Specifically, component library is pinned to 43.0.2 to ensure v1 of the file input component can still be used while the team works on migrating to mulitple file input. For now, please refrain from bumping the component library version in this dependeny list.",
-    "scripts": {
-      "demo": "echo DEMOING $npm_package_name v $npm_package_version with WORKSPACES"
-    },
-    "dependencies": {
-        "@department-of-veterans-affairs/component-library": "43.0.2"
-    },
-    "peerDependencies": {
-      "react": "*",
-      "react-redux": "*",
-      "prop-types": "*",
-      "moment": "*",
-      "@sentry/browser": "*",
-      "chai": "*",
-      "sinon": "*",
-      "enzyme": "*"
-    },
-    "license": "MIT",
-    "private": true
-  }
+  "name": "@department-of-veterans-affairs/applications-claims-status",
+  "version": "1.0.0",
+  "description": "Dependencies for claims-status tool. Specifically, component library is pinned to 43.0.2 to ensure v1 of the file input component can still be used while the team works on migrating to mulitple file input. For now, please refrain from bumping the component library version in this dependeny list.",
+  "scripts": {
+    "demo": "echo DEMOING $npm_package_name v $npm_package_version with WORKSPACES"
+  },
+  "dependencies": {
+    "@department-of-veterans-affairs/component-library": "43.0.2"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-redux": "*",
+    "prop-types": "*",
+    "moment": "*",
+    "@sentry/browser": "*",
+    "chai": "*",
+    "sinon": "*",
+    "enzyme": "*"
+  },
+  "license": "MIT",
+  "private": true
+}


### PR DESCRIPTION
## Summary

We created a workspace in [this](https://github.com/department-of-veterans-affairs/vets-website/pull/33036) pr but the changes were not being merges into Staging. Found [this](https://depo-platform-documentation.scrollhelp.site/developer-docs/guide-for-engineers#WorktreeandWorkspaceSetupGuide-src/platformcodeworkspaces:) platform doc about workspaces and I think we are missing our dependency in the nohoist section so I added that.


## Related issue(s)

- _Link to ticket created in https://github.com/department-of-veterans-affairs/va.gov-team/issues/96817
- _Link to previous change of the code/bug https://github.com/department-of-veterans-affairs/vets-website/pull/33036

## Testing done

For testing I deleted node-modules and did a `yarn install` on the app folder and root directory and things appear to be working correctly.

## Screenshots


https://github.com/user-attachments/assets/53ad719e-db59-4727-8591-607b76037ec7



## What areas of the site does it impact?

Claims Status Tool
## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
