### PR TITLE
Cc/96439/referral mock integration

### DIFF
--- a/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
@@ -19,13 +19,13 @@ export default function ScheduleReferral(props) {
   );
 
   const appointmentCountString =
-    currentReferral?.numberOfAppointments === 1
+    currentReferral.numberOfAppointments === 1
       ? '1 appointment'
-      : `${currentReferral?.numberOfAppointments} appointments`;
+      : `${currentReferral.numberOfAppointments} appointments`;
   return (
     <FormLayout pageTitle="Review Approved Referral">
       <div>
-        <h1>Referral for {currentReferral?.CategoryOfCare}</h1>
+        <h1>Referral for {currentReferral.CategoryOfCare}</h1>
         <p data-testid="subtitle">
           {`Your referring VA facility approved you for ${appointmentCountString} with a community care provider. You can now schedule your appointment with a community care provider.`}
         </p>
@@ -49,24 +49,24 @@ export default function ScheduleReferral(props) {
           <strong>Expiration date: </strong>
           {`All appointments for this referral must be scheduled by
           ${format(
-            new Date(currentReferral?.ReferralExpirationDate),
+            new Date(currentReferral.ReferralExpirationDate),
             'MMMM d, yyyy',
           )}`}
           <br />
           <strong>Type of care: </strong>
-          {currentReferral?.CategoryOfCare}
+          {currentReferral.CategoryOfCare}
           <br />
           <strong>Provider: </strong>
-          {currentReferral?.providerName}
+          {currentReferral.providerName}
           <br />
           <strong>Location: </strong>
-          {currentReferral?.providerLocation}
+          {currentReferral.providerLocation}
           <br />
           <strong>Number of appointments: </strong>
-          {currentReferral?.numberOfAppointments}
+          {currentReferral.numberOfAppointments}
           <br />
           <strong>Referral number: </strong>
-          {currentReferral?.ReferralNumber}
+          {currentReferral.ReferralNumber}
         </p>
         <va-additional-info
           data-testid="help-text"
@@ -88,10 +88,10 @@ export default function ScheduleReferral(props) {
         </p>
         <p>
           <strong>Referring VA facility: </strong>
-          {currentReferral?.ReferringFacilityInfo.FacilityName}
+          {currentReferral.ReferringFacilityInfo.FacilityName}
           <br />
           <strong>Phone: </strong>
-          {currentReferral?.ReferringFacilityInfo.Phone}
+          {currentReferral.ReferringFacilityInfo.Phone}
         </p>
       </div>
     </FormLayout>
@@ -99,5 +99,5 @@ export default function ScheduleReferral(props) {
 }
 
 ScheduleReferral.propTypes = {
-  currentReferral: PropTypes.object,
+  currentReferral: PropTypes.object.isRequired,
 };

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
@@ -1,56 +1,23 @@
 import React, { useEffect } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { format } from 'date-fns';
-import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FormLayout from '../new-appointment/components/FormLayout';
 import ReferralAppLink from './components/ReferralAppLink';
 import { setFormCurrentPage } from './redux/actions';
-import { FETCH_STATUS } from '../utils/constants';
-import { scrollAndFocus } from '../utils/scrollAndFocus';
-import { useGetReferralFromId } from './hooks/useGetReferralFromId';
 
-export default function ScheduleReferral() {
+export default function ScheduleReferral(props) {
+  const { currentReferral } = props;
   const location = useLocation();
   const dispatch = useDispatch();
-  const params = useParams();
-  const { id } = params;
-  const { currentReferral, referralFetchStatus } = useGetReferralFromId(id);
   useEffect(
     () => {
       dispatch(setFormCurrentPage('scheduleReferral'));
     },
     [location, dispatch],
   );
-  useEffect(
-    () => {
-      if (referralFetchStatus === FETCH_STATUS.succeeded) {
-        scrollAndFocus('h1');
-      } else if (referralFetchStatus === FETCH_STATUS.failed) {
-        scrollAndFocus('h2');
-      }
-    },
-    [referralFetchStatus],
-  );
 
-  if (!currentReferral || referralFetchStatus === FETCH_STATUS.loading) {
-    return (
-      <FormLayout pageTitle="Review Approved Referral">
-        <va-loading-indicator set-focus message="Loading your data..." />
-      </FormLayout>
-    );
-  }
-
-  if (referralFetchStatus === FETCH_STATUS.failed) {
-    return (
-      <VaAlert status="error" visible>
-        <h2 slot="headline">
-          There was an error trying to get your referral data
-        </h2>
-        <p>Please try again later, or contact your VA facility for help.</p>
-      </VaAlert>
-    );
-  }
   const appointmentCountString =
     currentReferral?.numberOfAppointments === 1
       ? '1 appointment'
@@ -73,7 +40,10 @@ export default function ScheduleReferral() {
             with a community care provider.
           </p>
         </va-additional-info>
-        <ReferralAppLink linkText="Schedule your appointment" />
+        <ReferralAppLink
+          linkText="Schedule your appointment"
+          id={currentReferral.UUID}
+        />
         <h2>Details about your referral</h2>
         <p>
           <strong>Expiration date: </strong>
@@ -127,3 +97,7 @@ export default function ScheduleReferral() {
     </FormLayout>
   );
 }
+
+ScheduleReferral.propTypes = {
+  currentReferral: PropTypes.object,
+};

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
@@ -1,38 +1,36 @@
 import React from 'react';
 import { expect } from 'chai';
-import sinon from 'sinon';
-import ScheduleReferral from './ScheduleReferral';
 import {
   createTestStore,
   renderWithStoreAndRouter,
 } from '../tests/mocks/setup';
+import ScheduleReferral from './ScheduleReferral';
 import { createReferral } from './utils/referrals';
 
 describe('scheduleReferral component', () => {
   it('should display the subtitle correctly given different numbers of appointments', async () => {
+    const referralOne = createReferral(new Date(), '111');
     const store = createTestStore();
-    const sandbox = sinon.createSandbox();
-    sandbox
-      .stub(createReferral(new Date(), '111'), 'numberOfAppointments')
-      .value(1);
-    const screen = renderWithStoreAndRouter(<ScheduleReferral />, {
-      store,
-    });
+    const screen = renderWithStoreAndRouter(
+      <ScheduleReferral currentReferral={referralOne} />,
+      {
+        store,
+      },
+    );
     const subtitle = await screen.findByTestId('subtitle');
     expect(subtitle).to.contain.text('1 appointment');
-    sandbox.restore();
   });
   it('should display the subtitle correctly given 2 appointments', async () => {
+    const referralTwo = createReferral(new Date(), '222');
     const store = createTestStore();
-    const sandbox = sinon.createSandbox();
-    sandbox
-      .stub(createReferral(new Date(), '111'), 'numberOfAppointments')
-      .value(2);
-    const screen = renderWithStoreAndRouter(<ScheduleReferral />, {
-      store,
-    });
+    referralTwo.numberOfAppointments = 2;
+    const screen = renderWithStoreAndRouter(
+      <ScheduleReferral currentReferral={referralTwo} />,
+      {
+        store,
+      },
+    );
     const subtitle = await screen.findByTestId('subtitle');
     expect(subtitle).to.contain.text('2 appointments');
-    sandbox.restore();
   });
 });

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
@@ -6,13 +6,15 @@ import {
   createTestStore,
   renderWithStoreAndRouter,
 } from '../tests/mocks/setup';
-import { referral } from './temp-data/referral';
+import { createReferral } from './utils/referrals';
 
 describe('scheduleReferral component', () => {
   it('should display the subtitle correctly given different numbers of appointments', async () => {
     const store = createTestStore();
     const sandbox = sinon.createSandbox();
-    sandbox.stub(referral, 'appointmentCount').value(1);
+    sandbox
+      .stub(createReferral(new Date(), '111'), 'numberOfAppointments')
+      .value(1);
     const screen = renderWithStoreAndRouter(<ScheduleReferral />, {
       store,
     });
@@ -23,8 +25,9 @@ describe('scheduleReferral component', () => {
   it('should display the subtitle correctly given 2 appointments', async () => {
     const store = createTestStore();
     const sandbox = sinon.createSandbox();
-    sandbox.stub(referral, 'appointmentCount').value(2);
-    referral.appointmentCount = 2;
+    sandbox
+      .stub(createReferral(new Date(), '111'), 'numberOfAppointments')
+      .value(2);
     const screen = renderWithStoreAndRouter(<ScheduleReferral />, {
       store,
     });

--- a/src/applications/vaos/referral-appointments/components/ReferralAppLink.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralAppLink.jsx
@@ -7,9 +7,8 @@ import { GA_PREFIX } from 'applications/vaos/utils/constants';
 import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
 import { routeToNextReferralPage } from '../flow';
 import { selectCurrentPage } from '../redux/selectors';
-import { referral } from '../temp-data/referral';
 
-function ReferralAppLinkComponent({ linkText }) {
+function ReferralAppLinkComponent({ linkText, id }) {
   const currentPage = useSelector(selectCurrentPage);
   const history = useHistory();
 
@@ -19,7 +18,7 @@ function ReferralAppLinkComponent({ linkText }) {
       recordEvent({
         event: `${GA_PREFIX}-review-upcoming-link`,
       });
-      routeToNextReferralPage(history, currentPage, referral.id);
+      routeToNextReferralPage(history, currentPage, id);
     };
   };
 
@@ -51,9 +50,10 @@ function ReferralAppLinkComponent({ linkText }) {
 }
 
 ReferralAppLinkComponent.propTypes = {
+  id: PropTypes.string.isRequired,
   linkText: PropTypes.string.isRequired,
 };
-export default function ReferralAppLink({ linkText }) {
+export default function ReferralAppLink({ linkText, id }) {
   const location = useLocation();
   // Only display on upcoming appointments page
   if (
@@ -62,9 +62,10 @@ export default function ReferralAppLink({ linkText }) {
   ) {
     return null;
   }
-  return <ReferralAppLinkComponent linkText={linkText} />;
+  return <ReferralAppLinkComponent linkText={linkText} id={id} />;
 }
 
 ReferralAppLink.propTypes = {
+  id: PropTypes.string.isRequired,
   linkText: PropTypes.string.isRequired,
 };

--- a/src/applications/vaos/referral-appointments/flow.js
+++ b/src/applications/vaos/referral-appointments/flow.js
@@ -20,19 +20,19 @@ export default function getPageFlow(referralId) {
       previous: 'appointments',
     },
     scheduleReferral: {
-      url: `/schedule-referral/${referralId}`,
+      url: `/schedule-referral?id=${referralId}`,
       label: 'Referral for',
       next: 'scheduleAppointment',
       previous: 'activeReferrals',
     },
     scheduleAppointment: {
-      url: '/schedule-referral/date-time',
+      url: `/schedule-referral/date-time?id=${referralId}`,
       label: 'Schedule an appointment with your provider',
       next: 'confirmAppointment',
       previous: 'scheduleReferral',
     },
     confirmAppointment: {
-      url: '/schedule-referral/review',
+      url: `/schedule-referral/review?id=${referralId}`,
       label: 'Review your appointment details',
       next: 'appointments',
       previous: 'scheduleAppointment',

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
@@ -5,7 +5,7 @@ import { fetchReferralById } from '../redux/actions';
 import { FETCH_STATUS } from '../../utils/constants';
 import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
 
-const useGetReferralFromId = id => {
+const useGetReferralById = id => {
   const [referralNotFound, setReferralNotFound] = useState(false);
   const [currentReferral, setCurrentReferral] = useState(null);
   const dispatch = useDispatch();
@@ -59,4 +59,4 @@ const useGetReferralFromId = id => {
   };
 };
 
-export { useGetReferralFromId };
+export { useGetReferralById };

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
@@ -5,6 +5,7 @@ import { fetchReferralById } from '../redux/actions';
 import { FETCH_STATUS } from '../../utils/constants';
 
 const useGetReferralFromId = id => {
+  const [referralNotFound, setReferralNotFound] = useState(false);
   const [currentReferral, setCurrentReferral] = useState(null);
   const dispatch = useDispatch();
   const { referrals, referralFetchStatus } = useSelector(
@@ -13,9 +14,21 @@ const useGetReferralFromId = id => {
   );
   useEffect(
     () => {
-      if (referrals && id) {
+      if (referralFetchStatus === FETCH_STATUS.succeeded && !referrals) {
+        setReferralNotFound(true);
+      }
+    },
+    [referralFetchStatus, referrals],
+  );
+  useEffect(
+    () => {
+      if (referrals.length && id) {
         const referralFromParam = referrals.find(ref => ref.UUID === id);
-        setCurrentReferral(referralFromParam);
+        if (referralFromParam) {
+          setCurrentReferral(referralFromParam);
+        } else {
+          setReferralNotFound(true);
+        }
       }
     },
     [id, referrals, referralFetchStatus],
@@ -34,6 +47,7 @@ const useGetReferralFromId = id => {
   return {
     currentReferral,
     referralFetchStatus,
+    referralNotFound,
   };
 };
 

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { useSelector, shallowEqual, useDispatch } from 'react-redux';
+import { getReferral } from '../redux/selectors';
+import { fetchReferralById } from '../redux/actions';
+import { FETCH_STATUS } from '../../utils/constants';
+
+const useGetReferralFromId = id => {
+  const [currentReferral, setCurrentReferral] = useState(null);
+  const dispatch = useDispatch();
+  const { referrals, referralFetchStatus } = useSelector(
+    state => getReferral(state),
+    shallowEqual,
+  );
+  useEffect(
+    () => {
+      if (referrals && id) {
+        const referralFromParam = referrals.find(ref => ref.UUID === id);
+        setCurrentReferral(referralFromParam);
+      }
+    },
+    [id, referrals, referralFetchStatus],
+  );
+  useEffect(
+    () => {
+      if (
+        !referrals.length &&
+        referralFetchStatus === FETCH_STATUS.notStarted
+      ) {
+        dispatch(fetchReferralById(id));
+      }
+    },
+    [dispatch, id, referralFetchStatus, referrals],
+  );
+  return {
+    currentReferral,
+    referralFetchStatus,
+  };
+};
+
+export { useGetReferralFromId };

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
@@ -3,26 +3,33 @@ import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { getReferral } from '../redux/selectors';
 import { fetchReferralById } from '../redux/actions';
 import { FETCH_STATUS } from '../../utils/constants';
+import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
 
 const useGetReferralFromId = id => {
   const [referralNotFound, setReferralNotFound] = useState(false);
   const [currentReferral, setCurrentReferral] = useState(null);
   const dispatch = useDispatch();
+  const featureCCDirectScheduling = useSelector(
+    selectFeatureCCDirectScheduling,
+  );
   const { referrals, referralFetchStatus } = useSelector(
     state => getReferral(state),
     shallowEqual,
   );
   useEffect(
     () => {
-      if (referralFetchStatus === FETCH_STATUS.succeeded && !referrals.length) {
+      if (
+        featureCCDirectScheduling &&
+        (referralFetchStatus === FETCH_STATUS.succeeded && !referrals.length)
+      ) {
         setReferralNotFound(true);
       }
     },
-    [referralFetchStatus, referrals],
+    [featureCCDirectScheduling, referralFetchStatus, referrals],
   );
   useEffect(
     () => {
-      if (referrals.length && id) {
+      if (featureCCDirectScheduling && (referrals.length && id)) {
         const referralFromParam = referrals.find(ref => ref.UUID === id);
         if (referralFromParam) {
           setCurrentReferral(referralFromParam);
@@ -31,18 +38,19 @@ const useGetReferralFromId = id => {
         }
       }
     },
-    [id, referrals, referralFetchStatus],
+    [id, referrals, referralFetchStatus, featureCCDirectScheduling],
   );
   useEffect(
     () => {
       if (
+        featureCCDirectScheduling &&
         !referrals.length &&
         referralFetchStatus === FETCH_STATUS.notStarted
       ) {
         dispatch(fetchReferralById(id));
       }
     },
-    [dispatch, id, referralFetchStatus, referrals],
+    [dispatch, featureCCDirectScheduling, id, referralFetchStatus, referrals],
   );
   return {
     currentReferral,

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralFromId.jsx
@@ -14,7 +14,7 @@ const useGetReferralFromId = id => {
   );
   useEffect(
     () => {
-      if (referralFetchStatus === FETCH_STATUS.succeeded && !referrals) {
+      if (referralFetchStatus === FETCH_STATUS.succeeded && !referrals.length) {
         setReferralNotFound(true);
       }
     },

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -77,10 +77,12 @@ export default function ReferralAppointments() {
   return (
     <>
       <Switch>
+        {/* TODO convert component to get referral as a prop */}
         <Route
           path={`${basePath.url}/review/`}
           component={ConfirmApprovedPage}
         />
+        {/* TODO convert component to get referral as a prop */}
         <Route
           path={`${basePath.url}/date-time/`}
           component={ChooseDateAndTime}

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -13,7 +13,7 @@ import ConfirmApprovedPage from './ConfirmApprovedPage';
 import ChooseDateAndTime from './ChooseDateAndTime';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 import { selectFeatureCCDirectScheduling } from '../redux/selectors';
-import { useGetReferralFromId } from './hooks/useGetReferralFromId';
+import { useGetReferralById } from './hooks/useGetReferralById';
 import { FETCH_STATUS } from '../utils/constants';
 import FormLayout from '../new-appointment/components/FormLayout';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
@@ -32,7 +32,7 @@ export default function ReferralAppointments() {
     currentReferral,
     referralNotFound,
     referralFetchStatus,
-  } = useGetReferralFromId(id);
+  } = useGetReferralById(id);
   const [referral, setReferral] = useState(currentReferral);
   useEffect(
     () => {
@@ -78,11 +78,11 @@ export default function ReferralAppointments() {
     <>
       <Switch>
         <Route
-          path={`${basePath.url}/review`}
+          path={`${basePath.url}/review/`}
           component={ConfirmApprovedPage}
         />
         <Route
-          path={`${basePath.url}/date-time`}
+          path={`${basePath.url}/date-time/`}
           component={ChooseDateAndTime}
         />
         <Route path={`${basePath.url}`} search={id}>

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -50,7 +50,10 @@ export default function ReferralAppointments() {
     },
     [referralFetchStatus],
   );
-  if (!referral || referralFetchStatus === FETCH_STATUS.loading) {
+  if (
+    (!referral || referralFetchStatus === FETCH_STATUS.loading) &&
+    !referralNotFound
+  ) {
     return (
       <FormLayout pageTitle="Review Approved Referral">
         <va-loading-indicator set-focus message="Loading your data..." />
@@ -68,11 +71,11 @@ export default function ReferralAppointments() {
       </VaAlert>
     );
   }
+  if (referralNotFound || !featureCCDirectScheduling) {
+    return <Redirect from={basePath.url} to="/" />;
+  }
   return (
     <>
-      {(!featureCCDirectScheduling || referralNotFound) && (
-        <Redirect from={basePath.url} to="/" />
-      )}
       <Switch>
         <Route
           path={`${basePath.url}/review`}

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -1,11 +1,22 @@
-import React from 'react';
-import { Switch, Route, useRouteMatch, Redirect } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import {
+  Switch,
+  Route,
+  useRouteMatch,
+  Redirect,
+  useLocation,
+} from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import ScheduleReferral from './ScheduleReferral';
 import ConfirmApprovedPage from './ConfirmApprovedPage';
 import ChooseDateAndTime from './ChooseDateAndTime';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 import { selectFeatureCCDirectScheduling } from '../redux/selectors';
+import { useGetReferralFromId } from './hooks/useGetReferralFromId';
+import { FETCH_STATUS } from '../utils/constants';
+import FormLayout from '../new-appointment/components/FormLayout';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 export default function ReferralAppointments() {
   useManualScrollRestoration();
@@ -13,9 +24,55 @@ export default function ReferralAppointments() {
   const featureCCDirectScheduling = useSelector(
     selectFeatureCCDirectScheduling,
   );
+  const { search } = useLocation();
+
+  const params = new URLSearchParams(search);
+  const id = params.get('id');
+  const {
+    currentReferral,
+    referralNotFound,
+    referralFetchStatus,
+  } = useGetReferralFromId(id);
+  const [referral, setReferral] = useState(currentReferral);
+  useEffect(
+    () => {
+      setReferral(currentReferral);
+    },
+    [currentReferral],
+  );
+  useEffect(
+    () => {
+      if (referralFetchStatus === FETCH_STATUS.succeeded) {
+        scrollAndFocus('h1');
+      } else if (referralFetchStatus === FETCH_STATUS.failed) {
+        scrollAndFocus('h2');
+      }
+    },
+    [referralFetchStatus],
+  );
+  if (!referral || referralFetchStatus === FETCH_STATUS.loading) {
+    return (
+      <FormLayout pageTitle="Review Approved Referral">
+        <va-loading-indicator set-focus message="Loading your data..." />
+      </FormLayout>
+    );
+  }
+
+  if (referralFetchStatus === FETCH_STATUS.failed) {
+    return (
+      <VaAlert status="error" visible>
+        <h2 slot="headline">
+          There was an error trying to get your referral data
+        </h2>
+        <p>Please try again later, or contact your VA facility for help.</p>
+      </VaAlert>
+    );
+  }
   return (
     <>
-      {!featureCCDirectScheduling && <Redirect from={basePath.url} to="/" />}
+      {(!featureCCDirectScheduling || referralNotFound) && (
+        <Redirect from={basePath.url} to="/" />
+      )}
       <Switch>
         <Route
           path={`${basePath.url}/review`}
@@ -25,7 +82,9 @@ export default function ReferralAppointments() {
           path={`${basePath.url}/date-time`}
           component={ChooseDateAndTime}
         />
-        <Route path={`${basePath.url}/:id`} component={ScheduleReferral} />
+        <Route path={`${basePath.url}`} search={id}>
+          <ScheduleReferral currentReferral={referral} />
+        </Route>
       </Switch>
     </>
   );

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -1,5 +1,9 @@
 import { captureError } from '../../utils/error';
-import { getProviderById } from '../../services/referral';
+import {
+  getProviderById,
+  getPatientReferrals,
+  getPatientReferralById,
+} from '../../services/referral';
 
 export const SET_FACILITY = 'SET_FACILITY';
 export const SET_APPOINTMENT_DETAILS = 'SET_APPOINTMENT_DETAILS';
@@ -10,6 +14,12 @@ export const FETCH_PROVIDER_DETAILS = 'FETCH_PROVIDER_DETAILS';
 export const FETCH_PROVIDER_DETAILS_SUCCEEDED =
   'FETCH_PROVIDER_DETAILS_SUCCEEDED';
 export const FETCH_PROVIDER_DETAILS_FAILED = 'FETCH_PROVIDER_DETAILS_FAILED';
+export const FETCH_REFERRALS = 'FETCH_REFERRALS';
+export const FETCH_REFERRALS_SUCCEEDED = 'FETCH_REFERRALS_SUCCEEDED';
+export const FETCH_REFERRALS_FAILED = 'FETCH_REFERRALS_FAILED';
+export const FETCH_REFERRAL = 'FETCH_REFERRAL';
+export const FETCH_REFERRAL_SUCCEEDED = 'FETCH_REFERRAL_SUCCEEDED';
+export const FETCH_REFERRAL_FAILED = 'FETCH_REFERRAL_FAILED';
 
 export function setFacility(facility) {
   return {
@@ -65,6 +75,50 @@ export function fetchProviderDetails(id) {
     } catch (error) {
       dispatch({
         type: FETCH_PROVIDER_DETAILS_FAILED,
+      });
+      return captureError(error);
+    }
+  };
+}
+
+export function fetchReferrals() {
+  return async dispatch => {
+    try {
+      dispatch({
+        type: FETCH_REFERRALS,
+      });
+      const referrals = await getPatientReferrals();
+
+      dispatch({
+        type: FETCH_REFERRALS_SUCCEEDED,
+        data: referrals,
+      });
+      return referrals;
+    } catch (error) {
+      dispatch({
+        type: FETCH_REFERRALS_FAILED,
+      });
+      return captureError(error);
+    }
+  };
+}
+
+export function fetchReferralById(id) {
+  return async dispatch => {
+    try {
+      dispatch({
+        type: FETCH_REFERRAL,
+      });
+      const referrals = await getPatientReferralById(id);
+
+      dispatch({
+        type: FETCH_REFERRAL_SUCCEEDED,
+        data: [referrals],
+      });
+      return referrals;
+    } catch (error) {
+      dispatch({
+        type: FETCH_REFERRAL_FAILED,
       });
       return captureError(error);
     }

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -110,10 +110,9 @@ export function fetchReferralById(id) {
         type: FETCH_REFERRAL,
       });
       const referrals = await getPatientReferralById(id);
-
       dispatch({
         type: FETCH_REFERRAL_SUCCEEDED,
-        data: [referrals],
+        data: Object.keys(referrals).length ? [referrals] : [],
       });
       return referrals;
     } catch (error) {

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -7,6 +7,12 @@ import {
   FETCH_PROVIDER_DETAILS,
   FETCH_PROVIDER_DETAILS_FAILED,
   FETCH_PROVIDER_DETAILS_SUCCEEDED,
+  FETCH_REFERRALS,
+  FETCH_REFERRALS_SUCCEEDED,
+  FETCH_REFERRALS_FAILED,
+  FETCH_REFERRAL,
+  FETCH_REFERRAL_SUCCEEDED,
+  FETCH_REFERRAL_FAILED,
 } from './actions';
 import { FETCH_STATUS } from '../../utils/constants';
 
@@ -15,6 +21,9 @@ const initialState = {
   sortProviderBy: '',
   selectedProvider: '',
   currentPage: null,
+  referrals: [],
+  referralsFetchStatus: FETCH_STATUS.notStarted,
+  referralFetchStatus: FETCH_STATUS.notStarted,
   providerFetchStatus: FETCH_STATUS.notStarted,
 };
 
@@ -61,6 +70,38 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         providerFetchStatus: FETCH_STATUS.failed,
+      };
+    case FETCH_REFERRALS:
+      return {
+        ...state,
+        referralsFetchStatus: FETCH_STATUS.loading,
+      };
+    case FETCH_REFERRALS_SUCCEEDED:
+      return {
+        ...state,
+        referralsFetchStatus: FETCH_STATUS.succeeded,
+        referrals: action.data,
+      };
+    case FETCH_REFERRALS_FAILED:
+      return {
+        ...state,
+        referralsFetchStatus: FETCH_STATUS.failed,
+      };
+    case FETCH_REFERRAL:
+      return {
+        ...state,
+        referralFetchStatus: FETCH_STATUS.loading,
+      };
+    case FETCH_REFERRAL_SUCCEEDED:
+      return {
+        ...state,
+        referralFetchStatus: FETCH_STATUS.succeeded,
+        referrals: [...state.referrals, ...action.data],
+      };
+    case FETCH_REFERRAL_FAILED:
+      return {
+        ...state,
+        referralFetchStatus: FETCH_STATUS.failed,
       };
     default:
       return state;

--- a/src/applications/vaos/referral-appointments/redux/selectors.js
+++ b/src/applications/vaos/referral-appointments/redux/selectors.js
@@ -9,3 +9,17 @@ export function getProviderInfo(state) {
     providerFetchStatus: state.referral.providerFetchStatus,
   };
 }
+
+export function getReferrals(state) {
+  return {
+    referrals: state.referral.referrals,
+    referralsFetchStatus: state.referral.referralsFetchStatus,
+  };
+}
+
+export function getReferral(state) {
+  return {
+    referrals: state.referral.referrals,
+    referralFetchStatus: state.referral.referralFetchStatus,
+  };
+}

--- a/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/TestComponent.jsx
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/TestComponent.jsx
@@ -1,0 +1,19 @@
+/* istanbul ignore file */
+import React from 'react';
+import { useGetReferralById } from '../../../hooks/useGetReferralById';
+
+export default function TestComponent() {
+  const {
+    currentReferral,
+    referralFetchStatus,
+    referralNotFound,
+  } = useGetReferralById('add2f0f4-a1ea-4dea-a504-a54ab57c6800');
+  return (
+    <div>
+      <p>Test component</p>
+      <p>{currentReferral?.UUID}</p>
+      <p>{referralFetchStatus}</p>
+      <p>{referralNotFound}</p>
+    </div>
+  );
+}

--- a/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import { getPatientReferralById } from '../../../../services/referral';
+
+import TestComponent from './TestComponent';
+
+describe('Community Care Referrals', () => {
+  describe('useGerReferralById hook', () => {
+    const sandbox = sinon.createSandbox();
+    let store;
+    const api = { fetchReferral: getPatientReferralById };
+    beforeEach(() => {
+      global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
+      const middleware = [];
+      const mockStore = configureStore(middleware);
+      const initState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: true,
+        },
+        referral: {
+          facility: null,
+          referrals: [],
+          referralFetchStatus: 'notStarted',
+        },
+      };
+      store = mockStore(initState);
+      sandbox.stub(api, 'fetchReferral').resolves({});
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+    it.skip('Loads test component with hook', () => {
+      const screen = render(
+        <Provider store={store}>
+          <TestComponent />
+        </Provider>,
+      );
+      expect(screen.getByText(/TestComponent/i)).to.exist;
+      sandbox.assert.calledOnce(api.fetchReferral);
+    });
+  });
+});

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -25,7 +25,7 @@ const createReferral = (startDate, uuid) => {
     ReferringProvider: '534_520824810',
     SourceOfReferral: 'Interfaced from VA',
     Status: 'Approved',
-    CategoryOfCare: 'CARDIOLOGY',
+    CategoryOfCare: 'Cardiology',
     StationID: '528A4',
     Sta6: '534',
     ReferringProviderNPI: '534_520824810',
@@ -44,6 +44,8 @@ const createReferral = (startDate, uuid) => {
     ReferralStatus: 'open',
     UUID: uuid,
     numberOfAppointments: 1,
+    providerName: 'Dr. Face',
+    providerLocation: 'New skin technologies bldg 2',
   };
 };
 

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -510,7 +510,7 @@ const responses = {
     );
     return res.json({
       data: referrals.find(
-        referral => referral?.uuid === req.params.referralId,
+        referral => referral?.UUID === req.params.referralId,
       ),
     });
   },

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -508,10 +508,11 @@ const responses = {
       3,
       new Date().toISOString(),
     );
+    const singleReferral = referrals.find(
+      referral => referral?.UUID === req.params.referralId,
+    );
     return res.json({
-      data: referrals.find(
-        referral => referral?.UUID === req.params.referralId,
-      ),
+      data: singleReferral ?? {},
     });
   },
   'GET /vaos/v2/epsApi/appointments': (req, res) => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR introduces a new hook to handle fetching single referrals for the pages that require referral data. The hook first attempts to match with existing referral data in redux. If no referral data is found, it will kick off a fetch and then select the referral if returned. 

This PR also refactors the router to switch the ID for the referral to be in the query params in the URL instead of in path params. 

Also included in this work, the schedule referral page is hooked up to use the data from the hook. Other pages and components will be hooked up in separate tickets.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#96439

## Testing done

Updates schedule referral unit tests. The unit test for the hook are going to be completed in a follow on ticket.

## What areas of the site does it impact?

Community Care self schedule referrals feature in VAOS

## Acceptance criteria
 - [ ] The single referral mock is implemented
 - [ ] An example of the mock is used on a page
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

