### PR TITLE
Move alert from Profile to My VA

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -54,6 +54,7 @@ import { canAccess } from '../../common/selectors';
 import RenderClaimsWidgetDowntimeNotification from './RenderClaimsWidgetDowntimeNotification';
 import BenefitApplications from './benefit-application-drafts/BenefitApplications';
 import EducationAndTraining from './education-and-training/EducationAndTraining';
+import { ContactInfoNeeded } from '../../profile/components/alerts/ContactInfoNeeded';
 
 const DashboardHeader = ({ showNotifications, user }) => {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
@@ -115,6 +116,7 @@ const DashboardHeader = ({ showNotifications, user }) => {
           });
         }}
       />
+      <ContactInfoNeeded />
       {showNotifications && !hideNotificationsSection && <Notifications />}
     </div>
   );

--- a/src/applications/personalization/profile/components/alerts/ContactInfoNeeded.jsx
+++ b/src/applications/personalization/profile/components/alerts/ContactInfoNeeded.jsx
@@ -27,7 +27,7 @@ export const ContactInfoNeeded = () => {
   return contactInfoIsNeeded ? (
     <Toggler toggleName={Toggler.TOGGLE_NAMES.veteranOnboardingContactInfoFlow}>
       <Toggler.Enabled>
-        <div className="vads-u-margin-bottom--4">
+        <div className="vads-u-margin-top--4 vads-u-margin-bottom--4">
           <VaAlert data-testid="account-blocked-alert" status="info" uswds>
             <h2 slot="headline">We need your contact information</h2>
             <p>

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -10,7 +10,6 @@ import { ProfileBreadcrumbs } from '@@profile/components/ProfileBreadcrumbs';
 import { ProfileLink } from '@@profile/components/ProfileLink';
 import BadAddressAlert from '@@profile/components/alerts/bad-address/ProfileAlert';
 import { HubCard } from './HubCard';
-import { ContactInfoNeeded } from '../alerts/ContactInfoNeeded';
 
 export const Hub = () => {
   const { label, link } = useSignInServiceProvider();
@@ -28,8 +27,6 @@ export const Hub = () => {
       <div className="vads-l-row">
         <h1>Profile</h1>
       </div>
-
-      <ContactInfoNeeded className="vads-u-margin-top--0 vads-u-margin-bottom--4 medium-screen:vads-l-col--10" />
 
       {hasBadAddress && (
         <BadAddressAlert className="vads-u-margin-top--0 vads-u-margin-bottom--4 vads-l-col--10" />


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Moves the "We need your contact information" alert from Profile to My VA.
- I work for VA IIR and we own this alert.

## Related issue(s)

[VA IIR issue 1261](https://github.com/department-of-veterans-affairs/va-iir/issues/1261)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="201" alt="Screenshot 2024-11-24 at 2 47 51 PM" src="https://github.com/user-attachments/assets/212dccbf-b166-4a12-8860-1119d74e5eb5">|<img width="431" alt="Screenshot 2024-11-24 at 2 48 03 PM" src="https://github.com/user-attachments/assets/2142eafa-fd93-4988-9d23-f99850052f6a">|
| Desktop |<img width="201" alt="Screenshot 2024-11-24 at 2 47 51 PM" src="https://github.com/user-attachments/assets/212dccbf-b166-4a12-8860-1119d74e5eb5">|<img width="1023" alt="Screenshot 2024-11-24 at 2 47 28 PM" src="https://github.com/user-attachments/assets/c6a1519b-3cd6-42be-a9cd-e31deaf85419">|


## What areas of the site does it impact?

Impacts Profile by removing an alert. Impacts My VA by adding it there.

## Acceptance criteria

- The "We need your contact information" alert appears on My VA but not on Profile.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
