### PR TITLE
99409 Update processing time copy - Form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -137,7 +137,14 @@ export function ConfirmationPage(props) {
 
       <h2>What to expect next</h2>
       <p>
-        It will take about 90 days to process your application.
+        {/* It will take about 90 days to process your application. */}
+        <b>
+          Note: Right now there's a delay in processing CHAMPVA applications.
+        </b>{' '}
+        We expect this delay to be temporary. If you have questions about the
+        status of your application, call us at{' '}
+        <VaTelephone contact="800-733-8387" />
+        (TTY: 711). We’re here Monday through Friday, 8:05 a.m. to 7:30 p.m. ET.
         <br />
         <br />
         If we have any questions or need additional information, we’ll contact

--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -141,8 +141,8 @@ export function ConfirmationPage(props) {
         <b>Note:</b> Right now there's a delay in processing CHAMPVA{' '}
         applications. We expect this delay to be temporary. If you have
         questions about the status of your application, call us at{' '}
-        <VaTelephone contact="800-733-8387" />
-        (TTY: 711). We’re here Monday through Friday, 8:05 a.m. to 7:30 p.m. ET.
+        <VaTelephone contact="800-733-8387" /> (TTY: 711). We’re here Monday
+        through Friday, 8:05 a.m. to 7:30 p.m. ET.
         <br />
         <br />
         If we have any questions or need additional information, we’ll contact

--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -138,11 +138,9 @@ export function ConfirmationPage(props) {
       <h2>What to expect next</h2>
       <p>
         {/* It will take about 90 days to process your application. */}
-        <b>
-          Note: Right now there's a delay in processing CHAMPVA applications.
-        </b>{' '}
-        We expect this delay to be temporary. If you have questions about the
-        status of your application, call us at{' '}
+        <b>Note:</b> Right now there's a delay in processing CHAMPVA{' '}
+        applications. We expect this delay to be temporary. If you have
+        questions about the status of your application, call us at{' '}
         <VaTelephone contact="800-733-8387" />
         (TTY: 711). We’re here Monday through Friday, 8:05 a.m. to 7:30 p.m. ET.
         <br />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the copy in the "What to expect next" section of the confirmation page to indicate a recent delay in processing times.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99409

## Testing done

- Manual

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         |
| ------- |
|![Screenshot 2024-12-18 at 15 03 51](https://github.com/user-attachments/assets/e762fbce-ba3e-4b20-82ef-be84dd525d83)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
