### PR TITLE
Fix code scanning alert no. 64: Regular expression injection

### DIFF
--- a/script/component-migration/index.js
+++ b/script/component-migration/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const chalk = require('chalk');
+const _ = require('lodash');
 const commandLineArgs = require('command-line-args');
 const fs = require('fs');
 const glob = require('glob');
@@ -13,10 +14,11 @@ const optionDefinitions = [
 ];
 const options = commandLineArgs(optionDefinitions);
 
+const safeComponent = _.escapeRegExp(options.component);
 const legacyImport = `import ${
-  options.component
+  safeComponent
 } from '@department-of-veterans-affairs/component-library/${
-  options.component
+  safeComponent
 }'`;
 
 function handleError(error) {
@@ -61,8 +63,8 @@ function translateProps(componentString, propMap) {
 function replaceTags(fileContents, newTag) {
   const unnamedClosingTags = fileContents.matchAll(
     new RegExp(
-      `(<${options.component}(?!.*<\\/${
-        options.component
+      `(<${safeComponent}(?!.*<\\/${
+        safeComponent
       }>).*?(^\\s+)?\\/>;?$)`,
       'gsm',
     ),
@@ -77,8 +79,8 @@ function replaceTags(fileContents, newTag) {
   );
 
   return namedClosingTags
-    .replace(new RegExp(`<${options.component}`, 'g'), `<${newTag}`)
-    .replace(new RegExp(`</${options.component}`, 'g'), `</${newTag}`);
+    .replace(new RegExp(`<${safeComponent}`, 'g'), `<${newTag}`)
+    .replace(new RegExp(`</${safeComponent}`, 'g'), `</${newTag}`);
 }
 
 /**


### PR DESCRIPTION
Fixes [https://github.com/department-of-veterans-affairs/vets-website/security/code-scanning/64](https://github.com/department-of-veterans-affairs/vets-website/security/code-scanning/64)

To fix the problem, we need to sanitize the `options.component` value before using it to construct the regular expression. The best way to do this is by using the `_.escapeRegExp` function from the lodash library, which escapes special characters in the string, making it safe to use in a regular expression.

1. Import the lodash library.
2. Use the `_.escapeRegExp` function to sanitize the `options.component` value before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
