### PR TITLE
provider and date reset

### DIFF
--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -410,9 +410,3 @@ export function selectFacilitiesRadioWidget(state) {
 export function selectAppointmentSlotsStatus(state) {
   return getNewAppointment(state).appointmentSlotsStatus;
 }
-
-export function getSelectedDate(state) {
-  return getFormData(state).selectedDates?.length
-    ? getFormData(state).selectedDates[0]
-    : '';
-}

--- a/src/applications/vaos/referral-appointments/ConfirmApprovedPage.jsx
+++ b/src/applications/vaos/referral-appointments/ConfirmApprovedPage.jsx
@@ -31,17 +31,15 @@ export default function ConfirmApprovedPage() {
   const dispatch = useDispatch();
 
   const [confirmedData, setConfirmedData] = useState(0);
-
   // on react component mount, fetch data
   useEffect(() => {
     setConfirmedData(getData());
   }, []);
-
   useEffect(
     () => {
       dispatch(setFormCurrentPage('confirmAppointment'));
     },
-    [location, dispatch],
+    [dispatch],
   );
 
   return (

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
@@ -11,12 +11,14 @@ export default function ScheduleReferral(props) {
   const { currentReferral } = props;
   const location = useLocation();
   const dispatch = useDispatch();
+  const selectedSlotKey = `selected-slot-referral-${currentReferral.UUID}`;
   useEffect(
     () => {
       dispatch(setFormCurrentPage('scheduleReferral'));
       dispatch(setInitReferralFlow());
+      sessionStorage.removeItem(selectedSlotKey);
     },
-    [location, dispatch],
+    [location, dispatch, selectedSlotKey],
   );
   const appointmentCountString =
     currentReferral.numberOfAppointments === 1

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 import { format } from 'date-fns';
 import ReferralLayout from './components/ReferralLayout';
 import ReferralAppLink from './components/ReferralAppLink';
-import { setFormCurrentPage } from './redux/actions';
+import { setFormCurrentPage, setInitReferralFlow } from './redux/actions';
 
 export default function ScheduleReferral(props) {
   const { currentReferral } = props;
@@ -14,10 +14,10 @@ export default function ScheduleReferral(props) {
   useEffect(
     () => {
       dispatch(setFormCurrentPage('scheduleReferral'));
+      dispatch(setInitReferralFlow());
     },
     [location, dispatch],
   );
-
   const appointmentCountString =
     currentReferral.numberOfAppointments === 1
       ? '1 appointment'

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
@@ -6,12 +6,13 @@ import { format } from 'date-fns';
 import ReferralLayout from './components/ReferralLayout';
 import ReferralAppLink from './components/ReferralAppLink';
 import { setFormCurrentPage, setInitReferralFlow } from './redux/actions';
+import { getReferralSlotKey } from './utils/referrals';
 
 export default function ScheduleReferral(props) {
   const { currentReferral } = props;
   const location = useLocation();
   const dispatch = useDispatch();
-  const selectedSlotKey = `selected-slot-referral-${currentReferral.UUID}`;
+  const selectedSlotKey = getReferralSlotKey(currentReferral.UUID);
   useEffect(
     () => {
       dispatch(setFormCurrentPage('scheduleReferral'));

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
@@ -6,7 +6,7 @@ import {
   createTestStore,
   renderWithStoreAndRouter,
 } from '../tests/mocks/setup';
-import { createReferral } from './utils/referrals';
+import { createReferral, getReferralSlotKey } from './utils/referrals';
 
 describe('VAOS Component: ScheduleReferral', () => {
   afterEach(() => {
@@ -72,7 +72,7 @@ describe('VAOS Component: ScheduleReferral', () => {
   });
   it('should reset slot selection', async () => {
     const referral = createReferral(referralDate, '222');
-    const selectedSlotKey = `selected-slot-referral-${referral.UUID}`;
+    const selectedSlotKey = getReferralSlotKey(referral.UUID);
     sessionStorage.setItem(selectedSlotKey, '0');
     const initialState = {
       featureToggles: {

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
@@ -9,6 +9,9 @@ import {
 import { createReferral } from './utils/referrals';
 
 describe('VAOS Component: ScheduleReferral', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
   const referralDate = '2024-09-09';
   it('should display the subtitle correctly given different numbers of appointments', async () => {
     const referralOne = createReferral(referralDate, '111');
@@ -66,5 +69,23 @@ describe('VAOS Component: ScheduleReferral', () => {
     expect(additionalAppointmentHelpText).to.exist;
 
     expect(facility).to.exist;
+  });
+  it('should reset slot selection', async () => {
+    const referral = createReferral(referralDate, '222');
+    const selectedSlotKey = `selected-slot-referral-${referral.UUID}`;
+    sessionStorage.setItem(selectedSlotKey, '0');
+    const initialState = {
+      featureToggles: {
+        vaOnlineSchedulingCCDirectScheduling: true,
+      },
+      referral: {
+        currentPage: 'scheduleAppointment',
+        selectedSlot: '0',
+      },
+    };
+    renderWithStoreAndRouter(<ScheduleReferral currentReferral={referral} />, {
+      initialState,
+    });
+    expect(sessionStorage.getItem(selectedSlotKey)).to.be.null;
   });
 });

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
@@ -62,18 +62,9 @@ describe('VAOS Component: ScheduleReferral', () => {
 
     expect(details).to.exist;
     expect(details).to.contain.text(expectedDate);
-    expect(details).to.contain.text('Type of care: Cardiology');
-    expect(details).to.contain.text('Provider: Dr. Face');
-    expect(details).to.contain.text('Location: New skin technologies bldg 2');
-    expect(details).to.contain.text('Number of appointments: 1');
-    expect(details).to.contain.text('Referral number: VA0000009880');
     expect(helpText).to.exist;
     expect(additionalAppointmentHelpText).to.exist;
 
     expect(facility).to.exist;
-    expect(facility).to.contain.text(
-      'Referring VA facility: Batavia VA Medical Center',
-    );
-    expect(facility).to.contain.text('Phone: (585) 297-1000');
   });
 });

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.jsx
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.jsx
@@ -18,6 +18,7 @@ import {
   getTimezoneDescByFacilityId,
   getTimezoneByFacilityId,
 } from '../../utils/timezone';
+import { getReferralSlotKey } from '../utils/referrals';
 
 export const DateAndTimeContent = props => {
   const { currentReferral, provider, appointmentsByMonth } = props;
@@ -31,7 +32,7 @@ export const DateAndTimeContent = props => {
   const facilityTimeZone = getTimezoneByFacilityId(
     currentReferral.ReferringFacilityInfo.FacilityCode,
   );
-  const selectedSlotKey = `selected-slot-referral-${currentReferral.UUID}`;
+  const selectedSlotKey = getReferralSlotKey(currentReferral.UUID);
   const latestAvailableSlot = new Date(
     Math.max.apply(
       null,

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -3,7 +3,7 @@ import { fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import MockDate from 'mockdate';
 import DateAndTimeContent from './DateAndTimeContent';
-import { createReferral } from '../utils/referrals';
+import { createReferral, getReferralSlotKey } from '../utils/referrals';
 import { createProviderDetails } from '../utils/provider';
 import { renderWithStoreAndRouter } from '../../tests/mocks/setup';
 
@@ -91,7 +91,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     ).to.exist;
   });
   it('should show error if conflicting appointment', async () => {
-    const selectedSlotKey = `selected-slot-referral-${referral.UUID}`;
+    const selectedSlotKey = getReferralSlotKey(referral.UUID);
     sessionStorage.setItem(selectedSlotKey, '0');
     const initialStateWithSelect = {
       featureToggles: {
@@ -125,7 +125,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     ).to.exist;
   });
   it('should select date if value in session storage', async () => {
-    const selectedSlotKey = `selected-slot-referral-${referral.UUID}`;
+    const selectedSlotKey = getReferralSlotKey(referral.UUID);
     sessionStorage.setItem(selectedSlotKey, '1');
     const screen = renderWithStoreAndRouter(
       <DateAndTimeContent

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -12,11 +12,6 @@ describe('VAOS Component: DateAndTimeContent', () => {
     featureToggles: {
       vaOnlineSchedulingCCDirectScheduling: true,
     },
-    newAppointment: {
-      data: {
-        selectedDates: [],
-      },
-    },
     referral: {
       currentPage: 'scheduleAppointment',
       selectedSlot: null,

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -48,7 +48,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     ],
   };
   beforeEach(() => {
-    MockDate.set('2024-12-05T08:00:00Z');
+    MockDate.set('2024-12-05T15:00:00-05:00');
   });
   afterEach(() => {
     sessionStorage.clear();

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -19,19 +19,19 @@ describe('VAOS Component: DateAndTimeContent', () => {
     },
     referral: {
       currentPage: 'scheduleAppointment',
+      selectedSlot: null,
     },
   };
   const referral = createReferral(
     '2024-12-05',
     'add2f0f4-a1ea-4dea-a504-a54ab57c68',
   );
-  const provider = createProviderDetails(1);
   const appointmentsByMonth = {
     '2024-12': [
       {
-        start: '2024-12-06T12:00:00-05:00',
+        start: '2024-12-06T15:00:00-05:00',
         timezone: 'America/New_York',
-        minutesDuration: 60,
+        minutesDuration: 30,
       },
       {
         start: '2024-12-19T08:40:00-05:00',
@@ -53,7 +53,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     ],
   };
   beforeEach(() => {
-    MockDate.set('2024-12-05T00:00:00Z');
+    MockDate.set('2024-12-05T08:00:00Z');
   });
   afterEach(() => {
     sessionStorage.clear();
@@ -63,7 +63,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     const screen = renderWithStoreAndRouter(
       <DateAndTimeContent
         currentReferral={referral}
-        provider={provider}
+        provider={createProviderDetails(1)}
         appointmentsByMonth={appointmentsByMonth}
       />,
       {
@@ -78,7 +78,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     const screen = renderWithStoreAndRouter(
       <DateAndTimeContent
         currentReferral={referral}
-        provider={provider}
+        provider={createProviderDetails(1)}
         appointmentsByMonth={appointmentsByMonth}
       />,
       {
@@ -96,11 +96,15 @@ describe('VAOS Component: DateAndTimeContent', () => {
     ).to.exist;
   });
   it('should show error if conflicting appointment', async () => {
-    const selectedDateKey = `selected-date-referral-${referral.UUID}`;
-    sessionStorage.setItem(selectedDateKey, '2024-12-06T17:00:00.000Z');
+    const selectedSlotKey = `selected-slot-referral-${referral.UUID}`;
+    sessionStorage.setItem(selectedSlotKey, '0');
     const initialStateWithSelect = {
       featureToggles: {
         vaOnlineSchedulingCCDirectScheduling: true,
+      },
+      referral: {
+        selectedSlot: '0',
+        currentPage: 'scheduleAppointment',
       },
       newAppointment: {
         data: {
@@ -111,7 +115,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     const screen = renderWithStoreAndRouter(
       <DateAndTimeContent
         currentReferral={referral}
-        provider={provider}
+        provider={createProviderDetails(1)}
         appointmentsByMonth={appointmentsByMonth}
       />,
       {
@@ -129,8 +133,8 @@ describe('VAOS Component: DateAndTimeContent', () => {
     ).to.exist;
   });
   it('should select date if value in session storage', async () => {
-    const selectedDateKey = `selected-date-referral-${referral.UUID}`;
-    sessionStorage.setItem(selectedDateKey, '2024-12-06T19:00:00.000Z');
+    const selectedSlotKey = `selected-slot-referral-${referral.UUID}`;
+    sessionStorage.setItem(selectedSlotKey, '1');
     const screen = renderWithStoreAndRouter(
       <DateAndTimeContent
         currentReferral={referral}

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -102,10 +102,12 @@ describe('VAOS Component: DateAndTimeContent', () => {
         currentPage: 'scheduleAppointment',
       },
     };
+    const provider = createProviderDetails(1);
+    provider.slots[0].start = '2024-12-06T15:00:00-05:00';
     const screen = renderWithStoreAndRouter(
       <DateAndTimeContent
         currentReferral={referral}
-        provider={createProviderDetails(1)}
+        provider={provider}
         appointmentsByMonth={appointmentsByMonth}
       />,
       {

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -101,11 +101,6 @@ describe('VAOS Component: DateAndTimeContent', () => {
         selectedSlot: '0',
         currentPage: 'scheduleAppointment',
       },
-      newAppointment: {
-        data: {
-          selectedDates: '2024-12-06T17:00:00.000Z',
-        },
-      },
     };
     const screen = renderWithStoreAndRouter(
       <DateAndTimeContent

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -48,7 +48,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
     ],
   };
   beforeEach(() => {
-    MockDate.set('2024-12-05T15:00:00-05:00');
+    MockDate.set('2024-12-05T05:00:00-05:00');
   });
   afterEach(() => {
     sessionStorage.clear();

--- a/src/applications/vaos/referral-appointments/components/PendingReferralCard.jsx
+++ b/src/applications/vaos/referral-appointments/components/PendingReferralCard.jsx
@@ -39,6 +39,7 @@ const PendingReferralCard = ({ referral, handleClick, index }) => {
                     padding="0"
                     // canceled={isCanceled}
                     className="vads-u-font-weight--bold vaos-appts__display--table"
+                    data-testid="typeOfCare"
                   >
                     {`${typeOfCareName} referral`}
                   </AppointmentColumn>

--- a/src/applications/vaos/referral-appointments/components/PendingReferralCard.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/PendingReferralCard.unit.spec.js
@@ -34,7 +34,7 @@ describe('VAOS Component: PendingReferralCard', () => {
   });
 
   it('should display the correct type of care name', () => {
-    expect(screen.getByText('Cardiology referral')).to.exist;
+    expect(screen.getByTestId('typeOfCare')).to.exist;
   });
   it('should display the correct number of appointments and expiration date', () => {
     expect(

--- a/src/applications/vaos/referral-appointments/components/ReferralLayout.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralLayout.jsx
@@ -20,7 +20,9 @@ function BreadCrumbNav() {
     currentPage === 'referralsAndRequests' || currentPage === 'scheduleReferral'
       ? 'Appointments'
       : 'Back';
-
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const id = params.get('id');
   return (
     <div className="vaos-hide-for-print mobile:vads-u-margin-bottom--0 mobile-lg:vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--2">
       <nav aria-label="backlink" className="vads-u-padding-y--2 ">
@@ -31,7 +33,7 @@ function BreadCrumbNav() {
           text={text}
           onClick={e => {
             e.preventDefault();
-            routeToPreviousReferralPage(history, currentPage);
+            routeToPreviousReferralPage(history, currentPage, id);
           }}
         />
       </nav>

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -20,6 +20,8 @@ export const FETCH_REFERRALS_FAILED = 'FETCH_REFERRALS_FAILED';
 export const FETCH_REFERRAL = 'FETCH_REFERRAL';
 export const FETCH_REFERRAL_SUCCEEDED = 'FETCH_REFERRAL_SUCCEEDED';
 export const FETCH_REFERRAL_FAILED = 'FETCH_REFERRAL_FAILED';
+export const SET_SELECTED_SLOT = 'SET_SELECTED_SLOT';
+export const SET_INIT_REFERRAL_FLOW = 'SET_INIT_REFERRAL_FLOW';
 
 export function setFacility(facility) {
   return {
@@ -121,5 +123,18 @@ export function fetchReferralById(id) {
       });
       return captureError(error);
     }
+  };
+}
+
+export function setSelectedSlot(slot) {
+  return {
+    type: SET_SELECTED_SLOT,
+    payload: slot,
+  };
+}
+
+export function setInitReferralFlow() {
+  return {
+    type: SET_INIT_REFERRAL_FLOW,
   };
 }

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -13,15 +13,18 @@ import {
   FETCH_REFERRAL,
   FETCH_REFERRAL_SUCCEEDED,
   FETCH_REFERRAL_FAILED,
+  SET_INIT_REFERRAL_FLOW,
+  SET_SELECTED_SLOT,
 } from './actions';
 import { FETCH_STATUS } from '../../utils/constants';
 
 const initialState = {
   facility: null,
   sortProviderBy: '',
-  selectedProvider: '',
+  selectedProvider: {},
   currentPage: null,
   referrals: [],
+  selectedSlot: '',
   referralsFetchStatus: FETCH_STATUS.notStarted,
   referralFetchStatus: FETCH_STATUS.notStarted,
   providerFetchStatus: FETCH_STATUS.notStarted,
@@ -102,6 +105,18 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         referralFetchStatus: FETCH_STATUS.failed,
+      };
+    case SET_SELECTED_SLOT:
+      return {
+        ...state,
+        selectedSlot: action.payload,
+      };
+    case SET_INIT_REFERRAL_FLOW:
+      return {
+        ...state,
+        selectedProvider: {},
+        providerFetchStatus: FETCH_STATUS.notStarted,
+        selectedSlot: null,
       };
     default:
       return state;

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -116,7 +116,7 @@ function ccAppointmentReducer(state = initialState, action) {
         ...state,
         selectedProvider: {},
         providerFetchStatus: FETCH_STATUS.notStarted,
-        selectedSlot: null,
+        selectedSlot: '',
       };
     default:
       return state;

--- a/src/applications/vaos/referral-appointments/redux/selectors.js
+++ b/src/applications/vaos/referral-appointments/redux/selectors.js
@@ -2,6 +2,7 @@ export const selectCCAppointment = state => state.ccAppointment;
 export const selectProvider = state => state.referral.selectedProvider;
 export const selectProviderSortBy = state => state.referral.sortProviderBy;
 export const selectCurrentPage = state => state.referral.currentPage;
+export const getSelectedSlot = state => state.referral.selectedSlot;
 
 export function getProviderInfo(state) {
   return {

--- a/src/applications/vaos/referral-appointments/tests/utils/provider.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/utils/provider.unit.spec.js
@@ -10,7 +10,7 @@ describe('VAOS provider utils', () => {
   });
   const tomorrow = addDays(startOfDay(new Date()), 1);
   describe('createProviderDetails', () => {
-    const providerObjectTwoSlots = providerUtil.createProviderDetails(2);
+    const providerObjectTwoSlots = providerUtil.createProviderDetails(2, '222');
     it('Creates a provider with specified number of slots', () => {
       expect(providerObjectTwoSlots.slots.length).to.equal(2);
     });

--- a/src/applications/vaos/referral-appointments/tests/utils/provider.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/utils/provider.unit.spec.js
@@ -1,13 +1,16 @@
 import { addDays, startOfDay, addHours } from 'date-fns';
 import { expect } from 'chai';
+import MockDate from 'mockdate';
 
 const providerUtil = require('../../utils/provider');
 
-describe('VAOS provider generator', () => {
+describe('VAOS provider utils', () => {
+  afterEach(() => {
+    MockDate.reset();
+  });
   const tomorrow = addDays(startOfDay(new Date()), 1);
   describe('createProviderDetails', () => {
     const providerObjectTwoSlots = providerUtil.createProviderDetails(2);
-    const providerObjectNoSlots = providerUtil.createProviderDetails(0);
     it('Creates a provider with specified number of slots', () => {
       expect(providerObjectTwoSlots.slots.length).to.equal(2);
     });
@@ -20,7 +23,64 @@ describe('VAOS provider generator', () => {
       );
     });
     it('Creates empty slots array with 0', () => {
+      const providerObjectNoSlots = providerUtil.createProviderDetails(0);
       expect(providerObjectNoSlots.slots.length).to.equal(0);
+    });
+  });
+  describe('getAddressString', () => {
+    it('Formats the address string', () => {
+      expect(
+        providerUtil.getAddressString(providerUtil.providers['111'].orgAddress),
+      ).to.equal('111 Lori Ln., New York, New York, 10016');
+    });
+  });
+  describe('getSlotByDate', () => {
+    it('returns the correct object for a given data', () => {
+      const provider = providerUtil.createProviderDetails(2);
+      const date = provider.slots[0].start;
+      expect(providerUtil.getSlotByDate(provider.slots, date)).to.equal(
+        provider.slots[0],
+      );
+    });
+  });
+  describe('getSlotById', () => {
+    it('returns the correct object for a given id', () => {
+      const provider = providerUtil.createProviderDetails(2);
+      const { id } = provider.slots[0];
+      expect(providerUtil.getSlotById(provider.slots, id)).to.equal(
+        provider.slots[0],
+      );
+    });
+  });
+  describe('hasConflict', () => {
+    MockDate.set('2024-12-05T00:00:00Z');
+    const tz = 'America/Los_Angeles';
+    const appointmentsByMonth = {
+      '2024-12': [
+        {
+          start: '2024-12-06T09:00:00-08:00',
+          timezone: tz,
+          minutesDuration: 60,
+        },
+      ],
+    };
+    it('returns false when there is no conflict', () => {
+      expect(
+        providerUtil.hasConflict(
+          '2024-12-06T16:00:00Z',
+          appointmentsByMonth,
+          tz,
+        ),
+      ).to.be.false;
+    });
+    it('returns true when there is no conflict', () => {
+      expect(
+        providerUtil.hasConflict(
+          '2024-12-06T17:00:00Z',
+          appointmentsByMonth,
+          tz,
+        ),
+      ).to.be.true;
     });
   });
 });

--- a/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.js
@@ -22,4 +22,9 @@ describe('VAOS referral generator', () => {
       expect(referrals[1].ReferralDate).to.equal('2024-10-31');
     });
   });
+  describe('getReferralSlotKey', () => {
+    expect(referralUtil.getReferralSlotKey('111')).to.equal(
+      'selected-slot-referral-111',
+    );
+  });
 });

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -62,4 +62,4 @@ const createProviderDetails = (numberOfSlots, providerId = '111') => {
   return provider;
 };
 
-module.exports = { createProviderDetails };
+module.exports = { createProviderDetails, providers };

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -54,7 +54,7 @@ const createProviderDetails = (numberOfSlots, providerId = '111') => {
     const startTime = dateFns.addHours(tomorrow, hourFromNow);
     provider.slots.push({
       end: dateFns.addMinutes(startTime, 30).toISOString(),
-      id: Math.floor(Math.random() * 90000) + 10000,
+      id: i,
       start: startTime.toISOString(),
     });
     hourFromNow++;

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -1,29 +1,11 @@
 /* eslint-disable no-plusplus */
 const dateFns = require('date-fns');
 
-/**
- * Creates a provider object with a configurable number of slots an hour apart.
- *
- * @param {Number} numberOfSlots How many slots to create
- * @returns {Object} Provider object
- */
-const createProviderDetails = numberOfSlots => {
-  const slots = [];
-  const tomorrow = dateFns.addDays(dateFns.startOfDay(new Date()), 1);
-  let hourFromNow = 12;
-  for (let i = 0; i < numberOfSlots; i++) {
-    const startTime = dateFns.addHours(tomorrow, hourFromNow);
-    slots.push({
-      end: dateFns.addMinutes(startTime, 30).toISOString(),
-      id: Math.floor(Math.random() * 90000) + 10000,
-      start: startTime.toISOString(),
-    });
-    hourFromNow++;
-  }
-  return {
-    providerName: 'Dr. Face',
-    typeOfCare: 'Dermatology',
-    orgName: 'New Skin Technologies',
+const providers = {
+  '111': {
+    providerName: 'Dr. Bones',
+    typeOfCare: 'Physical Therapy',
+    orgName: 'Stronger Bone Technologies',
     orgAddress: {
       street1: '111 Lori Ln.',
       street2: '',
@@ -32,12 +14,52 @@ const createProviderDetails = numberOfSlots => {
       state: 'New York',
       zip: '10016',
     },
-    orgPhone: '555-867-5309',
+    orgPhone: '555-600-8043',
     driveTime: '7 minute drive',
     driveDistance: '8 miles',
-    slots,
-    location: 'New skin technologies bldg 2',
-  };
+    location: 'Stronger bone technologies bldg 2',
+  },
+  '222': {
+    providerName: 'Dr. Peetee',
+    typeOfCare: 'Physical Therapy',
+    orgName: 'Physical Therapy Solutions',
+    orgAddress: {
+      street1: '222 John Dr.',
+      street2: '',
+      street3: '',
+      city: 'New York',
+      state: 'New York',
+      zip: '10016',
+    },
+    orgPhone: '555-867-5309',
+    driveTime: '3 minute drive',
+    driveDistance: '20 miles',
+    location: 'Physical Therapy Solutions World Headquarters',
+  },
+};
+
+/**
+ * Creates a provider object with a configurable number of slots an hour apart.
+ *
+ * @param {Number} numberOfSlots How many slots to create
+ * @param {String} providerId The ID for the provider
+ * @returns {Object} Provider object
+ */
+const createProviderDetails = (numberOfSlots, providerId = '111') => {
+  const provider = providers[providerId];
+  provider.slots = [];
+  const tomorrow = dateFns.addDays(dateFns.startOfDay(new Date()), 1);
+  let hourFromNow = 12;
+  for (let i = 0; i < numberOfSlots; i++) {
+    const startTime = dateFns.addHours(tomorrow, hourFromNow);
+    provider.slots.push({
+      end: dateFns.addMinutes(startTime, 30).toISOString(),
+      id: Math.floor(Math.random() * 90000) + 10000,
+      start: startTime.toISOString(),
+    });
+    hourFromNow++;
+  }
+  return provider;
 };
 
 module.exports = { createProviderDetails };

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -86,4 +86,14 @@ const createReferrals = (numberOfReferrals = 3, baseDate) => {
   return referrals;
 };
 
-module.exports = { createReferral, createReferrals };
+/**
+ * Returns the session key for a stored slot by referral id.
+ *
+ * @param {String} id The id of the referral.
+ * @returns {String} The storage key.
+ */
+const getReferralSlotKey = id => {
+  return `selected-slot-referral-${id}`;
+};
+
+module.exports = { createReferral, createReferrals, getReferralSlotKey };

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
 const { addDays, addMonths, format } = require('date-fns');
-
+const { providers } = require('./provider');
 /**
  * Creates a referral object relative to a start date.
  *
@@ -16,6 +16,7 @@ const createReferral = (startDate, uuid, providerId = '111') => {
 
   const mydFormat = 'yyyy-MM-dd';
   const mydWithTimeFormat = 'yyyy-MM-dd kk:mm:ss';
+  const provider = providers[providerId];
 
   return {
     ReferralCategory: 'Inpatient',
@@ -28,7 +29,7 @@ const createReferral = (startDate, uuid, providerId = '111') => {
     ReferringProvider: '534_520824810',
     SourceOfReferral: 'Interfaced from VA',
     Status: 'Approved',
-    CategoryOfCare: 'Cardiology',
+    CategoryOfCare: provider.typeOfCare,
     StationID: '528A4',
     Sta6: '534',
     ReferringProviderNPI: '534_520824810',
@@ -47,8 +48,8 @@ const createReferral = (startDate, uuid, providerId = '111') => {
     ReferralStatus: 'open',
     UUID: uuid,
     numberOfAppointments: 1,
-    providerName: 'Dr. Face',
-    providerLocation: 'New skin technologies bldg 2',
+    providerName: provider.providerName,
+    providerLocation: provider.providerLocation,
     providerId,
   };
 };
@@ -65,7 +66,7 @@ const createReferrals = (numberOfReferrals = 3, baseDate) => {
   const baseDateObject = new Date(year, month - 1, day);
   const referrals = [];
   const baseUUID = 'add2f0f4-a1ea-4dea-a504-a54ab57c68';
-  const providers = ['111', '222'];
+  const providerIds = ['111', '222'];
   const isOdd = number => {
     return number % 2;
   };
@@ -78,7 +79,7 @@ const createReferrals = (numberOfReferrals = 3, baseDate) => {
       createReferral(
         referralDate,
         `${baseUUID}${i.toString().padStart(2, '0')}`,
-        isOdd(i) ? providers[0] : providers[1],
+        isOdd(i) ? providerIds[0] : providerIds[1],
       ),
     );
   }

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -7,9 +7,10 @@ const { addDays, addMonths, format } = require('date-fns');
  *
  * @param {String} startDate The date in 'yyyy-MM-dd' format to base the referrals around
  * @param {String} uuid The UUID for the referral
+ * @param {String} providerId The ID for the provider
  * @returns {Object} Referral object
  */
-const createReferral = (startDate, uuid) => {
+const createReferral = (startDate, uuid, providerId = '111') => {
   const [year, month, day] = startDate.split('-');
   const relativeDate = new Date(year, month - 1, day);
 
@@ -48,7 +49,7 @@ const createReferral = (startDate, uuid) => {
     numberOfAppointments: 1,
     providerName: 'Dr. Face',
     providerLocation: 'New skin technologies bldg 2',
-    providerId: '111',
+    providerId,
   };
 };
 
@@ -64,6 +65,11 @@ const createReferrals = (numberOfReferrals = 3, baseDate) => {
   const baseDateObject = new Date(year, month - 1, day);
   const referrals = [];
   const baseUUID = 'add2f0f4-a1ea-4dea-a504-a54ab57c68';
+  const providers = ['111', '222'];
+  const isOdd = number => {
+    return number % 2;
+  };
+
   for (let i = 0; i < numberOfReferrals; i++) {
     const startDate = addDays(baseDateObject, i);
     const mydFormat = 'yyyy-MM-dd';
@@ -72,6 +78,7 @@ const createReferrals = (numberOfReferrals = 3, baseDate) => {
       createReferral(
         referralDate,
         `${baseUUID}${i.toString().padStart(2, '0')}`,
+        isOdd(i) ? providers[0] : providers[1],
       ),
     );
   }

--- a/src/applications/vaos/services/appointment/index.unit.spec.js
+++ b/src/applications/vaos/services/appointment/index.unit.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable @department-of-veterans-affairs/axe-check-required */
 import { expect } from 'chai';
 import sinon from 'sinon';
+import MockDate from 'mockdate';
 import {
   mockFetch,
   setFetchJSONFailure,
@@ -700,8 +701,9 @@ describe('VAOS Services: Appointment ', () => {
 
   //--------
 
-  const now = moment();
   describe('isUpcomingAppointmentOrRequest', () => {
+    MockDate.reset();
+    const now = moment();
     it('should filter future requests', () => {
       const apptRequests = [
         // canceled past - should filter out

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -675,7 +675,9 @@ const responses = {
     if (req.params.providerId === '3') {
       return res.status(500).json({ error: true });
     }
-    return res.json({ data: providerUtils.createProviderDetails(5) });
+    return res.json({
+      data: providerUtils.createProviderDetails(5, req.params.providerId),
+    });
   },
   'GET /v0/user': {
     data: {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR resets both the provider and selected slot in redux and the slot stored in session when someone visits the schedule-referral page. To that end it also updates our mock generators to produce multiple providers and it also swaps the session storage to be slotId based rather than date based. Plus it brings that slot selection into our area of the reducer.

I also made a few changes to get the back button working so that I could manually test this. In the process, I also refactored a few functions into utils to help with readability. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#98701

## Testing done

Manual testing and unit tests.

## What areas of the site does it impact?

Community Care referral scheduling in VAOS

## Acceptance criteria
 - [ ] Provider redux data is retained when moving forward past the date selector page and doesn't refetch when navigating back to page
 - [ ] Slot selection s retained when moving forward past the date selector page and is saved when navigation back to page
 - [ ] When navigating back to the schedule referral page and then forward again, provider is re-fetched and saved slot is reset
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Code Review steps
 - turn on `vaOnlineSchedulingCCDirectScheduling` feature locally
 - run mock and app locally
 - navigate to `http://localhost:3001/my-health/appointments/schedule-referral/date-time?id=add2f0f4-a1ea-4dea-a504-a54ab57c6800`
 - select a date/time and then click `continue`
 - click the back link in the bread crumb of the next page
 - observe that the selection is still made and there there was no API call
 - click the back link in the bread crumb again
 - click the `Schedule your appointment` action link
 - observe that the selection is no longer saved and there was an API call to get fresh provider data

