### PR TITLE
(feature) hid the PHR refresh message on the allergy page

### DIFF
--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -194,18 +194,20 @@ ${allergies.map(entry => generateAllergyListItemTxt(entry)).join('')}`;
         listCurrentAsOf={allergiesCurrentAsOf}
         initialFhirLoad={refresh.initialFhirLoad}
       >
-        <NewRecordsIndicator
-          refreshState={refresh}
-          extractType={refreshExtractTypes.ALLERGY}
-          newRecordsFound={
-            Array.isArray(allergies) &&
-            Array.isArray(updatedRecordList) &&
-            allergies.length !== updatedRecordList.length
-          }
-          reloadFunction={() => {
-            dispatch(reloadRecords());
-          }}
-        />
+        {!isAcceleratingAllergies && (
+          <NewRecordsIndicator
+            refreshState={refresh}
+            extractType={refreshExtractTypes.ALLERGY}
+            newRecordsFound={
+              Array.isArray(allergies) &&
+              Array.isArray(updatedRecordList) &&
+              allergies.length !== updatedRecordList.length
+            }
+            reloadFunction={() => {
+              dispatch(reloadRecords());
+            }}
+          />
+        )}
 
         <PrintDownload
           list

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/allergies/medical-records-view-allergies-list.hide-phr-message.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/allergies/medical-records-view-allergies-list.hide-phr-message.cypress.spec.js
@@ -1,0 +1,55 @@
+import MedicalRecordsSite from '../../mr_site/MedicalRecordsSite';
+import allergies from '../../fixtures/allergies/sample-lighthouse.json';
+import oracleHealthUser from '../../fixtures/user/oracle-health.json';
+
+describe('Medical Records View Allergies', () => {
+  beforeEach(() => {
+    const site = new MedicalRecordsSite();
+    site.login(oracleHealthUser, false);
+    site.mockFeatureToggles({
+      isAcceleratingEnabled: true,
+      isAcceleratingAllergies: true,
+    });
+
+    // set up intercepts
+    cy.intercept('POST', '/my_health/v1/medical_records/session').as('session');
+    cy.intercept('GET', '/my_health/v1/medical_records/allergies*', req => {
+      // check the correct param was used
+      expect(req.url).to.contain('use_oh_data_path=1');
+      req.reply(allergies);
+    }).as('allergiesList');
+  });
+
+  it('Visits Medical Records View Allergies List', () => {
+    cy.visit('my-health/medical-records');
+
+    // check for MY Va Health links
+    cy.get('[data-testid="labs-and-tests-oh-landing-page-link"]').should(
+      'be.visible',
+    );
+    cy.get('[data-testid="summary-and-notes-oh-landing-page-link"]').should(
+      'be.visible',
+    );
+    cy.get('[data-testid="vaccines-oh-landing-page-link"]').should(
+      'be.visible',
+    );
+    cy.get('[data-testid="health-conditions-oh-landing-page-link"]').should(
+      'be.visible',
+    );
+
+    cy.get('[data-testid="vitals-oh-landing-page-link"]').should('be.visible');
+
+    cy.get('[data-testid="allergies-landing-page-link"]')
+      .should('be.visible')
+      .click();
+
+    cy.injectAxeThenAxeCheck();
+    // // check the intercept that the correct param was used
+
+    cy.title().should(
+      'contain',
+      'Allergies and Reactions - Medical Records | Veterans Affairs',
+    );
+    cy.get('#new-records-indicator').should('not.exist');
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Hiding PHR refresh banner for Veterans using LH data
- NOTE: the PHR refresh call is still happening, but since this page is not using PHR data, the call status is not displayed. 

## Related issue(s)


Requirements defined in a slack canvas

## Testing done
- added e2e test

## Screenshots

before:
![Screenshot 2024-12-02 at 2 34 06 PM](https://github.com/user-attachments/assets/a10cb9da-c045-4412-a333-a02c0b9d1398)

after:
![Screenshot 2024-12-02 at 2 33 16 PM](https://github.com/user-attachments/assets/f0a1b25c-df94-40e5-9f04-acf75844e0c7)


## What areas of the site does it impact?

- MHV Allergies 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

