### PR TITLE
MHV-65010: Synced dispensed date for web and print view

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
@@ -87,7 +87,7 @@ const PrescriptionPrintOnly = props => {
           <div className="print-only-rx-details-container">
             <p>
               <strong>Last filled on:</strong>{' '}
-              {dateFormat(rx.dispensedDate, 'MMMM D, YYYY')}
+              {dateFormat(rx.sortedDispensedDate, 'MMMM D, YYYY')}
             </p>
             <p>
               <strong>Status:</strong>{' '}

--- a/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
@@ -15,6 +15,7 @@ import VaPharmacyText from '../shared/VaPharmacyText';
 const PrescriptionPrintOnly = props => {
   const { rx, hideLineBreak, refillHistory, isDetailsRx } = props;
   const pharmacyPhone = pharmacyPhoneNumber(rx);
+  const latestTrackingStatus = rx?.trackingList?.[0];
 
   const activeNonVaContent = pres => (
     <div className="print-only-rx-details-container vads-u-margin-top--1p5">
@@ -192,9 +193,7 @@ const PrescriptionPrintOnly = props => {
                       </p>
                       <p>
                         <strong>Shipped on:</strong>{' '}
-                        {entry?.trackingList?.[0]?.completeDateTime
-                          ? dateFormat(entry.trackingList[0].completeDateTime)
-                          : EMPTY_FIELD}
+                        {dateFormat(latestTrackingStatus?.completeDateTime)}
                       </p>
                       <p className="vads-u-margin--0">
                         <strong>Medication description: </strong>

--- a/src/applications/mhv-medications/util/pdfConfigs.js
+++ b/src/applications/mhv-medications/util/pdfConfigs.js
@@ -497,9 +497,9 @@ ${backImprint ? `* Back marking: ${backImprint}` : ''}`
                 },
                 {
                   title: `Shipped on`,
-                  value: entry?.trackingList?.[0]?.completeDateTime
-                    ? dateFormat(entry.trackingList[0].completeDateTime)
-                    : 'None noted',
+                  value: dateFormat(
+                    prescription?.trackingList?.[0]?.completeDateTime,
+                  ),
                   inline: true,
                 },
               ];

--- a/src/applications/mhv-medications/util/pdfConfigs.js
+++ b/src/applications/mhv-medications/util/pdfConfigs.js
@@ -137,7 +137,7 @@ export const buildPrescriptionsPDFList = prescriptions => {
           items: [
             {
               title: 'Last filled on',
-              value: dateFormat(rx.dispensedDate, 'MMMM D, YYYY'),
+              value: dateFormat(rx.sortedDispensedDate, 'MMMM D, YYYY'),
               inline: true,
             },
             {

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -256,11 +256,7 @@ Filled by pharmacy on: ${
       entry?.dispensedDate ? dateFormat(entry.dispensedDate) : 'None noted'
     }
 
-Shipped on: ${
-      entry?.trackingList?.[0]?.completeDateTime
-        ? dateFormat(entry.trackingList[0].completeDateTime)
-        : 'None noted'
-    }
+Shipped on: ${dateFormat(prescription?.trackingList?.[0].completeDateTime)}
 
 Description: ${description}
 

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -77,7 +77,7 @@ export const buildPrescriptionsTXT = prescriptions => {
     result += `
 ${rx.prescriptionName}
 
-Last filled on: ${dateFormat(rx.dispensedDate, 'MMMM D, YYYY')}
+Last filled on: ${dateFormat(rx.sortedDispensedDate, 'MMMM D, YYYY')}
 
 Status: ${validateField(rx.dispStatus)}
 ${(pdfStatusDefinitions[rx.refillStatus] || pdfDefaultStatusDefinition).reduce(

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -256,7 +256,7 @@ Filled by pharmacy on: ${
       entry?.dispensedDate ? dateFormat(entry.dispensedDate) : 'None noted'
     }
 
-Shipped on: ${dateFormat(prescription?.trackingList?.[0].completeDateTime)}
+Shipped on: ${dateFormat(prescription?.trackingList?.[0]?.completeDateTime)}
 
 Description: ${description}
 


### PR DESCRIPTION
## Summary

- Made sure print, pdf, and txt use the same fields for 'Last filled on' and 'Shipped on' fields as web does

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-65010

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Make sure all dates on the print pages match what is showing on the page they were printing from by using the same logic/manipulations in both places.
AC2: Specifically dispensed date was the one that was called out by a user so we need to make sure that one is fixed but also take a look at all other dates to make sure they match what is showing on the page. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
