### PR TITLE
remove update 5490 link for now due to link location

### DIFF
--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -80,11 +80,6 @@ class EducationWizard extends React.Component {
         url = `/education/apply-for-education-benefits/application/1990`;
         break;
       case '5490':
-        if (this?.props.meb160630Automation) {
-          url = `/education/survivor-dependent-education-benefit-22-5490`;
-          break;
-        }
-
         url = `/family-and-caregiver-benefits/education-and-careers/apply-dea-fry-form-22-5490`;
         break;
       default:


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove new link for 5490 from education wizard due to issues with link location

