### PR TITLE
SC | Fix focus trap

### DIFF
--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -15,7 +15,7 @@ import {
   isEmptyVaEntry,
 } from '../validations/evidence';
 
-import { focusEvidence, focusFirstError } from '../../shared/utils/focus';
+import { focusEvidence } from '../../shared/utils/focus';
 import {
   HeaderAndModal,
   IssueAndDates,
@@ -184,9 +184,6 @@ const EvidenceVaRecords = ({
         // event.detail from testing
         const fieldName = event.target?.getAttribute('name') || event.detail;
         updateState({ dirty: { ...currentState.dirty, [fieldName]: true } });
-        if (hasErrors(errors)) {
-          focusFirstError();
-        }
       }
     },
     onChange: event => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > On Supplemental Claim's VA evidence page, after activating the "Continue" button without filling out any fields, focus will get locked between the first input error message and the first input. Trying to tab or focus on any other field will shift focus back to the first error message.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Remove re-focus on first error in the on blur callback
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/98137

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| VA evidence  | ![focus trap between first error message and input](https://github.com/user-attachments/assets/3389e8e6-c007-45eb-bbfa-b797979dffe9) | ![first-error-after](https://github.com/user-attachments/assets/fcc33181-b0bd-44fc-b634-2cfa4e2704f6) |

## What areas of the site does it impact?

Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
