### PR TITLE
[CST] - Changes text and link on the Copy of Exam component

### DIFF
--- a/src/applications/claims-status/components/CopyOfExam.jsx
+++ b/src/applications/claims-status/components/CopyOfExam.jsx
@@ -3,14 +3,19 @@ import React from 'react';
 export default function CopyOfExam() {
   return (
     <>
-      <h2 className="help-heading">Want a copy of your claim exam?</h2>
+      <h2 className="help-heading vads-u-margin-top--5">
+        Want a copy of your claim exam?
+      </h2>
       <p>
-        You can obtain a copy of your claim exam (also known as a compensation
-        and pension, or C&amp;P, exam) by{' '}
-        <a href="/find-locations/?facilityType=benefits">
-          contacting your nearest regional office
-        </a>
-        .
+        Use{' '}
+        <a
+          data-testid="va-form-20-10206-link"
+          href="https://va.gov/find-forms/about-form-20-10206/"
+        >
+          VA Form 20-10206
+        </a>{' '}
+        to request a copy of your exam. You can submit the form using our online
+        tool, or download a pdf of the form and send it by mail.
       </p>
     </>
   );

--- a/src/applications/claims-status/tests/components/CopyOfExam.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/CopyOfExam.unit.spec.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import CopyOfExam from '../../components/CopyOfExam';
+
+describe('<CopyOfExam>', () => {
+  it('should render component', () => {
+    const { getByRole, getByText } = render(<CopyOfExam />);
+    getByRole('heading', { name: 'Want a copy of your claim exam?' });
+    getByRole('link', {
+      name: 'VA Form 20-10206',
+      href: 'https://va.gov/find-forms/about-form-20-10206/',
+    });
+    getByText(
+      /You can submit the form using our online tool, or download a pdf of the form and send it by mail./i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

User wrote in that they had a HLR and the sidebar content with the header `Want a copy of your claim exam?` had a text that was inaccurate. Updated the text to be accurate per @jstrothman guidance, added a new link to `https://va.gov/find-forms/about-form-20-10206/`, increased top heading padding to 40 px and added tests.

Slack Convo regarding this change and verification of changes - https://dsva.slack.com/archives/C04KHCT3ZMY/p1732207071698879

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#97601

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    ![Screenshot 2024-11-21 at 1 21 28 PM](https://github.com/user-attachments/assets/189f87d2-6ee8-48ee-9038-75e2751ffafc)    |     ![Screenshot 2024-11-21 at 11 53 24 AM](https://github.com/user-attachments/assets/7c23f05a-d464-4725-aa71-ee3d77620c0d)  |

Video of new experience: 

https://github.com/user-attachments/assets/5b48a205-16c3-452e-a480-e0fdf863440f

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [x] In Claim Status Tool, change content to match the language provided under Change to make in this ticket
- [x] Reply in this ticket re what claim types show this information. This info is for reference later, and won't change the work in this ticket.
- [x] Add a top margin of 40px to the 'Want a copy of your claim exam?' header

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
