### PR TITLE
MHV-64827: Back link issue for patient med info page

### DIFF
--- a/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
+++ b/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
@@ -50,7 +50,7 @@ const RxBreadcrumbs = () => {
           href={`${medicationsUrls.PRESCRIPTION_DETAILS}/${
             prescription?.prescriptionId
           }`}
-          text={`Back to ${prescription?.prescriptionName}`}
+          text="Back"
           data-testid="rx-breadcrumb-link"
         />
       </div>

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-accordion-reset-button-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-accordion-reset-button-list-page.cypress.spec.js
@@ -1,0 +1,33 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsLandingPage from './pages/MedicationsLandingPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+import { Data, Paths } from './utils/constants';
+import filterRx from './fixtures/filter-prescriptions.json';
+
+describe('Medications List Page Filter Accordion Reset Button', () => {
+  it('visits Medications List Page Reset Filter Button', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const landingPage = new MedicationsLandingPage();
+    site.login();
+    landingPage.visitLandingPageURL();
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.clickGotoMedicationsLink();
+    listPage.verifyLabelTextWhenFilterAccordionExpanded();
+    listPage.clickfilterAccordionDropdownOnListPage();
+    listPage.verifyFilterHeaderTextHasFocusafterExpanded();
+    listPage.verifyFilterButtonWhenAccordionExpanded();
+    listPage.clickFilterRadioButtonOptionOnListPage('Active');
+
+    listPage.clickFilterButtonOnAccordion(Paths.ACTIVE_FILTER, filterRx);
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      Data.PAGINATION_ACTIVE_TEXT,
+    );
+    listPage.clickResetFilterButtonOnFilterAccordionDropDown();
+    listPage.verifyAllMedicationsRadioButtonIsChecked();
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      Data.PAGINATION_ALL_MEDICATIONS,
+    );
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-patient-medication-information-details-page-breadcrumbs.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-patient-medication-information-details-page-breadcrumbs.cypress.spec.js
@@ -1,0 +1,33 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+import rxTrackingDetails from './fixtures/prescription-tracking-details.json';
+import MedicationsLandingPage from './pages/MedicationsLandingPage';
+import MedicationsInformationPage from './pages/MedicationsInformationPage';
+
+describe('Medications Details Page Medication Information Breadcrumb', () => {
+  it('visits Medications Details Page Medication Information Breadcrumb', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const detailsPage = new MedicationsDetailsPage();
+    const landingPage = new MedicationsLandingPage();
+    const medInfoPage = new MedicationsInformationPage();
+    const cardNumber = 16;
+    site.login();
+    landingPage.visitLandingPageURL();
+    listPage.clickGotoMedicationsLink();
+    detailsPage.clickMedicationDetailsLink(rxTrackingDetails, cardNumber);
+    detailsPage.clickLearnMoreAboutMedicationLinkOnDetailsPage(
+      rxTrackingDetails.data.attributes.prescriptionId,
+    );
+    detailsPage.verifyMedicationInformationTitle(
+      rxTrackingDetails.data.attributes.prescriptionName,
+    );
+    medInfoPage.verifyBreadCrumbsTextDoesNotHaveRxName(
+      'Back',
+      rxTrackingDetails.data.attributes.prescriptionName,
+    );
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
@@ -12,6 +12,13 @@ class MedicationsInformationPage {
       'If you’re on a public or shared computer',
     );
   };
+
+  verifyBreadCrumbsTextDoesNotHaveRxName = (breadcrumb, text) => {
+    cy.get('[data-testid="rx-breadcrumb-link"]')
+      .shadow()
+      .should('have.text', breadcrumb)
+      .and('not.have.text', text);
+  };
 }
 
 export default MedicationsInformationPage;

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -772,6 +772,12 @@ class MedicationsListPage {
 
   verifyAllMedicationsRadioButtonIsChecked = () => {
     cy.contains('All medications').should('be.visible');
+    cy.get('[data-testid="filter-button"]')
+      .shadow()
+      .find('[type="button"],[value="ALL Medications"],[aria-checked="true"]', {
+        force: true,
+      })
+      .should('exist');
   };
 
   verifyFocusOnPaginationTextInformationOnListPage = text => {
@@ -809,6 +815,13 @@ class MedicationsListPage {
     cy.get('[data-testid="zero-filter-results"]')
       .should('have.text', text)
       .and('be.focused');
+  };
+
+  clickResetFilterButtonOnFilterAccordionDropDown = () => {
+    cy.get('[data-testid="filter-reset-button"]').should('exist');
+    cy.get('[data-testid="filter-reset-button"]').click({
+      waitForAnimations: true,
+    });
   };
 }
 

--- a/src/applications/mhv-medications/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-medications/tests/e2e/utils/constants.js
@@ -1,5 +1,7 @@
 export const Data = {
   PAGINATION_TEXT: 'Showing 1 - 20 of 29 medications',
+  PAGINATION_ALL_MEDICATIONS:
+    'Showing 1 - 20 of 29 medications, alphabetically by status',
   PAGINATION_ACTIVE_TEXT:
     'Showing 1 - 20 of 29 active medications, alphabetically by status',
   PAGINATION_RENEW:


### PR DESCRIPTION
## Summary

Changed back link text for Medication Documentation

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-64827

## Testing done

- Manual testing

## Screenshots

<img width="256" alt="image" src="https://github.com/user-attachments/assets/dff3eb9c-6400-489a-9e48-f15649e84058">

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Back link with med name is switched out for a generic back link. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
