### PR TITLE
Add confirmation page

### DIFF
--- a/src/applications/burials-ez/components/DeathCertificateUploadMessage.jsx
+++ b/src/applications/burials-ez/components/DeathCertificateUploadMessage.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function DeathCertificateUploadMessage({ form }) {
+export default function DeathCertificateUploadMessage({ formData }) {
   const isAvailable =
-    form?.burialAllowanceRequested?.service === true ||
-    form?.locationOfDeath?.location !== 'vaMedicalCenter';
+    formData?.burialAllowanceRequested?.service === true ||
+    formData?.locationOfDeath?.location !== 'vaMedicalCenter';
 
   const isConnectedToMedicalCenter = Boolean(
-    form?.burialAllowanceRequested?.service === true &&
-    form?.locationOfDeath?.location === 'vaMedicalCenter'
+    formData?.burialAllowanceRequested?.service === true &&
+    formData?.locationOfDeath?.location === 'vaMedicalCenter'
       ? 0
       : 1,
   );
@@ -48,7 +48,7 @@ export default function DeathCertificateUploadMessage({ form }) {
 }
 
 DeathCertificateUploadMessage.propTypes = {
-  form: PropTypes.shape({
+  formData: PropTypes.shape({
     burialAllowanceRequested: PropTypes.shape({
       service: PropTypes.bool,
     }),

--- a/src/applications/burials-ez/components/ReviewRowView.jsx
+++ b/src/applications/burials-ez/components/ReviewRowView.jsx
@@ -19,10 +19,14 @@ ReviewRowView.propTypes = {
 };
 
 export const AltReviewRowView = ({ children }) => {
+  // children are usually a React element, but are an object on the confirmation page
+  const data = React.isValidElement(children)
+    ? children
+    : children?.props?.formData?.toString();
   return (
     <div className="review-row">
       <dt>{children?.props?.uiSchema?.['ui:title']}</dt>
-      <dd>{children}</dd>
+      <dd>{data}</dd>
     </div>
   );
 };

--- a/src/applications/burials-ez/config/chapters/05-additional-information/deathCertificate.js
+++ b/src/applications/burials-ez/config/chapters/05-additional-information/deathCertificate.js
@@ -27,6 +27,8 @@ export default {
           locationIsVaMedicalCenter
         );
       },
+      // Empty items object required for confirmation page
+      items: {},
     },
   },
   schema: {

--- a/src/applications/burials-ez/config/chapters/05-additional-information/deathCertificate.js
+++ b/src/applications/burials-ez/config/chapters/05-additional-information/deathCertificate.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import fullSchemaBurials from 'vets-json-schema/dist/21P-530V2-schema.json';
 import DeathCertificateUploadMessage from '../../../components/DeathCertificateUploadMessage';
 import { generateTitle } from '../../../utils/helpers';
@@ -9,9 +8,7 @@ const { files } = fullSchemaBurials.definitions;
 export default {
   uiSchema: {
     'ui:title': generateTitle('Death certificate'),
-    'ui:description': ({ formData }) => (
-      <DeathCertificateUploadMessage form={formData} />
-    ),
+    'ui:description': DeathCertificateUploadMessage,
     deathCertificate: {
       ...burialUploadUI('Upload the Veteran’s death certificate'),
       'ui:required': form => {

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -1,15 +1,21 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
+import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { benefitsLabels } from '../utils/labels';
+import formConfig from '../config/form';
 
 const ConfirmationPage = ({ form, isLoggedIn }) => {
+  const { TOGGLE_NAMES } = useFeatureToggle();
+
   useEffect(() => {
     focusElement('.confirmation-page-title');
     scrollToTop('topScrollElement');
   }, []);
 
+  const burialsConfirmationPage = TOGGLE_NAMES.burialConfirmationPage;
   const response = form?.submission?.response ?? {};
   const {
     'view:claimedBenefits': benefits,
@@ -64,6 +70,21 @@ const ConfirmationPage = ({ form, isLoggedIn }) => {
     } else {
       renderedTimestamp = timestamp;
     }
+  }
+
+  if (burialsConfirmationPage) {
+    return (
+      <ConfirmationView
+        submitDate={form?.submission?.timestamp}
+        confirmationNumber={response?.confirmationNumber}
+        formConfig={formConfig}
+        pdfUrl={response?.pdfUrl}
+        // devOnly={{
+        //   showButtons: true,
+        //   mockData,
+        // }}
+      />
+    );
   }
 
   return (

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -73,6 +73,80 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
     }
   }
 
+  const submissionInformation = (
+    <div className="inset">
+      <h3 className="vads-u-margin-top--0">Your submission information</h3>
+      <ul className="claim-list">
+        <li>
+          <h4>Who submitted this form</h4>
+          <span>
+            {claimantName?.first} {claimantName?.middle} {claimantName?.last}{' '}
+            {claimantName?.suffix}
+          </span>
+        </li>
+        <li>
+          <h4>Confirmation number</h4>
+          <span>{response?.confirmationNumber}</span>
+        </li>
+        <li>
+          <h4>Date submitted</h4>
+          <span>{renderedTimestamp}</span>
+        </li>
+        <li>
+          <h4>Deceased Veteran</h4>
+          <span>
+            {veteranName.first} {veteranName.middle} {veteranName.last}{' '}
+            {veteranName.suffix}
+          </span>
+        </li>
+        <li>
+          <h4>Benefits claimed</h4>
+          <ul className="benefits-claimed">
+            {Object.entries(benefits).map(([benefitName, isRequested]) => {
+              const label = benefitsLabels[benefitName];
+              return isRequested && label ? (
+                <li key={benefitName}>{label}</li>
+              ) : null;
+            })}
+          </ul>
+        </li>
+        {hasDocuments && (
+          <li>
+            <h4>Documents uploaded</h4>
+            {deathCertificate && <p>Death certificate: 1 file</p>}
+            {transportationReceipts && (
+              <p>
+                Transportation documentation: {transportationReceipts.length}{' '}
+                {transportationReceipts.length > 1 ? 'files' : 'file'}
+              </p>
+            )}
+          </li>
+        )}
+        <li>
+          <h4>Your application was sent to</h4>
+          <address className="schemaform-address-view">
+            {response?.regionalOffice?.map((line, index) => (
+              <p key={index}>{line}</p>
+            ))}
+          </address>
+        </li>
+        {burialsConfirmationPage ? null : (
+          <li>
+            <h4>Confirmation for your records</h4>
+            <p>You can print this confirmation page for your records</p>
+          </li>
+        )}
+      </ul>
+      {burialsConfirmationPage ? null : (
+        <va-button
+          className="usa-button screen-only"
+          onClick={() => window.print()}
+          text="Print this page"
+        />
+      )}
+    </div>
+  );
+
   if (burialsConfirmationPage) {
     return (
       <ConfirmationView
@@ -80,11 +154,19 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
         confirmationNumber={response?.confirmationNumber}
         formConfig={route?.formConfig}
         pdfUrl={response?.pdfUrl}
-        // devOnly={{
-        //   showButtons: true,
-        //   mockData,
-        // }}
-      />
+      >
+        <ConfirmationView.SubmissionAlert />
+        <ConfirmationView.SavePdfDownload />
+        {submissionInformation}
+        <ConfirmationView.PrintThisPage />
+        <ConfirmationView.WhatsNextProcessList
+          item1Content="This can take up to 10 days. When we receive your form, we'll update the status on My VA."
+          item2Content="If we need more information after reviewing your form, we'll contact you by phone, email, or mail. "
+        />
+        <ConfirmationView.HowToContact />
+        <ConfirmationView.GoBackLink />
+        <ConfirmationView.NeedHelp />
+      </ConfirmationView>
     );
   }
 
@@ -101,73 +183,7 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
           send you a letter with more information about your claim.
         </p>
       </va-alert>
-      <div className="inset">
-        <h3 className="vads-u-margin-top--0">Your submission information</h3>
-        <ul className="claim-list">
-          <li>
-            <h4>Who submitted this form</h4>
-            <span>
-              {claimantName?.first} {claimantName?.middle} {claimantName?.last}{' '}
-              {claimantName?.suffix}
-            </span>
-          </li>
-          <li>
-            <h4>Confirmation number</h4>
-            <span>{response?.confirmationNumber}</span>
-          </li>
-          <li>
-            <h4>Date submitted</h4>
-            <span>{renderedTimestamp}</span>
-          </li>
-          <li>
-            <h4>Deceased Veteran</h4>
-            <span>
-              {veteranName.first} {veteranName.middle} {veteranName.last}{' '}
-              {veteranName.suffix}
-            </span>
-          </li>
-          <li>
-            <h4>Benefits claimed</h4>
-            <ul className="benefits-claimed">
-              {Object.entries(benefits).map(([benefitName, isRequested]) => {
-                const label = benefitsLabels[benefitName];
-                return isRequested && label ? (
-                  <li key={benefitName}>{label}</li>
-                ) : null;
-              })}
-            </ul>
-          </li>
-          {hasDocuments && (
-            <li>
-              <h4>Documents uploaded</h4>
-              {deathCertificate && <p>Death certificate: 1 file</p>}
-              {transportationReceipts && (
-                <p>
-                  Transportation documentation: {transportationReceipts.length}{' '}
-                  {transportationReceipts.length > 1 ? 'files' : 'file'}
-                </p>
-              )}
-            </li>
-          )}
-          <li>
-            <h4>Your application was sent to</h4>
-            <address className="schemaform-address-view">
-              {response?.regionalOffice?.map((line, index) => (
-                <p key={index}>{line}</p>
-              ))}
-            </address>
-          </li>
-          <li>
-            <h4>Confirmation for your records</h4>
-            <p>You can print this confirmation page for your records</p>
-          </li>
-        </ul>
-        <va-button
-          className="usa-button screen-only"
-          onClick={() => window.print()}
-          text="Print this page"
-        />
-      </div>
+      {submissionInformation}
       <h2>How to submit supporting documents</h2>
 
       <p>

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -73,6 +73,11 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
     }
   }
 
+  const item1Content =
+    "This can take up to 10 days. When we receive your form, we'll update the status on My VA.";
+  const item2Content =
+    "If we need more information after reviewing your form, we'll contact you by phone, email, or mail.";
+
   const submissionInformation = (
     <div className="inset">
       <h2 className="vads-u-margin-top--0">Your submission information</h2>
@@ -264,14 +269,26 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
         formConfig={route?.formConfig}
         pdfUrl={response?.pdfUrl}
       >
-        <ConfirmationView.SubmissionAlert />
-        {/* <ConfirmationView.SavePdfDownload /> */}
+        {isLoggedIn ? (
+          <ConfirmationView.SubmissionAlert />
+        ) : (
+          <ConfirmationView.SubmissionAlert actions={<p />} />
+        )}
         {submissionInformation}
         <ConfirmationView.PrintThisPage />
-        <ConfirmationView.WhatsNextProcessList
-          item1Content="This can take up to 10 days. When we receive your form, we'll update the status on My VA."
-          item2Content="If we need more information after reviewing your form, we'll contact you by phone, email, or mail. "
-        />
+        <br />
+        {isLoggedIn ? (
+          <ConfirmationView.WhatsNextProcessList
+            item1Content={item1Content}
+            item2Content={item2Content}
+          />
+        ) : (
+          <ConfirmationView.WhatsNextProcessList
+            item1Content={item1Content}
+            item1Actions={<p />}
+            item2Content={item2Content}
+          />
+        )}
         {submitAdditionalDocuments}
         <ConfirmationView.GoBackLink />
         <ConfirmationView.NeedHelp />

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -5,17 +5,18 @@ import { ConfirmationView } from 'platform/forms-system/src/js/components/Confir
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { benefitsLabels } from '../utils/labels';
-import formConfig from '../config/form';
 
-const ConfirmationPage = ({ form, isLoggedIn }) => {
-  const { TOGGLE_NAMES } = useFeatureToggle();
+const ConfirmationPage = ({ form, isLoggedIn, route }) => {
+  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
+  const burialsConfirmationPage = useToggleValue(
+    TOGGLE_NAMES.burialConfirmationPage,
+  );
 
   useEffect(() => {
     focusElement('.confirmation-page-title');
     scrollToTop('topScrollElement');
   }, []);
 
-  const burialsConfirmationPage = TOGGLE_NAMES.burialConfirmationPage;
   const response = form?.submission?.response ?? {};
   const {
     'view:claimedBenefits': benefits,
@@ -77,7 +78,7 @@ const ConfirmationPage = ({ form, isLoggedIn }) => {
       <ConfirmationView
         submitDate={form?.submission?.timestamp}
         confirmationNumber={response?.confirmationNumber}
-        formConfig={formConfig}
+        formConfig={route?.formConfig}
         pdfUrl={response?.pdfUrl}
         // devOnly={{
         //   showButtons: true,

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -75,32 +75,32 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
 
   const submissionInformation = (
     <div className="inset">
-      <h3 className="vads-u-margin-top--0">Your submission information</h3>
+      <h2 className="vads-u-margin-top--0">Your submission information</h2>
       <ul className="claim-list">
         <li>
-          <h4>Who submitted this form</h4>
+          <h3>Who submitted this form</h3>
           <span>
             {claimantName?.first} {claimantName?.middle} {claimantName?.last}{' '}
             {claimantName?.suffix}
           </span>
         </li>
         <li>
-          <h4>Confirmation number</h4>
+          <h3>Confirmation number</h3>
           <span>{response?.confirmationNumber}</span>
         </li>
         <li>
-          <h4>Date submitted</h4>
+          <h3>Date submitted</h3>
           <span>{renderedTimestamp}</span>
         </li>
         <li>
-          <h4>Deceased Veteran</h4>
+          <h3>Deceased Veteran</h3>
           <span>
             {veteranName.first} {veteranName.middle} {veteranName.last}{' '}
             {veteranName.suffix}
           </span>
         </li>
         <li>
-          <h4>Benefits claimed</h4>
+          <h3>Benefits claimed</h3>
           <ul className="benefits-claimed">
             {Object.entries(benefits).map(([benefitName, isRequested]) => {
               const label = benefitsLabels[benefitName];
@@ -112,7 +112,7 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
         </li>
         {hasDocuments && (
           <li>
-            <h4>Documents uploaded</h4>
+            <h3>Documents uploaded</h3>
             {deathCertificate && <p>Death certificate: 1 file</p>}
             {transportationReceipts && (
               <p>
@@ -123,7 +123,7 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
           </li>
         )}
         <li>
-          <h4>Your application was sent to</h4>
+          <h3>Your application was sent to</h3>
           <address className="schemaform-address-view">
             {response?.regionalOffice?.map((line, index) => (
               <p key={index}>{line}</p>
@@ -132,7 +132,7 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
         </li>
         {burialsConfirmationPage ? null : (
           <li>
-            <h4>Confirmation for your records</h4>
+            <h3>Confirmation for your records</h3>
             <p>You can print this confirmation page for your records</p>
           </li>
         )}
@@ -147,6 +147,115 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
     </div>
   );
 
+  const submitAdditionalDocuments = (
+    <>
+      <h2>How to submit supporting documents</h2>
+      <p>
+        If you still need to submit additional supporting documents, you can
+        submit copies of them by mail.
+      </p>
+      <p>
+        Write the Veteran’s Social Security number or VA file number (if it’s
+        different than their Social Security number) on the first page of the
+        documents.
+      </p>
+      <p>Mail any supporting documents to this address:</p>
+      <p className="va-address-block">
+        Department of Veterans Affairs <br />
+        Pension Intake Center
+        <br />
+        PO Box 5365
+        <br />
+        Janesville, WI 53547-5365
+        <br />
+      </p>
+      <p>
+        <strong>Note:</strong> Mail us copies of your documents only. Don’t send
+        us your original documents. We can’t return them.
+      </p>
+      <h3>Medical records</h3>
+      <p>
+        If you’re claiming a burial allowance for a service-connected death, we
+        recommend submitting the Veteran’s medical records. How you submit their
+        records depends on if you have access to them right now.
+      </p>
+      <p>
+        <strong>Note:</strong> It’s your choice whether you want to submit the
+        Veteran’s medical records. They’ll help us process your claim and
+        confirm information about the Veteran’s medical history at the time of
+        their death.
+      </p>
+      <h4>If you have access</h4>
+      <p>
+        If you have access to the Veteran’s medical records, you can mail copies
+        of these documents to the address listed on this page.
+      </p>
+      <h4>If you don’t have access</h4>
+      <p>
+        If you don’t have access to the Veteran’s medical records, you’ll need
+        to authorize the release of their records to us. How you release their
+        records depends on where the Veteran was receiving care at the time of
+        their death.
+      </p>
+      <p>
+        Provide details about the records or information you want us to request.
+        This will help us request this information.
+      </p>
+      <p>
+        <strong>
+          If the Veteran was receiving care at a VA health facility at the time
+          of their death,
+        </strong>{' '}
+        you can fill out and submit a statement in support of your claim (VA
+        Form 21-4138). Mail this form to the address listed on this page.
+      </p>
+      <p>
+        <a href="/find-forms/about-form-21-4138/" target="_blank">
+          Get VA Form 21-4138 to download (opens in new tab)
+        </a>
+      </p>
+      <p>
+        <strong>
+          If the deceased Veteran was receiving care at a non-VA private health
+          facility at the time of their death,
+        </strong>
+        we’ll try to locate their medical records for you.
+      </p>
+      <p>You can authorize the release of their medical records online.</p>
+      <p>
+        <a
+          href="/supporting-forms-for-claims/release-information-to-va-form-21-4142/"
+          target="_blank"
+          className="vads-c-action-link--green"
+        >
+          Authorize the release of non-VA medical records (opens in new tab)
+        </a>
+      </p>
+      <p>
+        Or, you can fill out both of these forms and mail them to the address
+        listed on this screen:
+      </p>
+      <ul>
+        <li>
+          Authorization to Disclose Information to the Department of Veterans
+          Affairs (VA Form 21-4142)
+          <br />
+          <a href="/find-forms/about-form-21-4142/" target="_blank">
+            Get VA Form 21-4142 to download (opens in new tab)
+          </a>
+        </li>
+        <li>
+          General Release for Medical Provider Information to the Department of
+          Veterans Affairs (VA Form 21-4142a)
+          <br />
+          <a href="/find-forms/about-form-21-4142a/" target="_blank">
+            Get VA Form 21-4142a to download (opens in new tab)
+          </a>
+        </li>
+      </ul>
+    </>
+  );
+
   if (burialsConfirmationPage) {
     return (
       <ConfirmationView
@@ -156,14 +265,14 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
         pdfUrl={response?.pdfUrl}
       >
         <ConfirmationView.SubmissionAlert />
-        <ConfirmationView.SavePdfDownload />
+        {/* <ConfirmationView.SavePdfDownload /> */}
         {submissionInformation}
         <ConfirmationView.PrintThisPage />
         <ConfirmationView.WhatsNextProcessList
           item1Content="This can take up to 10 days. When we receive your form, we'll update the status on My VA."
           item2Content="If we need more information after reviewing your form, we'll contact you by phone, email, or mail. "
         />
-        <ConfirmationView.HowToContact />
+        {submitAdditionalDocuments}
         <ConfirmationView.GoBackLink />
         <ConfirmationView.NeedHelp />
       </ConfirmationView>
@@ -184,131 +293,7 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
         </p>
       </va-alert>
       {submissionInformation}
-      <h2>How to submit supporting documents</h2>
-
-      <p>
-        If you still need to submit additional supporting documents, you can
-        submit copies of them by mail.
-      </p>
-
-      <p>
-        Write the Veteran’s Social Security number or VA file number (if it’s
-        different than their Social Security number) on the first page of the
-        documents.
-      </p>
-
-      <p>Mail any supporting documents to this address:</p>
-
-      <p className="va-address-block">
-        Department of Veterans Affairs <br />
-        Pension Intake Center
-        <br />
-        PO Box 5365
-        <br />
-        Janesville, WI 53547-5365
-        <br />
-      </p>
-
-      <p>
-        <strong>Note:</strong> Mail us copies of your documents only. Don’t send
-        us your original documents. We can’t return them.
-      </p>
-
-      <h3>Medical records</h3>
-
-      <p>
-        If you’re claiming a burial allowance for a service-connected death, we
-        recommend submitting the Veteran’s medical records. How you submit their
-        records depends on if you have access to them right now.
-      </p>
-
-      <p>
-        <strong>Note:</strong> It’s your choice whether you want to submit the
-        Veteran’s medical records. They’ll help us process your claim and
-        confirm information about the Veteran’s medical history at the time of
-        their death.
-      </p>
-
-      <h4>If you have access</h4>
-
-      <p>
-        If you have access to the Veteran’s medical records, you can mail copies
-        of these documents to the address listed on this page.
-      </p>
-
-      <h4>If you don’t have access</h4>
-
-      <p>
-        If you don’t have access to the Veteran’s medical records, you’ll need
-        to authorize the release of their records to us. How you release their
-        records depends on where the Veteran was receiving care at the time of
-        their death.
-      </p>
-
-      <p>
-        Provide details about the records or information you want us to request.
-        This will help us request this information.
-      </p>
-
-      <p>
-        <strong>
-          If the Veteran was receiving care at a VA health facility at the time
-          of their death,
-        </strong>{' '}
-        you can fill out and submit a statement in support of your claim (VA
-        Form 21-4138). Mail this form to the address listed on this page.
-      </p>
-
-      <p>
-        <a href="/find-forms/about-form-21-4138/" target="_blank">
-          Get VA Form 21-4138 to download (opens in new tab)
-        </a>
-      </p>
-
-      <p>
-        <strong>
-          If the deceased Veteran was receiving care at a non-VA private health
-          facility at the time of their death,
-        </strong>
-        we’ll try to locate their medical records for you.
-      </p>
-
-      <p>You can authorize the release of their medical records online.</p>
-
-      <p>
-        <a
-          href="/supporting-forms-for-claims/release-information-to-va-form-21-4142/"
-          target="_blank"
-          className="vads-c-action-link--green"
-        >
-          Authorize the release of non-VA medical records (opens in new tab)
-        </a>
-      </p>
-
-      <p>
-        Or, you can fill out both of these forms and mail them to the address
-        listed on this screen:
-      </p>
-
-      <ul>
-        <li>
-          Authorization to Disclose Information to the Department of Veterans
-          Affairs (VA Form 21-4142)
-          <br />
-          <a href="/find-forms/about-form-21-4142/" target="_blank">
-            Get VA Form 21-4142 to download (opens in new tab)
-          </a>
-        </li>
-        <li>
-          General Release for Medical Provider Information to the Department of
-          Veterans Affairs (VA Form 21-4142a)
-          <br />
-          <a href="/find-forms/about-form-21-4142a/" target="_blank">
-            Get VA Form 21-4142a to download (opens in new tab)
-          </a>
-        </li>
-      </ul>
-
+      {submitAdditionalDocuments}
       <h2>What are my next steps?</h2>
 
       <p>

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -379,10 +379,10 @@ ConfirmationPage.propTypes = {
   form: PropTypes.shape({
     submission: PropTypes.shape({
       response: PropTypes.shape({}),
-      timestamp: PropTypes.number,
+      timestamp: PropTypes.instanceOf(Date),
     }),
     data: PropTypes.shape({
-      deathCertificate: PropTypes.shape({}),
+      deathCertificate: PropTypes.arrayOf(PropTypes.shape({})),
       transportationReceipts: PropTypes.arrayOf(PropTypes.shape({})),
     }),
   }),

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
@@ -373,6 +374,23 @@ function mapStateToProps(state) {
     isLoggedIn: state.user?.login?.currentlyLoggedIn,
   };
 }
+
+ConfirmationPage.propTypes = {
+  form: PropTypes.shape({
+    submission: PropTypes.shape({
+      response: PropTypes.shape({}),
+      timestamp: PropTypes.number,
+    }),
+    data: PropTypes.shape({
+      deathCertificate: PropTypes.shape({}),
+      transportationReceipts: PropTypes.arrayOf(PropTypes.shape({})),
+    }),
+  }),
+  isLoggedIn: PropTypes.bool,
+  route: PropTypes.shape({
+    formConfig: PropTypes.shape({}),
+  }),
+};
 
 export default connect(mapStateToProps)(ConfirmationPage);
 export { ConfirmationPage };

--- a/src/applications/burials-ez/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
+import { mount } from 'enzyme';
+import { render, cleanup } from '@testing-library/react';
 import { expect } from 'chai';
 
+import formConfig from '../../config/form';
 import ConfirmationPage from '../../containers/ConfirmationPage';
+
+const formPages = Object.values(formConfig.chapters).reduce(
+  (pages, chapter) => ({ ...pages, ...chapter.pages }),
+  {},
+);
 
 describe('<ConfirmationPage>', () => {
   const testDate = new Date('12-15-2021');
@@ -11,6 +18,7 @@ describe('<ConfirmationPage>', () => {
     transportationReceiptsLength = 2,
     claimedBenefits = true,
     hasDeathCertificate = true,
+    burialConfirmationPage = false,
   } = {}) => ({
     getState: () => ({
       user: {
@@ -23,6 +31,7 @@ describe('<ConfirmationPage>', () => {
         },
       },
       form: {
+        pages: formPages,
         data: {
           claimantFullName: {
             first: 'Sally',
@@ -40,9 +49,14 @@ describe('<ConfirmationPage>', () => {
             transportation: claimedBenefits,
           },
           ...(hasDeathCertificate && {
-            deathCertificate: {
-              length: 1,
-            },
+            deathCertificate: [
+              {
+                name: 'DeathCertificate.pdf',
+                confirmationCode: 'e22d5af8-848d-4fa1-b4f6-90953e0e3c8d',
+                attachmentId: '',
+                isEncrypted: false,
+              },
+            ],
           }),
           transportationReceipts: {
             length: transportationReceiptsLength,
@@ -65,6 +79,7 @@ describe('<ConfirmationPage>', () => {
       featureToggles: {
         loading: false,
         [`burials_form_enabled`]: true,
+        [`burial_confirmation_page`]: burialConfirmationPage,
       },
     }),
     subscribe: () => {},
@@ -75,9 +90,10 @@ describe('<ConfirmationPage>', () => {
     const mockStore = store();
     const { container, queryByText } = render(
       <Provider store={mockStore}>
-        <ConfirmationPage />
+        <ConfirmationPage route={{ formConfig }} />
       </Provider>,
     );
+
     expect(queryByText('V-EBC-177')).to.not.be.null;
     expect(
       container.querySelector('.benefits-claimed').children.length,
@@ -92,10 +108,47 @@ describe('<ConfirmationPage>', () => {
     });
     const { queryByText } = render(
       <Provider store={mockStore}>
-        <ConfirmationPage />
+        <ConfirmationPage route={{ formConfig }} />
       </Provider>,
     );
 
     expect(queryByText('Transportation documentation: 1 file')).to.exist;
+  });
+
+  context('with burialsConfirmationPage', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = mount(
+        <Provider store={store({ burialConfirmationPage: true })}>
+          <ConfirmationPage route={{ formConfig }} />
+        </Provider>,
+      );
+    });
+
+    afterEach(() => {
+      if (wrapper) {
+        wrapper.unmount();
+      }
+      cleanup();
+    });
+
+    it('it should show status success', () => {
+      const mockStore = store({ burialConfirmationPage: true });
+      const { container } = render(
+        <Provider store={mockStore}>
+          <ConfirmationPage route={{ formConfig }} />
+        </Provider>,
+      );
+      expect(container.querySelector('va-alert')).to.have.attr(
+        'status',
+        'success',
+      );
+    });
+
+    it('passes the correct props to ConfirmationPageView', () => {
+      const confirmationViewProps = wrapper.find('ConfirmationView').props();
+      expect(confirmationViewProps.submitDate).to.equal(1639544400000);
+      expect(confirmationViewProps.confirmationNumber).to.equal('V-EBC-177');
+    });
   });
 });

--- a/src/applications/burials-ez/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -147,7 +147,7 @@ describe('<ConfirmationPage>', () => {
 
     it('passes the correct props to ConfirmationPageView', () => {
       const confirmationViewProps = wrapper.find('ConfirmationView').props();
-      expect(confirmationViewProps.submitDate).to.equal(1639544400000);
+      expect(confirmationViewProps.submitDate).to.equal(testDate.getTime());
       expect(confirmationViewProps.confirmationNumber).to.equal('V-EBC-177');
     });
   });

--- a/src/applications/burials-ez/tests/fixtures/mocks/featuresEnabled.json
+++ b/src/applications/burials-ez/tests/fixtures/mocks/featuresEnabled.json
@@ -16,6 +16,14 @@
         {
           "name": "burial_form_v2",
           "value": true
+        },
+        {
+          "name": "burial_confirmation_page",
+          "value": true
+        },
+        {
+          "name": "burialConfirmationPage",
+          "value": true
         }
       ]
     }

--- a/src/applications/burials-ez/utils/labels.jsx
+++ b/src/applications/burials-ez/utils/labels.jsx
@@ -48,6 +48,6 @@ export const cemeteryTypeLabels = {
 
 export const fasterClaimLabels = {
   Y:
-    'Yes. I’ve uploaded all my supporting documents form my application for burial benefits',
+    'Yes. I’ve uploaded all my supporting documents for my application for burial benefits',
   N: 'No. I have other supporting documents to submit later',
 };

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -11,6 +11,7 @@
   "bannerUseAlternativeBanners": "banner_use_alternative_banners",
   "bcasLettersUseLighthouse": "bcas_letters_use_lighthouse",
   "benefitsDocumentsUseLighthouse": "benefits_documents_use_lighthouse",
+  "burialConfirmationPage": "burial_confirmation_page",
   "burialFormEnabled": "burial_form_enabled",
   "burialFormV2": "burial_form_v2",
   "caregiverBrowserMonitoringEnabled": "caregiver_browser_monitoring_enabled",


### PR DESCRIPTION
## Summary

- Implement the ConfirmationView component into the 21P-530 (Burials) form and update the confirmation page with a few MVP changes to meet the requirements of ZSF stage 2.

This is behind a flipper, which needs to be merged first https://github.com/department-of-veterans-affairs/vets-api/pull/19761. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95585
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98098

## Testing done

- Disable http://localhost:3000/flipper/features/burial_confirmation_page
     - Fill out and submit http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/introduction
     - Ensure the confirmation page has no changes from `main`

- Enable http://localhost:3000/flipper/features/burial_confirmation_page
     - Fill out and submit http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/introduction
     - Ensure the confirmation page matches the [wireframes](https://www.figma.com/design/jpJQSCKiGegacdW4RH5uQB/Burial-530-2024-Updates-MVP?node-id=3800-5635&t=Pz6zX8tqzdOEUGe9-4)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Authenticated  |   <img width="490" alt="Conf1a" src="https://github.com/user-attachments/assets/26afe7b9-0c6b-4adf-8bb2-d21ac8cd4e88"> <img width="463" alt="Conf1b" src="https://github.com/user-attachments/assets/741955d9-0e32-443b-aebf-246b1ce2b39e"> <img width="533" alt="Conf1c" src="https://github.com/user-attachments/assets/c1a36523-9e92-46d6-a7cb-2f0d0cfc8980">  |  <img width="472" alt="Conf2a" src="https://github.com/user-attachments/assets/981143f2-6850-4e24-9f05-7de24ccf914c"> <img width="349" alt="Screenshot 2024-12-09 at 10 31 49 AM" src="https://github.com/user-attachments/assets/570e0603-d210-4094-8716-0a9f40f27b3e"> <img width="484" alt="Conf2c" src="https://github.com/user-attachments/assets/3b7f87ba-4515-4fb9-9c29-ee046186d81f"> |
| Unauthenticated |    Duplicate    |     <img width="492" alt="Screenshot 2024-12-09 at 10 27 29 AM" src="https://github.com/user-attachments/assets/bc353ee3-92ae-467e-b4b5-25cb24220d18"> <img width="519" alt="Screenshot 2024-12-09 at 10 27 45 AM" src="https://github.com/user-attachments/assets/c649ab40-e451-4e52-88d0-686f97e62011">  |

## What areas of the site does it impact?

Burials

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

