### PR TITLE
Make back and breadcrumbs work

### DIFF
--- a/src/applications/vaos/referral-appointments/ConfirmApprovedPage.jsx
+++ b/src/applications/vaos/referral-appointments/ConfirmApprovedPage.jsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+
 import ReferralLayout from './components/ReferralLayout';
+import { routeToPreviousReferralPage } from './flow';
+import { setFormCurrentPage } from './redux/actions';
 
 const staticData = {
   typeOfCare: 'Primary Care',
@@ -22,12 +27,22 @@ const getData = (typeOfData = 'static') => {
 };
 
 export default function ConfirmApprovedPage() {
+  const history = useHistory();
+  const dispatch = useDispatch();
+
   const [confirmedData, setConfirmedData] = useState(0);
 
   // on react component mount, fetch data
   useEffect(() => {
     setConfirmedData(getData());
   }, []);
+
+  useEffect(
+    () => {
+      dispatch(setFormCurrentPage('confirmAppointment'));
+    },
+    [location, dispatch],
+  );
 
   return (
     <ReferralLayout hasEyebrow>
@@ -103,7 +118,16 @@ export default function ConfirmApprovedPage() {
         <div>{confirmedData.details}</div>
         <hr className="vads-u-margin-y--2" />
         <div className="vads-u-margin-top--4">
-          <va-button label="Back" text="Back" secondary uswds />
+          <va-button
+            label="Back"
+            text="Back"
+            secondary
+            uswds
+            onClick={e => {
+              e.preventDefault();
+              routeToPreviousReferralPage(history, 'confirmAppointment');
+            }}
+          />
           <va-button
             class="vads-u-margin-left--2"
             label="Continue"

--- a/src/applications/vaos/referral-appointments/components/ReferralLayout.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralLayout.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import DowntimeNotification, {
   externalServices,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { VaLink } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import NeedHelp from '../../components/NeedHelp';
 import ErrorBoundary from '../../components/ErrorBoundary';
@@ -13,7 +13,6 @@ import { selectCurrentPage } from '../redux/selectors';
 import { routeToPreviousReferralPage } from '../flow';
 
 function BreadCrumbNav() {
-  const dispatch = useDispatch();
   const history = useHistory();
   const currentPage = useSelector(selectCurrentPage);
 
@@ -32,7 +31,7 @@ function BreadCrumbNav() {
           text={text}
           onClick={e => {
             e.preventDefault();
-            dispatch(routeToPreviousReferralPage(history, currentPage));
+            routeToPreviousReferralPage(history, currentPage);
           }}
         />
       </nav>

--- a/src/applications/vaos/referral-appointments/flow.js
+++ b/src/applications/vaos/referral-appointments/flow.js
@@ -71,7 +71,14 @@ export function routeToPreviousReferralPage(
   current,
   referralId = null,
 ) {
-  return routeToPageInFlow(history, current, 'previous', referralId);
+  let resolvedReferralId = referralId;
+  // Give the router some context to keep the user in the same referral when navigating back if not
+  // explicitly passed
+  if (!referralId && history.location?.search) {
+    const params = new URLSearchParams(history.location.search);
+    resolvedReferralId = params.get('id');
+  }
+  return routeToPageInFlow(history, current, 'previous', resolvedReferralId);
 }
 
 export function routeToNextReferralPage(history, current, referralId = null) {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

### Test Plan
GIVEN the `vaOnlineSchedulingCCDirectScheduling` flag is ON
WHEN I visit my appointments from a link /my-health/appointments
AND I navigate to Review Requests and Referrals 
AND I navigate back to Appointments using the breadcrumbs 
THEN I should be directed to the initial Appointments page

GIVEN the `vaOnlineSchedulingCCDirectScheduling` flag is ON
WHEN I visit my appointments  /my-health/appointments 
AND I navigate to Review Requests and Referrals 
AND I click on "Schedule your appointment" for a referral
AND  I navigate back using the breadcrumbs 
THEN  I should be directed to the Review Requests and Referrals  page

GIVEN the `vaOnlineSchedulingCCDirectScheduling` flag is ON
WHEN I visit my appointments  /my-health/appointments 
AND I navigate to Review Requests and Referrals 
AND I click on "Schedule your appointment" for a referral
AND on the referral page I click on the  "Schedule your appointment"
AND on the schedule your appointment page I navigate back using the breadcrumbs 
THEN I should be directed to the referral page for the same referral

GIVEN the `vaOnlineSchedulingCCDirectScheduling` flag is ON
WHEN I visit my appointments  /my-health/appointments 
AND I navigate to Review Requests and Referrals 
AND I click on "Schedule your appointment" for a referral
AND on the referral page I click on the  "Schedule your appointment"
AND on the schedule your appointment page I navigate back using the "Back" button at the bottom of the calendar 
THEN I should be directed to the referral page for the same referral

GIVEN the `vaOnlineSchedulingCCDirectScheduling` flag is ON
WHEN I visit my appointments  /my-health/appointments 
AND I navigate to Review Requests and Referrals 
AND I click on "Schedule your appointment" for a referral
AND on the referral page I click on the  "Schedule your appointment"
AND on the schedule your appointment page select an available slot and click "Continue"
AND on the Review appointment details screen I navigate back using the breadcrumbs
THEN I should be directed to the schedule your appointment page 

## Screenshots



https://github.com/user-attachments/assets/8eebb638-3740-4104-81f4-e2c8f75faf76


## What areas of the site does it impact?

- VAOS

## Acceptance criteria

- [ ] All test scenarios above are sucesfull

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

- On navigating back the screen remains at the same scroll position. We should scroll the user back to the top of the page when navigating back. (possible follow up ticket?)
