### PR TITLE
Add link to facility name for Appointments Details pages

### DIFF
--- a/src/applications/vaos/components/layout/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layout/ClaimExamLayout.jsx
@@ -109,7 +109,7 @@ export default function ClaimExamLayout({ data: appointment }) {
           )}
         {!!facility && (
           <>
-            {facility.name}
+            <a href={facility.website}>{facility.name}</a>
             <br />
             <Address address={facility?.address} />
             <div className="vads-u-margin-top--1 vads-u-color--link-default">
@@ -143,7 +143,7 @@ export default function ClaimExamLayout({ data: appointment }) {
           )}
           {!!facility && (
             <>
-              {facility.name}
+              <a href={facility.website}>{facility.name}</a>
               <br />
               {facilityPhone && (
                 <FacilityPhone heading="Phone:" contact={facilityPhone} />

--- a/src/applications/vaos/components/layout/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/ClaimExamLayout.unit.spec.js
@@ -25,6 +25,8 @@ describe('VAOS Component: ClaimExamLayout', () => {
               value: '307-778-7550',
             },
           ],
+          website:
+            'https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/',
         },
       },
     },
@@ -318,6 +320,11 @@ describe('VAOS Component: ClaimExamLayout', () => {
         screen.getByRole('heading', { level: 2, name: /Where to attend/i }),
       );
       expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/"]',
+        ),
+      ).to.be.ok;
       expect(screen.getByText(/2360 East Pershing Boulevard/i));
 
       expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be

--- a/src/applications/vaos/components/layout/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layout/InPersonLayout.jsx
@@ -108,7 +108,7 @@ export default function InPersonLayout({ data: appointment }) {
           )}
         {!!facility && (
           <>
-            {facility.name}
+            <a href={facility.website}>{facility.name}</a>
             <br />
             <Address address={facility?.address} />
             <div className="vads-u-margin-top--1 vads-u-color--link-default">

--- a/src/applications/vaos/components/layout/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/InPersonLayout.unit.spec.js
@@ -25,6 +25,8 @@ describe('VAOS Component: InPersonLayout', () => {
               value: '307-778-7550',
             },
           ],
+          website:
+            'https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/',
         },
       },
     },
@@ -320,6 +322,11 @@ describe('VAOS Component: InPersonLayout', () => {
         screen.getByRole('heading', { level: 2, name: /Where to attend/i }),
       );
       expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/"]',
+        ),
+      ).to.be.ok;
       expect(screen.getByText(/2360 East Pershing Boulevard/i));
 
       expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be

--- a/src/applications/vaos/components/layout/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layout/PhoneLayout.jsx
@@ -86,7 +86,7 @@ export default function PhoneLayout({ data: appointment }) {
         )}
         {!!facility && (
           <>
-            {facility.name}
+            <a href={facility.website}>{facility.name}</a>
             <br />
             <Address address={facility?.address} />
           </>

--- a/src/applications/vaos/components/layout/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/PhoneLayout.unit.spec.js
@@ -25,6 +25,8 @@ describe('VAOS Component: PhoneLayout', () => {
               value: '307-778-7550',
             },
           ],
+          website:
+            'https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/',
         },
       },
     },
@@ -243,6 +245,11 @@ describe('VAOS Component: PhoneLayout', () => {
         }),
       );
       expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/"]',
+        ),
+      ).to.be.ok;
       expect(screen.getByText(/2360 East Pershing Boulevard/i));
       expect(screen.container.querySelector('va-icon[icon="directions"]')).not
         .to.exist;

--- a/src/applications/vaos/components/layout/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layout/VARequestLayout.jsx
@@ -89,7 +89,7 @@ export default function VARequestLayout({ data: appointment }) {
             )}
           {!!facility?.name && (
             <>
-              {facility.name}
+              <a href={facility.website}>{facility.name}</a>
               <br />
             </>
           )}

