### PR TITLE
[96833] [96834] Appoint a Rep update rep select validation logic

### DIFF
--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -31,6 +31,9 @@ const SelectAccreditedRepresentative = props => {
     formData?.['view:representativeSearchResults'],
   );
 
+  const query = formData['view:representativeQuery'];
+  const invalidQuery = query === undefined || !query.trim();
+
   const noSearchError =
     'Enter the name of the accredited representative or VSO you’d like to appoint';
 
@@ -64,8 +67,6 @@ const SelectAccreditedRepresentative = props => {
   };
 
   const handleGoForward = ({ selectionMade = false }) => {
-    const query = formData['view:representativeQuery'];
-    const invalidQuery = query === undefined || !query.trim();
     const selection = formData['view:selectedRepresentative'];
     const noSelectionExists = !selection && !selectionMade;
 
@@ -87,9 +88,6 @@ const SelectAccreditedRepresentative = props => {
   };
 
   const handleSearch = async () => {
-    const query = formData['view:representativeQuery'];
-    const invalidQuery = query === undefined || !query.trim();
-
     if (invalidQuery) {
       setError(noSearchError);
       scrollToFirstError({ focusOnAlertRole: true });

--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -34,6 +34,9 @@ const SelectAccreditedRepresentative = props => {
   const noSearchError =
     'Enter the name of the accredited representative or VSO you’d like to appoint';
 
+  const noSelectionError =
+    'Select the accredited representative or VSO you’d like to appoint below.';
+
   const isReviewPage = useReviewPage();
 
   const getRepStatus = async () => {
@@ -61,10 +64,16 @@ const SelectAccreditedRepresentative = props => {
   };
 
   const handleGoForward = ({ selectionMade = false }) => {
+    const query = formData['view:representativeQuery'];
+    const invalidQuery = query === undefined || !query.trim();
     const selection = formData['view:selectedRepresentative'];
+    const noSelectionExists = !selection && !selectionMade;
 
-    if (!selection && !selectionMade) {
-      setError('You must select an accredited representative');
+    if (noSelectionExists && !invalidQuery) {
+      setError(noSelectionError);
+      scrollToFirstError({ focusOnAlertRole: true });
+    } else if (noSelectionExists && invalidQuery) {
+      setError(noSearchError);
       scrollToFirstError({ focusOnAlertRole: true });
     } else if (isReviewPage) {
       if (selection === currentSelectedRep) {
@@ -79,8 +88,9 @@ const SelectAccreditedRepresentative = props => {
 
   const handleSearch = async () => {
     const query = formData['view:representativeQuery'];
+    const invalidQuery = query === undefined || !query.trim();
 
-    if (query === undefined || !query.trim()) {
+    if (invalidQuery) {
       setError(noSearchError);
       scrollToFirstError({ focusOnAlertRole: true });
       return;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- This pr updates the `handleGoForward` logic to account for the case when a search has not occurred yet which should trigger the no search error, not the no selection error
- This pr updates the no selection error text

## Related issue(s)
- [96833](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96833)
- [96834](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96834)

## Testing done
- Went through the flow locally testing search and selection combinations

## Screenshots
### Before
https://github.com/user-attachments/assets/1b0a052d-471d-436a-b7cb-a84ab71fbe1c

### After
https://github.com/user-attachments/assets/e19f46b5-073f-46c7-8336-193addac229c

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user