### PR TITLE
Add Referral Time taken

### DIFF
--- a/src/applications/vaos/referral-appointments/ConfirmReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ConfirmReferral.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { clearReferralTimer, getReferralElapsedSeconds } from './utils/timer';
+import ReferralLayout from './components/ReferralLayout';
+
+export default function ConfirmReferral(props) {
+  const { currentReferral } = props;
+  return (
+    <ReferralLayout>
+      <h1>Confirm Referral for {currentReferral.CategoryOfCare}</h1>
+      <p>{currentReferral.UUID}</p>
+      <va-button
+        className="va-button-link"
+        onClick={() => {
+          const referralTimeTaken = getReferralElapsedSeconds(
+            currentReferral.UUID,
+          );
+          // eslint-disable-next-line no-alert
+          alert(`Referral Confirmed and took ${referralTimeTaken} seconds`);
+          clearReferralTimer(currentReferral.UUID);
+        }}
+        text="Confirm"
+        uswds
+      />
+    </ReferralLayout>
+  );
+}
+ConfirmReferral.propTypes = {
+  currentReferral: PropTypes.object.isRequired,
+};

--- a/src/applications/vaos/referral-appointments/flow.js
+++ b/src/applications/vaos/referral-appointments/flow.js
@@ -1,3 +1,5 @@
+import { startReferralTimer } from './utils/timer';
+
 /**
  * Function to get referral page flow.
  *
@@ -50,6 +52,10 @@ export function routeToPageInFlow(history, current, action, referralId) {
   const pageFlow = getPageFlow(referralId);
   const nextPageString = pageFlow[current][action];
   const nextPage = pageFlow[nextPageString];
+
+  if (action === 'next' && nextPageString === 'scheduleReferral') {
+    startReferralTimer(referralId);
+  }
 
   if (nextPage?.url) {
     history.push(nextPage.url);

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import ScheduleReferral from './ScheduleReferral';
 import ConfirmApprovedPage from './ConfirmApprovedPage';
+import ConfirmReferral from './ConfirmReferral';
 import ChooseDateAndTime from './ChooseDateAndTime';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 import { selectFeatureCCDirectScheduling } from '../redux/selectors';
@@ -87,6 +88,10 @@ export default function ReferralAppointments() {
           path={`${basePath.url}/date-time/`}
           component={ChooseDateAndTime}
         />
+        {/* TODO: remove this mock page when referral complete page is built */}
+        <Route path={`${basePath.url}/confirm`}>
+          <ConfirmReferral currentReferral={referral} />
+        </Route>
         <Route path={`${basePath.url}`} search={id}>
           <ScheduleReferral currentReferral={referral} />
         </Route>

--- a/src/applications/vaos/referral-appointments/tests/utils/timer.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/utils/timer.unit.spec.js
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+
+const timerUtil = require('../../utils/timer');
+
+describe('VAOS referral timer util', () => {
+  const TEST_ID = '12345';
+  const KEY_PREFIX = 'referral_start_time_';
+  const TEST_KEY = `${KEY_PREFIX}${TEST_ID}`;
+
+  beforeEach(() => {
+    // Clear sessionStorage before each test
+    sessionStorage.clear();
+  });
+
+  describe('startReferralTimer', () => {
+    it('should not set a value if no ID is provided', () => {
+      timerUtil.startReferralTimer();
+      expect(sessionStorage.length).to.equal(0);
+    });
+
+    it('should set the current time in sessionStorage for the given ID', () => {
+      timerUtil.startReferralTimer(TEST_ID);
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.be.a('string');
+      expect(new Date(storedTime).toISOString()).to.equal(storedTime);
+    });
+
+    it('should not overwrite the start time if it already exists', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      sessionStorage.setItem(TEST_KEY, initialTime);
+
+      timerUtil.startReferralTimer(TEST_ID);
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.equal(initialTime);
+    });
+  });
+
+  describe('getReferralElapsedSeconds', () => {
+    it('should return 0 if no ID is provided', () => {
+      const elapsed = timerUtil.getReferralElapsedSeconds();
+      expect(elapsed).to.equal(0);
+    });
+
+    it('should return 0 if no start time exists for the given ID', () => {
+      const elapsed = timerUtil.getReferralElapsedSeconds(TEST_ID);
+      expect(elapsed).to.equal(0);
+    });
+
+    it('should return the elapsed seconds since the start time', () => {
+      const now = new Date();
+      const pastTime = new Date(now.getTime() - 5000).toISOString(); // 5 seconds ago
+      sessionStorage.setItem(TEST_KEY, pastTime);
+
+      const elapsed = timerUtil.getReferralElapsedSeconds(TEST_ID);
+      expect(elapsed).to.be.closeTo(5, 1); // Allow a small margin of error
+    });
+  });
+
+  describe('clearReferralTimer', () => {
+    it('should not clear anything if no ID is provided', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      sessionStorage.setItem(TEST_KEY, initialTime);
+
+      timerUtil.clearReferralTimer();
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.equal(initialTime);
+    });
+
+    it('should clear the start time for the given ID', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      sessionStorage.setItem(TEST_KEY, initialTime);
+
+      timerUtil.clearReferralTimer(TEST_ID);
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.be.null;
+    });
+
+    it('should not affect other keys in sessionStorage', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      const otherKey = `${KEY_PREFIX}67890`;
+      sessionStorage.setItem(TEST_KEY, initialTime);
+      sessionStorage.setItem(otherKey, initialTime);
+
+      timerUtil.clearReferralTimer(TEST_ID);
+
+      const storedOtherTime = sessionStorage.getItem(otherKey);
+      expect(storedOtherTime).to.equal(initialTime);
+    });
+  });
+});

