### PR TITLE
Removes My VA Health from VAOS direct schedule facility page

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -1,17 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual, useSelector } from 'react-redux';
-import { getCernerURL } from 'platform/utilities/cerner';
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { selectFacilitiesRadioWidget } from '../../redux/selectors';
 import State from '../../../components/State';
 import InfoAlert from '../../../components/InfoAlert';
 import { FACILITY_SORT_METHODS, FETCH_STATUS } from '../../../utils/constants';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
-import { isCernerLocation } from '../../../services/location';
 import NoAddressNote from '../NoAddressNote';
-import { useOHDirectScheduling } from '../../hooks/useOHDirectScheduling';
-import { useOHRequestScheduling } from '../../hooks/useOHRequestScheduling';
 
 const INITIAL_FACILITY_DISPLAY_COUNT = 5;
 /*
@@ -26,12 +22,10 @@ export default function FacilitiesRadioWidget({
   onChange,
   formContext,
 }) {
-  const {
-    cernerSiteIds,
-    requestLocationStatus,
-    sortMethod,
-    loadingEligibility,
-  } = useSelector(state => selectFacilitiesRadioWidget(state), shallowEqual);
+  const { requestLocationStatus, sortMethod, loadingEligibility } = useSelector(
+    state => selectFacilitiesRadioWidget(state),
+    shallowEqual,
+  );
 
   const { hasUserAddress, sortOptions, updateFacilitySortMethod } = formContext;
   const { enumOptions } = options;
@@ -66,9 +60,6 @@ export default function FacilitiesRadioWidget({
       </option>
     );
   });
-
-  const useOHDirectSchedule = useOHDirectScheduling();
-  const useOHRequestSchedule = useOHRequestScheduling();
 
   useEffect(
     () => {
@@ -128,7 +119,6 @@ export default function FacilitiesRadioWidget({
         displayedOptions.map((option, i) => {
           const { name, address, legacyVAR } = option?.label;
           const checked = option.value === value;
-          const isCerner = isCernerLocation(option.value, cernerSiteIds);
           let distance;
 
           if (sortMethod === FACILITY_SORT_METHODS.distanceFromResidential) {
@@ -165,12 +155,6 @@ export default function FacilitiesRadioWidget({
                     {distance} miles
                   </span>
                 )}
-                {isCerner &&
-                  (!useOHDirectSchedule && !useOHRequestSchedule) && (
-                    <a href={getCernerURL('/pages/scheduling/upcoming')}>
-                      Schedule online at <strong>My VA Health</strong>
-                    </a>
-                  )}
               </label>
             </div>
           );

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.unit.spec.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 // eslint-disable-next-line import/no-unresolved
 import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
-import { fireEvent, waitFor, within } from '@testing-library/dom';
+import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import VAFacilityPage from './VAFacilityPageV2';
 import {
@@ -1317,16 +1317,6 @@ describe('VAOS Page: VAFacilityPage', () => {
       expect(await screen.findByText(/First Cerner facility/i)).to.be.ok;
       expect(screen.getByText(/Second Cerner facility/i)).to.be.ok;
 
-      // Make sure Cerner link shows up
-      const cernerSiteLabel = document.querySelector(
-        `label[for="${screen.getByLabelText(/First Cerner facility/i).id}"]`,
-      );
-      expect(
-        within(cernerSiteLabel)
-          .getByRole('link', { name: /My VA Health/ })
-          .getAttribute('href'),
-      ).to.contain('pages/scheduling/upcoming');
-
       // Make sure Cerner facilities show up only once
       expect(screen.getAllByText(/Second Cerner facility/i)).to.have.length(1);
       userEvent.click(screen.getByLabelText(/First cerner facility/i));
@@ -1336,133 +1326,6 @@ describe('VAOS Page: VAFacilityPage', () => {
           '/new-appointment/how-to-schedule',
         ),
       );
-    });
-  });
-
-  describe('when OH Direct Scheduling is enabled', () => {
-    beforeEach(() => mockFetch());
-
-    const initialState = {
-      drupalStaticData: {
-        vamcEhrData: {
-          loading: false,
-          data: {
-            ehrDataByVhaId: {
-              '442': {
-                vhaId: '442',
-                vamcFacilityName: 'Cheyenne VA Medical Center',
-                vamcSystemName: 'VA Cheyenne health care',
-                ehr: 'cerner',
-              },
-              '552': {
-                vhaId: '552',
-                vamcFacilityName: 'Dayton VA Medical Center',
-                vamcSystemName: 'VA Dayton health care',
-                ehr: 'cerner',
-              },
-            },
-            cernerFacilities: [
-              {
-                vhaId: '442',
-                vamcFacilityName: 'Cheyenne VA Medical Center',
-                vamcSystemName: 'VA Cheyenne health care',
-                ehr: 'cerner',
-              },
-              {
-                vhaId: '552',
-                vamcFacilityName: 'Dayton VA Medical Center',
-                vamcSystemName: 'VA Dayton health care',
-                ehr: 'cerner',
-              },
-            ],
-            vistaFacilities: [],
-          },
-        },
-      },
-      featureToggles: {
-        vaOnlineSchedulingDirect: true,
-        vaOnlineSchedulingUseDsot: true,
-        vaOnlineSchedulingOhDirectSchedule: true,
-      },
-      user: {
-        profile: {
-          facilities: [
-            {
-              facilityId: '442', // Must use real facility id when using DSOT
-              isCerner: false, // Not used when using DSOT
-            },
-            { facilityId: '552', isCerner: false },
-          ],
-        },
-      },
-    };
-
-    it('should not display MHV scheduling link for foodAndNutrition appointments', async () => {
-      mockFacilitiesFetch({
-        children: true,
-        facilities: [
-          createMockFacility({
-            id: '983',
-            name: 'First cerner facility',
-            lat: 39.1362562,
-            long: -83.1804804,
-          }),
-          createMockFacility({
-            id: '984',
-            name: 'Second Cerner facility',
-            lat: 39.1362562,
-            long: -83.1804804,
-          }),
-        ],
-      });
-
-      mockSchedulingConfigurations([
-        getSchedulingConfigurationMock({
-          id: '983',
-          typeOfCareId: 'foodAndNutrition',
-          directEnabled: true,
-        }),
-        getSchedulingConfigurationMock({
-          id: '984',
-          typeOfCareId: 'foodAndNutrition',
-          directEnabled: true,
-        }),
-      ]);
-
-      const store = createTestStore({
-        ...initialState,
-        user: {
-          ...initialState.user,
-          profile: {
-            ...initialState.user.profile,
-            vapContactInfo: {
-              residentialAddress: {
-                latitude: 39.1362562,
-                longitude: -84.6804804,
-              },
-            },
-          },
-        },
-      });
-
-      await setTypeOfCare(store, /nutrition and food/i);
-
-      const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
-        store,
-      });
-
-      // Make sure Cerner facilities show up
-      expect(await screen.findByText(/First Cerner facility/i)).to.be.ok;
-      expect(await screen.getByText(/Second Cerner facility/i)).to.be.ok;
-
-      // Make sure Cerner link does not show up for foodAndNutrition
-      const cernerSiteLabel = document.querySelector(
-        `label[for="${screen.getByLabelText(/First Cerner facility/i).id}"]`,
-      );
-
-      expect(
-        within(cernerSiteLabel).queryByRole('link', { name: /My VA Health/ }),
-      ).not.to.exist;
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR removes the _My VA Health_ links from the VA facility page in within the direct schedule flow. Previously, the links were removed for a specific type of care in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/31410)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96902

## Testing done
- Manual local testing replacing local mocked responses with staging responses for `judy.morrison@id.me`
- Unit tests

## Screenshots

| Before | After |
| ------ | ----- |
|![localhost_3001_my-health_appointments_($small-screen) (1)](https://github.com/user-attachments/assets/cbe3dd6c-bb12-4d60-bd79-fec65b5f599f)|![localhost_3001_my-health_appointments_($small-screen) (2)](https://github.com/user-attachments/assets/35233127-38d9-4f83-8f84-449b46b5b44f)|

## Acceptance criteria
- [ ] Regardless of whether or not the `vaOnlineSchedulingOhDirectSchedule` flag is on or off, there should be no _My VA Health_ link next to any OH facility on the VA facility page within the direct scheduling flow

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
