### PR TITLE
VAGOV-TEAM-97974: Add Statement of Truth to forms rendered by Form Renderer

### DIFF
--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/formConfig.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/formConfig.unit.spec.js
@@ -8,7 +8,11 @@ import { render } from '@testing-library/react';
 import * as digitalFormPatterns from '../../../utils/digitalFormPatterns';
 import * as IntroductionPage from '../../../containers/IntroductionPage';
 import { normalizedForm } from '../../../_config/formConfig';
-import { createFormConfig, formatPages } from '../../../utils/formConfig';
+import {
+  createFormConfig,
+  formatPages,
+  statementOfTruthBody,
+} from '../../../utils/formConfig';
 
 const [
   yourPersonalInfo,
@@ -85,6 +89,13 @@ describe('createFormConfig', () => {
     expect(screen.getByTestId('res-burden')).to.have.text(
       `resBurden: ${normalizedForm.ombInfo.resBurden}`,
     );
+  });
+
+  it('includes a statement of truth', () => {
+    const statementOfTruth = formConfig.preSubmitInfo.statementOfTruth;
+
+    expect(statementOfTruth.body).to.eq(statementOfTruthBody);
+    expect(statementOfTruth.fullNamePath).to.eq('fullName');
   });
 });
 

--- a/src/applications/simple-forms-form-engine/shared/utils/formConfig.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/formConfig.js
@@ -45,21 +45,33 @@ const formatChapters = chapters =>
     {},
   );
 
+export const statementOfTruthBody =
+  'I confirm that the identifying information in this form is accurate and ' +
+  'has been represented correctly.';
+
+/** @returns {FormConfig} */
 export const createFormConfig = (form, options) => {
   const { chapters, formId, ombInfo, title } = form;
   const { rootUrl, trackingPrefix } = options;
   const subTitle = `VA Form ${formId}`;
 
   return {
+    preSubmitInfo: {
+      statementOfTruth: {
+        body: statementOfTruthBody,
+        messageAriaDescribedby: statementOfTruthBody,
+        fullNamePath: 'fullName',
+      },
+    },
     rootUrl,
     urlPrefix: '/',
-    trackingPrefix,
     // eslint-disable-next-line no-console
     submit: () => console.log(`Submitted ${subTitle}`),
     introduction: props => <IntroductionPage {...props} ombInfo={ombInfo} />,
     confirmation: ConfirmationPage,
     formId,
     saveInProgress: {},
+    trackingPrefix,
     version: 0,
     prefillEnabled: true,
     savedFormMessages: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds a "Statement of truth" to all forms rendered by the Form Renderer. This uses the standard statement of truth body found on virtually all forms that currently use the `preSubmitInfo` config.

## Related issue(s)

- Closes department-of-veterans-affairs/va.gov-team#97974

## Testing done

- New unit tests for `createFormConfig`
- Manually tested the `fullNamePath` to ensure it was picking up the right field.

## Screenshots

The statement of truth rendered on form 21-4140:
<img width="663" alt="Screenshot 2024-12-03 at 2 14 42 PM" src="https://github.com/user-attachments/assets/480aafdb-a826-49a1-885a-cee8d762f8d0">

When the name entered does not match the full name field:
<img width="659" alt="Screenshot 2024-12-03 at 2 15 28 PM" src="https://github.com/user-attachments/assets/27fd2f38-f436-4664-8bb7-7db3c3a2a48c">

## What areas of the site does it impact?

- All forms created using the `simple-forms-form-engine` shared code.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

- While testing, I noticed that the form will not submit successfully if the "Were you employed by the VA, others or self-employed at any time during the last 12 months?" question is answered with "No." I documented the bug in department-of-veterans-affairs/va.gov-team#98270 and will prioritize it for next sprint.
