### PR TITLE
97476 Add shared address dropdown to sponsor information section - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -441,6 +441,35 @@ const formConfig = {
             },
           },
         },
+        page10b0: {
+          path: 'sponsor-mailing-same',
+          title: formData => `${sponsorWording(formData)} address selection`,
+          // Only show if we have addresses to pull from:
+          depends: formData =>
+            !get('sponsorIsDeceased', formData) &&
+            get('certifierRole', formData) !== 'sponsor' &&
+            get('street', formData?.certifierAddress),
+          CustomPage: props => {
+            const extraProps = {
+              ...props,
+              customAddressKey: 'sponsorAddress',
+              customTitle: `${sponsorWording(props.data)} address selection`,
+              customDescription:
+                'We’ll send any important information about this form to this address.',
+              customSelectText: `Does ${sponsorWording(
+                props.data,
+                false,
+                false,
+              )} live at a previously entered address?`,
+              positivePrefix: 'Yes, their address is',
+              negativePrefix: 'No, they have a different address',
+            };
+            return ApplicantAddressCopyPage(extraProps);
+          },
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: blankSchema,
+        },
         page10b1: {
           path: 'sponsor-mailing-address',
           title: formData => `${sponsorWording(formData)} mailing address`,

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -121,6 +121,16 @@ const testConfig = createTestConfig(
           });
         });
       },
+      [ALL_PAGES.page10b0.path]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            cy.get('select').select(1);
+            cy.axeCheck();
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
       [ALL_PAGES.page13.path]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
@@ -9,6 +9,7 @@ import { applicantWording } from '../../utilities';
 export function ApplicantAddressCopyPage({
   contentBeforeButtons,
   contentAfterButtons,
+  customAddressKey, // optional override of `applicantAddress` so we can target arbitrary addresses in the form
   data,
   setFormData,
   goBack,
@@ -22,6 +23,7 @@ export function ApplicantAddressCopyPage({
   positivePrefix,
   negativePrefix,
 }) {
+  const addressKey = customAddressKey ?? 'applicantAddress';
   // Get the current applicant from list, OR if we don't have a list of
   // applicants, just treat the whole form data object as a single applicant
   const currentApp =
@@ -29,7 +31,9 @@ export function ApplicantAddressCopyPage({
       ? data?.applicants?.[pagePerItemIndex]
       : data;
   const [selectValue, setSelectValue] = useState(currentApp?.sharesAddressWith);
-  const [address, setAddress] = useState(currentApp?.applicantAddress);
+  const [address, setAddress] = useState(
+    data[addressKey] ?? currentApp?.[addressKey],
+  );
   // const [radioError, setRadioError] = useState(undefined);
   const [selectError, setSelectError] = useState(undefined);
   const [dirty, setDirty] = useState(false);
@@ -65,9 +69,7 @@ export function ApplicantAddressCopyPage({
     // Make sure that our <select> only shows options that:
     // 1. Have a valid address we can copy
     // 2. Are NOT the current applicant
-    return (
-      person?.applicantAddress?.country !== undefined && person !== currentApp
-    );
+    return person?.[addressKey]?.country !== undefined && person !== currentApp;
   }
 
   // Gets the veteran/sponsor address and third party address
@@ -94,8 +96,8 @@ export function ApplicantAddressCopyPage({
       data.applicants.filter(app => isValidOrigin(app)).forEach(app =>
         allAddresses.push({
           originatorName: fullName(app.applicantName),
-          originatorAddress: app.applicantAddress,
-          displayText: `${app.applicantAddress.street} ${app.applicantAddress
+          originatorAddress: app?.[addressKey],
+          displayText: `${app?.[addressKey].street} ${app?.[addressKey]
             ?.state ?? ''}`,
         }),
       );
@@ -146,7 +148,7 @@ export function ApplicantAddressCopyPage({
           : tmpVal;
       tmpApp.sharesAddressWith = selectValue;
       if (selectValue !== 'not-shared') {
-        tmpApp.applicantAddress = address;
+        tmpApp[addressKey] = address;
       }
       setFormData(tmpVal);
       if (onReviewPage) updatePage();
@@ -223,6 +225,7 @@ export function ApplicantAddressCopyPage({
 ApplicantAddressCopyPage.propTypes = {
   contentAfterButtons: PropTypes.element,
   contentBeforeButtons: PropTypes.element,
+  customAddressKey: PropTypes.string,
   customDescription: PropTypes.string,
   customSelectText: PropTypes.string,
   customTitle: PropTypes.string,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds a dropdown to the sponsor information section so that users can select a previously entered address to use for the sponsor.

- New "shares address" page added to form flow
- Shared address component has been updated with new `customAddressKey` prop to make it more generic
- E2E test for 10-10d has been updated

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97476

## Testing done

- Manual
- E2E

## Screenshots

|         | After |
| ------- | ----- |
| Sponsor shares address page |<img width="740" alt="Screenshot 2024-11-20 at 16 08 46" src="https://github.com/user-attachments/assets/0aad4252-6f33-4ab3-ba63-ca14854b8716">|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA