### PR TITLE
SA-102542 - add validation for state length

### DIFF
--- a/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
+++ b/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
@@ -181,8 +181,8 @@ const mailingAddress33 = {
             (errors, field) => {
               if (field?.length === 1) {
                 errors.addError('Must be more than 1 character');
-              } else if (field?.length > 30) {
-                errors.addError('Must be less than 30 characters');
+              } else if (field?.length > 31) {
+                errors.addError('Must be less than 31 characters');
               }
             },
           ],

--- a/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
+++ b/src/applications/my-education-benefits/config/chapters/33/contactInfo/mailingAddress.js
@@ -177,6 +177,15 @@ const mailingAddress33 = {
         },
         state: {
           'ui:title': 'State/County/Province',
+          'ui:validations': [
+            (errors, field) => {
+              if (field?.length === 1) {
+                errors.addError('Must be more than 1 character');
+              } else if (field?.length > 30) {
+                errors.addError('Must be less than 30 characters');
+              }
+            },
+          ],
           'ui:required': formData => {
             return (
               formData['view:mailingAddress']?.livesOnMilitaryBase ||

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -1019,8 +1019,8 @@ const formConfig = {
                     (errors, field) => {
                       if (field?.length === 1) {
                         errors.addError('Must be more than 1 character');
-                      } else if (field?.length > 30) {
-                        errors.addError('Must be less than 30 characters');
+                      } else if (field?.length > 31) {
+                        errors.addError('Must be less than 31 characters');
                       }
                     },
                   ],

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -1019,8 +1019,8 @@ const formConfig = {
                     (errors, field) => {
                       if (field?.length === 1) {
                         errors.addError('Must be more than 1 character');
-                      } else if (field?.length > 31) {
-                        errors.addError('Must be less than 31 characters');
+                      } else if (field?.length > 30) {
+                        errors.addError('Must be less than 30 characters');
                       }
                     },
                   ],

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -1015,6 +1015,15 @@ const formConfig = {
                   },
                 },
                 state: {
+                  'ui:validations': [
+                    (errors, field) => {
+                      if (field?.length === 1) {
+                        errors.addError('Must be more than 1 character');
+                      } else if (field?.length > 31) {
+                        errors.addError('Must be less than 31 characters');
+                      }
+                    },
+                  ],
                   'ui:options': {
                     replaceSchema: formData => {
                       if (


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Validate length of state if international and it is present


## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

<img width="714" alt="Screenshot 2024-11-21 at 12 23 23 PM" src="https://github.com/user-attachments/assets/b6e9aa75-d06f-4807-adb8-91120dae2d20">

<img width="628" alt="Screenshot 2024-11-21 at 12 23 30 PM" src="https://github.com/user-attachments/assets/c640ad55-bfad-4ec6-9b80-9d2bf54584c3">


