### PR TITLE
Revert "VEBT-911 SCO - Update 'Last Updated' date"

### DIFF
--- a/src/applications/sco/components/MainContent/LastUpdated.jsx
+++ b/src/applications/sco/components/MainContent/LastUpdated.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const LAST_UPDATED_DATE_TIME = '2024-05-07';
+const LAST_UPDATED_DATE = 'July 15, 2024';
+
+const LastUpdated = () => {
+  const feedbackButtonClicked = () => {
+    window.KAMPYLE_ONSITE_SDK?.showForm('17');
+  };
+
+  return (
+    <div className="last-updated usa-content vads-u-padding-x--1 desktop-lg:vads-u-padding-x--0">
+      <div className="mobile-lg:vads-u-display--flex above-footer-elements-container">
+        <div className="vads-u-flex--auto">
+          <span className="vads-u-text-align--justify">
+            <p>
+              Last updated:{' '}
+              <time dateTime={LAST_UPDATED_DATE_TIME}>{LAST_UPDATED_DATE}</time>
+            </p>
+          </span>
+        </div>
+        <div className="vads-u-flex--1 vads-u-text-align--right">
+          <span className="vads-u-text-align--right">
+            <button
+              type="button"
+              className="feedback-button usa-button"
+              id="mdFormButton"
+              aria-label="give feedback"
+              onClick={feedbackButtonClicked}
+            >
+              Feedback
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LastUpdated;

--- a/src/applications/sco/containers/App.jsx
+++ b/src/applications/sco/containers/App.jsx
@@ -7,6 +7,24 @@ const App = () => {
   return (
     <div>
       <div className="row">
+        {/* Delete lines 11 - 25 to rremove alert */}
+        <div className="vads-u-margin-top--2p5">
+          <va-alert
+            closeBtnAriaLabel="Close notification"
+            slim
+            full-width="false"
+            status="warning"
+            visible
+          >
+            <p className="vads-u-margin-y--0">
+              VA is aware of the Chapter 33, 6-credit hour exclusion (6x)
+              technical issue and is actively working on a solution. We will
+              keep you informed as we have updates.
+            </p>
+          </va-alert>
+        </div>
+        {/* Delete lines 11 - 25 to remove alert  */}
+
         <VaBreadcrumbs
           breadcrumbList={[
             {

--- a/src/applications/sco/tests/components/MainContent/LastUpdated.unit.spec.jsx
+++ b/src/applications/sco/tests/components/MainContent/LastUpdated.unit.spec.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import LastUpdated from '../../../components/MainContent/LastUpdated';
+
+describe('LastUpdated', () => {
+  it('renders without crashing', () => {
+    const tree = shallow(<LastUpdated />);
+    expect(tree.exists()).to.be.true;
+    tree.unmount();
+  });
+});


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#33470

Business is asking to keep the banner until 16 Dec 2024. Will remove then. For now, reverting code that removed the banner.