### PR TITLE
VACMS-20015: Add more unit test coverage for DUW

### DIFF
--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -561,7 +561,7 @@ export const stepHeaderLevel = formResponses => {
   return 2;
 };
 
-const handleDD215Update = (boardToSubmit, prevAppType, oldDischarge) => {
+export const handleDD215Update = (boardToSubmit, prevAppType, oldDischarge) => {
   if (
     ![
       RESPONSES.PREV_APPLICATION_BCMR,
@@ -594,7 +594,7 @@ export const isPreviousApplicationYear = prevAppYear => {
   ].includes(prevAppYear);
 };
 
-const shouldReapplyToBoard = (prevAppType, formResponses) => {
+export const shouldReapplyToBoard = (prevAppType, formResponses) => {
   return (
     [RESPONSES.PREV_APPLICATION_BCMR, RESPONSES.PREV_APPLICATION_BCNR].includes(
       prevAppType,
@@ -606,14 +606,18 @@ const shouldReapplyToBoard = (prevAppType, formResponses) => {
   );
 };
 
-const isDocumentaryOrNotSure = prevAppType => {
+export const isDocumentaryOrNotSure = prevAppType => {
   return [
     RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY,
     RESPONSES.NOT_SURE,
   ].includes(prevAppType);
 };
 
-const handleDRBExplanation = (boardToSubmit, serviceBranch, prevAppType) => {
+export const handleDRBExplanation = (
+  boardToSubmit,
+  serviceBranch,
+  prevAppType,
+) => {
   const boardName =
     boardToSubmit.abbr === DRB
       ? 'Discharge Review Board (DRB)'

--- a/src/applications/discharge-wizard/tests/actions/index.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/actions/index.unit.spec.js
@@ -1,8 +1,53 @@
 // Dependencies.
 import { expect } from 'chai';
 // relative imports
-import { DW_UPDATE_FIELD } from '../../constants';
-import { updateField } from '../../actions';
+import {
+  DW_UPDATE_FIELD,
+  // v2
+  DUW_UPDATE_FORM_STORE,
+  DUW_VIEWED_INTRO_PAGE,
+  DUW_UPDATE_SERVICE_BRANCH,
+  DUW_UPDATE_DISCHARGE_YEAR,
+  DUW_UPDATE_DISCHARGE_MONTH,
+  DUW_UPDATE_REASON,
+  DUW_UPDATE_DISCHARGE_TYPE,
+  DUW_UPDATE_COURT_MARTIAL,
+  DUW_UPDATE_INTENTION,
+  DUW_UPDATE_PREV_APPLICATION,
+  DUW_UPDATE_PREV_APPLICATION_TYPE,
+  DUW_UPDATE_PREV_APPLICATION_YEAR,
+  DUW_UPDATE_PRIOR_SERVICE,
+  DUW_UPDATE_FAILURE_TO_EXHAUST,
+  DUW_QUESTION_SELECTED_TO_EDIT,
+  DUW_EDIT_MODE,
+  DUW_QUESTION_FLOW_CHANGED,
+  DUW_ANSWER_CHANGED,
+  DUW_ROUTE_MAP,
+} from '../../constants';
+import { RESPONSES } from '../../constants/question-data-map';
+import {
+  updateField,
+  // v2
+  updateFormStore,
+  updateIntroPageViewed,
+  updateEditMode,
+  updateQuestionFlowChanged,
+  updateAnswerChanged,
+  updateQuestionSelectedToEdit,
+  updateRouteMap,
+  updateServiceBranch,
+  updateDischargeYear,
+  updateDischargeMonth,
+  updateReason,
+  updateCourtMartial,
+  updateIntention,
+  updateDischargeType,
+  updatePrevApplication,
+  updatePrevApplicationYear,
+  updatePrevApplicationType,
+  updatePriorService,
+  updateFailureToExhaust,
+} from '../../actions';
 
 describe('Discharge Wizard Redux Actions', () => {
   describe('updateField', () => {
@@ -15,6 +60,219 @@ describe('Discharge Wizard Redux Actions', () => {
         type: DW_UPDATE_FIELD,
         key: '1_branchOfService',
         value: 'Army',
+      });
+    });
+  });
+});
+
+describe('Discharge Wizard Redux Actions v2', () => {
+  describe('updateFormStore', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = 'Army';
+      const action = updateFormStore(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_FORM_STORE,
+        payload: 'Army',
+      });
+    });
+  });
+  describe('updateIntroPageViewed', () => {
+    it('should return an action for viewing the intro page', () => {
+      const value = true;
+      const action = updateIntroPageViewed(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_VIEWED_INTRO_PAGE,
+        payload: true,
+      });
+    });
+  });
+  describe('updateEditMode', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = true;
+      const action = updateEditMode(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_EDIT_MODE,
+        payload: true,
+      });
+    });
+  });
+
+  describe('updateQuestionFlowChanged', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = true;
+      const action = updateQuestionFlowChanged(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_QUESTION_FLOW_CHANGED,
+        payload: true,
+      });
+    });
+  });
+  describe('updateAnswerChanged', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = true;
+      const action = updateAnswerChanged(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_ANSWER_CHANGED,
+        payload: true,
+      });
+    });
+  });
+  describe('updateQuestionSelectedToEdit', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = 'SERVICE_BRANCH';
+      const action = updateQuestionSelectedToEdit(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_QUESTION_SELECTED_TO_EDIT,
+        payload: 'SERVICE_BRANCH',
+      });
+    });
+  });
+  describe('updateRouteMap', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = ['SERVICE_BRANCH'];
+      const action = updateRouteMap(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_ROUTE_MAP,
+        payload: ['SERVICE_BRANCH'],
+      });
+    });
+  });
+  describe('updateServiceBranch', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.ARMY;
+      const action = updateServiceBranch(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_SERVICE_BRANCH,
+        payload: RESPONSES.ARMY,
+      });
+    });
+  });
+  describe('updateDischargeYear', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = '2024';
+      const action = updateDischargeYear(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_DISCHARGE_YEAR,
+        payload: '2024',
+      });
+    });
+  });
+  describe('updateDischargeMonth', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = '1';
+      const action = updateDischargeMonth(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_DISCHARGE_MONTH,
+        payload: '1',
+      });
+    });
+  });
+  describe('updateReason', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.REASON_PTSD;
+      const action = updateReason(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_REASON,
+        payload: RESPONSES.REASON_PTSD,
+      });
+    });
+  });
+  describe('updateCourtMartial', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.COURT_MARTIAL_NO;
+      const action = updateCourtMartial(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_COURT_MARTIAL,
+        payload: RESPONSES.COURT_MARTIAL_NO,
+      });
+    });
+  });
+  describe('updateIntention', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.INTENTION_NO;
+      const action = updateIntention(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_INTENTION,
+        payload: RESPONSES.INTENTION_NO,
+      });
+    });
+  });
+  describe('updateDischargeType', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.DISCHARGE_DISHONORABLE;
+      const action = updateDischargeType(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_DISCHARGE_TYPE,
+        payload: RESPONSES.DISCHARGE_DISHONORABLE,
+      });
+    });
+  });
+  describe('updatePrevApplication', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.NO;
+      const action = updatePrevApplication(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_PREV_APPLICATION,
+        payload: RESPONSES.NO,
+      });
+    });
+  });
+  describe('updatePrevApplicationType', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.PREV_APPLICATION_BCMR;
+      const action = updatePrevApplicationType(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_PREV_APPLICATION_TYPE,
+        payload: RESPONSES.PREV_APPLICATION_BCMR,
+      });
+    });
+  });
+  describe('updatePrevApplicationYear', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.PREV_APPLICATION_AFTER_2011;
+      const action = updatePrevApplicationYear(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_PREV_APPLICATION_YEAR,
+        payload: RESPONSES.PREV_APPLICATION_AFTER_2011,
+      });
+    });
+  });
+  describe('updatePriorService', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.PRIOR_SERVICE_NO;
+      const action = updatePriorService(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_PRIOR_SERVICE,
+        payload: RESPONSES.PRIOR_SERVICE_NO,
+      });
+    });
+  });
+  describe('updateFailureToExhaust', () => {
+    it('should return an action in the shape we expect', () => {
+      const value = RESPONSES.FAILURE_TO_EXHAUST_BCMR_NO;
+      const action = updateFailureToExhaust(value);
+
+      expect(action).to.be.deep.equal({
+        type: DUW_UPDATE_FAILURE_TO_EXHAUST,
+        payload: RESPONSES.FAILURE_TO_EXHAUST_BCMR_NO,
       });
     });
   });