--- a/src/applications/vaos/referral-appointments/utils/timer.js
+++ b/src/applications/vaos/referral-appointments/utils/timer.js
@@ -1,0 +1,66 @@
+/**
+ * Prefix for session storage keys related to referral start times.
+ * @constant {string}
+ */
+const KEY_PREFIX = 'referral_start_time_';
+
+/**
+ * Starts the referral timer for a given ID.
+ * If a start time already exists in session storage, it will not be overwritten.
+ *
+ * @param {string} id - The unique identifier for the referral.
+ * @returns {void}
+ */
+const startReferralTimer = id => {
+  if (!id) {
+    return;
+  }
+  const key = KEY_PREFIX + id;
+  // If time already exist within the session don't re set it to a later date.
+  const existingStartTime = sessionStorage.getItem(key);
+  if (existingStartTime) {
+    return;
+  }
+
+  const now = new Date();
+  sessionStorage.setItem(key, now.toISOString());
+};
+
+/**
+ * Gets the elapsed time in seconds since the referral timer started for a given ID.
+ * Returns 0 if no start time exists or if the ID is invalid.
+ *
+ * @param {string} id - The unique identifier for the referral.
+ * @returns {number} The elapsed time in seconds, or 0 if no start time exists.
+ */
+const getReferralElapsedSeconds = id => {
+  if (!id) {
+    return 0;
+  }
+  const key = KEY_PREFIX + id;
+  const savedStartTime = sessionStorage.getItem(key);
+
+  if (!savedStartTime) {
+    return 0;
+  }
+
+  const now = new Date();
+  const savedDate = new Date(savedStartTime);
+  return Math.floor((now.getTime() - savedDate.getTime()) / 1000); // Elapsed time in seconds
+};
+
+/**
+ * Clears the referral timer for a given ID.
+ *
+ * @param {string} id - The unique identifier for the referral.
+ * @returns {void}
+ */
+const clearReferralTimer = id => {
+  if (!id) {
+    return;
+  }
+  const key = KEY_PREFIX + id;
+  sessionStorage.removeItem(key);
+};
+
+export { getReferralElapsedSeconds, startReferralTimer, clearReferralTimer };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Create a `timer` utility that records the start time of a referral and calculates the total time taken for a referral
- Create a mock page that calls the timer utility to get the total time in seconds the referral took to complete
- Hook into the navigation flow to trigger the start of a referral using the timer utility

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#96815

## Testing done

- Unit tests

Test Plan 

GIVEN CC feature flag is on 
WHEN I Visit http://localhost:3001/my-health/appointments/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801
AND I click on "Go to your referral details to start scheduling" in the Referral Task Card
AND I am redirected to the next page in the flow 
AND I visit http://localhost:3001/my-health/appointments/schedule-referral/confirm/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801
AND I press the "Confirm" button 
THEN I should se an alert that tells me how many seconds ago I clicked on "Go to your referral details to start scheduling" in the Referral Task Card


## What areas of the site does it impact?

- VAOS

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Mock referral complete page was created that has a simple button that shows the total time taken and clears the timer. This page will be removed once actual page and flow is built.
Actual flow does not yet exist and we are mocking this using a mock page.
