### PR TITLE
Remove print list aria label

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.unit.spec.js
@@ -315,7 +315,7 @@ describe('VAOS Page: AppointmentsPage', () => {
     });
 
     // Then it should display the tertiary print button
-    expect(screen.getByRole('button', { name: 'print list' })).to.be.ok;
+    expect(screen.getByTestId('print-list')).to.be.ok;
   });
 
   describe('when scheduling breadcrumb url update flag is on', () => {

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/PrintButton.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/PrintButton.jsx
@@ -16,7 +16,7 @@ export default function PrintButton() {
         className="tertiary-button vads-u-display--flex vads-u-align-items--center"
         onClick={handleClick()}
         type="button"
-        aria-label="print list"
+        data-testid="print-list"
         id="print-list"
       >
         <span className="vads-u-margin-right--0p5">


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove aria label from print button
- Appointments (VAOS) Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96012

## Testing done

- Tested locally
- Updated unit tests

## Screenshots

<img width="947" alt="image" src="https://github.com/user-attachments/assets/294b3d4f-09ea-4f37-90f7-4b3f0a3d18bf" />

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

