### PR TITLE
fix claim status endpoint call

### DIFF
--- a/src/applications/toe/actions.js
+++ b/src/applications/toe/actions.js
@@ -9,7 +9,7 @@ export const CLAIMANT_INFO_ENDPOINT = `${
 
 export const CLAIM_STATUS_ENDPOINT = `${
   environment.API_URL
-}/meb_api/v0/forms_claim_status`;
+}/meb_api/v0/forms_claim_status?type=ToeSubmission`;
 export const CLAIM_STATUS_RESPONSE_IN_PROGRESS = 'INPROGRESS';
 export const FETCH_CLAIM_STATUS = 'FETCH_CLAIM_STATUS';
 export const FETCH_CLAIM_STATUS_SUCCESS = 'FETCH_CLAIM_STATUS_SUCCESS';
@@ -160,7 +160,7 @@ function getNowDate() {
 
 export function fetchClaimStatus(selectedChapter) {
   return async dispatch => {
-    dispatch({ type: `${CLAIM_STATUS_ENDPOINT}?type=${selectedChapter}` });
+    dispatch({ type: CLAIM_STATUS_ENDPOINT });
     const timeoutResponse = {
       attributes: {
         claimStatus: CLAIM_STATUS_RESPONSE_IN_PROGRESS,
@@ -169,7 +169,7 @@ export function fetchClaimStatus(selectedChapter) {
     };
 
     poll({
-      endpoint: CLAIM_STATUS_ENDPOINT,
+      endpoint: `${CLAIM_STATUS_ENDPOINT}?type=${selectedChapter}`,
       validate: response => {
         return (
           response?.data?.attributes?.claimStatus &&

--- a/src/applications/toe/actions.js
+++ b/src/applications/toe/actions.js
@@ -9,7 +9,7 @@ export const CLAIMANT_INFO_ENDPOINT = `${
 
 export const CLAIM_STATUS_ENDPOINT = `${
   environment.API_URL
-}/meb_api/v0/forms_claim_status?type=ToeSubmission`;
+}/meb_api/v0/forms_claim_status`;
 export const CLAIM_STATUS_RESPONSE_IN_PROGRESS = 'INPROGRESS';
 export const FETCH_CLAIM_STATUS = 'FETCH_CLAIM_STATUS';
 export const FETCH_CLAIM_STATUS_SUCCESS = 'FETCH_CLAIM_STATUS_SUCCESS';

--- a/src/applications/toe/containers/ConfirmationPage.jsx
+++ b/src/applications/toe/containers/ConfirmationPage.jsx
@@ -28,7 +28,7 @@ export const ConfirmationPage = ({
   useEffect(
     () => {
       if (!claimStatus) {
-        getClaimStatus('toe')
+        getClaimStatus('ToeSubmission')
           .then(response => {
             // Only trigger error if response has a status code >= 400
             if (response?.status >= 400) {


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update claim status call to include selectedChapter

