### PR TITLE
set action to use v4

### DIFF
--- a/.github/workflows/download-artifact/action.yml
+++ b/.github/workflows/download-artifact/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- _Switched download_archive Action to use v4 to reintroduce retry logic when the archive returns a server code as HTML instead of JSON_


## Related issue(s)

- [Support ticket](https://dsva.slack.com/archives/CBU0KDSB1/p1733406238008519)

## Requested Feedback

While Github is not going to address the flakiness we are seeing with the use of our archives, switching from the specific SHA of this action to v4 should stabilize our CI flows and allow us to complete CI runs without being as heavily affected.
