### PR TITLE
MHV-65293: Self-entered pdf download spinner implemented

### DIFF
--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -310,7 +310,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
             that works with other providers’ medical records systems.
           </p>
           {generatingCCD ? (
-            <div id="generating-dl-indicator">
+            <div id="generating-ccd-indicator">
               <va-loading-indicator
                 label="Loading"
                 message="Preparing your download..."
@@ -349,10 +349,11 @@ const DownloadReportPage = ({ runningUnitTest }) => {
           {selfEnteredPdfRequested &&
           !successfulSeiDownload &&
           !seiPdfGenerationError ? (
-            <div className="generating-dl-indicator">
+            <div id="generating-sei-indicator">
               <va-loading-indicator
                 label="Loading"
                 message="Preparing your download..."
+                data-testid="sei-loading-indicator"
               />
             </div>
           ) : (

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -141,6 +141,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
   const generateSEIPdf = useCallback(
     async () => {
       setSelfEnteredPdfRequested(true);
+      setSeiPdfGenerationError(false);
 
       if (!isDataFetched) {
         // Fetch data if not all defined
@@ -309,7 +310,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
             that works with other providers’ medical records systems.
           </p>
           {generatingCCD ? (
-            <div id="generating-ccd-indicator">
+            <div id="generating-dl-indicator">
               <va-loading-indicator
                 label="Loading"
                 message="Preparing your download..."
@@ -345,12 +346,23 @@ const DownloadReportPage = ({ runningUnitTest }) => {
             directly. If you want to share this information with your care team,
             print this report and bring it to your next appointment.
           </p>
-          <va-link
-            download
-            onClick={generateSEIPdf}
-            text="Download PDF"
-            data-testid="downloadSelfEnteredButton"
-          />
+          {selfEnteredPdfRequested &&
+          !successfulSeiDownload &&
+          !seiPdfGenerationError ? (
+            <div className="generating-dl-indicator">
+              <va-loading-indicator
+                label="Loading"
+                message="Preparing your download..."
+              />
+            </div>
+          ) : (
+            <va-link
+              download
+              onClick={generateSEIPdf}
+              text="Download PDF"
+              data-testid="downloadSelfEnteredButton"
+            />
+          )}
           <p>
             <strong>Note:</strong> Self-entered My Goals are no longer available
             on My HealtheVet and not included in this report. To download your

--- a/src/applications/mhv-medical-records/sass/medical-records.scss
+++ b/src/applications/mhv-medical-records/sass/medical-records.scss
@@ -144,7 +144,7 @@ va-loading-indicator {
   margin: initial;
 }
 
-#generating-ccd-indicator va-loading-indicator {
+.generating-dl-indicator va-loading-indicator {
   margin: 0px;
 }
 

--- a/src/applications/mhv-medical-records/sass/medical-records.scss
+++ b/src/applications/mhv-medical-records/sass/medical-records.scss
@@ -144,7 +144,8 @@ va-loading-indicator {
   margin: initial;
 }
 
-.generating-dl-indicator va-loading-indicator {
+#generating-ccd-indicator va-loading-indicator,
+#generating-sei-indicator va-loading-indicator {
   margin: 0px;
 }
 

--- a/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
@@ -165,6 +165,21 @@ describe('DownloadRecordsPage triggering SEI PDF download', () => {
     fireEvent.click(downloadButton);
     expect(downloadButton).to.exist;
   });
+
+  it('generates sei pdf on button click', () => {
+    const seiAccordion = screen.getByTestId('selfEnteredAccordionItem');
+    expect(seiAccordion).to.exist;
+
+    fireEvent.click(seiAccordion);
+    const seiGenerateButton = screen.getByTestId('downloadSelfEnteredButton');
+    expect(seiGenerateButton).to.exist;
+
+    fireEvent.click(seiGenerateButton);
+    waitFor(() => {
+      expect(screen.container.querySelector('#generating-sei-indicator')).to
+        .exist;
+    });
+  });
 });
 
 describe('DownloadRecordsPage with a general BB download error', () => {


### PR DESCRIPTION
## Summary
Implemented a loading spinner for self-entered pdf generation. This mimicks the same behavior as ccd download. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-65293

> ### Self-entered pdf download spinner

## Testing done
Unit test written for the new spinner

## Screenshots
<img width="737" alt="Screenshot 2024-12-16 at 4 50 45 PM" src="https://github.com/user-attachments/assets/cb34abfc-458b-4024-8ff7-e0f9f99d96b5" />
<img width="696" alt="Screenshot 2024-12-16 at 4 50 59 PM" src="https://github.com/user-attachments/assets/adf370db-85d0-4c4e-9736-8cba4a35a239" />

## What areas of the site does it impact?
MHV medical records downloads page

## Acceptance criteria
Loading spinner works for self entered pdf download

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
