### PR TITLE
VACMS-19516 Fix email input focus on error

### DIFF
--- a/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
+++ b/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
@@ -1,10 +1,52 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { isValidEmail } from 'platform/forms/validations';
+import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const EmailSignup = () => {
   const [inputError, setInputError] = useState(null);
-  const [email, setEmail] = useState(null);
+  const [email, setEmail] = useState('');
+  const [headerHasFocused, setHeaderHasFocused] = useState(false);
+  const textInput = document?.querySelector('va-text-input');
+  const shadowRoot = textInput?.shadowRoot;
+
+  useEffect(
+    () => {
+      if (shadowRoot) {
+        const charCountStyle = document.createElement('style');
+
+        charCountStyle.textContent = `
+          #charcount-message {
+            color: #565c65;
+          }
+        `;
+
+        shadowRoot.appendChild(charCountStyle);
+      }
+    },
+    [shadowRoot],
+  );
+
+  useEffect(
+    () => {
+      if (shadowRoot && !headerHasFocused) {
+        const inputHeader = shadowRoot?.querySelector('h2');
+
+        if (inputHeader) {
+          inputHeader.addEventListener('focus', () => {
+            inputHeader.style.outline = 'none';
+          });
+        }
+
+        if (inputHeader && inputError) {
+          inputHeader.setAttribute('tabindex', '-1');
+          inputHeader.focus();
+          setHeaderHasFocused(true);
+        }
+      }
+    },
+    [inputError, shadowRoot],
+  );
 
   const setInputErrorState = () => {
     if (!email || !email?.length || !isValidEmail(email)) {
@@ -62,7 +104,7 @@ const EmailSignup = () => {
           id="homepage-hidden-email"
           value={email}
         />
-        <va-text-input
+        <VaTextInput
           autocomplete="email"
           charcount
           class="homepage-email-input"
@@ -82,6 +124,7 @@ const EmailSignup = () => {
           required
           type="email"
           use-forms-pattern="single"
+          value={email}
         />
         <va-button
           class="vads-u-width--auto vads-u-margin-bottom--2 vads-u-margin-top--1p5"

--- a/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
+++ b/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
@@ -7,28 +7,29 @@ const EmailSignup = () => {
   const [inputError, setInputError] = useState(null);
   const [email, setEmail] = useState('');
   const [headerHasFocused, setHeaderHasFocused] = useState(false);
-  const textInput = document?.querySelector('va-text-input');
-  const shadowRoot = textInput?.shadowRoot;
 
-  useEffect(
-    () => {
-      if (shadowRoot) {
-        const charCountStyle = document.createElement('style');
+  useEffect(() => {
+    const textInput = document?.querySelector('va-text-input');
+    const shadowRoot = textInput?.shadowRoot;
 
-        charCountStyle.textContent = `
+    if (shadowRoot) {
+      const charCountStyle = document.createElement('style');
+
+      charCountStyle.textContent = `
           #charcount-message {
             color: #565c65;
           }
         `;
 
-        shadowRoot.appendChild(charCountStyle);
-      }
-    },
-    [shadowRoot],
-  );
+      shadowRoot.appendChild(charCountStyle);
+    }
+  });
 
   useEffect(
     () => {
+      const textInput = document?.querySelector('va-text-input');
+      const shadowRoot = textInput?.shadowRoot;
+
       if (shadowRoot && !headerHasFocused) {
         const inputHeader = shadowRoot?.querySelector('h2');
 
@@ -45,7 +46,7 @@ const EmailSignup = () => {
         }
       }
     },
-    [inputError, shadowRoot],
+    [inputError],
   );
 
   const setInputErrorState = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
When the email signup widget has an error, the focus should be thrown to the header of the input so that the next element in the tab order is the input. This fixes that issue as well as resolves an issue with not enough color contrast between the character counter text and the blue background. ([Color contrast guidance from Laura here](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19516#issuecomment-2484157450)).

Also includes a tweak to make the input a `VaTextInput` so it will be properly attached to the React binding and event listeners. It was causing a console error that I did not notice before.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19516

## Testing done
**Requires testing locally with content-build running and pointed to https://cms-g1rglcuobmlvgewnhny9uo7f6vigntwi.demo.cms.va.gov/** - This is how you get the new email form because the feature toggle is in the correct state. Otherwise you will only see the old form.

1. Turn on Mac VoiceOver so you can tell where focus is thrown
2. Type in an invalid email address and tab out of the field (blur the input)
3. Validate that the focus is thrown to the header of the input (`Sign up to get the latest VA updates`)
4. Immediately after the header is read, the error message should be read
5. If you hit the tab key, the next element that you should focus on is the input where you can edit the email
6. Edit the email address to a valid input
7. Tab again to Sign up and verify that the button works correctly

## Screenshots

For the focus updates:

https://github.com/user-attachments/assets/73ae9c8b-cae9-418e-8a17-4c269474ad64

For the color contrast updates:

<img width="524" alt="Screenshot 2024-11-19 at 10 15 18 AM" src="https://github.com/user-attachments/assets/3a0e868b-d9ff-479b-b071-04b6d8836a74">

<img width="595" alt="Screenshot 2024-11-19 at 10 15 13 AM" src="https://github.com/user-attachments/assets/298a5c0a-4f8a-406e-8037-af21b5f8cc38">

## Acceptance criteria

- [x] Focus should be thrown to the header of the component so the next tabbable element is the input