### PR TITLE
Fix additional info icon (legacy formation component)

### DIFF
--- a/src/platform/site-wide/legacy-component-js/additional-info.js
+++ b/src/platform/site-wide/legacy-component-js/additional-info.js
@@ -29,24 +29,23 @@ export default function createAdditionalInfoWidget() {
         (titleNode && titleNode.textContent) || 'More information';
       const contentMarkup = qS(el, '.additional-info-content').innerHTML;
       const additionalInfoId = `additional-info-${index}`;
-
       const template = `
-          <button type="button" class="additional-info-button va-button-link" aria-controls="${additionalInfoId}" aria-expanded="false">
-            <span class="additional-info-title">${titleText}
-              <i class="fa fa-angle-down"></i>
-            </span>
-          </button>
-          <span id="${additionalInfoId}">
-            <div class="additional-info-content">
-              ${contentMarkup}
-            </div>
-          </span>`;
+        <button type="button" class="additional-info-button va-button-link" aria-controls="${additionalInfoId}" aria-expanded="false">
+          <span class="additional-info-title">${titleText}
+            <va-icon class="additional-arrow" icon="chevron_right" />
+          </span>
+        </button>
+        <span id="${additionalInfoId}">
+          <div class="additional-info-content">
+            ${contentMarkup}
+          </div>
+        </span>`;
 
       removeChildNodes(el);
 
       el.insertAdjacentHTML('afterbegin', template);
 
-      const chevron = qS(el, 'i.fa-angle-down');
+      const chevron = qS(el, 'va-icon.additional-arrow');
       const button = qS(el, 'button');
 
       const additionalInfoExpandEvent = document.createEvent('Event');
@@ -54,6 +53,24 @@ export default function createAdditionalInfoWidget() {
 
       const additionalInfoCollapseEvent = document.createEvent('Event');
       additionalInfoCollapseEvent.initEvent(EVENT_NAMES.COLLAPSE, true, true);
+
+      const iconShadowRoot = chevron.shadowRoot;
+
+      // Use MutationObserver to watch for changes in the shadow DOM
+      const observer = new MutationObserver(() => {
+        const svgInside = iconShadowRoot?.querySelector('.usa-icon');
+
+        if (svgInside) {
+          svgInside.style =
+            'transform: rotate(90deg); fill: #07648d; height: 1.5rem; width: 1.5rem; transition: transform 0.15s linear, -webkit-transform 0.15s linear;';
+
+          observer.disconnect();
+        }
+      });
+
+      if (iconShadowRoot) {
+        observer.observe(iconShadowRoot, { childList: true, subtree: true });
+      }
 
       button.addEventListener('click', () => {
         const ariaExpanded = JSON.parse(button.getAttribute('aria-expanded'));
@@ -64,7 +81,16 @@ export default function createAdditionalInfoWidget() {
           'form-expanding-group-open',
           isExpanded,
         );
+
         chevron.classList.toggle('open', isExpanded);
+
+        const svgInside = iconShadowRoot?.querySelector('.usa-icon');
+
+        if (Array.from(chevron.classList).includes('open')) {
+          svgInside.style.transform = 'rotate(270deg)';
+        } else {
+          svgInside.style.transform = 'rotate(90deg)';
+        }
 
         el.dispatchEvent(
           isExpanded ? additionalInfoExpandEvent : additionalInfoCollapseEvent,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
A defect was reported where the icon for the additional info component on `/manage-va-debt` was missing. This was caused by the recent [formation work](https://github.com/department-of-veterans-affairs/vets-website/pull/32154) done by DST. There was a component created in [legacy-component-js/additional-info.js](https://github.com/department-of-veterans-affairs/vets-website/blob/f2e094ef33aaf00d74fdd685e0fdc4bdc5d4e530/src/platform/site-wide/legacy-component-js/additional-info.js#L36) that replaced the old Formation implementation, and this component used Font Awesome, which is not supported anymore.

This caused the expand/collapse arrow on the additional info component (where Formation was previously being used) to disappear. I swapped it out with a `va-icon` instead and this will be the interim solution until we can completely convert the usage to the web component.

Related Slack thread: https://dsva.slack.com/archives/C52CL1PKQ/p1734052211597919

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20095

## Testing done

Tested at `/manage-va-debt`.

## Screenshots

| Before | After |
| ------ | ----- |
|    <img width="410" alt="Screenshot 2024-12-13 at 1 04 56 PM" src="https://github.com/user-attachments/assets/bcbc2dc0-9b17-4d3b-ad3c-d950ac11fff1" />    |   <img width="433" alt="Screenshot 2024-12-13 at 1 05 11 PM" src="https://github.com/user-attachments/assets/89256870-9845-4208-9d68-3b0a87d59802" />    |
 |    <img width="746" alt="Screenshot 2024-12-13 at 1 05 00 PM" src="https://github.com/user-attachments/assets/79e7d0b1-c5b0-4c49-bc1e-25f60fa7c184" />    |   <img width="745" alt="Screenshot 2024-12-13 at 1 05 15 PM" src="https://github.com/user-attachments/assets/0059eb84-853c-46f7-8392-8466a4ad527f" />   |