### PR TITLE
MHV-65160 Handle missing EDIPI

### DIFF
--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -2,6 +2,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { formatISO } from 'date-fns';
 import { findMatchingPhrAndCvixStudies } from '../util/radiologyUtil';
+import edipiNotFound from '../util/edipiNotFound';
 
 const apiBasePath = `${environment.API_URL}/my_health/v1`;
 
@@ -242,18 +243,25 @@ export const getDemographicInfo = async () => {
   });
 };
 
-// military service
 /**
  * Get a patient's military service info
  * @returns patient's military service info
  */
 export const getMilitaryService = async () => {
-  return apiRequest(`${apiBasePath}/medical_records/military_service`, {
-    textHeaders,
-  });
+  try {
+    return await apiRequest(`${apiBasePath}/medical_records/military_service`, {
+      textHeaders,
+    });
+  } catch (error) {
+    // Handle special case of missing EDIPI
+    if (error?.error === 'No EDIPI found for the current user') {
+      return edipiNotFound;
+    }
+    // Rethrow if it’s another error we don’t want to specially handle
+    throw error;
+  }
 };
 
-// account summary (treatment facilities)
 /**
  * Get a patient's account summary (treatment facilities)
  * @returns patient profile including a list of patient's treatment facilities

--- a/src/applications/mhv-medical-records/util/edipiNotFound.js
+++ b/src/applications/mhv-medical-records/util/edipiNotFound.js
@@ -1,0 +1,14 @@
+export default `NOTES:
+1) This report may not show your complete DoD Military Service Information.
+   Data prior to establishment of DEERS and full service reporting (c. 1980) 
+   may not appear.
+2) It is normal for the begin/end dates in DoD records, adjusted by the
+   Personnel Center after separation, to vary slightly from the DD-214.
+3) No peacetime deployments will be displayed.  For Gulf War I, only one
+   period will be displayed even if you deployed more than once.  No conflict
+   prior to Gulf War I will be displayed.  Kosovo, Bosnia, and Southern Watch
+   data is incomplete and may not display.
+4) For Guard/Reserve, periods of active duty may not display.  No periods of
+   Active duty service less than 30 days will display.
+   
+   ** No data was found. **`;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- A user might be missing an EDIPI. If this is the case, print the standard "not found" verbiage to the PDF

## Related issue(s)

### [MHV-65160](https://jira.devops.va.gov/browse/MHV-65160) - Resolve appointments/Military service call issues ###

## Testing done

- User without an EDIPI would get an error that military service could not be added to PDF.
- To verify, see that the BB PDF can now include military service even if the user has no EDIPI (call returns 400)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
