### PR TITLE
Implement useGetReferralById with Referral Task Card

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
@@ -28,9 +28,8 @@ import CernerAlert from '../../../components/CernerAlert';
 // import CernerTransitionAlert from '../../../components/CernerTransitionAlert';
 // import { selectPatientFacilities } from '~/platform/user/cerner-dsot/selectors';
 import ReferralAppLink from '../../../referral-appointments/components/ReferralAppLink';
-import ReferralTaskCard from '../../../referral-appointments/components/ReferralTaskCard';
+import ReferralTaskCardWithReferral from '../../../referral-appointments/components/ReferralTaskCardWithReferral';
 import { setFormCurrentPage } from '../../../referral-appointments/redux/actions';
-import { createReferral } from '../../../referral-appointments/utils/referrals';
 import { routeToCCPage } from '../../../referral-appointments/flow';
 
 function renderWarningNotification() {
@@ -54,7 +53,6 @@ export default function AppointmentsPage() {
   const dispatch = useDispatch();
   const [hasTypeChanged, setHasTypeChanged] = useState(false);
   let [pageTitle] = useState('VA online scheduling');
-  const [referral, setReferral] = useState();
 
   const featureCCDirectScheduling = useSelector(state =>
     selectFeatureCCDirectScheduling(state),
@@ -69,23 +67,6 @@ export default function AppointmentsPage() {
   // const featureBookingExclusion = useSelector(state =>
   //   selectFeatureBookingExclusion(state),
   // );
-
-  useEffect(
-    () => {
-      if (!featureCCDirectScheduling || !location?.search) {
-        return;
-      }
-      const params = new URLSearchParams(location.search);
-      const id = params.get('id');
-      if (!id) {
-        return;
-      }
-      // TODO: Get referral data from redux
-      const referralFromId = createReferral('2024-09-09', id);
-      setReferral(referralFromId);
-    },
-    [location, featureCCDirectScheduling],
-  );
 
   useEffect(
     () => {
@@ -191,7 +172,7 @@ export default function AppointmentsPage() {
           <ReferralAppLink linkText="Review and manage your appointment notifications" />
         </div>
       )}
-      {featureCCDirectScheduling && <ReferralTaskCard data={referral} />}
+      {featureCCDirectScheduling && <ReferralTaskCardWithReferral />}
       {featureCCDirectScheduling && (
         <div
           className={classNames(

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
@@ -17,6 +17,8 @@ import {
 import AppointmentsPage from '.';
 import { mockVAOSAppointmentsFetch } from '../../../tests/mocks/helpers';
 import { getVAOSRequestMock } from '../../../tests/mocks/mock';
+import { createReferral } from '../../../referral-appointments/utils/referrals';
+import { FETCH_STATUS } from '../../../utils/constants';
 
 const initialState = {
   featureToggles: {
@@ -542,43 +544,25 @@ describe('VAOS Page: AppointmentsPage', () => {
       expect(await screen.queryByTestId('referral-task-card')).not.to.exist;
     });
 
-    describe('when a referral UUID is passed', () => {
+    describe('when a referral ID is passed', () => {
       it('should display the referral task card', async () => {
-        // Given the veteran lands on the VAOS homepage with with a UUID passed
-        const appointment = getVAOSRequestMock();
-        appointment.id = '1';
-        appointment.attributes = {
-          id: '1',
-          kind: 'clinic',
-          locationId: '983',
-          requestedPeriods: [{}],
-          serviceType: 'primaryCare',
-          status: 'proposed',
-        };
-
-        mockVAOSAppointmentsFetch({
-          start: moment()
-            .subtract(1, 'month')
-            .format('YYYY-MM-DD'),
-          end: moment()
-            .add(395, 'days')
-            .format('YYYY-MM-DD'),
-          statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
-          requests: [appointment],
-        });
-        mockVAOSAppointmentsFetch({
-          start: moment()
-            .subtract(120, 'days')
-            .format('YYYY-MM-DD'),
-          end: moment().format('YYYY-MM-DD'),
-          statuses: ['proposed', 'cancelled'],
-          requests: [appointment],
-        });
-        // Given the veteran lands on the VAOS homepage with a UUID passed
+        // Given the veteran lands on the VAOS homepage with with a ID passed
         // When the page displays
         const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
-          initialState: defaultState,
-          path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c68',
+          initialState: {
+            ...defaultState,
+            referral: {
+              facility: null,
+              referrals: [
+                createReferral(
+                  new Date(),
+                  'add2f0f4-a1ea-4dea-a504-a54ab57c6801',
+                ),
+              ],
+              referralFetchStatus: FETCH_STATUS.succeeded,
+            },
+          },
+          path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801',
         });
 
         await screen.findByRole('heading', { name: 'Appointments' });

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
@@ -555,7 +555,7 @@ describe('VAOS Page: AppointmentsPage', () => {
               facility: null,
               referrals: [
                 createReferral(
-                  new Date(),
+                  moment().format('YYYY-MM-DD'),
                   'add2f0f4-a1ea-4dea-a504-a54ab57c6801',
                 ),
               ],

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { useGetReferralById } from '../hooks/useGetReferralById';
+import ReferralTaskCard from './ReferralTaskCard';
+
+export default function ReferralTaskCardWithReferral() {
+  const { search } = useLocation();
+
+  const params = new URLSearchParams(search);
+  const id = params.get('id');
+
+  const { currentReferral } = useGetReferralById(id);
+
+  if (!currentReferral) {
+    return null;
+  }
+
+  return <ReferralTaskCard data={currentReferral} />;
+}

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
+import MockDate from 'mockdate';
 
 import {
   renderWithStoreAndRouter,
@@ -17,13 +18,21 @@ const initialState = {
   referral: {
     facility: null,
     referrals: [
-      createReferral('11-29-2024', 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
+      createReferral('2024-11-29', 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
     ],
     referralFetchStatus: FETCH_STATUS.succeeded,
   },
 };
 
-describe('VAOS Component: ReferralTaskCard', () => {
+describe('VAOS Component: ReferralTaskCardWithReferral', () => {
+  beforeEach(() => {
+    // Set the current date to after the referral date but before the expiration date
+    MockDate.set('2025-01-01');
+  });
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   it('should display the task card when an ID is found', async () => {
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { expect } from 'chai';
+
+import {
+  renderWithStoreAndRouter,
+  createTestStore,
+} from '../../tests/mocks/setup';
+import ReferralTaskCardWithReferral from './ReferralTaskCardWithReferral';
+
+import { createReferral } from '../utils/referrals';
+import { FETCH_STATUS } from '../../utils/constants';
+
+const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingCCDirectScheduling: true,
+  },
+  referral: {
+    facility: null,
+    referrals: [
+      createReferral(new Date(), 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
+    ],
+    referralFetchStatus: FETCH_STATUS.succeeded,
+  },
+};
+
+describe('VAOS Component: ReferralTaskCard', () => {
+  it('should display the task card when an ID is found', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801',
+    });
+
+    expect(await screen.findByTestId('referral-task-card')).to.exist;
+  });
+
+  it('should not display the task card when feature toggle is off', async () => {
+    const modifiedState = {
+      ...initialState,
+      featureToggles: {
+        vaOnlineSchedulingCCDirectScheduling: false,
+      },
+    };
+    const store = createTestStore(modifiedState);
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=add2f0f4-a1ea-a504-a54ab57c6801',
+    });
+
+    const taskCard = screen.queryByTestId('referral-task-card');
+    expect(taskCard).to.be.null;
+  });
+
+  it('should not display the task card when referral ID is not found', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=non-existent-id',
+    });
+
+    const taskCard = screen.queryByTestId('referral-task-card');
+    expect(taskCard).to.be.null;
+  });
+
+  it('should not display the task card when no ID is provided in the URL', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/',
+    });
+
+    const taskCard = screen.queryByTestId('referral-task-card');
+    expect(taskCard).to.be.null;
+  });
+});

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -17,7 +17,7 @@ const initialState = {
   referral: {
     facility: null,
     referrals: [
-      createReferral(new Date(), 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
+      createReferral('11-29-2024', 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
     ],
     referralFetchStatus: FETCH_STATUS.succeeded,
   },


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Created `ReferralTaskCardWithReferral` that wraps `ReferralTaskCard` and utilizes the `useGetReferralById` hook to provide the task card with the referral from the hook.
- Updated tests

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#97636

## Testing done

- Prior task card used mock data directly
- Component now uses common hook for referral data

### Test Plan
GIVEN the `vaOnlineSchedulingCCDirectScheduling` feature flag is enabled 
WHEN I visit http://localhost:3001/my-health/appointments/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801
THEN I should see the Referral Task Card for the mock referral

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

- VAOS

## Acceptance criteria
 - [X] implement hook
 - [X] update tests to use referral from hook

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
