### PR TITLE
Fix Form Upload validation mismatched props bug

### DIFF
--- a/src/applications/simple-forms/form-upload/pages/helpers.jsx
+++ b/src/applications/simple-forms/form-upload/pages/helpers.jsx
@@ -28,13 +28,18 @@ export const CustomTopContent = () => {
   );
 };
 
+/** @type {CustomPageType} */
 export const CustomAlertPage = props => (
   <div className="form-panel">
     {props.alert}
     <SchemaForm {...props}>
       <>
         {props.contentBeforeButtons}
-        <FormNavButtons {...props} submitToContinue />
+        <FormNavButtons
+          goBack={props.goBack}
+          goForward={props.onContinue}
+          submitToContinue
+        />
         {props.contentAfterButtons}
       </>
     </SchemaForm>
@@ -45,4 +50,6 @@ CustomAlertPage.propTypes = {
   alert: PropTypes.element,
   contentAfterButtons: PropTypes.element,
   contentBeforeButtons: PropTypes.element,
+  goBack: PropTypes.func,
+  onContinue: PropTypes.func,
 };


### PR DESCRIPTION
## Summary
This PR fixes a prop mismatch that was causing validations to not fire when trying to continue on the Form Upload flow. Now it correctly stops the user if validations are not met.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=88732856&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1889
