### PR TITLE
[97464] Add ARM team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -244,6 +244,10 @@ src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appoi
 # Benefits Accredited Representative Facing (ARF)
 src/applications/accredited-representative-portal @department-of-veterans-affairs/benefits-accredited-rep-facing-engineers @department-of-veterans-affairs/va-platform-cop-frontend
 
+# Accredited Representation Management (ARM)
+src/applications/representative-appoint @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/representative-search @department-of-veterans-affairs/accredited-representation-management @department-of-veterans-affairs/va-platform-cop-frontend
+
 # Income and Asset Statement
 src/applications/income-and-asset-statement @department-of-veterans-affairs/pension-and-burials @department-of-veterans-affairs/va-platform-cop-frontend
 
@@ -274,6 +278,4 @@ src/applications/accreditation @department-of-veterans-affairs/va-platform-cop-f
 src/applications/benefit-eligibility-questionnaire @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/ivc-champv @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/office-directory @department-of-veterans-affairs/va-platform-cop-frontend
-src/applications/representative-appoint @department-of-veterans-affairs/va-platform-cop-frontend
-src/applications/representative-search @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/travel-pay @department-of-veterans-affairs/va-platform-cop-frontend


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds the ARM to as codeowner of their applications

## Related issue(s)

- [97464](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97464)