### PR TITLE
Update MHV verify sign-in widget

### DIFF
--- a/src/applications/static-pages/mhv-signin-cta/components/messages/CustomAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/CustomAlert.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
  * Custom alert similar to VAAlert that allows to set the icon.
  * @property {*} children the children components to include inside the alert
  * @property {bool} disableAnalytics true to disable analytics
+ * @property {number} headerLevel the heading level
  * @property {string} headline the text for the headline of the alert
  * @property {*} recordEvent the function to record the event
  * @property {string} status the status of the alert ('info', 'success', 'warning' or 'continue')
@@ -15,6 +16,7 @@ import classNames from 'classnames';
  */
 const CustomAlert = ({
   children,
+  headerLevel = 2,
   headline,
   recordEvent,
   status = 'info',
@@ -40,13 +42,15 @@ const CustomAlert = ({
     'mhv-u-reg-alert-info': status === 'info',
   });
 
+  const CustomHeaderLevel = `h${headerLevel}`;
+
   return (
     <div className={alertClasses} data-testid="mhv-custom-alert">
       <va-icon icon={icon} size={4} data-testid="mhv-custom-alert-icon" />
       <div className="mhv-u-reg-alert-col vads-u-flex-direction--col">
-        <h2 className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+        <CustomHeaderLevel className="vads-u-margin-top--0 vads-u-margin-bottom--1">
           {headline}
-        </h2>
+        </CustomHeaderLevel>
         <div className="mhv-u-reg-alert-body" role="presentation">
           {children}
         </div>
@@ -62,6 +66,7 @@ CustomAlert.defaultProps = {
 CustomAlert.propTypes = {
   children: PropTypes.any.isRequired,
   headline: PropTypes.string.isRequired,
+  headerLevel: PropTypes.number,
   icon: PropTypes.string,
   recordEvent: PropTypes.func,
   status: PropTypes.oneOf(['info', 'success', 'warning', 'continue']),

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
@@ -18,7 +18,7 @@ const UnauthenticatedAlert = ({ recordEvent, serviceDescription }) => {
 
   const dispatch = useDispatch();
   const handleSignIn = () => {
-    dispatch(toggleLoginModal(true, 'mhv-signin-cta'));
+    dispatch(toggleLoginModal(true, 'mhv-signin-cta', true));
   };
 
   return (
@@ -52,12 +52,10 @@ const UnauthenticatedAlert = ({ recordEvent, serviceDescription }) => {
               text="Sign in or create an account"
             />
           </p>
-          <p>
-            <va-link
-              href="/resources/creating-an-account-for-vagov/"
-              text="Learn about creating an account"
-            />
-          </p>
+          <va-link
+            href="/resources/creating-an-account-for-vagov/"
+            text="Learn about creating an account"
+          />
         </div>
       </CustomAlert>
     </div>

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
@@ -8,10 +8,15 @@ export const headingPrefix = 'Sign in with a verified account';
 
 /**
  * Alert to show a user that is not logged in.
+ * @property {number} headerLevel the heading level
  * @property {*} recordEvent the function to record the event
  * @property {string} serviceDescription the description of the service that requires verification
  */
-const UnauthenticatedAlert = ({ recordEvent, serviceDescription }) => {
+const UnauthenticatedAlert = ({
+  headerLevel,
+  recordEvent,
+  serviceDescription,
+}) => {
   const headline = serviceDescription
     ? `${headingPrefix} to ${serviceDescription}`
     : headingPrefix;
@@ -24,6 +29,7 @@ const UnauthenticatedAlert = ({ recordEvent, serviceDescription }) => {
   return (
     <div data-testid="mhv-unauthenticated-alert">
       <CustomAlert
+        headerLevel={headerLevel}
         headline={headline}
         icon="lock"
         status="info"
@@ -63,6 +69,7 @@ const UnauthenticatedAlert = ({ recordEvent, serviceDescription }) => {
 };
 
 UnauthenticatedAlert.propTypes = {
+  headerLevel: PropTypes.number,
   recordEvent: PropTypes.func,
   serviceDescription: PropTypes.string,
 };

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
@@ -6,8 +6,11 @@ import {
   SERVICE_PROVIDERS,
   CSP_IDS,
 } from '@department-of-veterans-affairs/platform-user/authentication/constants';
-import { logoutUrl } from '@department-of-veterans-affairs/platform-user/authentication/utilities';
-import { logoutUrlSiS } from '~/platform/utilities/oauth/utilities';
+import {
+  VerifyButton,
+  VerifyIdmeButton,
+  VerifyLogingovButton,
+} from '~/platform/user/authentication/components/VerifyButton';
 import CustomAlert from './CustomAlert';
 
 export const headingPrefix = 'Verify your identity';
@@ -19,7 +22,6 @@ export const headingPrefix = 'Verify your identity';
  * @property {string} signInService the ID of the sign in service
  */
 const UnverifiedAlert = ({
-  hasSsoe = false,
   recordEvent = recordEventFn,
   serviceDescription,
   signInService = CSP_IDS.ID_ME,
@@ -28,13 +30,12 @@ const UnverifiedAlert = ({
   const headline = serviceDescription
     ? `${headingPrefix} to ${serviceDescription}`
     : headingPrefix;
-
-  /**
-   * Directs the user to the sign out page.
-   */
-  const signOut = () => {
-    window.location = hasSsoe ? logoutUrl() : logoutUrlSiS();
-  };
+  const verifyServiceButton =
+    signInService === CSP_IDS.LOGIN_GOV ? (
+      <VerifyLogingovButton />
+    ) : (
+      <VerifyIdmeButton />
+    );
 
   /**
    * The default alert to show a user.
@@ -52,20 +53,19 @@ const UnverifiedAlert = ({
             <p>
               We need you to verify your identity for your{' '}
               <strong>{signinServiceLabel}</strong> account. This step helps us
-              keep your information safe and prevent fraud and identity theft.
+              protect all Veterans’ information and prevent scammers from
+              stealing your benefits.
             </p>
             <p>
               This one-time process often takes about 10 minutes. You’ll need to
               provide certain personal information and identification.
             </p>
+            <p>{verifyServiceButton}</p>
             <p>
-              <a
-                className="vads-c-action-link--green"
+              <va-link
                 href="/resources/verifying-your-identity-on-vagov/"
-                hrefLang="en"
-              >
-                Verify your identity with {signinServiceLabel}
-              </a>
+                text="Learn more about verifying your identity"
+              />
             </p>
           </div>
         </CustomAlert>
@@ -81,60 +81,31 @@ const UnverifiedAlert = ({
       <CustomAlert headline={headline} icon="lock" status="warning">
         <div>
           <p>
-            To protect your information and prevent fraud and identity theft, we
-            need you to sign in with a verified account. You have 2 options: a
-            verified <strong>Login.gov</strong> or a verified{' '}
-            <strong>ID.me</strong> account.
+            We need you to sign in with an identity-verified account. This helps
+            us protect all Veterans’ information and prevent scammers from
+            stealing your benefits. You have 2 options: a verified{' '}
+            <strong>Login.gov</strong> or a verified <strong>ID.me</strong>{' '}
+            account.
           </p>
           <p>
             <strong>If you already have a Login.gov or ID.me account,</strong>{' '}
-            sign out of VA.gov. Then sign back in using that account. We’ll tell
-            you if you need to verify your identity.
+            sign in with that account. If you still need to verify your identity
+            for your account, we’ll help you do that now.
           </p>
           <p>
-            <strong>If you want to create a Login.gov or ID.me account,</strong>{' '}
-            follow these steps:
+            <strong>If you don’t have a Login.gov or ID.me account,</strong>{' '}
+            create one now. We’ll help you verify your identity.
           </p>
           <p>
-            <strong>
-              Not sure if you already have a Login.gov or ID.me account?
-            </strong>
-          </p>
-          <ul>
-            <li>Sign out of VA.gov</li>
-            <li>On the VA.gov homepage, select Create an account</li>
-            <li>
-              Create a Login.gov or ID.me account. Come back to VA.gov and sign
-              in with your Login.gov or ID.me account. We’ll help you verify
-              your identity.
-            </li>
-          </ul>
-          <p>
-            You may have one if you’ve ever signed in to a federal website to
-            manage your benefits—like Social Security or disability benefits. Or
-            we may have started creating an <strong>ID.me</strong> account for
-            you when you signed in to VA.gov.
+            <VerifyButton csp={CSP_IDS.LOGIN_GOV} />
           </p>
           <p>
-            To check, sign out of VA.gov. Then try to create a new account with
-            the email address you think the account is attached to. If you
-            already have one, the sign-in service provider will tell you. You
-            can then try to reset your password.
+            <VerifyButton csp={CSP_IDS.ID_ME} />
           </p>
-          <p>
-            <va-button
-              data-testid="sign-out-button"
-              text="Sign out"
-              onClick={signOut}
-              label="Sign out"
-            />
-          </p>
-          <p>
-            <va-link
-              href="/resources/creating-an-account-for-vagov/"
-              text="Learn about creating an account"
-            />
-          </p>
+          <va-link
+            href="/resources/creating-an-account-for-vagov/"
+            text="Learn about creating an account"
+          />
         </div>
       </CustomAlert>
     );
@@ -147,7 +118,6 @@ const UnverifiedAlert = ({
 
 UnverifiedAlert.propTypes = {
   signInService: PropTypes.string.isRequired,
-  hasSsoe: PropTypes.bool,
   recordEvent: PropTypes.func,
   serviceDescription: PropTypes.string,
 };

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
@@ -14,22 +14,25 @@ import {
 import CustomAlert from './CustomAlert';
 
 export const headingPrefix = 'Verify your identity';
+export const mhvHeadingPrefix = 'You need to sign in with a different account';
 
 /**
  * Alert to show a user that is not verified (LOA1).
+ * @property {number} headerLevel the heading level
  * @property {*} recordEvent the function to record the event
  * @property {string} serviceDescription optional description of the service that requires verification
  * @property {string} signInService the ID of the sign in service
  */
 const UnverifiedAlert = ({
+  headerLevel,
   recordEvent = recordEventFn,
   serviceDescription,
   signInService = CSP_IDS.ID_ME,
 }) => {
   /**
-   * The default alert to show a user.
+   * The verify service alert to show a user that is logged in with Login.gov or ID.me.
    */
-  const DefaultAlert = () => {
+  const VerifyServiceAlert = () => {
     const signinServiceLabel = SERVICE_PROVIDERS[signInService]?.label;
     const headline = serviceDescription
       ? `${headingPrefix} to ${serviceDescription}`
@@ -43,6 +46,7 @@ const UnverifiedAlert = ({
     return (
       <div data-testid="mhv-unverified-alert">
         <CustomAlert
+          headerLevel={headerLevel}
           headline={headline}
           icon="lock"
           status="warning"
@@ -76,12 +80,16 @@ const UnverifiedAlert = ({
    * The alert to show a user that is logged in with an MHV account.
    */
   const MhvAlert = () => {
-    const mhvHeadingPrefix = 'You need to sign in with a different account';
     const headline = serviceDescription
       ? `${mhvHeadingPrefix} to ${serviceDescription}`
       : mhvHeadingPrefix;
     return (
-      <CustomAlert headline={headline} icon="lock" status="warning">
+      <CustomAlert
+        headerLevel={headerLevel}
+        headline={headline}
+        icon="lock"
+        status="warning"
+      >
         <div>
           <p>
             We need you to sign in with an identity-verified account. This helps
@@ -114,13 +122,15 @@ const UnverifiedAlert = ({
     );
   };
 
-  if (signInService === CSP_IDS.MHV) return MhvAlert();
+  if ([CSP_IDS.ID_ME, CSP_IDS.LOGIN_GOV].includes(signInService))
+    return VerifyServiceAlert();
 
-  return DefaultAlert();
+  return MhvAlert();
 };
 
 UnverifiedAlert.propTypes = {
   signInService: PropTypes.string.isRequired,
+  headerLevel: PropTypes.number,
   recordEvent: PropTypes.func,
   serviceDescription: PropTypes.string,
 };

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnverifiedAlert.jsx
@@ -26,21 +26,20 @@ const UnverifiedAlert = ({
   serviceDescription,
   signInService = CSP_IDS.ID_ME,
 }) => {
-  const signinServiceLabel = SERVICE_PROVIDERS[signInService]?.label;
-  const headline = serviceDescription
-    ? `${headingPrefix} to ${serviceDescription}`
-    : headingPrefix;
-  const verifyServiceButton =
-    signInService === CSP_IDS.LOGIN_GOV ? (
-      <VerifyLogingovButton />
-    ) : (
-      <VerifyIdmeButton />
-    );
-
   /**
    * The default alert to show a user.
    */
   const DefaultAlert = () => {
+    const signinServiceLabel = SERVICE_PROVIDERS[signInService]?.label;
+    const headline = serviceDescription
+      ? `${headingPrefix} to ${serviceDescription}`
+      : headingPrefix;
+    const verifyServiceButton =
+      signInService === CSP_IDS.LOGIN_GOV ? (
+        <VerifyLogingovButton />
+      ) : (
+        <VerifyIdmeButton />
+      );
     return (
       <div data-testid="mhv-unverified-alert">
         <CustomAlert
@@ -77,6 +76,10 @@ const UnverifiedAlert = ({
    * The alert to show a user that is logged in with an MHV account.
    */
   const MhvAlert = () => {
+    const mhvHeadingPrefix = 'You need to sign in with a different account';
+    const headline = serviceDescription
+      ? `${mhvHeadingPrefix} to ${serviceDescription}`
+      : mhvHeadingPrefix;
     return (
       <CustomAlert headline={headline} icon="lock" status="warning">
         <div>

--- a/src/applications/static-pages/mhv-signin-cta/index.js
+++ b/src/applications/static-pages/mhv-signin-cta/index.js
@@ -13,12 +13,14 @@ import UnverifiedAlert from './components/messages/UnverifiedAlert';
 /**
  * MHV Signin CTA widget. This widget displays an alert if the user is not authenticated or verified.
  * Otherwise, it displays provided HTML content.
+ * @property {number} headerLevel the heading level
  * @property {HTMLElement} noAlertContent optional content to display if no alerts are shown
  * @property {String} signInServiceName the signin service name is available
  * @property {bool} userIsLoggedIn true if the user is logged in
  * @property {bool} userIsVerified true if the user is verified
  */
 export const MhvSigninCallToAction = ({
+  headerLevel,
   noAlertContent,
   serviceDescription,
   serviceName,
@@ -26,12 +28,18 @@ export const MhvSigninCallToAction = ({
   userIsVerified = false,
 }) => {
   if (!userIsLoggedIn) {
-    return <UnauthenticatedAlert serviceDescription={serviceDescription} />;
+    return (
+      <UnauthenticatedAlert
+        headerLevel={headerLevel}
+        serviceDescription={serviceDescription}
+      />
+    );
   }
 
   if (!userIsVerified) {
     return (
       <UnverifiedAlert
+        headerLevel={headerLevel}
         signInService={serviceName}
         serviceDescription={serviceDescription}
       />
@@ -50,6 +58,7 @@ export const MhvSigninCallToAction = ({
 };
 
 MhvSigninCallToAction.propTypes = {
+  headerLevel: PropTypes.number,
   noAlertContent: PropTypes.instanceOf(HTMLElement),
   serviceDescription: PropTypes.string,
   serviceName: PropTypes.string,

--- a/src/applications/static-pages/mhv-signin-cta/index.js
+++ b/src/applications/static-pages/mhv-signin-cta/index.js
@@ -2,10 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import DOMPurify from 'dompurify';
-import {
-  signInServiceName,
-  isAuthenticatedWithSSOe,
-} from '@department-of-veterans-affairs/platform-user/authentication/selectors';
+import { signInServiceName } from '@department-of-veterans-affairs/platform-user/authentication/selectors';
 import {
   isLoggedIn,
   isLOA3,
@@ -22,7 +19,6 @@ import UnverifiedAlert from './components/messages/UnverifiedAlert';
  * @property {bool} userIsVerified true if the user is verified
  */
 export const MhvSigninCallToAction = ({
-  hasSsoe = false,
   noAlertContent,
   serviceDescription,
   serviceName,
@@ -36,7 +32,6 @@ export const MhvSigninCallToAction = ({
   if (!userIsVerified) {
     return (
       <UnverifiedAlert
-        hasSsoe={hasSsoe}
         signInService={serviceName}
         serviceDescription={serviceDescription}
       />
@@ -55,7 +50,6 @@ export const MhvSigninCallToAction = ({
 };
 
 MhvSigninCallToAction.propTypes = {
-  hasSsoe: PropTypes.bool,
   noAlertContent: PropTypes.instanceOf(HTMLElement),
   serviceDescription: PropTypes.string,
   serviceName: PropTypes.string,
@@ -70,7 +64,6 @@ MhvSigninCallToAction.propTypes = {
  */
 export const mapStateToProps = state => {
   return {
-    hasSsoe: isAuthenticatedWithSSOe(state),
     serviceName: signInServiceName(state),
     userIsLoggedIn: isLoggedIn(state),
     userIsVerified: isLOA3(state),

--- a/src/applications/static-pages/mhv-signin-cta/sass/mhv-signin-cta.scss
+++ b/src/applications/static-pages/mhv-signin-cta/sass/mhv-signin-cta.scss
@@ -1,5 +1,10 @@
 @import "~@department-of-veterans-affairs/css-library/dist/tokens/scss/variables";
 
+// Override VSDS Alert component icon to fix overlapping custom icon
+.usa-alert::before {
+  background-image: none;
+}
+
 // Match the va-alert styling.
 .mhv-c-reg-alert {
   border-left: 0.5rem solid;

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/CustomAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/CustomAlert.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('Custom Alert component', () => {
           <p>{contentText}</p>
         </CustomAlert>,
       );
-      expect(getByRole('heading', { name: headline })).to.exist;
+      expect(getByRole('heading', { level: 2, name: headline })).to.exist;
       expect(getByText(contentText)).to.exist;
       const alertEl = getByTestId('mhv-custom-alert');
       expect(alertEl.className).to.include('mhv-u-reg-alert-info');

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnauthenticatedAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnauthenticatedAlert.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('Unauthenticated Alert component', () => {
         <UnauthenticatedAlert />
       </Provider>,
     );
-    expect(getByRole('heading', { name: headingPrefix })).to.exist;
+    expect(getByRole('heading', { level: 2, name: headingPrefix })).to.exist;
   });
 
   it('with service description', () => {
@@ -30,6 +30,15 @@ describe('Unauthenticated Alert component', () => {
     );
     const expectedHeadline = `${headingPrefix} to ${serviceDescription}`;
     expect(getByRole('heading', { name: expectedHeadline })).to.exist;
+  });
+
+  it('with header level 3', () => {
+    const { getByRole } = render(
+      <Provider store={mockStore()}>
+        <UnauthenticatedAlert headerLevel={3} />
+      </Provider>,
+    );
+    expect(getByRole('heading', { level: 3, name: headingPrefix })).to.exist;
   });
 
   it('reports analytics', async () => {

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnverifiedAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnverifiedAlert.unit.spec.jsx
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import { CSP_IDS } from '~/platform/user/authentication/constants';
 import UnverifiedAlert, {
   headingPrefix,
+  mhvHeadingPrefix,
 } from '../../../components/messages/UnverifiedAlert';
 
 const mockStore = createMockStore([]);
@@ -18,7 +19,7 @@ describe('Unverified Alert component', () => {
         <UnverifiedAlert />
       </Provider>,
     );
-    expect(getByRole('heading', { name: headingPrefix })).to.exist;
+    expect(getByRole('heading', { level: 2, name: headingPrefix })).to.exist;
   });
 
   it('with service description', () => {
@@ -33,12 +34,22 @@ describe('Unverified Alert component', () => {
     expect(getByRole('heading', { name: expectedHeadline })).to.exist;
   });
 
+  it('with header level 3', () => {
+    const { getByRole } = render(
+      <Provider store={mockStore()}>
+        <UnverifiedAlert headerLevel={3} />
+      </Provider>,
+    );
+    expect(getByRole('heading', { level: 3, name: headingPrefix })).to.exist;
+  });
+
   it('renders MHV account alert', () => {
-    const { getByText } = render(
+    const { getByRole, getByText } = render(
       <Provider store={mockStore()}>
         <UnverifiedAlert signInService={CSP_IDS.MHV} />
       </Provider>,
     );
+    expect(getByRole('heading', { level: 2, name: mhvHeadingPrefix })).to.exist;
     expect(getByText(/You have 2 options/)).to.exist;
   });
 

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnverifiedAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnverifiedAlert.unit.spec.jsx
@@ -5,8 +5,6 @@ import { render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { CSP_IDS } from '~/platform/user/authentication/constants';
-import { logoutUrl } from '~/platform/user/authentication/utilities';
-import { logoutUrlSiS } from '~/platform/utilities/oauth/utilities';
 import UnverifiedAlert, {
   headingPrefix,
 } from '../../../components/messages/UnverifiedAlert';
@@ -44,13 +42,35 @@ describe('Unverified Alert component', () => {
     expect(getByText(/You have 2 options/)).to.exist;
   });
 
-  it('renders alert for non-MHV accounts', () => {
-    const { getByRole } = render(
+  it('renders alert for Login.gov account', () => {
+    const { getByRole, queryByRole } = render(
+      <Provider store={mockStore()}>
+        <UnverifiedAlert signInService={CSP_IDS.LOGIN_GOV} />
+      </Provider>,
+    );
+    expect(getByRole('button', { name: /Verify with Login.gov/ })).to.exist;
+    expect(queryByRole('button', { name: /Verify with ID.me/ })).not.to.exist;
+  });
+
+  it('renders alert for ID.me account', () => {
+    const { getByRole, queryByRole } = render(
       <Provider store={mockStore()}>
         <UnverifiedAlert signInService={CSP_IDS.ID_ME} />
       </Provider>,
     );
-    expect(getByRole('link', { name: /Verify your identity with/ })).to.exist;
+    expect(getByRole('button', { name: /Verify with ID.me/ })).to.exist;
+    expect(queryByRole('button', { name: /Verify with Login.gov/ })).not.to
+      .exist;
+  });
+
+  it('renders alert for MHV Basic account', () => {
+    const { getByRole } = render(
+      <Provider store={mockStore()}>
+        <UnverifiedAlert signInService={CSP_IDS.MHV} />
+      </Provider>,
+    );
+    expect(getByRole('button', { name: /Verify with ID.me/ })).to.exist;
+    expect(getByRole('button', { name: /Verify with Login.gov/ })).to.exist;
   });
 
   it('reports analytics', async () => {
@@ -62,28 +82,6 @@ describe('Unverified Alert component', () => {
     );
     await waitFor(() => {
       expect(recordEventSpy.calledOnce).to.be.true;
-    });
-  });
-
-  describe('sign out', () => {
-    it('with ssoe', async () => {
-      const { getByTestId } = render(
-        <Provider store={mockStore()}>
-          <UnverifiedAlert hasSsoe={false} signInService={CSP_IDS.MHV} />
-        </Provider>,
-      );
-      getByTestId('sign-out-button').click();
-      expect(window.location).to.be.eql(logoutUrlSiS());
-    });
-
-    it('without ssoe', async () => {
-      const { getByTestId } = render(
-        <Provider store={mockStore()}>
-          <UnverifiedAlert hasSsoe signInService={CSP_IDS.MHV} />
-        </Provider>,
-      );
-      getByTestId('sign-out-button').click();
-      expect(window.location).to.be.eql(logoutUrl());
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Update content of MHV verify sign-in widget for supply reorder page to match the global [VSDS alert-sign-in](https://design.va.gov/components/alert/alert-sign-in/) version that was recently finalized for VA.gov site.
- use service specific buttons
- update the sign-in alert that requires a verified user to dispatch(toggleLoginModal(true, 'mhv-signin-cta', true), the last true targets the "forced modal"
- add `headerLevel` prop for overriding the default heading level 2
- fix the default usa-alert icon overlapping custom icon 


## Related issue(s)
department-of-veterans-affairs/va.gov-team/issues/94862

## Testing done

- Manual testing of the widget replacement
  - Run a watch on `content-build`. Make sure to use the `cached-assets` to build the repo. This process can take hours.
  - Edit the file `build/localhost/health-care/order-medical-supplies/index.html` in your local `content-build` repo. Replace the `Order hearing aid and CPAP supplies online` link (`<a>` tag) with the template in the README.md file under directory `/src/application/static-pages/mhv-signin-cta`.
  - Save the file. DO NOT RESTART the content-build watch.
  - Build this branch in `vets-website` with `yarn build --env --entry=static-pages`.
  - Open http://localhost:3002/health-care/order-medical-supplies/ and verify the widget is shown.

** I don't know how to test user sign-in using different services, therefore, I've manually updated the code to simulate user sign-in and capture the screenshots for below: eg.

Commented out unnecessary code in file `/src/application/static-pages/mhv-signin-cta/index.jsx` and just return below snippet:
``` 
return (
    <UnverifiedAlert
      signInService="idme"
      serviceDescription={serviceDescription}
    />
)

Note: test for signInService="idme", "logingov" or "mhv"
```

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="289" alt="Screenshot 2024-12-18 at 9 39 58 AM" src="https://github.com/user-attachments/assets/d4e0c6d5-c78a-462c-a5fa-b7b02a7d2478" />     |  <img width="291" alt="Screenshot 2024-12-18 at 9 34 26 AM" src="https://github.com/user-attachments/assets/bceedaa4-e653-4453-bc1d-5d90b2444fe2" />     |
| Desktop  |   <img width="712" alt="Screenshot 2024-12-17 at 5 32 08 PM" src="https://github.com/user-attachments/assets/3cc95d59-8192-4e29-86dc-ed52e2120565" />     |  <img width="683" alt="Screenshot 2024-12-18 at 9 34 40 AM" src="https://github.com/user-attachments/assets/0d88653d-7a1d-4e58-85c6-663dfa64081b" />     |
| Mobile  |   <img width="385" alt="Screenshot 2024-12-17 at 5 34 34 PM" src="https://github.com/user-attachments/assets/383ffd72-8633-4832-9e18-f3efab9b0c32" />     |  <img width="384" alt="Screenshot 2024-12-18 at 9 30 14 AM" src="https://github.com/user-attachments/assets/0b1856b2-87d1-481d-ab40-70fe80f5a7fa" />     |
| Desktop |  <img width="712" alt="Screenshot 2024-12-17 at 5 34 13 PM" src="https://github.com/user-attachments/assets/e58fe59f-ea11-45c8-a75b-ca3ba8fb6534" />      |    <img width="682" alt="Screenshot 2024-12-18 at 9 30 30 AM" src="https://github.com/user-attachments/assets/412ac8f0-69bc-4b5f-9ad6-7caa5cd54f50" />   |
| Mobile  |    <img width="386" alt="Screenshot 2024-12-17 at 5 41 00 PM" src="https://github.com/user-attachments/assets/c1c6e640-d6d4-4cc5-9cab-e03acee6f6d5" />     |   <img width="384" alt="Screenshot 2024-12-18 at 9 25 42 AM" src="https://github.com/user-attachments/assets/14bba237-3cd3-4889-b1ce-e26cc81f7f43" />   |
| Desktop |  <img width="713" alt="Screenshot 2024-12-17 at 5 40 41 PM" src="https://github.com/user-attachments/assets/3fb1358a-14d8-4685-bc1b-989fa8f4da67" />      |   <img width="688" alt="Screenshot 2024-12-18 at 9 25 25 AM" src="https://github.com/user-attachments/assets/ff943e9a-b062-4887-85c2-bf066af58017" />    |
| Mobile  |    <img width="291" alt="Screenshot 2024-12-17 at 5 37 25 PM" src="https://github.com/user-attachments/assets/a76e4884-7231-4820-afbb-419c586f4819" />    |   <img width="291" alt="Screenshot 2024-12-18 at 9 32 01 AM" src="https://github.com/user-attachments/assets/5c48a0ed-3073-437d-92a4-a4aa41d5c350" />    |
| Desktop |   <img width="713" alt="Screenshot 2024-12-17 at 5 37 48 PM" src="https://github.com/user-attachments/assets/327aaa4a-dbf8-45db-b461-a318fef89c76" />     |   <img width="682" alt="Screenshot 2024-12-18 at 9 31 46 AM" src="https://github.com/user-attachments/assets/72097697-a2ff-465f-a0e7-d415ed9ecaf5" />    |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
