### PR TITLE
updated style of va-card and moved alert inside, focus alert after confirm

### DIFF
--- a/src/applications/mhv-medical-records/containers/SettingsPage.jsx
+++ b/src/applications/mhv-medical-records/containers/SettingsPage.jsx
@@ -46,11 +46,14 @@ const SettingsPage = () => {
       dispatch(updateSharingStatus(!currentOptInStatus)).then(() => {
         setShowSuccessAlert(true);
         // Focus the button after opt-in, when it turns to "Opt out"
-        if (!currentOptInStatus && buttonRef.current) {
-          setTimeout(() => focusElement('button', {}, buttonRef.current));
-        }
+        setTimeout(() => focusElement('#opt-in-out-alert'));
       });
     });
+  };
+
+  const handleCloseModal = () => {
+    setShowSharingModal(false);
+    setTimeout(() => focusElement('button', {}, buttonRef.current));
   };
 
   const sharingCardContent = () => {
@@ -120,50 +123,54 @@ const SettingsPage = () => {
       );
     }
     return (
-      <>
-        <va-alert
-          background-only
-          class="vads-u-margin-bottom--4"
-          close-btn-aria-label="Close notification"
-          disable-analytics="false"
-          full-width="false"
-          status="success"
-          visible={showSuccessAlert}
-          aria-live="polite"
-        >
-          <p className="vads-u-margin-y--0">
-            You’ve opted {isSharing ? 'back in to' : 'out of'} sharing
+      <va-card className="vads-u-padding--3">
+        <h3 className="vads-u-margin-top--0">
+          Your sharing setting: {isSharing ? 'Opted in' : 'Opted out'}
+        </h3>
+
+        {showSuccessAlert && (
+          <va-alert
+            slim
+            background-only
+            class="vads-u-margin-bottom--2"
+            close-btn-aria-label="Close notification"
+            disable-analytics="false"
+            full-width="false"
+            status="success"
+            visible={showSuccessAlert}
+            aria-live="polite"
+            id="opt-in-out-alert"
+          >
+            <p className="vads-u-margin-y--0">
+              You’ve opted {isSharing ? 'back in to' : 'out of'} sharing
+            </p>
+          </va-alert>
+        )}
+
+        {isSharing ? (
+          <p>
+            We’ll share your electronic health information with participating
+            non-VA providers when they’re treating you. You can opt out (ask us
+            not to share your records) at any time.
           </p>
-        </va-alert>
-        <va-card background className="vads-u-padding--3">
-          <h3 className="vads-u-margin-top--0">
-            Your sharing setting: {isSharing ? 'Opted in' : 'Opted out'}
-          </h3>
-          {isSharing ? (
-            <p>
-              We’ll share your electronic health information with participating
-              non-VA providers when they’re treating you. You can opt out (ask
-              us not to share your records) at any time.
-            </p>
-          ) : (
-            <p>
-              We’re not currently sharing your records online with your
-              community care providers. If you want us to start sharing your
-              records, you can opt back in.
-            </p>
-          )}
-          <va-button
-            ref={buttonRef}
-            data-testid="open-opt-in-out-modal-button"
-            text={isSharing ? 'Opt out' : 'Opt back in'}
-            onClick={() => {
-              setShowSharingModal(true);
-              sendDataDogAction(isSharing ? 'Opt out' : 'Opt in');
-              // If you want to focus an element, you can call it here or handle it elsewhere
-            }}
-          />
-        </va-card>
-      </>
+        ) : (
+          <p>
+            We’re not currently sharing your records online with your community
+            care providers. If you want us to start sharing your records, you
+            can opt back in.
+          </p>
+        )}
+        <va-button
+          ref={buttonRef}
+          data-testid="open-opt-in-out-modal-button"
+          text={isSharing ? 'Opt out' : 'Opt back in'}
+          onClick={() => {
+            setShowSharingModal(true);
+            sendDataDogAction(isSharing ? 'Opt out' : 'Opt in');
+            // If you want to focus an element, you can call it here or handle it elsewhere
+          }}
+        />
+      </va-card>
     );
   };
 
