### PR TITLE
minor tweak and unit test for useGetReferralById hook

### DIFF
--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -105,10 +105,10 @@ export function fetchReferrals() {
 
 export function fetchReferralById(id) {
   return async dispatch => {
+    dispatch({
+      type: FETCH_REFERRAL,
+    });
     try {
-      dispatch({
-        type: FETCH_REFERRAL,
-      });
       const referrals = await getPatientReferralById(id);
       dispatch({
         type: FETCH_REFERRAL_SUCCEEDED,

--- a/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/TestComponent.jsx
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/TestComponent.jsx
@@ -13,7 +13,7 @@ export default function TestComponent() {
       <p>Test component</p>
       <p>{currentReferral?.UUID}</p>
       <p>{referralFetchStatus}</p>
-      <p>{referralNotFound}</p>
+      <p>{`Referral not found: ${referralNotFound}`}</p>
     </div>
   );
 }

--- a/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
@@ -1,46 +1,117 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
 import { expect } from 'chai';
+import { waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-import { render } from '@testing-library/react';
-import { getPatientReferralById } from '../../../../services/referral';
+import * as getPatientReferralByIdModule from '../../../../services/referral';
+import { renderWithStoreAndRouter } from '../../../../tests/mocks/setup';
+import { createReferral } from '../../../utils/referrals';
+import { FETCH_STATUS } from '../../../../utils/constants';
 
 import TestComponent from './TestComponent';
 
 describe('Community Care Referrals', () => {
-  describe('useGerReferralById hook', () => {
+  describe('useGetReferralById hook', () => {
+    const now = new Date();
     const sandbox = sinon.createSandbox();
-    let store;
-    const api = { fetchReferral: getPatientReferralById };
     beforeEach(() => {
       global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
-      const middleware = [];
-      const mockStore = configureStore(middleware);
-      const initState = {
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+    it('Loads test component with hook and fetches referral when state is empty', () => {
+      sandbox
+        .stub(getPatientReferralByIdModule, 'getPatientReferralById')
+        .resolves(createReferral(now, '111'));
+      const initialState = {
         featureToggles: {
           vaOnlineSchedulingCCDirectScheduling: true,
         },
         referral: {
           facility: null,
           referrals: [],
-          referralFetchStatus: 'notStarted',
+          referralFetchStatus: FETCH_STATUS.notStarted,
         },
       };
-      store = mockStore(initState);
-      sandbox.stub(api, 'fetchReferral').resolves({});
-    });
-    afterEach(() => {
-      sandbox.restore();
-    });
-    it.skip('Loads test component with hook', () => {
-      const screen = render(
-        <Provider store={store}>
-          <TestComponent />
-        </Provider>,
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      expect(screen.getByText(/Test component/i)).to.exist;
+      sandbox.assert.calledOnce(
+        getPatientReferralByIdModule.getPatientReferralById,
       );
-      expect(screen.getByText(/TestComponent/i)).to.exist;
-      sandbox.assert.calledOnce(api.fetchReferral);
+    });
+    it('Returns the referral from store if exists without calling endpoint', () => {
+      sandbox
+        .stub(getPatientReferralByIdModule, 'getPatientReferralById')
+        .resolves(createReferral(now, '111'));
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: true,
+        },
+        referral: {
+          facility: null,
+          referrals: [
+            createReferral(now, 'add2f0f4-a1ea-4dea-a504-a54ab57c6800'),
+          ],
+          referralFetchStatus: FETCH_STATUS.notStarted,
+        },
+      };
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      expect(screen.getByText('add2f0f4-a1ea-4dea-a504-a54ab57c6800')).to.exist;
+      sandbox.assert.notCalled(
+        getPatientReferralByIdModule.getPatientReferralById,
+      );
+    });
+    it('Returns the referral not found when referral not in store', () => {
+      sandbox
+        .stub(getPatientReferralByIdModule, 'getPatientReferralById')
+        .resolves(createReferral(now, '111'));
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: true,
+        },
+        referral: {
+          facility: null,
+          referrals: [
+            createReferral(now, 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
+          ],
+          referralFetchStatus: FETCH_STATUS.notStarted,
+        },
+      };
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      expect(screen.getByText('Referral not found: true')).to.exist;
+      sandbox.assert.notCalled(
+        getPatientReferralByIdModule.getPatientReferralById,
+      );
+    });
+    it('Returns the referral not found when referral not in fetch', async () => {
+      sandbox
+        .stub(getPatientReferralByIdModule, 'getPatientReferralById')
+        .resolves({});
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: true,
+        },
+        referral: {
+          facility: null,
+          referrals: [],
+          referralFetchStatus: FETCH_STATUS.notStarted,
+        },
+      };
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Referral not found: true')).to.exist;
+      });
+      sandbox.assert.calledOnce(
+        getPatientReferralByIdModule.getPatientReferralById,
+      );
     });
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

A minor change to the hook (setting the loading status outside the try block) and complete unit tests for the hook.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#97724

## Testing done

Created unit tests

## What areas of the site does it impact?

Community Care referral scheduling feature in VAOS

## Acceptance criteria
 - [ ] The hook is unit tested
 - [ ] Tests pass
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


