### PR TITLE
[CDP] Add intro text back to overpayment summary and fix payment disclaimer on copays

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -189,6 +189,11 @@ const DebtLettersSummary = () => {
         >
           {title}
         </h1>
+        <p className="va-introtext">
+          Check the details of debt you might have from VA education, disability
+          compensation, or pension programs. Find out how to pay your debt and
+          what to do if you need financial assistance.
+        </p>
         <p>
           Please note that payments may take up to 4 business days to reflect
           after processing.

--- a/src/applications/combined-debt-portal/medical-copays/components/Balances.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/Balances.jsx
@@ -19,9 +19,8 @@ export const Balances = ({ statements }) => {
     <article className="vads-u-padding-x--0">
       {statements?.length === 1 ? single : multiple}
       <p>
-        Any payments you may have made to your current copays will not be
-        reflected here until our systems are updated with your next monthly
-        statement.
+        Any payments you have made will not be reflected here until our systems
+        are updated with your next monthly statement.
       </p>
       <ul className="no-bullets vads-u-padding-x--0">
         {statements?.map((balance, idx) => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixed some confusing copy on the copay summary page
- Added the intro text back to the overpayment summary page

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#92536

## Testing done

- Tested locally 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Copays verb change  | <img width="761" alt="Screenshot 2024-12-23 at 1 29 48 PM" src="https://github.com/user-attachments/assets/076667bc-a24e-4dac-9675-0d3009b8e297" /> | <img width="733" alt="Screenshot 2024-12-23 at 1 27 40 PM" src="https://github.com/user-attachments/assets/1e7fb3d1-600f-4126-ae70-801c30fd87e4" /> |
| Overpayment intro text cahnge | <img width="812" alt="Screenshot 2024-12-23 at 1 30 05 PM" src="https://github.com/user-attachments/assets/994f0269-9e25-4575-aaa0-9f0d0ca02a03" /> | <img width="730" alt="Screenshot 2024-12-23 at 1 30 47 PM" src="https://github.com/user-attachments/assets/e3b29a1a-0825-4b01-8ae2-cb71569eaf32" /> |

## What areas of the site does it impact?

Combined Debt Portal

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
