### PR TITLE
MHV-64687: Add a "Reset Filter" button

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListFilter.jsx
@@ -57,6 +57,12 @@ const MedicationsListFilter = props => {
     focusElement(document.getElementById('showingRx'));
   };
 
+  const handleFilterReset = () => {
+    setFilterOption(ALL_MEDICATIONS_FILTER_KEY);
+    updateFilter(ALL_MEDICATIONS_FILTER_KEY);
+    focusElement(document.getElementById('showingRx'));
+  };
+
   const handleAccordionItemToggle = ({ target }) => {
     if (target) {
       const isOpen = target.getAttribute('open');
@@ -114,12 +120,23 @@ const MedicationsListFilter = props => {
             />
           ))}
         </VaRadio>
-        <VaButton
-          className="vads-u-width--full tablet:vads-u-width--auto filter-submit-btn vads-u-margin-top--3"
-          onClick={handleFilterSubmit}
-          text="Apply filter"
-          data-testid="filter-button"
-        />
+        <div>
+          <VaButton
+            className="vads-u-width--full tablet:vads-u-width--auto filter-submit-btn vads-u-margin-top--3"
+            onClick={handleFilterSubmit}
+            text="Apply filter"
+            data-testid="filter-button"
+          />
+        </div>
+        <div>
+          <VaButton
+            className="vads-u-width--full tablet:vads-u-width--auto filter-submit-btn vads-u-margin-top--3"
+            secondary
+            onClick={handleFilterReset}
+            text="Reset filter"
+            data-testid="filter-reset-button"
+          />
+        </div>
       </VaAccordionItem>
     </VaAccordion>
   );

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListFilter.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedicationsListFilter.unit.spec.jsx
@@ -88,9 +88,30 @@ describe('Medicaitons List Filter component', () => {
       />,
     );
 
-    const filterButton = wrapper.find('VaButton');
+    const filterButton = wrapper.find('VaButton[data-testid="filter-button"]');
 
     filterButton.simulate('click');
+    expect(updateFilter.calledOnce).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('calls setFilterOption AND updateFilter when user presses the Reset button ', () => {
+    const updateFilter = Sinon.spy();
+    const setFilterOption = Sinon.spy();
+    const wrapper = mount(
+      <MedicationsListFilter
+        updateFilter={updateFilter}
+        filterOption={filterOptions.ACTIVE.label}
+        setFilterOption={setFilterOption}
+      />,
+    );
+
+    const resetButton = wrapper.find(
+      'VaButton[data-testid="filter-reset-button"]',
+    );
+
+    resetButton.simulate('click');
+    expect(setFilterOption.calledOnce).to.be.true;
     expect(updateFilter.calledOnce).to.be.true;
     wrapper.unmount();
   });


### PR DESCRIPTION
## Summary

Added a "Reset filter" button to `MedicationsListFilter` component

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-64687

## Testing done

- Manual testing
- Unit testing

## Screenshots

<img width="798" alt="image" src="https://github.com/user-attachments/assets/1b9dd066-4acd-480f-b3d4-51556934a17e">
<img width="374" alt="image" src="https://github.com/user-attachments/assets/d1206499-b608-4618-beb5-d34f0ce8a8c9">

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Add "Reset filter" button to the filters that changes the list back to the "All medications" remote button option. 
AC2: Make sure this also changes the Showing.... as going back to all medications as well. 
AC3: Button will match the size of the apply filter button. 

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
