### PR TITLE
VEBT-879 FE - CT - Remove late payment & learn more section

### DIFF
--- a/src/applications/gi/containers/CalculateYourBenefits.jsx
+++ b/src/applications/gi/containers/CalculateYourBenefits.jsx
@@ -14,7 +14,6 @@ import { getCalculatedBenefits } from '../selectors/calculator';
 import CalculateYourBenefitsForm from '../components/profile/CalculateYourBenefitsForm';
 import EstimatedBenefits from '../components/profile/EstimatedBenefits';
 import EstimateYourBenefitsSummarySheet from '../components/profile/EstimateYourBenefitsSummarySheet';
-import LearnMoreLabel from '../components/LearnMoreLabel';
 
 export function CalculateYourBenefits({
   calculated,
@@ -184,23 +183,6 @@ export function CalculateYourBenefits({
                 )
               </span>
             )}
-          </div>
-
-          <div className="vads-u-padding-bottom--1 small-screen-font">
-            <LearnMoreLabel
-              text="Protection against late VA payments"
-              onClick={() => {
-                dispatchShowModal('section103');
-              }}
-              buttonClassName="small-screen-font"
-              bold
-              buttonId="protection-against-late-payments-learn-more"
-            />
-            <strong>:</strong>
-            &nbsp;
-            {profile.attributes.section103Message
-              ? profile.attributes.section103Message
-              : 'No'}
           </div>
         </>
       )}

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import recordEvent from 'platform/monitoring/record-event';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import * as actions from '../actions';
 import AccreditationModalContent from '../components/content/modals/AccreditationModalContent';
@@ -354,59 +353,6 @@ export function Modals({ hideModal, modals, profile }) {
         large
       >
         <IndependentStudyModalContent />
-      </VaModal>
-
-      <VaModal
-        onCloseEvent={hideModal}
-        visible={shouldDisplayModal('section103')}
-        modalTitle="Protection against late VA payments"
-        large
-      >
-        <p>
-          If VA is late making a tuition payment to a GI Bill school, the school
-          can’t prevent a GI Bill student from attending classes or accessing
-          school facilities.
-        </p>
-        <p>
-          Schools may require students to provide proof of their GI Bill
-          eligibility in the form of:
-        </p>
-        <ul>
-          <li>
-            Certificate of Eligibility (COE) <strong>or</strong>
-          </li>
-          <li>
-            Certificate of Eligibility (COE) and additional criteria like an
-            award letter or other documents the school specifies
-          </li>
-        </ul>
-        <p>
-          <strong>
-            In addition, schools can’t charge late fees or otherwise penalize GI
-            Bill students if VA is late making a tuition and/or fees payment.
-          </strong>{' '}
-          This restriction on penalties doesn’t apply if the student owes
-          additional fees to the school beyond the tuition and fees that VA
-          pays. Students are protected from these penalties for up to 90 days
-          from the beginning of the term.
-        </p>
-        <p>
-          Contact the School Certifying Official (SCO) to learn more about the
-          school’s policy.{' '}
-          <a
-            href="https://benefits.va.gov/gibill/fgib/transition_act.asp"
-            onClick={() => {
-              recordEvent({
-                event: 'gibct-modal-link-click',
-              });
-            }}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our policy on protecting students from late VA payments
-          </a>
-          .
-        </p>
       </VaModal>
     </>
   );

--- a/src/applications/gi/tests/containers/Modals.unit.spec.jsx
+++ b/src/applications/gi/tests/containers/Modals.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import createCommonStore from 'platform/startup/store';
 import { mockModalProfileData } from '../helpers';
 
@@ -494,34 +494,6 @@ describe('<Modals>', () => {
       expect(wrapper.html()).to.contain(
         'Beneficiaries may use educational assistance to access online learning',
       );
-      wrapper.unmount();
-    });
-  });
-
-  describe('Section 103 modal', () => {
-    const props = {
-      ...defaultProps,
-      modals: {
-        displaying: 'section103',
-      },
-    };
-
-    it('should render', () => {
-      const wrapper = shallow(<Modals {...props} />);
-      expect(wrapper.html()).to.contain('Protection against late VA payments');
-      wrapper.unmount();
-    });
-
-    it('should track link click', () => {
-      const wrapper = mount(<Modals {...props} />);
-      const anchorText =
-        'Read our policy on protecting students from late VA payments';
-      const [anchor] = Array.from(wrapper.find('a')).filter(a =>
-        a.props.children.toString().startsWith(anchorText),
-      );
-      anchor.props.onClick();
-      const recordedEvent = global.window.dataLayer[0];
-      expect(recordedEvent.event).to.eq('gibct-modal-link-click');
       wrapper.unmount();
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- FE - CT - Remove late payment & learn more section
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Jira
As a...

VEBT Developer

I want…

To remove the late payment section in the CT tool

So that…

It no longer appears in the CT school details page

Acceptance Criteria

Remove the following from the CT school details page for all institutions.
Protection against late VA payments (Learn more): Yes
Remove the text in the hyperlink (Learn more). – Note –> This might be removed with the main line item by default. 

Technical Details:

Dependencies: 

Feature Flag needed: No

Demo needed: No

UAT needed: No

Additional Notes:  No

Testing Details:

( X ) Quick Turn Around/Direct to Production

(  ) Remains in Staging

(  ) Staging Environment unavailable, coordinate w/ developer

Requested by and when:

Cinda/Brian, 11/26

Definition of Done: 

(  )  Demo/UAT completed with EDU

(  )  Passed all internal testing in Staging

(  )  Passed all internal testing in Production

(  )  All work documented in Jira ticket

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

![Screenshot 2024-12-13 at 2 41 53 PM](https://github.com/user-attachments/assets/effa5e3d-914c-468a-aa8f-7308e8f20b8a)


_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