--- a/src/applications/vaos/components/layout/VARequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/VARequestLayout.unit.spec.js
@@ -24,6 +24,8 @@ describe('VAOS Component: VARequestLayout', () => {
               value: '307-778-7550',
             },
           ],
+          website:
+            'https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/',
         },
       },
     },
@@ -112,6 +114,11 @@ describe('VAOS Component: VARequestLayout', () => {
 
       expect(screen.getByRole('heading', { level: 2, name: /Facility/i }));
       expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/"]',
+        ),
+      ).to.be.ok;
       expect(screen.getByText(/2360 East Pershing Boulevard/i));
 
       expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be

--- a/src/applications/vaos/components/layout/VideoLayout.jsx
+++ b/src/applications/vaos/components/layout/VideoLayout.jsx
@@ -91,7 +91,7 @@ export default function VideoLayout({ data: appointment }) {
         <Section heading="Scheduling facility">
           {!!facility && (
             <>
-              {facility.name}
+              <a href={facility.website}>{facility.name}</a>
               <br />
               <span>
                 {address.city}, <State state={address.state} />
@@ -140,7 +140,7 @@ export default function VideoLayout({ data: appointment }) {
             <br />
             {facility ? (
               <>
-                {facility.name}
+                <a href={facility.website}>{facility.name}</a>
                 <br />
                 <span>
                   {address.city}, <State state={address.state} />

--- a/src/applications/vaos/components/layout/VideoLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/VideoLayout.unit.spec.js
@@ -25,6 +25,8 @@ describe('VAOS Component: VideoLayout', () => {
               value: '307-778-7550',
             },
           ],
+          website:
+            'https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/',
         },
       },
     },
@@ -276,6 +278,11 @@ describe('VAOS Component: VideoLayout', () => {
         }),
       );
       expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/"]',
+        ),
+      ).to.be.ok;
       expect(screen.queryByText(/2360 East Pershing Boulevard/i)).not.to.exist;
 
       expect(screen.getByText(/Clinic: Clinic 1/i));

--- a/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
@@ -113,7 +113,7 @@ export default function VideoLayoutAtlas({ data: appointment }) {
           )}
           {!!facility && (
             <>
-              {facility.name}
+              <a href={facility.website}>{facility.name}</a>
               <br />
               <ClinicOrFacilityPhone
                 clinicPhone={clinicPhone}
@@ -156,7 +156,7 @@ export default function VideoLayoutAtlas({ data: appointment }) {
             <br />
             {facility ? (
               <>
-                {facility.name}
+                <a href={facility.website}>{facility.name}</a>
                 <br />
                 <span>
                   {address.city}, <State state={address.state} />

--- a/src/applications/vaos/components/layout/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/layout/VideoLayoutAtlas.unit.spec.js
@@ -25,6 +25,8 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
               value: '307-778-7550',
             },
           ],
+          website:
+            'https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/',
         },
       },
     },
@@ -354,6 +356,11 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
         }),
       );
       expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/"]',
+        ),
+      ).to.be.ok;
       expect(screen.queryByText(/2360 East Pershing Boulevard/i)).not.to.exist;
       expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be
         .ok;

--- a/src/applications/vaos/components/layout/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutVA.jsx
@@ -106,7 +106,7 @@ export default function VideoLayoutVA({ data: appointment }) {
           )}
         {!!facility && (
           <>
-            {facility.name}
+            <a href={facility.website}>{facility.name}</a>
             <br />
             <Address address={facility?.address} />
             <div className="vads-u-margin-top--1 vads-u-color--link-default">

--- a/src/applications/vaos/components/layout/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/layout/VideoLayoutVA.unit.spec.js
@@ -25,6 +25,8 @@ describe('VAOS Component: VideoLayoutVA', () => {
               value: '307-778-7550',
             },
           ],
+          website:
+            'https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/',
         },
       },
     },
@@ -379,6 +381,11 @@ describe('VAOS Component: VideoLayoutVA', () => {
           }),
         );
         expect(screen.getByText(/Cheyenne VA Medical Center/i));
