### PR TITLE
MHV-65298 Settings-Updates-Found In-Testing

### DIFF
--- a/src/applications/mhv-medical-records/containers/SettingsPage.jsx
+++ b/src/applications/mhv-medical-records/containers/SettingsPage.jsx
@@ -295,10 +295,7 @@ const SettingsPage = () => {
         <p>
           <ExternalLink
             ddTag="Go to your profile on MHV"
-            href={mhvUrl(
-              isAuthenticatedWithSSOe(fullState),
-              'download-my-data',
-            )}
+            href={mhvUrl(isAuthenticatedWithSSOe(fullState), 'profiles')}
             text="Go to your profile on the My Healthevet website"
           />
         </p>


### PR DESCRIPTION
## Summary
Updated SettingsPage.js to manage your notification settings under the "Profiles" section instead of "Download My Data."

## Related issue(s)

[65298](https://jira.devops.va.gov/browse/MHV-65298) - Settings Updates found in Testing

SETTINGS

1. Medical Record Settings-> Manage your notification settings has a link for your profile page on MyHealtheVet-but it takes you to Download My Data page instead-- see attachments.  should be /profiles instead of the /download-my-data

## Testing done
Testing  the availability of the link 

## What areas of the site does it impact?
Settings section in medical records. 

## Acceptance criteria
User can view the profile page link

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
