### PR TITLE
Updating GHA action to use a more stable version of actions/download-artifact

### DIFF
--- a/src/applications/ask-va/config/helpers.jsx
+++ b/src/applications/ask-va/config/helpers.jsx
@@ -342,7 +342,10 @@ export const isLocationOfResidenceRequired = data => {
 
   // Check general question
   // eslint-disable-next-line sonarjs/prefer-single-boolean-return
-  if (whoIsYourQuestionAbout === whoIsYourQuestionAboutLabels.GENERAL) {
+  if (
+    (GuardianshipAndVRE || EducationAndVRE) &&
+    whoIsYourQuestionAbout === whoIsYourQuestionAboutLabels.GENERAL
+  ) {
     return true;
   }
 
@@ -456,6 +459,13 @@ export const isPostalCodeRequired = data => {
     return true;
   }
 
+  if (
+    selectCategory === 'Health care' &&
+    whoIsYourQuestionAbout === whoIsYourQuestionAboutLabels.GENERAL
+  ) {
+    return true;
+  }
+
   // Default to false if none of the conditions are met
   return false;
 };
@@ -498,5 +508,29 @@ export const isVRERequired = data => {
     selectCategory === CategoryVeteranReadinessAndEmployment ||
     (selectCategory === CategoryEducation &&
       selectTopic === TopicVeteranReadinessAndEmploymentChapter31)
+  );
+};
+
+export const isHealthFacilityRequired = data => {
+  const { selectCategory, selectTopic, whoIsYourQuestionAbout } = data;
+
+  const healthTopics = [
+    'Prosthetics',
+    'Audiology and hearing aids',
+    'Getting care at a local VA medical center',
+  ];
+
+  if (
+    selectCategory === 'Health care' &&
+    whoIsYourQuestionAbout === whoIsYourQuestionAboutLabels.GENERAL
+  ) {
+    return false;
+  }
+
+  return (
+    (selectCategory === 'Health care' && healthTopics.includes(selectTopic)) ||
+    (selectCategory ===
+      'Debt for benefit overpayments and health care copay bills' &&
+      selectTopic === 'Health care copay debt')
   );
 };

--- a/src/applications/ask-va/config/schema-helpers/formFlowHelper.js
+++ b/src/applications/ask-va/config/schema-helpers/formFlowHelper.js
@@ -3,7 +3,6 @@ import {
   CategoryEducation,
   CHAPTER_2,
   CHAPTER_3,
-  healthcareCategoryLabels,
   schoolInYourProfileOptions,
   yourRoleOptionsEducation,
 } from '../../constants';
@@ -13,6 +12,7 @@ import {
   isPostalCodeRequired,
   isStateOfPropertyRequired,
   isVRERequired,
+  isHealthFacilityRequired,
 } from '../helpers';
 
 // Personal Information
