### PR TITLE
[20-10207] Implement new confirmation page and support existing File Upload

### DIFF
--- a/src/applications/simple-forms/20-10207/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/20-10207/containers/ConfirmationPage.jsx
@@ -1,26 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
+import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 
-import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
-import { getSubmitterName } from '../helpers';
-
-const content = {
-  headlineText: 'You’ve submitted your request for priority processing',
-  nextStepsText: (
-    <>
-      <p>
-        We’ll review your request along with the supporting documents you
-        provided. And we’ll decide if we can prioritize your request. We’ll
-        notify you about our decision by mail.
-      </p>
-      <p>
-        If you are homeless, we’ll try to contact you by phone to get an address
-        if one was not provided.
-      </p>
-    </>
-  ),
-};
 const childContent = (
   <div>
     <h2>Where to mail additional documents</h2>
@@ -75,23 +57,48 @@ const childContent = (
   </div>
 );
 
-export const ConfirmationPage = () => {
+export const ConfirmationPage = props => {
   const form = useSelector(state => state.form || {});
   const { submission } = form;
   const submitDate = submission.timestamp;
   const confirmationNumber = submission.response?.confirmationNumber;
-  const submitterFullName = getSubmitterName(form.data);
 
   return (
-    <ConfirmationPageView
-      formType="submission"
-      submitterHeader="Who submitted this form"
-      submitterName={submitterFullName}
+    <ConfirmationView
+      formConfig={props.route?.formConfig}
       submitDate={submitDate}
       confirmationNumber={confirmationNumber}
-      content={content}
-      childContent={childContent}
-    />
+      pdfUrl={submission.response?.pdfUrl}
+      devOnly={{
+        showButtons: true,
+      }}
+    >
+      <ConfirmationView.SubmissionAlert
+        content={
+          <>
+            <p>
+              We’ll review your request along with any supporting documents you
+              provided. And we’ll decide if we can prioritize your request.
+              We’ll notify you about our decision by the mailing address
+              provided.
+            </p>
+            <p>
+              If you are homeless, we’ll try to contact you by phone to get an
+              address if one was not provided.
+            </p>
+            <p>Your confirmation number is {confirmationNumber}.</p>
+          </>
+        }
+      />
+      <ConfirmationView.SavePdfDownload />
+      <ConfirmationView.ChapterSectionCollection />
+      <ConfirmationView.PrintThisPage />
+      <ConfirmationView.WhatsNextProcessList />
+      <ConfirmationView.HowToContact />
+      <ConfirmationView.GoBackLink />
+      {childContent}
+      <ConfirmationView.NeedHelp />
+    </ConfirmationView>
   );
 };
 
@@ -125,6 +132,9 @@ ConfirmationPage.propTypes = {
     }),
   }),
   name: PropTypes.string,
+  route: PropTypes.shape({
+    formConfig: PropTypes.object,
+  }),
 };
 
 function mapStateToProps(state) {

--- a/src/applications/simple-forms/20-10207/helpers.js
+++ b/src/applications/simple-forms/20-10207/helpers.js
@@ -207,18 +207,6 @@ export const statementOfTruthFullNamePath = ({ formData }) => {
   }
 };
 
-export const getSubmitterName = formData => {
-  const { preparerType } = formData;
-  switch (preparerType) {
-    case PREPARER_TYPES.VETERAN:
-      return formData.veteranFullName;
-    case PREPARER_TYPES.NON_VETERAN:
-      return formData.nonVeteranFullName;
-    default:
-      return formData.thirdPartyFullName;
-  }
-};
-
 export const evidenceConfinementHintUpdateUiSchema = ({
   formData,
   beganEndedString,

--- a/src/applications/simple-forms/20-10207/pages/evidenceALS.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceALS.js
@@ -21,6 +21,10 @@ export default {
     alsDocuments: {
       'ui:title': 'Upload additional evidence',
       'ui:field': FileField,
+      'ui:confirmationField': ({ formData }) => ({
+        data: formData.map(item => item.fileName),
+        label: uiTitle,
+      }),
       'ui:options': {
         hideLabelText: false,
         showFieldLabel: true,

--- a/src/applications/simple-forms/20-10207/pages/evidenceFinancialHardship.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceFinancialHardship.js
@@ -20,6 +20,10 @@ export default {
     financialHardshipDocuments: {
       'ui:title': 'Upload additional evidence',
       'ui:field': FileField,
+      'ui:confirmationField': ({ formData }) => ({
+        data: formData.map(item => item.fileName),
+        label: uiTitle,
+      }),
       'ui:options': {
         hideLabelText: false,
         showFieldLabel: true,

--- a/src/applications/simple-forms/20-10207/pages/evidenceMedalAward.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceMedalAward.js
@@ -21,6 +21,10 @@ export default {
     medalAwardDocuments: {
       'ui:title': 'Upload additional evidence',
       'ui:field': FileField,
+      'ui:confirmationField': ({ formData }) => ({
+        data: formData.map(item => item.fileName),
+        label: uiTitle,
+      }),
       'ui:options': {
         hideLabelText: false,
         showFieldLabel: true,

--- a/src/applications/simple-forms/20-10207/pages/evidencePowDocuments.js
+++ b/src/applications/simple-forms/20-10207/pages/evidencePowDocuments.js
@@ -20,6 +20,10 @@ export default {
     powDocuments: {
       'ui:title': 'Upload additional evidence',
       'ui:field': FileField,
+      'ui:confirmationField': ({ formData }) => ({
+        data: formData.map(item => item.fileName),
+        label: uiTitle,
+      }),
       'ui:options': {
         hideLabelText: false,
         showFieldLabel: true,

--- a/src/applications/simple-forms/20-10207/pages/evidenceTerminalIllness.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceTerminalIllness.js
@@ -20,6 +20,10 @@ export default {
     terminalIllnessDocuments: {
       'ui:title': 'Upload additional evidence',
       'ui:field': FileField,
+      'ui:confirmationField': ({ formData }) => ({
+        data: formData.map(item => item.fileName),
+        label: uiTitle,
+      }),
       'ui:options': {
         hideLabelText: false,
         showFieldLabel: true,

--- a/src/applications/simple-forms/20-10207/pages/evidenceVSI.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceVSI.js
@@ -21,6 +21,10 @@ export default {
     vsiDocuments: {
       'ui:title': 'Upload additional evidence',
       'ui:field': FileField,
+      'ui:confirmationField': ({ formData }) => ({
+        data: formData.map(item => item.fileName),
+        label: uiTitle,
+      }),
       'ui:options': {
         hideLabelText: false,
         showFieldLabel: true,

--- a/src/applications/simple-forms/20-10207/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10207/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -1,103 +1,105 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-import { expect } from 'chai';
 
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { createStore } from 'redux';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { cleanup } from '@testing-library/react';
+import { format } from 'date-fns';
+import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/state/helpers';
 import formConfig from '../../../config/form';
 import ConfirmationPage from '../../../containers/ConfirmationPage';
+import testData from '../../e2e/fixtures/data/backend-mapping-support/veteran-maximal-2.json';
 
-const veteranFullName = {
-  first: 'John',
-  middle: '',
-  last: 'Veteran',
-};
-const storeBase = {
-  form: {
-    formId: formConfig.formId,
-    submission: {
-      response: {
-        confirmationNumber: '123456',
+describe('ConfirmationPage', () => {
+  let wrapper;
+  let store;
+  const mockStore = configureMockStore();
+  const initialState = {
+    form: {
+      data: {
+        ...createInitialState(formConfig),
+        ...testData.data,
       },
-      timestamp: Date.now(),
+      submission: {
+        response: {
+          confirmationNumber: '1234567890',
+        },
+        timestamp: '2022-01-01T00:00:00Z',
+      },
     },
-    data: {
-      preparerType: 'veteran',
-      veteranFullName,
-    },
-  },
-};
-const fullNameString = veteranFullName.middle
-  ? `${veteranFullName.first} ${veteranFullName.middle} ${veteranFullName.last}`
-  : `${veteranFullName.first} ${veteranFullName.last}`;
-const fullNameStringRegex = new RegExp(fullNameString, 'i');
+  };
 
-describe('Confirmation page', () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-
-  it('throws error if state.form is undefined', () => {
-    const storeWithUndefinedForm = {
-      ...storeBase,
-      form: undefined,
-    };
-
-    expect(() => {
-      render(
-        <Provider store={mockStore(storeWithUndefinedForm)}>
-          <ConfirmationPage />
-        </Provider>,
-      );
-    }).to.throw();
-  });
-
-  it('shows status success and the correct name of applicant', () => {
-    const { container, getByText } = render(
-      <Provider store={mockStore(storeBase)}>
-        <ConfirmationPage />
+  beforeEach(() => {
+    store = mockStore(initialState);
+    wrapper = mount(
+      <Provider store={store}>
+        <ConfirmationPage route={{ formConfig }} />
       </Provider>,
     );
-    expect(container.querySelector('va-alert')).to.have.attr(
-      'status',
-      'success',
-    );
-    getByText(fullNameStringRegex);
   });
 
-  it('handles missing submission response', () => {
-    const storeWithMissingResponse = {
-      ...storeBase,
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    cleanup();
+  });
+
+  it('passes the correct props to ConfirmationPageView', () => {
+    const confirmationViewProps = wrapper.find('ConfirmationView').props();
+
+    expect(confirmationViewProps.submitDate).to.equal('2022-01-01T00:00:00Z');
+    expect(confirmationViewProps.confirmationNumber).to.equal('1234567890');
+  });
+
+  it('should select form from state when state.form is defined', () => {
+    const submitDate = new Date();
+    const mockInitialState = {
       form: {
-        ...storeBase.form,
         submission: {
-          ...storeBase.form.submission,
-          response: null,
+          timestamp: submitDate,
+          response: { confirmationNumber: '1234' },
+        },
+        data: {
+          ...createInitialState(formConfig),
+          ...testData.data,
         },
       },
     };
+    const mockDefinedState = createStore(() => mockInitialState);
 
-    const { queryByText } = render(
-      <Provider store={mockStore(storeWithMissingResponse)}>
-        <ConfirmationPage />
+    const definedWrapper = mount(
+      <Provider store={mockDefinedState}>
+        <ConfirmationPage route={{ formConfig }} />
       </Provider>,
     );
 
-    expect(queryByText(/123456/)).to.be.null;
+    expect(definedWrapper.text()).to.include(
+      format(submitDate, 'MMMM d, yyyy'),
+    );
+    expect(definedWrapper.text()).to.include('1234');
+
+    definedWrapper.unmount();
   });
 
-  it('throws error when state.form is empty', () => {
-    const storeWithEmptyForm = {
-      ...storeBase,
-      form: {},
-    };
+  it('should throw error when state.form is undefined', () => {
+    const mockEmptyState = {};
+    const mockEmptyStore = createStore(() => mockEmptyState);
+
+    let errorWrapper;
 
     expect(() => {
-      render(
-        <Provider store={mockStore(storeWithEmptyForm)}>
-          <ConfirmationPage />
+      errorWrapper = mount(
+        <Provider store={mockEmptyStore}>
+          <ConfirmationPage route={{ formConfig }} />
         </Provider>,
       );
     }).to.throw();
+
+    if (errorWrapper) {
+      errorWrapper.unmount();
+    }
   });
 });

--- a/src/applications/simple-forms/20-10207/tests/unit/helpers.unit.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/unit/helpers.unit.spec.js
@@ -22,7 +22,6 @@ import {
   powConfinementDateRangeValidation,
   powConfinement2DateRangeValidation,
   statementOfTruthFullNamePath,
-  getSubmitterName,
   evidenceConfinementHintUpdateUiSchema,
 } from '../../helpers';
 
@@ -609,35 +608,6 @@ describe('statementOfTruthFullNamePath()', () => {
         formData: { preparerType: PREPARER_TYPES.THIRD_PARTY_NON_VETERAN },
       }),
     ).to.equal('thirdPartyFullName');
-  });
-});
-
-describe('getSubmitterName()', () => {
-  it('returns correct name for preparerType', () => {
-    expect(
-      getSubmitterName({
-        preparerType: PREPARER_TYPES.VETERAN,
-        veteranFullName: 'veteranName',
-      }),
-    ).to.equal('veteranName');
-    expect(
-      getSubmitterName({
-        preparerType: PREPARER_TYPES.NON_VETERAN,
-        nonVeteranFullName: 'nonVeteranName',
-      }),
-    ).to.equal('nonVeteranName');
-    expect(
-      getSubmitterName({
-        preparerType: PREPARER_TYPES.THIRD_PARTY_VETERAN,
-        thirdPartyFullName: 'thirdPartyName',
-      }),
-    ).to.equal('thirdPartyName');
-    expect(
-      getSubmitterName({
-        preparerType: PREPARER_TYPES.THIRD_PARTY_NON_VETERAN,
-        thirdPartyFullName: 'thirdPartyName',
-      }),
-    ).to.equal('thirdPartyName');
   });
 });
 

--- a/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
@@ -76,6 +76,18 @@ const reviewEntry = (description, key, uiSchema, label, data) => {
   const className = nextClass;
   nextClass = '';
 
+  // for multiple lines of data under one label
+  if (Array.isArray(data)) {
+    return (
+      <li key={keyString} className={className}>
+        <div className="vads-u-color--gray">{label}</div>
+        {data.map((item, index) => {
+          return <div key={`${keyString}-${index}`}>{item}</div>;
+        })}
+      </li>
+    );
+  }
+
   return (
     <li key={keyString} className={className}>
       <div className="vads-u-color--gray">{label}</div>
@@ -116,7 +128,11 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
   } else if (uiSchema['ui:options']?.labels?.[refinedData]) {
     refinedData = uiSchema['ui:options'].labels[refinedData];
   } else if (
-    uiSchema['ui:webComponentField']?.identifier === 'VaCheckboxGroupField'
+    uiSchema['ui:webComponentField']?.identifier === 'VaCheckboxGroupField' ||
+    (uiSchema?.['ui:field']?.WrappedComponent.name === 'FileField' &&
+      Array.isArray(data))
+    // may be able to remove Array.isArray check depending on
+    // non-array File Upload and how we render that
   ) {
     refinedData = data;
   } else if (
@@ -129,10 +145,13 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
 
   if (ConfirmationField) {
     if (typeof ConfirmationField === 'function') {
-      const { data: confirmData = refinedData } = ConfirmationField({
+      const {
+        data: confirmData = refinedData,
+        label: confirmLabel = label,
+      } = ConfirmationField({
         formData: refinedData,
       });
-      return reviewEntry(description, key, uiSchema, label, confirmData);
+      return reviewEntry(description, key, uiSchema, confirmLabel, confirmData);
     }
 
     if (isReactComponent(ConfirmationField)) {


### PR DESCRIPTION
## Summary
This pull request implements the new confirmation page on form 20-10207. Because this form uses the existing implementation of file upload, those pages have had specific support added for the new confirmation page through the use of `ui:confirmationField`. Long term, pattern level support will be added for the new File Upload pattern.

Because this file upload field allows uploading multiple files, it uses an array. This means that each uploaded file needs to be displayed in a series on the confirmation page. Additional functionality has been added to the confirmation page to allow multiple lines of data to be displayed per label to support this.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1744

## Testing done
Deleted no longer relevant unit tests

## Screenshots
<img width="659" alt="Screenshot 2024-12-05 at 11 53 52 AM" src="https://github.com/user-attachments/assets/39f4d02a-1aa9-43e2-9ef7-f7a46abe0b9d">