@@ -179,7 +186,7 @@ const SettingsPage = () => {
       <VaModal
         modalTitle={title}
         onCloseEvent={() => {
-          setShowSharingModal(false);
+          handleCloseModal();
           sendDataDogAction(`Close opt ${isSharing ? 'out' : 'in'} modal`);
         }}
         onPrimaryButtonClick={() => {
@@ -187,7 +194,7 @@ const SettingsPage = () => {
           sendDataDogAction(primaryButtonText);
         }}
         onSecondaryButtonClick={() => {
-          setShowSharingModal(false);
+          handleCloseModal();
           sendDataDogAction(secondaryButtonText);
         }}
         primaryButtonText={primaryButtonText}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- on the settings page for MR, the "share your electronic health record" card was not focusing on the alert after clicking the opt out/opt modal
- new behavior:  from the opt in/opt out modal:
  - clicking the "x" or "cancel" buttons will return focus to the opt in/opt out button
  - clicking "confirm" button will cause an alert and focus will be on the alert
- success/failure alert moved below the heading of the card

## Related issue(s)

### [MHV-64791](https://jira.devops.va.gov/browse/MHV-64791) - Launch Blocker: Focus Issue on share your electronic health record ###

> Windows/NVDA:
> 
> When the user interacts with the "Opt Out" button and changes their setting, NVDA announces a <p> tag containing the text: "We securely share your electronic health information with participating non-VA health care providers and federal partners when they’re treating you."
> 
> When the user interacts with the "Opt In" button and changes their setting, the focus remains on the button, but NVDA does not announce the alert.
> 
> Mac/VoiceOver:
> 
> After opting out, VoiceOver navigates to the "Skip to main content" link.
> 
> After opting in, VoiceOver first navigates to the "Skip to main content" link and then returns focus to the "Opt" button.
> 
> Solution for now:
> 
> Slim alert underneath card header
> Keep the focus on the slim alert (when opting in and out)
> 
>  https://dsva.slack.com/archives/C0669CU6LUB/p1733158855255659
> 
> This bug will be a blocker due to 4.1.2
> So, in summary...
> Folks are left disoriented or unaware of a critical update due to lack of proper focus management.
> Dynamic changes are not announced programmatically or focus is moved arbitrarily without context.
> 11:01
> Robert M Bailey
> Here are the detect list we are basing this one
> https://depo-platform-documentation.scrollhelp.site/developer-docs/accessibility-defect-severity-rubric
> 11:01
> Robert M Bailey
> It outlines
> a11y-defect-1
> ️ Critical. Must be fixed before launch.
> These issues have the potential to severely disrupt the user experience and must be fixed before the Platform will certify a staging accessibility review.
> User Story: As a Medical Records User, I want to  
> 
> Feature Flag Y/N ? N
> 
> DataDog/Analytics Y/N ? N
> 
> Manual Testing Y/N ? 
> 
> Automated Testing Y/N ? N
> 
> Accessibility Testing Y/N ? N
> 
> UCD Validation Y/N N
> 
> Links to UCD:
> 
> Figma Link: https://www.figma.com/design/SGP1z2LejUWqDZyT61po5J/Medical-Records---Phase-1?node-id=12850-53951&t=14zbzaaP0gLFnlUD-1

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| No Alert  |![Screenshot 2024-12-06 at 2 21 05 PM](https://github.com/user-attachments/assets/320d54ac-c9f8-4d8f-8fa3-621e253bb6f9)|![Screenshot 2024-12-06 at 10 34 24 AM](https://github.com/user-attachments/assets/521cb13e-4986-4c8a-acbc-eac7f05effa6)|
| Alert |![Screenshot 2024-12-06 at 2 21 18 PM](https://github.com/user-attachments/assets/166e6f5e-23f1-4127-ab62-3160d3e0394a)|![Screenshot 2024-12-06 at 10 28 07 AM](https://github.com/user-attachments/assets/2a95cd5f-7447-445a-832d-74d663c00f7e)|

## What areas of the site does it impact?

Va.gov - Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_