### PR TITLE
VACMS 19842 - Situation Update Banners to use Vets-API and depend on feature toggle

### DIFF
--- a/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
+++ b/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
@@ -19,7 +19,7 @@ export const BannerContainer = () => {
 
   useEffect(() => {
     let pathForSituationUpdate = window.location.pathname;
-     pathForSituationUpdate = pathForSituationUpdate.replace(/\/$/, '');
+    pathForSituationUpdate = pathForSituationUpdate.replace(/\/$/, '');
     if (
       pathForSituationUpdate.includes('health-care') ||
       pathForSituationUpdate.includes('manila-va-clinic')

--- a/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
+++ b/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
+import SituationUpdateBanner from './situationUpdateBanner';
+import { getDataForPath } from './helpers/getDataForPath';
+
+export const BannerContainer = () => {
+  const {
+    TOGGLE_NAMES,
+    useToggleValue,
+    useToggleLoadingValue,
+  } = useFeatureToggle();
+
+  const alternativeBannersEnabled = useToggleValue(
+    TOGGLE_NAMES.bannerUseAlternativeBanners,
+  );
+  const isLoadingFeatureFlags = useToggleLoadingValue();
+
+  const [bannerState, setBannerState] = useState(null);
+
+  useEffect(() => {
+    let pathForSituationUpdate = window.location.pathname;
+    if (pathForSituationUpdate.endsWith('/')) {
+      pathForSituationUpdate = pathForSituationUpdate.slice(0, -1);
+    }
+    if (
+      pathForSituationUpdate.includes('health-care') ||
+      pathForSituationUpdate.includes('manila-va-clinic')
+    ) {
+      getDataForPath(pathForSituationUpdate)
+        .then(data => {
+          setBannerState(data?.banners?.[0] || {});
+        })
+        .catch(_ => {
+          setBannerState(null);
+        });
+    }
+  }, []);
+
+  if (isLoadingFeatureFlags || !alternativeBannersEnabled) {
+    return null;
+  }
+
+  if (!bannerState?.id) {
+    return null;
+  }
+  return <SituationUpdateBanner {...bannerState} />;
+};

--- a/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
+++ b/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
@@ -19,9 +19,7 @@ export const BannerContainer = () => {
 
   useEffect(() => {
     let pathForSituationUpdate = window.location.pathname;
-    if (pathForSituationUpdate.endsWith('/')) {
-      pathForSituationUpdate = pathForSituationUpdate.slice(0, -1);
-    }
+     pathForSituationUpdate = pathForSituationUpdate.replace(/\/$/, '');
     if (
       pathForSituationUpdate.includes('health-care') ||
       pathForSituationUpdate.includes('manila-va-clinic')

--- a/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
+++ b/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import SituationUpdateBanner from './situationUpdateBanner';
 import { getDataForPath } from './helpers/getDataForPath';
+import { getOperatingStatusPage } from './helpers/getOperatingStatusPage';
 
 export const BannerContainer = () => {
   const {
@@ -41,5 +42,15 @@ export const BannerContainer = () => {
   if (!bannerState?.id) {
     return null;
   }
-  return <SituationUpdateBanner {...bannerState} />;
+
+  const operatingStatusPage = getOperatingStatusPage(
+    bannerState?.context?.[0]?.entity?.entityUrl?.path,
+  );
+
+  return (
+    <SituationUpdateBanner
+      {...bannerState}
+      operatingStatusPage={operatingStatusPage}
+    />
+  );
 };

--- a/src/applications/static-pages/situation-updates-banner/createSituationUpdatesBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/createSituationUpdatesBanner.jsx
@@ -1,42 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
-import SituationUpdateBanner from './situationUpdateBanner';
-
-export const BannerContainer = () => {
-  const {
-    TOGGLE_NAMES,
-    useToggleValue,
-    useToggleLoadingValue,
-  } = useFeatureToggle();
-
-  const alternativeBannersEnabled = useToggleValue(
-    TOGGLE_NAMES.bannerUseAlternativeBanners,
-  );
-  const isLoadingFeatureFlags = useToggleLoadingValue();
-
-  if (isLoadingFeatureFlags || !alternativeBannersEnabled) {
-    return null;
-  }
-
-  const defaultProps = {
-    id: '1',
-    bundle: 'situation-updates',
-    headline: 'Situation update',
-    alertType: 'warning',
-    content:
-      "We're having issues at this location. Please avoid this facility until further notice.",
-    context: 'global',
-    showClose: true,
-    operatingStatusCTA: false,
-    emailUpdatesButton: false,
-    findFacilitiesCTA: false,
-    limitSubpageInheritance: false,
-  };
-
-  return <SituationUpdateBanner {...defaultProps} />;
-};
+import { BannerContainer } from './bannerContainer';
 
 export default async function createSituationUpdatesBanner(store, widgetType) {
   const bannerWidget = document.querySelector(

--- a/src/applications/static-pages/situation-updates-banner/helpers/getDataForPath.js
+++ b/src/applications/static-pages/situation-updates-banner/helpers/getDataForPath.js
@@ -1,0 +1,5 @@
+import { apiRequest } from '~/platform/utilities/api';
+
+export async function getDataForPath(path) {
+  return apiRequest(`/banners/?path=${path}`, { apiVersion: 'v0' });
+}

--- a/src/applications/static-pages/situation-updates-banner/helpers/getOperatingStatusPage.js
+++ b/src/applications/static-pages/situation-updates-banner/helpers/getOperatingStatusPage.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the operating status page path for the given path or current path.
+ * @param {string?} path
+ */
+export const getOperatingStatusPage = path => {
+  if (path?.includes('operating-status')) {
+    return path;
+  }
+  return `${window.location.pathname.split('/')[0]}/operating-status`;
+};

--- a/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import DOMPurify from 'dompurify';
+import recordEvent from '~/platform/monitoring/record-event';
 
 export default function SituationUpdateBanner({
   id,
@@ -10,12 +12,19 @@ export default function SituationUpdateBanner({
 }) {
   return (
     <va-banner
+      data-testid="situation-update-banner"
       banner-id={id}
       type={alertType}
       headline={headline}
       show-close={showClose}
+      disable-analytics
+      onclick={recordEvent({
+        event: 'nav-warning-alert-box-content-link-click',
+        alertBoxHeading: '{{ entity.title }}',
+      })}
     >
-      <p>{content}</p>
+      {/* eslint-disable-next-line react/no-danger */}
+      <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />
     </va-banner>
   );
 }

--- a/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
@@ -9,6 +9,8 @@ export default function SituationUpdateBanner({
   headline,
   showClose,
   content,
+  operatingStatusCta = false,
+  operatingStatusPage,
 }) {
   return (
     <va-banner
@@ -17,14 +19,23 @@ export default function SituationUpdateBanner({
       type={alertType}
       headline={headline}
       show-close={showClose}
-      disable-analytics
-      onclick={recordEvent({
-        event: 'nav-warning-alert-box-content-link-click',
-        alertBoxHeading: '{{ entity.title }}',
-      })}
     >
       {/* eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />
+      {operatingStatusCta &&
+        operatingStatusPage && (
+          <p>
+            <va-link
+              disable-analytics
+              onclick={recordEvent({
+                event: 'nav-warning-alert-box-content-link-click',
+                alertBoxHeading: headline,
+              })}
+              href={operatingStatusPage}
+              text="Get updates on affected services and facilities"
+            />
+          </p>
+        )}
     </va-banner>
   );
 }
@@ -34,5 +45,7 @@ SituationUpdateBanner.propTypes = {
   content: PropTypes.node.isRequired,
   headline: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  operatingStatusCta: PropTypes.bool,
+  operatingStatusPage: PropTypes.string,
   showClose: PropTypes.bool,
 };

--- a/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
@@ -13,7 +13,7 @@ export default function SituationUpdateBanner({
   return (
     <va-banner
       data-testid="situation-update-banner"
-      banner-id={id}
+      banner-id={`situation-update-banner-${id}`}
       type={alertType}
       headline={headline}
       show-close={showClose}

--- a/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
@@ -9,7 +9,11 @@ import { mount } from 'enzyme';
 import { mockApiRequest } from 'platform/testing/unit/helpers';
 
 import { BannerContainer } from '../bannerContainer';
-import { birmingham, maine } from './mocks/mockSituationUpdatesBanner';
+import {
+  birmingham,
+  birminghamWoContext,
+  maine,
+} from './mocks/mockSituationUpdatesBanner';
 
 const getData = ({ isLoading = false, useBanners = true } = {}) => ({
   featureToggles: {
@@ -43,6 +47,28 @@ describe('featureToggles allow banners', () => {
       done();
     }, 1000);
   });
+
+  it('should display the Birmingham banner and display link even without context', done => {
+    sinon.stub(window, 'location').value({
+      pathname:
+        '/birmingham-health-care/locations/birmingham-va-medical-center',
+    });
+    mockApiRequest(birminghamWoContext);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      const banner = wrapper.find('va-banner');
+      expect(banner.find('va-link')).to.have.length(1);
+      wrapper.unmount();
+      done();
+    }, 1500);
+  });
+
   it('should NOT display the Maine banner because toggles', done => {
     sinon.stub(window, 'location').value({ pathname: '/maine-health-care' });
     mockApiRequest(maine);

--- a/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
@@ -41,7 +41,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(1);
       wrapper.unmount();
       done();
-    }, 200);
+    }, 1000);
   });
   it('should NOT display the Maine banner because toggles', done => {
     sinon.stub(window, 'location').value({ pathname: '/maine-health-care' });
@@ -56,7 +56,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(0);
       wrapper.unmount();
       done();
-    }, 200);
+    }, 1000);
   });
   it('should NOT display the Faine banner because data does not exist', done => {
     sinon.stub(window, 'location').value({ pathname: '/faine-health-care' });
@@ -70,7 +70,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(0);
       wrapper.unmount();
       done();
-    }, 200);
+    }, 1000);
   });
 
   it('should display the Birmingham banner but accept with trailing slash', done => {
@@ -88,7 +88,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(1);
       wrapper.unmount();
       done();
-    }, 200);
+    }, 1000);
   });
 
   it('should accept accept manila-va-clinic but not display banner since none exists', done => {
@@ -103,6 +103,6 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(0);
       wrapper.unmount();
       done();
-    }, 200);
+    }, 1000);
   });
 });

--- a/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import sinon from 'sinon';
+import thunk from 'redux-thunk';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import { mockApiRequest } from 'platform/testing/unit/helpers';
+
+import { BannerContainer } from '../bannerContainer';
+import { birmingham, maine } from './mocks/mockSituationUpdatesBanner';
+
+const getData = ({ isLoading = false, useBanners = true } = {}) => ({
+  featureToggles: {
+    loading: isLoading,
+    bannerUseAlternativeBanners: useBanners,
+    // eslint-disable-next-line camelcase
+    banner_use_alternative_banners: useBanners,
+  },
+  subscribe: () => {},
+  dispatch: () => {},
+});
+
+describe('featureToggles allow banners', () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+
+  it('should display the Birmingham banner', done => {
+    sinon
+      .stub(window, 'location')
+      .value({ pathname: '/birmingham-health-care/operating-status' });
+    mockApiRequest(birmingham);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      wrapper.unmount();
+      done();
+    }, 0);
+  });
+  it('should NOT display the Maine banner because toggles', done => {
+    sinon.stub(window, 'location').value({ pathname: '/maine-health-care' });
+    mockApiRequest(maine);
+    const wrapper = mount(
+      <Provider store={mockStore(getData({ useBanners: false }))}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 0);
+  });
+  it('should NOT display the Faine banner because data does not exist', done => {
+    sinon.stub(window, 'location').value({ pathname: '/faine-health-care' });
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 0);
+  });
+
+  it('should display the Birmingham banner but accept with trailing slash', done => {
+    sinon
+      .stub(window, 'location')
+      .value({ pathname: '/birmingham-health-care/' });
+    mockApiRequest(birmingham);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      wrapper.unmount();
+      done();
+    }, 0);
+  });
+
+  it('should accept accept manila-va-clinic but not display banner since none exists', done => {
+    sinon.stub(window, 'location').value({ pathname: '/manila-va-clinic/' });
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 0);
+  });
+});

--- a/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
@@ -41,7 +41,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(1);
       wrapper.unmount();
       done();
-    }, 0);
+    }, 200);
   });
   it('should NOT display the Maine banner because toggles', done => {
     sinon.stub(window, 'location').value({ pathname: '/maine-health-care' });
@@ -56,7 +56,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(0);
       wrapper.unmount();
       done();
-    }, 0);
+    }, 200);
   });
   it('should NOT display the Faine banner because data does not exist', done => {
     sinon.stub(window, 'location').value({ pathname: '/faine-health-care' });
@@ -70,7 +70,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(0);
       wrapper.unmount();
       done();
-    }, 0);
+    }, 200);
   });
 
   it('should display the Birmingham banner but accept with trailing slash', done => {
@@ -88,7 +88,7 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(1);
       wrapper.unmount();
       done();
-    }, 0);
+    }, 200);
   });
 
   it('should accept accept manila-va-clinic but not display banner since none exists', done => {
@@ -103,6 +103,6 @@ describe('featureToggles allow banners', () => {
       expect(wrapper.find('va-banner')).to.have.length(0);
       wrapper.unmount();
       done();
-    }, 0);
+    }, 200);
   });
 });

--- a/src/applications/static-pages/situation-updates-banner/tests/createSituationUpdatesBanner.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/createSituationUpdatesBanner.unit.spec.js
@@ -3,9 +3,8 @@ import sinon from 'sinon';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
-import createSituationUpdatesBanner, {
-  BannerContainer,
-} from '../createSituationUpdatesBanner';
+import { BannerContainer } from '../bannerContainer';
+import createSituationUpdatesBanner from '../createSituationUpdatesBanner';
 import widgetTypes from '../../widgetTypes';
 
 describe('createSituationUpdatesBanner', () => {

--- a/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
@@ -77,3 +77,26 @@ export const maine = {
   path: '/maine-health-care',
   bannerType: 'full_width_banner_alert',
 };
+
+export const birminghamWoContext = {
+  banners: [
+    {
+      id: 28,
+      entityId: 75239,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'Birmingham Outpatient Clinic (Annex) Parking Deck Alert',
+      alertType: 'information',
+      showClose: false,
+      content:
+        '<p>Please be aware of the current renovations for the Birmingham Outpatient Clinic (Annex) Parking deck over the next six to seven months. Contractors will initiate construction from the top of the parking deck, progressing downwards through each floor in the following weeks and months.</p>\n',
+      operatingStatusCta: true,
+      emailUpdatesButton: true,
+      findFacilitiesCta: false,
+      limitSubpageInheritance: false,
+      createdAt: '2024-12-04T17:36:13.306Z',
+      updatedAt: '2024-12-04T17:36:13.306Z',
+    },
+  ],
+  path: '/birmingham-health-care/locations/birmingham-va-medical-center',
+  bannerType: 'full_width_banner_alert',
+};

--- a/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
@@ -1,0 +1,79 @@
+export const birmingham = {
+  banners: [
+    {
+      id: 28,
+      entityId: 75239,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'Birmingham Outpatient Clinic (Annex) Parking Deck Alert',
+      alertType: 'information',
+      showClose: false,
+      content:
+        '<p>Please be aware of the current renovations for the Birmingham Outpatient Clinic (Annex) Parking deck over the next six to seven months. Contractors will initiate construction from the top of the parking deck, progressing downwards through each floor in the following weeks and months.</p>\n',
+      context: [
+        {
+          entity: {
+            title: 'Operating status | VA Birmingham health care',
+            entityUrl: {
+              path: '/birmingham-health-care/operating-status',
+            },
+            fieldOffice: {
+              entity: {
+                title: 'VA Birmingham health care',
+                entityUrl: {
+                  path: '/birmingham-health-care',
+                },
+                fieldVamcEhrSystem: 'vista',
+              },
+            },
+          },
+        },
+      ],
+      operatingStatusCta: true,
+      emailUpdatesButton: true,
+      findFacilitiesCta: false,
+      limitSubpageInheritance: false,
+      createdAt: '2024-12-04T17:36:13.306Z',
+      updatedAt: '2024-12-04T17:36:13.306Z',
+    },
+  ],
+  path: '/birmingham-health-care/operating-status',
+  bannerType: 'full_width_banner_alert',
+};
+
+export const maine = {
+  banners: [
+    {
+      id: 17,
+      entityId: 72825,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'No-Cost VA Flu/COVID Shots for Eligible Veterans',
+      alertType: 'information',
+      showClose: true,
+      content:
+        '<p>Visit one of VA Maine\'s upcoming Drive-Up Flu/COVID events to get your flu shot this flu season: <a href="https://www.va.gov/maine-health-care/news-releases/no-cost-va-flu-shots-for-eligible-veterans-0/"><strong>No-Cost VA Flu/COVID Shots for Eligible Veterans</strong>&nbsp;</a></p>\n',
+      context: [
+        {
+          entity: {
+            title: 'Operating status | VA Maine health care',
+            entityUrl: { path: '/maine-health-care/operating-status' },
+            fieldOffice: {
+              entity: {
+                title: 'VA Maine health care',
+                entityUrl: { path: '/maine-health-care' },
+                fieldVamcEhrSystem: 'vista',
+              },
+            },
+          },
+        },
+      ],
+      operatingStatusCta: false,
+      emailUpdatesButton: false,
+      findFacilitiesCta: false,
+      limitSubpageInheritance: false,
+      createdAt: '2024-12-04T17:36:13.248Z',
+      updatedAt: '2024-12-04T17:36:13.248Z',
+    },
+  ],
+  path: '/maine-health-care',
+  bannerType: 'full_width_banner_alert',
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Updated Situation Banner component to use vets-api resource /v0/banners, broke out helper function for possible stubbing, added tests.
- Sitewide team
- Uses CMS flipper for whether to use data-widget-type on content-build and vets-api flipper `banner_use_alternative_banners`
 
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19842

## Testing done

- Manual testing (Banners::UpdateAll run on local vets-api from staging CMS, tested several types of banners). Tested with toggle on vets-api on and off. Tested building with and without CMS feature toggle on. Tested on health-care sub pages (Facilities and others) and on va-manila-clinic pages.
- Added unit tests to cover 94.56% of lines

## Screenshots

<details>
<summary>Birmingham - Info Banner - not dismissible - desktop</summary>
<img width="1728" alt="Screenshot 2024-12-05 at 8 53 29 PM" src="https://github.com/user-attachments/assets/910085eb-ca92-479d-9e69-3e29cb2c58a1">
<img width="1728" alt="Screenshot 2024-12-05 at 8 54 11 PM" src="https://github.com/user-attachments/assets/b1b85f0a-bec5-4bf2-b7a2-bf33656e3e34">
</details>

<details>
<summary>Birmingham - Info Banner - not dismissible - 481px</summary>
<img width="1728" alt="Screenshot 2024-12-05 at 8 54 42 PM" src="https://github.com/user-attachments/assets/caff2591-3603-4f4f-8fd8-41a59182c089">
</details>

<details>
<summary>Maine - Info Banner - dismissible - desktop </summary>
<img width="1728" alt="Screenshot 2024-12-05 at 8 53 38 PM" src="https://github.com/user-attachments/assets/0bcc01d7-016d-4ae5-932e-58b4dce5dd15">
<img width="1728" alt="Screenshot 2024-12-05 at 8 53 58 PM" src="https://github.com/user-attachments/assets/b2ee1140-d243-447d-9354-191c3285ecb4">
</details>

<details>
<summary>Maine - Info Banner - dismissible - 481px</summary>
<img width="1728" alt="Screenshot 2024-12-05 at 8 54 54 PM" src="https://github.com/user-attachments/assets/855b5d29-4870-4d36-8ad4-f39c9a801662">
</details>


<details>
<summary>Birmingham - Info Banner - operating status page</summary>
<img width="1728" alt="Screenshot 2024-12-05 at 9 20 50 PM" src="https://github.com/user-attachments/assets/67362904-1f22-40dd-a8a5-40f0376ef4a3">
</details>


<details>
<summary></summary>
</details>


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
