### PR TITLE
Propagate all field values to formData for autocomplete

### DIFF
--- a/src/applications/caregivers/components/FormDescriptions/AddressCountyDescriptions.jsx
+++ b/src/applications/caregivers/components/FormDescriptions/AddressCountyDescriptions.jsx
@@ -4,6 +4,7 @@ export const CaregiverCountyDescription = () => (
   <va-additional-info
     trigger="Why we ask for this information"
     class="vads-u-margin-y--1p5"
+    onBlur={event => event.stopPropagation()}
   >
     <p>
       Providing the county helps the Caregiver Support Team connect caregivers

--- a/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
+++ b/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
@@ -66,6 +66,17 @@ const PrimaryAddressWithAutofill = props => {
     [addDirtyField, formData, onChange, veteranAddress],
   );
 
+  const ALL_FIELDS = [...REQUIRED_ADDRESS_FIELDS, 'street2'];
+
+  const updateAllFormDataForAutocomplete = () => {
+    ALL_FIELDS.forEach(field => {
+      const f = `root_${props.name}_${field}`;
+      const element = document.getRootNode().getElementById(f);
+      const { value } = element;
+      formData[field] = value;
+    });
+  };
+
   // define our non-checkbox input change event
   const handleChange = useCallback(
     event => {
@@ -74,18 +85,32 @@ const PrimaryAddressWithAutofill = props => {
       // uncheck autofill since we have modified the input value
       if (formData['view:autofill']) formData['view:autofill'] = false;
       // send updated date to the form
+      updateAllFormDataForAutocomplete();
       onChange(formData);
     },
-    [formData, onChange],
+    [formData, onChange, updateAllFormDataForAutocomplete],
   );
 
   // define our non-checkbox input blur event
   const handleBlur = useCallback(
     event => {
-      const fieldName = event.target.name.split('_').pop();
+      const { name } = event.target;
+
+      if (!name) {
+        // blurring the County's AddressCountyDescription component causes
+        // an error below when attempting the split. this avoids cascading the
+        // remaining blur behavior to it.
+        return;
+      }
+
+      const fieldName = name.split('_').pop();
       addDirtyField(fieldName);
+      // make sure that formData has all field values
+      // browser autocomplete does not consistently trigger input/change events
+      updateAllFormDataForAutocomplete();
+      onChange(formData);
     },
-    [addDirtyField],
+    [addDirtyField, formData, onChange, updateAllFormDataForAutocomplete],
   );
 
   // check for validation errors if field is dirty or form has been submitted
@@ -106,7 +131,6 @@ const PrimaryAddressWithAutofill = props => {
     }
     return null;
   };
-
   return reviewMode ? (
     <AddressWithAutofillReviewField
       formData={formData}
@@ -144,6 +168,7 @@ const PrimaryAddressWithAutofill = props => {
         onInput={handleChange}
         onBlur={handleBlur}
         required
+        autocomplete="address-line1"
       />
 
       <VaTextInput
@@ -154,6 +179,7 @@ const PrimaryAddressWithAutofill = props => {
         className="cg-address-input"
         onInput={handleChange}
         onBlur={handleBlur}
+        autocomplete="address-line2"
       />
 
       <VaTextInput
@@ -166,6 +192,7 @@ const PrimaryAddressWithAutofill = props => {
         onInput={handleChange}
         onBlur={handleBlur}
         required
+        autocomplete="address-level2"
       />
 
       <VaSelect
@@ -178,6 +205,7 @@ const PrimaryAddressWithAutofill = props => {
         onVaSelect={handleChange}
         onBlur={handleBlur}
         required
+        autocomplete="address-level1"
       >
         {states.USA.map(state => (
           <option key={state.value} value={state.value}>
@@ -197,6 +225,7 @@ const PrimaryAddressWithAutofill = props => {
         onInput={handleChange}
         onBlur={handleBlur}
         required
+        autocomplete="postal-code"
       />
 
       <VaTextInput

--- a/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
+++ b/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
@@ -66,16 +66,16 @@ const PrimaryAddressWithAutofill = props => {
     [addDirtyField, formData, onChange, veteranAddress],
   );
 
-  const ALL_FIELDS = [...REQUIRED_ADDRESS_FIELDS, 'street2'];
-
-  const updateAllFormDataForAutocomplete = () => {
-    ALL_FIELDS.forEach(field => {
-      const f = `root_${props.name}_${field}`;
-      const element = document.getRootNode().getElementById(f);
-      const { value } = element;
-      formData[field] = value;
-    });
-  };
+  const updateAllFormDataForAutocomplete = useCallback(
+    () => {
+      [...REQUIRED_ADDRESS_FIELDS, 'street2'].forEach(field => {
+        const fieldName = `root_${props.name}_${field}`;
+        const { value } = document.getElementById(fieldName);
+        formData[field] = value;
+      });
+    },
+    [formData, props.name],
+  );
 
   // define our non-checkbox input change event
   const handleChange = useCallback(
@@ -95,14 +95,6 @@ const PrimaryAddressWithAutofill = props => {
   const handleBlur = useCallback(
     event => {
       const { name } = event.target;
-
-      if (!name) {
-        // blurring the County's AddressCountyDescription component causes
-        // an error below when attempting the split. this avoids cascading the
-        // remaining blur behavior to it.
-        return;
-      }
-
       const fieldName = name.split('_').pop();
       addDirtyField(fieldName);
       // make sure that formData has all field values

--- a/src/applications/caregivers/tests/unit/components/FormDescriptions/AddressCountyDescriptions.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormDescriptions/AddressCountyDescriptions.unit.spec.js
@@ -1,22 +1,38 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import {
   CaregiverCountyDescription,
   VeteranCountyDescription,
 } from '../../../../components/FormDescriptions/AddressCountyDescriptions';
 
 describe('CG <CaregiverCountyDescription>', () => {
-  it('should render `va-additional-info` component with neccessary attribute(s)', () => {
+  it('should render `va-additional-info` component with necessary attribute(s)', () => {
     const { container } = render(<CaregiverCountyDescription />);
     const selector = container.querySelector('va-additional-info');
     expect(selector).to.exist;
     expect(selector).to.have.attr('trigger');
   });
+
+  it('should prevent an outside blur event from executing', () => {
+    const externalBlur = sinon.spy();
+    const { container } = render(
+      <div onBlur={externalBlur}>
+        <CaregiverCountyDescription />
+      </div>,
+    );
+    const selector = container.querySelector('va-additional-info');
+    const blurEvent = new Event('blur');
+
+    fireEvent.blur(selector, blurEvent);
+
+    expect(externalBlur.notCalled).to.be.true;
+  });
 });
 
 describe('CG <VeteranCountyDescription>', () => {
-  it('should render `va-additional-info` component with neccessary attribute(s)', () => {
+  it('should render `va-additional-info` component with necessary attribute(s)', () => {
     const { container } = render(<VeteranCountyDescription />);
     const selector = container.querySelector('va-additional-info');
     expect(selector).to.exist;

--- a/src/applications/caregivers/tests/unit/components/FormFields/AddressWithAutofill.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/AddressWithAutofill.unit.spec.js
@@ -27,6 +27,7 @@ describe('CG <AddressWithAutofill>', () => {
         state: 'DC',
         postalCode: '20005',
         'view:autofill': autofill,
+        county: undefined,
       },
       errorSchema: {
         city: errorSchemas.required,
@@ -49,6 +50,7 @@ describe('CG <AddressWithAutofill>', () => {
       },
       schema: addressWithAutofillSchema(address),
       onChange: sinon.spy(),
+      name: 'caregiverAddress',
     },
     mockStore: {
       getState: () => ({
@@ -81,6 +83,7 @@ describe('CG <AddressWithAutofill>', () => {
       reviewRow: container.querySelectorAll('.review-row'),
       vaCheckbox: container.querySelector('#root_caregiverAddress_autofill'),
       vaTextInput: container.querySelector('#root_caregiverAddress_postalCode'),
+      streetInput: container.querySelector('#root_caregiverAddress_street'),
     });
     return { container, selectors };
   };
@@ -160,6 +163,31 @@ describe('CG <AddressWithAutofill>', () => {
       });
 
       await waitFor(() => {
+        fireEvent.blur(selectors().vaTextInput);
+        expect(selectors().vaTextInput).to.not.have.attr('error');
+      });
+    });
+
+    it('should call all `onChange` methods to update the form data in case of autocomplete', async () => {
+      const { mockStore, props } = getData({});
+      const { container, selectors } = subject({ mockStore, props });
+      const formData = {
+        ...props.formData,
+        postalCode: postalCode.valid,
+        street: '123 Fake st.',
+      };
+
+      await waitFor(() => {
+        selectors().streetInput.value = formData.street;
+        inputVaTextInput(
+          container,
+          formData.postalCode,
+          selectors().vaTextInput,
+        );
+        const blurEvent = new CustomEvent('blur');
+        selectors().vaTextInput.dispatchEvent(blurEvent);
+        expect(props.onChange.calledWith(formData)).to.be.true;
+
         fireEvent.blur(selectors().vaTextInput);
         expect(selectors().vaTextInput).to.not.have.attr('error');
       });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary
- Bulk-filling fields with a browser's autocomplete may not fire Input/Change/Blur events.
- To reproduce this bug, Safari is the most consistent. Start the [10-10CG application](https://staging.va.gov/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg/introduction) and proceed to the Veteran's home address page. Populate the fields from address autocomplete data (cmd-shift-A in Safari), and note that while this puts values in some fields, clicking Continue blanks them out, since the values were not added to the formData. 
- While addressing this for the Veteran is difficult due to the FormUI, we're able to fix it for the Primary Caregiver and both Secondary Caregivers by propagating all field values to the formData on any of their Change or Blur events.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94536

## Testing done
- confirmed that we can autocomplete the Caregiver address fields, and the values are stored when continuing instead of being discarded on blur. we can see the final values on the Review page at the end.

## Screenshots
Before: 
<img width="541" alt="Screenshot 2024-12-11 at 2 16 29 PM" src="https://github.com/user-attachments/assets/168f0f1a-e46b-4831-b434-966c8f7a1070" />

After:
<img width="542" alt="Screenshot 2024-12-11 at 2 16 21 PM" src="https://github.com/user-attachments/assets/ba8cc16d-f9ad-4f24-b5d1-c83b4d678af8" />

## What areas of the site does it impact?
- 10-10CG Caregiver Address pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
