### PR TITLE
update verify alert content to use service branded buttons

### DIFF
--- a/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.jsx
@@ -25,7 +25,7 @@ const AlertMhvBasicAccount = ({ headline, recordEvent, testId }) => {
       <div>
         <p className="vads-u-margin-y--0">
           We need you to sign in with an identity-verified account. This helps
-          us protect all Veterans' information and prevent scammers from
+          us protect all Veterans’ information and prevent scammers from
           stealing your benefits. You have 2 options: a verified{' '}
           <strong>Login.gov</strong> or a verified <strong>ID.me</strong>{' '}
           account.

--- a/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.jsx
@@ -2,14 +2,11 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
-import { logoutUrl } from '@department-of-veterans-affairs/platform-user/authentication/utilities';
-import { logoutUrlSiS } from '~/platform/utilities/oauth/utilities';
-import {
-  VaAlert,
-  VaButton,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { CSP_IDS } from '~/platform/user/authentication/constants';
+import { VerifyButton } from '~/platform/user/authentication/components/VerifyButton';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-const AlertMhvBasicAccount = ({ headline, recordEvent, testId, ssoe }) => {
+const AlertMhvBasicAccount = ({ headline, recordEvent, testId }) => {
   useEffect(
     () => {
       recordEvent({
@@ -22,87 +19,50 @@ const AlertMhvBasicAccount = ({ headline, recordEvent, testId, ssoe }) => {
     [headline, recordEvent],
   );
 
-  const signOut = () => {
-    window.location = ssoe ? logoutUrl() : logoutUrlSiS();
-  };
-
   return (
     <VaAlert status="warning" data-testid={testId} disableAnalytics>
       <h2 slot="headline">{headline}</h2>
       <div>
         <p className="vads-u-margin-y--0">
-          To protect your health information and prevent fraud and identity
-          theft, we can only give you access when you sign in with a verified
-          account. You have 2 options: a verified <b>Login.gov</b> or a verified{' '}
-          <b>ID.me</b> account.
+          We need you to sign in with an identity-verified account. This helps
+          us protect all Veterans' information and prevent scammers from
+          stealing your benefits. You have 2 options: a verified{' '}
+          <strong>Login.gov</strong> or a verified <strong>ID.me</strong>{' '}
+          account.
         </p>
         <p>
-          <b>If you already have a Login.gov or ID.me account</b>, sign out of
-          VA.gov. Then sign back in using that account. We’ll tell you if you
-          need to verify your identity or take any other steps.
+          <strong>If you already have a Login.gov or ID.me account,</strong>{' '}
+          sign in with that account. If you still need to verify your identity
+          for your account, we’ll help you do that now.
         </p>
         <p>
-          <b>If you want to create an account now</b>, follow these steps:
-        </p>
-        <ul>
-          <li>Sign out of VA.gov</li>
-          <li>
-            On the VA.gov homepage, select <b>Create an account</b>. Create a{' '}
-            <b>Login.gov</b> or <b>ID.me</b> account.
-          </li>
-          <li>
-            Come back to VA.gov and sign in with your <b>Login.gov</b> or{' '}
-            <b>ID.me</b> account. We’ll help you verify your identity and
-            register your account to access My HealtheVet on VA.gov.
-          </li>
-        </ul>
-        <p>
-          <b>Not sure if you already have a Login.gov or ID.me account?</b>
+          <strong>If you don’t have a Login.gov or ID.me account,</strong>{' '}
+          create one now. We’ll help you verify your identity.
         </p>
         <p>
-          You may have one if you’ve ever signed in to a federal website to
-          manage your benefits—like Social Security or disability benefits. Or
-          we may have started creating an <b>ID.me</b> account for you when you
-          signed in to VA.gov.
+          <VerifyButton csp={CSP_IDS.LOGIN_GOV} />
         </p>
         <p>
-          To check, sign out of VA.gov. Then try to create a <b>Login.gov</b> or{' '}
-          <b>ID.me</b>
-          account with the email address you think you may have used for that
-          account in the past. If you already have an account, the sign-in
-          service provider will tell you. You can then try to reset your
-          password for that account.
+          <VerifyButton csp={CSP_IDS.ID_ME} />
         </p>
-        <div className="vads-u-margin-top--2">
-          <VaButton
-            data-testid="mhv-button--sign-out"
-            label="Sign out"
-            onClick={signOut}
-            text="Sign out"
-          />
-        </div>
-        <p className="vads-u-margin-top--2">
-          <a href="/resources/how-to-access-my-healthevet-on-vagov">
-            Learn more about how to access My HealtheVet on VA.gov
-          </a>
-        </p>
+        <va-link
+          href="/resources/creating-an-account-for-vagov/"
+          text="Learn about creating an account"
+        />
       </div>
     </VaAlert>
   );
 };
 
 AlertMhvBasicAccount.defaultProps = {
-  headline:
-    'You need to sign in with a different account to access My HealtheVet',
+  headline: 'You need to sign in with a different account',
   recordEvent: recordEventFn,
-  ssoe: false,
   testId: 'mhv-alert--mhv-basic-account',
 };
 
 AlertMhvBasicAccount.propTypes = {
   headline: PropTypes.string,
   recordEvent: PropTypes.func,
-  ssoe: PropTypes.bool,
   testId: PropTypes.string,
 };
 

--- a/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.jsx
@@ -5,7 +5,10 @@ import {
   CSP_IDS,
   SERVICE_PROVIDERS,
 } from '~/platform/user/authentication/constants';
-
+import {
+  VerifyIdmeButton,
+  VerifyLogingovButton,
+} from '~/platform/user/authentication/components/VerifyButton';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 
@@ -14,13 +17,12 @@ import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/
 const AlertVerifyAndRegister = ({ cspId, recordEvent, testId }) => {
   const headline = 'Verify your identity';
   const serviceProviderLabel = SERVICE_PROVIDERS[cspId].label;
-  const verifyIdentityUrl = {
-    [CSP_IDS.LOGIN_GOV]:
-      '/resources/how-to-verify-your-identity-for-your-logingov-account/',
-    [CSP_IDS.ID_ME]:
-      '/resources/how-to-verify-your-identity-for-your-idme-account/',
-  };
-  const learnHowToVerifyIdentityUrl = verifyIdentityUrl[cspId];
+  const verifyServiceButton =
+    cspId === CSP_IDS.LOGIN_GOV ? (
+      <VerifyLogingovButton />
+    ) : (
+      <VerifyIdmeButton />
+    );
 
   useEffect(
     () => {
@@ -39,8 +41,8 @@ const AlertVerifyAndRegister = ({ cspId, recordEvent, testId }) => {
       <h2 slot="headline">{headline}</h2>
       <div>
         <p className="vads-u-margin-y--2">
-          We need you to verify your identity for your
-          <strong> {serviceProviderLabel}</strong> account. This step helps us
+          We need you to verify your identity for your{' '}
+          <strong>{serviceProviderLabel}</strong> account. This step helps us
           protect all Veterans’ information and prevent scammers from stealing
           your benefits.
         </p>
@@ -48,16 +50,11 @@ const AlertVerifyAndRegister = ({ cspId, recordEvent, testId }) => {
           This one-time process often takes about 10 minutes. You’ll need to
           provide certain personal information and identification.
         </p>
-        <p>
-          <a href="/verify" className="vads-c-action-link--green">
-            Verify your identity with {serviceProviderLabel}
-          </a>
-        </p>
-        <p>
-          <a href={learnHowToVerifyIdentityUrl}>
-            Learn more about verifying your identity
-          </a>
-        </p>
+        <p>{verifyServiceButton}</p>
+        <va-link
+          href="/resources/verifying-your-identity-on-vagov/"
+          text="Learn more about verifying your identity"
+        />
       </div>
     </VaAlert>
   );

--- a/src/applications/mhv-landing-page/containers/Alerts.jsx
+++ b/src/applications/mhv-landing-page/containers/Alerts.jsx
@@ -29,7 +29,7 @@ const Alerts = () => {
   const ssoe = useSelector(isAuthenticatedWithSSOe);
 
   if (userHasMhvBasicAccount) {
-    return <AlertMhvBasicAccount ssoe={ssoe} />;
+    return <AlertMhvBasicAccount />;
   }
 
   if (renderVerifyAndRegisterAlert) {

--- a/src/applications/mhv-landing-page/tests/components/alerts/AlertMhvBasicAccount.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/components/alerts/AlertMhvBasicAccount.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
@@ -8,38 +9,22 @@ import AlertMhvBasicAccount from '../../../components/alerts/AlertMhvBasicAccoun
 
 const { defaultProps } = AlertMhvBasicAccount;
 
-const generateStore = ({
-  csp = 'logingov',
-  verified = false,
-  loading = false,
-} = {}) => ({
-  getState: () => ({
-    user: {
-      profile: {
-        loading,
-        signIn: { serviceName: csp },
-        verified,
-        session: { authBroker: 'iam' },
-      },
-    },
-  }),
-  dispatch: () => {},
-  subscribe: () => {},
-});
+const mockStore = createMockStore([]);
 
 describe('<AlertMhvBasicAccount />', () => {
   it('renders', async () => {
-    const store = generateStore();
     const recordEvent = sinon.spy();
     const props = { ...defaultProps, recordEvent };
     const { getByRole, getByTestId } = render(
-      <Provider store={store}>
+      <Provider store={mockStore()}>
         <AlertMhvBasicAccount {...props} />,
       </Provider>,
     );
     getByTestId(defaultProps.testId);
 
     getByRole('heading', { name: defaultProps.headline });
+    expect(getByRole('button', { name: /Verify with ID.me/ })).to.exist;
+    expect(getByRole('button', { name: /Verify with Login.gov/ })).to.exist;
     await waitFor(() => {
       expect(recordEvent.calledOnce).to.be.true;
       expect(recordEvent.calledTwice).to.be.false;

--- a/src/applications/mhv-landing-page/tests/components/alerts/AlertMhvBasicAccount.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/components/alerts/AlertMhvBasicAccount.unit.spec.jsx
@@ -1,47 +1,48 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
-import { logoutUrl } from '@department-of-veterans-affairs/platform-user/authentication/utilities';
-import { logoutUrlSiS } from '~/platform/utilities/oauth/utilities';
 
 import AlertMhvBasicAccount from '../../../components/alerts/AlertMhvBasicAccount';
 
 const { defaultProps } = AlertMhvBasicAccount;
 
+const generateStore = ({
+  csp = 'logingov',
+  verified = false,
+  loading = false,
+} = {}) => ({
+  getState: () => ({
+    user: {
+      profile: {
+        loading,
+        signIn: { serviceName: csp },
+        verified,
+        session: { authBroker: 'iam' },
+      },
+    },
+  }),
+  dispatch: () => {},
+  subscribe: () => {},
+});
+
 describe('<AlertMhvBasicAccount />', () => {
   it('renders', async () => {
+    const store = generateStore();
     const recordEvent = sinon.spy();
     const props = { ...defaultProps, recordEvent };
     const { getByRole, getByTestId } = render(
-      <AlertMhvBasicAccount {...props} />,
+      <Provider store={store}>
+        <AlertMhvBasicAccount {...props} />,
+      </Provider>,
     );
     getByTestId(defaultProps.testId);
+
     getByRole('heading', { name: defaultProps.headline });
     await waitFor(() => {
       expect(recordEvent.calledOnce).to.be.true;
       expect(recordEvent.calledTwice).to.be.false;
-    });
-  });
-
-  describe('Sign out button', () => {
-    it('redirects to logoutUrlSis() when ssoe is false', async () => {
-      const props = { ...defaultProps, ssoe: false };
-      const { getByTestId } = render(<AlertMhvBasicAccount {...props} />);
-      getByTestId('mhv-button--sign-out').click();
-      await waitFor(() => {
-        expect(window.location).to.equal(logoutUrlSiS());
-      });
-    });
-
-    it('redirects to logoutUrl() when ssoe is true', async () => {
-      const props = { ...defaultProps, ssoe: true };
-      const { getByTestId } = render(<AlertMhvBasicAccount {...props} />);
-      getByTestId('mhv-button--sign-out').click();
-      await waitFor(() => {
-        expect(window.location).to.equal(logoutUrl());
-      });
     });
   });
 });

--- a/src/applications/mhv-landing-page/tests/components/alerts/AlertVerifyAndRegister.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/components/alerts/AlertVerifyAndRegister.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -7,11 +8,35 @@ import AlertVerifyAndRegister from '../../../components/alerts/AlertVerifyAndReg
 
 const { defaultProps } = AlertVerifyAndRegister;
 
+const generateStore = ({
+  csp = 'logingov',
+  verified = false,
+  loading = false,
+} = {}) => ({
+  getState: () => ({
+    user: {
+      profile: {
+        loading,
+        signIn: { serviceName: csp },
+        verified,
+        session: { authBroker: 'iam' },
+      },
+    },
+  }),
+  dispatch: () => {},
+  subscribe: () => {},
+});
+
 describe('<AlertVerifyAndRegister />', () => {
   it('renders', async () => {
+    const store = generateStore();
     const recordEvent = sinon.spy();
     const props = { recordEvent };
-    const { getByTestId } = render(<AlertVerifyAndRegister {...props} />);
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <AlertVerifyAndRegister {...props} />
+      </Provider>,
+    );
     getByTestId(defaultProps.testId);
     await waitFor(() => {
       expect(recordEvent.calledOnce).to.be.true;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

With the [VADS components alert-sign-in added but not ready for usage yet](https://design.va.gov/components/alert/alert-sign-in/), we need to update the custom alerts to reflect the VADS alert content & service specific buttons:
- "Verify" – Login.gov acct
- "Verify" – ID.me acct
- "Sign in with a different credential" for MHV Basic accts

## Related issue(s)

department-of-veterans-affairs/va.gov-team/issues/98854


## Testing done

- Manual testing in local development:
  - `yarn watch` from `vets-website`
  - Run `yarn mock-api --responses src/applications/mhv-landing-page/mocks/api/index.js`, and set users to:
     - USER_MOCKS.UNVERIFIED for ID.me account sign-in, then
     - USER_MOCKS.LOGIN_GOV_UNVERIFIED for Login.gov account sign-in
     - USER_MOCKS.MHV_BASIC_ACCOUNT for MHV basic account sign-in

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="297" alt="Screenshot 2024-12-17 at 10 30 51 AM" src="https://github.com/user-attachments/assets/3f54273f-2ee1-4186-ab63-a6016283d444" />     |   <img width="377" alt="Screenshot 2024-12-16 at 5 37 22 PM" src="https://github.com/user-attachments/assets/b9bffaf4-a1a1-46b8-952d-6893f80aff7d" />    |
| Desktop |   <img width="869" alt="Screenshot 2024-12-17 at 10 30 33 AM" src="https://github.com/user-attachments/assets/f63b776b-ccf1-483a-948a-0057b6f7891a" />     |   <img width="1013" alt="Screenshot 2024-12-16 at 5 37 03 PM" src="https://github.com/user-attachments/assets/4c84d252-fb90-4919-92ea-99064581010a" />    |
| Mobile  |    <img width="369" alt="Screenshot 2024-12-17 at 10 31 51 AM" src="https://github.com/user-attachments/assets/873ae686-5067-445c-aae2-dca358732a43" />    |    <img width="375" alt="Screenshot 2024-12-16 at 5 39 11 PM" src="https://github.com/user-attachments/assets/fb20d689-0638-460a-ac7b-d15583032cf1" />   |
| Desktop |   <img width="880" alt="Screenshot 2024-12-17 at 10 32 05 AM" src="https://github.com/user-attachments/assets/366d6d60-b4a7-456f-aa9d-7040afe743b4" />     |   <img width="1016" alt="Screenshot 2024-12-16 at 5 38 53 PM" src="https://github.com/user-attachments/assets/d3abcbb1-8c46-4982-a934-ed2effed71dd" />    |
| Mobile  |    <img width="196" alt="Screenshot 2024-12-17 at 10 29 28 AM" src="https://github.com/user-attachments/assets/8942a23c-dcb4-43f4-a2dc-717e32a8ac96" />    |   <img width="376" alt="Screenshot 2024-12-16 at 5 31 55 PM" src="https://github.com/user-attachments/assets/116f1d87-a98b-4ca4-abad-58427c9a6bcb" />    |
| Desktop |  <img width="869" alt="Screenshot 2024-12-17 at 10 28 43 AM" src="https://github.com/user-attachments/assets/73503cc4-1fa4-4ddd-98f1-5d1e85ee5100" />     |    <img width="1019" alt="Screenshot 2024-12-16 at 5 31 08 PM" src="https://github.com/user-attachments/assets/58182c3c-aabf-4737-a4d0-a481c218e890" />   |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
