### PR TITLE
VACMS-11597 Remove unused CC provider flipper

### DIFF
--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -2,7 +2,6 @@ import { VaPagination } from '@department-of-veterans-affairs/component-library/
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { LocationType } from '../constants';
-import { facilityLocatorRestoreCommunityCarePagination } from '../utils/featureFlagSelectors';
 
 export class PaginationWrapper extends Component {
   shouldComponentUpdate = nextProps =>
@@ -40,17 +39,6 @@ export class PaginationWrapper extends Component {
 
 const mapStateToProps = state => {
   let shouldHidePagination = false;
-
-  if (
-    [
-      LocationType.CC_PROVIDER,
-      LocationType.URGENT_CARE_PHARMACIES,
-      LocationType.EMERGENCY_CARE,
-    ].includes(state.searchQuery.facilityType) &&
-    !facilityLocatorRestoreCommunityCarePagination(state)
-  ) {
-    shouldHidePagination = true;
-  }
 
   // pagination not yet supported for PPMS urgent care
   if (

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -19,8 +19,3 @@ export const facilityLocatorShowOperationalHoursSpecialInstructions = state =>
 
 export const facilityLocatorLatLongOnly = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilityLocatorLatLongOnly];
-
-export const facilityLocatorRestoreCommunityCarePagination = state =>
-  toggleValues(state)[
-    FEATURE_FLAG_NAMES.facilityLocatorRestoreCommunityCarePagination
-  ];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -72,7 +72,6 @@
   "facilityLocatorLatLongOnly": "facility_locator_lat_long_only",
   "facilityLocatorPredictiveLocationSearch": "facility_locator_predictive_location_search",
   "facilityLocatorRailsEngine": "facility_locator_rails_engine",
-  "facilityLocatorRestoreCommunityCarePagination": "facility_locator_restore_community_care_pagination",
   "facilityLocatorShowCommunityCares": "facility_locator_show_community_cares",
   "facilityLocatorShowHealthConnectNumber": "facility_locator_show_health_connect_number",
   "facilityLocatorShowOperationalHoursSpecialInstructions": "facility_locator_show_operational_hours_special_instructions",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removes `facility_locator_restore_community_care_pagination` as its "on" state is now the default.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11597

## Testing done
Tested community care providers locally and verified the results are the same as in production.

## Screenshots
The flipper is **ON** in dev, staging and production:

### Production (flipper admin)
<img width="879" alt="Screenshot 2024-12-16 at 9 58 41 AM" src="https://github.com/user-attachments/assets/a261246d-5d97-4521-9405-d37f5475d51b" />

### Staging (flipper admin)
<img width="874" alt="Screenshot 2024-12-16 at 9 58 34 AM" src="https://github.com/user-attachments/assets/d7450f62-43ab-43c7-a07f-afd85729b42f" />

### Dev (flipper admin)
<img width="902" alt="Screenshot 2024-12-16 at 9 58 45 AM" src="https://github.com/user-attachments/assets/1465f1e3-6ff7-4864-ae54-f55bffbbc300" />

No visual regressions expected.

### Production (app)
<img width="1000" alt="Screenshot 2024-12-16 at 10 08 09 AM" src="https://github.com/user-attachments/assets/3fbe99b4-2431-47bc-bf21-9bbb3b680cad" />
<img width="1000" alt="Screenshot 2024-12-16 at 10 08 27 AM" src="https://github.com/user-attachments/assets/873198ea-8300-41ae-8cd9-101c5b2043b8" />

### Local (app)
<img width="1000" alt="Screenshot 2024-12-16 at 10 08 55 AM" src="https://github.com/user-attachments/assets/0e62d58c-83bf-4f3d-a2d4-17d3f25829ac" />
<img width="1000" alt="Screenshot 2024-12-16 at 10 09 01 AM" src="https://github.com/user-attachments/assets/5ecd0dd6-2f0a-44a4-9f44-69ef678d8f87" />