### PR TITLE
MHV Test accounts page

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -470,7 +470,6 @@ module.exports = async (env = {}) => {
           },
         },
       },
-      runtimeChunk: 'single',
     },
     plugins: [
       new webpack.DefinePlugin({

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -470,6 +470,7 @@ module.exports = async (env = {}) => {
           },
         },
       },
+      runtimeChunk: 'single',
     },
     plugins: [
       new webpack.DefinePlugin({

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -18,7 +18,10 @@ export default function MhvSignIn() {
   };
 
   const handleButtonClick = () => {
-    apiRequest('/v0/test_account_user_email', { method: 'POST' });
+    apiRequest('/v0/test_account_user_email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
     login({
       policy: 'mhv',
       queryParams: { operation: 'prod-test-acct' },

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -18,7 +18,7 @@ export default function MhvSignIn() {
   };
 
   const handleButtonClick = () => {
-    apiRequest('/something here', { method: 'POST' });
+    apiRequest('/v0/test_account_user_email', { method: 'POST' });
     login({
       policy: 'mhv',
       queryParams: { operation: 'prod-test-acct' },

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -4,7 +4,6 @@ import { login } from 'platform/user/authentication/utilities';
 
 export default function MhvSignIn() {
   const [email, setEmail] = useState('');
-  const [checkboxChecked, setCheckboxChecked] = useState(false);
   const [isValidEmail, setIsValidEmail] = useState(false);
 
   const isAllowedEmail = user => {
@@ -16,10 +15,6 @@ export default function MhvSignIn() {
     const emailValue = e.target.value;
     setEmail(emailValue);
     setIsValidEmail(isAllowedEmail(emailValue));
-  };
-
-  const handleCheckboxChange = e => {
-    setCheckboxChecked(e.target.checked);
   };
 
   const handleButtonClick = () => {
@@ -35,7 +30,9 @@ export default function MhvSignIn() {
   return (
     <section className="container row login">
       <div className="columns small-12 vads-u-padding--0">
-        <h1 id="signin-signup-modal-title">My HealtheVet test account</h1>
+        <h1 id="signin-signup-modal-title">
+          Access My HealtheVet test account
+        </h1>
         <p>
           My HealtheVet test accounts are available for VA and Oracle Health
           staff only.
@@ -46,9 +43,9 @@ export default function MhvSignIn() {
       </h2>
       <va-text-input
         hint={null}
-        label="Your email"
+        label="Your email address"
         data-testid="mvhemailinput"
-        message-aria-describedby="Your email"
+        message-aria-describedby="Your email adress"
         name="Your VA or Oracle Health email"
         value={email}
         required
@@ -59,22 +56,19 @@ export default function MhvSignIn() {
         }
       />
       <div className="vads-u-margin-y--2">
-        <va-checkbox
-          label="I’m using My HealtheVet for official VA testing, training, or development purposes."
-          aria-label="I’m using My HealtheVet for official VA testing, training, or development purposes."
-          checked={checkboxChecked}
-          onVaChange={handleCheckboxChange}
-          required
-          className="vads-u-padding-y--2"
-        />
-        {/* <p><strong>Disclaimer:</strong>By clicking the button below you are agreeing to only use <br></br>My HealtheVet for official VA testing, training, or development purposes.</p> */}
+        <p>
+          <strong>Disclaimer:</strong> By providing your email address you are
+          agreeing to only use <br />
+          My HealtheVet for official VA testing, training, or development
+          purposes.
+        </p>
       </div>
       <div className="vads-u-margin-y--2">
-        {/* <va-button onClick={handleButtonClick} text='Access My HealtheVet' role='button' disabled={!isValidEmail} /> */}
         <va-button
           onClick={handleButtonClick}
           text="Access My HealtheVet"
-          role="button"
+          data-testid="accessMhvBtn"
+          disabled={!isValidEmail}
         />
       </div>
       <div className="vads-u-margin-y--6">

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -1,18 +1,35 @@
 import React from 'react';
 import LoginButton from 'platform/user/authentication/components/LoginButton';
-import LoginInfo from 'platform/user/authentication/components/LoginInfo';
 
 export default function MhvSignIn() {
   return (
-    <div>
+    <section className="login">
+      <div className="columns small-12">
+        <h1 id="signin-signup-modal-title">My HealtheVet test account</h1>
+        <p>
+          My HealtheVet test accounts are available for VA and Oracle Health
+          staff only.
+        </p>
+      </div>
+      <h2>Enter your VA or Oracle Health email</h2>
+      <va-text-input
+        hint={null}
+        label="Your VA email"
+        message-aria-describedby="Your VA email"
+        name="Your VA or Oracle Health email"
+        onBlur={function noRefCheck() {}}
+        onInput={function noRefCheck() {}}
+        show-input-error
+      />
       <va-checkbox
         required
-        label="I am authorized to use this"
-        message-aria-describedby="I am authorized to use this"
+        label="I’m using My HealtheVet for official VA testing, training, or development purposes."
+        message-aria-describedby="I’m using My HealtheVet for official VA testing, training, or development purposes."
         enable-analytics
       />
       <LoginButton csp="mhv" key="mhv" useOAuth={false} />
-      <LoginInfo />
-    </div>
+      <h2>Having trouble signing in?</h2>
+      <p>Contact the administrator who gave you access to your test account.</p>
+    </section>
   );
 }

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import LoginButton from 'platform/user/authentication/components/LoginButton';
+import { apiRequest } from 'platform/utilities/api';
+import { login } from 'platform/user/authentication/utilities';
 
 export default function MhvSignIn() {
   const [email, setEmail] = useState('');
   const [checkboxChecked, setCheckboxChecked] = useState(false);
-  const [isValidEmail, setIsValidEmail] = useState(true);
+  const [isValidEmail, setIsValidEmail] = useState(false);
 
   const isAllowedEmail = user => {
     const pattern = /^[a-zA-Z0-9._%+-]+@(va\.gov|oracle\.com)$/;
@@ -21,6 +22,16 @@ export default function MhvSignIn() {
     setCheckboxChecked(e.target.checked);
   };
 
+  const handleButtonClick = () => {
+    apiRequest('/something here', { method: 'POST' });
+    login({
+      policy: 'mhv',
+      queryParams: { operation: 'prod-test-acct' },
+    });
+  };
+
+  const notDisable = isValidEmail || email.length === 0;
+
   return (
     <section className="container row login">
       <div className="columns small-12 vads-u-padding--0">
@@ -35,26 +46,37 @@ export default function MhvSignIn() {
       </h2>
       <va-text-input
         hint={null}
-        label="Your VA email"
-        message-aria-describedby="Your VA email"
+        label="Your email"
+        data-testid="mvhemailinput"
+        message-aria-describedby="Your email"
         name="Your VA or Oracle Health email"
         value={email}
         required
         onInput={handleEmailChange}
-        show-input-error={!isValidEmail}
+        show-input-error={!notDisable}
         error={
-          isValidEmail ? null : 'Please enter a valid VA or Oracle Health email'
+          !notDisable ? 'Please enter a valid VA or Oracle Health email' : null
         }
       />
-      <va-checkbox
-        label="I’m using My HealtheVet for official VA testing, training, or development purposes."
-        aria-label="I’m using My HealtheVet for official VA testing, training, or development purposes."
-        checked={checkboxChecked}
-        onChange={handleCheckboxChange}
-        required
-        className="vads-u-padding-y--2"
-      />
-      <LoginButton csp="mhv" key="mhv" useOAuth={false} />
+      <div className="vads-u-margin-y--2">
+        <va-checkbox
+          label="I’m using My HealtheVet for official VA testing, training, or development purposes."
+          aria-label="I’m using My HealtheVet for official VA testing, training, or development purposes."
+          checked={checkboxChecked}
+          onVaChange={handleCheckboxChange}
+          required
+          className="vads-u-padding-y--2"
+        />
+        {/* <p><strong>Disclaimer:</strong>By clicking the button below you are agreeing to only use <br></br>My HealtheVet for official VA testing, training, or development purposes.</p> */}
+      </div>
+      <div className="vads-u-margin-y--2">
+        {/* <va-button onClick={handleButtonClick} text='Access My HealtheVet' role='button' disabled={!isValidEmail} /> */}
+        <va-button
+          onClick={handleButtonClick}
+          text="Access My HealtheVet"
+          role="button"
+        />
+      </div>
       <div className="vads-u-margin-y--6">
         <h2>Having trouble signing in?</h2>
         <p>

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -1,9 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import LoginButton from 'platform/user/authentication/components/LoginButton';
 
 export default function MhvSignIn() {
+  const [email, setEmail] = useState('');
+  const [checkboxChecked, setCheckboxChecked] = useState(false);
+  const [isValidEmail, setIsValidEmail] = useState(true);
+
+  const isAllowedEmail = user => {
+    const pattern = /^[a-zA-Z0-9._%+-]+@(va\.gov|myhealth\.com)$/;
+    return pattern.test(user);
+  };
+
+  const handleEmailChange = e => {
+    const emailValue = e.target.value;
+    setEmail(emailValue);
+    setIsValidEmail(isAllowedEmail(emailValue));
+  };
+
+  const handleCheckboxChange = e => {
+    setCheckboxChecked(e.target.checked);
+  };
+
   return (
-    <section className="login">
+    <section className="container login">
       <div className="columns small-12">
         <h1 id="signin-signup-modal-title">My HealtheVet test account</h1>
         <p>
@@ -17,17 +36,22 @@ export default function MhvSignIn() {
         label="Your VA email"
         message-aria-describedby="Your VA email"
         name="Your VA or Oracle Health email"
-        onBlur={function noRefCheck() {}}
-        onInput={function noRefCheck() {}}
-        show-input-error
+        value={email}
+        required
+        onInput={handleEmailChange}
+        show-input-error={!isValidEmail}
+        error={
+          isValidEmail ? null : 'Please enter a valid VA or Oracle Health email'
+        }
       />
       <va-checkbox
-        required
         label="I’m using My HealtheVet for official VA testing, training, or development purposes."
         message-aria-describedby="I’m using My HealtheVet for official VA testing, training, or development purposes."
         enable-analytics
+        checked={checkboxChecked}
+        onChange={handleCheckboxChange}
       />
-      <LoginButton csp="mhv" key="mhv" useOAuth={false} />
+      <LoginButton csp="mhv" key="mhv" useOAuth={false} disabled />
       <h2>Having trouble signing in?</h2>
       <p>Contact the administrator who gave you access to your test account.</p>
     </section>

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -7,7 +7,7 @@ export default function MhvSignIn() {
   const [isValidEmail, setIsValidEmail] = useState(true);
 
   const isAllowedEmail = user => {
-    const pattern = /^[a-zA-Z0-9._%+-]+@(va\.gov|myhealth\.com)$/;
+    const pattern = /^[a-zA-Z0-9._%+-]+@(va\.gov|oracle\.com)$/;
     return pattern.test(user);
   };
 
@@ -22,7 +22,7 @@ export default function MhvSignIn() {
   };
 
   return (
-    <section className="container login">
+    <section className="container row login">
       <div className="columns small-12">
         <h1 id="signin-signup-modal-title">My HealtheVet test account</h1>
         <p>
@@ -30,7 +30,9 @@ export default function MhvSignIn() {
           staff only.
         </p>
       </div>
-      <h2>Enter your VA or Oracle Health email</h2>
+      <h2 className="vads-u-padding-top--4">
+        Enter your VA or Oracle Health email
+      </h2>
       <va-text-input
         hint={null}
         label="Your VA email"
@@ -46,19 +48,19 @@ export default function MhvSignIn() {
       />
       <va-checkbox
         label="I’m using My HealtheVet for official VA testing, training, or development purposes."
-        message-aria-describedby="I’m using My HealtheVet for official VA testing, training, or development purposes."
-        enable-analytics
+        aria-label="I’m using My HealtheVet for official VA testing, training, or development purposes."
         checked={checkboxChecked}
         onChange={handleCheckboxChange}
+        required
+        clasName="vads-u-padding-y--2"
       />
-      <LoginButton
-        csp="mhv"
-        key="mhv"
-        useOAuth={false}
-        disabled={isValidEmail && checkboxChecked}
-      />
-      <h2>Having trouble signing in?</h2>
-      <p>Contact the administrator who gave you access to your test account.</p>
+      <LoginButton csp="mhv" key="mhv" useOAuth={false} />
+      <div className="vads-u-margin-y--6">
+        <h2>Having trouble signing in?</h2>
+        <p>
+          Contact the administrator who gave you access to your test account.
+        </p>
+      </div>
     </section>
   );
 }

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -23,7 +23,7 @@ export default function MhvSignIn() {
 
   return (
     <section className="container row login">
-      <div className="columns small-12">
+      <div className="columns small-12 vads-u-padding--0">
         <h1 id="signin-signup-modal-title">My HealtheVet test account</h1>
         <p>
           My HealtheVet test accounts are available for VA and Oracle Health
@@ -52,7 +52,7 @@ export default function MhvSignIn() {
         checked={checkboxChecked}
         onChange={handleCheckboxChange}
         required
-        clasName="vads-u-padding-y--2"
+        className="vads-u-padding-y--2"
       />
       <LoginButton csp="mhv" key="mhv" useOAuth={false} />
       <div className="vads-u-margin-y--6">

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import LoginButton from 'platform/user/authentication/components/LoginButton';
+import LoginInfo from 'platform/user/authentication/components/LoginInfo';
+
+export default function MhvSignIn() {
+  return (
+    <div>
+      <va-checkbox
+        required
+        label="I am authorized to use this"
+        message-aria-describedby="I am authorized to use this"
+        enable-analytics
+      />
+      <LoginButton csp="mhv" key="mhv" useOAuth={false} />
+      <LoginInfo />
+    </div>
+  );
+}

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -51,7 +51,12 @@ export default function MhvSignIn() {
         checked={checkboxChecked}
         onChange={handleCheckboxChange}
       />
-      <LoginButton csp="mhv" key="mhv" useOAuth={false} disabled />
+      <LoginButton
+        csp="mhv"
+        key="mhv"
+        useOAuth={false}
+        disabled={isValidEmail && checkboxChecked}
+      />
       <h2>Having trouble signing in?</h2>
       <p>Contact the administrator who gave you access to your test account.</p>
     </section>

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -2,6 +2,7 @@ import environment from 'platform/utilities/environment';
 import SignInApp from './containers/SignInApp';
 import SignInWrapper from './components/SignInWrapper';
 import MockAuth from './containers/MockAuth';
+import MhvSignIn from './containers/MhvSignIn';
 
 const routes = {
   path: '/',
@@ -15,7 +16,12 @@ const routes = {
             component: MockAuth,
           },
         ]
-      : [],
+      : [
+          {
+            path: 'mhv-sign-in',
+            component: MhvSignIn,
+          },
+        ],
 };
 
 export default routes;

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -15,6 +15,10 @@ const routes = {
             path: 'mocked-auth',
             component: MockAuth,
           },
+          {
+            path: 'access-myhealthevet-test-account',
+            component: MhvSignIn,
+          },
         ]
       : [
           {

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -15,10 +15,6 @@ const routes = {
             path: 'mocked-auth',
             component: MockAuth,
           },
-          {
-            path: 'access-myhealthevet-test-account',
-            component: MhvSignIn,
-          },
         ]
       : [
           {

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -18,7 +18,7 @@ const routes = {
         ]
       : [
           {
-            path: 'mhv-sign-in',
+            path: 'access-myhealthevet-test-account',
             component: MhvSignIn,
           },
         ],

--- a/src/applications/login/tests/containers/MhvSignIn.unit.spec.js
+++ b/src/applications/login/tests/containers/MhvSignIn.unit.spec.js
@@ -8,9 +8,9 @@ import * as auth from 'platform/user/authentication/utilities';
 import MhvSignIn from '../../containers/MhvSignIn';
 
 describe('MhvSignIn Component', () => {
-  afterEach(() => {
-    sinon.restore();
-  });
+  // afterEach(() => {
+  //   sinon.restore();
+  // });
 
   it('renders the heading and description', () => {
     const screen = renderInReduxProvider(<MhvSignIn />);
@@ -48,9 +48,7 @@ describe('MhvSignIn Component', () => {
 
     const screen = renderInReduxProvider(<MhvSignIn />);
     const emailInput = screen.getByTestId('mvhemailinput');
-    const loginButton = screen.getByRole('button', {
-      name: /Access My HealtheVet/i,
-    });
+    const loginButton = screen.getByTestId('accessMhvBtn');
 
     fireEvent.input(emailInput, { detail: { value: 'test@va.gov' } });
     expect(loginButton).to.not.have.attribute('disabled');
@@ -68,9 +66,7 @@ describe('MhvSignIn Component', () => {
   it('disables the login button for invalid email', () => {
     const screen = renderInReduxProvider(<MhvSignIn />);
     const emailInput = screen.getByTestId('mvhemailinput');
-    const loginButton = screen.getByRole('button', {
-      name: /Access My HealtheVet/i,
-    });
+    const loginButton = screen.getByTestId('accessMhvBtn');
 
     fireEvent.input(emailInput, { detail: { value: 'invalid-email' } });
     expect(loginButton).to.have.attribute('disabled');

--- a/src/applications/login/tests/containers/MhvSignIn.unit.spec.js
+++ b/src/applications/login/tests/containers/MhvSignIn.unit.spec.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { fireEvent } from '@testing-library/react';
+import { expect } from 'chai';
+import MhvSignIn from '../../containers/MhvSignIn';
+
+describe('MhvSignIn Component', () => {
+  it('renders the heading and description', () => {
+    const screen = renderInReduxProvider(<MhvSignIn />);
+    expect(screen.getByRole('heading', { name: /My HealtheVet test account/i }))
+      .to.exist;
+    expect(
+      screen.getByText(
+        /My HealtheVet test accounts are available for VA and Oracle Health staff only\./i,
+      ),
+    ).to.exist;
+  });
+
+  it('renders email input and checkbox', () => {
+    const screen = renderInReduxProvider(<MhvSignIn />);
+    const emailInput = screen.getByLabelText(/Your email/i);
+    const checkbox = screen.getByLabelText(
+      /I’m using My HealtheVet for official VA testing, training, or development purposes\./i,
+    );
+    expect(emailInput).to.exist;
+    expect(checkbox).to.exist;
+  });
+
+  it('validates email input with allowed domains', () => {
+    const screen = renderInReduxProvider(<MhvSignIn />);
+    const emailInput = screen.getByLabelText(/Your email/i);
+
+    fireEvent.input(emailInput, { target: { value: 'test@va.gov' } });
+    expect(emailInput).to.have.value('test@va.gov');
+    expect(
+      screen.queryByText(/Please enter a valid VA or Oracle Health email/i),
+    ).to.not.exist;
+
+    fireEvent.input(emailInput, { target: { value: 'test@gmail.com' } });
+    expect(emailInput).to.have.value('test@gmail.com');
+    expect(screen.getByText(/Please enter a valid VA or Oracle Health email/i))
+      .to.exist;
+  });
+
+  // it('toggles checkbox state correctly', () => {
+  //   const screen = renderInReduxProvider(<MhvSignIn />);
+
+  //   const checkbox = screen.getByLabelText(
+  //     /I’m using My HealtheVet for official VA testing, training, or development purposes\./i
+  //   );
+
+  //   expect(checkbox.checked).to.be.false;
+  //   fireEvent.click(checkbox);
+  //   expect(checkbox.checked).to.be.true;
+  //   fireEvent.click(checkbox);
+  //   expect(checkbox.checked).to.be.false;
+  // });
+
+  it('renders the login button with correct props', () => {
+    const screen = renderInReduxProvider(<MhvSignIn />);
+    expect(screen.getByRole('button', { text: /Access My HealtheVet/i })).to
+      .exist;
+  });
+
+  it('renders the "Having trouble signing in?" section', () => {
+    const screen = renderInReduxProvider(<MhvSignIn />);
+    expect(
+      screen.getByRole('heading', { name: /Having trouble signing in\?/i }),
+    ).to.exist;
+    expect(
+      screen.getByText(
+        /Contact the administrator who gave you access to your test account\./i,
+      ),
+    ).to.exist;
+  });
+});

--- a/src/applications/login/tests/containers/MhvSignIn.unit.spec.js
+++ b/src/applications/login/tests/containers/MhvSignIn.unit.spec.js
@@ -18,17 +18,17 @@ describe('MhvSignIn Component', () => {
 
   it('renders email input and checkbox', () => {
     const screen = renderInReduxProvider(<MhvSignIn />);
-    const emailInput = screen.getByLabelText(/Your email/i);
-    const checkbox = screen.getByLabelText(
-      /I’m using My HealtheVet for official VA testing, training, or development purposes\./i,
-    );
+    const emailInput = screen.getByTestId('mvhemailinput');
+    // const checkbox = screen.getByLabelText(
+    //   /I’m using My HealtheVet for official VA testing, training, or development purposes\./i,
+    // );
     expect(emailInput).to.exist;
-    expect(checkbox).to.exist;
+    // expect(checkbox).to.exist;
   });
 
   it('validates email input with allowed domains', () => {
     const screen = renderInReduxProvider(<MhvSignIn />);
-    const emailInput = screen.getByLabelText(/Your email/i);
+    const emailInput = screen.getByTestId('mvhemailinput');
 
     fireEvent.input(emailInput, { target: { value: 'test@va.gov' } });
     expect(emailInput).to.have.value('test@va.gov');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Goal: Provide a dedicated My HealtheVet (MHV) prod test account sign-in page to enable continued access to production test accounts after MHV credential deprecation on January 31, 2025, ensuring no interruption to critical use cases while aligning with credential modernization.

Production test account users rely on MHV credentials for various critical purposes, such as staff training, troubleshooting, and development testing. With the planned deprecation of MHV credentials, an interim solution is required to maintain functionality.


This epic involves creating a dedicated MHV sign-in page:

•Separate from the main VA.gov sign-in page. *no additional restrictions at this time

•Publicly accessible but not prominently linked from the main site.

 

Additional info from [slack](https://dsva.slack.com/archives/C07H32GHX8B/p1734379141115819)

## Related issue(s)

[Jira Ticket](https://jira.devops.va.gov/browse/VI-893)

## Testing done

- unit tests updated

## Screenshots

<img width="1080" alt="PTAenabled" src="https://github.com/user-attachments/assets/09d63a72-62c5-4a21-bd4b-0404e047b3ec" />

## What areas of the site does it impact?

`staging.va.gov/sign-in/access-my-healthevet-test-account`

## Acceptance criteria

- A publicly accessible but standalone MHV sign-in page is implemented.
- Staging test account users can log in with MHV credentials via the dedicated page until January 2, 2025.
- Production test account users can log in with MHV credentials via the dedicated page until January 31, 2025.
- The page has clear access limitations and disclaimers to prevent general public misuse.
- Analytics are enabled to monitor page usage and credential transition progress.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

