### PR TITLE
98725 Stamp full country name rather than just country code - form 10-7959f-1

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import CONSTANTS from 'vets-json-schema/dist/constants.json'; // For countries
 import { formatDateShort } from 'platform/utilities/date';
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 import { concatStreets } from '../../shared/utilities';
@@ -10,6 +11,21 @@ function stringifyAddress(addr) {
         addr.state
       }\n${addr.postalCode}`
     : '';
+}
+
+/**
+ * Converts country codes to full country names and returns updated address.
+ * e.g., {country: 'USA'} => {country: 'United States'}
+ * @param {object} addr Standard address object provided by the addressUI component.
+ * @returns Updated address object with country value replaced or left alone depending on presence of matching country label in the CONSTANTS file.
+ */
+function getCountryLabel(addr) {
+  const tmpAdr = addr;
+  // Find country label that matches country code in `addr`
+  tmpAdr.country =
+    CONSTANTS.countries.filter(c => c.value === tmpAdr.country)[0]?.label ??
+    tmpAdr.country; // leave untouched if no match found
+  return tmpAdr;
 }
 
 export default function transformForSubmit(formConfig, form) {
@@ -59,6 +75,14 @@ export default function transformForSubmit(formConfig, form) {
     dataPostTransform.veteran.physical_address,
   );
   dataPostTransform.veteran.mailingAddressString = stringifyAddress(
+    dataPostTransform.veteran.mailing_address,
+  );
+
+  // Replace country code with full name:
+  dataPostTransform.veteran.physical_address = getCountryLabel(
+    dataPostTransform.veteran.physical_address,
+  );
+  dataPostTransform.veteran.mailing_address = getCountryLabel(
     dataPostTransform.veteran.mailing_address,
   );
 

--- a/src/applications/ivc-champva/10-7959f-1/tests/unit/config/submitTransformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959f-1/tests/unit/config/submitTransformer.unit.spec.js
@@ -4,35 +4,53 @@ import formConfig from '../../../config/form';
 import transformForSubmit from '../../../config/submitTransformer';
 
 describe('submit transformer', () => {
-  it('should return expected data', () => {
-    const formData = {
-      data: {
-        veteranDateOfBirth: '2004-02-19',
-        fullName: 'John Smith',
-        physical_address: {
-          street: '1 Main st',
-          city: 'Canton',
-          state: 'NY',
-          postalCode: '13625',
-          country: 'US',
-        },
-        mailing_address: {
-          street: '21 Jump St',
-          city: 'Prattville',
-          state: 'WA',
-          postalCode: '12569',
-          country: 'US',
-        },
-        ssn: '963879632',
-        va_claim_number: '5236978',
-        phone_number: '2056321459',
-        email_address: 'john@gmail.com0',
+  const formData = {
+    data: {
+      veteranDateOfBirth: '2004-02-19',
+      fullName: 'John Smith',
+      veteranAddress: {
+        street: '1 Main st',
+        city: 'Canton',
+        state: 'NY',
+        postalCode: '13625',
+        country: 'AFG',
       },
-    };
+      physicalAddress: {
+        street: '21 Jump St',
+        city: 'Prattville',
+        state: 'WA',
+        postalCode: '12569',
+        country: 'USA',
+      },
+      ssn: '963879632',
+      va_claim_number: '5236978',
+      phone_number: '2056321459',
+      email_address: 'john@gmail.com0',
+    },
+  };
+  it('should return expected data', () => {
     const newTransformData = JSON.parse(
       transformForSubmit(formConfig, formData),
     );
     // eslint-disable-next-line no-console
     expect(newTransformData.veteran.date_of_birth).to.equal('02/19/2004');
+  });
+  it('should replace country code with full country name', () => {
+    const data = JSON.parse(
+      transformForSubmit(formConfig, {
+        data: {
+          veteranDateOfBirth: '2004-02-19',
+          sameMailingAddress: true,
+          veteranAddress: {
+            street: '1 Main st',
+            city: 'Canton',
+            state: 'NY',
+            postalCode: '13625',
+            country: 'USA',
+          },
+        },
+      }),
+    );
+    expect(data.veteran.physical_address.country).to.equal('United States');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the submit transformer so that address country codes are replaced with the corresponding country name. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98725

## Testing done

- Manual
- Unit

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-12-23 at 09 47 22](https://github.com/user-attachments/assets/6ae998f5-c3d7-49f3-acf5-768ab35e130b)|![Screenshot 2024-12-23 at 09 41 09](https://github.com/user-attachments/assets/7a5a5a9d-f7e1-435a-b98d-23df65decab7)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA