### PR TITLE
Fix a few page details

### DIFF
--- a/src/applications/vaos/referral-appointments/temp-data/referral.js
+++ b/src/applications/vaos/referral-appointments/temp-data/referral.js
@@ -19,7 +19,7 @@ const getAvailableSlots = (number = 2) => {
 const referral = {
   id: 123456,
   providerName: 'Dr. Face',
-  provider: '111',
+  provider: '540',
   typeOfCare: 'Dermatology',
   appointmentCount: 2,
   orgName: 'New Skin Technologies',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Moved validation to the `onSubmit` function 
- Added the a `va-telephone` component to render the `provider.orgPhone`
- Restore and save selected date for the referral so that it persist a reload
- use existing VAOS functions to get the timezone based on referral
- use existing VAOS date format function to display the timezone information.  

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#95272

## Testing done

- Schedule referral date and time would not persist the selected date and time for the referral
- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![Screen Shot 2024-11-22 at 11 35 42](https://github.com/user-attachments/assets/a363d776-e5d5-4b54-a297-94648cb64aa6)|![Screen Shot 2024-11-22 at 11 18 52](https://github.com/user-attachments/assets/92338de5-7c00-4180-89e4-d63412512be0)|
| Desktop |![Screenshot 2024-11-22 at 11-35-54 VA Online Scheduling Veterans Affairs](https://github.com/user-attachments/assets/8de56bc0-c54c-4860-9088-309015262d1a)|![Screenshot 2024-11-22 at 11-18-43 VA Online Scheduling Veterans Affairs](https://github.com/user-attachments/assets/73e2384c-231b-4d36-99b2-ed0f85c125d3)|



https://github.com/user-attachments/assets/21053eff-4927-4d22-9567-c31bab84fd59


## What areas of the site does it impact?

- VAOS

## Acceptance criteria

 - [X] Selected date validation should happen after clicking to continue
 - [X] Telephone number should be clickable with `href=://tel:` 
 - [x] ~~Store selected date keyed on referral UUID in session to restore on refresh~~
 - [X] Restore selected date from session on reload
 - [X] Time zone should be based off of referring facility
 - [X] Use existing VAOS TZ formatters

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
