### PR TITLE
[99002] Update select button text to use rep name

### DIFF
--- a/src/applications/representative-appoint/components/SearchResult.jsx
+++ b/src/applications/representative-appoint/components/SearchResult.jsx
@@ -145,7 +145,7 @@ const SearchResult = ({
           ) : (
             <VaButton
               data-testid={`rep-select-${id}`}
-              text="Select this representative"
+              text={`Select ${representativeName}`}
               secondary
               onClick={() => handleSelectRepresentative(representative.data)}
             />

--- a/src/applications/representative-appoint/components/SearchResult.jsx
+++ b/src/applications/representative-appoint/components/SearchResult.jsx
@@ -166,6 +166,8 @@ SearchResult.propTypes = {
   city: PropTypes.string,
   distance: PropTypes.string,
   email: PropTypes.string,
+  handleSelectRepresentative: PropTypes.func,
+  loadingPOA: PropTypes.bool,
   location: PropTypes.object,
   phone: PropTypes.string,
   query: PropTypes.shape({

--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -64,7 +64,7 @@ const SelectAccreditedRepresentative = props => {
     }
   };
 
-  const handleGoForward = ({ selectionMade = false }) => {
+  const handleGoForward = ({ selectionMade = false, newSelection = null }) => {
     const selection = formData['view:selectedRepresentative'];
     const noSelectionExists = !selection && !selectionMade;
 
@@ -75,7 +75,7 @@ const SelectAccreditedRepresentative = props => {
       setError(noSearchError);
       scrollToFirstError({ focusOnAlertRole: true });
     } else if (isReviewPage) {
-      if (selection === currentSelectedRep.current) {
+      if (!newSelection || newSelection === currentSelectedRep.current) {
         goToPath('/review-and-submit');
       } else {
         goToPath('/representative-contact?review=true');
@@ -133,9 +133,14 @@ const SelectAccreditedRepresentative = props => {
       // similar to the tempData trick above with async state variables,
       //  we need to trick our routing logic to know that a selection has
       //  been made before that selection is reflected in formData.
-      //  Otherwise, one would have to double click the select
+      //
+      // selectionMade: prevents users from needing to double click the select
       //  representative button to register that a selection was made.
-      handleGoForward({ selectionMade: true });
+      //
+      // newSelection: prevents issue with routing from the review page
+      //   where selecting a new representative is treated as the original
+      //   representative due to formData not updating synchronously.
+      handleGoForward({ selectionMade: true, newSelection: selectedRepResult });
     }
   };
 

--- a/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
@@ -54,4 +54,34 @@ describe('SearchResult Component', () => {
     expect(addressAnchor).to.exist;
     expect(addressAnchor.textContent).to.contain('Anytown, CT');
   });
+
+  it('includes the representative name in the select button text', () => {
+    const representative = {
+      data: {
+        id: 1,
+        attributes: {
+          addressLine1: '123 Main St',
+          city: '',
+          stateCode: '',
+          zipCode: '',
+          fullName: 'Robert Smith',
+        },
+      },
+    };
+
+    const { container } = render(
+      <SearchResult
+        representative={representative}
+        query={{}}
+        handleSelectRepresentative={() => {}}
+        loadingPOA={false}
+      />,
+    );
+
+    const selectButton = container.querySelector(
+      '[data-testid="rep-select-1"]',
+    );
+    expect(selectButton).to.exist;
+    expect(selectButton.getAttribute('text')).to.contain('Robert Smith');
+  });
 });

--- a/src/applications/representative-appoint/tests/e2e/navigation/2122.cypress.spec.js
+++ b/src/applications/representative-appoint/tests/e2e/navigation/2122.cypress.spec.js
@@ -40,7 +40,7 @@ describe('Authenticated', () => {
 
       cy.contains('Billy Ryan').should('be.visible');
 
-      cy.contains('button', 'Select this representative')
+      cy.contains('button', 'Select Billy Ryan')
         .first()
         .click();
 

--- a/src/applications/representative-appoint/tests/e2e/navigation/2122a.cypress.spec.js
+++ b/src/applications/representative-appoint/tests/e2e/navigation/2122a.cypress.spec.js
@@ -41,7 +41,7 @@ describe('Unauthenticated', () => {
 
       cy.contains('John Adams').should('be.visible');
 
-      cy.contains('button', 'Select this representative')
+      cy.contains('button', 'Select John Adams')
         .first()
         .click();
 

--- a/src/applications/representative-appoint/tests/pages/representative/selectAccreditedRepresentative.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/pages/representative/selectAccreditedRepresentative.unit.spec.jsx
@@ -9,13 +9,20 @@ import {
   cleanup,
 } from '@testing-library/react';
 import sinon from 'sinon';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import { SelectAccreditedRepresentative } from '../../../components/SelectAccreditedRepresentative';
 import * as api from '../../../api/fetchRepStatus';
+import * as searchAPI from '../../../api/fetchRepresentatives';
 import repResults from '../../fixtures/data/representative-results.json';
 import * as reviewPageHook from '../../../hooks/useReviewPage';
 
 describe('<SelectAccreditedRepresentative>', () => {
-  const getProps = ({ submitted = false } = {}) => {
+  const getProps = ({
+    currentRep = undefined,
+    query = undefined,
+    results = repResults,
+    submitted = false,
+  } = {}) => {
     return {
       props: {
         formContext: {
@@ -23,7 +30,11 @@ describe('<SelectAccreditedRepresentative>', () => {
         },
 
         loggedIn: true,
-        formData: { 'view:representativeSearchResults': repResults },
+        formData: {
+          'view:representativeQuery': query,
+          'view:representativeSearchResults': results,
+          'view:selectedRepresentative': currentRep,
+        },
         setFormData: sinon.spy(),
         goToPath: sinon.spy(),
         goBack: sinon.spy(),
@@ -32,7 +43,11 @@ describe('<SelectAccreditedRepresentative>', () => {
       mockStore: {
         getState: () => ({
           form: {
-            data: { 'view:representativeSearchResults': repResults },
+            data: {
+              'view:representativeQuery': query,
+              'view:representativeSearchResults': results,
+              'view:selectedRepresentative': currentRep,
+            },
           },
         }),
         subscribe: () => {},
@@ -61,155 +76,344 @@ describe('<SelectAccreditedRepresentative>', () => {
     expect(container).to.exist;
   });
 
-  it('calls getRepStatus and update state accordingly on search', async () => {
-    const { props, mockStore } = getProps();
+  context('when searching', () => {
+    context('when the search input is invalid', () => {
+      it('displays the no search error', async () => {
+        const { mockStore, props } = getProps();
 
-    const fetchRepStatusStub = sinon.stub(api, 'fetchRepStatus').resolves({
-      data: { status: 'active' },
-    });
+        const container = renderContainer(props, mockStore);
 
-    const container = renderContainer(props, mockStore);
+        const searchButton = container.querySelector('va-button');
 
-    const selectRepButton = getByTestId(container, 'rep-select-19731');
+        fireEvent.click(searchButton);
 
-    expect(selectRepButton).to.exist;
+        const searchBox = $('va-text-input', container);
 
-    fireEvent.click(selectRepButton);
-
-    await waitFor(() => {
-      expect(fetchRepStatusStub.calledOnce).to.be.true;
-      expect(props.setFormData.called).to.be.true;
-      expect(props.goToPath.called).to.be.false;
-      expect(props.setFormData.args[0][0]).to.include({
-        'view:selectedRepresentative': repResults[0].data,
+        await waitFor(() => {
+          expect(searchBox).to.have.attr(
+            'error',
+            'Enter the name of the accredited representative or VSO you’d like to appoint',
+          );
+        });
       });
     });
 
-    fetchRepStatusStub.restore();
+    context('when the search input is valid', () => {
+      it('sets the results in state', async () => {
+        const { props, mockStore } = getProps({
+          query: 'Bob',
+          results: undefined,
+        });
+
+        const fetchRepStub = sinon
+          .stub(searchAPI, 'fetchRepresentatives')
+          .resolves(repResults);
+
+        const container = renderContainer(props, mockStore);
+
+        const searchButton = container.querySelector('va-button');
+
+        fireEvent.click(searchButton);
+
+        await waitFor(() => {
+          expect(fetchRepStub.calledOnce).to.be.true;
+          expect(props.setFormData.called).to.be.true;
+          expect(props.setFormData.args[0][0]).to.include({
+            'view:representativeSearchResults': repResults,
+          });
+        });
+
+        fetchRepStub.restore();
+      });
+    });
   });
 
-  it('calls getRepStatus and update state accordingly is review mode', async () => {
-    const { props, mockStore } = getProps();
+  context('when navigating', () => {
+    context('when not in review mode', () => {
+      context('when clicking the back button', () => {
+        it('calls goBack', async () => {
+          const { mockStore, props } = getProps();
 
-    const fetchRepStatusStub = sinon.stub(api, 'fetchRepStatus').resolves({
-      data: { status: 'active' },
-    });
+          const useReviewPageStub = sinon
+            .stub(reviewPageHook, 'useReviewPage')
+            .returns(false);
 
-    const useReviewPageStub = sinon
-      .stub(reviewPageHook, 'useReviewPage')
-      .returns(true);
+          const container = renderContainer(props, mockStore);
 
-    const container = renderContainer(props, mockStore);
+          const backButton = container.querySelector('.usa-button-secondary');
 
-    const selectRepButton = getByTestId(container, 'rep-select-19731');
+          fireEvent.click(backButton);
 
-    expect(selectRepButton).to.exist;
+          await waitFor(() => {
+            expect(props.goBack.called).to.be.true;
+          });
 
-    fireEvent.click(selectRepButton);
+          useReviewPageStub.restore();
+        });
+      });
 
-    await waitFor(() => {
-      expect(fetchRepStatusStub.calledOnce).to.be.true;
-      expect(props.setFormData.called).to.be.true;
-      expect(props.goToPath.called).to.be.true;
-      expect(props.setFormData.args[0][0]).to.include({
-        'view:selectedRepresentative': repResults[0].data,
+      context('when clicking the select a rep button', () => {
+        it('calls getRepStatus and updates state accordingly', async () => {
+          const { props, mockStore } = getProps();
+
+          const fetchRepStatusStub = sinon
+            .stub(api, 'fetchRepStatus')
+            .resolves({
+              data: { status: 'active' },
+            });
+
+          const container = renderContainer(props, mockStore);
+
+          const selectRepButton = getByTestId(container, 'rep-select-19731');
+
+          expect(selectRepButton).to.exist;
+
+          fireEvent.click(selectRepButton);
+
+          await waitFor(() => {
+            expect(fetchRepStatusStub.calledOnce).to.be.true;
+            expect(props.setFormData.called).to.be.true;
+            expect(props.goToPath.called).to.be.false;
+            expect(props.setFormData.args[0][0]).to.include({
+              'view:selectedRepresentative': repResults[0].data,
+            });
+          });
+
+          fetchRepStatusStub.restore();
+        });
       });
     });
 
-    useReviewPageStub.restore();
-  });
+    context('when in review mode', () => {
+      context('when clicking the back button', () => {
+        it('calls goToPath', async () => {
+          const { mockStore, props } = getProps();
 
-  // it('displays query error when query is invalid', async () => {
-  //   const { mockStore, props } = getProps();
+          const useReviewPageStub = sinon
+            .stub(reviewPageHook, 'useReviewPage')
+            .returns(true);
 
-  //   const container = renderContainer(props, mockStore);
+          const container = renderContainer(props, mockStore);
 
-  //   const forwardButton = container.querySelectorAll(
-  //     'button[id*="continueButton"]',
-  //   )[1];
+          const backButton = container.querySelector('.usa-button-secondary');
 
-  //   fireEvent.click(forwardButton);
+          fireEvent.click(backButton);
 
-  //   await waitFor(() => {
-  //     expect(container.textContent).to.contain('Enter the name');
-  //   });
-  // });
+          await waitFor(() => {
+            expect(props.goToPath.called).to.be.true;
+          });
 
-  it('displays selection error when query is valid but rep is null', async () => {
-    const { mockStore } = getProps();
+          useReviewPageStub.restore();
+        });
+      });
 
-    const props = {
-      formData: {
-        'view:representativeQuery': 'Valid Query',
-        'view:selectedRepresentative': null,
-      },
-    };
+      context('when clicking the select a rep button', () => {
+        context('when selecting a new representative', () => {
+          it('sets the new selection in state', async () => {
+            const { props, mockStore } = getProps({
+              currentRep: repResults[1].data,
+            });
 
-    const container = renderContainer(props, mockStore);
+            const fetchRepStatusStub = sinon
+              .stub(api, 'fetchRepStatus')
+              .resolves({
+                data: { status: 'active' },
+              });
 
-    const forwardButton = container.querySelectorAll(
-      'button[id*="continueButton"]',
-    )[1];
-    fireEvent.click(forwardButton);
+            const useReviewPageStub = sinon
+              .stub(reviewPageHook, 'useReviewPage')
+              .returns(true);
 
-    await waitFor(() => {
-      expect(container.textContent).to.contain('Select the accredited');
+            const container = renderContainer(props, mockStore);
+
+            const selectRepButton = getByTestId(container, 'rep-select-19731');
+
+            fireEvent.click(selectRepButton);
+
+            await waitFor(() => {
+              expect(props.setFormData.args[0][0]).to.include({
+                'view:selectedRepresentative': repResults[0].data,
+              });
+            });
+
+            fetchRepStatusStub.restore();
+            useReviewPageStub.restore();
+          });
+
+          it('routes to the contact representative page', async () => {
+            const { props, mockStore } = getProps({
+              currentRep: repResults[1].data,
+            });
+
+            const fetchRepStatusStub = sinon
+              .stub(api, 'fetchRepStatus')
+              .resolves({
+                data: { status: 'active' },
+              });
+
+            const useReviewPageStub = sinon
+              .stub(reviewPageHook, 'useReviewPage')
+              .returns(true);
+
+            const container = renderContainer(props, mockStore);
+
+            const selectRepButton = getByTestId(container, 'rep-select-19731');
+
+            fireEvent.click(selectRepButton);
+
+            await waitFor(() => {
+              expect(
+                props.goToPath.calledWith(
+                  '/representative-contact?review=true',
+                ),
+              ).to.be.true;
+            });
+
+            fetchRepStatusStub.restore();
+            useReviewPageStub.restore();
+          });
+        });
+
+        context('when selecting the same representative', () => {
+          it('does not attempt to update state', async () => {
+            const { props, mockStore } = getProps({
+              currentRep: repResults[0].data,
+            });
+
+            const fetchRepStatusStub = sinon
+              .stub(api, 'fetchRepStatus')
+              .resolves({
+                data: { status: 'active' },
+              });
+
+            const useReviewPageStub = sinon
+              .stub(reviewPageHook, 'useReviewPage')
+              .returns(true);
+
+            const container = renderContainer(props, mockStore);
+
+            const selectRepButton = getByTestId(container, 'rep-select-19731');
+
+            fireEvent.click(selectRepButton);
+
+            await waitFor(() => {
+              expect(props.setFormData.called).to.be.false;
+            });
+
+            fetchRepStatusStub.restore();
+            useReviewPageStub.restore();
+          });
+
+          it('routes to the review page', async () => {
+            const { props, mockStore } = getProps({
+              currentRep: repResults[0].data,
+            });
+
+            const fetchRepStatusStub = sinon
+              .stub(api, 'fetchRepStatus')
+              .resolves({
+                data: { status: 'active' },
+              });
+
+            const useReviewPageStub = sinon
+              .stub(reviewPageHook, 'useReviewPage')
+              .returns(true);
+
+            const container = renderContainer(props, mockStore);
+
+            const selectRepButton = getByTestId(container, 'rep-select-19731');
+
+            fireEvent.click(selectRepButton);
+
+            await waitFor(() => {
+              expect(props.goToPath.calledWith('/review-and-submit')).to.be
+                .true;
+            });
+
+            fetchRepStatusStub.restore();
+            useReviewPageStub.restore();
+          });
+        });
+      });
+
+      context('when clicking the continue button', () => {
+        it('routes to the review page', async () => {
+          const { props, mockStore } = getProps({
+            currentRep: repResults[0].data,
+          });
+
+          const useReviewPageStub = sinon
+            .stub(reviewPageHook, 'useReviewPage')
+            .returns(true);
+
+          const container = renderContainer(props, mockStore);
+
+          const forwardButton = container.querySelector('.usa-button-primary');
+
+          fireEvent.click(forwardButton);
+
+          await waitFor(() => {
+            expect(props.goToPath.calledWith('/review-and-submit')).to.be.true;
+          });
+
+          useReviewPageStub.restore();
+        });
+      });
+    });
+
+    context('error states', () => {
+      context('when the search input is invalid', () => {
+        it('displays the no search error', async () => {
+          const { mockStore, props } = getProps();
+
+          const container = renderContainer(props, mockStore);
+
+          const forwardButton = container.querySelector('.usa-button-primary');
+
+          fireEvent.click(forwardButton);
+
+          const searchBox = $('va-text-input', container);
+
+          await waitFor(() => {
+            expect(searchBox).to.have.attr(
+              'error',
+              'Enter the name of the accredited representative or VSO you’d like to appoint',
+            );
+          });
+        });
+      });
+
+      context('when the search input is valid', () => {
+        context('when there is no selected representative', () => {
+          it('displays the no selection error', async () => {
+            const { mockStore } = getProps();
+
+            const props = {
+              formData: {
+                'view:representativeQuery': 'Valid Query',
+                'view:selectedRepresentative': null,
+              },
+            };
+
+            const container = renderContainer(props, mockStore);
+
+            const forwardButton = container.querySelector(
+              '.usa-button-primary',
+            );
+
+            fireEvent.click(forwardButton);
+
+            const searchBox = $('va-text-input', container);
+
+            await waitFor(() => {
+              expect(searchBox).to.have.attr(
+                'error',
+                'Select the accredited representative or VSO you’d like to appoint below.',
+              );
+            });
+          });
+        });
+      });
     });
   });
-
-  it('goes back when not in review mode', async () => {
-    const { mockStore, props } = getProps();
-
-    const useReviewPageStub = sinon
-      .stub(reviewPageHook, 'useReviewPage')
-      .returns(false);
-
-    const container = renderContainer(props, mockStore);
-
-    const backButton = container.querySelectorAll(
-      'button[id*="continueButton"]',
-    )[0];
-    fireEvent.click(backButton);
-
-    await waitFor(() => {
-      expect(props.goBack.called).to.be.true;
-    });
-
-    useReviewPageStub.restore();
-  });
-
-  it('goes to path when in review mode', async () => {
-    const { mockStore, props } = getProps();
-
-    const useReviewPageStub = sinon
-      .stub(reviewPageHook, 'useReviewPage')
-      .returns(true);
-
-    const container = renderContainer(props, mockStore);
-
-    const backButton = container.querySelectorAll(
-      'button[id*="continueButton"]',
-    )[0];
-    fireEvent.click(backButton);
-
-    await waitFor(() => {
-      expect(props.goToPath.called).to.be.true;
-    });
-
-    useReviewPageStub.restore();
-  });
-
-  // it('displays error on search when no query exists', async () => {
-  //   const { mockStore, props } = getProps();
-
-  //   const container = renderContainer(props, mockStore);
-
-  //   const vaButton = container.querySelector('va-button[text="Search"]');
-
-  //   fireEvent.click(vaButton);
-
-  //   await waitFor(() => {
-  //     expect(container.textContent).to.contain('Enter the name');
-  //   });
-  // });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds the representative name to the select a rep button
- This pr fixes a review page routing issue for rep select

## Related issue(s)

- [99002](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99002)

## Testing done

- Went through flow locally with various rep types when authed and unauthed.

## Screenshots

### Before
https://github.com/user-attachments/assets/67254cc5-f443-4bc6-83d6-12aeb4eebfb8

#### Desktop
![image](https://github.com/user-attachments/assets/9dd86f74-9b7c-444a-bb23-28530470deda)

#### Mobile
![image](https://github.com/user-attachments/assets/84030d60-9dbe-46ce-afc9-27d663795e46)



### After
https://github.com/user-attachments/assets/ee69f2ce-d0a4-4e9f-a178-2b78908d683c

#### Desktop
![image](https://github.com/user-attachments/assets/03c66a3d-5532-4539-9f5a-45576d84f7b1)

#### Mobile
![image](https://github.com/user-attachments/assets/a3f7276e-7159-4798-b6c4-fe8c9e047413)

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user