--- a/src/applications/discharge-wizard/tests/v2/cypress/discharge-upgrade-wizard.cypress.spec.js
+++ b/src/applications/discharge-wizard/tests/v2/cypress/discharge-upgrade-wizard.cypress.spec.js
@@ -2,7 +2,7 @@ import * as h from './helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
 
-describe('Discharge Upgrade Wizard', () => {
+xdescribe('Discharge Upgrade Wizard', () => {
   describe('Base navigation', () => {
     it('navigates through the flow forward successfully', () => {
       cy.visit(`${h.ROOT}/introduction1`);

--- a/src/applications/discharge-wizard/tests/v2/cypress/discharge-upgrade-wizard.cypress.spec.js
+++ b/src/applications/discharge-wizard/tests/v2/cypress/discharge-upgrade-wizard.cypress.spec.js
@@ -2,7 +2,7 @@ import * as h from './helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
 
-xdescribe('Discharge Upgrade Wizard', () => {
+describe('Discharge Upgrade Wizard', () => {
   describe('Base navigation', () => {
     it('navigates through the flow forward successfully', () => {
       cy.visit(`${h.ROOT}/introduction1`);

--- a/src/applications/discharge-wizard/tests/v2/cypress/helpers.js
+++ b/src/applications/discharge-wizard/tests/v2/cypress/helpers.js
@@ -24,6 +24,19 @@ export const verifyUrl = link => cy.url().should('contain', `${ROOT}/${link}`);
 
 export const get15YearsPast = () => (new Date().getFullYear() - 15).toString();
 
+export const verifyFormErrorNotShown = selector =>
+  cy
+    .findByTestId(selector)
+    .get('span[role="alert"]')
+    .should('have.text', '');
+
+export const checkFormAlertText = (selector, expectedValue) =>
+  cy
+    .findByTestId(selector)
+    .get('span[role="alert"]')
+    .should('be.visible')
+    .should('have.text', expectedValue);
+
 export const verifyElement = selector =>
   cy.findByTestId(selector).should('exist');
 

--- a/src/applications/discharge-wizard/tests/v2/helpers/index.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/v2/helpers/index.unit.spec.js
@@ -1,10 +1,19 @@
 import { expect } from 'chai';
+import { render } from '@testing-library/react';
 
 import {
   answerReviewLabel,
   determineBoardObj,
+  determineVenueAddress,
   determineAirForceAFRBAPortal,
   determineFormData,
+  handleDD215Update,
+  isPreviousApplicationYear,
+  shouldReapplyToBoard,
+  isDocumentaryOrNotSure,
+  handleDRBExplanation,
+  renderMedicalRecordInfo,
+  getBoardExplanation,
 } from '../../../helpers/index';
 import {
   RESPONSES,
@@ -12,22 +21,21 @@ import {
 } from '../../../constants/question-data-map';
 
 describe('Discharge Wizard helpers', () => {
-  const formResponses = {
-    SERVICE_BRANCH: RESPONSES.ARMY,
-    DISCHARGE_YEAR: '2022',
-    DISCHARGE_MONTH: '',
-    REASON: RESPONSES.REASON_PTSD,
-    DISCHARGE_TYPE: null,
-    INTENTION: RESPONSES.INTENTION_YES,
-    COURT_MARTIAL: RESPONSES.COURT_MARTIAL_YES,
-    PREV_APPLICATION: RESPONSES.YES,
-    PREV_APPLICATION_YEAR: RESPONSES.PREV_APPLICATION_BEFORE_2014,
-    PREV_APPLICATION_TYPE: RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY,
-    FAILURE_TO_EXHAUST: null,
-    PRIOR_SERVICE: RESPONSES.PRIOR_SERVICE_PAPERWORK_YES,
-  };
-
   it('helps determine which form number and portal to use', () => {
+    const formResponses = {
+      SERVICE_BRANCH: RESPONSES.ARMY,
+      DISCHARGE_YEAR: '2022',
+      DISCHARGE_MONTH: '',
+      REASON: RESPONSES.REASON_PTSD,
+      DISCHARGE_TYPE: null,
+      INTENTION: RESPONSES.INTENTION_YES,
+      COURT_MARTIAL: RESPONSES.COURT_MARTIAL_YES,
+      PREV_APPLICATION: RESPONSES.YES,
+      PREV_APPLICATION_YEAR: RESPONSES.PREV_APPLICATION_BEFORE_2014,
+      PREV_APPLICATION_TYPE: RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY,
+      FAILURE_TO_EXHAUST: null,
+      PRIOR_SERVICE: RESPONSES.PRIOR_SERVICE_PAPERWORK_YES,
+    };
     const formNumber = determineFormData(formResponses);
     expect(formNumber).to.deep.equal({
       num: 149,
@@ -37,6 +45,20 @@ describe('Discharge Wizard helpers', () => {
   });
 
   it('helps determine which board for the user to seek their request for re-review', () => {
+    const formResponses = {
+      SERVICE_BRANCH: RESPONSES.ARMY,
+      DISCHARGE_YEAR: '2022',
+      DISCHARGE_MONTH: '',
+      REASON: RESPONSES.REASON_PTSD,
+      DISCHARGE_TYPE: null,
+      INTENTION: RESPONSES.INTENTION_YES,
+      COURT_MARTIAL: RESPONSES.COURT_MARTIAL_YES,
+      PREV_APPLICATION: RESPONSES.YES,
+      PREV_APPLICATION_YEAR: RESPONSES.PREV_APPLICATION_BEFORE_2014,
+      PREV_APPLICATION_TYPE: RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY,
+      FAILURE_TO_EXHAUST: null,
+      PRIOR_SERVICE: RESPONSES.PRIOR_SERVICE_PAPERWORK_YES,
+    };
     const boardOfReview = determineBoardObj(formResponses);
     expect(boardOfReview).to.deep.equal({
       name: 'Board for Correction of Military Records (BCMR)',
@@ -48,7 +70,7 @@ describe('Discharge Wizard helpers', () => {
     const isAirForcePortal = determineAirForceAFRBAPortal({
       SERVICE_BRANCH: RESPONSES.AIR_FORCE,
       DISCHARGE_YEAR: '2020',
-      DISCHARGE_MONTH: '',
+      DISCHARGE_MONTH: '2',
       REASON: RESPONSES.REASON_SEXUAL_ASSAULT,
       DISCHARGE_TYPE: null,
       INTENTION: RESPONSES.INTENTION_NO,
@@ -63,6 +85,21 @@ describe('Discharge Wizard helpers', () => {
   });
 
   it('determines correct answer review label', () => {
+    const formResponses = {
+      SERVICE_BRANCH: RESPONSES.ARMY,
+      DISCHARGE_YEAR: '2022',
+      DISCHARGE_MONTH: '',
+      REASON: RESPONSES.REASON_PTSD,
+      DISCHARGE_TYPE: null,
+      INTENTION: RESPONSES.INTENTION_YES,
+      COURT_MARTIAL: RESPONSES.COURT_MARTIAL_YES,
+      PREV_APPLICATION: RESPONSES.YES,
+      PREV_APPLICATION_YEAR: RESPONSES.PREV_APPLICATION_BEFORE_2014,
+      PREV_APPLICATION_TYPE: RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY,
+      FAILURE_TO_EXHAUST: null,
+      PRIOR_SERVICE: RESPONSES.PRIOR_SERVICE_PAPERWORK_YES,
+    };
+
     const serviceBranchLabel = answerReviewLabel(
       SHORT_NAME_MAP.SERVICE_BRANCH,
       formResponses,
@@ -81,13 +118,52 @@ describe('Discharge Wizard helpers', () => {
       formResponses,
     );
 
+    const dischargeMonthLabel = answerReviewLabel(
+      SHORT_NAME_MAP.DISCHARGE_MONTH,
+      formResponses,
+    );
+
     const prevApplicationTypeLabel = answerReviewLabel(
       SHORT_NAME_MAP.PREV_APPLICATION_TYPE,
       formResponses,
     );
 
+    const oldDischargYearLabel = answerReviewLabel(
+      SHORT_NAME_MAP.DISCHARGE_YEAR,
+      { [SHORT_NAME_MAP.DISCHARGE_YEAR]: 'Before 1992' },
+    );
+
+    const notSureCourtMartialLabel = answerReviewLabel(
+      SHORT_NAME_MAP.COURT_MARTIAL,
+      { [SHORT_NAME_MAP.COURT_MARTIAL]: RESPONSES.NOT_SURE },
+    );
+
+    const prevAppYearLabel = answerReviewLabel(
+      SHORT_NAME_MAP.PREV_APPLICATION_YEAR,
+      {
+        [SHORT_NAME_MAP.PREV_APPLICATION_YEAR]:
+          RESPONSES.PREV_APPLICATION_AFTER_2014,
+      },
+    );
+
+    const notSurePrevAppTypeLabel = answerReviewLabel(
+      SHORT_NAME_MAP.PREV_APPLICATION_TYPE,
+      { [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.NOT_SURE },
+    );
+
     expect(serviceBranchLabel).to.equal('I served in the Army.');
     expect(dischargeYearLabel).to.equal('I was discharged in 2022.');
+    expect(oldDischargYearLabel).to.equal('I was discharged before 1992.');
+    expect(notSureCourtMartialLabel).to.equal(
+      `I'm not sure if my discharge was the outcome of a general court-martial.`,
+    );
+    expect(notSurePrevAppTypeLabel).to.equal(
+      `I'm not sure what kind of discharge upgrade application I previously made.`,
+    );
+    expect(dischargeMonthLabel).to.equal('');
+    expect(prevAppYearLabel).to.equal(
+      'I made my previous application after 2014.',
+    );
     expect(prevApplicationLabel).to.equal(
       'I have previously applied for a discharge upgrade for this period of service.',
     );
@@ -95,5 +171,446 @@ describe('Discharge Wizard helpers', () => {
     expect(prevApplicationTypeLabel).to.equal(
       RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY,
     );
+  });
+
+  describe('determineVenueAddress', () => {
+    it('should render Army Review Boards Agency address for Army with DRB', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.ARMY,
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_DD215_UPDATE_TO_DD214,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.YES,
+      };
+      const noDRB = false;
+
+      const { container } = render(determineVenueAddress(formResponses, noDRB));
+
+      expect(container.textContent).to.contain('Army Review Boards Agency');
+      expect(container.textContent).to.contain('251 18th Street South');
+      expect(container.textContent).to.contain('Suite 385');
+      expect(container.textContent).to.contain('Arlington, VA 22202-3531');
+    });
+
+    it('should render Air Force Discharge Review Board address for Air Force with AFDRB', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.AIR_FORCE,
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_DD215_UPDATE_TO_DD214,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.YES,
+      };
+      const noDRB = false;
+
+      const { container } = render(determineVenueAddress(formResponses, noDRB));
+
+      expect(container.textContent).to.contain(
+        'Air Force Board for Correction of Military Records',
+      );
+      expect(container.textContent).to.contain('3351 Celmers Lane');
+      expect(container.textContent).to.contain(
+        'Joint Base Andrews, MD 20762-6435',
+      );
+    });
+
+    it('should render Coast Guard address when Coast Guard is selected with DRB', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.COAST_GUARD,
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_DD215_UPDATE_TO_DD214,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.YES,
+        [SHORT_NAME_MAP.COURT_MARTIAL]: RESPONSES.COURT_MARTIAL_YES,
+      };
+      const noDRB = false;
+
+      const { container } = render(determineVenueAddress(formResponses, noDRB));
+
+      expect(container.textContent).to.contain(
+        'DHS Office of the General Counsel',
+      );
+      expect(container.textContent).to.contain(
+        'Board for Correction of Military Records, Stop 0485',
+      );
+      expect(container.textContent).to.contain(
+        '2707 Martin Luther King Jr. Ave., SE',
+      );
+      expect(container.textContent).to.contain('Washington, DC 20528');
+    });
+
+    it('should render Navy address when Navy or Marines is selected with DRB', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.NAVY,
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_DD215_UPDATE_TO_DD214,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.YES,
+        [SHORT_NAME_MAP.COURT_MARTIAL]: RESPONSES.COURT_MARTIAL_NO,
+      };
+      const noDRB = true;
+
+      const { container } = render(determineVenueAddress(formResponses, noDRB));
+
+      expect(container.textContent).to.contain(
+        'Board for Correction of Naval Records',
+      );
+      expect(container.textContent).to.contain(
+        '701 S. Courthouse Road, Suite 1001',
+      );
+      expect(container.textContent).to.contain('Arlington, VA 22204-2490');
+    });
+
+    it('should render the Board for Correction of Military Records address if no DRB', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.ARMY,
+      };
+      const noDRB = true;
+
+      const { container } = render(determineVenueAddress(formResponses, noDRB));
+
+      expect(container.textContent).to.contain('Army Review Boards Agency');
+      expect(container.textContent).to.contain('251 18th Street South');
+      expect(container.textContent).to.contain('Suite 385');
+      expect(container.textContent).to.contain('Arlington, VA 22202-3531');
+    });
+
+    it('should return null if no formResponses are provided', () => {
+      const { container } = render(determineVenueAddress(null, false));
+      expect(container).to.be.empty;
+    });
+  });
+
+  describe('handleDD215Update', () => {
+    it('should return the appropriate message when old discharge is provided', () => {
+      const boardToSubmit = {
+        name: 'Board for Correction of Military Records (BCMR)',
+        abbr: 'BCMR',
+      };
+      const prevAppType = RESPONSES.PREV_APPLICATION_BCMR;
+      const oldDischarge = true;
+
+      const result = handleDD215Update(
+        boardToSubmit,
+        prevAppType,
+        oldDischarge,
+      );
+      expect(result).to.equal(
+        'the Board for Correction of Military Records (BCMR). The BCMR was the Board that granted your previous upgrade request, so you must apply to them for a new DD214.',
+      );
+    });
+
+    it('should return the appropriate message when old discharge is provided', () => {
+      const boardToSubmit = {
+        name: 'Discharge Review Board (DRB)',
+        abbr: 'DRB',
+      };
+      const prevAppType = RESPONSES.PREV_APPLICATION_DRB_PERSONAL;
+      const oldDischarge = true;
+
+      const result = handleDD215Update(
+        boardToSubmit,
+        prevAppType,
+        oldDischarge,
+      );
+      expect(result).to.equal(
+        'the Discharge Review Board (DRB). The Board handles all cases from 15 or more years ago.',
+      );
+    });
+  });
+
+  describe('isPreviousApplicationYear', () => {
+    it('should return true for valid previous application years', () => {
+      const result = isPreviousApplicationYear(
+        RESPONSES.PREV_APPLICATION_BEFORE_2011,
+      );
+      expect(result).to.be.true;
+    });
+
+    it('should return false for invalid previous application years', () => {
+      const result = isPreviousApplicationYear(
+        RESPONSES.PREV_APPLICATION_BEFORE_2020,
+      );
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('shouldReapplyToBoard', () => {
+    it('should return true if prevAppType and failure conditions are met', () => {
+      const prevAppType = RESPONSES.PREV_APPLICATION_BCMR;
+      const formResponses = {
+        [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]:
+          RESPONSES.FAILURE_TO_EXHAUST_BCMR_YES,
+      };
+
+      const result = shouldReapplyToBoard(prevAppType, formResponses);
+      expect(result).to.be.true;
+    });
+
+    it('should return false if failure condition is not met', () => {
+      const prevAppType = RESPONSES.PREV_APPLICATION_BCMR;
+      const formResponses = {
+        [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]: RESPONSES.NO,
+      };
+
+      const result = shouldReapplyToBoard(prevAppType, formResponses);
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('isDocumentaryOrNotSure', () => {
+    it('should return true if prevAppType is DOCUMENTARY or NOT_SURE', () => {
+      let prevAppType = RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY;
+      expect(isDocumentaryOrNotSure(prevAppType)).to.be.true;
+
+      prevAppType = RESPONSES.NOT_SURE;
+      expect(isDocumentaryOrNotSure(prevAppType)).to.be.true;
+    });
+
+    it('should return false if prevAppType is neither DOCUMENTARY nor NOT_SURE', () => {
+      const prevAppType = RESPONSES.PREV_APPLICATION_BCMR;
+      expect(isDocumentaryOrNotSure(prevAppType)).to.be.false;
+    });
+  });
+
+  describe('handleDRBExplanation', () => {
+    it('should return the correct DRB explanation for the given service branch', () => {
+      const boardToSubmit = {
+        abbr: 'DRB',
+        name: 'Discharge Review Board (DRB)',
+      };
+      const serviceBranch = 'Army';
+      const prevAppType = RESPONSES.PREV_APPLICATION_DRB_DOCUMENTARY;
+
+      const result = handleDRBExplanation(
+        boardToSubmit,
+        serviceBranch,
+        prevAppType,
+      );
+      expect(result).to.include(
+        'the Discharge Review Board (DRB) for the Army',
+      );
+      expect(result).to.include(
+        'Because your application was rejected by the DRB on Documentary Review',
+      );
+    });
+
+    it('should return the correct explanation if no documentary rejection', () => {
+      const boardToSubmit = {
+        abbr: 'DRB',
+        name: 'Discharge Review Board (DRB)',
+      };
+      const serviceBranch = 'Army';
+      const prevAppType = RESPONSES.PREV_APPLICATION_DRB_PERSONAL;
+
+      const result = handleDRBExplanation(
+        boardToSubmit,
+        serviceBranch,
+        prevAppType,
+      );
+      expect(result).to.include(
+        'the Discharge Review Board (DRB) for the Army',
+      );
+      expect(result).to.not.include(
+        'Because your application was rejected by the DRB on Documentary Review',
+      );
+    });
+  });
+
+  describe('getBoardExplanation', () => {
+    it('should return explanation for DD215 update', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_DD215_UPDATE_TO_DD214,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.YES,
+        [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]:
+          RESPONSES.FAILURE_TO_EXHAUST_BCMR_YES,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).to.include(
+        `the Discharge Review Board (DRB). The DRB was the Board that granted your previous upgrade request, so you must apply to them for a new DD214.`,
+      );
+    });
+
+    it('should return explanation for DRB Personal', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_PTSD,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]:
+          RESPONSES.PREV_APPLICATION_DRB_PERSONAL,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.YES,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).to.include(
+        `This is because your application was denied by the Discharge Review Board (DRB) on a Personal Appearance Review.`,
+      );
+    });
+
+    it('should return explanation for should reapply', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.COURT_MARTIAL]: RESPONSES.COURT_MARTIAL_YES,
+        [SHORT_NAME_MAP.PREV_APPLICATION_YEAR]:
+          RESPONSES.PREV_APPLICATION_AFTER_2014,
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.COAST_GUARD,
+        [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]:
+          RESPONSES.FAILURE_TO_EXHAUST_BCMR_YES,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).to.include(
+        'If you’ve applied before, you must re-apply to the BCMR for reconsideration.',
+      );
+    });
+
+    it('should return explanation for should reapply to the AFDRB', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.PREV_APPLICATION_YEAR]:
+          RESPONSES.PREV_APPLICATION_AFTER_2014,
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.AIR_FORCE,
+        [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]:
+          RESPONSES.FAILURE_TO_EXHAUST_BCMR_YES,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).to.include(
+        'the AFDRB. If you’ve applied before, you must re-apply to the AFDRB for reconsideration.',
+      );
+    });
+
+    it('should return explanation for previous application year before 2011', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.PREV_APPLICATION_YEAR]:
+          RESPONSES.PREV_APPLICATION_BEFORE_2011,
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.ARMY,
+        [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]:
+          RESPONSES.FAILURE_TO_EXHAUST_BCMR_YES,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).to.include('the Discharge Review Board (DRB)');
+      expect(explanation).to.include(
+        'the Boards may treat your application as a new case',
+      );
+    });
+
+    it('should return explanation for a court martial', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.COURT_MARTIAL]: RESPONSES.COURT_MARTIAL_YES,
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.NAVY,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.NO,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+        [SHORT_NAME_MAP.PREV_APPLICATION_YEAR]:
+          RESPONSES.PREV_APPLICATION_AFTER_2014,
+        [SHORT_NAME_MAP.DISCHARGE_YEAR]: 2024,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).to.include('the BCNR for the Navy.');
+      expect(explanation).to.include(
+        'This is because your discharge was the result of a general court-martial.',
+      );
+    });
+
+    it('should return explanation for failure to exhaust and DRB', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]:
+          RESPONSES.FAILURE_TO_EXHAUST_BCMR_YES,
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.ARMY,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).to.include(
+        'the Discharge Review Board (DRB) for the Army',
+      );
+      expect(explanation).to.include(
+        'The DRB is a panel of commissioned officers, or a mix of senior non-commissioned officers (NCOs) and officers',
+      );
+    });
+
+    it('should return explanation for discharge', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_TRANSGENDER,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.NOT_SURE,
+        [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.NAVY,
+        [SHORT_NAME_MAP.PREV_APPLICATION]: RESPONSES.NO,
+        [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: RESPONSES.PREV_APPLICATION_BCMR,
+        [SHORT_NAME_MAP.PREV_APPLICATION_YEAR]:
+          RESPONSES.PREV_APPLICATION_AFTER_2014,
+        [SHORT_NAME_MAP.DISCHARGE_YEAR]: 2024,
+      };
+
+      const explanation = getBoardExplanation(formResponses);
+
+      expect(explanation).include(
+        'the BCNR for the Navy. This is because you want to change information other than your characterization of discharge, re-enlistment code, separation code, and narrative reason for discharge.',
+      );
+    });
+  });
+
+  describe('renderMedicalRecordInfo', () => {
+    it('should render medical records information for PTSD', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_PTSD,
+        [SHORT_NAME_MAP.DISCHARGE_YEAR]: '2000',
+      };
+
+      const { getByText } = render(renderMedicalRecordInfo(formResponses));
+
+      expect(getByText('You’ll need to submit copies of your medical records.'))
+        .to.exist;
+      expect(
+        getByText(
+          'If you’ve seen a non-VA health care provider for diagnosis or treatment of PTSD or another mental health condition,',
+        ),
+      ).to.exist;
+    });
+
+    it('should render medical records information for TBI', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_TBI,
+        [SHORT_NAME_MAP.DISCHARGE_YEAR]: '2000',
+      };
+
+      const { getByText } = render(renderMedicalRecordInfo(formResponses));
+
+      expect(
+        getByText(
+          'If you’ve seen a non-VA health care provider for diagnosis or treatment of TBI,',
+        ),
+      ).to.exist;
+    });
+
+    it('should render medical records information for sexual assault', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_SEXUAL_ASSAULT,
+        [SHORT_NAME_MAP.DISCHARGE_YEAR]: '2000',
+      };
+
+      const { getByText } = render(renderMedicalRecordInfo(formResponses));
+
+      expect(
+        getByText(
+          'If you’ve seen a non-VA health care provider for for treatment after your assault or harassment,',
+        ),
+      ).to.exist;
+    });
+
+    it('should not render anything if reason is not related to medical records', () => {
+      const formResponses = {
+        [SHORT_NAME_MAP.REASON]: 'Other Reason',
+        [SHORT_NAME_MAP.DISCHARGE_YEAR]: '2000',
+      };
+
+      const { queryByText } = render(renderMedicalRecordInfo(formResponses));
+
+      expect(
+        queryByText('You’ll need to submit copies of your medical records.'),
+      ).to.not.exist;
+    });
   });
 });

--- a/src/applications/discharge-wizard/tests/v2/results/careful-consideration-statement.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/v2/results/careful-consideration-statement.unit.spec.js
@@ -51,4 +51,106 @@ describe('Discharge Wizard CarefulConsiderationStatement', () => {
     );
     wrapper.unmount();
   });
+
+  it('should show the correct text for HONORABLE discharge when REASON is Sexual Orientation', () => {
+    const wrapper = mount(
+      <CarefulConsiderationStatement
+        formResponses={{
+          [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_SEXUAL_ORIENTATION,
+          [SHORT_NAME_MAP.DISCHARGE_TYPE]: RESPONSES.DISCHARGE_HONORABLE,
+        }}
+      />,
+    );
+    expect(wrapper.html()).to.include(
+      'Many Veterans have received general or honorable discharges due to their sexual orientation',
+    );
+    wrapper.unmount();
+  });
+
+  it('should show the correct text when REASON is PTSD', () => {
+    const wrapper = mount(
+      <CarefulConsiderationStatement
+        formResponses={{
+          [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_PTSD,
+          [SHORT_NAME_MAP.DISCHARGE_TYPE]: RESPONSES.DISCHARGE_HONORABLE,
+        }}
+      />,
+    );
+    expect(wrapper.html()).to.include(
+      'Because you answered that your discharge was related to posttraumatic stress disorder (PTSD)',
+    );
+    wrapper.unmount();
+  });
+
+  it('should show the correct text when REASON is TBI', () => {
+    const wrapper = mount(
+      <CarefulConsiderationStatement
+        formResponses={{
+          [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_TBI,
+          [SHORT_NAME_MAP.DISCHARGE_TYPE]: RESPONSES.DISCHARGE_HONORABLE,
+        }}
+      />,
+    );
+    expect(wrapper.html()).to.include(
+      'Because you answered that your discharge was related to a traumatic brain injury (TBI)',
+    );
+    wrapper.unmount();
+  });
+
+  it('should show the correct text for DISCHARGE_TYPE as Dishonorable', () => {
+    const wrapper = mount(
+      <CarefulConsiderationStatement
+        formResponses={{
+          [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_SEXUAL_ORIENTATION,
+          [SHORT_NAME_MAP.DISCHARGE_TYPE]: RESPONSES.DISCHARGE_DISHONORABLE,
+        }}
+      />,
+    );
+    expect(wrapper.html()).to.include(
+      'Because you answered that your discharge was due to your sexual orientation',
+    );
+    wrapper.unmount();
+  });
+
+  it('should show the correct text for Reason is Transgender', () => {
+    const wrapper = mount(
+      <CarefulConsiderationStatement
+        formResponses={{
+          [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_TRANSGENDER,
+        }}
+      />,
+    );
+    expect(wrapper.html()).to.include(
+      `This is a common request for transgender Veterans whose DD214 name does not match the name they currently use.`,
+    );
+    wrapper.unmount();
+  });
+
+  it('should show the correct text for REASON is Sexual Assault', () => {
+    const wrapper = mount(
+      <CarefulConsiderationStatement
+        formResponses={{
+          [SHORT_NAME_MAP.REASON]: RESPONSES.REASON_SEXUAL_ASSAULT,
+        }}
+      />,
+    );
+    expect(wrapper.html()).to.include(
+      'Because you answered that your discharge was related to sexual assault or harassment',
+    );
+    wrapper.unmount();
+  });
+
+  it('should show the correct text for PRIOR_SERVICE', () => {
+    const wrapper = mount(
+      <CarefulConsiderationStatement
+        formResponses={{
+          [SHORT_NAME_MAP.PRIOR_SERVICE]: RESPONSES.PRIOR_SERVICE_PAPERWORK_NO,
+        }}
+      />,
+    );
+    expect(wrapper.html()).to.include(
+      'Because you served honorably in one period of service, you can apply for VA benefits using that honorable characterization.',
+    );
+    wrapper.unmount();
+  });
 });

--- a/src/applications/discharge-wizard/tests/v2/review/ReviewPage.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/v2/review/ReviewPage.unit.spec.js
@@ -49,6 +49,40 @@ const mockStoreStandard = {
   dispatch: () => {},
 };
 
+const mockStoreStandardNoIntro = {
+  getState: () => ({
+    dischargeUpgradeWizard: {
+      duwForm: {
+        form: {
+          [SHORT_NAME_MAP.SERVICE_BRANCH]: null,
+          [SHORT_NAME_MAP.DISCHARGE_YEAR]: null,
+          [SHORT_NAME_MAP.DISCHARGE_MONTH]: null,
+          [SHORT_NAME_MAP.REASON]: null,
+          [SHORT_NAME_MAP.DISCHARGE_TYPE]: null,
+          [SHORT_NAME_MAP.INTENTION]: null,
+          [SHORT_NAME_MAP.COURT_MARTIAL]: null,
+          [SHORT_NAME_MAP.PREV_APPLICATION]: null,
+          [SHORT_NAME_MAP.PREV_APPLICATION_YEAR]: null,
+          [SHORT_NAME_MAP.PREV_APPLICATION_TYPE]: null,
+          [SHORT_NAME_MAP.FAILURE_TO_EXHAUST]: null,
+          [SHORT_NAME_MAP.PRIOR_SERVICE]: null,
+        },
+        viewedIntroPage: false,
+        editMode: false,
+        questionFlowChanged: false,
+        routeMap: [
+          ROUTES.HOME,
+          ROUTES.SERVICE_BRANCH,
+          ROUTES.REASON,
+          ROUTES.PREV_APPLICATION_TYPE,
+        ],
+      },
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
 const propsStandard = {
   //   formResponses: {
   //     [SHORT_NAME_MAP.SERVICE_BRANCH]: RESPONSES.AIR_FORCE,
@@ -80,9 +114,31 @@ const propsStandard = {
   //   ],
 };
 
+const propsNoIntroPage = {
+  formResponses: {},
+  answerChanged: false,
+  routeMap: [],
+  setQuestionSelectedToEdit: () => {},
+  setRouteMap: () => {},
+  toggleEditMode: () => {},
+  toggleQuestionFlowChanged: () => {},
+  viewedIntroPage: false,
+  router: {
+    push: pushStub,
+  },
+};
+
 describe('Review Page', () => {
   afterEach(() => {
     pushStub.resetHistory();
+  });
+  it('should show the return home without seeing the intro page', () => {
+    render(
+      <Provider store={mockStoreStandardNoIntro}>
+        <ReviewPage {...propsNoIntroPage} />
+      </Provider>,
+    );
+    expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
   });
   it('should show the review page component', () => {
     const tree = shallow(

--- a/src/applications/discharge-wizard/tests/v2/utilities/page-navigation.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/v2/utilities/page-navigation.unit.spec.js
@@ -1,0 +1,192 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  navigateBackward,
+  navigateForward,
+} from '../../../utilities/page-navigation';
+import { ROUTES } from '../../../constants';
+import {
+  RESPONSES,
+  SHORT_NAME_MAP,
+} from '../../../constants/question-data-map';
+
+describe('Navigation Utilities', () => {
+  let routerMock;
+  let setRouteMapMock;
+  let routeMap;
+
+  beforeEach(() => {
+    routerMock = { push: sinon.spy() };
+    setRouteMapMock = sinon.spy();
+    routeMap = [ROUTES.HOME, ROUTES.SERVICE_BRANCH, ROUTES.DISCHARGE_YEAR];
+  });
+
+  describe('navigateBackward', () => {
+    it('should navigate to the last route for non-edit mode', () => {
+      navigateBackward(
+        routerMock,
+        setRouteMapMock,
+        routeMap,
+        SHORT_NAME_MAP.DISCHARGE_YEAR,
+        false,
+        false,
+        false,
+      );
+
+      expect(setRouteMapMock.calledWith([ROUTES.HOME, ROUTES.SERVICE_BRANCH]))
+        .to.be.true;
+      expect(routerMock.push.calledWith(ROUTES.SERVICE_BRANCH)).to.be.true;
+    });
+
+    it('should navigate to the review page for edit mode (non-forkable)', () => {
+      navigateBackward(
+        routerMock,
+        setRouteMapMock,
+        [
+          ROUTES.HOME,
+          ROUTES.SERVICE_BRANCH,
+          ROUTES.DISCHARGE_YEAR,
+          ROUTES.REASON,
+          ROUTES.PREV_APPLICATION,
+          ROUTES.REVIEW,
+        ],
+        SHORT_NAME_MAP.REASON,
+        true,
+        false,
+        false,
+      );
+
+      expect(routerMock.push.calledWith(ROUTES.REVIEW)).to.be.true;
+    });
+
+    it('should update the route map for edit mode(forkable question)', () => {
+      navigateBackward(
+        routerMock,
+        setRouteMapMock,
+        routeMap,
+        SHORT_NAME_MAP.DISCHARGE_YEAR,
+        true,
+        true,
+        true,
+      );
+
+      expect(setRouteMapMock.calledWith([ROUTES.HOME, ROUTES.SERVICE_BRANCH]))
+        .to.be.true;
+      expect(routerMock.push.calledWith(ROUTES.SERVICE_BRANCH)).to.be.true;
+    });
+  });
+
+  describe('navigateForward', () => {
+    it('should navigate to the next route', () => {
+      const formResponses = {
+        SERVICE_BRANCH: RESPONSES.AIR_FORCE,
+        DISCHARGE_YEAR: null,
+        DISCHARGE_MONTH: null,
+        REASON: null,
+        DISCHARGE_TYPE: null,
+        INTENTION: null,
+        COURT_MARTIAL: null,
+        PREV_APPLICATION: null,
+        PREV_APPLICATION_YEAR: null,
+        PREV_APPLICATION_TYPE: null,
+        FAILURE_TO_EXHAUST: null,
+        PRIOR_SERVICE: null,
+        REVIEW: null,
+      };
+      navigateForward(
+        SHORT_NAME_MAP.SERVICE_BRANCH,
+        formResponses,
+        routerMock,
+        false,
+        setRouteMapMock,
+        [ROUTES.HOME, ROUTES.SERVICE_BRANCH],
+        false,
+        false,
+        '',
+      );
+
+      expect(
+        setRouteMapMock.calledWith([
+          ROUTES.HOME,
+          ROUTES.SERVICE_BRANCH,
+          ROUTES.DISCHARGE_YEAR,
+        ]),
+      ).to.be.true;
+      expect(routerMock.push.calledWith(ROUTES.DISCHARGE_YEAR)).to.be.true;
+    });
+
+    it('should skip questions where display conditions are not met', () => {
+      const formResponses = {
+        SERVICE_BRANCH: RESPONSES.AIR_FORCE,
+        DISCHARGE_YEAR: '2024',
+        DISCHARGE_MONTH: null,
+        REASON: null,
+        DISCHARGE_TYPE: null,
+        INTENTION: null,
+        COURT_MARTIAL: null,
+        PREV_APPLICATION: null,
+        PREV_APPLICATION_YEAR: null,
+        PREV_APPLICATION_TYPE: null,
+        FAILURE_TO_EXHAUST: null,
+        PRIOR_SERVICE: null,
+        REVIEW: null,
+      };
+      navigateForward(
+        SHORT_NAME_MAP.DISCHARGE_YEAR,
+        formResponses,
+        routerMock,
+        false,
+        setRouteMapMock,
+        [ROUTES.HOME, ROUTES.SERVICE_BRANCH, ROUTES.DISCHARGE_YEAR],
+        false,
+        false,
+        '',
+      );
+
+      expect(
+        setRouteMapMock.calledWith([
+          ROUTES.HOME,
+          ROUTES.SERVICE_BRANCH,
+          ROUTES.DISCHARGE_YEAR,
+          ROUTES.REASON,
+        ]),
+      ).to.be.true;
+      expect(routerMock.push.calledWith(ROUTES.REASON)).to.be.true;
+    });
+
+    it('should handle reaching the end of the flow', () => {
+      const formResponses = {
+        SERVICE_BRANCH: RESPONSES.AIR_FORCE,
+        DISCHARGE_YEAR: 2024,
+        DISCHARGE_MONTH: null,
+        REASON: RESPONSES.REASON_DD215_UPDATE_TO_DD214,
+        DISCHARGE_TYPE: null,
+        INTENTION: null,
+        COURT_MARTIAL: null,
+        PREV_APPLICATION: RESPONSES.PREV_APPLICATION_BCMR,
+        PREV_APPLICATION_YEAR: null,
+        PREV_APPLICATION_TYPE: null,
+        FAILURE_TO_EXHAUST: null,
+        PRIOR_SERVICE: null,
+        REVIEW: null,
+      };
+      navigateForward(
+        SHORT_NAME_MAP.PREV_APPLICATION,
+        formResponses,
+        routerMock,
+        false,
+        setRouteMapMock,
+        [
+          ROUTES.HOME,
+          ROUTES.SERVICE_BRANCH,
+          ROUTES.DISCHARGE_YEAR,
+          ROUTES.PREV_APPLICATION,
+        ],
+        false,
+        false,
+        '',
+      );
+      expect(routerMock.push.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR adds some additional coverage to v2 of the DUW. This is in response to the DUW staging review

## Test Coverage Details
### helpers/index.jsx
Added some exports so we can test the helper functions

### actions/index.unit.spec.js
Added missing actions unit tests

### results/careful-considerations-statement.unit.spec.js
Added more coverage of dynamic text testing

### review/ReviewPage.unit.spec.js
Added one case for the return to homepage when trying to navigate straight to Review Screen

### utilites/page-navigation.unit.spec.js
Added unit tests to account for backward and forward navigation. Cypress is already included but added some unit coverage as well. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20015

## Testing done
Ran the test suite locally and all were passing.

## Screenshots
Before PR
![Code_coverage_report_for_All_files](https://github.com/user-attachments/assets/ec9a1707-aee9-4b19-9e0f-d3cf47cfcca5)

After PR with v1 code stripped out
![Code_coverage_report_for_All_files](https://github.com/user-attachments/assets/4348ea93-7e97-4713-a450-679c5aedff0a)



## What areas of the site does it impact?
DUW v2

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
