### PR TITLE
99262 Update focus selector - form 10-7959f-2

### DIFF
--- a/src/applications/ivc-champva/shared/components/fileUploads/upload.js
+++ b/src/applications/ivc-champva/shared/components/fileUploads/upload.js
@@ -23,9 +23,17 @@ export function createPayload(file, _formId, password) {
 }
 
 export function findAndFocusLastSelect() {
-  const lastSelect = [...document.querySelectorAll('select')].slice(-1);
+  const lastSelect = [...document.querySelectorAll('va-select')].slice(-1);
   if (lastSelect.length) {
     focusElement(lastSelect[0]);
+  } else {
+    // focus on upload button as a fallback
+    focusElement(
+      // including `#upload-button` because RTL can't access the shadowRoot
+      'button, #upload-button',
+      {},
+      document.querySelector(`#upload-button`)?.shadowRoot,
+    );
   }
   return lastSelect;
 }
@@ -48,7 +56,7 @@ export const fileUploadUi = content => {
     parseResponse: (response, file) => {
       setTimeout(() => {
         findAndFocusLastSelect();
-      });
+      }, 500);
       return {
         name: file.name,
         confirmationCode: response.data.attributes.confirmationCode,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates the focus to be on the "Uplaod another" button after a file upload. Also fixed issue where focus on file uploads with <va-select> wasn't correct.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99262

## Testing done

- Manual

## Screenshots

Focus shifted to "Upload another file" after upload complete: 
![Screenshot 2024-12-19 at 10 24 48](https://github.com/user-attachments/assets/25891695-aa71-4da8-9ec7-85d3bae80098)

## What areas of the site does it impact?

IVC champva forms with file upload component

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA