### PR TITLE
[SIMPLE-FORMS] fix: remove submit transformer check for has items

### DIFF
--- a/src/applications/simple-forms/20-10207/config/submit-transformer.js
+++ b/src/applications/simple-forms/20-10207/config/submit-transformer.js
@@ -2,9 +2,6 @@ import sharedTransformForSubmit from '../../shared/config/submit-transformer';
 import { PREPARER_TYPES } from './constants';
 
 export default function transformForSubmit(formConfig, form) {
-  const hasReceivedMedicalTreatment =
-    form?.data?.['view:hasReceivedMedicalTreatment'];
-
   const transformedData = JSON.parse(
     sharedTransformForSubmit(formConfig, form),
   );
@@ -26,10 +23,6 @@ export default function transformForSubmit(formConfig, form) {
     ],
     MEDAL_AWARD: 'medalAwardDocuments',
   };
-
-  if (!hasReceivedMedicalTreatment && transformedData.medicalTreatments) {
-    delete transformedData.medicalTreatments;
-  }
 
   // TODO: Once PDF has been updated to remove OCR-boxes,
   // remove this name-values truncation-block below.


### PR DESCRIPTION
## Summary

- This work is behind a feature toggle (flipper): NO
- This PR addresses the issue where medical facility treatment records were not being correctly mapped to the generated PDF for form 20-10207. The changes ensure that all relevant treatment center data is included in the PDF output.
- To reproduce the bug, users would need to fill out form 20-10207 with medical treatment center information and generate the PDF, which previously did not display this data.
- The solution involved debugging the existing mapping logic and ensuring that the data model for treatment records is correctly populated before the PDF generation process. This approach was chosen to ensure that all relevant data is accurately reflected in the output.
- I work for the Veteran Facing Forms Team, which owns the maintenance of the PDF generation component as well as form 20-10207.
- There is no flipper introduced in this change, so no specific success criteria are targeted.

## Related issue(s)

- [20-10207 Medical facility treatment records are not being mapped to PDF](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1914)

## Testing done

- [x] New code is covered by unit tests
- Prior to this change, the PDF generated did not display any medical treatment centers entered in the form.
- To verify the changes, the following steps were taken:
  1. Fill out form 20-10207 with various medical treatment center entries.
  2. Generate the PDF and confirm that all entered treatment centers are displayed correctly.
  3. Review the console for any errors or warnings during the form submission and PDF generation processes.

## What areas of the site does it impact?

- This change impacts the submission of form 20-10207, specifically the mapping of medical treatment records. The code changes primarily affect the submission transformer logic.

## Acceptance criteria

- [x] No error nor warning in the console.
- [x] Events are being sent to the appropriate logging solution.
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.

## Requested Feedback

Any