### PR TITLE
VA.gov-team#97721 Little rock RO redirect

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1555,5 +1555,17 @@
     "src": "/RODETROIT",
     "dest": "/detroit-va-regional-benefit-office/",
     "catchAll": true
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/littlerock",
+    "dest": "/little-rock-va-regional-benefit-office-at-eugene-j-towbin-healthcare-center/",
+    "catchAll": true
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/ROLITTLEROCK",
+    "dest": "/little-rock-va-regional-benefit-office-at-eugene-j-towbin-healthcare-center/",
+    "catchAll": true
   }
 ]


### PR DESCRIPTION
## Summary
PR only contains a proxy-rewrite client-side redirect for VBA Little Rock Regional office teamsite, to the new modernized page. No other changes.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/97721


## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

