### PR TITLE
Dependents 81671: Remove custom routing

### DIFF
--- a/src/applications/disability-benefits/686c-674-v2/config/form.js
+++ b/src/applications/disability-benefits/686c-674-v2/config/form.js
@@ -926,24 +926,24 @@ export const formConfig = {
                 formData,
                 TASK_KEYS.reportStepchildNotInHousehold,
               ),
-            onNavForward: ({
-              formData,
-              pathname,
-              urlParams,
-              goPath,
-              goNextPath,
-            }) => {
-              const index = getArrayIndexFromPathName(pathname);
-              const urlParamsString = stringifyUrlParams(urlParams) || '';
+            // onNavForward: ({
+            //   formData,
+            //   pathname,
+            //   urlParams,
+            //   goPath,
+            //   goNextPath,
+            // }) => {
+            //   const index = getArrayIndexFromPathName(pathname);
+            //   const urlParamsString = stringifyUrlParams(urlParams) || '';
 
-              if (formData?.supportingStepchild) {
-                goNextPath(urlParams);
-              } else {
-                goPath(
-                  `686-stepchild-no-longer-part-of-household/${index}/child-address${urlParamsString}`,
-                );
-              }
-            },
+            //   if (formData?.supportingStepchild) {
+            //     goNextPath(urlParams);
+            //   } else {
+            //     goPath(
+            //       `686-stepchild-no-longer-part-of-household/${index}/child-address${urlParamsString}`,
+            //     );
+            //   }
+            // },
           }),
           // conditional page
           removeChildHouseholdPartThree: pageBuilder.itemPage({
@@ -971,20 +971,20 @@ export const formConfig = {
                 formData,
                 TASK_KEYS.reportStepchildNotInHousehold,
               ),
-            onNavBack: ({
-              _formData,
-              pathname,
-              urlParams,
-              goPath,
-              _goNextPath,
-            }) => {
-              const index = getArrayIndexFromPathName(pathname);
-              const urlParamsString = stringifyUrlParams(urlParams) || '';
+            // onNavBack: ({
+            //   _formData,
+            //   pathname,
+            //   urlParams,
+            //   goPath,
+            //   _goNextPath,
+            // }) => {
+            //   const index = getArrayIndexFromPathName(pathname);
+            //   const urlParamsString = stringifyUrlParams(urlParams) || '';
 
-              return goPath(
-                `686-stepchild-no-longer-part-of-household/${index}/veteran-supports-child${urlParamsString}`,
-              );
-            },
+            //   return goPath(
+            //     `686-stepchild-no-longer-part-of-household/${index}/veteran-supports-child${urlParamsString}`,
+            //   );
+            // },
           }),
           removeChildHouseholdPartFive: pageBuilder.itemPage({
             title:
@@ -1038,23 +1038,23 @@ export const formConfig = {
             schema: deceasedDependentTypePage.schema,
             depends: formData =>
               isChapterFieldRequired(formData, TASK_KEYS.reportDeath),
-            onNavForward: ({
-              formData,
-              pathname,
-              urlParams,
-              goPath,
-              goNextPath,
-            }) => {
-              if (formData.dependentType !== 'child') {
-                const index = getArrayIndexFromPathName(pathname);
-                const urlParamsString = stringifyUrlParams(urlParams) || '';
-                goPath(
-                  `/686-report-dependent-death/${index}/date-of-death${urlParamsString}`,
-                );
-              } else {
-                goNextPath(urlParams);
-              }
-            },
+            // onNavForward: ({
+            //   formData,
+            //   pathname,
+            //   urlParams,
+            //   goPath,
+            //   goNextPath,
+            // }) => {
+            //   if (formData.dependentType !== 'child') {
+            //     const index = getArrayIndexFromPathName(pathname);
+            //     const urlParamsString = stringifyUrlParams(urlParams) || '';
+            //     goPath(
+            //       `/686-report-dependent-death/${index}/date-of-death${urlParamsString}`,
+            //     );
+            //   } else {
+            //     goNextPath(urlParams);
+            //   }
+            // },
           }),
           // conditional page
           dependentAdditionalInformationPartThree: pageBuilder.itemPage({
@@ -1072,20 +1072,20 @@ export const formConfig = {
             schema: deceasedDependentDateOfDeathPage.schema,
             depends: formData =>
               isChapterFieldRequired(formData, TASK_KEYS.reportDeath),
-            onNavBack: ({
-              _formData,
-              pathname,
-              urlParams,
-              goPath,
-              _goNextPath,
-            }) => {
-              const index = getArrayIndexFromPathName(pathname);
-              const urlParamsString = stringifyUrlParams(urlParams) || '';
+            // onNavBack: ({
+            //   _formData,
+            //   pathname,
+            //   urlParams,
+            //   goPath,
+            //   _goNextPath,
+            // }) => {
+            //   const index = getArrayIndexFromPathName(pathname);
+            //   const urlParamsString = stringifyUrlParams(urlParams) || '';
 
-              return goPath(
-                `686-report-dependent-death/${index}/dependent-type${urlParamsString}`,
-              );
-            },
+            //   return goPath(
+            //     `686-report-dependent-death/${index}/dependent-type${urlParamsString}`,
+            //   );
+            // },
           }),
           dependentAdditionalInformationPartFive: pageBuilder.itemPage({
             title: 'Information needed to remove a dependent who has died',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removes custom routing to be re-worked using depends instead

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/33108

## Testing done

- Manual
- Unit / E2E
- Axe

## Screenshots


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
