### PR TITLE
My VA - update copy for GI bill benefits 

### DIFF
--- a/src/applications/personalization/dashboard/components/education-and-training/EducationAndTraining.jsx
+++ b/src/applications/personalization/dashboard/components/education-and-training/EducationAndTraining.jsx
@@ -45,15 +45,15 @@ const EducationAndTraining = ({ isLOA1, rE = recordEvent }) => {
                 }
               />
               <IconCTALink
-                text="Check your Post-9/11 GI Bill benefits"
+                text="Check your remaining Post-9/11 GI Bill benefits"
                 icon="attach_money"
-                href="/education/gi-bill/post-9-11/ch-33-benefit/status"
+                href="/education/check-remaining-post-9-11-gi-bill-benefits/status/"
                 testId="check-gi-bill-benefits-from-cta"
                 onClick={() =>
                   rE({
                     event: 'nav-linkslist',
                     'links-list-header':
-                      'Check your Post-9/11 GI Bill benefits',
+                      'Check your remaining Post-9/11 GI Bill benefits',
                     'links-list-section-header': 'Education and training',
                   })
                 }

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard-notifications.cypress.spec.js
@@ -9,6 +9,7 @@ import { mockUser } from '@@profile/tests/fixtures/users/user';
 import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
+import { mockLocalStorage } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
 import {
   notificationsError,
   notificationSuccessDismissed,
@@ -16,7 +17,6 @@ import {
   notificationSuccessNotDismissed,
   multipleNotificationSuccess,
 } from '../fixtures/test-notifications-response';
-import { mockLocalStorage } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
 
 describe('The My VA Dashboard - Notifications', () => {
   // TODO: Fix for CI (try local headless)
@@ -109,7 +109,7 @@ describe('The My VA Dashboard - Notifications', () => {
       cy.get('va-alert')
         .shadow()
         .find('button.va-alert-close')
-        .click({ waitForAnimations: true });
+        .click({ waitForAnimations: true, force: true });
       cy.wait('@patch');
       cy.findAllByTestId('dashboard-notification-alert').should('not.exist');
       cy.findByTestId('dashboard-notifications').should('not.exist');
@@ -190,7 +190,7 @@ describe('The My VA Dashboard - Notifications', () => {
       cy.wait(['@nameB', '@serviceB', '@notifications6']);
       cy.findByTestId('dashboard-notifications').should('exist');
       cy.findAllByTestId('onsite-notification-card').should('have.length', 1);
-      cy.get('button.va-notification-close').click();
+      cy.get('button.va-notification-close').click({ force: true });
       cy.wait('@patch');
       cy.findByTestId('onsite-notification-card').should('not.exist');
       cy.findByTestId('dashboard-notifications').should('not.exist');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR updates copy and URL

|         | Before | After |
| ------- | ------ | ----- |
| Copy  |  Check your Post-9/11 GI Bill benefits   |    Check your remaining Post-9/11 GI Bill benefits   |
| URL |    [va.gov/education/gi-bill/post-9-11/ch-33-benefit/status](http://va.gov/education/gi-bill/post-9-11/ch-33-benefit/status)   |   [va.gov/education/check-remaining-post-9-11-gi-bill-benefits/status/](http://va.gov/education/check-remaining-post-9-11-gi-bill-benefits/status/)    |

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/99285

## Testing done
- visually, locally
- updated failing e2e test (`dashboard-notifications.cypress.spec.js`)
- all unit and e2e tests still pass 

## What areas of the site does it impact?
My VA - Education and 

## Acceptance criteria
- [ ] new copy and URL are correct
