### PR TITLE
Travel Pay/add "status explainer" page and routes

### DIFF
--- a/src/applications/travel-pay/components/Breadcrumbs.jsx
+++ b/src/applications/travel-pay/components/Breadcrumbs.jsx
@@ -5,8 +5,9 @@ import { useLocation, useHistory, Link } from 'react-router-dom';
 export default function BreadCrumbs() {
   const { pathname } = useLocation();
   const history = useHistory();
-  const uuidPathRegex = /^\/[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[89abcd][\da-f]{3}-[\da-f]{12}$/i;
+  const uuidPathRegex = /^\/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[89ABCD][0-9A-F]{3}-[0-9A-F]{12}$/i;
   const isDetailsPage = pathname.match(uuidPathRegex);
+  const isStatusExplainer = pathname.includes('/help');
 
   const breadcrumbList = [
     {
@@ -20,11 +21,19 @@ export default function BreadCrumbs() {
       label: 'My HealtheVet',
     },
     {
-      href: '/my-health/travel-claim-status',
+      href: '/',
       label: 'Check your travel reimbursement claim status',
       isRouterLink: true,
     },
   ];
+
+  if (isStatusExplainer) {
+    breadcrumbList.push({
+      href: '/help',
+      label: 'Help: Claim Status Meanings',
+      isRouterLink: true,
+    });
+  }
 
   const handleRouteChange = ({ detail }) => {
     const { href } = detail;
@@ -32,7 +41,7 @@ export default function BreadCrumbs() {
   };
 
   return isDetailsPage ? (
-    <div className="claim-details-breadcrumb-wrapper">
+    <div className="travel-pay-breadcrumb-wrapper">
       {isDetailsPage && <va-icon class="back-arrow" icon="arrow_back" />}
       <Link className="go-back-link" to="/">
         Back to your travel reimbursement claims

--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -22,15 +22,18 @@ export default function ClaimDetailsContent(props) {
   return (
     <>
       <h1>Your travel reimbursement claim for {appointmentDate}</h1>
-      <span className="claim-details-claim-number">
+      <span
+        className="vads-u-font-size--h2 vads-u-font-weight--bold"
+        data-testid="claim-details-claim-number"
+      >
         Claim number: {claimNumber}
       </span>
-      <h2 className="claim-details-h3">Where</h2>
+      <h2 className="vads-u-font-size--h3">Where</h2>
       <p className="vads-u-margin-bottom--0">
         {appointmentDate} at {appointmentTime} appointment
       </p>
       <p className="vads-u-margin-y--0">{facilityName}</p>
-      <h2 className="claim-details-h3">Claim status: {claimStatus}</h2>
+      <h2 className="vads-u-font-size--h3">Claim status: {claimStatus}</h2>
       <p className="vads-u-margin-bottom--0">
         Submitted on {createDate} at {createTime}
       </p>

--- a/src/applications/travel-pay/components/HelpText.jsx
+++ b/src/applications/travel-pay/components/HelpText.jsx
@@ -1,28 +1,47 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 export function HelpTextContent() {
   const BTSSS_PORTAL_URL = 'https://dvagov-btsss.dynamics365portals.us/';
 
   return (
-    <p>
-      To manage your travel claims, file a new claim, or learn what your claim
-      status means, go to our{' '}
-      <a className="btsss-portal-link" href={BTSSS_PORTAL_URL}>
-        Beneficiary Travel Self Service System (BTSSS) portal (opens in new tab)
-      </a>
-      .<br />
-      Or call <va-telephone contact="8555747292" /> from 7 a.m. to 7 p.m. Monday
-      through Friday. Have your claim number ready to share when you call.
-    </p>
-  );
-}
-
-export default function HelpText() {
-  return (
     <div>
-      <p>You can use this tool to check the status of your VA travel claims.</p>
-      <h2>How to manage your claims or get more information</h2>
-      <HelpTextContent />
+      <p>
+        To manage your travel claims, file a new claim, or learn what your claim
+        status means, go to our{' '}
+        <va-link
+          external
+          href={BTSSS_PORTAL_URL}
+          text="Beneficiary Travel Self Service System (BTSSS) portal"
+        />
+        .
+      </p>
+      <p className="vads-u-margin-top--2">
+        Or call <va-telephone contact="8555747292" /> from 7 a.m. to 7 p.m.
+        Monday through Friday. Have your claim number ready to share when you
+        call.
+      </p>
+      <p className="vads-u-margin-top--2">
+        <Link
+          data-testid="status-explainer-link"
+          to={{
+            pathname: '/help',
+          }}
+          className="vads-u-display--flex vads-u-align-items--center"
+        >
+          What does my claim status mean?
+        </Link>
+      </p>
     </div>
   );
 }
+
+// export default function HelpText() {
+//   return (
+//     <div>
+//       <p>You can use this tool to check the status of your VA travel claims.</p>
+//       <h2>How to manage your claims or get more information</h2>
+//       <HelpTextContent />
+//     </div>
+//   );
+// }

--- a/src/applications/travel-pay/components/HelpText.jsx
+++ b/src/applications/travel-pay/components/HelpText.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-export function HelpTextContent() {
+export default function HelpTextContent() {
   const BTSSS_PORTAL_URL = 'https://dvagov-btsss.dynamics365portals.us/';
 
   return (
     <div>
       <p>
-        To manage your travel claims, file a new claim, or learn what your claim
-        status means, go to our{' '}
+        To manage your travel claims or file a new claim, go to our{' '}
         <va-link
           external
           href={BTSSS_PORTAL_URL}
@@ -35,13 +34,3 @@ export function HelpTextContent() {
     </div>
   );
 }
-
-// export default function HelpText() {
-//   return (
-//     <div>
-//       <p>You can use this tool to check the status of your VA travel claims.</p>
-//       <h2>How to manage your claims or get more information</h2>
-//       <HelpTextContent />
-//     </div>
-//   );
-// }

--- a/src/applications/travel-pay/components/TravelClaimCard.jsx
+++ b/src/applications/travel-pay/components/TravelClaimCard.jsx
@@ -31,7 +31,7 @@ export default function TravelClaimCard(props) {
   return (
     <va-card key={id} class="travel-claim-card vads-u-margin-bottom--2">
       <h3
-        className="vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-size--h3"
+        className="vads-u-margin-top--2 vads-u-margin-bottom--0"
         data-testid="travel-claim-details"
       >
         {appointmentDateTitle}

--- a/src/applications/travel-pay/components/TravelClaimDetails.jsx
+++ b/src/applications/travel-pay/components/TravelClaimDetails.jsx
@@ -9,7 +9,7 @@ import { Element } from 'platform/utilities/scroll';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
-import { HelpTextContent } from './HelpText';
+import HelpTextContent from './HelpText';
 import BreadCrumbs from './Breadcrumbs';
 import ClaimDetailsContent from './ClaimDetailsContent';
 

--- a/src/applications/travel-pay/constants.js
+++ b/src/applications/travel-pay/constants.js
@@ -1,0 +1,129 @@
+export const STATUS_GROUPINGS = [
+  {
+    name: 'Saved or Incomplete',
+    description:
+      'These are claims that the Beneficiary Travel office cannot process. Either you have not submitted the claim, or you submitted a claim without required information.',
+    includes: ['Incomplete', 'Saved'],
+  },
+  {
+    name: 'Under VA Review',
+    description:
+      'These claims require action from VA. If VA needs more information from you, your Travel Clerk will contact you.',
+    includes: [
+      'In Process',
+      'Claim Submitted',
+      'In Manual Review',
+      'On Hold',
+      'Appealed',
+    ],
+  },
+  {
+    name: 'Closed',
+    description:
+      'The Beneficiary Travel office finished their review of your claim and closed it. In some situations you can appeal Beneficiary Travel department’s decision and re-open a claim. If you have questions about why your claim has one of the following statuses, contact your local VAMC and ask for the Beneficiary Travel department.',
+    includes: [
+      'Partial Payment',
+      'Denied',
+      'Approved for Payment',
+      'Submitted for Payment',
+      'Fiscal Rescinded',
+      'Claim Paid',
+      'Payment Canceled',
+    ],
+  },
+];
+
+export const STATUSES = [
+  {
+    name: 'Incomplete',
+    description:
+      'You submitted a claim without required expense information. You must provide the required information for BTSSS to process the claim.',
+    reasons: null,
+  },
+  {
+    name: 'Saved',
+    description:
+      'You saved changes to your claim, but you did not submit it to BTSSS for review. Submit the claim so BTSSS can begin processing your claim.',
+    reasons: null,
+  },
+  {
+    name: 'In Process',
+    description:
+      'You submitted a claim, and now BTSSS is reviewing your claim.',
+    reasons: null,
+  },
+  {
+    name: 'Claim Submitted',
+    description: 'You submitted a claim for a completed appointment.',
+    reasons: null,
+  },
+  {
+    name: 'In Manual Review',
+    description:
+      'Your claim requires a manual review by a Travel Clerk due to one or more of the following reasons:',
+    reasons: [
+      'Your claim includes receipts',
+      'The mileage is not equal to or less than the calculated limit',
+      'Your travel does not meet the eligibility requirements. For detailed information about your claim, contact your local VAMC and ask for the Beneficiary Travel department.',
+    ],
+  },
+  {
+    name: 'On Hold',
+    description:
+      'You must provide the needed information for the claim to be processed. Your Travel Clerk will contact you when they put your claim on hold and tell you what additional information is required. For more information about your claim, please contact your local VAMC and ask for the Beneficiary Travel department.',
+    reasons: null,
+  },
+  {
+    name: 'Appealed',
+    description:
+      'You appealed the denial of your claim. The Travel Clerk will review your appeal.',
+    reasons: null,
+  },
+  {
+    name: 'Partial Payment',
+    description:
+      'The Travel Clerk determined the claim does not qualify for a full reimbursement. Instead, they approved a partial payment and a Partial Payment letter was sent to you.',
+    reasons: null,
+  },
+  {
+    name: 'Denied',
+    description:
+      'The Travel Clerk denied your claim for one or more of the following reasons:',
+    reasons: [
+      'Claim is not eligible for reimbursement.',
+      'The Travel Clerk could not verify the services in your claim.',
+      'Your appointment does not exist in VISTA, either because the VA clinic you went to did not enter it or you received care at a non-VA facility.',
+      'The Travel Clerk sent you a denial letter. The letter contains information on how to appeal the decision.',
+    ],
+  },
+  {
+    name: 'Approved for Payment',
+    description:
+      'The Travel Clerk approved your claim for payment. The payment is pending and has not been paid.',
+    reasons: null,
+  },
+  {
+    name: 'Submitted for Payment',
+    description:
+      'The approved claim payment is assigned to the Financial Service Center (FSC) so that you can receive reimbursement.',
+    reasons: null,
+  },
+  {
+    name: 'Fiscal Rescinded',
+    description:
+      'The Financial Service Center (FSC) rejected payment. You will not be able to appeal this decision. For more detailed information about your claim, please contact your local VAMC and ask for the Beneficiary Travel department.',
+    reasons: null,
+  },
+  {
+    name: 'Claim Paid',
+    description:
+      'The reimbursement on the approved claim is paid to the submitter. Note that reimbursements for claims submitted by a Caregiver on behalf of a Veteran claimant are sent to the Caregiver’s address or deposited in the Caregiver’s account.',
+    reasons: null,
+  },
+  {
+    name: 'Payment Canceled',
+    description:
+      'The fund transfer did not complete because of the claimant’s bank. Payment has been canceled. You may create a new claim and reference the original claim number in the Notes section of the new claim.',
+    reasons: null,
+  },
+];

--- a/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
+++ b/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
@@ -21,7 +21,7 @@ import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import BreadCrumbs from '../components/Breadcrumbs';
 import TravelClaimCard from '../components/TravelClaimCard';
 import TravelPayClaimFilters from '../components/TravelPayClaimFilters';
-import { HelpTextContent } from '../components/HelpText';
+import HelpTextContent from '../components/HelpText';
 import { getTravelClaims } from '../redux/actions';
 import { getDateFilters } from '../util/dates';
 

--- a/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
+++ b/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
@@ -14,11 +14,14 @@ import { intersection, difference } from 'lodash';
 
 import PropTypes from 'prop-types';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles/useFeatureToggle';
+import { focusElement } from 'platform/utilities/ui';
+import { Element } from 'platform/utilities/scroll';
+import { scrollTo } from 'platform/utilities/ui/scroll';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import BreadCrumbs from '../components/Breadcrumbs';
 import TravelClaimCard from '../components/TravelClaimCard';
 import TravelPayClaimFilters from '../components/TravelPayClaimFilters';
-import HelpText from '../components/HelpText';
+import { HelpTextContent } from '../components/HelpText';
 import { getTravelClaims } from '../redux/actions';
 import { getDateFilters } from '../util/dates';
 
@@ -28,6 +31,11 @@ export default function App({ children }) {
   const userLoggedIn = useSelector(state => isLoggedIn(state));
 
   const filterInfoRef = useRef();
+
+  useEffect(() => {
+    focusElement('h1');
+    scrollTo('topScrollElement');
+  });
 
   // TODO: utilize user info for authenticated requests
   // and validating logged in status
@@ -265,18 +273,20 @@ export default function App({ children }) {
   }
 
   return (
-    <>
+    <Element name="topScrollElement">
       <article className="usa-grid-full vads-u-padding-bottom--0">
         <BreadCrumbs />
-        <h1
-          className="claims-controller-title"
-          tabIndex="-1"
-          data-testid="header"
-        >
+        <h1 tabIndex="-1" data-testid="header">
           Check your travel reimbursement claim status
         </h1>
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-          <HelpText />
+          <h2 className="vads-u-font-size--h4">
+            You can use this tool to check the status of your VA travel claims.
+          </h2>
+          <va-additional-info trigger="How to manage your claims or get more information">
+            <HelpTextContent />
+          </va-additional-info>
+
           {isLoading && (
             <va-loading-indicator
               label="Loading"
@@ -298,7 +308,7 @@ export default function App({ children }) {
             travelClaims.length > 0 && (
               <>
                 <div className="btsss-claims-sort-and-filter-container">
-                  <h2>Your travel claims</h2>
+                  <h2 className="vads-u-font-size--h4">Your travel claims</h2>
                   <p>
                     This list shows all the appointments you've filed a travel
                     claim for.
@@ -377,7 +387,7 @@ export default function App({ children }) {
       </article>
 
       {children}
-    </>
+    </Element>
   );
 }
 

--- a/src/applications/travel-pay/containers/pages/ClaimStatusExplainerPage.jsx
+++ b/src/applications/travel-pay/containers/pages/ClaimStatusExplainerPage.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect } from 'react';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles/useFeatureToggle';
+import { Element } from 'platform/utilities/scroll';
+import { focusElement } from 'platform/utilities/ui';
+import { scrollTo } from 'platform/utilities/ui/scroll';
+
+import { VaBackToTop } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+import BreadCrumbs from '../../components/Breadcrumbs';
+import { STATUSES, STATUS_GROUPINGS } from '../../constants';
+
+const ClaimStatusExplainerPage = () => {
+  useEffect(() => {
+    focusElement('h1');
+    scrollTo('topScrollElement');
+  });
+
+  const {
+    useToggleValue,
+    useToggleLoadingValue,
+    TOGGLE_NAMES,
+  } = useFeatureToggle();
+
+  const toggleIsLoading = useToggleLoadingValue();
+  const appEnabled = useToggleValue(TOGGLE_NAMES.travelPayPowerSwitch);
+
+  if (toggleIsLoading) {
+    return (
+      <div className="vads-l-grid-container vads-u-padding-y--3">
+        <va-loading-indicator
+          label="Loading"
+          message="Please wait while we load the application for you."
+          data-testid="travel-pay-loading-indicator"
+        />
+      </div>
+    );
+  }
+
+  if (!appEnabled) {
+    window.location.replace('/');
+    return null;
+  }
+
+  return (
+    <Element name="topScrollElement">
+      <article className="usa-grid-full vads-u-padding-bottom--0">
+        <BreadCrumbs />
+        <h1 tabIndex="-1" data-testid="status-explainer-header">
+          What does my claim status mean?
+        </h1>
+        <div className="vads-l-row vads-u-margin-x--neg2p5">
+          <div className="vads-l-col--10 vads-u-padding-x--2p5 ">
+            <p>
+              VA uses many statuses to track claims from before you submit to
+              after you receive payment. This page provides descriptions for
+              what each status means. If you continue to have questions about
+              your claim, please contact your local VA Medical Center (VAMC) and
+              ask to speak with the Beneficiary Travel department.
+            </p>
+            <p>
+              On the Dashboard and Claims pages, each claim has a status. These
+              pages also include filters which allow you to filter by one of the
+              following categories: Saved or Incomplete, Under VA Review, and
+              Closed. The claim categories and statuses within Beneficiary
+              Travel Self Service System (BTSSS) are:
+            </p>
+
+            {STATUS_GROUPINGS.map(grouping => (
+              <React.Fragment key={grouping.name}>
+                <h2 className="vads-u-font-size--h3">{grouping.name}</h2>
+                <p>{grouping.description}</p>
+                <ul>
+                  {STATUSES.map(
+                    status =>
+                      grouping.includes.includes(status.name) && (
+                        <li key={status.name}>
+                          <b>{status.name} — </b> {status.description}
+                          {status.reasons && (
+                            <ul>
+                              {status.reasons.map((reason, index) => (
+                                <li key={index}>{reason}</li>
+                              ))}
+                            </ul>
+                          )}
+                        </li>
+                      ),
+                  )}
+                </ul>
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+        <VaBackToTop />
+      </article>
+    </Element>
+  );
+};
+
+export default ClaimStatusExplainerPage;

--- a/src/applications/travel-pay/routes.jsx
+++ b/src/applications/travel-pay/routes.jsx
@@ -3,6 +3,7 @@ import { Switch, Route } from 'react-router-dom';
 import { MhvSecondaryNav } from '@department-of-veterans-affairs/mhv/exports';
 import TravelPayStatusApp from './containers/TravelPayStatusApp';
 import TravelClaimDetails from './components/TravelClaimDetails';
+import ClaimStatusExplainerPage from './containers/pages/ClaimStatusExplainerPage';
 
 const routes = (
   <Switch>
@@ -10,7 +11,11 @@ const routes = (
       <MhvSecondaryNav />
       <TravelPayStatusApp />
     </Route>
-    <Route exact path="/:id">
+    <Route exact path="/help">
+      <MhvSecondaryNav />
+      <ClaimStatusExplainerPage />
+    </Route>
+    <Route path="/:id">
       <MhvSecondaryNav />
       <TravelClaimDetails />
     </Route>

--- a/src/applications/travel-pay/sass/travel-pay.scss
+++ b/src/applications/travel-pay/sass/travel-pay.scss
@@ -7,15 +7,6 @@
 @import "../../../platform/forms/sass/m-form-confirmation";
 @import "../../../platform/mhv/secondary-nav/sass/mhv-sec-nav";
 
-.btsss-portal-link {
-  display: inline-flex;
-  align-items: center;
-}
-
-.btsss-portal-link va-icon {
-  margin-left: 4px;
-}
-
 .btsss-claims-sort-and-filter-container {
   min-width: fit-content;
   max-width: 35rem;
@@ -49,12 +40,7 @@ h2#pagination-info {
   }
 }
 
-.claims-controller-title {
-  font-size: 4rem;
-  font-weight: 700;
-}
-
-.claim-details-breadcrumb-wrapper {
+.travel-pay-breadcrumb-wrapper {
   display: flex;
   align-items: center;
 
@@ -77,16 +63,4 @@ h2#pagination-info {
       padding-bottom: 48px;
     }
   }
-}
-
-.claim-details-claim-number {
-  // Matches styles for <h2>
-  font-size: 1.875rem;
-  font-weight: 700;
-}
-
-.claim-details-h3 {
-  // Styling <h3>s to match <h2>s
-  font-size: 1.25rem;
-  font-weight: 700;
 }

--- a/src/applications/travel-pay/tests/containers/ClaimStatusExplainerPage.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/containers/ClaimStatusExplainerPage.unit.spec.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { expect } from 'chai';
+import { waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import ClaimStatusExplainerPage from '../../containers/pages/ClaimStatusExplainerPage';
+
+describe('ClaimStatusExplainerPage', () => {
+  const getState = ({
+    featureTogglesAreLoading = false,
+    hasStatusFeatureFlag = true,
+  } = {}) => ({
+    featureToggles: {
+      loading: featureTogglesAreLoading,
+      /* eslint-disable camelcase */
+      travel_pay_power_switch: hasStatusFeatureFlag,
+      /* eslint-enable camelcase */
+    },
+  });
+
+  let oldLocation;
+  beforeEach(() => {
+    oldLocation = global.window.location;
+    delete global.window.location;
+
+    global.window.location = {
+      replace: sinon.spy(),
+    };
+  });
+
+  afterEach(() => {
+    global.window.location = oldLocation;
+  });
+
+  it('Successfully renders', async () => {
+    const screen = renderWithStoreAndRouter(<ClaimStatusExplainerPage />, {
+      initialState: { ...getState() },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('What does my claim status mean?')).to.exist;
+    });
+  });
+
+  it('redirects to the root path when claim statuses feature flag is false', async () => {
+    renderWithStoreAndRouter(<ClaimStatusExplainerPage />, {
+      initialState: { ...getState({ hasStatusFeatureFlag: false }) },
+    });
+
+    await waitFor(() => {
+      expect(window.location.replace.calledWith('/')).to.be.true;
+    });
+  });
+
+  it('shows a loading spinner of toggles are loading', async () => {
+    const screenFeatureToggle = renderWithStoreAndRouter(
+      <ClaimStatusExplainerPage />,
+      {
+        initialState: { ...getState({ featureTogglesAreLoading: true }) },
+      },
+    );
+
+    expect(
+      await screenFeatureToggle.getByTestId('travel-pay-loading-indicator'),
+    ).to.exist;
+  });
+});

--- a/src/applications/travel-pay/tests/e2e/travel-pay.cypress.spec.js
+++ b/src/applications/travel-pay/tests/e2e/travel-pay.cypress.spec.js
@@ -60,12 +60,36 @@ describe(`${appName} -- Status Page`, () => {
     );
 
     // TODO: update mock data to reflect proper claim number formatting
-    cy.get('.claim-details-claim-number').should(
+    cy.get('span[data-testid="claim-details-claim-number"]').should(
       'include.text',
       'Claim number: d00606da-ee39-4a0c-b505-83f6aa052594',
     );
 
-    cy.get('.claim-details-breadcrumb-wrapper .go-back-link').click();
+    cy.get('.travel-pay-breadcrumb-wrapper .go-back-link').click();
+    cy.location('pathname').should('eq', '/my-health/travel-claim-status/');
+  });
+  it('navigates to the status explainer page and back to status page', () => {
+    cy.get('va-additional-info')
+      .first()
+      .click();
+
+    cy.get('a[data-testid="status-explainer-link"]')
+      .first()
+      .click();
+
+    cy.location('pathname').should('eq', '/my-health/travel-claim-status/help');
+
+    cy.get('h1').should('include.text', 'What does my claim status mean?');
+
+    // // get the 4th Breadcrumb, test that it is correct for the page
+    cy.get('a')
+      .eq(3)
+      .should('include.text', 'Help: Claim Status Meanings');
+
+    // The 3rd Breadcrumb link (since there are 2 with path: "/")
+    cy.get('a')
+      .eq(2)
+      .click();
     cy.location('pathname').should('eq', '/my-health/travel-claim-status/');
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_

Added a new page, rearranged some styles so travel pay fits better with the rest of the site, added an `additional info` dropdown component to hold the link to the new `/help` status explainer page.

_NOTE: THIS REPLACES[ PR #33327](https://github.com/department-of-veterans-affairs/vets-website/pull/33327) per Platform guidance_ 

- _(What is the solution, why is this the solution)_
VTP requested an "explainer" page for status definitions. 
- _(Which team do you work for, does your team own the maintenance of this component?)_
Travel Pay
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
We will be doing a phased rollout, beginning mid-December

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#97985](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97985)

## Testing done

- _Describe what the old behavior was prior to the change_
Net new page
- _Describe the steps required to verify your changes are working as expected_
On staging, Log In with Nolle Barakat user, navigate to `va.gov/my-health/travel-claim-status`. Open the additional info drop down and click "What does my claim status mean" and you should be directed to the status explainer page (`my-health/travel-claim-status/help`).
- _Describe the tests completed and the results_
Unit test for status list page updated and unit test for status explainer page (and cypress test) added.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| status list |  <img width="90%" alt="Screenshot 2024-12-04 at 1 10 28 PM" src="https://github.com/user-attachments/assets/950478d4-9b4f-43b1-8fd9-61474d82cab1">      |    <img width="90%" alt="Screenshot 2024-12-04 at 1 08 58 PM" src="https://github.com/user-attachments/assets/b31e4a0a-97ba-4239-938e-a3f699872733">   |

New page:
`my-health/travel-claim-status/help`

![travel-claim-status_help](https://github.com/user-attachments/assets/450bab63-87cd-440b-9d9b-f0039094c2cd)



## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
Only Travel Pay app

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
