### PR TITLE
10-7959f-2 Update Payment Screen for Screen Readers

### DIFF
--- a/src/applications/ivc-champva/10-7959f-2/components/PaymentSelection.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/components/PaymentSelection.jsx
@@ -5,25 +5,6 @@ import { radioUI } from 'platform/forms-system/src/js/web-component-patterns/rad
 const PaymentSelectionUI = () => {
   return radioUI({
     title: 'Tell us where to send the payment for this claim',
-    description: (
-      <>
-        <ul>
-          <li>
-            Select <strong>Veteran</strong> if you’ve already paid this
-            provider. We’ll send a check to your mailing address to pay you back
-            (also called reimbursement).
-          </li>
-          <li>
-            Select <strong>Provider</strong> if you haven’t paid the provider.
-            We’ll send a check to the provider’s mailing address to pay them
-            directly.
-          </li>
-        </ul>
-        <p>
-          <strong>Send payment to:</strong>
-        </p>
-      </>
-    ),
     labels: {
       Veteran: 'Veteran',
       Provider: 'Provider',

--- a/src/applications/ivc-champva/10-7959f-2/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-2/config/form.js
@@ -1,6 +1,7 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { cloneDeep } from 'lodash';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
+import React from 'react';
 
 import {
   ssnOrVaFileNumberNoHintSchema,
@@ -254,7 +255,23 @@ const formConfig = {
           path: 'payment-selection',
           title: 'Where to send the payment',
           uiSchema: {
-            ...titleUI('Where to send the payment'),
+            ...titleUI(
+              'Where to send the payment',
+              <>
+                <ul>
+                  <li>
+                    Select <strong>Veteran</strong> if you’ve already paid this
+                    provider. We’ll send a check to your mailing address to pay
+                    you back (also called reimbursement).
+                  </li>
+                  <li>
+                    Select <strong>Provider</strong> if you haven’t paid the
+                    provider. We’ll send a check to the provider’s mailing
+                    address to pay them directly.
+                  </li>
+                </ul>
+              </>,
+            ),
             sendPayment: PaymentSelectionUI(),
           },
           schema: {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR updates the Payment Screen so that the descriptive text (bullet points) are located in the fieldset class. This makes it possible for screen readers to include that text. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/99260

## Testing done
e2e
unit

## Screenshots
Screen with dev console:
![Screenshot 2024-12-19 at 8 20 14 AM](https://github.com/user-attachments/assets/7f1c0a43-81db-4061-b439-23c9a8936ced)
Close up of dev console:
![Screenshot 2024-12-19 at 8 20 24 AM](https://github.com/user-attachments/assets/25bef71d-1ea9-4372-9841-4575bb61b179)

## What areas of the site does it impact?
Just this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA