### PR TITLE
98936 Text updates - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
@@ -26,7 +26,7 @@ export const certifierRoleSchema = {
       required: () => true,
       labels: {
         applicant: 'I’m the beneficiary submitting a claim for myself',
-        sponsor: 'I’m a Veteran submitting a claim for my spouse or dependant',
+        sponsor: 'I’m a Veteran submitting a claim for my spouse or dependent',
         other:
           'I’m a representative submitting a claim on behalf of the beneficiary',
       },

--- a/src/applications/ivc-champva/10-7959a/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/sponsorInformation.js
@@ -21,7 +21,7 @@ fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 const sponsorHint = (
   <>
     You selected that you’re the Veteran filling out this form for your spouse
-    or dependant. This means that you’re their sponsor (this is the Veteran or
+    or dependent. This means that you’re their sponsor (this is the Veteran or
     service member the beneficiary is connected to).
     <br />
     <br />

--- a/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
@@ -33,8 +33,7 @@ export default function IntroductionPage(props) {
         <li>
           You must file your claim within <b>1 year</b> of when you got the
           care. And if you stayed at a hospital for care, you must file your
-          claim within
-          <b>1 year</b> of when you left the hospital.
+          claim within <b>1 year</b> of when you left the hospital.
         </li>
         <li>
           Each claim needs its own {appType}. If you need to submit more than


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds a space on the intro page
- Updates spelling from `dependant` to `dependent`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98936#issuecomment-2546990759

## Testing done

- Manual

## Screenshots

| | |
|-|-|
|![Image](https://github.com/user-attachments/assets/11c13815-d4ec-4268-90ee-6188880eac95)|![Image](https://github.com/user-attachments/assets/b874c89e-6250-4777-a949-c12e6035e5b5)|
|![Image](https://github.com/user-attachments/assets/7c0cf2fd-0fa4-4c72-bb24-992e2a2b0bc3)| |

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA