### PR TITLE
[92622] Add presubmit unit tests

### DIFF
--- a/src/applications/representative-appoint/containers/PreSubmitInfo.jsx
+++ b/src/applications/representative-appoint/containers/PreSubmitInfo.jsx
@@ -111,6 +111,7 @@ export const PreSubmitInfo = ({
               setTermsAndConditionsChecked(value.detail.checked)
             }
             error={termsAndConditionsError ? 'This field is mandatory' : null}
+            data-testid="terms-and-conditions"
           />
           <VaCheckbox
             label="I accept that this form will replace all my other VA Forms 21-22 and 21-22a"
@@ -122,6 +123,7 @@ export const PreSubmitInfo = ({
               setFormReplacementChecked(value.detail.checked)
             }
             error={formReplacementError ? 'This field is mandatory' : null}
+            data-testid="form-replacement"
           />
         </VaCheckboxGroup>
       </div>

--- a/src/applications/representative-appoint/tests/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/containers/PreSubmitInfo.unit.spec.jsx
@@ -120,7 +120,7 @@ describe('<PreSubmitInfo>', () => {
       });
     });
 
-    it('form replacement shows an error message', async () => {
+    it('shows an error message for form replacement', async () => {
       const { props, mockStore } = getProps({ showError: true, status: null });
 
       const { container } = renderContainer(props, mockStore);
@@ -158,7 +158,7 @@ describe('<PreSubmitInfo>', () => {
       });
     });
 
-    it('terms and conditions shows an error message', async () => {
+    it('shows an error message for terms and conditions ', async () => {
       const { props, mockStore } = getProps({ showError: true, status: null });
 
       const { container } = renderContainer(props, mockStore);

--- a/src/applications/representative-appoint/tests/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/containers/PreSubmitInfo.unit.spec.jsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import PreSubmitInfo from '../../containers/PreSubmitInfo';
+import repResults from '../fixtures/data/representative-results.json';
+
+describe('<PreSubmitInfo>', () => {
+  const getProps = ({
+    showError = false,
+    status = 'applicationSubmitted',
+  } = {}) => {
+    return {
+      props: {
+        formData: {
+          veteranFullName: {
+            first: 'John',
+            middle: 'Edmund',
+            last: 'Doe',
+            suffix: 'Sr.',
+          },
+          selectedAccreditedOrganizationName: 'American Legion',
+          'view:applicantIsVeteran': 'Yes',
+          'view:selectedRepresentative': repResults[0].data,
+        },
+        showError,
+        onSectionComplete: sinon.spy(),
+        formSubmission: { status },
+      },
+      mockStore: {
+        getState: () => ({
+          form: {
+            submission: { status },
+          },
+        }),
+        subscribe: () => {},
+        dispatch: () => ({}),
+      },
+    };
+  };
+
+  const renderContainer = (props, mockStore) => {
+    return render(
+      <Provider store={mockStore}>
+        <PreSubmitInfo {...props} />
+      </Provider>,
+    );
+  };
+
+  it('should render component', () => {
+    const { props, mockStore } = getProps();
+
+    const { container } = renderContainer(props, mockStore);
+
+    expect(container).to.exist;
+  });
+
+  it('should include the applicant name', () => {
+    const { props, mockStore } = getProps();
+
+    const { container } = renderContainer(props, mockStore);
+    const content = $('va-accordion-item', container);
+
+    expect(content.textContent).to.contain('John Edmund Doe Sr.');
+  });
+
+  it('should include the representative name', () => {
+    const { props, mockStore } = getProps();
+
+    const { container } = renderContainer(props, mockStore);
+    const content = $('va-accordion-item', container);
+
+    expect(content.textContent).to.contain('American Legion');
+  });
+
+  context('when terms and conditions and form replacement are accepted', () => {
+    it('calls onSectionComplete with true', async () => {
+      const { props, mockStore } = getProps({ status: null });
+
+      const { container } = renderContainer(props, mockStore);
+
+      const tcBox = container.querySelector(
+        '[data-testid="terms-and-conditions"]',
+      );
+
+      tcBox.__events.vaChange({
+        detail: { checked: true },
+      });
+
+      const frBox = container.querySelector('[data-testid="form-replacement"]');
+
+      frBox.__events.vaChange({
+        detail: { checked: true },
+      });
+
+      await waitFor(() => {
+        expect(props.onSectionComplete.calledWith(true)).to.be.true;
+      });
+    });
+  });
+
+  context('when only terms and conditions is accepted', () => {
+    it('calls onSectionComplete with false', async () => {
+      const { props, mockStore } = getProps({ status: null });
+
+      const { container } = renderContainer(props, mockStore);
+
+      const tcBox = container.querySelector(
+        '[data-testid="terms-and-conditions"]',
+      );
+
+      tcBox.__events.vaChange({
+        detail: { checked: true },
+      });
+
+      await waitFor(() => {
+        expect(props.onSectionComplete.calledWith(false)).to.be.true;
+      });
+    });
+
+    it('form replacement shows an error message', async () => {
+      const { props, mockStore } = getProps({ showError: true, status: null });
+
+      const { container } = renderContainer(props, mockStore);
+
+      const tcBox = container.querySelector(
+        '[data-testid="terms-and-conditions"]',
+      );
+
+      tcBox.__events.vaChange({
+        detail: { checked: true },
+      });
+
+      const frBox = container.querySelector('[data-testid="form-replacement"]');
+
+      await waitFor(() => {
+        expect(frBox).to.have.attr('error', 'This field is mandatory');
+      });
+    });
+  });
+
+  context('when only form replacement is accepted', () => {
+    it('calls onSectionComplete with false', async () => {
+      const { props, mockStore } = getProps({ status: null });
+
+      const { container } = renderContainer(props, mockStore);
+
+      const frBox = container.querySelector('[data-testid="form-replacement"]');
+
+      frBox.__events.vaChange({
+        detail: { checked: true },
+      });
+
+      await waitFor(() => {
+        expect(props.onSectionComplete.calledWith(false)).to.be.true;
+      });
+    });
+
+    it('terms and conditions shows an error message', async () => {
+      const { props, mockStore } = getProps({ showError: true, status: null });
+
+      const { container } = renderContainer(props, mockStore);
+
+      const frBox = container.querySelector('[data-testid="form-replacement"]');
+
+      frBox.__events.vaChange({
+        detail: { checked: true },
+      });
+
+      const tcBox = container.querySelector(
+        '[data-testid="terms-and-conditions"]',
+      );
+
+      await waitFor(() => {
+        expect(tcBox).to.have.attr('error', 'This field is mandatory');
+      });
+    });
+  });
+
+  context('submission pending', () => {
+    it('displays the loading message', () => {
+      const { props, mockStore } = getProps({ status: 'submitPending' });
+
+      const { container } = renderContainer(props, mockStore);
+
+      expect(
+        $('va-loading-indicator', container).getAttribute('message'),
+      ).to.contain('We’re processing your form');
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds unit test for the PreSubmitInfo container

## Related issue(s)

- [92622](https://github.com/department-of-veterans-affairs/va.gov-team/issues/92622)

## Testing done

- Went through form flow locally with auth and unauth users to confirm adding unit tests didn't break anything

## What areas of the site does it impact?

There should be no impact from adding unit tests. If any, it would be Appoint a Rep Form 21-22 and 21-22a.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user