### PR TITLE
[DOCS] Update pull request template, accessibility review link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -69,7 +69,7 @@ _Note: This field is mandatory for UI changes (non-component work should NOT hav
 - [ ] Linting warnings have been addressed
 - [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
 - [ ] Screenshot of the developed feature is added
-- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
+- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed
 
 ### Error Handling
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The Accessibility Review link in our pull request template `404's` when you click on it. I updated it to the current [Prepare for an accessibility staging review](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) page on Platform docs.


## Testing done

- I updated the link and tested the PR Markdown page for proper link resolution on the Platform docs

## What areas of the site does it impact?

Pull request template