### PR TITLE
Do not route back to the Review page if the rep selection changes

### DIFF
--- a/src/applications/representative-appoint/components/ContactAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/ContactAccreditedRepresentative.jsx
@@ -28,7 +28,7 @@ const ContactAccreditedRepresentative = props => {
 
   const handleGoBack = () => {
     if (isReviewPage) {
-      goToPath('/representative-select?review=true');
+      goToPath('/representative');
     } else {
       goBack(formData);
     }
@@ -37,7 +37,7 @@ const ContactAccreditedRepresentative = props => {
   const handleGoForward = () => {
     if (isReviewPage) {
       if (orgSelectionRequired) {
-        goToPath('/representative-organization?review=true');
+        goToPath('/representative-organization');
       } else {
         goToPath('/review-and-submit');
       }

--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentativeReview.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentativeReview.jsx
@@ -97,7 +97,7 @@ const SelectedAccreditedRepresentativeReview = props => {
           <va-button
             text="Edit"
             label="Edit Accredited Representative Information"
-            onClick={() => goToPath('/representative-select?review=true')}
+            onClick={() => goToPath('/representative-select')}
             secondary
             uswds
           />

--- a/src/applications/representative-appoint/tests/pages/representative/contactAccreditedRepresentative.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/pages/representative/contactAccreditedRepresentative.unit.spec.jsx
@@ -111,8 +111,7 @@ describe('<ContactAccreditedRepresentative>', () => {
       fireEvent.click(getByText('Back'));
 
       await waitFor(() => {
-        expect(goToPathSpy.calledWith('/representative-select?review=true')).to
-          .be.true;
+        expect(goToPathSpy.calledWith('/representative-select')).to.be.true;
       });
     });
 
@@ -139,9 +138,8 @@ describe('<ContactAccreditedRepresentative>', () => {
       fireEvent.click(getByText('Continue'));
 
       await waitFor(() => {
-        expect(
-          goToPathSpy.calledWith('/representative-organization?review=true'),
-        ).to.be.true;
+        expect(goToPathSpy.calledWith('/representative-organization')).to.be
+          .true;
       });
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Do not route back to the Review page if the rep selection changes the associated form.

## Related issue(s)

[Github Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97215)

## Testing done

- Modified specs.
- Went through workflow twice.


## What areas of the site does it impact?

[Accredited Representation Management](https://github.com/orgs/department-of-veterans-affairs/projects/1180)