+        expect(
+          screen.container.querySelector(
+            'a[href="https://www.va.gov/cheyenne-health-care/locations/cheyenne-va-medical-center/"]',
+          ),
+        ).to.be.ok;
         expect(screen.getByText(/2360 East Pershing Boulevard/i));
         expect(screen.container.querySelector('va-icon[icon="directions"]')).to
           .be.ok;

--- a/src/applications/vaos/services/location/transformers.js
+++ b/src/applications/vaos/services/location/transformers.js
@@ -48,6 +48,7 @@ export function transformFacilityV2(facility) {
       state: facility.physicalAddress.state,
       postalCode: facility.physicalAddress.postalCode,
     },
+    website: facility.website,
   };
 }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR adds links to the facility website to the appointment details pages
- Appointments (VAOS) Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89129

## Testing done

- Tested locally
- Updated unit tests to test for the new links

## Screenshots

Note that the full matrix of all changed pages will need 2 (before, after) * (6 (VA appointment modes) * 3(upcoming confirmed, upcoming cancelled, past) + 1 (VA request) * 2 (pending, pending cancelled)) =  40 screenshots which is probably too many. Instead I'll sample a subset of the full matrix of changed pages.

|         | Before | After |
| ------- | ------ | ----- |
| VA Request - Pending |   <img width="502" alt="image" src="https://github.com/user-attachments/assets/514b0fa2-6bb3-4fa1-9879-f14566b91639" />   |   <img width="504" alt="image" src="https://github.com/user-attachments/assets/3f0f4733-2000-4706-a435-4bbb2c8a660c" />  |
| VA Request - Pending cancelled |   <img width="496" alt="image" src="https://github.com/user-attachments/assets/87d637b2-db1e-498f-bc02-46dd6dcaab7a" />    |   <img width="504" alt="image" src="https://github.com/user-attachments/assets/ee290103-0c1a-4858-b7fb-121deeb9f274" />   |
| Video ATLAS - Upcoming |   <img width="496" alt="image" src="https://github.com/user-attachments/assets/feeaee88-ffa6-4cfa-839c-f5935c7a7d3b" />    |   <img width="504" alt="image" src="https://github.com/user-attachments/assets/fa8e32d5-da40-4e79-bd27-8f7fc7627801" />   |
| Video VA - Upcoming cancelled |   <img width="496" alt="image" src="https://github.com/user-attachments/assets/49cdf748-91f8-48b9-a061-e057d1baa2b8" />    |   <img width="497" alt="image" src="https://github.com/user-attachments/assets/e81280e2-019a-4a9f-84f1-9755b4976268" />   |
| Claims - Past |    <img width="495" alt="image" src="https://github.com/user-attachments/assets/16684f70-04d9-4be5-9ebc-0e77f01db6ed" />   |  <img width="501" alt="image" src="https://github.com/user-attachments/assets/1fa72fbf-65d3-477e-85a2-2954bc51c4f4" />  |
| In Person - Upcoming |    <img width="500" alt="image" src="https://github.com/user-attachments/assets/8d97200c-cbb0-46e5-8706-07db6bd41df4" />   |   <img width="505" alt="image" src="https://github.com/user-attachments/assets/889bb118-93c1-492c-971a-097853767013" />   |
| Phone - Upcoming cancelled |   <img width="498" alt="image" src="https://github.com/user-attachments/assets/9a4c4d95-ce54-4fac-a91f-d506455f8aa9" />    |   <img width="499" alt="image" src="https://github.com/user-attachments/assets/53f6859b-0582-4823-9665-cda3768ee5c8" />   |
| Video - Past |    <img width="495" alt="image" src="https://github.com/user-attachments/assets/0239169f-d56f-4fb8-91fc-1bab120ac618" />   |   <img width="502" alt="image" src="https://github.com/user-attachments/assets/2156cce5-4183-49f9-835b-4049ff41e684" />  |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

