### PR TITLE
[26-4555] Implement new confirmation page

### DIFF
--- a/src/applications/simple-forms/21P-0847/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -18,10 +18,8 @@ describe('ConfirmationPage', () => {
   const mockStore = configureMockStore();
   const initialState = {
     form: {
-      data: {
-        ...createInitialState(formConfig),
-        ...testData.data,
-      },
+      ...createInitialState(formConfig),
+      data: testData,
       submission: {
         response: {
           confirmationNumber: '1234567890',
@@ -58,14 +56,12 @@ describe('ConfirmationPage', () => {
     const submitDate = new Date();
     const mockInitialState = {
       form: {
+        ...createInitialState(formConfig),
         submission: {
           timestamp: submitDate,
           response: { confirmationNumber: '1234' },
         },
-        data: {
-          ...createInitialState(formConfig),
-          ...testData.data,
-        },
+        data: testData,
       },
     };
     const mockDefinedState = createStore(() => mockInitialState);

--- a/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
@@ -1,66 +1,108 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
+import { connect, useSelector } from 'react-redux';
+import { format, isValid } from 'date-fns';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 
 export const ConfirmationPage = props => {
-  const { form } = props;
-  const { submission, data } = form;
-
-  const { fullName } = data.veteran;
+  const form = useSelector(state => state.form || {});
+  const { submission } = form;
   const submitDate = submission.timestamp;
-  const { referenceNumber, status } = submission.response;
+  const { confirmationNumber, referenceNumber, status } =
+    submission.response || {};
 
-  let content = {
-    headlineText: 'Thank you for completing your benefit application',
-    nextStepsText: `After we review your application, we’ll contact you to validate your information. If you have any questions about your application, contact us at 877-827-3702, select the Specially Adapted Housing grant option, and give them your confirmation number ${referenceNumber}.`,
-  };
+  let submissionAlertContent = (
+    <p>
+      After we review your application, we’ll contact you to validate your
+      information. If you have any questions about your application, contact us
+      at 877-827-3702, select the Specially Adapted Housing grant option, and
+      give them your confirmation number {referenceNumber}.
+    </p>
+  );
 
   if (status === 'REJECTED') {
-    content = {
-      headlineText: 'Thank you for completing your benefit application',
-      nextStepsText: `We received your application, but there was a problem. For more information, contact us at 877-827-3702, select the Specially Adapted Housing grant option, and give them your confirmation number ${referenceNumber}.`,
-    };
+    submissionAlertContent = (
+      <p>
+        We received your application, but there was a problem. For more
+        information, contact us at 877-827-3702, select the Specially Adapted
+        Housing grant option, and give them your confirmation number{' '}
+        {referenceNumber}.
+      </p>
+    );
   } else if (status === 'DUPLICATE') {
-    content = {
-      headlineText: 'Thank you for completing your benefit application',
-      nextStepsText: `We received your application, but we already have an existing housing grant application from you on file. We're still processing your existing application. If you have any questions, contact us at 877-827-3702, select the Specially Adapted Housing grant option.`,
-    };
+    submissionAlertContent = (
+      <p>
+        We received your application, but we already have an existing housing
+        grant application from you on file. We’re still processing your existing
+        application. If you have any questions, contact us at 877-827-3702,
+        select the Specially Adapted Housing grant option.
+      </p>
+    );
   }
 
   return (
-    <ConfirmationPageView
-      submitterName={fullName}
+    <ConfirmationView
+      formConfig={props.route?.formConfig}
       submitDate={submitDate}
-      confirmationNumber={referenceNumber}
-      content={content}
-    />
+      confirmationNumber={confirmationNumber}
+      devOnly={{
+        showButtons: true,
+      }}
+    >
+      <ConfirmationView.SubmissionAlert
+        title={`Your form submission was succesful${
+          isValid(submitDate) ? ` on ${format(submitDate, 'MMMM d, yyyy')}` : ''
+        }`}
+        content={submissionAlertContent}
+      />
+      <ConfirmationView.ChapterSectionCollection />
+      <ConfirmationView.PrintThisPage />
+      <ConfirmationView.HowToContact
+        content={
+          <>
+            <p>
+              Call us at <va-telephone contact="8008773702" /> (
+              <va-telephone tty="true" contact={CONTACTS[711]} />) and select
+              the specially adapted housing grant option. We’re here Monday
+              through Friday, from 8:00 a.m. to 6:00 p.m. ET.
+            </p>
+            <p>
+              Or you can ask us a question online through Ask VA. Select the
+              category and topic for the VA benefit this form is related to.
+            </p>
+            <p>
+              <va-link
+                href="https://ask.va.gov/"
+                text="Contact us online through Ask VA"
+              />
+            </p>
+          </>
+        }
+      />
+      <ConfirmationView.GoBackLink />
+      <ConfirmationView.NeedHelp />
+    </ConfirmationView>
   );
 };
 
 ConfirmationPage.propTypes = {
   form: PropTypes.shape({
-    data: PropTypes.shape({
-      veteran: {
-        fullName: {
-          first: PropTypes.string,
-          middle: PropTypes.string,
-          last: PropTypes.string,
-          suffix: PropTypes.string,
-        },
-      },
-    }),
+    data: PropTypes.object,
     formId: PropTypes.string,
     submission: PropTypes.shape({
       timestamp: PropTypes.string,
       response: {
+        confirmationNumber: PropTypes.string,
         referenceNumber: PropTypes.string,
         status: PropTypes.string,
       },
     }),
   }),
   name: PropTypes.string,
+  route: PropTypes.shape({
+    formConfig: PropTypes.object,
+  }),
 };
 
 function mapStateToProps(state) {

--- a/src/applications/simple-forms/26-4555/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,47 +1,102 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
+
 import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { createStore } from 'redux';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { cleanup } from '@testing-library/react';
+import { format } from 'date-fns';
+import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/state/helpers';
 import formConfig from '../../config/form';
 import ConfirmationPage from '../../containers/ConfirmationPage';
+import testData from '../e2e/fixtures/data/maximal-test.json';
 
-const storeBase = {
-  form: {
-    formId: formConfig.formId,
-    submission: {
-      response: {
-        confirmationNumber: '123456',
-      },
-      timestamp: Date.now(),
-    },
-    data: {
-      veteran: {
-        fullName: {
-          first: 'Jack',
-          middle: 'W',
-          last: 'Witness',
+describe('ConfirmationPage', () => {
+  let wrapper;
+  let store;
+  const mockStore = configureMockStore();
+  const initialState = {
+    form: {
+      ...createInitialState(formConfig),
+      testData,
+      submission: {
+        response: {
+          confirmationNumber: '1234567890',
+          referenceNumber: '9876543210',
         },
+        timestamp: '2022-01-01T00:00:00Z',
       },
     },
-  },
-};
+  };
 
-describe('Confirmation page', () => {
-  const middleware = [thunk];
-  const mockStore = configureStore(middleware);
-
-  it('it should show status success and the correct name of person', () => {
-    const { container, getByText } = render(
-      <Provider store={mockStore(storeBase)}>
-        <ConfirmationPage />
+  beforeEach(() => {
+    store = mockStore(initialState);
+    wrapper = mount(
+      <Provider store={store}>
+        <ConfirmationPage route={{ formConfig }} />
       </Provider>,
     );
-    expect(container.querySelector('va-alert')).to.have.attr(
-      'status',
-      'success',
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    cleanup();
+  });
+
+  it('passes the correct props to ConfirmationPageView', () => {
+    const confirmationViewProps = wrapper.find('ConfirmationView').props();
+
+    expect(confirmationViewProps.submitDate).to.equal('2022-01-01T00:00:00Z');
+    expect(confirmationViewProps.confirmationNumber).to.equal('1234567890');
+  });
+
+  it('should select form from state when state.form is defined', () => {
+    const submitDate = new Date();
+    const mockInitialState = {
+      form: {
+        ...createInitialState(formConfig),
+        testData,
+        submission: {
+          timestamp: submitDate,
+          response: { referenceNumber: '1234' },
+        },
+      },
+    };
+    const mockDefinedState = createStore(() => mockInitialState);
+
+    const definedWrapper = mount(
+      <Provider store={mockDefinedState}>
+        <ConfirmationPage route={{ formConfig }} />
+      </Provider>,
     );
-    getByText(/Jack W Witness/);
+
+    expect(definedWrapper.text()).to.include(
+      format(submitDate, 'MMMM d, yyyy'),
+    );
+    expect(definedWrapper.text()).to.include('1234');
+
+    definedWrapper.unmount();
+  });
+
+  it('should throw error when state.form is undefined', () => {
+    const mockEmptyState = {};
+    const mockEmptyStore = createStore(() => mockEmptyState);
+
+    let errorWrapper;
+
+    expect(() => {
+      errorWrapper = mount(
+        <Provider store={mockEmptyStore}>
+          <ConfirmationPage route={{ formConfig }} />
+        </Provider>,
+      );
+    }).to.throw();
+
+    if (errorWrapper) {
+      errorWrapper.unmount();
+    }
   });
 });


### PR DESCRIPTION
## Summary
This pull request implements the new confirmation page for form 26-4555. This confirmation page does not display a few of the elements that other new confirmation pages do, such as the PDF download link, next steps, etc. However, it does have three unique alerts that are all "success" but with different content. The reference number from the SAHSHA API is displayed in the alert instead of the usual confirmation number.

Also in this PR is a small fix to form 21P-0847's confirmation page unit test as I realized I structured the form object incorrectly. It wasn't impacting the result of the test as the data was being mostly overwritten by the form object initialization function, but now it is actually pulling from the mock data like it is supposed to.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1798

## Testing done

- Refactored and updated unit tests for new confirmation page in 26-4555
- Slightly altered new confirmation page unit test in form 21P-0847 because it was scoping the data incorrectly

## Screenshots
Successful submission
![Screenshot 2024-12-19 at 4 27 38 PM](https://github.com/user-attachments/assets/969043a3-e253-4e69-bbc2-57781d31ea36)

Problem with submission, but accepted
![Screenshot 2024-12-19 at 4 28 15 PM](https://github.com/user-attachments/assets/128748ed-a890-42ad-b474-9c4f4aafd3cf)

Already existing submission
![Screenshot 2024-12-19 at 4 28 56 PM](https://github.com/user-attachments/assets/0cb6cab2-d3fa-4ce9-af5f-130db00e33e3)

