### PR TITLE
98360 landing page renders different alerts for user actionable errors and all other errors

### DIFF
--- a/src/applications/mhv-landing-page/components/CardLayout.jsx
+++ b/src/applications/mhv-landing-page/components/CardLayout.jsx
@@ -9,6 +9,7 @@ import {
   mrPhase1Enabled,
   apiAccountStatusEnabled,
   mhvAccountStatusUserError,
+  mhvAccountStatusErrorsSorted,
 } from '../selectors';
 
 import NavCard from './NavCard';
@@ -28,6 +29,9 @@ const layoutData = data => {
 const CardLayout = ({ data }) => {
   const isAccountStatusApiEnabled = useSelector(apiAccountStatusEnabled);
   const mhvAccountStatusUserErrors = useSelector(mhvAccountStatusUserError);
+  const mhvAccountStatusSortedErrors = useSelector(
+    mhvAccountStatusErrorsSorted,
+  );
   const isMrPhase1Enabled = useSelector(mrPhase1Enabled);
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const blueButtonUrl = mhvUrl(ssoe, 'download-my-data');
@@ -57,11 +61,12 @@ const CardLayout = ({ data }) => {
             key={`col-${y}`}
           >
             {isAccountStatusApiEnabled ? (
-              mhvAccountStatusUserErrors.length > 0 &&
+              mhvAccountStatusSortedErrors.length > 0 &&
               MHV_ACCOUNT_CARDS.includes(col.title) ? (
                 <ErrorNavCard
                   title={col.title}
-                  code={mhvAccountStatusUserErrors[0].code}
+                  code={mhvAccountStatusSortedErrors[0].code}
+                  userActionable={mhvAccountStatusUserErrors.length > 0}
                 />
               ) : col.title === HEALTH_TOOL_HEADINGS.MEDICAL_RECORDS &&
               !isMrPhase1Enabled ? (

--- a/src/applications/mhv-landing-page/components/ErrorNavCard.jsx
+++ b/src/applications/mhv-landing-page/components/ErrorNavCard.jsx
@@ -15,6 +15,7 @@ const ErrorNavCard = ({
   iconClasses = 'vads-u-margin-right--1p5',
   title,
   code,
+  userActionable = false,
 }) => {
   const slug = `mhv-c-card-${title.replaceAll(/\W+/g, '-').toLowerCase()}`;
   return (
@@ -41,29 +42,47 @@ const ErrorNavCard = ({
         </div>
       </div>
 
-      <p
-        className={classnames(
-          'vads-u-padding-left--0',
-          'vads-u-margin-top--2',
-          'vads-u-margin-bottom--0',
-          'vada-u-font-size--md',
-        )}
-      >
-        Error {code}: We can’t give you access to {title.toLowerCase()}
-      </p>
+      {userActionable ? (
+        <div>
+          <p
+            className={classnames(
+              'vads-u-padding-left--0',
+              'vads-u-margin-top--2',
+              'vads-u-margin-bottom--0',
+              'vada-u-font-size--md',
+            )}
+          >
+            Error {code}: We can’t give you access to {title.toLowerCase()}
+          </p>
 
-      <p
-        className={classnames(
-          'vads-u-padding-left--0',
-          'vads-u-margin-top--2',
-          'vads-u-margin-bottom--0',
-          'vada-u-font-size--md',
-        )}
-      >
-        Call us at <va-telephone contact="8773270022" />({' '}
-        <va-telephone contact={CONTACTS[711]} tty /> ). We’re here Monday
-        through Friday, 8:00 a.m. to 8:00 p.m. ET.
-      </p>
+          <p
+            className={classnames(
+              'vads-u-padding-left--0',
+              'vads-u-margin-top--2',
+              'vads-u-margin-bottom--0',
+              'vada-u-font-size--md',
+            )}
+          >
+            Call us at <va-telephone contact="8773270022" />({' '}
+            <va-telephone contact={CONTACTS[711]} tty /> ). We’re here Monday
+            through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          </p>
+        </div>
+      ) : (
+        <div>
+          <p
+            className={classnames(
+              'vads-u-padding-left--0',
+              'vads-u-margin-top--2',
+              'vads-u-margin-bottom--0',
+              'vada-u-font-size--md',
+            )}
+          >
+            We’ve run into a problem and can’t give you access to {title} right
+            now.
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+// eslint-disable-next-line import/no-named-default
+import { default as recordEventFn } from '~/platform/monitoring/record-event';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const AlertMhvNoAction = ({ errorCode, testId, recordEvent }) => {
+  const headline = `You can't access messages, medications, or medical records right now`;
+  useEffect(
+    () => {
+      recordEvent({
+        event: 'nav-alert-box-load',
+        action: 'load',
+        'alert-box-headline': headline,
+        'alert-box-status': 'warning',
+      });
+    },
+    [headline, recordEvent],
+  );
+
+  return (
+    <VaAlert
+      className="vads-u-margin-bottom--3"
+      data-testid={testId}
+      status="error"
+      visible
+    >
+      <h2 className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+        {headline}
+      </h2>
+      <div className="mhv-u-reg-alert-body" role="presentation">
+        <p className="vads-u-margin-y--0">
+          We’re sorry. There’s a problem with our system. Try refreshing this
+          page. Or check back later.
+        </p>
+
+        <p>
+          If the problem persists, call the My HealtheVet helpdesk at
+          877-327-0022 (TTY: 711). We’re here Monday through Friday, 8:00 a.m.
+          to 8 p.m. ET. Tell the representative that you received{' '}
+          <b>error code {errorCode}</b>.
+        </p>
+
+        <p>
+          If you need to contact your care team now, call your VA health
+          facility.
+        </p>
+
+        <a href="/find-locations/?page=1&facilityType=health">
+          Find your VA health facility
+        </a>
+      </div>
+    </VaAlert>
+  );
+};
+
+AlertMhvNoAction.defaultProps = {
+  title: 'Contact the My HealtheVet help desk: Error code',
+  errorCode: 'unknown',
+  recordEvent: recordEventFn,
+  testId: 'mhv-alert--mhv-registration',
+};
+
+AlertMhvNoAction.propTypes = {
+  errorCode: PropTypes.string,
+  title: PropTypes.string,
+  headline: PropTypes.string,
+  recordEvent: PropTypes.func,
+  testId: PropTypes.string,
+};
+
+export default AlertMhvNoAction;

--- a/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.jsx
@@ -55,7 +55,7 @@ const AlertMhvNoAction = ({ errorCode, testId, recordEvent }) => {
 };
 
 AlertMhvNoAction.defaultProps = {
-  title: 'Contact the My HealtheVet help desk: Error code',
+  title: "You can't access messages, medications, or medical records right now",
   errorCode: 'unknown',
   recordEvent: recordEventFn,
   testId: 'mhv-alert--mhv-registration',

--- a/src/applications/mhv-landing-page/components/alerts/index.js
+++ b/src/applications/mhv-landing-page/components/alerts/index.js
@@ -4,6 +4,7 @@ import AlertNotVerified from './AlertNotVerified';
 import AlertUnregistered from './AlertUnregistered';
 import AlertVerifyAndRegister from './AlertVerifyAndRegister';
 import AlertMhvUserAction from './AlertMhvUserAction';
+import AlertMhvNoAction from './AlertMhvNoAction';
 
 export {
   AlertMhvBasicAccount,
@@ -12,4 +13,5 @@ export {
   AlertUnregistered,
   AlertVerifyAndRegister,
   AlertMhvUserAction,
+  AlertMhvNoAction,
 };

--- a/src/applications/mhv-landing-page/containers/Alerts.jsx
+++ b/src/applications/mhv-landing-page/containers/Alerts.jsx
@@ -7,6 +7,7 @@ import {
   AlertUnregistered,
   AlertVerifyAndRegister,
   AlertMhvUserAction,
+  AlertMhvNoAction,
 } from '../components/alerts';
 
 import {
@@ -19,6 +20,7 @@ import {
   mhvAccountStatusLoading,
   mhvAccountStatusUserError,
   mhvAccountStatusUsersuccess,
+  mhvAccountStatusNonUserError,
   showVerifyAndRegisterAlert,
   signInServiceName,
 } from '../selectors';
@@ -33,6 +35,9 @@ const Alerts = () => {
   const renderVerifyAndRegisterAlert = useSelector(showVerifyAndRegisterAlert);
   const cspId = useSelector(signInServiceName);
   const ssoe = useSelector(isAuthenticatedWithSSOe);
+  const mhvAccountStatusNonUserErrors = useSelector(
+    mhvAccountStatusNonUserError,
+  );
   const mhvAccountStatusUserErrors = useSelector(mhvAccountStatusUserError);
   const mhvAccountStatusSuccess = useSelector(mhvAccountStatusUsersuccess);
   const mhvAccountStatusIsLoading = useSelector(mhvAccountStatusLoading);
@@ -47,6 +52,12 @@ const Alerts = () => {
 
   if (!userRegistered) {
     return <AlertUnregistered />;
+  }
+
+  if (mhvAccountStatusNonUserErrors.length > 0 && isAccountStatusApiEnabled) {
+    return (
+      <AlertMhvNoAction errorCode={mhvAccountStatusNonUserErrors[0].code} />
+    );
   }
 
   if (mhvAccountStatusUserErrors.length > 0 && isAccountStatusApiEnabled) {

--- a/src/applications/mhv-landing-page/mocks/api/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/index.js
@@ -17,7 +17,8 @@ const responses = (userMock = USER_MOCKS.DEFAULT) => ({
 
   // 'GET /v0/user/mhv_user_account': MHVAccountStatus.accountSuccess,
   // 'GET /v0/user/mhv_user_account': MHVAccountStatus.eightZeroOne,
-  'GET /v0/user/mhv_user_account': MHVAccountStatus.eightZeroFive,
+  // 'GET /v0/user/mhv_user_account': MHVAccountStatus.eightZeroFive,
+  'GET /v0/user/mhv_user_account': MHVAccountStatus.fiveZeroZero,
 });
 
 module.exports = responses(USER_MOCKS.DEFAULT);

--- a/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
+++ b/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
@@ -88,6 +88,16 @@ const accountStatusEightZeroOne = {
   ],
 };
 
+const accountStatusFiveZeroZero = {
+  errors: [
+    {
+      title: 'The server responded with status 422',
+      detail: 'things fall apart',
+      code: '500',
+    },
+  ],
+};
+
 module.exports = {
   accountSuccess,
   eightZeroOne,
@@ -96,4 +106,5 @@ module.exports = {
   fiveZeroZero,
   accountStatusSuccessResponse,
   accountStatusEightZeroOne,
+  accountStatusFiveZeroZero,
 };

--- a/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
+++ b/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
@@ -51,6 +51,18 @@ const eightZeroSix = (req, res) => {
   });
 };
 
+const fiveZeroZero = (req, res) => {
+  return res.status(500).json({
+    errors: [
+      {
+        title: 'The server responded with status 500',
+        detail: 'things fall apart',
+        code: '500',
+      },
+    ],
+  });
+};
+
 const accountStatusSuccessResponse = {
   data: {
     id: '12345678',
@@ -81,6 +93,7 @@ module.exports = {
   eightZeroOne,
   eightZeroFive,
   eightZeroSix,
+  fiveZeroZero,
   accountStatusSuccessResponse,
   accountStatusEightZeroOne,
 };

--- a/src/applications/mhv-landing-page/selectors/index.js
+++ b/src/applications/mhv-landing-page/selectors/index.js
@@ -29,6 +29,7 @@ import {
   mhvAccountStatusUsersuccess,
   mhvAccountStatusUserError,
   mhvAccountStatusNonUserError,
+  mhvAccountStatusErrorsSorted,
 } from './mhvAccountStatus';
 
 export {
@@ -45,6 +46,7 @@ export {
   mhvAccountStatusLoading,
   mhvAccountStatusUsersuccess,
   mhvAccountStatusUserError,
+  mhvAccountStatusErrorsSorted,
   mhvAccountStatusNonUserError,
   mrPhase1Enabled,
   personalizationEnabled,

--- a/src/applications/mhv-landing-page/selectors/mhvAccountStatus.js
+++ b/src/applications/mhv-landing-page/selectors/mhvAccountStatus.js
@@ -11,6 +11,17 @@ export const mhvAccountStatusUsersuccess = state => {
   );
 };
 
+export const mhvAccountStatusErrorsSorted = state => {
+  if (state?.myHealth?.accountStatus?.data?.errors) {
+    return state?.myHealth?.accountStatus?.data?.errors.sort(
+      (a, b) =>
+        userActionErrorCodes.includes(b.code) -
+        userActionErrorCodes.includes(a.code),
+    );
+  }
+  return [];
+};
+
 export const mhvAccountStatusUserError = state => {
   if (state?.myHealth?.accountStatus?.data?.errors) {
     return state?.myHealth?.accountStatus?.data?.errors.filter(error =>

--- a/src/applications/mhv-landing-page/selectors/mhvAccountStatus.js
+++ b/src/applications/mhv-landing-page/selectors/mhvAccountStatus.js
@@ -11,6 +11,8 @@ export const mhvAccountStatusUsersuccess = state => {
   );
 };
 
+// Prioritize user actionable errors (userActionErrorCodes)
+// over other less actionable errors
 export const mhvAccountStatusErrorsSorted = state => {
   if (state?.myHealth?.accountStatus?.data?.errors) {
     return state?.myHealth?.accountStatus?.data?.errors.sort(

--- a/src/applications/mhv-landing-page/tests/e2e/alerts/no-mhv-account.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/alerts/no-mhv-account.cypress.spec.js
@@ -2,6 +2,7 @@ import { appName } from '../../../manifest.json';
 import ApiInitializer from '../utilities/ApiInitializer';
 import LandingPage from '../pages/LandingPage';
 import AlertMhvUserAction from '../../../components/alerts/AlertMhvUserAction.jsx';
+import AlertMhvNoAction from '../../../components/alerts/AlertMhvNoAction.jsx';
 
 describe(`${appName} - MHV Registration Alert - `, () => {
   beforeEach(() => {
@@ -42,6 +43,49 @@ describe(`${appName} - MHV Registration Alert - `, () => {
       cy.findByText(/Error \d+: We can('|’)t give you access to medications/, {
         exact: false,
       }).should.exist;
+    });
+  });
+
+  context('for non-user api errors', () => {
+    beforeEach(() => {
+      ApiInitializer.initializeAccountStatus.with500();
+      LandingPage.visit({ mhvAccountState: 'NONE' });
+    });
+
+    it(`shows a 'try again later' alert`, () => {
+      cy.injectAxeThenAxeCheck();
+      cy.findByText(AlertMhvNoAction.defaultProps.title, {
+        exact: false,
+      }).should.exist;
+
+      // Check the cards and hubs are visible
+      cy.findAllByTestId(/^mhv-link-group-card-/).should.exist;
+      cy.findAllByTestId(/^mhv-link-group-hub-/).should.exist;
+    });
+
+    it(`displays error card for messages`, () => {
+      cy.findByText(
+        'We’ve run into a problem and can’t give you access to Messages right now.',
+        {
+          exact: false,
+        },
+      ).should.exist;
+    });
+
+    it(`displays error card for medical records`, () => {
+      cy.findByText(
+        'We’ve run into a problem and can’t give you access to Medical records right now.',
+        { exact: false },
+      ).should.exist;
+    });
+
+    it(`displays error card for medications`, () => {
+      cy.findByText(
+        'We’ve run into a problem and can’t give you access to Medications right now.',
+        {
+          exact: false,
+        },
+      ).should.exist;
     });
   });
 

--- a/src/applications/mhv-landing-page/tests/e2e/utilities/ApiInitializer.js
+++ b/src/applications/mhv-landing-page/tests/e2e/utilities/ApiInitializer.js
@@ -7,6 +7,7 @@ import {
 import {
   accountStatusSuccessResponse,
   accountStatusEightZeroOne,
+  accountStatusFiveZeroZero,
 } from '../../../mocks/api/user/mhvAccountStatus';
 
 class ApiInitializer {
@@ -76,6 +77,13 @@ class ApiInitializer {
         'GET',
         '/v0/user/mhv_user_account',
         accountStatusEightZeroOne,
+      );
+    },
+    with500: () => {
+      cy.intercept(
+        'GET',
+        '/v0/user/mhv_user_account',
+        accountStatusFiveZeroZero,
       );
     },
   };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Handle general errors when hitting the mhv account creation api.

## Related issue(s)
[98360](https://github.com/department-of-veterans-affairs/va.gov-team/issues/98360)

## Testing done
Tests added

## Screenshots
<img width="1015" alt="Screenshot 2024-12-19 at 2 51 53 PM" src="https://github.com/user-attachments/assets/3f7c6880-8193-4264-94a6-0a5030379cca" />
<img width="1019" alt="Screenshot 2024-12-19 at 2 52 48 PM" src="https://github.com/user-attachments/assets/d2ba2aa8-052b-4e73-bc27-30b0c425dbb1" />


## What areas of the site does it impact?
MHV landing page

## Acceptance criteria
When API returns any error code _not_ in this list: [801,805,806,807] a specific alert should be rendered and certain cards should change.

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
