### PR TITLE
VACMS-20124 DUW content updates

### DIFF
--- a/src/applications/discharge-wizard/components/v2/Homepage.jsx
+++ b/src/applications/discharge-wizard/components/v2/Homepage.jsx
@@ -82,7 +82,7 @@ const HomePage = ({ router, setIntroPageViewed }) => {
               Veterans Service Organization (VSO) can collect and submit
               supporting documents for you.{' '}
               <va-link
-                href="https://www.benefits.va.gov/vso/varo.asp"
+                href="https://www.va.gov/get-help-from-accredited-representative/find-rep"
                 text="Find a VSO near you."
               />
             </p>

--- a/src/applications/discharge-wizard/components/v2/RequestDD214.jsx
+++ b/src/applications/discharge-wizard/components/v2/RequestDD214.jsx
@@ -47,6 +47,7 @@ const RequestDD214v2 = ({ router, formResponses, viewedIntroPage }) => {
         </div>
         <va-process-list>
           <va-process-list-item
+            className="vads-u-font-size--h3"
             header="Download and fill out DoD Form 149"
             level="2"
           >
@@ -88,7 +89,11 @@ const RequestDD214v2 = ({ router, formResponses, viewedIntroPage }) => {
               Download Form 149 (opens in a new tab)
             </a>
           </va-process-list-item>
-          <va-process-list-item header="Mail your completed form" level="2">
+          <va-process-list-item
+            className="vads-u-font-size--h3"
+            header="Mail your completed form"
+            level="2"
+          >
             <p>
               There are a number of different boards that handle discharge
               upgrades and corrections. Because you want a new DD214, which is

--- a/src/applications/discharge-wizard/components/v2/RequestDD214.jsx
+++ b/src/applications/discharge-wizard/components/v2/RequestDD214.jsx
@@ -47,7 +47,6 @@ const RequestDD214v2 = ({ router, formResponses, viewedIntroPage }) => {
         </div>
         <va-process-list>
           <va-process-list-item
-            className="vads-u-font-size--h3"
             header="Download and fill out DoD Form 149"
             level="2"
           >
@@ -89,11 +88,7 @@ const RequestDD214v2 = ({ router, formResponses, viewedIntroPage }) => {
               Download Form 149 (opens in a new tab)
             </a>
           </va-process-list-item>
-          <va-process-list-item
-            className="vads-u-font-size--h3"
-            header="Mail your completed form"
-            level="2"
-          >
+          <va-process-list-item header="Mail your completed form" level="2">
             <p>
               There are a number of different boards that handle discharge
               upgrades and corrections. Because you want a new DD214, which is

--- a/src/applications/discharge-wizard/components/v2/questions/Reason.jsx
+++ b/src/applications/discharge-wizard/components/v2/questions/Reason.jsx
@@ -17,7 +17,7 @@ const Reason = ({ formResponses, setReason, router, viewedIntroPage }) => {
   const H1 = QUESTION_MAP[shortName];
   const reason = formResponses[shortName];
   const hint =
-    'Note: If more than one of these descriptions matches your situation, choose the one that started the events that led to your discharge. For example, if you sustained a traumatic brain injury, which led to posttraumatic stress disorder (PTSD), choose number 2.';
+    'Note: If more than one of these descriptions matches your situation, choose the one that started the events that led to your discharge. For example, if you sustained a traumatic brain injury (TBI), which led to posttraumatic stress disorder (PTSD), choose the option associated with TBI.';
   const {
     REASON_PTSD,
     REASON_TBI,

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/AdditionalInstructions.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/AdditionalInstructions.jsx
@@ -65,7 +65,7 @@ const AdditionalInstructions = ({ formResponses }) => {
             Service Organization (VSO) can collect and submit supporting
             documents for you.{' '}
             <a
-              href="https://www.benefits.va.gov/vso/varo.asp"
+              href="https://www.va.gov/get-help-from-accredited-representative/find-rep"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
@@ -171,11 +171,7 @@ const StepOne = ({ formResponses }) => {
   const header = `Download and fill out DoD Form ${form.num}`;
 
   return (
-    <va-process-list-item
-      className="vads-u-font-size--h3"
-      header={header}
-      level="2"
-    >
+    <va-process-list-item header={header} level="2">
       <p>Important tips for completing Form {form.num}:</p>
       {formResponses[SHORT_NAME_MAP.REASON] ===
       RESPONSES.REASON_DD215_UPDATE_TO_DD214

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import AlertMessage from './AlertMessage';
-import {
-  determineBoardObj,
-  determineFormData,
-  stepHeaderLevel,
-} from '../../../helpers';
+import { determineBoardObj, determineFormData } from '../../../helpers';
 
 import {
   SHORT_NAME_MAP,
@@ -173,10 +169,9 @@ const StepOne = ({ formResponses }) => {
 
   const form = determineFormData(formResponses);
   const header = `Download and fill out DoD Form ${form.num}`;
-  const level = stepHeaderLevel(formResponses);
 
   return (
-    <va-process-list-item header={header} level={level}>
+    <va-process-list-item header={header} level="2">
       <p>Important tips for completing Form {form.num}:</p>
       {formResponses[SHORT_NAME_MAP.REASON] ===
       RESPONSES.REASON_DD215_UPDATE_TO_DD214
@@ -214,7 +209,7 @@ const StepOne = ({ formResponses }) => {
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://www.benefits.va.gov/vso/varo.asp"
+                href="https://www.va.gov/get-help-from-accredited-representative/find-rep"
               >
                 Find a VSO near you (opens in a new tab)
               </a>

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
@@ -171,7 +171,11 @@ const StepOne = ({ formResponses }) => {
   const header = `Download and fill out DoD Form ${form.num}`;
 
   return (
-    <va-process-list-item header={header} level="2">
+    <va-process-list-item
+      className="vads-u-font-size--h3"
+      header={header}
+      level="2"
+    >
       <p>Important tips for completing Form {form.num}:</p>
       {formResponses[SHORT_NAME_MAP.REASON] ===
       RESPONSES.REASON_DD215_UPDATE_TO_DD214

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepThree.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepThree.jsx
@@ -53,7 +53,11 @@ const StepThree = ({ formResponses }) => {
       : 'Mail your completed form and all supporting materials';
 
   return (
-    <va-process-list-item header={headerText} level="2">
+    <va-process-list-item
+      className="vads-u-font-size--h3"
+      header={headerText}
+      level="2"
+    >
       <p>
         There are a number of different boards that handle discharge upgrades
         and corrections. Based on your answers on the previous page, you need to

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepThree.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepThree.jsx
@@ -9,7 +9,6 @@ import { BCNR, BCMR, DRB, AFDRB } from '../../../constants';
 import {
   determineBoardObj,
   determineVenueAddress,
-  stepHeaderLevel,
   getBoardExplanation,
   isPreviousApplicationYear,
 } from '../../../helpers';
@@ -53,10 +52,8 @@ const StepThree = ({ formResponses }) => {
       ? 'Submit your completed application form and all supporting documents online or by mail'
       : 'Mail your completed form and all supporting materials';
 
-  const level = stepHeaderLevel(formResponses);
-
   return (
-    <va-process-list-item header={headerText} level={level}>
+    <va-process-list-item header={headerText} level="2">
       <p>
         There are a number of different boards that handle discharge upgrades
         and corrections. Based on your answers on the previous page, you need to

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepThree.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepThree.jsx
@@ -53,11 +53,7 @@ const StepThree = ({ formResponses }) => {
       : 'Mail your completed form and all supporting materials';
 
   return (
-    <va-process-list-item
-      className="vads-u-font-size--h3"
-      header={headerText}
-      level="2"
-    >
+    <va-process-list-item header={headerText} level="2">
       <p>
         There are a number of different boards that handle discharge upgrades
         and corrections. Based on your answers on the previous page, you need to

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepTwo.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  determineBoardObj,
-  stepHeaderLevel,
-  renderMedicalRecordInfo,
-} from '../../../helpers';
+import { determineBoardObj, renderMedicalRecordInfo } from '../../../helpers';
 
 import {
   SHORT_NAME_MAP,
@@ -136,10 +132,8 @@ const StepTwo = ({ formResponses }) => {
     );
   };
 
-  const level = stepHeaderLevel(formResponses);
-
   return (
-    <va-process-list-item header="Add supporting information" level={level}>
+    <va-process-list-item header="Add supporting information" level="2">
       <p>
         To improve your chances of success, also include as many of the below
         documents as you can.

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepTwo.jsx
@@ -133,11 +133,7 @@ const StepTwo = ({ formResponses }) => {
   };
 
   return (
-    <va-process-list-item
-      className="vads-u-font-size--h3"
-      header="Add supporting information"
-      level="2"
-    >
+    <va-process-list-item header="Add supporting information" level="2">
       <p>
         To improve your chances of success, also include as many of the below
         documents as you can.

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepTwo.jsx
@@ -133,7 +133,11 @@ const StepTwo = ({ formResponses }) => {
   };
 
   return (
-    <va-process-list-item header="Add supporting information" level="2">
+    <va-process-list-item
+      className="vads-u-font-size--h3"
+      header="Add supporting information"
+      level="2"
+    >
       <p>
         To improve your chances of success, also include as many of the below
         documents as you can.

--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -548,19 +548,6 @@ export const determineAirForceAFRBAPortal = formResponses =>
   determineBoardObj(formResponses).abbr === BCMR &&
   determineFormData(formResponses).num === 149;
 
-// Determines step header level.
-export const stepHeaderLevel = formResponses => {
-  if (
-    [
-      RESPONSES.PRIOR_SERVICE_PAPERWORK_NO,
-      RESPONSES.PRIOR_SERVICE_PAPERWORK_YES,
-    ].includes(formResponses[SHORT_NAME_MAP.PRIOR_SERVICE])
-  ) {
-    return 3;
-  }
-  return 2;
-};
-
 export const handleDD215Update = (boardToSubmit, prevAppType, oldDischarge) => {
   if (
     ![


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
DUW content updates after Staging Review.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20124

## Screenshots

<details><summary>AC1: Link to find a VSO is outdated</summary>

<br />

### Intro page

<img width="680" alt="Screenshot 2024-12-30 at 9 39 36 AM" src="https://github.com/user-attachments/assets/cefe488a-a438-4489-81a6-097cd0cc2120" />
<img width="377" alt="Screenshot 2024-12-30 at 9 39 47 AM" src="https://github.com/user-attachments/assets/d2b47995-8e32-4ffb-bfa2-5998c57a5725" />

### Results page

`/discharge-upgrade-instructions/results`

#### How to get here
<img width="400" alt="Screenshot 2024-12-30 at 10 07 38 AM" src="https://github.com/user-attachments/assets/e45d49b2-3789-4398-8faa-0313d011e1d7" />

#### "Can I get VA benefits without a discharge upgrade?" accordion
<img width="561" alt="Screenshot 2024-12-30 at 10 06 38 AM" src="https://github.com/user-attachments/assets/f8575bbc-127c-4efe-9d15-60adbbcb2b9b" />
<img width="663" alt="Screenshot 2024-12-30 at 10 06 53 AM" src="https://github.com/user-attachments/assets/c39cd699-c252-4681-9f2b-0d48042fd609" />

#### Alert under Step 1
<img width="615" alt="Screenshot 2024-12-30 at 10 05 45 AM" src="https://github.com/user-attachments/assets/e873d137-d346-492a-bdff-b1bb5dd18bd9" />
<img width="665" alt="Screenshot 2024-12-30 at 10 07 05 AM" src="https://github.com/user-attachments/assets/36a73452-8660-49bf-8e96-5166c83c0a8b" />

</details>

<details><summary>AC2 & AC3: Unclear guidance in "tell us why you want to change your discharge paperwork" and Missing initialization in "tell us why you want to change your discharge paperwork</summary>

<br />

`/discharge-upgrade-instructions/reason`

<img width="516" alt="Screenshot 2024-12-30 at 9 40 07 AM" src="https://github.com/user-attachments/assets/7e1f9812-64ce-43fc-bbef-2f3c6ccc898b" />

</details>

<details><summary>AC4: All Steps on the Results page should be H2s</summary>

<img width="645" alt="Screenshot 2024-12-30 at 10 15 12 AM" src="https://github.com/user-attachments/assets/cb7c9dd6-45b1-401a-ae52-5ce1bcccdd9a" />
<img width="397" alt="Screenshot 2024-12-30 at 10 04 20 AM" src="https://github.com/user-attachments/assets/244bd28f-7998-4731-9c7c-1580d2b29b14" />

<img width="672" alt="Screenshot 2024-12-30 at 10 04 05 AM" src="https://github.com/user-attachments/assets/1a343bb0-9686-4129-957a-c94f0ee2c74f" />
<img width="401" alt="Screenshot 2024-12-30 at 10 04 28 AM" src="https://github.com/user-attachments/assets/c1a39a8e-adc3-450a-9f89-cc7ed3394dda" />
<img width="587" alt="Screenshot 2024-12-30 at 10 04 11 AM" src="https://github.com/user-attachments/assets/2a5e2c7e-2dd0-4e2f-9edd-3d617fe3c2cb" />
<img width="397" alt="Screenshot 2024-12-30 at 10 04 35 AM" src="https://github.com/user-attachments/assets/853954e8-3982-40b9-8f3a-75f3891243e6" />

</details>

### Acceptance Criteria

- [x] All 'Find a VSO' links now opens the following: https://www.va.gov/get-help-from-accredited-representative/find-rep
  - [x] the link on the introduction page in the accordion opens in the same tab
  - [x] links on the results page open in a new tab
- [x] The guidance text on the last sentence of Question 3 (Tell us why you want to change your discharge paperwork) is now: For example, if you sustained a traumatic brain injury (TBI), which led to posttraumatic stress disorder (PTSD), choose the option associated with TBI.
- [x] On the results pages, all the steps should be updated to be h2s, regardless of it there is an alert or not (i.e. the steps will be siblings of the alert if it exists)