### PR TITLE
[96836] Appoint a Rep prefill

### DIFF
--- a/src/applications/representative-appoint/components/ClaimantType.jsx
+++ b/src/applications/representative-appoint/components/ClaimantType.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 import { getNextPagePath } from '~/platform/forms-system/src/js/routing';
 import { setData } from '~/platform/forms-system/src/js/actions';
 import { toggleLoginModal as toggleLoginModalAction } from '~/platform/site-wide/user-nav/actions';
@@ -9,9 +9,8 @@ import ClaimantTypeForm from './ClaimantTypeForm';
 import prefillTransformer from '../config/prefillTransformer';
 
 const ClaimantType = props => {
-  const { router, setFormData, loggedIn } = props;
+  const { formData, router, setFormData, loggedIn } = props;
 
-  const { data: formData } = useSelector(state => state.form);
   const [localData, setLocalData] = useState({});
 
   const handlers = {
@@ -58,6 +57,7 @@ const ClaimantType = props => {
 };
 
 ClaimantType.propTypes = {
+  formData: PropTypes.object,
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),
@@ -73,6 +73,7 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = state => ({
+  formData: state.form?.data,
   loggedIn: isLoggedIn(state),
 });
 

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -12,7 +12,6 @@ import {
   preparerIsVeteran,
   isAttorneyOrClaimsAgent,
 } from '../utilities/helpers';
-// import prefillTransformer from './prefillTransformer';
 import {
   authorizeMedical,
   authorizeMedicalSelect,
@@ -84,7 +83,6 @@ const formConfig = {
   },
   version: 0,
   prefillEnabled: true,
-  // prefillTransformer,
   v3SegmentedProgressBar: true,
   additionalRoutes: [
     {

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -1,5 +1,5 @@
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+// import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 // import profileContactInfo from 'platform/forms-system/src/js/definitions/profileContactInfo';
 import configService from '../utilities/configService';
 import manifest from '../manifest.json';
@@ -12,7 +12,7 @@ import {
   preparerIsVeteran,
   isAttorneyOrClaimsAgent,
 } from '../utilities/helpers';
-
+// import prefillTransformer from './prefillTransformer';
 import {
   authorizeMedical,
   authorizeMedicalSelect,
@@ -36,7 +36,7 @@ import {
   contactAccreditedRepresentative,
 } from '../pages';
 
-import initialData from '../tests/fixtures/data/test-data.json';
+// import initialData from '../tests/fixtures/data/test-data.json';
 import ClaimantType from '../components/ClaimantType';
 import SelectAccreditedRepresentative from '../components/SelectAccreditedRepresentative';
 import SelectedAccreditedRepresentativeReview from '../components/SelectAccreditedRepresentativeReview';
@@ -45,7 +45,7 @@ import SelectOrganization from '../components/SelectOrganization';
 
 import SubmissionError from '../components/SubmissionError';
 
-const mockData = initialData;
+// const mockData = initialData;
 
 const { fullName, ssn, date, dateRange, usaPhone } = commonDefinitions;
 
@@ -84,6 +84,7 @@ const formConfig = {
   },
   version: 0,
   prefillEnabled: true,
+  // prefillTransformer,
   v3SegmentedProgressBar: true,
   additionalRoutes: [
     {
@@ -183,11 +184,11 @@ const formConfig = {
         claimantPersonalInformation: {
           path: 'claimant-personal-information',
           depends: formData => !preparerIsVeteran({ formData }),
-          initialData:
-            /* istanbul ignore next */
-            !!mockData && environment.isLocalhost() && !window.Cypress
-              ? mockData
-              : undefined,
+          // initialData:
+          //   /* istanbul ignore next */
+          //   !!mockData && environment.isLocalhost() && !window.Cypress
+          //     ? mockData
+          //     : undefined,
           title: 'Your Personal Information',
           uiSchema: claimantPersonalInformation.uiSchema,
           schema: claimantPersonalInformation.schema,

--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -21,6 +21,18 @@ export default function prefillTransformer(formData) {
     newFormData['Primary phone'] = formData?.contactInformation?.primaryPhone;
     newFormData['Branch of Service'] =
       formData?.militaryInformation?.serviceBranch;
+    // reset the applicant information in case of claimant type change
+    newFormData.applicantName = undefined;
+    newFormData.applicantDOB = undefined;
+    newFormData.applicantEmail = undefined;
+    newFormData.applicantPhone = undefined;
+    newFormData.homeAddress = {
+      city: undefined,
+      country: undefined,
+      postalCode: undefined,
+      state: undefined,
+      street: undefined,
+    };
   } else {
     newFormData.applicantName = formData?.personalInformation?.fullName;
     newFormData.applicantDOB = formData?.personalInformation?.dateOfBirth;
@@ -33,6 +45,21 @@ export default function prefillTransformer(formData) {
       state: formData?.contactInformation?.address?.state,
       street: formData?.contactInformation?.address?.street,
     };
+
+    // reset the applicant information in case of claimant type change
+    newFormData.veteranFullName = undefined;
+    newFormData.veteranDateOfBirth = undefined;
+    newFormData.veteranSocialSecurityNumber = undefined;
+    newFormData.veteranHomeAddress = {
+      city: undefined,
+      country: undefined,
+      postalCode: undefined,
+      state: undefined,
+      street: undefined,
+    };
+    newFormData.veteranEmail = undefined;
+    newFormData['Primary phone'] = undefined;
+    newFormData['Branch of Service'] = undefined;
   }
 
   return newFormData;

--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -1,0 +1,39 @@
+import { preparerIsVeteran } from '../utilities/helpers';
+
+export default function prefillTransformer(formData) {
+  const newFormData = {
+    ...formData,
+  };
+
+  if (preparerIsVeteran({ formData })) {
+    newFormData.veteranFullName = formData?.personalInformation?.fullName;
+    newFormData.veteranDateOfBirth = formData?.personalInformation?.dateOfBirth;
+    newFormData.veteranSocialSecurityNumber =
+      formData?.personalInformation?.ssn;
+    newFormData.veteranHomeAddress = {
+      city: formData?.contactInformation?.address?.city,
+      country: formData?.contactInformation?.address?.country,
+      postalCode: formData?.contactInformation?.address?.postalCode,
+      state: formData?.contactInformation?.address?.state,
+      street: formData?.contactInformation?.address?.street,
+    };
+    newFormData.veteranEmail = formData?.contactInformation?.email;
+    newFormData['Primary phone'] = formData?.contactInformation?.primaryPhone;
+    newFormData['Branch of Service'] =
+      formData?.militaryInformation?.serviceBranch;
+  } else {
+    newFormData.applicantName = formData?.personalInformation?.fullName;
+    newFormData.applicantDOB = formData?.personalInformation?.dateOfBirth;
+    newFormData.applicantEmail = formData?.contactInformation?.email;
+    newFormData.applicantPhone = formData?.contactInformation?.primaryPhone;
+    newFormData.homeAddress = {
+      city: formData?.contactInformation?.address?.city,
+      country: formData?.contactInformation?.address?.country,
+      postalCode: formData?.contactInformation?.address?.postalCode,
+      state: formData?.contactInformation?.address?.state,
+      street: formData?.contactInformation?.address?.street,
+    };
+  }
+
+  return newFormData;
+}

--- a/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
+++ b/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import prefill from '../fixtures/data/prefill.json';
+import prefillTransformer from '../../config/prefillTransformer';
+
+describe('prefillTransformer', () => {
+  context('when the applicant is the Veteran', () => {
+    it('should set the Veteran attributes with prefill information', () => {
+      const data = { ...prefill, 'view:applicantIsVeteran': 'Yes' };
+
+      const result = prefillTransformer(data);
+
+      expect(result.veteranFullName).to.eql({
+        first: 'Greg',
+        last: 'Anderson',
+        middle: 'A',
+      });
+      expect(result.veteranDateOfBirth).to.eql('1933-04-05');
+      expect(result.veteranSocialSecurityNumber).to.eql('796121200');
+      expect(result.veteranHomeAddress).to.eql({
+        street: '123 avenue du Maine',
+        city: 'Paris',
+        state: 'Paris',
+        country: 'FRA',
+        postalCode: '75014',
+      });
+      expect(result.veteranEmail).to.eql('test2@test1.net');
+      expect(result['Primary phone']).to.eql('4445551212');
+      expect(result['Branch of Service']).to.eql('Army');
+    });
+
+    it('should reset the applicant attributes', () => {
+      const data = {
+        ...prefill,
+        'view:applicantIsVeteran': 'Yes',
+        applicantName: 'test',
+        applicantDOB: 'test',
+        applicantEmail: 'test',
+        applicantPhone: 'test',
+        homeAddress: {
+          city: 'test',
+          country: 'test',
+          postalCode: 'test',
+          state: 'test',
+          street: 'test',
+        },
+      };
+
+      const result = prefillTransformer(data);
+
+      expect(result.applicantName).to.be.undefined;
+      expect(result.applicantDOB).to.be.undefined;
+      expect(result.applicantEmail).to.be.undefined;
+      expect(result.applicantPhone).to.be.undefined;
+      expect(result.homeAddress).to.eql({
+        city: undefined,
+        country: undefined,
+        postalCode: undefined,
+        state: undefined,
+        street: undefined,
+      });
+    });
+  });
+
+  context('when the applicant is not the Veteran', () => {
+    it('should set the applicant attributes with prefill information', () => {
+      const data = { ...prefill, 'view:applicantIsVeteran': 'No' };
+
+      const result = prefillTransformer(data);
+
+      expect(result.applicantName).to.eql({
+        first: 'Greg',
+        last: 'Anderson',
+        middle: 'A',
+      });
+      expect(result.applicantDOB).to.eql('1933-04-05');
+      expect(result.homeAddress).to.eql({
+        street: '123 avenue du Maine',
+        city: 'Paris',
+        state: 'Paris',
+        country: 'FRA',
+        postalCode: '75014',
+      });
+      expect(result.applicantEmail).to.eql('test2@test1.net');
+      expect(result.applicantPhone).to.eql('4445551212');
+    });
+
+    it('should reset the Veteran attributes', () => {
+      const data = {
+        ...prefill,
+        'view:applicantIsVeteran': 'No',
+        veteranFullName: 'test',
+        veteranDateOfBirth: 'test',
+        veteranEmail: 'test',
+        'Primary phone': 'test',
+        veteranHomeAddress: {
+          city: 'test',
+          country: 'test',
+          postalCode: 'test',
+          state: 'test',
+          street: 'test',
+        },
+        'Branch of Service': 'test',
+        veteranSocialSecurityNumber: 'test',
+      };
+
+      const result = prefillTransformer(data);
+
+      expect(result.veteranFullName).to.be.undefined;
+      expect(result.veteranDateOfBirth).to.be.undefined;
+      expect(result.veteranEmail).to.be.undefined;
+      expect(result['Primary phone']).to.be.undefined;
+      expect(result.veteranHomeAddress).to.eql({
+        city: undefined,
+        country: undefined,
+        postalCode: undefined,
+        state: undefined,
+        street: undefined,
+      });
+      expect(result['Branch of Service']).to.be.undefined;
+      expect(result.veteranSocialSecurityNumber).to.be.undefined;
+    });
+  });
+});

--- a/src/applications/representative-appoint/tests/fixtures/data/prefill.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/prefill.json
@@ -1,0 +1,29 @@
+{
+  "personalInformation": {
+    "fullName": {
+      "first": "Greg",
+      "last": "Anderson",
+      "middle": "A"
+    },
+    "dateOfBirth": "1933-04-05",
+    "ssn": "796121200"
+  },
+  "contactInformation": {
+    "address": {
+      "street": "123 avenue du Maine",
+      "city": "Paris",
+      "state": "Paris",
+      "country": "FRA",
+      "postalCode": "75014"
+    },
+    "email": "test2@test1.net",
+    "primaryPhone": "4445551212"
+  },
+  "militaryInformation": {
+    "serviceBranch": "Army"
+  },
+  "identityValidation": {
+    "hasIcn": true,
+    "hasParticipantId": true
+  }
+}

--- a/src/applications/representative-appoint/tests/pages/claimant/claimantType.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/pages/claimant/claimantType.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import ClaimantType from '../../../components/ClaimantType';
 import prefill from '../../fixtures/data/prefill.json';
-import formConfig from '../../../config/form.js';
+import formConfig from '../../../config/form';
 
 describe('<ClaimantType /> handlers', async () => {
   const getProps = ({ loggedIn = false } = {}) => {

--- a/src/applications/representative-appoint/tests/pages/claimant/claimantType.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/pages/claimant/claimantType.unit.spec.jsx
@@ -12,12 +12,14 @@ describe('<ClaimantType /> handlers', async () => {
       props: {
         setFormData: sinon.spy(),
         formData: initialFormData,
+        loggedIn: false,
       },
       mockStore: {
         getState: () => ({
           form: {
             data: initialFormData,
           },
+          user: { login: { currentlyLoggedIn: false } },
         }),
         subscribe: () => {},
         dispatch: () => ({

--- a/src/applications/representative-appoint/tests/pages/claimant/claimantType.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/pages/claimant/claimantType.unit.spec.jsx
@@ -1,33 +1,42 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ClaimantType from '../../../components/ClaimantType';
-import initialFormData from '../../fixtures/data/initial-form-data.json';
+import prefill from '../../fixtures/data/prefill.json';
+import formConfig from '../../../config/form.js';
 
 describe('<ClaimantType /> handlers', async () => {
-  const getProps = () => {
+  const getProps = ({ loggedIn = false } = {}) => {
     return {
       props: {
-        setFormData: sinon.spy(),
-        formData: initialFormData,
-        loggedIn: false,
+        router: { push: sinon.spy() },
+        location: { pathname: '/claimant-type' },
+        route: {
+          pageList: [
+            { path: '/introduction', formConfig },
+            { path: '/claimant-type', formConfig },
+            { path: '/select-representative', formConfig },
+          ],
+        },
       },
       mockStore: {
         getState: () => ({
           form: {
-            data: initialFormData,
+            data: prefill,
           },
-          user: { login: { currentlyLoggedIn: false } },
+          user: { login: { currentlyLoggedIn: loggedIn } },
         }),
         subscribe: () => {},
-        dispatch: () => ({
-          setFormData: () => {},
-        }),
+        dispatch: sinon.spy(),
       },
     };
   };
+
+  afterEach(() => {
+    cleanup();
+  });
 
   const renderContainer = (props, mockStore) => {
     return render(
@@ -51,5 +60,158 @@ describe('<ClaimantType /> handlers', async () => {
     );
     expect(radioButtonYes).to.exist;
     expect(radioButtonNo).to.exist;
+  });
+
+  context('when selecting Yes', () => {
+    it('updates state correctly', async () => {
+      const { props, mockStore } = getProps({ loggedIn: true });
+      const { dispatch } = mockStore;
+
+      const { container } = renderContainer(props, mockStore);
+
+      const radioSelector = container.querySelector('va-radio');
+      radioSelector.__events.vaValueChange({ detail: { value: 'Yes' } });
+
+      await waitFor(() => {
+        expect(dispatch.firstCall.args[0].data).to.deep.include({
+          'view:applicantIsVeteran': 'Yes',
+        });
+      });
+    });
+  });
+
+  context('when selecting No', () => {
+    it('updates state correctly', async () => {
+      const { props, mockStore } = getProps({ loggedIn: true });
+      const { dispatch } = mockStore;
+
+      const { container } = renderContainer(props, mockStore);
+
+      const radioSelector = container.querySelector('va-radio');
+      radioSelector.__events.vaValueChange({ detail: { value: 'No' } });
+
+      await waitFor(() => {
+        expect(dispatch.firstCall.args[0].data).to.deep.include({
+          'view:applicantIsVeteran': 'No',
+        });
+      });
+    });
+  });
+
+  context('when navigating forward', () => {
+    context('when a selection has been made', () => {
+      context('when logged in', () => {
+        it('attempts to prefill', async () => {
+          const { props, mockStore } = getProps({ loggedIn: true });
+          const { dispatch } = mockStore;
+
+          const { container } = renderContainer(props, mockStore);
+
+          const radioSelector = container.querySelector('va-radio');
+          radioSelector.__events.vaValueChange({ detail: { value: 'Yes' } });
+
+          const continueButton = container.querySelector('.usa-button-primary');
+
+          fireEvent.click(continueButton);
+
+          await waitFor(() => {
+            expect(dispatch.calledTwice).to.be.true;
+          });
+        });
+
+        it('routes to the representative select page', async () => {
+          const { props, mockStore } = getProps({ loggedIn: true });
+
+          const { container } = renderContainer(props, mockStore);
+
+          const radioSelector = container.querySelector('va-radio');
+          radioSelector.__events.vaValueChange({ detail: { value: 'Yes' } });
+
+          const continueButton = container.querySelector('.usa-button-primary');
+
+          fireEvent.click(continueButton);
+
+          await waitFor(() => {
+            expect(props.router.push.calledWith('/select-representative')).to.be
+              .true;
+          });
+        });
+      });
+
+      context('when not logged in', () => {
+        it('does not attempt to prefill', async () => {
+          const { props, mockStore } = getProps({ loggedIn: false });
+          const { dispatch } = mockStore;
+
+          const { container } = renderContainer(props, mockStore);
+
+          const radioSelector = container.querySelector('va-radio');
+          radioSelector.__events.vaValueChange({ detail: { value: 'Yes' } });
+
+          const continueButton = container.querySelector('.usa-button-primary');
+
+          fireEvent.click(continueButton);
+
+          await waitFor(() => {
+            expect(dispatch.calledOnce).to.be.true;
+          });
+        });
+
+        it('routes to the representative select page', async () => {
+          const { props, mockStore } = getProps({ loggedIn: true });
+
+          const { container } = renderContainer(props, mockStore);
+
+          const radioSelector = container.querySelector('va-radio');
+          radioSelector.__events.vaValueChange({ detail: { value: 'Yes' } });
+
+          const continueButton = container.querySelector('.usa-button-primary');
+
+          fireEvent.click(continueButton);
+
+          await waitFor(() => {
+            expect(props.router.push.calledWith('/select-representative')).to.be
+              .true;
+          });
+        });
+      });
+    });
+
+    context('when no selection has been made', () => {
+      it('displays an error', async () => {
+        const { props, mockStore } = getProps({ loggedIn: true });
+
+        const { container } = renderContainer(props, mockStore);
+
+        const radioSelector = container.querySelector('va-radio');
+
+        const continueButton = container.querySelector('.usa-button-primary');
+
+        fireEvent.click(continueButton);
+
+        await waitFor(() => {
+          expect(radioSelector).to.have.attr(
+            'error',
+            'You must provide a response',
+          );
+        });
+      });
+    });
+  });
+
+  context('when navigating backward', () => {
+    it('routes to the introduction page', async () => {
+      const { props, mockStore } = getProps({ loggedIn: true });
+
+      const { container } = renderContainer(props, mockStore);
+
+      const backButton = container.querySelector('.usa-button-secondary');
+
+      fireEvent.click(backButton);
+
+      await waitFor(() => {
+        expect(props.router.push.calledWith('/introduction')).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds prefill to the Appoint a Rep Form 21-22 and 21-22a

## Related issue(s)

- [96836](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96836)

## Testing done

- Went through the flow with authed and unauthed users
- Went backwards in flow to change the claimant type

## Before
https://github.com/user-attachments/assets/79037b8c-09b8-4c19-a493-1e0a19eff1ae

## After
https://github.com/user-attachments/assets/6a9cc542-6e8e-49b0-bd8e-630f7bcf5d48

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user