### PR TITLE
Update aria-label and unit tests in discover-your-benefits

### DIFF
--- a/src/applications/discover-your-benefits/components/BenefitCard.jsx
+++ b/src/applications/discover-your-benefits/components/BenefitCard.jsx
@@ -18,7 +18,7 @@ const BenefitCard = ({ benefit }) => {
           href={url}
           rel="noreferrer"
           className="link--center"
-          aria-label={label}
+          aria-label={`${label} (opens in a new tab)`}
           target="_blank"
         >
           {text} (opens in a new tab)

--- a/src/applications/discover-your-benefits/tests/unit/mocks/mockFormData.js
+++ b/src/applications/discover-your-benefits/tests/unit/mocks/mockFormData.js
@@ -7,7 +7,8 @@ export const mockFormData = {
   characterOfDischarge: 'honorable',
   characterOfDischargeTWO: {},
   separation: 'OVER_3YRS',
-  militaryServiceCurrentlyServing: 'No',
+  militaryServiceCurrentlyServing: false,
+  militaryServiceCompleted: false,
   militaryServiceTotalTimeServed: 'More than 3 years',
   goals: {
     understandMyBenefits: true,
@@ -18,7 +19,7 @@ export const mockFormData = {
 export const getData = ({
   loggedIn = true,
   isVerified = true,
-  data = {},
+  data = mockFormData,
   contestableIssues = {},
 } = {}) => ({
   props: {

--- a/src/applications/discover-your-benefits/tests/unit/pages/separation.unit.spec.js
+++ b/src/applications/discover-your-benefits/tests/unit/pages/separation.unit.spec.js
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { getData } from '../mocks/mockFormData';
+import { getData, mockFormData } from '../mocks/mockFormData';
 import separationConfig from '../../../pages/separation';
 
 describe('separation page', () => {
@@ -22,5 +22,14 @@ describe('separation page', () => {
       </Provider>,
     );
     expect($('va-radio', container)).to.exist;
+  });
+
+  it('should updateUiSchema', () => {
+    const data = { ...mockFormData, militaryServiceCurrentlyServing: true };
+    const result = separationConfig.uiSchema.separation[
+      'ui:options'
+    ].updateUiSchema(data);
+
+    expect(result['ui:options'].hideOnReview).to.be.true;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update aria-label and unit tests in discover-your-benefits as requested for accessibility.

## Related issue(s)

[https://jira.devops.va.gov/browse/PTEMSVT-366](https://jira.devops.va.gov/browse/PTEMSVT-366)

## Testing done

Local testing and unit tests.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

[https://staging.va.gov/discover-your-benefits/](https://staging.va.gov/discover-your-benefits/)

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
