### PR TITLE
97281 add mhv_account_creation_api_consumption feature flipper

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -128,6 +128,7 @@
   "mhvAcceleratedDeliveryEnabled": "mhv_accelerated_delivery_enabled",
   "mhvAcceleratedDeliveryAllergiesEnabled": "mhv_accelerated_delivery_allergies_enabled",
   "mhvAcceleratedDeliveryVitalSignsEnabled": "mhv_accelerated_delivery_vital_signs_enabled",
+  "mhvAccountCreationApiConsumption": "mhv_account_creation_api_consumption",
   "mhvIntegrationMedicalRecordsToPhase1": "mhv_integration_medical_records_to_phase_1",
   "mhvInterstitialEnabled": "mhv_interstitial_enabled",
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
Adding the `mhv_account_creation_api_consumption` feature flipper. End date expected within the first quarter of 2025.

## Related issue(s)
[Related PR](https://github.com/department-of-veterans-affairs/vets-api/pull/19875)