### PR TITLE
Add support for extensions in main phone numbers

### DIFF
--- a/src/applications/vaos/components/FacilityPhone.jsx
+++ b/src/applications/vaos/components/FacilityPhone.jsx
@@ -13,6 +13,22 @@ export default function FacilityPhone({
   if (!contact) {
     return null;
   }
+
+  let number = contact;
+  let numberExtension = extension;
+
+  // Extract number and extension from contact if extension not explicitly set and
+  // contact contains an 'x' character, usually in the format "123-456-7890 x1234"
+  if (contact.includes('x')) {
+    const [contactNumber, contactExtension] = contact
+      .split('x')
+      .map(item => item.trim());
+    number = contactNumber;
+    if (!numberExtension) {
+      numberExtension = contactExtension;
+    }
+  }
+
   const isClinic = !!heading.includes('Clinic');
   const Heading = `h${level}`;
 
@@ -32,8 +48,8 @@ export default function FacilityPhone({
         typeof level === 'undefined' &&
         `${heading} `}
       <VaTelephone
-        contact={contact}
-        extension={extension}
+        contact={number}
+        extension={numberExtension}
         data-testid={!isClinic ? 'facility-telephone' : 'clinic-telephone'}
       />
       {!isClinic && (

--- a/src/applications/vaos/components/FacilityPhone.jsx
+++ b/src/applications/vaos/components/FacilityPhone.jsx
@@ -19,14 +19,8 @@ export default function FacilityPhone({
 
   // Extract number and extension from contact if extension not explicitly set and
   // contact contains an 'x' character, usually in the format "123-456-7890 x1234"
-  if (contact.includes('x')) {
-    const [contactNumber, contactExtension] = contact
-      .split('x')
-      .map(item => item.trim());
-    number = contactNumber;
-    if (!numberExtension) {
-      numberExtension = contactExtension;
-    }
+  if (!extension && contact.includes('x')) {
+    [number, numberExtension] = contact.split('x').map(item => item.trim());
   }
 
   const isClinic = !!heading.includes('Clinic');

--- a/src/applications/vaos/components/FacilityPhone.unit.spec.js
+++ b/src/applications/vaos/components/FacilityPhone.unit.spec.js
@@ -59,22 +59,4 @@ describe('VAOS Component: FacilityPhone', () => {
 
     expect(screen.getByTestId('tty-telephone')).to.exist;
   });
-
-  it('should render contact number preferring extension parameter', () => {
-    const screen = renderWithStoreAndRouter(
-      <FacilityPhone contact="123-456-7890 x1234" extension="1111" />,
-      {
-        initialState,
-      },
-    );
-
-    expect(screen.getByText(new RegExp(`Main phone:`))).to.exist;
-
-    const vaPhone = screen.getByTestId('facility-telephone');
-    expect(vaPhone).to.exist;
-    expect(vaPhone).to.have.attribute('contact', '123-456-7890');
-    expect(vaPhone).to.have.attribute('extension', '1111');
-
-    expect(screen.getByTestId('tty-telephone')).to.exist;
-  });
 });

--- a/src/applications/vaos/components/FacilityPhone.unit.spec.js
+++ b/src/applications/vaos/components/FacilityPhone.unit.spec.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderWithStoreAndRouter } from '~/platform/testing/unit/react-testing-library-helpers';
+import FacilityPhone from './FacilityPhone';
+
+describe('VAOS Component: FacilityPhone', () => {
+  const initialState = {};
+
+  it('should render contact number', () => {
+    const screen = renderWithStoreAndRouter(
+      <FacilityPhone contact="123-456-7890" />,
+      {
+        initialState,
+      },
+    );
+
+    expect(screen.getByText(new RegExp(`Main phone:`))).to.exist;
+
+    const vaPhone = screen.getByTestId('facility-telephone');
+    expect(vaPhone).to.exist;
+    expect(vaPhone).to.have.attribute('contact', '123-456-7890');
+    expect(vaPhone).not.to.have.attribute('extension');
+
+    expect(screen.getByTestId('tty-telephone')).to.exist;
+  });
+
+  it('should render contact number with extension', () => {
+    const screen = renderWithStoreAndRouter(
+      <FacilityPhone contact="123-456-7890 x1234" />,
+      {
+        initialState,
+      },
+    );
+
+    expect(screen.getByText(new RegExp(`Main phone:`))).to.exist;
+
+    const vaPhone = screen.getByTestId('facility-telephone');
+    expect(vaPhone).to.exist;
+    expect(vaPhone).to.have.attribute('contact', '123-456-7890');
+    expect(vaPhone).to.have.attribute('extension', '1234');
+
+    expect(screen.getByTestId('tty-telephone')).to.exist;
+  });
+
+  it('should render contact number and extension', () => {
+    const screen = renderWithStoreAndRouter(
+      <FacilityPhone contact="123-456-7890" extension="1111" />,
+      {
+        initialState,
+      },
+    );
+
+    expect(screen.getByText(new RegExp(`Main phone:`))).to.exist;
+
+    const vaPhone = screen.getByTestId('facility-telephone');
+    expect(vaPhone).to.exist;
+    expect(vaPhone).to.have.attribute('contact', '123-456-7890');
+    expect(vaPhone).to.have.attribute('extension', '1111');
+
+    expect(screen.getByTestId('tty-telephone')).to.exist;
+  });
+
+  it('should render contact number preferring extension parameter', () => {
+    const screen = renderWithStoreAndRouter(
+      <FacilityPhone contact="123-456-7890 x1234" extension="1111" />,
+      {
+        initialState,
+      },
+    );
+
+    expect(screen.getByText(new RegExp(`Main phone:`))).to.exist;
+
+    const vaPhone = screen.getByTestId('facility-telephone');
+    expect(vaPhone).to.exist;
+    expect(vaPhone).to.have.attribute('contact', '123-456-7890');
+    expect(vaPhone).to.have.attribute('extension', '1111');
+
+    expect(screen.getByTestId('tty-telephone')).to.exist;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add logic to extract extension information from main facility phone numbers
- Appointments (VAOS) Team
- This is not behind a Flipper toggle

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96156

## Screenshots

Given a facility such as:
```json
{
      "id": "984",
      "type": "facilities",
      "attributes": {
        "id": "984",
        "phone": { "main": "937-268-6511 x9999" },
        ...
      }
    },
```

| Before | After |
| ------ | ----- |
|    <img width="631" alt="image" src="https://github.com/user-attachments/assets/8b754581-c8e8-4d67-9125-72aee98ec8bd">   |   <img width="624" alt="image" src="https://github.com/user-attachments/assets/a0bc68b7-361c-44d4-9ccc-c10f7c7c0924">  |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
