### PR TITLE
VACMS 19842 - update to CtA and tests

### DIFF
--- a/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 import DOMPurify from 'dompurify';
 import recordEvent from '~/platform/monitoring/record-event';
 
+// showClose is disabled until we can determine if dangerouslySetInnerHTML can work with the close button
 export default function SituationUpdateBanner({
   id,
   alertType,
   headline,
-  showClose,
+  // showClose,
   content,
   operatingStatusCta = false,
   operatingStatusPage,
@@ -19,7 +20,7 @@ export default function SituationUpdateBanner({
       banner-id={`situation-update-banner-${id}`}
       type={alertType}
       headline={headline}
-      show-close={showClose}
+      // show-close={showClose}
     >
       {/* eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />

--- a/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
+++ b/src/applications/static-pages/situation-updates-banner/situationUpdateBanner.jsx
@@ -11,6 +11,7 @@ export default function SituationUpdateBanner({
   content,
   operatingStatusCta = false,
   operatingStatusPage,
+  findFacilitiesCta = false,
 }) {
   return (
     <va-banner
@@ -36,6 +37,14 @@ export default function SituationUpdateBanner({
             />
           </p>
         )}
+      {findFacilitiesCta && (
+        <p>
+          <va-link
+            href="/find-locations"
+            text="Find other VA facilities near you"
+          />
+        </p>
+      )}
     </va-banner>
   );
 }
@@ -45,6 +54,7 @@ SituationUpdateBanner.propTypes = {
   content: PropTypes.node.isRequired,
   headline: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  findFacilitiesCta: PropTypes.bool,
   operatingStatusCta: PropTypes.bool,
   operatingStatusPage: PropTypes.string,
   showClose: PropTypes.bool,

--- a/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
@@ -179,4 +179,49 @@ describe('featureToggles allow banners', () => {
       done();
     }, 1000);
   });
+
+  it('should not display and deal with vets-api error when vets-api fails on manila-va-clinic', done => {
+    sinon.stub(window, 'location').value({ pathname: '/manila-va-clinic/' });
+    mockApiRequest({ errors: 'some error' }, false);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
+  it('should not display and deal with vets-api error when vets-api fails on health-care', done => {
+    sinon.stub(window, 'location').value({ pathname: '/boston-health-care/' });
+    mockApiRequest({ errors: 'some error' }, false);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
+  it('should not display on some other page', done => {
+    sinon.stub(window, 'location').value({ pathname: '/some-other-page/' });
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(0);
+      wrapper.unmount();
+      done();
+    }, 1000);
+  });
 });

--- a/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/bannerContainer.unit.spec.js
@@ -12,6 +12,8 @@ import { BannerContainer } from '../bannerContainer';
 import {
   birmingham,
   birminghamWoContext,
+  bostonTestWithBothCtAs,
+  bostonTestWithJustFind,
   maine,
 } from './mocks/mockSituationUpdatesBanner';
 
@@ -63,7 +65,53 @@ describe('featureToggles allow banners', () => {
       wrapper.update();
       expect(wrapper.find('va-banner')).to.have.length(1);
       const banner = wrapper.find('va-banner');
-      expect(banner.find('va-link')).to.have.length(1);
+      const vaLink = banner.find('va-link');
+      expect(vaLink).to.have.length(1);
+      expect(vaLink.props().text).to.equal(
+        'Get updates on affected services and facilities',
+      );
+      wrapper.unmount();
+      done();
+    }, 1500);
+  });
+
+  it('should display the Boston banner and display 1 link for find locations', done => {
+    sinon.stub(window, 'location').value({
+      pathname: '/boston-health-care',
+    });
+    mockApiRequest(bostonTestWithJustFind);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      const banner = wrapper.find('va-banner');
+      const vaLink = banner.find('va-link');
+      expect(vaLink).to.have.length(1);
+      expect(vaLink.props().text).to.equal('Find other VA facilities near you');
+      wrapper.unmount();
+      done();
+    }, 1500);
+  });
+
+  it('should display the Boston banner and display 2 links for find locations and updates', done => {
+    sinon.stub(window, 'location').value({
+      pathname: '/boston-health-care',
+    });
+    mockApiRequest(bostonTestWithBothCtAs);
+    const wrapper = mount(
+      <Provider store={mockStore(getData())}>
+        <BannerContainer />
+      </Provider>,
+    );
+    setTimeout(() => {
+      wrapper.update();
+      expect(wrapper.find('va-banner')).to.have.length(1);
+      const banner = wrapper.find('va-banner');
+      expect(banner.find('va-link')).to.have.length(2);
       wrapper.unmount();
       done();
     }, 1500);

--- a/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
+++ b/src/applications/static-pages/situation-updates-banner/tests/mocks/mockSituationUpdatesBanner.js
@@ -100,3 +100,87 @@ export const birminghamWoContext = {
   path: '/birmingham-health-care/locations/birmingham-va-medical-center',
   bannerType: 'full_width_banner_alert',
 };
+
+export const bostonTestWithJustFind = {
+  banners: [
+    {
+      id: 29,
+      entityId: 75538,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'Boston Update',
+      alertType: 'warning',
+      showClose: true,
+      content:
+        '<ul>\n<li>Limited to Homepage and Operating status page</li>\n<li>Warning type</li>\n<li>Dismissible</li>\n<li>Find other VA Facilities link</li>\n<li>NO Get updates link or Subscribe link</li>\n</ul>\n',
+      context: [
+        {
+          entity: {
+            title: 'Operating status | VA Boston health care',
+            entityUrl: {
+              path: '/boston-health-care/operating-status',
+            },
+            fieldOffice: {
+              entity: {
+                title: 'VA Boston health care',
+                entityUrl: {
+                  path: '/boston-health-care',
+                },
+                fieldVamcEhrSystem: 'vista',
+              },
+            },
+          },
+        },
+      ],
+      operatingStatusCta: false,
+      emailUpdatesButton: false,
+      findFacilitiesCta: true,
+      limitSubpageInheritance: true,
+      createdAt: '2024-12-09T16:48:59.471Z',
+      updatedAt: '2024-12-09T16:48:59.471Z',
+    },
+  ],
+  path: '/boston-health-care',
+  bannerType: 'full_width_banner_alert',
+};
+
+export const bostonTestWithBothCtAs = {
+  banners: [
+    {
+      id: 29,
+      entityId: 75538,
+      entityBundle: 'full_width_banner_alert',
+      headline: 'Boston Update',
+      alertType: 'warning',
+      showClose: true,
+      content:
+        '<ul>\n<li>Limited to Homepage and Operating status page</li>\n<li>Warning type</li>\n<li>Dismissible</li>\n<li>Find other VA Facilities link</li>\n<li>NO Get updates link or Subscribe link</li>\n</ul>\n',
+      context: [
+        {
+          entity: {
+            title: 'Operating status | VA Boston health care',
+            entityUrl: {
+              path: '/boston-health-care/operating-status',
+            },
+            fieldOffice: {
+              entity: {
+                title: 'VA Boston health care',
+                entityUrl: {
+                  path: '/boston-health-care',
+                },
+                fieldVamcEhrSystem: 'vista',
+              },
+            },
+          },
+        },
+      ],
+      operatingStatusCta: true,
+      emailUpdatesButton: false,
+      findFacilitiesCta: true,
+      limitSubpageInheritance: true,
+      createdAt: '2024-12-09T16:48:59.471Z',
+      updatedAt: '2024-12-09T16:48:59.471Z',
+    },
+  ],
+  path: '/boston-health-care',
+  bannerType: 'full_width_banner_alert',
+};


### PR DESCRIPTION
Just updates CtA (link presence) and tests

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates CtA to include find locations link when present in vets-api response
- Sitewide team
- uses banners flippers

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19842

## Testing done

- tested manually and added unit tests

## Screenshots

<img width="970" alt="Screenshot 2024-12-09 at 10 46 28 AM" src="https://github.com/user-attachments/assets/8775ff1a-9dcb-4097-a33b-11f148dbc4dc">


## What areas of the site does it impact?

Affects realtime banners

## Acceptance criteria

Shows correct link

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

