### PR TITLE
Conditions 646 Fix Validate Not Duplicate on Edit

### DIFF
--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
@@ -11,20 +11,22 @@ import { conditionOptions } from '../../content/conditionOptions';
 import { conditionInstructions } from '../../content/newConditions';
 import { arrayBuilderOptions, createDefaultAndEditTitles } from './utils';
 
-const missingConditionMessage =
+const { arrayPath } = arrayBuilderOptions;
+
+export const missingConditionMessage =
   'Enter a condition, diagnosis, or short description of your symptoms';
 
 const regexNonWord = /[^\w]/g;
 const generateSaveInProgressId = str =>
   (str || 'blank').replace(regexNonWord, '').toLowerCase();
 
-const validateLength = (err, fieldData) => {
+export const validateLength = (err, fieldData) => {
   if (fieldData.length > 255) {
     err.addError('This needs to be less than 256 characters');
   }
 };
 
-const validateNotMissing = (err, fieldData) => {
+export const validateNotMissing = (err, fieldData) => {
   const isMissingCondition =
     !fieldData?.trim() ||
     fieldData.toLowerCase() === NULL_CONDITION_STRING.toLowerCase();
@@ -34,13 +36,12 @@ const validateNotMissing = (err, fieldData) => {
   }
 };
 
-const validateNotDuplicate = (err, fieldData, formData) => {
+export const validateNotDuplicate = (err, fieldData, formData, path) => {
   const index = getUrlPathIndex(window.location.pathname);
 
   const lowerCasedConditions =
-    formData?.[arrayBuilderOptions.arrayPath]?.map(condition =>
-      condition.condition?.toLowerCase(),
-    ) || [];
+    formData?.[path]?.map(condition => condition.condition?.toLowerCase()) ||
+    [];
 
   const fieldDataLowerCased = fieldData?.toLowerCase() || '';
   const fieldDataSaveInProgressId = generateSaveInProgressId(fieldData || '');
@@ -59,10 +60,10 @@ const validateNotDuplicate = (err, fieldData, formData) => {
   }
 };
 
-export const validateCondition = (err, fieldData = '', formData = {}) => {
+const validateCondition = (err, fieldData = '', formData = {}) => {
   validateLength(err, fieldData);
   validateNotMissing(err, fieldData);
-  validateNotDuplicate(err, fieldData, formData);
+  validateNotDuplicate(err, fieldData, formData, arrayPath);
 };
 
 /** @returns {PageSchema} */

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/condition.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getUrlPathIndex } from 'platform/forms-system/src/js/helpers';
 import {
   titleUI,
   withAlertOrDescription,
@@ -14,7 +15,7 @@ const missingConditionMessage =
   'Enter a condition, diagnosis, or short description of your symptoms';
 
 const regexNonWord = /[^\w]/g;
-const sippableId = str =>
+const generateSaveInProgressId = str =>
   (str || 'blank').replace(regexNonWord, '').toLowerCase();
 
 const validateLength = (err, fieldData) => {
@@ -33,20 +34,27 @@ const validateNotMissing = (err, fieldData) => {
   }
 };
 
-// TODO: On edit, allows previous index value to be the same as later index value
-// Note: Does not allow later index to be same as previous on edit
 const validateNotDuplicate = (err, fieldData, formData) => {
-  const currentList =
+  const index = getUrlPathIndex(window.location.pathname);
+
+  const lowerCasedConditions =
     formData?.[arrayBuilderOptions.arrayPath]?.map(condition =>
       condition.condition?.toLowerCase(),
     ) || [];
-  const itemLowerCased = fieldData?.toLowerCase() || '';
-  const itemSippableId = sippableId(fieldData || '');
-  const itemCount = currentList.filter(
-    item => item === itemLowerCased || sippableId(item) === itemSippableId,
-  );
 
-  if (itemCount.length > 1) {
+  const fieldDataLowerCased = fieldData?.toLowerCase() || '';
+  const fieldDataSaveInProgressId = generateSaveInProgressId(fieldData || '');
+
+  const hasDuplicate = lowerCasedConditions.some((condition, i) => {
+    if (index === i) return false;
+
+    return (
+      condition === fieldDataLowerCased ||
+      generateSaveInProgressId(condition) === fieldDataSaveInProgressId
+    );
+  });
+
+  if (hasDuplicate) {
     err.addError('You’ve already added this condition to your claim');
   }
 };

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/condition.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/condition.js
@@ -5,54 +5,22 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import Autocomplete from '../../components/Autocomplete';
-import { NULL_CONDITION_STRING } from '../../constants';
 import { conditionOptions } from '../../content/conditionOptions';
 import { conditionInstructions } from '../../content/newConditions';
+import {
+  missingConditionMessage,
+  validateLength,
+  validateNotDuplicate,
+  validateNotMissing,
+} from '../conditionByConditionPages/condition';
 import { arrayBuilderOptions, createDefaultAndEditTitles } from './utils';
 
-const missingConditionMessage =
-  'Enter a condition, diagnosis, or short description of your symptoms';
+const { arrayPath } = arrayBuilderOptions;
 
-const regexNonWord = /[^\w]/g;
-const sippableId = str =>
-  (str || 'blank').replace(regexNonWord, '').toLowerCase();
-
-const validateLength = (err, fieldData) => {
-  if (fieldData.length > 255) {
-    err.addError('This needs to be less than 256 characters');
-  }
-};
-
-const validateNotMissing = (err, fieldData) => {
-  const isMissingCondition =
-    !fieldData?.trim() ||
-    fieldData.toLowerCase() === NULL_CONDITION_STRING.toLowerCase();
-
-  if (isMissingCondition) {
-    err.addError(missingConditionMessage);
-  }
-};
-
-const validateNotDuplicate = (err, fieldData, formData) => {
-  const currentList =
-    formData?.[arrayBuilderOptions.arrayPath]?.map(condition =>
-      condition.condition?.toLowerCase(),
-    ) || [];
-  const itemLowerCased = fieldData?.toLowerCase() || '';
-  const itemSippableId = sippableId(fieldData || '');
-  const itemCount = currentList.filter(
-    item => item === itemLowerCased || sippableId(item) === itemSippableId,
-  );
-
-  if (itemCount.length > 1) {
-    err.addError('You’ve already added this condition to your claim');
-  }
-};
-
-export const validateCondition = (err, fieldData = '', formData = {}) => {
+const validateCondition = (err, fieldData = '', formData = {}) => {
   validateLength(err, fieldData);
   validateNotMissing(err, fieldData);
-  validateNotDuplicate(err, fieldData, formData);
+  validateNotDuplicate(err, fieldData, formData, arrayPath);
 };
 
 /** @returns {PageSchema} */


### PR DESCRIPTION
## Summary

- Summarize the changes that have been made to the platform
  - [Fix validate not duplicate on edit](https://github.com/department-of-veterans-affairs/vets-website/commit/a99b8edbf7c18c59cfe17c3a85ffccf2c6a6bec0)
    - Previously - the duplicate validation function would compare the fieldData and the formData (which was updating as the user types) and if the formData had 2 strings equal to the fieldData (itself and another) then it would throw the error. For some reason the validation formData in the multi-page list and loop is not updating as the user types so it was not counting itself as 1 match to the fieldData:
      - <img width="920" alt="Screenshot 2024-12-16 at 11 54 29 AM" src="https://github.com/user-attachments/assets/241af037-cee3-49c5-a356-1109a9705e06" />
    - Current - the duplicate validation function compares the fieldData and the formData, but it automatically ignores the current condition. Therefore, if just 1 string is equal to the fieldData then it would throw the error.
  - [Update conditionsFirst to use conditionByCondition condition validation functions](https://github.com/department-of-veterans-affairs/vets-website/commit/7dc75dc69662d179c8e76538bcbd352b4bf227ae)
- Which team do you work for, does your team own the maintenance of this component? Conditions Team and Yes

## Related issue(s)
- [Conditions prototype code enhancement #646](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/646)

## Screen Recording with Audio Voiceover
### Before
"Before this change the following lack of validation work occur..."

https://github.com/user-attachments/assets/7b2e897f-9d7c-4dfb-953a-800ad958f4d9



### After

https://github.com/user-attachments/assets/90f65689-7b57-469c-b5b1-f9d4d515e2d0


