### PR TITLE
NOD |  Confirmation page fixes

### DIFF
--- a/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
+++ b/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
@@ -11,6 +11,7 @@ import { selectProfile } from '~/platform/user/selectors';
 import { boardReviewConfirmationLabels } from '../content/boardReview';
 import { hearingTypeLabels } from '../content/hearingType';
 import {
+  wantsToUploadEvidence,
   canUploadEvidence,
   needsHearingType,
   isDirectReview,
@@ -233,13 +234,13 @@ export const ConfirmationPageV2 = () => {
             {boardReviewConfirmationLabels[data.boardReviewOption] || ''}
           </div>
         </li>
-        {choseEvidence &&
-          data.evidence.length && (
-            <li>
-              <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-                Uploaded evidence
-              </div>
-              {data.evidence?.map((file, index) => (
+        {choseEvidence && (
+          <li>
+            <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+              Uploaded evidence
+            </div>
+            {wantsToUploadEvidence(data) && data.evidence.length ? (
+              data.evidence?.map((file, index) => (
                 <div
                   key={index}
                   className="vads-u-margin-bottom--2 dd-privacy-hidden"
@@ -247,9 +248,12 @@ export const ConfirmationPageV2 = () => {
                 >
                   {file.name}
                 </div>
-              ))}
-            </li>
-          )}
+              ))
+            ) : (
+              <span>I’ll submit it later.</span>
+            )}
+          </li>
+        )}
         {choseHearing && (
           <>
             <li>

--- a/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
+++ b/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
@@ -116,7 +116,9 @@ export const ConfirmationPageV2 = () => {
               <div>P.O. Box 27063</div>
               <div>Washington, DC 20038</div>
             </div>
-            <p>Fax: 1-844-678-8979</p>
+            <p>
+              <strong>Fax:</strong> 1-844-678-8979
+            </p>
           </>
         )}
         {choseHearing && (
@@ -250,7 +252,7 @@ export const ConfirmationPageV2 = () => {
                 </div>
               ))
             ) : (
-              <span>I’ll submit it later.</span>
+              <span className="evidence-later">I’ll submit it later.</span>
             )}
           </li>
         )}

--- a/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
@@ -135,7 +135,23 @@ describe('ConfirmationPageV2', () => {
       'file-1.pdf',
       'file-2.pdf',
     ]);
+    expect($('.evidence-later', container)).to.not.exist;
     expect($$('.vads-c-action-link--green', container).length).to.eq(1);
+  });
+
+  it('should render the confirmation page with evidence submitted later', () => {
+    const data = getData({
+      'view:additionalEvidence': false,
+    });
+    const { container } = render(
+      <Provider store={mockStore(data)}>
+        <ConfirmationPageV2 />
+      </Provider>,
+    );
+
+    expect($('.evidence-later', container).textContent).to.eq(
+      'I’ll submit it later.',
+    );
   });
 
   it('should render the confirmation page with a hearing request', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Fixed:
  > - When uploading evidence is selected, but election to upload later is made, the data now shows "I'll submit it later."
  > - Bolded "Fax:" label
  > - Informed Design System Team about the missing `va-address-block` style since deprecating formation
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/98111

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Confirmation evidence note  | <img width="600" alt="nod-evidence before" src="https://github.com/user-attachments/assets/c78724b2-a200-4ec4-9d59-2127c0382e55"> | <img width="600" alt="fax label now bolded, Board appeals address note that design system team is aware" src="https://github.com/user-attachments/assets/ac25cbe8-d1fe-4ade-abec-508f11f2e1a5"> |
| Evidene data (submit later selected) | <img width="268" alt="submit later selected, but 2 uploaded files are showing" src="https://github.com/user-attachments/assets/f95a24aa-6c53-4022-bcee-f378a72920da"> | <img width="287" alt="I'll submit it later showing under uploaded evidence label" src="https://github.com/user-attachments/assets/328b4359-1749-4094-9b66-a95f4a7ba815"> |
<img width="666" alt="391680474-bb61d52e-2e3e-4e4d-96b7-88b0032bf178" src="">

## What areas of the site does it impact?

Notice of Disagreement confirmation page (behind feature toggle)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
