### PR TITLE
99461 The auth header adjusts capitalization so we should too

### DIFF
--- a/src/applications/mhv-landing-page/mocks/api/user/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/user/index.js
@@ -76,6 +76,8 @@ const generateUser = ({
   loa = 3,
   mhvAccountState = 'OK',
   vaPatient = true,
+  firstName = 'Gina',
+  preferredName = 'Ginny',
 } = {}) => {
   return {
     ...defaultUser,
@@ -90,6 +92,8 @@ const generateUser = ({
         },
         profile: {
           ...defaultUser.data.attributes.profile,
+          first_name: firstName,
+          preferred_Name: preferredName,
           loa: { current: loa },
           sign_in: {
             service_name: serviceName,
@@ -108,6 +112,7 @@ const CSP_IDS = {
 };
 
 const USER_MOCKS = Object.freeze({
+  ALL_CAPS_NAME: generateUser({ firstName: 'KEVIN', preferredName: '' }),
   UNREGISTERED: generateUser({ vaPatient: false }),
   UNVERIFIED: generateUser({ loa: 1, vaPatient: false }),
   LOGIN_GOV_UNVERIFIED: generateUser({

--- a/src/applications/mhv-landing-page/selectors/personalInformation.js
+++ b/src/applications/mhv-landing-page/selectors/personalInformation.js
@@ -1,7 +1,9 @@
+import { startCase, toLower } from 'lodash';
+
 export const selectGreetingName = state => {
   return (
     state?.user?.profile?.preferredName ||
-    state?.user?.profile?.userFullName?.first ||
+    startCase(toLower(state?.user?.profile?.userFullName?.first)) ||
     null
   );
 };

--- a/src/applications/mhv-landing-page/tests/e2e/personalization/welcome-message.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/personalization/welcome-message.cypress.spec.js
@@ -1,17 +1,28 @@
 import { appName } from '../../../manifest.json';
 import ApiInitializer from '../utilities/ApiInitializer';
 import LandingPage from '../pages/LandingPage';
+import { USER_MOCKS } from '../../../mocks/api/user';
 
 describe(`${appName} -- Welcome message`, () => {
   beforeEach(() => {
     ApiInitializer.initializeMessageData.withUnreadMessages();
   });
 
-  it('personalization enabled', () => {
-    ApiInitializer.initializeFeatureToggle.withAllFeatures();
-    LandingPage.visit();
-    cy.findByRole('heading', { level: 2, name: /^Welcome/ }).should.exist;
-    cy.injectAxeThenAxeCheck();
+  context('personalization enabled', () => {
+    beforeEach(() => {
+      ApiInitializer.initializeFeatureToggle.withAllFeatures();
+    });
+
+    it('shows the Welcome', () => {
+      LandingPage.visit();
+      cy.findByRole('heading', { level: 2, name: /^Welcome/ }).should.exist;
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('should match name capitalization to auth header', () => {
+      LandingPage.visit({ user: USER_MOCKS.ALL_CAPS_NAME });
+      cy.findAllByText('Kevin').should('have.length', 2);
+    });
   });
 
   it('personalization disabled', () => {

--- a/src/applications/mhv-landing-page/tests/selectors/selectGreetingName.unit.spec.js
+++ b/src/applications/mhv-landing-page/tests/selectors/selectGreetingName.unit.spec.js
@@ -36,6 +36,12 @@ describe(`${appName} -- selectGreetingName`, () => {
     expect(result).to.eq('Robert');
   });
 
+  it('capitalizes first name', () => {
+    state = stateFn({ preferredName: null, first: 'KEVIN' });
+    result = selectGreetingName(state);
+    expect(result).to.eq('Kevin');
+  });
+
   it('returns null, when preferredName nor first name are present', () => {
     state = stateFn({ preferredName: null, first: null });
     result = selectGreetingName(state);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Correcting a discrepancy in capitalization between the user's first name in the auth header and in the MHV welcome message.

## Related issue(s)
[99461](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99461)

## Testing done
e2e spec added

## Screenshots
<img width="1116" alt="Screenshot 2024-12-27 at 1 09 48 PM" src="https://github.com/user-attachments/assets/a2270a8e-912f-4361-92c8-e7131028a324" />

## What areas of the site does it impact?

MHV landing page

## Acceptance criteria
MHV welcome message honors the capitalization applied to the auth header.
(preferred name unchanged, first name is capitalized)

