### PR TITLE
Show $ref schemas in ConfirmationView

### DIFF
--- a/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
@@ -87,7 +87,12 @@ const reviewEntry = (description, key, uiSchema, label, data) => {
 const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
   if (data === undefined || data === null) return null;
   if (key.startsWith('view:') || key.startsWith('ui:')) return null;
-  if (schema.properties[key] === undefined || !uiSchema) return null;
+
+  let schemaPropertiesKey = schema.properties?.[key];
+  if (schemaPropertiesKey?.$ref) {
+    schemaPropertiesKey = schemaFromState.properties?.[key];
+  }
+  if (schemaPropertiesKey === undefined || !uiSchema) return null;
 
   const {
     'ui:confirmationField': ConfirmationField,
@@ -120,7 +125,7 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
     refinedData = refinedData ? 'Selected' : '';
   }
 
-  const dataType = schema.properties[key].type;
+  const dataType = schemaPropertiesKey.type;
 
   if (ConfirmationField) {
     if (typeof ConfirmationField === 'function') {
@@ -172,7 +177,7 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
         objKey,
         objVal,
         data[objKey],
-        schema.properties[key],
+        schemaPropertiesKey,
         schemaFromState?.properties?.[key],
       ),
     );
@@ -193,7 +198,7 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
         arrKey,
         arrVal,
         data[index][arrKey],
-        schema.properties[key].items,
+        schemaPropertiesKey.items,
         schemaFromState?.properties?.[key].items?.[index],
       );
     });


### PR DESCRIPTION
## Summary

- Show $ref schemas in ConfirmationView

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1898

## Testing done

- Confirmed that schemas using $ref now appear on ConfirmationView

## Screenshots

![image](https://github.com/user-attachments/assets/105c3a87-d628-4dcd-bbb2-16fd25706647)

Before:
![image](https://github.com/user-attachments/assets/6d9421fc-adf9-4eea-b8de-81c5af2cb6d4)

After:
![image](https://github.com/user-attachments/assets/5088a818-eecc-4529-8a56-98b4d3ccc96d)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
