### PR TITLE
MHV-63966: Feedback button is going full width on desktop and should not

### DIFF
--- a/src/applications/mhv-medications/sass/medications.scss
+++ b/src/applications/mhv-medications/sass/medications.scss
@@ -62,9 +62,6 @@
     text-decoration: none;
   }
 }
-.usa-button:not(.feedback-button) {
-  width: 100%;
-}
 .va-button {
   margin: 4px 0;
 }

--- a/src/applications/mhv-medications/sass/medications.scss
+++ b/src/applications/mhv-medications/sass/medications.scss
@@ -62,7 +62,7 @@
     text-decoration: none;
   }
 }
-.usa-button {
+.usa-button:not(.feedback-button) {
   width: 100%;
 }
 .va-button {


### PR DESCRIPTION
## Summary

Removed overriding styles from `.feedback-button`

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-63966

## Testing done

- Manual testing

## Screenshots

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/5de84ed6-e765-4a0b-8fcd-494053a4ae04">

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Feedback button is at the normal length and verified by UCD

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
