### PR TITLE
Conditions 646 arrayPath, FormFooter, depends, and remove conditional from cause

### DIFF
--- a/src/applications/user-testing/new-conditions/components/Autocomplete.jsx
+++ b/src/applications/user-testing/new-conditions/components/Autocomplete.jsx
@@ -161,6 +161,7 @@ const Autocomplete = ({
   return (
     <div className="cc-autocomplete" ref={containerRef}>
       <VaTextInput
+        autocomplete="off"
         data-testid="autocomplete-input"
         id={id}
         label={label}

--- a/src/applications/user-testing/new-conditions/components/FormFooter.jsx
+++ b/src/applications/user-testing/new-conditions/components/FormFooter.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import CallVBACenter from 'platform/static-data/CallVBACenter';
+
+const FormFooter = () => (
+  <div className="row vads-u-margin-bottom--2">
+    <div className="usa-width-two-thirds medium-8 columns">
+      <va-need-help>
+        <div slot="content">
+          <div>
+            <p className="help-talk">
+              For help filling out this form, or if the form isn’t working
+              right, <CallVBACenter />
+            </p>
+          </div>
+        </div>
+      </va-need-help>
+    </div>
+  </div>
+);
+
+export default FormFooter;

--- a/src/applications/user-testing/new-conditions/config/form.js
+++ b/src/applications/user-testing/new-conditions/config/form.js
@@ -1,7 +1,6 @@
-import React from 'react';
 import { VA_FORM_IDS } from 'platform/forms/constants';
-import CallVBACenter from 'platform/static-data/CallVBACenter';
 
+import FormFooter from '../components/FormFooter';
 import { SUBTITLE, TITLE } from '../constants';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import IntroductionPage from '../containers/IntroductionPage';
@@ -13,23 +12,6 @@ import followUpCause from '../pages/followUpCause';
 import followUpCauseDescription from '../pages/followUpCauseDescription';
 import followUpDate from '../pages/followUpDate';
 import followUpIntro from '../pages/followUpIntro';
-
-const FormFooter = () => (
-  <div className="row vads-u-margin-bottom--2">
-    <div className="usa-width-two-thirds medium-8 columns">
-      <va-need-help>
-        <div slot="content">
-          <div>
-            <p className="help-talk">
-              For help filling out this form, or if the form isn’t working
-              right, <CallVBACenter />
-            </p>
-          </div>
-        </div>
-      </va-need-help>
-    </div>
-  </div>
-);
 
 /** @type {FormConfig} */
 const formConfig = {

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/causeFollowUp.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/causeFollowUp.js
@@ -7,7 +7,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import { conditionOptions } from '../../content/conditionOptions';
-import { createItemName } from './utils';
+import { arrayBuilderOptions, createItemName } from './utils';
 
 export const createCauseFollowUpTitles = formData => {
   const causeTitle = {
@@ -31,8 +31,8 @@ export const createCauseFollowUpTitles = formData => {
 // TODO: Fix formData so that shape is consistent
 // formData changes shape between add and edit which results in the need for the conditional below
 const createCauseFollowUpConditional = (formData, index, causeType) => {
-  const cause = formData?.conditionByCondition
-    ? formData.conditionByCondition[index]?.cause
+  const cause = formData?.[arrayBuilderOptions.arrayPath]
+    ? formData?.[arrayBuilderOptions.arrayPath][index]?.cause
     : formData.cause;
   return cause !== causeType;
 };
@@ -46,7 +46,7 @@ const getOtherConditions = (formData, currentIndex) => {
     formData?.ratedDisabilities?.map(disability => disability.name) || [];
 
   const otherNewConditions =
-    formData?.conditionByCondition
+    formData?.[arrayBuilderOptions.arrayPath]
       ?.filter((_, index) => index !== currentIndex)
       ?.map(condition => createItemName(condition)) || [];
 

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
@@ -35,7 +35,7 @@ const validateNotMissing = (err, fieldData) => {
 
 const validateNotDuplicate = (err, fieldData, formData) => {
   const currentList =
-    formData?.conditionByCondition?.map(condition =>
+    formData?.[arrayBuilderOptions.arrayPath]?.map(condition =>
       condition.condition?.toLowerCase(),
     ) || [];
   const itemLowerCased = fieldData?.toLowerCase() || '';

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
@@ -33,6 +33,8 @@ const validateNotMissing = (err, fieldData) => {
   }
 };
 
+// TODO: On edit, allows previous index value to be the same as later index value
+// Note: Does not allow later index to be same as previous on edit
 const validateNotDuplicate = (err, fieldData, formData) => {
   const currentList =
     formData?.[arrayBuilderOptions.arrayPath]?.map(condition =>

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/date.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/date.js
@@ -12,6 +12,9 @@ const datePage = {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) => `Start date of ${createItemName(formData)}`,
     ),
+    // TODO: Can we make just year required?
+    // Could use month-optional https://design.va.gov/storybook/?path=/story/components-va-date--month-optional
+    // TODO: Why is there the empty option when both are required?
     date: currentOrPastMonthYearDateUI({
       title: 'What’s the approximate date your condition started?',
     }),

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/index.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/index.js
@@ -1,6 +1,4 @@
-import { stringifyUrlParams } from '@department-of-veterans-affairs/platform-forms-system/helpers';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
-import { getArrayIndexFromPathName } from 'platform/forms-system/src/js/patterns/array-builder/helpers';
 
 import causePage from './cause';
 import causeFollowUpPage from './causeFollowUp';
@@ -12,33 +10,33 @@ import summaryPage from './summary';
 import { arrayBuilderOptions, hasSideOfBody } from './utils';
 import { CONDITION_BY_CONDITION } from '../../constants';
 
+const isActiveDemo = formData => formData.demo === 'CONDITION_BY_CONDITION';
+
 const conditionByConditionPages = arrayBuilderPages(
   arrayBuilderOptions,
   (pageBuilder, helpers) => ({
     conditionByConditionIntro: pageBuilder.introPage({
       title: 'New conditions intro',
       path: `new-conditions-${CONDITION_BY_CONDITION}-intro`,
-      depends: formData => formData.demo === 'CONDITION_BY_CONDITION',
+      depends: isActiveDemo,
       uiSchema: introPage.uiSchema,
       schema: introPage.schema,
     }),
     conditionByConditionSummary: pageBuilder.summaryPage({
       title: 'Review your new conditions',
       path: `new-conditions-${CONDITION_BY_CONDITION}-summary`,
-      depends: formData => formData.demo === 'CONDITION_BY_CONDITION',
+      depends: isActiveDemo,
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
     conditionByConditionCondition: pageBuilder.itemPage({
       title: 'Claim a new condition',
       path: `new-conditions-${CONDITION_BY_CONDITION}/:index/condition`,
-      depends: formData => formData.demo === 'CONDITION_BY_CONDITION',
+      depends: isActiveDemo,
       uiSchema: conditionPage.uiSchema,
       schema: conditionPage.schema,
-      // TODO: use depends: (formData, index) instead on the dynamic page for routing.
       onNavForward: props => {
-        const { formData, urlParams, goPath, index } = props;
-        const urlParamsString = stringifyUrlParams(urlParams) || '';
+        const { formData, index } = props;
         const item = formData?.[arrayBuilderOptions.arrayPath]?.[index];
 
         if (item) {
@@ -48,50 +46,34 @@ const conditionByConditionPages = arrayBuilderPages(
           item.sideOfBody = undefined;
         }
 
-        return hasSideOfBody(item, index)
-          ? helpers.navForwardKeepUrlParams(props)
-          : goPath(
-              `new-conditions-${CONDITION_BY_CONDITION}/${index}/date${urlParamsString}`,
-            );
+        return helpers.navForwardKeepUrlParams(props);
       },
     }),
     conditionByConditionSideOfBody: pageBuilder.itemPage({
       title: 'Side of body of new condition',
       path: `new-conditions-${CONDITION_BY_CONDITION}/:index/side-of-body`,
-      depends: formData => formData.demo === 'CONDITION_BY_CONDITION',
+      depends: isActiveDemo && hasSideOfBody,
       uiSchema: sideOfBodyPage.uiSchema,
       schema: sideOfBodyPage.schema,
     }),
     conditionByConditionDate: pageBuilder.itemPage({
       title: 'Date of new condition',
       path: `new-conditions-${CONDITION_BY_CONDITION}/:index/date`,
-      depends: formData => formData.demo === 'CONDITION_BY_CONDITION',
+      depends: isActiveDemo,
       uiSchema: datePage.uiSchema,
       schema: datePage.schema,
-      // TODO: use depends: (formData, index) instead on the dynamic page.
-      onNavBack: props => {
-        const { formData, pathname, urlParams, goPath } = props;
-        const index = getArrayIndexFromPathName(pathname);
-        const urlParamsString = stringifyUrlParams(urlParams) || '';
-
-        return hasSideOfBody(formData, index)
-          ? helpers.navBackKeepUrlParams(props)
-          : goPath(
-              `new-conditions-${CONDITION_BY_CONDITION}/${index}/condition${urlParamsString}`,
-            );
-      },
     }),
     conditionByConditionCause: pageBuilder.itemPage({
       title: 'Cause of new condition',
       path: `new-conditions-${CONDITION_BY_CONDITION}/:index/cause`,
-      depends: formData => formData.demo === 'CONDITION_BY_CONDITION',
+      depends: isActiveDemo,
       uiSchema: causePage.uiSchema,
       schema: causePage.schema,
     }),
     conditionByConditionCauseFollowUp: pageBuilder.itemPage({
       title: 'Cause follow up for new condition',
       path: `new-conditions-${CONDITION_BY_CONDITION}/:index/cause-follow-up`,
-      depends: formData => formData.demo === 'CONDITION_BY_CONDITION',
+      depends: isActiveDemo,
       uiSchema: causeFollowUpPage.uiSchema,
       schema: causeFollowUpPage.schema,
     }),

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/index.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/index.js
@@ -39,10 +39,11 @@ const conditionByConditionPages = arrayBuilderPages(
         const { formData, index } = props;
         const item = formData?.[arrayBuilderOptions.arrayPath]?.[index];
 
+        // TODO: This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
+        // However, with this fix, when user doesn't change condition, side of body is still cleared which could confuse users
+        // The depends should potentially clear the data of the dependent pages when the condition is no longer true
+        // TODO: use setFormData instead of mutating formData directly.
         if (item) {
-          // TODO: This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
-          // However, with this fix, when user doesn't change condition, side of body is cleared which could confuse users
-          // TODO: use setFormData instead of mutating formData directly.
           item.sideOfBody = undefined;
         }
 
@@ -52,7 +53,8 @@ const conditionByConditionPages = arrayBuilderPages(
     conditionByConditionSideOfBody: pageBuilder.itemPage({
       title: 'Side of body of new condition',
       path: `new-conditions-${CONDITION_BY_CONDITION}/:index/side-of-body`,
-      depends: isActiveDemo && hasSideOfBody,
+      depends: (formData, index) =>
+        isActiveDemo(formData) && hasSideOfBody(formData, index),
       uiSchema: sideOfBodyPage.uiSchema,
       schema: sideOfBodyPage.schema,
     }),

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/summary.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/summary.js
@@ -16,6 +16,7 @@ const summaryPage = {
     'view:hasConditions': arrayBuilderYesNoUI(
       arrayBuilderOptions,
       {},
+      // TODO: Is this the best way to handle hiding the hint?
       {
         hint: ' ', // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
       },

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/utils.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/utils.js
@@ -58,7 +58,7 @@ export const arrayBuilderOptions = {
     !item?.condition ||
     !item?.date ||
     !item?.cause ||
-    (causeFollowUpChecks[item.cause] && causeFollowUpChecks[item.cause](item)),
+    causeFollowUpChecks[item.cause](item),
   maxItems: 100,
   text: {
     getItemName: item => createItemName(item, true),
@@ -66,6 +66,8 @@ export const arrayBuilderOptions = {
   },
 };
 
+// TODO: Fix formData so that shape is consistent
+// formData changes shape between add and edit which results in the need for the conditional below
 export const hasSideOfBody = (formData, index) => {
   const condition = formData?.[arrayBuilderOptions.arrayPath]
     ? formData?.[arrayBuilderOptions.arrayPath][index]?.condition

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/utils.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/utils.js
@@ -12,18 +12,6 @@ export const createDefaultAndEditTitles = (defaultTitle, editTitle) => {
   return defaultTitle;
 };
 
-export const hasSideOfBody = (formData, index) => {
-  const condition = formData?.conditionByCondition
-    ? formData.conditionByCondition[index]?.condition
-    : formData.condition;
-
-  const conditionObject = conditionObjects.find(
-    conditionObj => conditionObj.option === condition,
-  );
-
-  return conditionObject ? conditionObject.sideOfBody : false;
-};
-
 const createCauseDescriptions = item => {
   return {
     NEW: 'Caused by an injury or exposure during my service.',
@@ -76,4 +64,16 @@ export const arrayBuilderOptions = {
     getItemName: item => createItemName(item, true),
     cardDescription: item => createCauseDescriptions(item)[(item?.cause)],
   },
+};
+
+export const hasSideOfBody = (formData, index) => {
+  const condition = formData?.[arrayBuilderOptions.arrayPath]
+    ? formData?.[arrayBuilderOptions.arrayPath][index]?.condition
+    : formData.condition;
+
+  const conditionObject = conditionObjects.find(
+    conditionObj => conditionObj.option === condition,
+  );
+
+  return conditionObject ? conditionObject.sideOfBody : false;
 };

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/condition.js
@@ -35,7 +35,7 @@ const validateNotMissing = (err, fieldData) => {
 
 const validateNotDuplicate = (err, fieldData, formData) => {
   const currentList =
-    formData?.conditionsFirst?.map(condition =>
+    formData?.[arrayBuilderOptions.arrayPath]?.map(condition =>
       condition.condition?.toLowerCase(),
     ) || [];
   const itemLowerCased = fieldData?.toLowerCase() || '';

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/index.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/index.js
@@ -1,5 +1,4 @@
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
-import { getArrayIndexFromPathName } from 'platform/forms-system/src/js/patterns/array-builder/helpers';
 
 import { CONDITIONS_FIRST } from '../../constants';
 import introPage from '../conditionByConditionPages/intro'; // Same content as conditionByCondition so using to ensure consistency
@@ -8,33 +7,33 @@ import conditionPage from './condition';
 import summaryPage from './summary'; // Same content as conditionByCondition so using to ensure consistency
 import { arrayBuilderOptions, hasSideOfBody } from './utils';
 
+const isActiveDemo = formData => formData.demo === 'CONDITIONS_FIRST';
+
 const conditionsFirstPages = arrayBuilderPages(
   arrayBuilderOptions,
   (pageBuilder, helpers) => ({
     conditionsFirstIntro: pageBuilder.introPage({
       title: 'New conditions intro',
       path: `new-conditions-${CONDITIONS_FIRST}-intro`,
-      depends: formData => formData.demo === 'CONDITIONS_FIRST',
+      depends: isActiveDemo,
       uiSchema: introPage.uiSchema,
       schema: introPage.schema,
     }),
     conditionsFirstSummary: pageBuilder.summaryPage({
       title: 'Review your new conditions',
       path: `new-conditions-${CONDITIONS_FIRST}-summary`,
-      depends: formData => formData.demo === 'CONDITIONS_FIRST',
+      depends: isActiveDemo,
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
     conditionsFirstCondition: pageBuilder.itemPage({
       title: 'Claim a new condition',
       path: `new-conditions-${CONDITIONS_FIRST}/:index/condition`,
-      depends: formData => formData.demo === 'CONDITIONS_FIRST',
+      depends: isActiveDemo,
       uiSchema: conditionPage.uiSchema,
       schema: conditionPage.schema,
-      // TODO: use depends: (formData, index) instead on the dynamic page.
       onNavForward: props => {
-        const { formData, pathname } = props;
-        const index = getArrayIndexFromPathName(pathname);
+        const { formData, index } = props;
         const item = formData?.[arrayBuilderOptions.arrayPath]?.[index];
 
         if (item) {
@@ -52,7 +51,7 @@ const conditionsFirstPages = arrayBuilderPages(
     conditionsFirstSideOfBody: pageBuilder.itemPage({
       title: 'Side of body of new condition',
       path: `new-conditions-${CONDITIONS_FIRST}/:index/side-of-body`,
-      depends: formData => formData.demo === 'CONDITIONS_FIRST',
+      depends: isActiveDemo && hasSideOfBody,
       uiSchema: sideOfBodyPage.uiSchema,
       schema: sideOfBodyPage.schema,
     }),

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/index.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/index.js
@@ -36,10 +36,11 @@ const conditionsFirstPages = arrayBuilderPages(
         const { formData, index } = props;
         const item = formData?.[arrayBuilderOptions.arrayPath]?.[index];
 
+        // TODO: This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
+        // However, with this fix, when user doesn't change condition, side of body is still cleared which could confuse users
+        // The depends should potentially clear the data of the dependent pages when the condition is no longer true
+        // TODO: use setFormData instead of mutating formData directly
         if (item) {
-          // TODO: This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
-          // However, with this fix, when user doesn't change condition, side of body is cleared which could confuse users
-          // TODO: use setFormData instead of mutating formData directly
           item.sideOfBody = undefined;
         }
 
@@ -51,7 +52,8 @@ const conditionsFirstPages = arrayBuilderPages(
     conditionsFirstSideOfBody: pageBuilder.itemPage({
       title: 'Side of body of new condition',
       path: `new-conditions-${CONDITIONS_FIRST}/:index/side-of-body`,
-      depends: isActiveDemo && hasSideOfBody,
+      depends: (formData, index) =>
+        isActiveDemo(formData) && hasSideOfBody(formData, index),
       uiSchema: sideOfBodyPage.uiSchema,
       schema: sideOfBodyPage.schema,
     }),

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
@@ -42,6 +42,8 @@ export const arrayBuilderOptions = {
   },
 };
 
+// TODO: Fix formData so that shape is consistent
+// formData changes shape between add and edit which results in the need for the conditional below
 export const hasSideOfBody = (formData, index) => {
   const condition = formData?.[arrayBuilderOptions.arrayPath]
     ? formData?.[arrayBuilderOptions.arrayPath][index]?.condition

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
@@ -12,18 +12,6 @@ export const createDefaultAndEditTitles = (defaultTitle, editTitle) => {
   return defaultTitle;
 };
 
-export const hasSideOfBody = (formData, index) => {
-  const condition = formData?.conditionsFirst
-    ? formData.conditionsFirst[index]?.condition
-    : formData.condition;
-
-  const conditionObject = conditionObjects.find(
-    conditionObj => conditionObj.option === condition,
-  );
-
-  return conditionObject ? conditionObject.sideOfBody : false;
-};
-
 // Different than lodash _capitalize because does not make rest of string lowercase which would break acronyms
 export const capitalizeFirstLetter = string => {
   return string?.charAt(0).toUpperCase() + string?.slice(1);
@@ -52,4 +40,16 @@ export const arrayBuilderOptions = {
   text: {
     getItemName: item => createItemName(item, true),
   },
+};
+
+export const hasSideOfBody = (formData, index) => {
+  const condition = formData?.[arrayBuilderOptions.arrayPath]
+    ? formData?.[arrayBuilderOptions.arrayPath][index]?.condition
+    : formData.condition;
+
+  const conditionObject = conditionObjects.find(
+    conditionObj => conditionObj.option === condition,
+  );
+
+  return conditionObject ? conditionObject.sideOfBody : false;
 };

--- a/src/applications/user-testing/new-conditions/pages/followUpCause.js
+++ b/src/applications/user-testing/new-conditions/pages/followUpCause.js
@@ -7,10 +7,13 @@ import {
 import { CONDITIONS_FIRST } from '../constants';
 import { ServiceConnectedDisabilityDescription } from '../content/newConditions';
 import { causeOptions } from './conditionByConditionPages/cause';
-import { createItemName } from './conditionsFirstPages/utils';
+import {
+  arrayBuilderOptions,
+  createItemName,
+} from './conditionsFirstPages/utils';
 
 const getOtherConditions = (formData, currentIndex) => {
-  const otherNewConditions = formData?.conditionsFirst
+  const otherNewConditions = formData?.[arrayBuilderOptions.arrayPath]
     ?.filter((_, index) => index !== currentIndex)
     ?.map(item => createItemName(item));
 

--- a/src/applications/user-testing/new-conditions/pages/followUpCause.js
+++ b/src/applications/user-testing/new-conditions/pages/followUpCause.js
@@ -7,21 +7,7 @@ import {
 import { CONDITIONS_FIRST } from '../constants';
 import { ServiceConnectedDisabilityDescription } from '../content/newConditions';
 import { causeOptions } from './conditionByConditionPages/cause';
-import {
-  arrayBuilderOptions,
-  createItemName,
-} from './conditionsFirstPages/utils';
-
-const getOtherConditions = (formData, currentIndex) => {
-  const otherNewConditions = formData?.[arrayBuilderOptions.arrayPath]
-    ?.filter((_, index) => index !== currentIndex)
-    ?.map(item => createItemName(item));
-
-  return [...otherNewConditions];
-};
-
-const allCauses = ['NEW', 'SECONDARY', 'WORSENED', 'VA'];
-const causesWithoutSecondary = allCauses.filter(cause => cause !== 'SECONDARY');
+import { createItemName } from './conditionsFirstPages/utils';
 
 /** @type {PageSchema} */
 export default {
@@ -38,13 +24,6 @@ export default {
         cause: radioUI({
           title: 'What caused your condition?',
           labels: causeOptions,
-          options: {
-            updateSchema: (formData, _causeSchema, _causeUISchema, index) => ({
-              enum: getOtherConditions(formData, index).length
-                ? allCauses
-                : causesWithoutSecondary,
-            }),
-          },
         }),
         'view:serviceConnectedDisabilityDescription': {
           'ui:description': ServiceConnectedDisabilityDescription,

--- a/src/applications/user-testing/new-conditions/pages/followUpCauseDescription.js
+++ b/src/applications/user-testing/new-conditions/pages/followUpCauseDescription.js
@@ -8,11 +8,14 @@ import {
 
 import { CONDITIONS_FIRST } from '../constants';
 import { conditionOptions } from '../content/conditionOptions';
-import { createItemName } from './conditionsFirstPages/utils';
+import {
+  arrayBuilderOptions,
+  createItemName,
+} from './conditionsFirstPages/utils';
 import { createCauseFollowUpTitles } from './conditionByConditionPages/causeFollowUp';
 
 const getOtherConditions = (formData, currentIndex) => {
-  const otherNewConditions = formData?.conditionsFirst
+  const otherNewConditions = formData?.[arrayBuilderOptions.arrayPath]
     ?.filter((_, index) => index !== currentIndex)
     ?.map(item => createItemName(item));
 
@@ -20,7 +23,7 @@ const getOtherConditions = (formData, currentIndex) => {
 };
 
 const createCauseFollowUpConditional = (formData, index, causeType) => {
-  return formData.conditionsFirst[index]?.cause !== causeType;
+  return formData?.[arrayBuilderOptions.arrayPath][index]?.cause !== causeType;
 };
 
 /** @type {PageSchema} */


### PR DESCRIPTION
Codespace: https://potential-winner-jrvw4xpg4pfqj9-3001.app.github.dev/user-testing/new-conditions

## Summary

- Summarize the changes that have been made to the platform
  - [For conditionByCondition, update arrayPath to come from arrayBuilderOptions](https://github.com/department-of-veterans-affairs/vets-website/pull/33405/commits/34e7d9ac77a6bfe365af30249145469a8eac9c09) 
  - [For conditionsFirst, update arrayPath to come from arrayBuilderOptions](https://github.com/department-of-veterans-affairs/vets-website/pull/33405/commits/5e4521bc078fb6c067a0f1a57cf54060a72d7161)
  - [Move FormFooter to its own component to simplify form.js](https://github.com/department-of-veterans-affairs/vets-website/pull/33405/commits/4c0d4f7f2b8325c73f79816e1a7fc0ec1ba6c13f)
  - [Update conditionsFirst depends to be more DRY](https://github.com/department-of-veterans-affairs/vets-website/pull/33405/commits/54a8c9671698e7be3c2cb3d8b2a8a9aa7966ffc6)
  - [Update conditionByCondition depends to be more DRY and be used to hide sideOfBody](https://github.com/department-of-veterans-affairs/vets-website/pull/33405/commits/ab927c1a7a2dfd81f910cd2ff00c4d6f43a4bc35) 
  - [Remove conditional radio options from followUpCause](https://github.com/department-of-veterans-affairs/vets-website/pull/33405/commits/255b90ae5c049aa4edb0df5055cb3fbaff7329b3) 
  - [Turn off autocomplete for our Autocomplete component](https://github.com/department-of-veterans-affairs/vets-website/pull/33405/commits/d9589201f9854363149c91bb3b1f52e3ff566d41)
- Which team do you work for, does your team own the maintenance of this component? Conditions Team and Yes

## Related issue(s)
- [Conditions prototype code enhancement #646](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/646)

## Screenshots
### Before - with no `autocomplete` attribute
<img width="1225" alt="Screenshot 2024-12-09 at 1 21 36 PM" src="https://github.com/user-attachments/assets/f22a8010-73f6-4ee5-a218-e9fbc9b54ad5">

### After  - `autocomplete="off"`
<img width="974" alt="Screenshot 2024-12-09 at 2 28 19 PM" src="https://github.com/user-attachments/assets/71b4ade2-ce45-4a47-842f-f014aeaab6c8">


## TODOs and their issues:
- index.js
  - [ ] Depends should clear the data of the dependent pages when the condition is no longer true 
- condition.js
  - [x] On edit, allows previous index value to be the same as later index value - [Conditions prototype code enhancement #646](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/646)
- date.js
  - [ ] Make month optional in currentOrPastMonthYearDateUI
  - [ ] Remove empty first select option in currentOrPastMonthYearDateUI
- causeFollowUp.js
  - [ ] Fix formData so that shape is consistent and giving all form data (closely related to an issue I created previously https://github.com/department-of-veterans-affairs/va.gov-team/issues/87159 - could combine) Note: biggest current issue is that formData for `hideIf` and `required` is all form data on add and then item formData on edit 
- summary.js
  - [ ] Add better way of removing hint from multi-page yes/no then `hint: ' '`
- utils.js
  -  Same TODO as "Fix formData so that shape is consistent..."

## Key issues, their effect on our prototype, and the actions items:
  1. Depends should clear the data of the dependent pages when the condition is no longer true
    - Effect: we have a workaround but it has the potential to create a confusing user experience in that the sideOfBody is cleared on edit even if the condition is not changed (noted this depends issue at the architecture intent yesterday as well)
    - Action:  As mentioned this has been raised to the forms team in that PR but am formally raising it with an issue
  2. Make month optional in currentOrPastMonthYearDateUI
    - Effect: makes them chose a month even though they may not have any idea which month
    - Action: make a decision on the following - are we confident that we want to use currentOrPastMonthYearDateUI in form and that we want the forms team to explore this issue?
  3. Fix formData so that shape is consistent and providing access  to all form data (rather then just item data)
    - Effect: we have a workaround except for the select on the SECONDARY page which is unable to get ratedDisabilities on edit because the formData is itemData.
    - Action: Also raised this in the above depends PR, but am formally raising it with an issue