### PR TITLE
Fix environment check for web vitals

### DIFF
--- a/src/platform/monitoring/web-vitals.js
+++ b/src/platform/monitoring/web-vitals.js
@@ -23,7 +23,7 @@ const recordWebVitalsEvent = event => {
 
 const trackWebVitals =
   // Exclude production for now.
-  !environment.isProduction &&
+  !environment.isProduction() &&
   // Exclude cypress containers and localhost from tracking web vitals.
   environment.BASE_URL.indexOf('localhost') < 0;
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Fixing mistaken call to non-existent property instead of function. I verified that `!environment.isProduction` evaluates to `false`, so this will not affect behavior on production.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/33277

## Testing done

Validated locally
