### PR TITLE
Conditions-608 | Address Axe DevTools errors on the 526 add conditions page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -179,6 +179,7 @@ const Autocomplete = ({
           data-testid="autocomplete-list"
           role="listbox"
           tabIndex={-1}
+          aria-label="List of matching conditions"
         >
           {results.map((result, index) => (
             <li

--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -332,7 +332,7 @@ export class ComboBox extends React.Component {
         onKeyDown={this.handleKeyPress}
         label="new-condition-option"
         role="option"
-        aria-selected={this.state.highlightedIndex === 0 ? 'true' : 'false'}
+        aria-selected={highlightedIndex === 0}
       >
         Enter your condition as "
         <span style={{ fontWeight: 'bold' }}>{option}</span>"
@@ -341,7 +341,13 @@ export class ComboBox extends React.Component {
   }
 
   render() {
-    const { searchTerm, ariaLive1, ariaLive2, filteredOptions } = this.state;
+    const {
+      searchTerm,
+      ariaLive1,
+      ariaLive2,
+      filteredOptions,
+      highlightedIndex,
+    } = this.state;
     const autocompleteHelperText =
       searchTerm?.length > 0
         ? null
@@ -350,6 +356,11 @@ export class ComboBox extends React.Component {
       review and enter to select. Touch device users, explore by touch or
       with swipe gestures.
     `;
+
+    const activedescendant =
+      highlightedIndex === -1 || filteredOptions.length === 0
+        ? null
+        : `option-${highlightedIndex}`;
 
     return (
       <div className="cc-combobox">
@@ -378,11 +389,7 @@ export class ComboBox extends React.Component {
           aria-hidden={filteredOptions.length === 0}
           aria-label="List of matching conditions"
           id="combobox-list"
-          aria-activedescendant={
-            filteredOptions.length > 0
-              ? `option-${this.state.highlightedIndex}`
-              : null
-          }
+          aria-activedescendant={activedescendant}
           tabIndex={-1}
         >
           {this.drawFreeTextOption(searchTerm)}
@@ -390,7 +397,7 @@ export class ComboBox extends React.Component {
             filteredOptions.map((option, index) => {
               const optionIndex = index + 1;
               let classNameStr = 'cc-combobox__option';
-              if (optionIndex === this.state.highlightedIndex) {
+              if (optionIndex === highlightedIndex) {
                 classNameStr += ' cc-combobox__option--active';
               }
               return (
@@ -408,11 +415,7 @@ export class ComboBox extends React.Component {
                   onKeyDown={this.handleKeyPress}
                   label={option}
                   role="option"
-                  aria-selected={
-                    optionIndex === this.state.highlightedIndex
-                      ? 'true'
-                      : 'false'
-                  }
+                  aria-selected={optionIndex === highlightedIndex}
                   id={`option-${optionIndex}`}
                 >
                   {option}

--- a/src/applications/user-testing/new-conditions/components/Autocomplete.jsx
+++ b/src/applications/user-testing/new-conditions/components/Autocomplete.jsx
@@ -180,6 +180,7 @@ const Autocomplete = ({
           data-testid="autocomplete-list"
           role="listbox"
           tabIndex={-1}
+          aria-label="List of matching conditions"
         >
           {results.map((result, index) => (
             <li


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
To get these errors you have to enter a letter into the new condition component and then run the Axe DevTools scan. You won't get an error there if the dropdown is closed, or if you have entered the dropdown list by pressing the DOWN arrow key or mousing over the list.

Combobox component - currently on prod / OR on staging/local dev in Flipper set `all_claims_add_disabilities_enhancement` flag to `false`
- There were some Axe DevTools errors on the Combobox component, both in a scan and in the console. It was saying that the `aria-activedescendant` value on the dropdown component (an unordered list) was incorrect. It was `aria-activedescendant="option--1"`. We call the input -1, and the items of the dropdown start at "option-0", "option-1", etc. Really the value should be null, because the input is not a part of the dropdown box.
- While I was in the file I cleaned up a little of the code for the Combobox.

Autocomplete component - found on staging/local dev in Flipper set `all_claims_add_disabilities_enhancement` flag to `true`
- When running a DevTools scan here I ran into two issues, one of a missing `aria-label`, and another for ensuring the scrollable region has keyboard access.
- I added the missing `aria-label` to the dropdown component, and checked on the scrollable region. The scrollable dropdown contents are keyboard operable, so I'm not going to address this issue. The automated suggestion was to add a `tabIndex=0` to the dropdown, but we don't want users to tab to get to the dropdown results. Instead they use the up and down arrows.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/608

## Testing done

- Fixed DevTools errors and checked that functionality still worked.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Combobox  |    <img width="979" alt="combobox_before" src="https://github.com/user-attachments/assets/f4a365ee-5bae-4987-a3d0-0880080f60e5" />  | <img width="1166" alt="combobox_after" src="https://github.com/user-attachments/assets/feddb982-a4da-4ec9-b220-6c1413c0febb" />|
| Autocomplete | <img width="1139" alt="autcomplete_before" src="https://github.com/user-attachments/assets/6451b59c-9559-4cbd-a113-c1f2a050db83" /> |  <img width="1171" alt="autocomplete_after" src="https://github.com/user-attachments/assets/2ffc7be6-e930-4f8e-8766-2d30689f03d2" />|

## What areas of the site does it impact?

The add new condition page of the 526ez form

staging.va.gov/disability/file-disability-claim-form-21-526ez/new-disabilities/add

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