@@ -302,7 +302,7 @@ const ch3Pages = {
     CustomPageReview: CustomPageReviewField,
   },
   yourVAHealthFacility: {
-    depends: form => healthcareCategoryLabels.includes(form.selectCategory),
+    depends: form => isHealthFacilityRequired(form),
     path: CHAPTER_3.YOUR_VA_HEALTH_FACILITY.PATH,
     title: CHAPTER_3.YOUR_VA_HEALTH_FACILITY.TITLE,
     CustomPage: YourVAHealthFacilityPage,

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -40,6 +40,7 @@ import {
   isUploadingSTR,
   needsToEnter781,
   needsToEnter781a,
+  showAdditionalFormsChapter,
   showPtsdCombat,
   showPtsdNonCombat,
   showSeparationLocation,
@@ -109,7 +110,10 @@ import {
   veteranInfo,
   workBehaviorChanges,
 } from '../pages';
+import * as additionalFormsChapterWrapper from '../pages/additionalFormsChapterWrapper';
+
 import { toxicExposurePages } from '../pages/toxicExposure/toxicExposurePages';
+import { form0781PagesConfig } from './form0781/index';
 
 import { ancillaryFormsWizardDescription } from '../content/ancillaryFormsWizardIntro';
 
@@ -615,6 +619,19 @@ const formConfig = {
           uiSchema: summaryOfDisabilities.uiSchema,
           schema: summaryOfDisabilities.schema,
         },
+      },
+    },
+    additionalForms: {
+      title: 'Additional Forms',
+      pages: {
+        additionalFormsChapterWrapper: {
+          title: 'Additional forms to support your claim',
+          path: 'additional-forms',
+          depends: formData => showAdditionalFormsChapter(formData),
+          uiSchema: additionalFormsChapterWrapper.uiSchema,
+          schema: additionalFormsChapterWrapper.schema,
+        },
+        ...form0781PagesConfig,
       },
     },
     supportingEvidence: {

--- a/src/applications/disability-benefits/all-claims/config/form0781/index.js
+++ b/src/applications/disability-benefits/all-claims/config/form0781/index.js
@@ -1,0 +1,16 @@
+import * as workflowChoicePage from '../../pages/form0781/workflowChoicePage';
+import { showForm0781Pages } from '../../utils/form0781';
+
+/**
+ * Configuration for our modern 0781 paper sync (2024/2025)
+ *
+ * @returns Object
+ */
+export const form0781PagesConfig = {
+  workflowChoicePage: {
+    path: 'additional-forms/mental-health-statement',
+    depends: formData => showForm0781Pages(formData),
+    uiSchema: workflowChoicePage.uiSchema,
+    schema: workflowChoicePage.schema,
+  },
+};

--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -1,0 +1,1 @@
+export const additionalFormsTitle = 'Additional Forms';

--- a/src/applications/disability-benefits/all-claims/pages/additionalFormsChapterWrapper.js
+++ b/src/applications/disability-benefits/all-claims/pages/additionalFormsChapterWrapper.js
@@ -1,0 +1,9 @@
+// TODO: this is a placeholder. Structure will be added to this page in this ticket #97065
+export const uiSchema = {
+  'ui:description': 'Placeholder Text for Start Page',
+};
+
+export const schema = {
+  type: 'object',
+  properties: {},
+};

--- a/src/applications/disability-benefits/all-claims/pages/form0781/workflowChoicePage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/workflowChoicePage.js
@@ -1,0 +1,9 @@
+// TODO: this is a placeholder. Structure will be added to this page in this ticket #97067
+export const uiSchema = {
+  'ui:description': 'Placeholder Text for workflow choice page',
+};
+
+export const schema = {
+  type: 'object',
+  properties: {},
+};

--- a/src/applications/disability-benefits/all-claims/tests/config/form0781.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/config/form0781.unit.spec.js
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+
+import { form0781PagesConfig } from '../../config/form0781/index';
+
+describe('the form0781PagesConfig entry point object', () => {
+  it('should return a config object', () => {
+    expect(form0781PagesConfig).to.be.an('object');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalFormsChapterWrapper.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalFormsChapterWrapper.unit.spec.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as additionalFormsChapterWrapper from '../../pages/additionalFormsChapterWrapper';
+
+describe('Additional Forms chapter wrapper page', () => {
+  it('should define a uiSchema object', () => {
+    expect(additionalFormsChapterWrapper.uiSchema).to.be.an('object');
+  });
+
+  it('should define a schema object', () => {
+    expect(additionalFormsChapterWrapper.schema).to.be.an('object');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/workflowChoicePage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/workflowChoicePage.unit.spec.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as workflowChoicePage from '../../../pages/form0781/workflowChoicePage';
+
+describe('Form 0781 workflow choice page', () => {
+  it('should define a uiSchema object', () => {
+    expect(workflowChoicePage.uiSchema).to.be.an('object');
+  });
+
+  it('should define a schema object', () => {
+    expect(workflowChoicePage.schema).to.be.an('object');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/utils/form0781.js
+++ b/src/applications/disability-benefits/all-claims/utils/form0781.js
@@ -1,0 +1,25 @@
+// All flippers for the 0781 Papersync should be added to this file
+import { isClaimingNew } from '.';
+
+/**
+ * Checks if the modern 0781 flow should be shown if the flipper is active for this veteran
+ * All 0781 page-specific flippers should include a check against this top level flipper
+ *
+ * @returns
+ *   TRUE if
+ *     - is set on form via the backend
+ *     - Veteran is claiming a new disability
+ *     - Veteran has selected connected condition choices on 'screener page'
+ *   else
+ *     - returns false
+ */
+export function showForm0781Pages(formData) {
+  const conditions = formData?.mentalHealth?.conditions || {};
+  return (
+    formData?.syncModern0781Flow === true &&
+    isClaimingNew(formData) &&
+    Object.entries(conditions).some(
+      ([key, value]) => key !== 'none' && value === true,
+    )
+  );
+}

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -394,6 +394,11 @@ export const hasNewPtsdDisability = formData =>
     isDisabilityPtsd(disability.condition),
   );
 
+// NOTE: this will need to be updated or removed when we have a usecase for the
+// Additional Forms chapter beyond the new 0781 flow
+export const showAdditionalFormsChapter = formData =>
+  formData?.syncModern0781Flow === true;
+
 export const showPtsdCombat = formData =>
   hasNewPtsdDisability(formData) &&
   _.get('view:selectablePtsdTypes.view:combatPtsdType', formData, false);

--- a/src/applications/discover-your-benefits/components/NoResultsBanner.jsx
+++ b/src/applications/discover-your-benefits/components/NoResultsBanner.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const NoResultsBanner = ({ data, handleBackClick }) => (
+const NoResultsBanner = ({ handleBackClick }) => (
   <va-banner
     className="response-no-results"
     headline="No Results Found"
@@ -9,21 +9,18 @@ const NoResultsBanner = ({ data, handleBackClick }) => (
     visible
   >
     <p>
-      <>
-        {data && data.length > 0
-          ? "We're unable to recomend benefits based on your responses. You can "
-          : "We're unable to recomend benefits that match your filters. You can adjust your filters or "}
-      </>
-      <va-link
-        data-testid="back-link-banner"
-        href="#"
-        onClick={handleBackClick}
-        text="Go back review and update your entries"
-      />
+      We didn’t find any results that match your answers. If you added filters,
+      try removing the filters. Or you can review or change your answers.
     </p>
+    <va-link
+      data-testid="back-link-banner"
+      href="#"
+      onClick={handleBackClick}
+      text="Review or change your answers"
+    />
     <p>
-      We’re adding more benefits, so we encourage you to try again in the
-      future.
+      We’re also planning to add more benefits and resources to this tool. Check
+      back soon to find more benefits you may want to apply for.
     </p>
   </va-banner>
 );

--- a/src/applications/discover-your-benefits/constants/benefits.js
+++ b/src/applications/discover-your-benefits/constants/benefits.js
@@ -547,7 +547,7 @@ export const BENEFITS_LIST = [
       'https://www.va.gov/health-care/foreign-medical-program/register-form-10-7959f-1/introduction',
   },
   {
-    name: 'Veterans Group Life Insurance (VGLI)',
+    name: "Veterans' Group Life Insurance (VGLI)",
     category: categories.LIFE_INSURANCE,
     id: 'VGL',
     description:
@@ -558,18 +558,14 @@ export const BENEFITS_LIST = [
       [mappingTypes.LENGTH_OF_SERVICE]: [anyType.ANY],
       [mappingTypes.CURRENTLY_SERVING]: [anyType.ANY],
       [mappingTypes.EXPECTED_SEPARATION]: [anyType.ANY],
-      [mappingTypes.PREVIOUS_SERVICE]: [yesNoType.YES],
+      [mappingTypes.PREVIOUS_SERVICE]: [anyType.ANY],
       [mappingTypes.SEPARATION]: [
         separationTypes.UP_TO_3_MONTHS,
         separationTypes.UP_TO_6_MONTHS,
         separationTypes.UP_TO_1_YEAR,
         separationTypes.UP_TO_2_YEARS,
       ],
-      [mappingTypes.CHARACTER_OF_DISCHARGE]: [
-        characterOfDischargeTypes.HONORABLE,
-        characterOfDischargeTypes.UNDER_HONORABLE_CONDITIONS_GENERAL,
-        characterOfDischargeTypes.UNCHARACTERIZED,
-      ],
+      [mappingTypes.CHARACTER_OF_DISCHARGE]: [anyType.ANY],
       [mappingTypes.DISABILITY_RATING]: [anyType.ANY],
       [mappingTypes.GI_BILL]: [anyType.ANY],
     },

--- a/src/applications/discover-your-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/discover-your-benefits/containers/ConfirmationPage.jsx
@@ -281,7 +281,7 @@ export class ConfirmationPage extends React.Component {
               text="Visit this page"
               type="secondary"
               label="visit this page"
-            />
+            />{' '}
             to find out which benefits
           </span>
           <br />

--- a/src/applications/discover-your-benefits/containers/IntroductionPage.jsx
+++ b/src/applications/discover-your-benefits/containers/IntroductionPage.jsx
@@ -45,7 +45,7 @@ const IntroductionPage = ({ router }) => {
             text="visit this page"
             type="secondary"
             label="visit this page"
-          />
+          />{' '}
           to learn about potential benefits for you.
         </p>
       </div>

--- a/src/applications/discover-your-benefits/containers/components/Benefits.jsx
+++ b/src/applications/discover-your-benefits/containers/components/Benefits.jsx
@@ -36,10 +36,7 @@ const Benefits = ({
         {!queryString.allBenefits &&
           !results.isLoading &&
           benefits.length === 0 && (
-            <NoResultsBanner
-              data={results.data}
-              handleBackClick={handleBackClick}
-            />
+            <NoResultsBanner handleBackClick={handleBackClick} />
           )}
       </div>
       {queryString.allBenefits &&

--- a/src/applications/discover-your-benefits/tests/unit/components/BenefitCard.unit.spec.js
+++ b/src/applications/discover-your-benefits/tests/unit/components/BenefitCard.unit.spec.js
@@ -14,4 +14,14 @@ describe('<BenefitCard>', () => {
     expect(container.querySelector('p')).to.have.text(benefit.description);
     expect(container.querySelectorAll('va-link')).to.have.lengthOf(1);
   });
+
+  it('renders time sensitive benefit card', () => {
+    const benefit = BENEFITS_LIST.find(b => b.isTimeSensitive);
+    const { container } = render(<BenefitCard benefit={benefit} />);
+
+    expect(container.querySelector('h3')).to.contain.text(benefit.name);
+    expect(container.querySelector('p')).to.have.text(benefit.description);
+    expect(container.querySelectorAll('va-link')).to.have.lengthOf(1);
+    expect(container.querySelector('div.blue-heading')).to.exist;
+  });
 });

--- a/src/applications/edu-benefits/10282/pages/applicantInformation/applicantState.js
+++ b/src/applications/edu-benefits/10282/pages/applicantInformation/applicantState.js
@@ -16,13 +16,15 @@ export const uiSchema = {
     },
   }),
 };
+
 export const schema = {
   type: 'object',
   required: ['state'],
   properties: {
     state: {
       ...state,
-      enum: constants.states.USA.map(st => st.label),
+      enum: constants.states.USA.map(st => st.value),
+      enumNames: constants.states.USA.map(st => st.label),
     },
   },
 };

--- a/src/applications/facility-locator/actions/mapbox/genBBoxFromAddress.js
+++ b/src/applications/facility-locator/actions/mapbox/genBBoxFromAddress.js
@@ -45,22 +45,21 @@ export const genBBoxFromAddress = (query, expandedRadius = false) => {
     if (isPostcode) {
       types = ['postcode'];
     }
-
     mbxClient
       .forwardGeocode({
         countries: CountriesList,
         types,
         autocomplete: false, // set this to true when build the predictive search UI (feature-flipped)
         query: query.searchString,
+        proximity: 'ip',
       })
       .send()
       .then(({ body: { features } }) => {
         const zip =
-          features[0].context.find(v => v.id.includes('postcode')) || {};
+          features[0].context?.find(v => v.id.includes('postcode')) || {};
         const coordinates = features[0].center;
         const zipCode = zip.text || features[0].place_name;
         const featureBox = features[0].box;
-
         dispatch({
           type: GEOCODE_COMPLETE,
           payload: query.usePredictiveGeolocation
@@ -123,7 +122,7 @@ export const genBBoxFromAddress = (query, expandedRadius = false) => {
           },
         });
       })
-      .catch(_ => {
+      .catch(_e => {
         dispatch({ type: GEOCODE_FAILED });
         dispatch({ type: SEARCH_FAILED, error: { type: 'mapBox' } });
       });

--- a/src/applications/facility-locator/actions/mapbox/genSearchAreaFromCenter.js
+++ b/src/applications/facility-locator/actions/mapbox/genSearchAreaFromCenter.js
@@ -37,7 +37,6 @@ export const genSearchAreaFromCenter = query => {
           // Radius is computed as the distance from the center point
           // to the western edge of the bounding box
           const radius = distBetween(lat, lng, lat, currentBounds[0]);
-
           dispatch({
             type: SEARCH_QUERY_UPDATED,
             payload: {

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -158,13 +158,19 @@ export const MapboxInit = {
  * Mapbox api request countries
  */
 
-export const CountriesList = ['us', 'pr', 'ph', 'gu', 'as', 'mp'];
+export const CountriesList = ['us', 'pr', 'ph', 'gu', 'as', 'mp', 'vi'];
 
 /**
  * Mapbox api request types
  */
 
-export const MAPBOX_QUERY_TYPES = ['place', 'region', 'postcode', 'locality'];
+export const MAPBOX_QUERY_TYPES = [
+  'place',
+  'region',
+  'postcode',
+  'locality',
+  'country',
+];
 
 /**
  * Max search area in miles

--- a/src/applications/facility-locator/utils/mapbox.js
+++ b/src/applications/facility-locator/utils/mapbox.js
@@ -12,6 +12,7 @@ const getFeaturesFromAddress = query => {
         types: MAPBOX_QUERY_TYPES,
         autocomplete: false,
         query,
+        proximity: 'ip',
       })
       .send()
       .then(features => {

--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -22,7 +22,12 @@ fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
 export const applicantNameDobSchema = {
   uiSchema: {
-    ...titleUI('Beneficiary’s name'),
+    ...titleUI(
+      ({ formData }) =>
+        `${
+          formData.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
+        } name`,
+    ),
     applicantName: fullNameMiddleInitialUI,
   },
   schema: {
@@ -70,6 +75,7 @@ export const applicantAddressInfoSchema = {
     applicantNewAddress: {
       ...radioUI({
         updateUiSchema: formData => {
+          const name = nameWording(formData, undefined, false, true);
           const labels = {
             yes: 'Yes',
             no: 'No',
@@ -77,12 +83,9 @@ export const applicantAddressInfoSchema = {
           };
 
           return {
-            'ui:title': `Has ${nameWording(
-              formData,
-              undefined,
-              undefined,
-              true,
-            )} mailing address changed since their last CHAMPVA form submission?`,
+            'ui:title': `Has ${name} mailing address changed since ${
+              name === 'your' ? name : 'their'
+            } last CHAMPVA form submission?`,
             'ui:options': {
               labels,
               hint: `If yes, we will update our records with the new mailing address.`,
@@ -145,7 +148,7 @@ export const applicantGenderSchema = {
             'ui:title': `What's ${nameWording(
               formData,
               undefined,
-              undefined,
+              false,
               true,
             )} sex listed at birth?`,
             'ui:options': {
@@ -153,7 +156,7 @@ export const applicantGenderSchema = {
               hint: `Enter the sex that appears on ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} birth certificate.`,
             },

--- a/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
@@ -6,32 +6,15 @@ import {
 
 export const formSignatureSchema = {
   uiSchema: {
-    ...titleUI('Signer information'),
+    ...titleUI('Your information'),
     certifierRole: {
       ...radioUI({
-        updateUiSchema: formData => {
-          const labels = {
-            applicant: `I'm ${
-              formData?.applicantName?.first
-            } and I'm signing for myself`,
-            other: `I'm a parent, spouse, or legal representative signing on behalf of ${
-              formData?.applicantName?.first
-            }`,
-          };
-
-          return {
-            'ui:title': `Who’s signing this form for ${
-              formData?.applicantName?.first
-            }?`,
-            'ui:options': {
-              labels,
-            },
-          };
-        },
+        title: 'Which of these best describes you?',
         required: () => true,
         labels: {
-          applicant: 'The beneficiary',
-          other: 'A representative on behalf of the beneficiary',
+          applicant: 'I’m filling out this form for myself',
+          other:
+            'I’m a parent, spouse, or legal representative signing on behalf of the beneficiary',
         },
       }),
     },

--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
@@ -12,7 +12,7 @@ import {
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { nameWording } from '../helpers/utilities';
+import { nameWording, nameWordingExt } from '../helpers/utilities';
 import {
   fileWithMetadataSchema,
   fileUploadBlurb,
@@ -58,12 +58,9 @@ export function applicantHasInsuranceSchema(isPrimary) {
         ...yesNoUI({
           updateUiSchema: formData => {
             return {
-              'ui:title': `Does ${nameWording(
-                formData,
-                false,
-                undefined,
-                true,
-              )} have ${
+              'ui:title': `${
+                formData.certifierRole === 'applicant' ? 'Do' : 'Does'
+              } ${nameWording(formData, false, false, true)} have ${
                 isPrimary ? '' : 'any other'
               } medical health insurance information to provide or update at this time?`,
               'ui:options': {
@@ -154,7 +151,7 @@ export function applicantInsuranceThroughEmployerSchema(isPrimary) {
               'ui:title': `Is this insurance through ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} employer?`,
             };
@@ -195,7 +192,7 @@ export function applicantInsurancePrescriptionSchema(isPrimary) {
               'ui:title': `Does ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} health insurance cover prescriptions?`,
               'ui:options': {
@@ -238,7 +235,7 @@ export function applicantInsuranceEobSchema(isPrimary) {
               'ui:title': `Does ${nameWording(
                 formData,
                 undefined,
-                undefined,
+                false,
                 true,
               )} health insurance have an explanation of benefits (EOB) for prescriptions?`,
               'ui:options': {
@@ -328,16 +325,15 @@ export function applicantInsuranceTypeSchema(isPrimary) {
           },
           required: () => true,
           updateUiSchema: formData => {
+            const wording = nameWordingExt(formData);
             return {
-              'ui:title': `Select the type of insurance plan or program ${nameWording(
-                formData,
-                false,
-                undefined,
-                true,
-              )} is enrolled in`,
+              'ui:title': `Select the type of insurance plan or program ${
+                wording.beingVerb
+              } enrolled in`,
               'ui:options': {
-                hint:
-                  'You may find this information on the front of your health insurance card.',
+                hint: `You may find this information on the front of ${
+                  wording.posessive
+                } health insurance card.`,
               },
             };
           },
@@ -378,13 +374,11 @@ export function applicantMedigapSchema(isPrimary) {
           required: () => true,
           labels: MEDIGAP,
           updateUiSchema: formData => {
+            const wording = nameWordingExt(formData);
             return {
-              'ui:title': `Select the Medigap plan ${nameWording(
-                formData,
-                false,
-                undefined,
-                true,
-              )} is enrolled in`,
+              'ui:title': `Select the Medigap plan ${
+                wording.beingVerb
+              } enrolled in`,
             };
           },
         }),
@@ -421,7 +415,7 @@ export function applicantInsuranceCommentsSchema(isPrimary) {
             'ui:title': `Any additional comments about ${nameWording(
               formData,
               undefined,
-              undefined,
+              false,
               true,
             )} health insurance?`,
           };

--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -37,10 +37,12 @@ export const applicantHasMedicareSchema = {
       ...yesNoUI({
         updateUiSchema: formData => {
           return {
-            'ui:title': `Does ${nameWording(
+            'ui:title': `${
+              formData.certifierRole === 'applicant' ? 'Do' : 'Does'
+            } ${nameWording(
               formData,
               false,
-              undefined,
+              false,
               true,
             )} have Medicare information to provide or update at this time?`,
             'ui:options': { hint: additionalFilesHint },
@@ -79,12 +81,9 @@ export const applicantMedicareClassSchema = {
         },
         updateUiSchema: formData => {
           return {
-            'ui:title': `Which Medicare plan is ${nameWording(
-              formData,
-              false,
-              false,
-              true,
-            )} enrolled in?`,
+            'ui:title': `Which Medicare plan ${
+              formData.certifierRole === 'applicant' ? 'are' : 'is'
+            } ${nameWording(formData, false, false, true)} enrolled in?`,
             'ui:options': {
               hint:
                 'You can find this information on the front of your Medicare card.',
@@ -121,7 +120,7 @@ export const applicantMedicarePharmacySchema = {
             'ui:title': `Does ${nameWording(
               formData,
               undefined,
-              undefined,
+              false,
               true,
             )} Medicare plan provide pharmacy benefits?`,
             'ui:options': {
@@ -217,7 +216,7 @@ export const applicantMedicareABUploadSchema = {
     ...titleUI(
       'Upload Medicare card for hospital and medical coverage',
       ({ formData }) => {
-        const appName = nameWording(formData, undefined, undefined, true);
+        const appName = nameWording(formData, undefined, false, true);
         return (
           <>
             You’ll need to submit a copy of the front and back of {appName}{' '}
@@ -279,10 +278,12 @@ export const applicantHasMedicareDSchema = {
       ...yesNoUI({
         updateUiSchema: formData => {
           return {
-            'ui:title': `Does ${nameWording(
+            'ui:title': `${
+              formData.certifierRole === 'applicant' ? 'Do' : 'Does'
+            } ${nameWording(
               formData,
               false,
-              undefined,
+              false,
               true,
             )} have Medicare Part D information to provide or update at this time?`,
             'ui:options': { hint: additionalFilesHint },
@@ -331,7 +332,7 @@ export const applicantMedicarePartDCarrierSchema = {
 export const applicantMedicareDUploadSchema = {
   uiSchema: {
     ...titleUI('Upload Medicare Part D card', ({ formData }) => {
-      const appName = nameWording(formData, undefined, undefined, true);
+      const appName = nameWording(formData, undefined, false, true);
       return (
         <>
           You’ll need to submit a copy of the front and back of {appName}{' '}

--- a/src/applications/ivc-champva/10-7959C/components/FileUploadWrapper.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/FileUploadWrapper.jsx
@@ -1,5 +1,5 @@
 import FileFieldCustom from '../../shared/components/fileUploads/FileUpload';
-import { requiredFiles, UPLOADS_COMPLETE_PATH } from '../config/constants';
+import { requiredFiles } from '../config/constants';
 
 // Wrap shared fileFieldCustom so we can pass the form-specific
 // list of required uploads (for use with MissingFileOverview)
@@ -7,8 +7,5 @@ export default function FileFieldWrapped(props) {
   return FileFieldCustom({
     ...props,
     requiredFiles,
-    // Since `MissingFileOverview` isn't the last page in this form, go to the
-    // appropriate next page after all uploads are complete:
-    uploadsCompletePath: UPLOADS_COMPLETE_PATH,
   });
 }

--- a/src/applications/ivc-champva/10-7959C/config/constants.js
+++ b/src/applications/ivc-champva/10-7959C/config/constants.js
@@ -1,8 +1,5 @@
 import React from 'react';
 
-// When all files shown on `MissingFileOverview` are uploaded, go here next:
-export const UPLOADS_COMPLETE_PATH = 'form-signature';
-
 /* List of required files - not enforced by the form because we want
 users to be able to opt into mailing these documents. This object 
 performs double duty by also providing a map to presentable names. */

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -46,7 +46,6 @@ import {
 
 import { formSignatureSchema } from '../chapters/formSignature';
 import CustomAttestation from '../components/CustomAttestation';
-import { UPLOADS_COMPLETE_PATH } from './constants';
 
 import GetFormHelp from '../../shared/components/GetFormHelp';
 import { hasReq } from '../../shared/components/fileUploads/MissingFileOverview';
@@ -126,13 +125,26 @@ const formConfig = {
   subTitle: 'CHAMPVA Other Health Insurance Certification (VA Form 10-7959c)',
   defaultDefinitions: {},
   chapters: {
+    formSignature: {
+      title: 'Signer information',
+      pages: {
+        formSignature: {
+          path: 'form-signature',
+          title: 'Form signature',
+          ...formSignatureSchema,
+        },
+      },
+    },
     applicantInformation: {
       title: 'Beneficiary information',
       pages: {
         applicantNameDob: {
           // initialData: mockdata.data,
           path: 'applicant-info',
-          title: 'Beneficiary’s name',
+          title: formData =>
+            `${
+              formData.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
+            } name`,
           ...applicantNameDobSchema,
         },
         applicantIdentity: {
@@ -467,16 +479,6 @@ const formConfig = {
             },
           },
           schema: blankSchema,
-        },
-      },
-    },
-    formSignature: {
-      title: 'Form signature',
-      pages: {
-        formSignature: {
-          path: UPLOADS_COMPLETE_PATH,
-          title: 'Form signature',
-          ...formSignatureSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959C/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-7959C/helpers/utilities.js
@@ -22,6 +22,14 @@ export function nameWording(
   return sharedNameWording(formData, isPosessive, cap, firstNameOnly);
 }
 
+export function nameWordingExt(formData) {
+  const posessive = nameWording(formData, true, false, true);
+  const nonPosessive = nameWording(formData, false, false, true);
+  const beingVerb =
+    nonPosessive === 'you' ? `${nonPosessive}’re` : `${nonPosessive} is`;
+  return { posessive, nonPosessive, beingVerb };
+}
+
 /**
  * Retrieves an array of objects containing the property 'attachmentId'
  * from the given object.

--- a/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
@@ -27,7 +27,6 @@ const testConfig = createTestConfig(
     // Rename and modify the test data as needed.
     /* 
     1. test-data: standard run-through of the form
-    2. no-secondary: no secondary insurance (skips all secondary ins pages) 
     The rest of the tests are described by their filenames and are just
     variations designed to trigger the conditionals in the form/follow different paths. 
     */

--- a/src/applications/ivc-champva/10-7959C/tests/helpers/utilities.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/helpers/utilities.unit.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   isRequiredFile,
   nameWording,
+  nameWordingExt,
   getObjectsWithAttachmentId,
 } from '../../helpers/utilities';
 import { requiredFiles } from '../../config/constants';
@@ -50,6 +51,14 @@ describe('nameWording', () => {
         false, // capitalize
       ),
     ).to.equal('John William Ferrell');
+  });
+});
+
+describe('nameWordingExt', () => {
+  it("should set `beingVerb` to 'you’re' if certifierRole is 'applicant'", () => {
+    expect(nameWordingExt({ certifierRole: 'applicant' }).beingVerb).to.equal(
+      'you’re',
+    );
   });
 });
 

--- a/src/applications/mhv-medical-records/containers/LandingPage.jsx
+++ b/src/applications/mhv-medical-records/containers/LandingPage.jsx
@@ -24,7 +24,6 @@ import {
   selectVaccinesFlag,
   selectVitalsFlag,
   selectLabsAndTestsFlag,
-  selectSettingsPageFlag,
 } from '../util/selectors';
 import ExternalLink from '../components/shared/ExternalLink';
 import FeedbackEmail from '../components/shared/FeedbackEmail';
@@ -39,7 +38,6 @@ const LandingPage = () => {
   const displayConditions = useSelector(selectConditionsFlag);
   const displayVitals = useSelector(selectVitalsFlag);
   const displayLabsAndTest = useSelector(selectLabsAndTestsFlag);
-  const displayMedicalRecordsSettings = useSelector(selectSettingsPageFlag);
   const killExternalLinks = useSelector(
     state => state.featureToggles.mhv_medical_records_kill_external_links,
   );
@@ -289,7 +287,7 @@ const LandingPage = () => {
           )}
         </section>
       )}
-      {displayMedicalRecordsSettings && (
+      {phase0p5Flag && (
         <section>
           <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
             Manage your medical records settings
@@ -299,10 +297,7 @@ const LandingPage = () => {
             settings.
           </p>
           <Link
-            to={mhvUrl(
-              isAuthenticatedWithSSOe(fullState),
-              'electronic-record-sharing-options',
-            )}
+            to="/settings"
             className="vads-c-action-link--blue"
             data-testid="settings-landing-page-link"
           >
@@ -310,31 +305,55 @@ const LandingPage = () => {
           </Link>
         </section>
       )}
-      <section>
-        <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
-          Download your Blue Button report or health summary
-        </h2>
-        <p className="vads-u-margin-bottom--2">
-          We’re working on a way to download all your medical records here as a
-          single file or a summary.
-        </p>
-        <p className="vads-u-margin-bottom--2">
-          For now, you can continue to download your VA Blue Button® report or
-          your VA Health Summary on the previous version of My HealtheVet.
-        </p>
-        <p
-          data-testid="go-to-mhv-download-records"
-          className="vads-u-margin-bottom--2"
-        >
-          <ExternalLink
-            href={mhvUrl(
-              isAuthenticatedWithSSOe(fullState),
-              'download-my-data',
-            )}
-            text="Go back to the previous version of My HealtheVet to download your records"
-          />
-        </p>
-      </section>
+      {phase0p5Flag ? (
+        <section>
+          <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
+            Download your medical records reports
+          </h2>
+          <p className="vads-u-margin-bottom--2">
+            Download full reports of your medical records or your self entered
+            health information.
+          </p>
+          <p
+            data-testid="go-to-mhv-download-records"
+            className="vads-u-margin-bottom--2"
+          >
+            <Link
+              to="/download"
+              className="vads-c-action-link--blue"
+              data-testid="go-to-download-mr-reports"
+            >
+              Go to download your medical records reports
+            </Link>
+          </p>
+        </section>
+      ) : (
+        <section>
+          <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
+            Download your Blue Button report or health summary
+          </h2>
+          <p className="vads-u-margin-bottom--2">
+            We’re working on a way to download all your medical records here as
+            a single file or a summary.
+          </p>
+          <p className="vads-u-margin-bottom--2">
+            For now, you can continue to download your VA Blue Button® report or
+            your VA Health Summary on the previous version of My HealtheVet.
+          </p>
+          <p
+            data-testid="go-to-mhv-download-records"
+            className="vads-u-margin-bottom--2"
+          >
+            <ExternalLink
+              href={mhvUrl(
+                isAuthenticatedWithSSOe(fullState),
+                'download-my-data',
+              )}
+              text="Go back to the previous version of My HealtheVet to download your records"
+            />
+          </p>
+        </section>
+      )}
       <section>
         <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
           What to know as you try out this tool
@@ -368,23 +387,38 @@ const LandingPage = () => {
             <h3 className="vads-u-font-size--h6" slot="headline">
               Where can I find health information I entered myself?
             </h3>
-            <p className="vads-u-margin-bottom--2">
-              Right now, your records on VA.gov only include health information
-              your VA providers have entered.
-            </p>
-            <p className="vads-u-margin-bottom--2">
-              To find health information you entered yourself, go to your
-              medical records on the My HealtheVet website.
-            </p>
-            <p className="vads-u-margin-bottom--2">
-              <ExternalLink
-                href={mhvUrl(
-                  isAuthenticatedWithSSOe(fullState),
-                  'download-my-data',
-                )}
-                text="Go to your medical records on the My HealtheVet website"
-              />
-            </p>
+            {phase0p5Flag ? (
+              <div>
+                <p className="vads-u-margin-bottom--2">
+                  Download your self-entered health information report.
+                </p>
+                <p className="vads-u-margin-bottom--2">
+                  <Link to="/download">
+                    Go to download your medical records reports
+                  </Link>
+                </p>
+              </div>
+            ) : (
+              <div>
+                <p className="vads-u-margin-bottom--2">
+                  Right now, your records on VA.gov only include health
+                  information your VA providers have entered.
+                </p>
+                <p className="vads-u-margin-bottom--2">
+                  To find health information you entered yourself, go to your
+                  medical records on the My HealtheVet website.
+                </p>
+                <p className="vads-u-margin-bottom--2">
+                  <ExternalLink
+                    href={mhvUrl(
+                      isAuthenticatedWithSSOe(fullState),
+                      'download-my-data',
+                    )}
+                    text="Go to your medical records on the My HealtheVet website"
+                  />
+                </p>
+              </div>
+            )}
           </va-accordion-item>
           <va-accordion-item bordered="true">
             <h3 className="vads-u-font-size--h6" slot="headline">

--- a/src/applications/mhv-medical-records/reducers/vitals.js
+++ b/src/applications/mhv-medical-records/reducers/vitals.js
@@ -56,8 +56,13 @@ const getMeasurement = (record, type) => {
     );
     return `${systolic.valueQuantity.value}/${diastolic.valueQuantity.value}`;
   }
-  const unit = getUnit(type, record.valueQuantity?.code);
-  return `${record.valueQuantity?.value}${unit}`;
+
+  if (record.valueQuantity) {
+    const unit = getUnit(type, record.valueQuantity?.code);
+    return `${record.valueQuantity?.value}${unit}`;
+  }
+
+  return record.valueString || EMPTY_FIELD;
 };
 
 export const extractLocation = vital => {

--- a/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
@@ -117,6 +117,8 @@ describe('Landing Page', () => {
         mhv_medical_records_display_vitals: true,
         // eslint-disable-next-line camelcase
         mhv_medical_records_display_settings_page: true,
+        // eslint-disable-next-line camelcase
+        mhv_integration_medical_records_to_phase_1: true,
       },
       ...initialState,
     };
@@ -207,5 +209,36 @@ describe('Landing Page', () => {
     //     exact: true,
     //   }).length,
     // ).to.eq(2);
+  });
+
+  it('displays Questions about this medical records tool section', () => {
+    const screen = renderWithStoreAndRouter(<LandingPage />, {});
+
+    expect(
+      screen.getByText('Questions about this medical records tool', {
+        selector: 'h2',
+        exact: true,
+      }),
+    ).to.exist;
+
+    expect(
+      screen.getByText(
+        'Where can I find health information I entered myself?',
+        {
+          selector: 'h3',
+          exact: true,
+        },
+      ),
+    ).to.exist;
+
+    expect(
+      screen.getAllByText(
+        'Go to your medical records on the My HealtheVet website',
+        {
+          selector: 'a',
+          exact: true,
+        },
+      ),
+    ).to.exist;
   });
 });

--- a/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
@@ -7,6 +7,7 @@ import reducer from '../../reducers';
 import { user } from '../fixtures/user-reducer.json';
 import VitalDetails from '../../containers/VitalDetails';
 import vital from '../fixtures/vital.json';
+import vitalWithVitalString from '../fixtures/vitalWithVitalString.json';
 import { convertVital } from '../../reducers/vitals';
 
 describe('Vital details container', () => {
@@ -131,6 +132,33 @@ describe('Vitals details container with errors', () => {
           exact: false,
         }),
       ).to.exist;
+    });
+  });
+});
+
+describe('Vitals details container with valueString', () => {
+  const initialState = {
+    mr: {
+      vitals: {
+        vitalDetails: [convertVital(vitalWithVitalString)],
+      },
+    },
+    user,
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<VitalDetails runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/vitals/breathing-rate-history',
+    });
+  });
+
+  it('displays the result string when the vital has valueString instead of valueQuantity', async () => {
+    await waitFor(() => {
+      const result = screen.getByTestId('vital-result');
+      expect(result.innerHTML).to.equal('Unavailable');
     });
   });
 });

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-landing-page-authenticated.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-landing-page-authenticated.cypress.spec.js
@@ -1,16 +1,24 @@
 import MedicalRecordsSite from './mr_site/MedicalRecordsSite';
 import LandingPage from './pages/MedicalRecordsLandingPage';
-// import VitalsDetailsPage from './pages/VitalsDetailsPage';
 
 describe('Medical Records Authenticated Users', () => {
   it('Visits Medical Records Authenticated Users', () => {
     const site = new MedicalRecordsSite();
     site.login();
     site.loadPage();
+    LandingPage.handleSession();
     cy.visit('my-health/medical-records');
-    LandingPage.verifyDownloadOnMhvLink(
-      'Go back to the previous version of My HealtheVet to download your records',
-    );
+    // LandingPage.verifyDownloadOnMhvLink(
+    //   'Go back to the previous version of My HealtheVet to download your records',
+    // );
+    LandingPage.verifyLabsAndTestsLink();
+    LandingPage.verifyNotesLink();
+    LandingPage.verifyVaccinesLink();
+    LandingPage.verifyAllergiesLink();
+    LandingPage.verifyConditionsLink();
+    LandingPage.verifyVitalsLink();
+    LandingPage.verifySettingsLink();
+    LandingPage.verifyDownloadReportsLink();
     // Axe check
     cy.injectAxe();
     cy.axeCheck('main');

--- a/src/applications/mhv-medical-records/tests/e2e/pages/MedicalRecordsLandingPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/MedicalRecordsLandingPage.js
@@ -1,4 +1,17 @@
+import sessionStatus from '../fixtures/session-status.json';
+
 class MedicalRecordsLandingPage {
+  handleSession = () => {
+    cy.intercept('POST', '/my_health/v1/medical_records/session', {
+      statusCode: 204,
+      body: {},
+    }).as('session');
+    cy.intercept('GET', '/my_health/v1/medical_records/session/status', {
+      statusCode: 200,
+      body: sessionStatus, // status response copied from staging
+    }).as('status');
+  };
+
   clickExpandAllAccordionButton = () => {
     cy.contains('Expand all').click({ force: true });
   };
@@ -16,6 +29,54 @@ class MedicalRecordsLandingPage {
         'contain',
         'myhealth.va.gov/mhv-portal-web/download-my-data', // mhv-syst.
       );
+  };
+
+  verifyLabsAndTestsLink = () => {
+    cy.get('[data-testid="labs-and-tests-landing-page-link"]')
+      .should('have.attr', 'href')
+      .and('include', '/my-health/medical-records/labs-and-tests');
+  };
+
+  verifyNotesLink = () => {
+    cy.get('[data-testid="notes-landing-page-link"]')
+      .should('have.attr', 'href')
+      .and('include', '/my-health/medical-records/summaries-and-notes');
+  };
+
+  verifyVaccinesLink = () => {
+    cy.get('[data-testid="vaccines-landing-page-link"]')
+      .should('have.attr', 'href')
+      .and('include', '/my-health/medical-records/vaccines');
+  };
+
+  verifyAllergiesLink = () => {
+    cy.get('[data-testid="allergies-landing-page-link"]')
+      .should('have.attr', 'href')
+      .and('include', '/my-health/medical-records/allergies');
+  };
+
+  verifyConditionsLink = () => {
+    cy.get('[data-testid="conditions-landing-page-link"]')
+      .should('have.attr', 'href')
+      .and('include', '/my-health/medical-records/conditions');
+  };
+
+  verifyVitalsLink = () => {
+    cy.get('[data-testid="vitals-landing-page-link"]')
+      .should('have.attr', 'href')
+      .and('include', '/my-health/medical-records/vitals');
+  };
+
+  verifySettingsLink = () => {
+    cy.get('[data-testid="settings-landing-page-link"]')
+      .should('have.attr', 'href')
+      .and('include', 'my-health/medical-records/settings');
+  };
+
+  verifyDownloadReportsLink = () => {
+    cy.get('[data-testid="go-to-download-mr-reports"]')
+      .should('have.attr', 'href')
+      .and('include', 'my-health/medical-records/download');
   };
 }
 export default new MedicalRecordsLandingPage();

--- a/src/applications/mhv-medical-records/tests/fixtures/vitalWithVitalString.json
+++ b/src/applications/mhv-medical-records/tests/fixtures/vitalWithVitalString.json
@@ -1,0 +1,33 @@
+  {
+    "code": {
+      "coding": [
+        {
+          "code": "9279-1",
+          "display": "Respiratory Rate"
+        }
+      ],
+      "text": "RESPIRATION"
+    },
+    "valueString": "Unavailable",
+    "contained": [
+      {
+        "id": "Location-0",
+        "name": "Washington DC VAMC",
+        "resourceType": "Location"
+      }
+    ],
+    "effectiveDateTime": "2024-03-12T13:27:00-05:00",
+    "id": "2001",
+    "performer": [
+      {
+        "extension": [
+          {
+            "valueReference": {
+              "reference": "#Location-0"
+            }
+          }
+        ]
+      }
+    ]
+  }
+

--- a/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
+++ b/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
@@ -50,7 +50,7 @@ const RxBreadcrumbs = () => {
           href={`${medicationsUrls.PRESCRIPTION_DETAILS}/${
             prescription?.prescriptionId
           }`}
-          text={`Back to ${prescription?.prescriptionName}`}
+          text="Back"
           data-testid="rx-breadcrumb-link"
         />
       </div>

--- a/src/applications/mhv-medications/tests/e2e/medications-filter-accordion-reset-button-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-filter-accordion-reset-button-list-page.cypress.spec.js
@@ -1,0 +1,33 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsLandingPage from './pages/MedicationsLandingPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+import { Data, Paths } from './utils/constants';
+import filterRx from './fixtures/filter-prescriptions.json';
+
+describe('Medications List Page Filter Accordion Reset Button', () => {
+  it('visits Medications List Page Reset Filter Button', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const landingPage = new MedicationsLandingPage();
+    site.login();
+    landingPage.visitLandingPageURL();
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.clickGotoMedicationsLink();
+    listPage.verifyLabelTextWhenFilterAccordionExpanded();
+    listPage.clickfilterAccordionDropdownOnListPage();
+    listPage.verifyFilterHeaderTextHasFocusafterExpanded();
+    listPage.verifyFilterButtonWhenAccordionExpanded();
+    listPage.clickFilterRadioButtonOptionOnListPage('Active');
+
+    listPage.clickFilterButtonOnAccordion(Paths.ACTIVE_FILTER, filterRx);
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      Data.PAGINATION_ACTIVE_TEXT,
+    );
+    listPage.clickResetFilterButtonOnFilterAccordionDropDown();
+    listPage.verifyAllMedicationsRadioButtonIsChecked();
+    listPage.verifyFocusOnPaginationTextInformationOnListPage(
+      Data.PAGINATION_ALL_MEDICATIONS,
+    );
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-patient-medication-information-details-page-breadcrumbs.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-patient-medication-information-details-page-breadcrumbs.cypress.spec.js
@@ -1,0 +1,33 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+import rxTrackingDetails from './fixtures/prescription-tracking-details.json';
+import MedicationsLandingPage from './pages/MedicationsLandingPage';
+import MedicationsInformationPage from './pages/MedicationsInformationPage';
+
+describe('Medications Details Page Medication Information Breadcrumb', () => {
+  it('visits Medications Details Page Medication Information Breadcrumb', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const detailsPage = new MedicationsDetailsPage();
+    const landingPage = new MedicationsLandingPage();
+    const medInfoPage = new MedicationsInformationPage();
+    const cardNumber = 16;
+    site.login();
+    landingPage.visitLandingPageURL();
+    listPage.clickGotoMedicationsLink();
+    detailsPage.clickMedicationDetailsLink(rxTrackingDetails, cardNumber);
+    detailsPage.clickLearnMoreAboutMedicationLinkOnDetailsPage(
+      rxTrackingDetails.data.attributes.prescriptionId,
+    );
+    detailsPage.verifyMedicationInformationTitle(
+      rxTrackingDetails.data.attributes.prescriptionName,
+    );
+    medInfoPage.verifyBreadCrumbsTextDoesNotHaveRxName(
+      'Back',
+      rxTrackingDetails.data.attributes.prescriptionName,
+    );
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
@@ -12,6 +12,13 @@ class MedicationsInformationPage {
       'If you’re on a public or shared computer',
     );
   };
+
+  verifyBreadCrumbsTextDoesNotHaveRxName = (breadcrumb, text) => {
+    cy.get('[data-testid="rx-breadcrumb-link"]')
+      .shadow()
+      .should('have.text', breadcrumb)
+      .and('not.have.text', text);
+  };
 }
 
 export default MedicationsInformationPage;

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -772,6 +772,12 @@ class MedicationsListPage {
 
   verifyAllMedicationsRadioButtonIsChecked = () => {
     cy.contains('All medications').should('be.visible');
+    cy.get('[data-testid="filter-button"]')
+      .shadow()
+      .find('[type="button"],[value="ALL Medications"],[aria-checked="true"]', {
+        force: true,
+      })
+      .should('exist');
   };
 
   verifyFocusOnPaginationTextInformationOnListPage = text => {
@@ -809,6 +815,13 @@ class MedicationsListPage {
     cy.get('[data-testid="zero-filter-results"]')
       .should('have.text', text)
       .and('be.focused');
+  };
+
+  clickResetFilterButtonOnFilterAccordionDropDown = () => {
+    cy.get('[data-testid="filter-reset-button"]').should('exist');
+    cy.get('[data-testid="filter-reset-button"]').click({
+      waitForAnimations: true,
+    });
   };
 }
 

--- a/src/applications/mhv-medications/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-medications/tests/e2e/utils/constants.js
@@ -1,5 +1,7 @@
 export const Data = {
   PAGINATION_TEXT: 'Showing 1 - 20 of 29 medications',
+  PAGINATION_ALL_MEDICATIONS:
+    'Showing 1 - 20 of 29 medications, alphabetically by status',
   PAGINATION_ACTIVE_TEXT:
     'Showing 1 - 20 of 29 active medications, alphabetically by status',
   PAGINATION_RENEW:

--- a/src/applications/personalization/review-information/config/form.js
+++ b/src/applications/personalization/review-information/config/form.js
@@ -63,7 +63,7 @@ const formConfig = {
   submit: () =>
     Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: 'welcome-va-setup-review-information-',
-  introduction: <></>,
+  introduction: () => <></>,
   confirmation: ConfirmationPage,
   dev: {
     showNavLinks: true,

--- a/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
+++ b/src/applications/static-pages/situation-updates-banner/bannerContainer.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
+import SituationUpdateBanner from './situationUpdateBanner';
+import { getDataForPath } from './helpers/getDataForPath';
+import { getOperatingStatusPage } from './helpers/getOperatingStatusPage';
+
+export const BannerContainer = () => {
+  const {
+    TOGGLE_NAMES,
+    useToggleValue,
+    useToggleLoadingValue,
+  } = useFeatureToggle();
+
+  const alternativeBannersEnabled = useToggleValue(
+    TOGGLE_NAMES.bannerUseAlternativeBanners,
+  );
+  const isLoadingFeatureFlags = useToggleLoadingValue();
+
+  const [bannerState, setBannerState] = useState(null);
+
+  useEffect(() => {
+    let pathForSituationUpdate = window.location.pathname;
+    pathForSituationUpdate = pathForSituationUpdate.replace(/\/$/, '');
+    if (
+      pathForSituationUpdate.includes('health-care') ||
+      pathForSituationUpdate.includes('manila-va-clinic')
+    ) {
+      getDataForPath(pathForSituationUpdate)
+        .then(data => {
+          setBannerState(data?.banners?.[0] || {});
+        })
+        .catch(_ => {
+          setBannerState(null);
+        });
+    }
+  }, []);
+
+  if (isLoadingFeatureFlags || !alternativeBannersEnabled) {
+    return null;
+  }
+
+  if (!bannerState?.id) {
+    return null;
+  }
+
+  const operatingStatusPage = getOperatingStatusPage(
+    bannerState?.context?.[0]?.entity?.entityUrl?.path,
+  );
+
+  return (
+    <SituationUpdateBanner
+      {...bannerState}
+      operatingStatusPage={operatingStatusPage}
+    />
+  );
+};

--- a/src/applications/static-pages/situation-updates-banner/createSituationUpdatesBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/createSituationUpdatesBanner.jsx
@@ -1,42 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
-import SituationUpdateBanner from './situationUpdateBanner';
-
-export const BannerContainer = () => {
-  const {
-    TOGGLE_NAMES,
-    useToggleValue,
-    useToggleLoadingValue,
-  } = useFeatureToggle();
-
-  const alternativeBannersEnabled = useToggleValue(
-    TOGGLE_NAMES.bannerUseAlternativeBanners,
-  );
-  const isLoadingFeatureFlags = useToggleLoadingValue();
-
-  if (isLoadingFeatureFlags || !alternativeBannersEnabled) {
-    return null;
-  }
-
-  const defaultProps = {
-    id: '1',
-    bundle: 'situation-updates',
-    headline: 'Situation update',
-    alertType: 'warning',
-    content:
-      "We're having issues at this location. Please avoid this facility until further notice.",
-    context: 'global',
-    showClose: true,
-    operatingStatusCTA: false,
-    emailUpdatesButton: false,
-    findFacilitiesCTA: false,
-    limitSubpageInheritance: false,
-  };
-
-  return <SituationUpdateBanner {...defaultProps} />;
-};
+import { BannerContainer } from './bannerContainer';
 
 export default async function createSituationUpdatesBanner(store, widgetType) {
   const bannerWidget = document.querySelector(

--- a/src/applications/static-pages/situation-updates-banner/helpers/getDataForPath.js
+++ b/src/applications/static-pages/situation-updates-banner/helpers/getDataForPath.js
@@ -1,0 +1,5 @@
+import { apiRequest } from '~/platform/utilities/api';
+
+export async function getDataForPath(path) {
+  return apiRequest(`/banners/?path=${path}`, { apiVersion: 'v0' });
+}

--- a/src/applications/static-pages/situation-updates-banner/helpers/getOperatingStatusPage.js
+++ b/src/applications/static-pages/situation-updates-banner/helpers/getOperatingStatusPage.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the operating status page path for the given path or current path.
+ * @param {string?} path
+ */
+export const getOperatingStatusPage = path => {
+  if (path?.includes('operating-status')) {
+    return path;
+  }
+  return `${window.location.pathname.split('/')[0]}/operating-status`;
+};

--- a/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import DOMPurify from 'dompurify';
+import recordEvent from '~/platform/monitoring/record-event';
 
 export default function SituationUpdateBanner({
   id,
@@ -7,15 +9,33 @@ export default function SituationUpdateBanner({
   headline,
   showClose,
   content,
+  operatingStatusCta = false,
+  operatingStatusPage,
 }) {
   return (
     <va-banner
-      banner-id={id}
+      data-testid="situation-update-banner"
+      banner-id={`situation-update-banner-${id}`}
       type={alertType}
       headline={headline}
       show-close={showClose}
     >
-      <p>{content}</p>
+      {/* eslint-disable-next-line react/no-danger */}
+      <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />
+      {operatingStatusCta &&
+        operatingStatusPage && (
+          <p>
+            <va-link
+              disable-analytics
+              onclick={recordEvent({
+                event: 'nav-warning-alert-box-content-link-click',
+                alertBoxHeading: headline,
+              })}
+              href={operatingStatusPage}
+              text="Get updates on affected services and facilities"
+            />
+          </p>
+        )}
     </va-banner>
   );
 }
@@ -25,5 +45,7 @@ SituationUpdateBanner.propTypes = {
   content: PropTypes.node.isRequired,
   headline: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  operatingStatusCta: PropTypes.bool,
+  operatingStatusPage: PropTypes.string,
   showClose: PropTypes.bool,
 };

--- a/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import sinon from 'sinon';
+import thunk from 'redux-thunk';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import { mockApiRequest } from 'platform/testing/unit/helpers';
+
+import { BannerContainer } from '../bannerContainer';
+import {
+  birmingham,
+  birminghamWoContext,
+  maine,
+} from './mocks/mockSituationUpdatesBanner';
+
+const getData = ({ isLoading = false, useBanners = true } = {}) => ({
+  featureToggles: {
+    loading: isLoading,
+    bannerUseAlternativeBanners: useBanners,
+    // eslint-disable-next-line camelcase
+    banner_use_alternative_banners: useBanners,
+  },
+  subscribe: () => {},
+  dispatch: () => {},
+});
+
+describe('featureToggles allow banners', () => {
+  const middleware = [thunk];
+  const mockStore = configureStore(middleware);
+
+  it('should display the Birmingham banner', done => {
+    sinon
+      .stub(window, 'location')
+      .value({ pathname: '/birmingham-health-care/operating-status' });
+    mockApiRequest(birmingham);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
+
+  it('should display the Birmingham banner and display link even without context', done => {
+    sinon.stub(window, 'location').value({
+      pathname:
+        '/birmingham-health-care/locations/birmingham-va-medical-center',
+    });
+    mockApiRequest(birminghamWoContext);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      const banner = wrapper.find('va-banner');
+      expect(banner.find('va-link')).to.have.length(1);
+      wrapper.unmount();
+      done();
+    }, 1500);
+  });
+
+  it('should NOT display the Maine banner because toggles', done => {
+    sinon.stub(window, 'location').value({ pathname: '/maine-health-care' });
+    mockApiRequest(maine);
+    const wrapper = mount(
+      <Provider store={mockStore(getData({ useBanners: false }))}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
+  it('should NOT display the Faine banner because data does not exist', done => {
+    sinon.stub(window, 'location').value({ pathname: '/faine-health-care' });
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
+
+  it('should display the Birmingham banner but accept with trailing slash', done => {
+    sinon
+      .stub(window, 'location')
+      .value({ pathname: '/birmingham-health-care/' });
+    mockApiRequest(birmingham);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
+
+  it('should accept accept manila-va-clinic but not display banner since none exists', done => {
+    sinon.stub(window, 'location').value({ pathname: '/manila-va-clinic/' });
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
+});

--- a/src/applications/static-pages/situation-updates-banner/tests/createSituationUpdatesBanner.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/createSituationUpdatesBanner.unit.spec.js
@@ -3,9 +3,8 @@ import sinon from 'sinon';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
-import createSituationUpdatesBanner, {
-  BannerContainer,
-} from '../createSituationUpdatesBanner';
+import { BannerContainer } from '../bannerContainer';
+import createSituationUpdatesBanner from '../createSituationUpdatesBanner';
 import widgetTypes from '../../widgetTypes';
 
 describe('createSituationUpdatesBanner', () => {

--- a/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
@@ -1,0 +1,102 @@
+export const birmingham = {
+  banners: [
+    {
+      id: 28,
+      entityId: 75239,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'Birmingham Outpatient Clinic (Annex) Parking Deck Alert',
+      alertType: 'information',
+      showClose: false,
+      content:
+        '<p>Please be aware of the current renovations for the Birmingham Outpatient Clinic (Annex) Parking deck over the next six to seven months. Contractors will initiate construction from the top of the parking deck, progressing downwards through each floor in the following weeks and months.</p>\n',
+      context: [
+        {
+          entity: {
+            title: 'Operating status | VA Birmingham health care',
+            entityUrl: {
+              path: '/birmingham-health-care/operating-status',
+            },
+            fieldOffice: {
+              entity: {
+                title: 'VA Birmingham health care',
+                entityUrl: {
+                  path: '/birmingham-health-care',
+                },
+                fieldVamcEhrSystem: 'vista',
+              },
+            },
+          },
+        },
+      ],
+      operatingStatusCta: true,
+      emailUpdatesButton: true,
+      findFacilitiesCta: false,
+      limitSubpageInheritance: false,
+      createdAt: '2024-12-04T17:36:13.306Z',
+      updatedAt: '2024-12-04T17:36:13.306Z',
+    },
+  ],
+  path: '/birmingham-health-care/operating-status',
+  bannerType: 'full_width_banner_alert',
+};
+
+export const maine = {
+  banners: [
+    {
+      id: 17,
+      entityId: 72825,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'No-Cost VA Flu/COVID Shots for Eligible Veterans',
+      alertType: 'information',
+      showClose: true,
+      content:
+        '<p>Visit one of VA Maine\'s upcoming Drive-Up Flu/COVID events to get your flu shot this flu season: <a href="https://www.va.gov/maine-health-care/news-releases/no-cost-va-flu-shots-for-eligible-veterans-0/"><strong>No-Cost VA Flu/COVID Shots for Eligible Veterans</strong>&nbsp;</a></p>\n',
+      context: [
+        {
+          entity: {
+            title: 'Operating status | VA Maine health care',
+            entityUrl: { path: '/maine-health-care/operating-status' },
+            fieldOffice: {
+              entity: {
+                title: 'VA Maine health care',
+                entityUrl: { path: '/maine-health-care' },
+                fieldVamcEhrSystem: 'vista',
+              },
+            },
+          },
+        },
+      ],
+      operatingStatusCta: false,
+      emailUpdatesButton: false,
+      findFacilitiesCta: false,
+      limitSubpageInheritance: false,
+      createdAt: '2024-12-04T17:36:13.248Z',
+      updatedAt: '2024-12-04T17:36:13.248Z',
+    },
+  ],
+  path: '/maine-health-care',
+  bannerType: 'full_width_banner_alert',
+};
+
+export const birminghamWoContext = {
+  banners: [
+    {
+      id: 28,
+      entityId: 75239,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'Birmingham Outpatient Clinic (Annex) Parking Deck Alert',
+      alertType: 'information',
+      showClose: false,
+      content:
+        '<p>Please be aware of the current renovations for the Birmingham Outpatient Clinic (Annex) Parking deck over the next six to seven months. Contractors will initiate construction from the top of the parking deck, progressing downwards through each floor in the following weeks and months.</p>\n',
+      operatingStatusCta: true,
+      emailUpdatesButton: true,
+      findFacilitiesCta: false,
+      limitSubpageInheritance: false,
+      createdAt: '2024-12-04T17:36:13.306Z',
+      updatedAt: '2024-12-04T17:36:13.306Z',
+    },
+  ],
+  path: '/birmingham-health-care/locations/birmingham-va-medical-center',
+  bannerType: 'full_width_banner_alert',
+};

--- a/src/applications/vaos/referral-appointments/ConfirmReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ConfirmReferral.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { clearReferralTimer, getReferralElapsedSeconds } from './utils/timer';
+import ReferralLayout from './components/ReferralLayout';
+
+export default function ConfirmReferral(props) {
+  const { currentReferral } = props;
+  return (
+    <ReferralLayout>
+      <h1>Confirm Referral for {currentReferral.CategoryOfCare}</h1>
+      <p>{currentReferral.UUID}</p>
+      <va-button
+        className="va-button-link"
+        onClick={() => {
+          const referralTimeTaken = getReferralElapsedSeconds(
+            currentReferral.UUID,
+          );
+          // eslint-disable-next-line no-alert
+          alert(`Referral Confirmed and took ${referralTimeTaken} seconds`);
+          clearReferralTimer(currentReferral.UUID);
+        }}
+        text="Confirm"
+        uswds
+      />
+    </ReferralLayout>
+  );
+}
+ConfirmReferral.propTypes = {
+  currentReferral: PropTypes.object.isRequired,
+};

--- a/src/applications/vaos/referral-appointments/flow.js
+++ b/src/applications/vaos/referral-appointments/flow.js
@@ -1,3 +1,5 @@
+import { startReferralTimer } from './utils/timer';
+
 /**
  * Function to get referral page flow.
  *
@@ -50,6 +52,10 @@ export function routeToPageInFlow(history, current, action, referralId) {
   const pageFlow = getPageFlow(referralId);
   const nextPageString = pageFlow[current][action];
   const nextPage = pageFlow[nextPageString];
+
+  if (action === 'next' && nextPageString === 'scheduleReferral') {
+    startReferralTimer(referralId);
+  }
 
   if (nextPage?.url) {
     history.push(nextPage.url);

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import ScheduleReferral from './ScheduleReferral';
 import ConfirmApprovedPage from './ConfirmApprovedPage';
+import ConfirmReferral from './ConfirmReferral';
 import ChooseDateAndTime from './ChooseDateAndTime';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 import { selectFeatureCCDirectScheduling } from '../redux/selectors';
@@ -87,6 +88,10 @@ export default function ReferralAppointments() {
           path={`${basePath.url}/date-time/`}
           component={ChooseDateAndTime}
         />
+        {/* TODO: remove this mock page when referral complete page is built */}
+        <Route path={`${basePath.url}/confirm`}>
+          <ConfirmReferral currentReferral={referral} />
+        </Route>
         <Route path={`${basePath.url}`} search={id}>
           <ScheduleReferral currentReferral={referral} />
         </Route>

--- a/src/applications/vaos/referral-appointments/tests/utils/timer.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/utils/timer.unit.spec.js
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+
+const timerUtil = require('../../utils/timer');
+
+describe('VAOS referral timer util', () => {
+  const TEST_ID = '12345';
+  const KEY_PREFIX = 'referral_start_time_';
+  const TEST_KEY = `${KEY_PREFIX}${TEST_ID}`;
+
+  beforeEach(() => {
+    // Clear sessionStorage before each test
+    sessionStorage.clear();
+  });
+
+  describe('startReferralTimer', () => {
+    it('should not set a value if no ID is provided', () => {
+      timerUtil.startReferralTimer();
+      expect(sessionStorage.length).to.equal(0);
+    });
+
+    it('should set the current time in sessionStorage for the given ID', () => {
+      timerUtil.startReferralTimer(TEST_ID);
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.be.a('string');
+      expect(new Date(storedTime).toISOString()).to.equal(storedTime);
+    });
+
+    it('should not overwrite the start time if it already exists', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      sessionStorage.setItem(TEST_KEY, initialTime);
+
+      timerUtil.startReferralTimer(TEST_ID);
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.equal(initialTime);
+    });
+  });
+
+  describe('getReferralElapsedSeconds', () => {
+    it('should return 0 if no ID is provided', () => {
+      const elapsed = timerUtil.getReferralElapsedSeconds();
+      expect(elapsed).to.equal(0);
+    });
+
+    it('should return 0 if no start time exists for the given ID', () => {
+      const elapsed = timerUtil.getReferralElapsedSeconds(TEST_ID);
+      expect(elapsed).to.equal(0);
+    });
+
+    it('should return the elapsed seconds since the start time', () => {
+      const now = new Date();
+      const pastTime = new Date(now.getTime() - 5000).toISOString(); // 5 seconds ago
+      sessionStorage.setItem(TEST_KEY, pastTime);
+
+      const elapsed = timerUtil.getReferralElapsedSeconds(TEST_ID);
+      expect(elapsed).to.be.closeTo(5, 1); // Allow a small margin of error
+    });
+  });
+
+  describe('clearReferralTimer', () => {
+    it('should not clear anything if no ID is provided', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      sessionStorage.setItem(TEST_KEY, initialTime);
+
+      timerUtil.clearReferralTimer();
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.equal(initialTime);
+    });
+
+    it('should clear the start time for the given ID', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      sessionStorage.setItem(TEST_KEY, initialTime);
+
+      timerUtil.clearReferralTimer(TEST_ID);
+
+      const storedTime = sessionStorage.getItem(TEST_KEY);
+      expect(storedTime).to.be.null;
+    });
+
+    it('should not affect other keys in sessionStorage', () => {
+      const initialTime = new Date(2023, 0, 1).toISOString();
+      const otherKey = `${KEY_PREFIX}67890`;
+      sessionStorage.setItem(TEST_KEY, initialTime);
+      sessionStorage.setItem(otherKey, initialTime);
+
+      timerUtil.clearReferralTimer(TEST_ID);
+
+      const storedOtherTime = sessionStorage.getItem(otherKey);
+      expect(storedOtherTime).to.equal(initialTime);
+    });
+  });
+});

--- a/src/applications/vaos/referral-appointments/utils/timer.js
+++ b/src/applications/vaos/referral-appointments/utils/timer.js
@@ -1,0 +1,66 @@
+/**
+ * Prefix for session storage keys related to referral start times.
+ * @constant {string}
+ */
+const KEY_PREFIX = 'referral_start_time_';
+
+/**
+ * Starts the referral timer for a given ID.
+ * If a start time already exists in session storage, it will not be overwritten.
+ *
+ * @param {string} id - The unique identifier for the referral.
+ * @returns {void}
+ */
+const startReferralTimer = id => {
+  if (!id) {
+    return;
+  }
+  const key = KEY_PREFIX + id;
+  // If time already exist within the session don't re set it to a later date.
+  const existingStartTime = sessionStorage.getItem(key);
+  if (existingStartTime) {
+    return;
+  }
+
+  const now = new Date();
+  sessionStorage.setItem(key, now.toISOString());
+};
+
+/**
+ * Gets the elapsed time in seconds since the referral timer started for a given ID.
+ * Returns 0 if no start time exists or if the ID is invalid.
+ *
+ * @param {string} id - The unique identifier for the referral.
+ * @returns {number} The elapsed time in seconds, or 0 if no start time exists.
+ */
+const getReferralElapsedSeconds = id => {
+  if (!id) {
+    return 0;
+  }
+  const key = KEY_PREFIX + id;
+  const savedStartTime = sessionStorage.getItem(key);
+
+  if (!savedStartTime) {
+    return 0;
+  }
+
+  const now = new Date();
+  const savedDate = new Date(savedStartTime);
+  return Math.floor((now.getTime() - savedDate.getTime()) / 1000); // Elapsed time in seconds
+};
+
+/**
+ * Clears the referral timer for a given ID.
+ *
+ * @param {string} id - The unique identifier for the referral.
+ * @returns {void}
+ */
+const clearReferralTimer = id => {
+  if (!id) {
+    return;
+  }
+  const key = KEY_PREFIX + id;
+  sessionStorage.removeItem(key);
+};
+
+export { getReferralElapsedSeconds, startReferralTimer, clearReferralTimer };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- _Switched download_archive Action to use v4 to reintroduce retry logic when the archive returns a server code as HTML instead of JSON_


## Related issue(s)

- [Support ticket](https://dsva.slack.com/archives/CBU0KDSB1/p1733406238008519)

## Requested Feedback

While Github is not going to address the flakiness we are seeing with the use of our archives, switching from the specific SHA of this action to v4 should stabilize our CI flows and allow us to complete CI runs without being as heavily affected.
