### PR TITLE
Update alert for no recent visit in the request flow

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
@@ -143,7 +143,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
         screen.queryByText(/San Diego VA Medical Center/i);
       });
       await screen.findByText(
-        /you need to have had a mental health appointment at this facility within the last 12 months/,
+        /You haven’t had a recent appointment at this facility/i,
       );
     });
 
@@ -679,14 +679,16 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       fireEvent.click(screen.getByText(/Continue/));
       await screen.findByTestId('eligibilityModal');
       expect(screen.getByRole('alertdialog')).to.be.ok;
-      expect(screen.baseElement).to.contain.text('last 36 months');
+      // expect(screen.baseElement).to.contain.text('last 36 months');
       fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
       await waitFor(
         () =>
           expect(
-            screen.queryByText(/We can’t find a recent appointment for you/i),
-          ).to.not.exist,
+            screen.queryByText(
+              /You haven’t had a recent appointment at this facility/i,
+            ),
+          ).to.exist,
       );
     });
 

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
@@ -679,7 +679,6 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       fireEvent.click(screen.getByText(/Continue/));
       await screen.findByTestId('eligibilityModal');
       expect(screen.getByRole('alertdialog')).to.be.ok;
-      // expect(screen.baseElement).to.contain.text('last 36 months');
       fireEvent.click(screen.getByRole('button', { name: /Continue/i }));
 
       await waitFor(

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
@@ -2,26 +2,23 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FacilityAddress from '../../../components/FacilityAddress';
-import NewTabAnchor from '../../../components/NewTabAnchor';
 import { ELIGIBILITY_REASONS } from '../../../utils/constants';
-import { aOrAn, lowerCase } from '../../../utils/formatters';
 
 export default function getEligibilityMessage({
-  typeOfCare,
   eligibility,
   facilityDetails,
   includeFacilityContactInfo = false,
 }) {
   let content = null;
   let title = null;
-  const settings = facilityDetails?.legacyVAR?.settings?.[typeOfCare.id];
 
   const requestReason = eligibility.requestReasons[0];
   const directReason = eligibility.directReasons[0];
 
   if (
-    requestReason === ELIGIBILITY_REASONS.notSupported &&
-    directReason === ELIGIBILITY_REASONS.noRecentVisit
+    (requestReason === ELIGIBILITY_REASONS.notSupported &&
+      directReason === ELIGIBILITY_REASONS.noRecentVisit) ||
+    requestReason === ELIGIBILITY_REASONS.noRecentVisit
   ) {
     title = 'You can’t schedule an appointment online at this facility';
     const contact = facilityDetails?.telecom?.find(
@@ -86,23 +83,6 @@ export default function getEligibilityMessage({
         You’ll need to call your VA health facility to schedule this
         appointment. Not all VA facilities offer online scheduling for all types
         of care.
-      </>
-    );
-  } else if (requestReason === ELIGIBILITY_REASONS.noRecentVisit) {
-    const monthRequirement = settings?.request?.patientHistoryDuration
-      ? (settings.request.patientHistoryDuration / 365) * 12
-      : '24';
-    title = 'We can’t find a recent appointment for you';
-    content = (
-      <>
-        To request an appointment online at this location, you need to have had{' '}
-        {aOrAn(typeOfCare?.name)} {lowerCase(typeOfCare?.name)} appointment at
-        this facility within the last {monthRequirement} months. Please call
-        this facility to schedule your appointment or{' '}
-        <NewTabAnchor href="/find-locations">
-          search for another VA facility
-        </NewTabAnchor>
-        .
       </>
     );
   } else if (requestReason === ELIGIBILITY_REASONS.overRequestLimit) {

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-facilities-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/multiple-facilities-dead-ends.cypress.spec.js
@@ -272,7 +272,7 @@ describe('VAOS direct schedule flow - Multiple facilities dead ends', () => {
           .selectLocation(/Facility 983/i)
           .clickNextButton()
           .assertWarningModal({
-            text: /We can’t find a recent appointment for you/i,
+            text: /You haven’t had a recent appointment at this facility/i,
           });
 
         // Assert

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-clinic-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/single-clinic-dead-ends.cypress.spec.js
@@ -127,7 +127,7 @@ describe('VAOS direct schedule flow - Single clinic dead ends', () => {
             text: /You can.t schedule this appointment online/i,
           })
           .assertText({
-            text: /To request an appointment online at this location, you need to have had a primary care appointment at this facility within the last 24 months/i,
+            text: /You haven’t had a recent appointment at this facility/i,
           })
           .assertButton({ exist: false, label: /Continue/i });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder



### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update the alert message in the request flow when there is no recent visit eligibility

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#96999


## Testing done
unit and e2e

## How to test locally
**Scenario:**

Request is enabled
Facility requires a recent visit
AND User doesn’t have a recent visit (VATS: noRecentVisit)
AND DS are disabled




### Steps to test
___
1. Update `scheduling_configurations.json` to enable the request toggle to `true` in amputation care for facility 984 and 983
```
      "id": "984",
      "type": "scheduling_configuration",
      "attributes": {
        "facilityId": "984",
        "services": [
          {
            "id": "amputation",
            "name": "Amputation Services",
            "stopCodes": [{ "primary": "211" }],
            "direct": { "canCancel": true, "enabled": false },
            "request": { "enabled": true }
          },

```

```
      "id": "983",
      "type": "scheduling_configuration",
      "attributes": {
        "facilityId": "983",
        "services": [
          {
            "id": "amputation",
            "name": "Amputation Services",
            "stopCodes": [{ "primary": "211" }],
            "direct": {
              "patientHistoryRequired": true,
              "patientHistoryDuration": 365,
              "canCancel": true,
              "enabled": false
            },
            "request": { "enabled": true }

```
2. Replace "facility-request-limit-exceeded" with "patient-history-insufficient"  in `mocks/index.js` on line 462 to match below
```
    if (!isDirect && !req.query.facility_id.startsWith('983')) {
      ineligibilityReasons.push({
        coding: [
          {
            code: 'patient-history-insufficient',
          },
        ],
      });
    }
```
3. Make a new amputation appointment using Dayton VAMC
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile |   ![Screenshot 2024-12-09 at 11 50 52 AM](https://github.com/user-attachments/assets/d9267c2b-d893-4b51-b484-28f6f732f975)     |   ![Screenshot 2024-12-09 at 10 57 54 AM](https://github.com/user-attachments/assets/15c33d5a-d219-4d30-9118-38935485d9c9)    |

## What areas of the site does it impact?

Eligibility alert message

## Acceptance criteria

- [ ] Alert is updated
- [ ] Update unit tests
- [ ] Update/create e2e test

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
