### PR TITLE
98329 Dynamic pronoun usage - form 10-7959C

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -22,7 +22,12 @@ fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
 export const applicantNameDobSchema = {
   uiSchema: {
-    ...titleUI('Beneficiary’s name'),
+    ...titleUI(
+      ({ formData }) =>
+        `${
+          formData.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
+        } name`,
+    ),
     applicantName: fullNameMiddleInitialUI,
   },
   schema: {
@@ -70,6 +75,7 @@ export const applicantAddressInfoSchema = {
     applicantNewAddress: {
       ...radioUI({
         updateUiSchema: formData => {
+          const name = nameWording(formData, undefined, false, true);
           const labels = {
             yes: 'Yes',
             no: 'No',
@@ -77,12 +83,9 @@ export const applicantAddressInfoSchema = {
           };
 
           return {
-            'ui:title': `Has ${nameWording(
-              formData,
-              undefined,
-              undefined,
-              true,
-            )} mailing address changed since their last CHAMPVA form submission?`,
+            'ui:title': `Has ${name} mailing address changed since ${
+              name === 'your' ? name : 'their'
+            } last CHAMPVA form submission?`,
             'ui:options': {
               labels,
               hint: `If yes, we will update our records with the new mailing address.`,
@@ -145,7 +148,7 @@ export const applicantGenderSchema = {
             'ui:title': `What's ${nameWording(
               formData,
               undefined,
-              undefined,
+              false,
               true,
             )} sex listed at birth?`,
             'ui:options': {
@@ -153,7 +156,7 @@ export const applicantGenderSchema = {
               hint: `Enter the sex that appears on ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} birth certificate.`,
             },

--- a/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
@@ -6,32 +6,15 @@ import {
 
 export const formSignatureSchema = {
   uiSchema: {
-    ...titleUI('Signer information'),
+    ...titleUI('Your information'),
     certifierRole: {
       ...radioUI({
-        updateUiSchema: formData => {
-          const labels = {
-            applicant: `I'm ${
-              formData?.applicantName?.first
-            } and I'm signing for myself`,
-            other: `I'm a parent, spouse, or legal representative signing on behalf of ${
-              formData?.applicantName?.first
-            }`,
-          };
-
-          return {
-            'ui:title': `Who’s signing this form for ${
-              formData?.applicantName?.first
-            }?`,
-            'ui:options': {
-              labels,
-            },
-          };
-        },
+        title: 'Which of these best describes you?',
         required: () => true,
         labels: {
-          applicant: 'The beneficiary',
-          other: 'A representative on behalf of the beneficiary',
+          applicant: 'I’m filling out this form for myself',
+          other:
+            'I’m a parent, spouse, or legal representative signing on behalf of the beneficiary',
         },
       }),
     },

--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
@@ -12,7 +12,7 @@ import {
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { nameWording } from '../helpers/utilities';
+import { nameWording, nameWordingExt } from '../helpers/utilities';
 import {
   fileWithMetadataSchema,
   fileUploadBlurb,
@@ -58,12 +58,9 @@ export function applicantHasInsuranceSchema(isPrimary) {
         ...yesNoUI({
           updateUiSchema: formData => {
             return {
-              'ui:title': `Does ${nameWording(
-                formData,
-                false,
-                undefined,
-                true,
-              )} have ${
+              'ui:title': `${
+                formData.certifierRole === 'applicant' ? 'Do' : 'Does'
+              } ${nameWording(formData, false, false, true)} have ${
                 isPrimary ? '' : 'any other'
               } medical health insurance information to provide or update at this time?`,
               'ui:options': {
@@ -154,7 +151,7 @@ export function applicantInsuranceThroughEmployerSchema(isPrimary) {
               'ui:title': `Is this insurance through ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} employer?`,
             };
@@ -195,7 +192,7 @@ export function applicantInsurancePrescriptionSchema(isPrimary) {
               'ui:title': `Does ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} health insurance cover prescriptions?`,
               'ui:options': {
@@ -238,7 +235,7 @@ export function applicantInsuranceEobSchema(isPrimary) {
               'ui:title': `Does ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} health insurance have an explanation of benefits (EOB) for prescriptions?`,
               'ui:options': {
@@ -328,16 +325,15 @@ export function applicantInsuranceTypeSchema(isPrimary) {
           },
           required: () => true,
           updateUiSchema: formData => {
+            const wording = nameWordingExt(formData);
             return {
-              'ui:title': `Select the type of insurance plan or program ${nameWording(
-                formData,
-                false,
-                undefined,
-                true,
-              )} is enrolled in`,
+              'ui:title': `Select the type of insurance plan or program ${
+                wording.beingVerb
+              } enrolled in`,
               'ui:options': {
-                hint:
-                  'You may find this information on the front of your health insurance card.',
+                hint: `You may find this information on the front of ${
+                  wording.posessive
+                } health insurance card.`,
               },
             };
           },
@@ -378,13 +374,11 @@ export function applicantMedigapSchema(isPrimary) {
           required: () => true,
           labels: MEDIGAP,
           updateUiSchema: formData => {
+            const wording = nameWordingExt(formData);
             return {
-              'ui:title': `Select the Medigap plan ${nameWording(
-                formData,
-                false,
-                undefined,
-                true,
-              )} is enrolled in`,
+              'ui:title': `Select the Medigap plan ${
+                wording.beingVerb
+              } enrolled in`,
             };
           },
         }),
@@ -421,7 +415,7 @@ export function applicantInsuranceCommentsSchema(isPrimary) {
             'ui:title': `Any additional comments about ${nameWording(
               formData,
               undefined,
-              undefined,
+              false,
               true,
             )} health insurance?`,
           };

--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -37,10 +37,12 @@ export const applicantHasMedicareSchema = {
       ...yesNoUI({
         updateUiSchema: formData => {
           return {
-            'ui:title': `Does ${nameWording(
+            'ui:title': `${
+              formData.certifierRole === 'applicant' ? 'Do' : 'Does'
+            } ${nameWording(
               formData,
               false,
-              undefined,
+              false,
               true,
             )} have Medicare information to provide or update at this time?`,
             'ui:options': { hint: additionalFilesHint },
@@ -79,12 +81,9 @@ export const applicantMedicareClassSchema = {
         },
         updateUiSchema: formData => {
           return {
-            'ui:title': `Which Medicare plan is ${nameWording(
-              formData,
-              false,
-              false,
-              true,
-            )} enrolled in?`,
+            'ui:title': `Which Medicare plan ${
+              formData.certifierRole === 'applicant' ? 'are' : 'is'
+            } ${nameWording(formData, false, false, true)} enrolled in?`,
             'ui:options': {
               hint:
                 'You can find this information on the front of your Medicare card.',
@@ -121,7 +120,7 @@ export const applicantMedicarePharmacySchema = {
             'ui:title': `Does ${nameWording(
               formData,
               undefined,
-              undefined,
+              false,
               true,
             )} Medicare plan provide pharmacy benefits?`,
             'ui:options': {
@@ -217,7 +216,7 @@ export const applicantMedicareABUploadSchema = {
     ...titleUI(
       'Upload Medicare card for hospital and medical coverage',
       ({ formData }) => {
-        const appName = nameWording(formData, undefined, undefined, true);
+        const appName = nameWording(formData, undefined, false, true);
         return (
           <>
             You’ll need to submit a copy of the front and back of {appName}{' '}
@@ -279,10 +278,12 @@ export const applicantHasMedicareDSchema = {
       ...yesNoUI({
         updateUiSchema: formData => {
           return {
-            'ui:title': `Does ${nameWording(
+            'ui:title': `${
+              formData.certifierRole === 'applicant' ? 'Do' : 'Does'
+            } ${nameWording(
               formData,
               false,
-              undefined,
+              false,
               true,
             )} have Medicare Part D information to provide or update at this time?`,
             'ui:options': { hint: additionalFilesHint },
@@ -331,7 +332,7 @@ export const applicantMedicarePartDCarrierSchema = {
 export const applicantMedicareDUploadSchema = {
   uiSchema: {
     ...titleUI('Upload Medicare Part D card', ({ formData }) => {
-      const appName = nameWording(formData, undefined, undefined, true);
+      const appName = nameWording(formData, undefined, false, true);
       return (
         <>
           You’ll need to submit a copy of the front and back of {appName}{' '}

--- a/src/applications/ivc-champva/10-7959C/components/FileUploadWrapper.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/FileUploadWrapper.jsx
@@ -1,5 +1,5 @@
 import FileFieldCustom from '../../shared/components/fileUploads/FileUpload';
-import { requiredFiles, UPLOADS_COMPLETE_PATH } from '../config/constants';
+import { requiredFiles } from '../config/constants';
 
 // Wrap shared fileFieldCustom so we can pass the form-specific
 // list of required uploads (for use with MissingFileOverview)
@@ -7,8 +7,5 @@ export default function FileFieldWrapped(props) {
   return FileFieldCustom({
     ...props,
     requiredFiles,
-    // Since `MissingFileOverview` isn't the last page in this form, go to the
-    // appropriate next page after all uploads are complete:
-    uploadsCompletePath: UPLOADS_COMPLETE_PATH,
   });
 }

--- a/src/applications/ivc-champva/10-7959C/config/constants.js
+++ b/src/applications/ivc-champva/10-7959C/config/constants.js
@@ -1,8 +1,5 @@
 import React from 'react';
 
-// When all files shown on `MissingFileOverview` are uploaded, go here next:
-export const UPLOADS_COMPLETE_PATH = 'form-signature';
-
 /* List of required files - not enforced by the form because we want
 users to be able to opt into mailing these documents. This object 
 performs double duty by also providing a map to presentable names. */

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -46,7 +46,6 @@ import {
 
 import { formSignatureSchema } from '../chapters/formSignature';
 import CustomAttestation from '../components/CustomAttestation';
-import { UPLOADS_COMPLETE_PATH } from './constants';
 
 import GetFormHelp from '../../shared/components/GetFormHelp';
 import { hasReq } from '../../shared/components/fileUploads/MissingFileOverview';
@@ -126,13 +125,26 @@ const formConfig = {
   subTitle: 'CHAMPVA Other Health Insurance Certification (VA Form 10-7959c)',
   defaultDefinitions: {},
   chapters: {
+    formSignature: {
+      title: 'Signer information',
+      pages: {
+        formSignature: {
+          path: 'form-signature',
+          title: 'Form signature',
+          ...formSignatureSchema,
+        },
+      },
+    },
     applicantInformation: {
       title: 'Beneficiary information',
       pages: {
         applicantNameDob: {
           // initialData: mockdata.data,
           path: 'applicant-info',
-          title: 'Beneficiary’s name',
+          title: formData =>
+            `${
+              formData.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
+            } name`,
           ...applicantNameDobSchema,
         },
         applicantIdentity: {
@@ -467,16 +479,6 @@ const formConfig = {
             },
           },
           schema: blankSchema,
-        },
-      },
-    },
-    formSignature: {
-      title: 'Form signature',
-      pages: {
-        formSignature: {
-          path: UPLOADS_COMPLETE_PATH,
-          title: 'Form signature',
-          ...formSignatureSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959C/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-7959C/helpers/utilities.js
@@ -22,6 +22,14 @@ export function nameWording(
   return sharedNameWording(formData, isPosessive, cap, firstNameOnly);
 }
 
+export function nameWordingExt(formData) {
+  const posessive = nameWording(formData, true, false, true);
+  const nonPosessive = nameWording(formData, false, false, true);
+  const beingVerb =
+    nonPosessive === 'you' ? `${nonPosessive}’re` : `${nonPosessive} is`;
+  return { posessive, nonPosessive, beingVerb };
+}
+
 /**
  * Retrieves an array of objects containing the property 'attachmentId'
  * from the given object.

--- a/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
@@ -27,7 +27,6 @@ const testConfig = createTestConfig(
     // Rename and modify the test data as needed.
     /* 
     1. test-data: standard run-through of the form
-    2. no-secondary: no secondary insurance (skips all secondary ins pages) 
     The rest of the tests are described by their filenames and are just
     variations designed to trigger the conditionals in the form/follow different paths. 
     */

--- a/src/applications/ivc-champva/10-7959C/tests/helpers/utilities.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/helpers/utilities.unit.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   isRequiredFile,
   nameWording,
+  nameWordingExt,
   getObjectsWithAttachmentId,
 } from '../../helpers/utilities';
 import { requiredFiles } from '../../config/constants';
@@ -50,6 +51,14 @@ describe('nameWording', () => {
         false, // capitalize
       ),
     ).to.equal('John William Ferrell');
+  });
+});
+
+describe('nameWordingExt', () => {
+  it("should set `beingVerb` to 'you’re' if certifierRole is 'applicant'", () => {
+    expect(nameWordingExt({ certifierRole: 'applicant' }).beingVerb).to.equal(
+      'you’re',
+    );
   });
 });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates copy in several places so that it addresses the user as "You/r" depending on context.

- Moves signer info page to front of form
- Updates pronoun usage in multiple places so that it says `your` or `<FIRSTNAME>` appropriately
- Added new convenience func and unit test

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98329

## Testing done

- Manual
- Unit
- E2E passed

## Screenshots

The below screenshots are not comprehensive, but are indicative of the changes made across the form:

|         | Is third party | Is applicant |
| ------- | ------ | ----- |
| Mailing address 1 |![before1](https://github.com/user-attachments/assets/f18bbead-400f-492e-abeb-cc657e51a58c)|![after1](https://github.com/user-attachments/assets/6f9b0a2a-1e3f-4e46-b33d-de36a576edeb)|
| Mailing address 2 |![before2](https://github.com/user-attachments/assets/e0ac4526-cc6d-4528-b70d-c3a8c70e3043)|![after2](https://github.com/user-attachments/assets/abae0cd4-97df-4e7f-99d2-551bc56707cf)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA