### PR TITLE
Updates UI description to fragment and matcher for schema

### DIFF
--- a/src/applications/my-education-benefits/config/chapters/33/serviceHistory/serviceHistory.js
+++ b/src/applications/my-education-benefits/config/chapters/33/serviceHistory/serviceHistory.js
@@ -25,14 +25,9 @@ const checkBoxValidation = {
 const serviceHistory33 = {
   uiSchema: {
     'view:subHeading': {
-      'ui:description': <h3>Review your service history</h3>,
-      'ui:options': {
-        hideIf: formData => formData?.showMebDgi40Features,
-      },
-    },
-    'view:newSubHeading': {
       'ui:description': (
         <>
+          <h3>Review your service history</h3>
           <p>
             The displayed service history is reported to VA by DOD and may
             include service which is not creditable for the Post-9/11 GI Bill.
@@ -51,9 +46,6 @@ const serviceHistory33 = {
           </p>
         </>
       ),
-      'ui:options': {
-        hideIf: formData => !formData?.showMebDgi40Features,
-      },
     },
     [formFields.toursOfDuty]: {
       ...toursOfDutyUI,
@@ -156,10 +148,6 @@ const serviceHistory33 = {
     type: 'object',
     properties: {
       'view:subHeading': {
-        type: 'object',
-        properties: {},
-      },
-      'view:newSubHeading': {
         type: 'object',
         properties: {},
       },

--- a/src/applications/my-education-benefits/config/chapters/33/serviceHistory/serviceHistory.js
+++ b/src/applications/my-education-benefits/config/chapters/33/serviceHistory/serviceHistory.js
@@ -46,6 +46,37 @@ const serviceHistory33 = {
           </p>
         </>
       ),
+      'ui:options': {
+        hideIf: formData => formData?.meb160630Automation,
+      },
+    },
+    'view:newSubHeading': {
+      'ui:description': (
+        <>
+          <h3>Review your service history</h3>
+          <p>
+            The displayed service history is reported to the VA by DOD and may
+            include service which is not creditable for the benefit you are
+            applying for
+          </p>
+          <p>
+            VA will only consider active duty service (
+            <a
+              target="_blank"
+              href="https://uscode.house.gov/view.xhtml?req=(title:38%20section:3301%20edition:prelim)%20OR%20(granuleid:USC-prelim-title38-section3301)&f=treesort&edition=prelim&num=0&jumpTo=true"
+              rel="noreferrer"
+            >
+              Authority 38 U.S.C. 3301(1)
+            </a>
+            ) and a 6-year service obligation (you agreed to serve 6 years) in
+            the Selective Reserve when determining your eligibility. Please
+            review your service history and indicate if anything is incorrect.
+          </p>
+        </>
+      ),
+      'ui:options': {
+        hideIf: formData => !formData?.meb160630Automation,
+      },
     },
     [formFields.toursOfDuty]: {
       ...toursOfDutyUI,
@@ -148,6 +179,10 @@ const serviceHistory33 = {
     type: 'object',
     properties: {
       'view:subHeading': {
+        type: 'object',
+        properties: {},
+      },
+      'view:newSubHeading': {
         type: 'object',
         properties: {},
       },

--- a/src/applications/my-education-benefits/config/chapters/33/serviceHistory/serviceHistory.js
+++ b/src/applications/my-education-benefits/config/chapters/33/serviceHistory/serviceHistory.js
@@ -57,7 +57,7 @@ const serviceHistory33 = {
           <p>
             The displayed service history is reported to the VA by DOD and may
             include service which is not creditable for the benefit you are
-            applying for
+            applying for.
           </p>
           <p>
             VA will only consider active duty service (

--- a/src/applications/my-education-benefits/tests/form.unit.spec.js
+++ b/src/applications/my-education-benefits/tests/form.unit.spec.js
@@ -7,13 +7,8 @@ describe('Service History Chapter', () => {
     uiSchema,
   } = formConfig?.chapters?.serviceHistoryChapter?.pages?.serviceHistory;
 
-  it('renders the old Service History header', () => {
+  it('renders Service History header', () => {
     expect(uiSchema['view:subHeading']).to.exist;
     expect(schema.properties['view:subHeading']).to.exist;
-  });
-
-  it('renders the new Service History header', () => {
-    expect(uiSchema['view:newSubHeading']).to.exist;
-    expect(schema.properties['view:newSubHeading']).to.exist;
   });
 });

--- a/src/applications/my-education-benefits/tests/form.unit.spec.js
+++ b/src/applications/my-education-benefits/tests/form.unit.spec.js
@@ -7,8 +7,12 @@ describe('Service History Chapter', () => {
     uiSchema,
   } = formConfig?.chapters?.serviceHistoryChapter?.pages?.serviceHistory;
 
-  it('renders Service History header', () => {
+  it('renders original Ch33 Service History header', () => {
     expect(uiSchema['view:subHeading']).to.exist;
     expect(schema.properties['view:subHeading']).to.exist;
+  });
+  it('renders the new multiple chapter Service History header', () => {
+    expect(uiSchema['view:newSubHeading']).to.exist;
+    expect(schema.properties['view:newSubHeading']).to.exist;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updates Sub Heading component to show ui:description.

## Related issue(s)
<img width="823" alt="Screenshot 2024-11-22 at 10 12 47 AM" src="https://github.com/user-attachments/assets/66218e9c-8204-4f2f-a9fc-6e011cd9938a">


## Testing done
Manual testing logged in and verified the updated description

## Screenshots
### R7 Feature flag Off
<img width="811" alt="Screenshot 2024-11-22 at 9 50 21 AM" src="https://github.com/user-attachments/assets/6a58672d-8eeb-43f2-b03f-7b708f97de4a">

### R7 Feature flag On
<img width="811" alt="Screenshot 2024-11-22 at 11 30 51 AM" src="https://github.com/user-attachments/assets/9ca2898c-0338-4c1f-8f4f-04000210fb57">


## What areas of the site does it impact?
My Education Benefits Service History Chapter.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user