### PR TITLE
combined two unordered lists into one on landing page FAQ

### DIFF
--- a/src/applications/mhv-secure-messaging/components/FrequentlyAskedQuestions.jsx
+++ b/src/applications/mhv-secure-messaging/components/FrequentlyAskedQuestions.jsx
@@ -85,12 +85,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
             </li>
 
             <CrisisLineConnectButton />
-          </ul>
 
-          <ul>
             <li>
               <strong>If you think your life or health is in danger, </strong>{' '}
-              call <va-telephone contact="911" data-dd-action-name="911 link" />
+              call <va-telephone contact="911" data-dd-action-name="911 link" />{' '}
               or go to the nearest emergency room.
             </li>
           </ul>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- In the FAQ for the SM Landing page, one of the accordions was coded as two <ul> elements.  This change combines separate the <li> elements into one <ul>

## Related issue(s)

### [MHV-63940](https://jira.devops.va.gov/browse/MHV-63940) - Error in the accordion code on the landing page ###

> Slack thread for multiple lines in compiled html from jsx string interpolation
> Medical Records worked on a solution but their solution might not be the solution here. I highly recommend reading over the thread and/or contacting other developers in this thread who has worked on this in the past.
> 
> https://dsva.slack.com/archives/C044WNQT4P9/p1702657137899519
> 
> Where to find this issue
> Error in the accordion code on the landing page (From Duke's audit)
> Emergency contact information.
> 
> Issue: Unordered list that appears in the accordion heading “What if I have an emergency or an urgent question?“ is broken up into two lists.
> Severity: Low
> Recommendation: Create one list out of two. A similar accordion appears on the Medical Records landing page and is coded correctly.
> Feature Flag Y/N ?
> 
> DataDog Analytics  Y/N ?
> 
> Manual Testing Y/N ?  Y-Rakesh
> 
> Automated Testing Y/N  
> 
> Accessibility Testing Y/N ? Y-Bobby
> 
> UCD Validation Y/N N
> 
> Acceptance Criteria:
> 
> AC1 One list has been created and follows design in medications

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

![Screenshot 2024-11-18 at 1 01 47 PM](https://github.com/user-attachments/assets/42a13adf-6cc9-4fe5-b3cc-6946ae93ad3e)


## What areas of the site does it impact?

Va.gov - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
