### PR TITLE
Use platform's renderWithStoreAndRouter

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
@@ -179,9 +179,11 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       await waitFor(() => {
         screen.queryByText(/San Diego VA Medical Center/i);
       });
-      expect(screen.baseElement).to.contain.text(
-        'You’ll need to call to schedule at this facility',
-      );
+      expect(
+        await screen.findByText(
+          /You.ll need to call to schedule at this facility/,
+        ),
+      ).to.exist;
 
       expect(await screen.queryByText(/Continue/)).not.to.exist;
     });

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -1,7 +1,7 @@
 /** @module testing/mocks/setup */
 
 import React from 'react';
-import { Route, Router } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import { createMemoryHistory } from 'history-v4';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
@@ -10,7 +10,7 @@ import sinon from 'sinon';
 import { fireEvent, waitFor } from '@testing-library/dom';
 
 import { commonReducer } from '@department-of-veterans-affairs/platform-startup/store';
-import { renderInReduxProvider } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { renderWithStoreAndRouter as platformRenderWithStoreAndRouter } from '~/platform/testing/unit/react-testing-library-helpers';
 
 import { cleanup } from '@testing-library/react';
 import reducers from '../../redux/reducer';
@@ -101,25 +101,13 @@ export function renderWithStoreAndRouter(
   ui,
   { initialState, store = null, path = '/', history = null },
 ) {
-  const testStore =
-    store ||
-    createStore(
-      combineReducers({ ...commonReducer, ...reducers }),
-      initialState,
-      applyMiddleware(thunk),
-    );
-
-  const historyObject = history || createTestHistory(path);
-  const screen = renderInReduxProvider(
-    <Router history={historyObject}>{ui}</Router>,
-    {
-      store: testStore,
-      initialState,
-      reducers,
-    },
-  );
-
-  return { ...screen, history: historyObject };
+  return platformRenderWithStoreAndRouter(ui, {
+    initialState,
+    reducers,
+    store,
+    path,
+    history,
+  });
 }
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- It turns out we can't exactly remove our custom `renderWithStoreAndRouter` function since it uses VAOS custom reducers by default. However, given the function implementation are identical, we can wrap the call to the platform's `renderWithStoreAndRouter` in our test utility.
- I also fixed a flaky unit test that I noticed was failing fairly consistently on my local machine
- This is a test only change
- Appointments (VAOS) Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96542

## Testing done

- Ensured unit tests pass locally and on the CI

## Screenshots

N/A

## What areas of the site does it impact?

Appointments (VAOS) 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
