### PR TITLE
add font faces manually

### DIFF
--- a/src/platform/site-wide/sass/fonts.scss
+++ b/src/platform/site-wide/sass/fonts.scss
@@ -1,0 +1,15 @@
+$font-path: "~/src/site/assets/fonts";
+
+@font-face {
+    font-family: "Source Sans Pro";
+    font-style: normal;
+    font-weight: 400;
+    src: url("../../../site/assets/fonts/sourcesanspro-regular-webfont.ttf") format("truetype");
+}
+
+@font-face {
+    font-family: "Source Sans Pro";
+    font-style: normal;
+    font-weight: 700;
+    src: url("../../../site/assets/fonts//sourcesanspro-bold-webfont.ttf") format("truetype");
+}

--- a/src/platform/site-wide/sass/style.scss
+++ b/src/platform/site-wide/sass/style.scss
@@ -5,6 +5,7 @@
 @import "~@department-of-veterans-affairs/css-library/dist/tokens/scss/variables";
 
 @import "v1-grid";
+@import "fonts";
 
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/core";
 


### PR DESCRIPTION
## Description
This pull request patches a couple of font faces directly into vets-website in an attempt to resolve some missing font faces that get added to the vets-website s3 bucket. [Thread for more context](https://dsva.slack.com/archives/CBU0KDSB1/p1733852575539749)

## Screenshots
Before, local generated directory is missing `.ttf` fonts for sourcesanspro regular and bold: 
![Screenshot from 2024-12-10 23-02-17](https://github.com/user-attachments/assets/e479bafb-a923-48ce-9d38-e77f300092b6)

Now, `.ttf` files are included in `/generated`:
![Screenshot from 2024-12-11 00-33-46](https://github.com/user-attachments/assets/07b889a9-48d0-4286-8caf-07faeddd1f09)
