### PR TITLE
Remove unused VAOS V1 APIs

### DIFF
--- a/src/applications/vaos/services/utils.js
+++ b/src/applications/vaos/services/utils.js
@@ -5,25 +5,6 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 
-function vaosFHIRRequest(url, ...options) {
-  return apiRequest(`${environment.API_URL}/vaos/v1/${url}`, ...options);
-}
-
-/**
- * Fetches a searchset from a FHIR endpoint in VAOS and returns an array of
- * resources
- *
- * @export
- * @param {Object} params
- * @param {String} params.query The FHIR resource and query string to fetch
- * @returns {Array} An array of FHIR resources (not necessarily all the same type as the resource in the query)
- */
-export function fhirSearch({ query }) {
-  return vaosFHIRRequest(query).then(
-    resp => resp.entry?.map(item => item.resource) || [],
-  );
-}
-
 /**
  * Maps the JSON API error format to the FHIR OperationOutcome format
  *

--- a/src/applications/vaos/services/utils.unit.spec.js
+++ b/src/applications/vaos/services/utils.unit.spec.js
@@ -1,9 +1,5 @@
 import { expect } from 'chai';
-
-import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
-
-import { mapToFHIRErrors, fhirSearch } from './utils';
-import mockData from './mocks/fhir/mock_organizations.json';
+import { mapToFHIRErrors } from './utils';
 
 describe('VAOS Utils: FHIR ', () => {
   describe('mapToFHIRError', () => {
@@ -37,19 +33,6 @@ describe('VAOS Utils: FHIR ', () => {
           },
         ],
       });
-    });
-  });
-
-  describe('fhirSearch', () => {
-    it('should search a FHIR resource and return results', async () => {
-      mockFetch();
-      setFetchJSONResponse(global.fetch, mockData);
-      const results = await fhirSearch({ query: 'Organization?id=test' });
-      expect(global.fetch.firstCall.args[0]).to.contain(
-        '/vaos/v1/Organization?id=test',
-      );
-      expect(results.length).to.equal(2);
-      expect(results[0].resourceType).to.equal('Organization');
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR removes two V1 API util functions that are no longer used
- Appointments (VAOS) Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95620

## Testing done

- Removed 1 redundant unit test and ensured all existing unit and e2e tests pass

## Screenshots

N/A

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

