### PR TITLE
bump axe-core and @axe-core/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "devDependencies": {
     "@actions/core": "^1.9.1",
-    "@axe-core/react": "^4.10.0",
+    "@axe-core/react": "^4.10.1",
     "@babel/core": "^7.26.0",
     "@babel/eslint-parser": "^7.25.9",
     "@babel/parser": "^7.26.2",
@@ -143,7 +143,7 @@
     "@webpack-cli/serve": "^1.6.0",
     "append-query": "^2.1.1",
     "autoprefixer": "^10.3.5",
-    "axe-core": "^4.4.3",
+    "axe-core": "^4.10.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/src/applications/claims-status/components/appeals-v2/PastEvent.jsx
+++ b/src/applications/claims-status/components/appeals-v2/PastEvent.jsx
@@ -6,7 +6,7 @@ const PastEvent = ({ title, date, description, hideSeparator }) => {
     hideSeparator === true ? null : <div className="separator" />;
 
   return (
-    <li role="presentation" className={'process-step section-complete'}>
+    <li className="process-step section-complete">
       <h3>{title}</h3>
       <div className="appeal-event-date">on {date}</div>
       <p>{description}</p>

--- a/src/applications/claims-status/tests/e2e/07.appeal-status.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/07.appeal-status.cypress.spec.js
@@ -81,6 +81,7 @@ describe('Appeals page test', () => {
     cy.get('a.ddl-link').click();
 
     cy.get('h1').should('contain', 'Your VA claim and appeal letters');
+    cy.injectAxeThenAxeCheck();
   });
 
   it('should show DDL link for post-decided appeal ', () => {
@@ -96,5 +97,6 @@ describe('Appeals page test', () => {
     cy.get('a.ddl-link').click();
 
     cy.get('h1').should('contain', 'Your VA claim and appeal letters');
+    cy.injectAxeThenAxeCheck();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,12 +30,12 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@axe-core/react@^4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@axe-core/react/-/react-4.10.0.tgz#124cde86b9bbbf44fd0f2c787beed186b8b9a3d4"
-  integrity sha512-gpFj1+G0zabbd0ZDum1N5FPJtUOfPIfslXNH58WuR7opSK0WTwPJ49ZlYr/Wg2fA4VGI5lfkG5fAZSG9p8ecKw==
+"@axe-core/react@^4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/react/-/react-4.10.1.tgz#f9ab3012e14a399426b1f2599bfe5cae4957bc0d"
+  integrity sha512-GRGx/3Gbce9WQYXgY0iZzqOaHIRXBNGyV+zoUhJzBuDeoTL+XoeY3u/9PzdIVyH0pbNs1n1RChfsmWBy6hzKPg==
   dependencies:
-    axe-core "~4.10.0"
+    axe-core "~4.10.2"
     requestidlecallback "^0.3.0"
 
 "@babel/code-frame@7.12.11":
@@ -5875,15 +5875,10 @@ axe-core@=4.7.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.0.tgz#34ba5a48a8b564f67e103f0aa5768d76e15bbbbf"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
-axe-core@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
-  integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
-
-axe-core@~4.10.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.1.tgz#7d2589b0183f05b0f23e55c2f4cdf97b5bdc66d9"
-  integrity sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==
+axe-core@^4.10.2, axe-core@~4.10.2:
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
+  integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
 
 axios@^0.21.1, axios@^1.1.3:
   version "0.21.4"


### PR DESCRIPTION
## Summary

- bump `axe-core` and `@axe-core/react` due to a [regression](https://github.com/dequelabs/axe-core/pull/4617) in `axe-core`
- This error no longer shows up in new version.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1872

## Testing done

Browser testing

## Screenshots

Fixes the following issue while developing on the front end:
![image](https://github.com/user-attachments/assets/e0d412c9-4875-481f-806f-0f88e32dbece)

## What areas of the site does it impact?

Development

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
