### PR TITLE
[10-10CG] Add aria-live div to Show More Facilities functionality

### DIFF
--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -8,6 +8,7 @@ import { focusElement } from 'platform/utilities/ui';
 import { fetchMapBoxGeocoding } from '../../actions/fetchMapBoxGeocoding';
 import { fetchFacilities } from '../../actions/fetchFacilities';
 import FacilityList from './FacilityList';
+import { replaceStrValues } from '../../utils/helpers';
 import content from '../../locales/en/content.json';
 
 const FacilitySearch = props => {
@@ -37,11 +38,14 @@ const FacilitySearch = props => {
   };
 
   const ariaLiveMessage = () => {
-    if (newFacilitiesCount > 0) {
-      const facilitySuffix = newFacilitiesCount === 1 ? 'y' : 'ies';
-      return `${newFacilitiesCount} new facilit${facilitySuffix} loaded`;
-    }
-    return '';
+    if (newFacilitiesCount === 0) return '';
+    if (newFacilitiesCount === 1)
+      return content['facilities-aria-live-message'];
+
+    return replaceStrValues(
+      content['facilities-aria-live-message-multiple'],
+      newFacilitiesCount,
+    );
   };
 
   const isReviewPage = () => {

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -247,7 +247,11 @@ const FacilitySearch = props => {
       return (
         <>
           <FacilityList {...facilityListProps} />
-          <div aria-live="polite" role="status">
+          <div
+            aria-live="polite"
+            role="status"
+            className="vads-u-visibility--screen-reader"
+          >
             {ariaLiveMessage()}
           </div>
           {loadingMoreFacilities && loader()}

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -19,6 +19,7 @@ const FacilitySearch = props => {
   const [searchInputError, setSearchInputError] = useState(null);
   const [facilitiesListError, setFacilitiesListError] = useState(null);
   const [facilities, setFacilities] = useState([]);
+  const [newFacilitiesCount, setNewFacilitiesCount] = useState(0);
   const [pagination, setPagination] = useState({
     currentPage: 0,
     totalEntries: 0,
@@ -33,6 +34,14 @@ const FacilitySearch = props => {
 
   const hasMoreFacilities = () => {
     return facilities?.length < pagination.totalEntries;
+  };
+
+  const ariaLiveMessage = () => {
+    if (newFacilitiesCount > 0) {
+      const facilitySuffix = newFacilitiesCount === 1 ? 'y' : 'ies';
+      return `${newFacilitiesCount} new facilit${facilitySuffix} loaded`;
+    }
+    return '';
   };
 
   const isReviewPage = () => {
@@ -198,6 +207,7 @@ const FacilitySearch = props => {
 
   const showMoreFacilities = async e => {
     e.preventDefault();
+    setNewFacilitiesCount(0);
     setLoadingMoreFacilities(true);
     const facilitiesResponse = await fetchFacilities({
       ...coordinates,
@@ -213,6 +223,7 @@ const FacilitySearch = props => {
     }
 
     setFacilities([...facilities, ...facilitiesResponse.facilities]);
+    setNewFacilitiesCount(facilitiesResponse.facilities.length);
     setPagination(facilitiesResponse.meta.pagination);
     setSubmittedQuery(query);
     setLoadingMoreFacilities(false);
@@ -236,6 +247,9 @@ const FacilitySearch = props => {
       return (
         <>
           <FacilityList {...facilityListProps} />
+          <div aria-live="polite" role="status">
+            {ariaLiveMessage()}
+          </div>
           {loadingMoreFacilities && loader()}
           {hasMoreFacilities() && (
             <button

--- a/src/applications/caregivers/locales/en/content.json
+++ b/src/applications/caregivers/locales/en/content.json
@@ -44,6 +44,8 @@
   "error--fetching-coordinates": "Error fetching MapBox coordinates",
   "error--no-results-found": "No search results found.",
   "facilities-loading-text": "Loading available facilities...",
+  "facilities-aria-live-message": "1 new facility loaded",
+  "facilities-aria-live-message-multiple": "%s new facilities loaded",
   "form-address-same-as-label": "Is the %s mailing address the same as their home address? ",
   "form-address-street-label": "%s street address",
   "form-address-street2-label": "Street address line 2",

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
@@ -78,6 +78,7 @@ describe('CG <FacilitySearch>', () => {
       radioList: container.querySelector('va-radio'),
       searchInputError: queryByRole('alert'),
       moreFacilities: queryByText('Load more facilities'),
+      ariaLiveStatus: queryByRole('status'),
       formNavButtons: {
         back: getByText('Back'),
         forward: getByText('Continue'),
@@ -100,6 +101,7 @@ describe('CG <FacilitySearch>', () => {
       expect(selectors().input).to.exist;
       expect(selectors().radioList).not.to.exist;
       expect(selectors().moreFacilities).not.to.exist;
+      expect(selectors().ariaLiveStatus).not.to.exist;
       expect(queryByText(content['form-facilities-search-label'])).to.exist;
       expect(queryByText('(*Required)')).to.exist;
     });
@@ -138,6 +140,7 @@ describe('CG <FacilitySearch>', () => {
       await waitFor(() => {
         expect(selectors().radioList).to.exist;
         expect(selectors().loader).to.not.exist;
+        expect(selectors().ariaLiveStatus.textContent).to.eq('');
         expect(selectors().input).to.not.have.attr('error');
         sinon.assert.calledWith(mapboxStub, 'Tampa');
         sinon.assert.calledWith(facilitiesStub, {
@@ -382,7 +385,7 @@ describe('CG <FacilitySearch>', () => {
     });
 
     context('more facilities buttons', () => {
-      it('successfully loads more facilities on click', async () => {
+      it('successfully loads 1 more facility on click', async () => {
         const { props, mockStore } = getData({});
         const { selectors, getByText, container } = subject({
           props,
@@ -405,12 +408,14 @@ describe('CG <FacilitySearch>', () => {
           expect(selectors().loader).to.not.exist;
           expect(selectors().input).to.not.have.attr('error');
           expect(getByText(/Showing 1-1 of 1 facilities for/)).to.exist;
+          expect(selectors().ariaLiveStatus.textContent).to.eq('');
         });
 
         await waitFor(() => {
           userEvent.click(selectors().moreFacilities);
           expect(selectors().radioList).to.exist;
           expect(selectors().loader).to.exist;
+          expect(selectors().ariaLiveStatus.textContent).to.eq('');
         });
 
         await waitFor(() => {
@@ -418,6 +423,68 @@ describe('CG <FacilitySearch>', () => {
           expect(selectors().loader).to.not.exist;
           expect(getByText(/Showing 1-2 of 2 facilities for/)).to.exist;
           expect(selectors().input).to.not.have.attr('error');
+          expect(selectors().ariaLiveStatus.textContent).to.eq(
+            '1 new facility loaded',
+          );
+        });
+
+        await waitFor(() => {
+          sinon.assert.calledWith(mapboxStub, 'Tampa');
+          sinon.assert.calledWith(facilitiesStub, {
+            lat,
+            long,
+            perPage,
+            radius,
+            page: 2,
+          });
+          expect(mapboxStub.callCount).to.equal(1);
+          // This is 3 because there is an existing bug that using submit with the va-search-input component triggers two requests
+          // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3117
+          expect(facilitiesStub.callCount).to.equal(3);
+        });
+      });
+
+      it('successfully loads 2 more facilities on click', async () => {
+        const { props, mockStore } = getData({});
+        const { selectors, getByText, container } = subject({
+          props,
+          mockStore,
+        });
+
+        mapboxStub.resolves(mapBoxSuccessResponse);
+        facilitiesStub
+          .onFirstCall()
+          .resolves(mockFetchChildFacilityWithCaregiverSupportResponse);
+        facilitiesStub.onSecondCall().resolves(mockFetchFacilitiesResponse);
+
+        await waitFor(() => {
+          inputVaSearchInput(container, 'Tampa', selectors().input);
+          expect(selectors().loader).to.exist;
+        });
+
+        await waitFor(() => {
+          expect(selectors().radioList).to.exist;
+          expect(selectors().loader).to.not.exist;
+          expect(selectors().input).to.not.have.attr('error');
+          expect(getByText(/Showing 1-1 of 1 facilities for/)).to.exist;
+          expect(selectors().ariaLiveStatus.textContent).to.eq('');
+        });
+
+        await waitFor(() => {
+          userEvent.click(selectors().moreFacilities);
+          expect(selectors().radioList).to.exist;
+          expect(selectors().loader).to.exist;
+          expect(selectors().ariaLiveStatus.textContent).to.eq('');
+        });
+
+        await waitFor(() => {
+          expect(selectors().radioList).to.exist;
+          expect(selectors().loader).to.not.exist;
+          expect(getByText(/Showing 1-3 of 3 facilities for/)).to.exist;
+          expect(selectors().input).to.not.have.attr('error');
+          expect(selectors().ariaLiveStatus.textContent).to.eq(
+            '2 new facilities loaded',
+          );
         });
 
         await waitFor(() => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added new `aria-live` status role to `FacilitySearch` component to notify screen readers that more facilities have loaded.
- 1010 Health Apps
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99049

## Testing done

- Previously, new facilities radio options would load on the page, but screen readers were not notified. Now, screen readers will be notified with `x new facilities loaded`. 
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

The UI did not change as the new div is hidden.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

10-10CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
