### PR TITLE
Mhv 60731 save empty message error

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -47,9 +47,10 @@ import { RadioCategories } from '../../util/inputContants';
 import { getCategories } from '../../actions/categories';
 import ElectronicSignature from './ElectronicSignature';
 import RecipientsSelect from './RecipientsSelect';
+import { getPatientSignature } from '../../actions/preferences';
 
 const ComposeForm = props => {
-  const { pageTitle, headerRef, draft, recipients, signature } = props;
+  const { pageTitle, headerRef, draft, recipients } = props;
   const {
     noAssociations,
     allTriageGroupsBlocked,
@@ -58,10 +59,21 @@ const ComposeForm = props => {
   const dispatch = useDispatch();
   const history = useHistory();
 
+  const signature = useSelector(state => state.sm.preferences?.signature);
+
   const [recipientsList, setRecipientsList] = useState(allowedRecipients);
   const [selectedRecipientId, setSelectedRecipientId] = useState(null);
   const [isSignatureRequired, setIsSignatureRequired] = useState(null);
   const [checkboxMarked, setCheckboxMarked] = useState(false);
+
+  useEffect(
+    () => {
+      if (!signature) {
+        dispatch(getPatientSignature());
+      }
+    },
+    [signature, dispatch],
+  );
 
   useEffect(
     () => {
@@ -346,7 +358,11 @@ const ComposeForm = props => {
         setSubjectError(ErrorMessages.ComposeForm.SUBJECT_REQUIRED);
         messageValid = false;
       }
-      if (messageBody === '' || messageBody.match(/^[\s]+$/)) {
+      if (
+        messageBody === '' ||
+        messageBody.match(/^[\s]+$/) ||
+        messageBody.trim() === formattedSignature.trim()
+      ) {
         setBodyError(ErrorMessages.ComposeForm.BODY_REQUIRED);
         messageValid = false;
       }
@@ -372,6 +388,7 @@ const ComposeForm = props => {
       messageBody,
       category,
       isSignatureRequired,
+      formattedSignature,
       electronicSignature,
       checkboxMarked,
       setMessageInvalid,

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -361,7 +361,7 @@ const ComposeForm = props => {
       if (
         messageBody === '' ||
         messageBody.match(/^[\s]+$/) ||
-        messageBody.trim() === formattedSignature.trim()
+        (formattedSignature && messageBody.trim() === formattedSignature.trim())
       ) {
         setBodyError(ErrorMessages.ComposeForm.BODY_REQUIRED);
         messageValid = false;

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyDraftItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyDraftItem.jsx
@@ -107,7 +107,7 @@ const ReplyDraftItem = props => {
     clearTimeout(timeoutId);
   };
 
-  const formattededSignature = useMemo(
+  const formattedSignature = useMemo(
     () => {
       return messageSignatureFormatter(signature);
     },
@@ -152,14 +152,18 @@ const ReplyDraftItem = props => {
   const checkMessageValidity = useCallback(
     () => {
       let messageValid = true;
-      if (messageBody === '' || messageBody.match(/^[\s]+$/)) {
+      if (
+        messageBody === '' ||
+        messageBody.match(/^[\s]+$/) ||
+        (formattedSignature && messageBody.trim() === formattedSignature.trim())
+      ) {
         setBodyError(ErrorMessages.ComposeForm.BODY_REQUIRED);
         messageValid = false;
       }
       setMessageInvalid(!messageValid);
       return { messageValid };
     },
-    [messageBody],
+    [formattedSignature, messageBody],
   );
 
   const messageBodyHandler = e => {
@@ -523,7 +527,7 @@ const ReplyDraftItem = props => {
               draftSequence ? `-${draftSequence}` : ''
             }`}
             onInput={messageBodyHandler}
-            value={draft?.body || formattededSignature} // populate with the signature, unless there is a saved draft
+            value={draft?.body || formattedSignature} // populate with the signature, unless there is a saved draft
             error={bodyError}
             onFocus={e => {
               setCaretToPos(e.target.shadowRoot.querySelector('textarea'), 0);

--- a/src/applications/mhv-secure-messaging/containers/Compose.jsx
+++ b/src/applications/mhv-secure-messaging/containers/Compose.jsx
@@ -8,13 +8,11 @@ import ComposeForm from '../components/ComposeForm/ComposeForm';
 import InterstitialPage from './InterstitialPage';
 import { closeAlert } from '../actions/alerts';
 import { PageTitles, Paths } from '../util/constants';
-import { getPatientSignature } from '../actions/preferences';
 
 const Compose = () => {
   const dispatch = useDispatch();
   const recipients = useSelector(state => state.sm.recipients);
   const { drafts, saveError } = useSelector(state => state.sm.threadDetails);
-  const signature = useSelector(state => state.sm.preferences.signature);
   const draftMessage = drafts?.[0] ?? null;
   const { draftId } = useParams();
 
@@ -45,15 +43,6 @@ const Compose = () => {
       };
     },
     [dispatch, draftId, location.pathname],
-  );
-
-  useEffect(
-    () => {
-      if (!signature) {
-        dispatch(getPatientSignature());
-      }
-    },
-    [signature, dispatch],
   );
 
   useEffect(
@@ -96,7 +85,6 @@ const Compose = () => {
             headerRef={header}
             draft={draftMessage}
             recipients={!recipients.error && recipients}
-            signature={signature}
           />
         </>
       );

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/ComposeForm.unit.spec.jsx
@@ -352,6 +352,31 @@ describe('Compose form component', () => {
       );
   });
 
+  it('displays error states on message body field when send button is clicked and message body only has signature', async () => {
+    const customState = {
+      ...initialState,
+      sm: {
+        ...initialState.sm,
+        triageTeams: { triageTeams },
+        categories: { categories },
+        preferences: signatureReducers.signatureEnabled,
+      },
+      featureToggles: {},
+    };
+    const screen = setup(customState, Paths.COMPOSE, {
+      draft: { ...draftMessage, body: '\n\nName\nTitle' },
+    });
+
+    const sendButton = screen.getByTestId('send-button');
+
+    fireEvent.click(sendButton);
+
+    const messageInput = await screen.getByTestId('message-body-field');
+    const messageInputError = messageInput[getProps(messageInput)].error;
+
+    expect(messageInputError).to.equal('Message body cannot be blank.');
+  });
+
   it('displays an error on attempt to save a draft with attachments', async () => {
     const customProps = {
       ...draftMessage,

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientInboxPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientInboxPage.js
@@ -347,13 +347,13 @@ class PatientInboxPage {
   };
 
   navigateToInterstitialPage = () => {
-    cy.intercept(
-      'GET',
-      Paths.SM_API_EXTENDED + Paths.SIGNATURE,
-      mockSignature,
-    ).as('signature');
+    // cy.intercept(
+    //   'GET',
+    //   Paths.SM_API_EXTENDED + Paths.SIGNATURE,
+    //   mockSignature,
+    // ).as('signature');
     cy.get(Locators.LINKS.CREATE_NEW_MESSAGE).click({ force: true });
-    cy.wait('@signature');
+    // cy.wait('@signature');
   };
 
   navigateToComposePageByKeyboard = () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -355,7 +355,7 @@ class PatientMessageDetailsPage {
       'GET',
       `${Paths.SM_API_EXTENDED}/${singleThreadData.data[0].id}/thread*`,
       singleThreadData,
-    ).as('replyThread');
+    ).as('replyThreadInfo');
 
     cy.get(Locators.BUTTONS.REPLY).click({ force: true });
     PatientInterstitialPage.getContinueButton().click();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft-errors.cypress.spec.js
@@ -3,7 +3,7 @@ import PatientInboxPage from './pages/PatientInboxPage';
 import PatientComposePage from './pages/PatientComposePage';
 import { AXE_CONTEXT, Data } from './utils/constants';
 
-describe('Secure Messaging Compose Errors', () => {
+describe('SM COMPOSE ERRORS', () => {
   beforeEach(() => {
     SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-reply-draft-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-reply-draft-errors.cypress.spec.js
@@ -1,0 +1,70 @@
+import SecureMessagingSite from './sm_site/SecureMessagingSite';
+import PatientMessageDetailsPage from './pages/PatientMessageDetailsPage';
+import PatientInboxPage from './pages/PatientInboxPage';
+import PatientMessageDraftsPage from './pages/PatientMessageDraftsPage';
+import PatientReplyPage from './pages/PatientReplyPage';
+import mockMessages from './fixtures/messages-response.json';
+import mockSingleThread from './fixtures/thread-response.json';
+import { AXE_CONTEXT, Data, Locators } from './utils/constants';
+import PatientComposePage from './pages/PatientComposePage';
+
+describe('SM REPLY ERRORS', () => {
+  const bodyText = 'Updated body text';
+  const singleMessage = { data: mockSingleThread.data[0] };
+  singleMessage.data.attributes.body = `${bodyText}\n\n\nName\nTitletest`;
+
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages(mockMessages);
+    PatientInboxPage.loadSingleThread(mockSingleThread);
+    PatientMessageDetailsPage.clickReplyButton(mockSingleThread);
+  });
+
+  it('verify empty message body error', () => {
+    PatientMessageDraftsPage.saveNewDraftMessage(
+      mockSingleThread,
+      singleMessage,
+    );
+    PatientComposePage.verifyErrorText(Data.BODY_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage('TEXTAREA');
+
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('verify deleted data in body error', () => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages(mockMessages);
+    PatientInboxPage.loadSingleThread(mockSingleThread);
+    PatientMessageDetailsPage.clickReplyButton(mockSingleThread);
+
+    PatientReplyPage.getMessageBodyField().type(bodyText, {
+      force: true,
+    });
+
+    PatientMessageDraftsPage.saveNewDraftMessage(
+      mockSingleThread,
+      singleMessage,
+    );
+
+    cy.get(Locators.ALERTS.SAVE_DRAFT).should(
+      'include.text',
+      Data.MESSAGE_WAS_SAVED,
+    );
+
+    PatientReplyPage.getMessageBodyField().clear({
+      force: true,
+    });
+
+    PatientMessageDraftsPage.saveNewDraftMessage(
+      mockSingleThread,
+      singleMessage,
+    );
+
+    PatientComposePage.verifyErrorText(Data.BODY_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage('TEXTAREA');
+
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- bug: when editing a saved draft, deleting the message body but keeping only the patient signature and clicking save or send would allow saving or sending, but the message body should not be blank.
- fix: added a check to the message body that compares it to the patient's signature.  If the signature is enabled and the message body matches just the signature, throw an error.

## Related issue(s)

### [MHV-60731](https://jira.devops.va.gov/browse/MHV-60731) - User able to save draft when user edit the message. ###

> User able to save the draft, when user edit the message.
> 
> Step to Reproduce
> 1) Start a new Message
> 2) Fill the all required field.
> 3) Click on Save Draft
> 4) Edit message box (Remove the whole text)
> 5) Click on save draft
> 
> Issue- User able to Save the draft successfully.
> 
> User Story:  As a SM user, I want to    so that I can
> 
> GIVEN:
> 
> WHEN:
> 
> THEN:
> 
> Feature Flag Y/N ? N
> 
> DataDog Analytics  Y/N ? N
> 
> Manual Testing Y/N ? Y-Rakesh
> 
> Automated Testing Y/N ?
> 
> Accessibility Testing Y/N ?
> 
> UCD Validation Y/N


## Testing done

- Manual testing
- Added unit test

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Description  |  clicking save with an empty message body allows saving      |  clicking save with an empty message body triggers an error     |
| Desktop |![Screenshot 2024-11-27 at 11 53 06 AM](https://github.com/user-attachments/assets/7e7bc34a-755e-44f4-bf3a-13e56ec7ead1)|![Screenshot 2024-11-27 at 11 51 30 AM](https://github.com/user-attachments/assets/8b83a4cc-0a83-4370-8d3d-a3fc3f6dcdd9)|

## What areas of the site does it impact?

Va.gov - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
