### PR TITLE
Mhv 64616 vitals undefined

### DIFF
--- a/src/applications/mhv-medical-records/reducers/vitals.js
+++ b/src/applications/mhv-medical-records/reducers/vitals.js
@@ -56,8 +56,13 @@ const getMeasurement = (record, type) => {
     );
     return `${systolic.valueQuantity.value}/${diastolic.valueQuantity.value}`;
   }
-  const unit = getUnit(type, record.valueQuantity?.code);
-  return `${record.valueQuantity?.value}${unit}`;
+
+  if (record.valueQuantity) {
+    const unit = getUnit(type, record.valueQuantity?.code);
+    return `${record.valueQuantity?.value}${unit}`;
+  }
+
+  return record.valueString || EMPTY_FIELD;
 };
 
 export const extractLocation = vital => {

--- a/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
@@ -7,6 +7,7 @@ import reducer from '../../reducers';
 import { user } from '../fixtures/user-reducer.json';
 import VitalDetails from '../../containers/VitalDetails';
 import vital from '../fixtures/vital.json';
+import vitalWithVitalString from '../fixtures/vitalWithVitalString.json';
 import { convertVital } from '../../reducers/vitals';
 
 describe('Vital details container', () => {
@@ -131,6 +132,33 @@ describe('Vitals details container with errors', () => {
           exact: false,
         }),
       ).to.exist;
+    });
+  });
+});
+
+describe('Vitals details container with valueString', () => {
+  const initialState = {
+    mr: {
+      vitals: {
+        vitalDetails: [convertVital(vitalWithVitalString)],
+      },
+    },
+    user,
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<VitalDetails runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/vitals/breathing-rate-history',
+    });
+  });
+
+  it('displays the result string when the vital has valueString instead of valueQuantity', async () => {
+    await waitFor(() => {
+      const result = screen.getByTestId('vital-result');
+      expect(result.innerHTML).to.equal('Unavailable');
     });
   });
 });

--- a/src/applications/mhv-medical-records/tests/fixtures/vitalWithVitalString.json
+++ b/src/applications/mhv-medical-records/tests/fixtures/vitalWithVitalString.json
@@ -1,0 +1,33 @@
+  {
+    "code": {
+      "coding": [
+        {
+          "code": "9279-1",
+          "display": "Respiratory Rate"
+        }
+      ],
+      "text": "RESPIRATION"
+    },
+    "valueString": "Unavailable",
+    "contained": [
+      {
+        "id": "Location-0",
+        "name": "Washington DC VAMC",
+        "resourceType": "Location"
+      }
+    ],
+    "effectiveDateTime": "2024-03-12T13:27:00-05:00",
+    "id": "2001",
+    "performer": [
+      {
+        "extension": [
+          {
+            "valueReference": {
+              "reference": "#Location-0"
+            }
+          }
+        ]
+      }
+    ]
+  }
+


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- bug: vitals were not recognizing the valueString parameter that occasionally replaces the valueQuantity parameter, resulting in the rendered component displaying "undefined undefined"
- fix: updated getMeasurement to handle valueString

## Related issue(s)

### [MHV-64616](https://jira.devops.va.gov/browse/MHV-64616) - Pre release-Priority 5: Vitals marked "unavailable" or "refused" by providers create an error state on MHV ###

> Pre release-Priority 5: Vitals marked "unavailable" or "refused" by providers create an error state on MHV
> 
> 1. Log into Staging as test patient Silva
> 2. Select Vitals
> 3. Select Breathing Rate
> 4. Observe the October 18, 2024 entry
> 5. Observe that the Result field contains "undefined undefined"
>  
>  
> 
> Already reported to BL; being worked on
> 
> This scenario results in a "Unavailable/min" note in MHVC.  This should probably be correct to simply say Unavailable in the new MR experience.  Including the unit of measure is confusing.
> 
> Domain:  VItals
> 
> MR Phase 1 Bugs.xlsx (sharepoint.com)
> 
> Feature Flag Y/N ?
> 
> DataDog Analytics  Y/N ?
> 
> Manual Testing Y/N ? 
> 
> Automated Testing Y/N ?
> 
> Accessibility Testing Y/N ?
> 
> UCD Validation Y/N 
> 
> Acceptance Criteria:
> 
> AC1  Vitals marked "unavailable" or "refused" by providers no longer create an error state on MHV

## Testing done

- Manual testing
- added unit test

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |![Screenshot 2024-12-04 at 8 31 26 AM](https://github.com/user-attachments/assets/cfd2aec4-ca31-45c7-9b18-ad8e55f1a5a8)|![Screenshot 2024-12-04 at 8 29 50 AM](https://github.com/user-attachments/assets/f5074c90-b54f-4fae-852b-6d13f6d3b9ab)|

## What areas of the site does it impact?

Va.gov - Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
