### PR TITLE
Record type of care null states

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
@@ -256,7 +256,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     button = screen.getByText(/Yes, cancel request/i);
     button.click();
 
-    expect(window.dataLayer[0]).to.deep.equal({
+    expect(window.dataLayer).to.deep.include({
       event: 'vaos-cancel-request-clicked',
     });
 
@@ -394,7 +394,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
       button = screen.getByText(/Yes, cancel request/i);
       button.click();
 
-      expect(window.dataLayer[0]).to.deep.equal({
+      expect(window.dataLayer).to.deep.include({
         event: 'vaos-cancel-request-clicked',
       });
 

--- a/src/applications/vaos/components/layout/CCLayout.jsx
+++ b/src/applications/vaos/components/layout/CCLayout.jsx
@@ -19,6 +19,10 @@ import AddToCalendarButton from '../AddToCalendarButton';
 import FacilityDirectionsLink from '../FacilityDirectionsLink';
 import FacilityPhone from '../FacilityPhone';
 import Address from '../Address';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function CCLayout({ data: appointment }) {
   const {
@@ -43,6 +47,10 @@ export default function CCLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled community care appointment';
   else heading = 'Community care appointment';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <>

--- a/src/applications/vaos/components/layout/CCLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/CCLayout.unit.spec.js
@@ -64,6 +64,19 @@ describe('VAOS Component: CCLayout', () => {
           );
         }),
       );
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
   });
 
@@ -184,6 +197,19 @@ describe('VAOS Component: CCLayout', () => {
       expect(
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).not.to.exist;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
   });
 

--- a/src/applications/vaos/components/layout/CCRequestLayout.jsx
+++ b/src/applications/vaos/components/layout/CCRequestLayout.jsx
@@ -10,6 +10,10 @@ import Section from '../Section';
 import ListBestTimeToCall from '../../appointment-list/components/ListBestTimeToCall';
 import PageLayout from '../../appointment-list/components/PageLayout';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function CCRequestLayout({ data: appointment }) {
   const { search } = useLocation();
@@ -41,6 +45,10 @@ export default function CCRequestLayout({ data: appointment }) {
     heading = 'Request for community care appointment';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled request for community care appointment';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <PageLayout isDetailPage showNeedHelp>

--- a/src/applications/vaos/components/layout/CCRequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/CCRequestLayout.unit.spec.js
@@ -29,7 +29,7 @@ describe('VAOS Component: VARequestLayout', () => {
     },
   };
 
-  describe('When viewing upcomming CC appointment details', () => {
+  describe('When viewing upcoming CC appointment details', () => {
     it('should display CC request layout', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -163,6 +163,19 @@ describe('VAOS Component: VARequestLayout', () => {
         .ok;
       expect(screen.container.querySelector('va-button[text="Cancel request"]'))
         .to.be.ok;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
   });
 

--- a/src/applications/vaos/components/layout/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layout/ClaimExamLayout.jsx
@@ -23,6 +23,10 @@ import Address from '../Address';
 import AddToCalendarButton from '../AddToCalendarButton';
 import NewTabAnchor from '../NewTabAnchor';
 import FacilityPhone from '../FacilityPhone';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function ClaimExamLayout({ data: appointment }) {
   const {
@@ -50,6 +54,10 @@ export default function ClaimExamLayout({ data: appointment }) {
   if (isPastAppointment) heading = 'Past claim exam';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled claim exam';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layout/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/ClaimExamLayout.unit.spec.js
@@ -189,7 +189,21 @@ describe('VAOS Component: ClaimExamLayout', () => {
           );
         }),
       );
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
+
     it('should display facility phone when clinic phone is missing', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -382,6 +396,19 @@ describe('VAOS Component: ClaimExamLayout', () => {
       expect(
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).to.not.exist;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
   });
 

--- a/src/applications/vaos/components/layout/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layout/InPersonLayout.jsx
@@ -22,6 +22,10 @@ import FacilityDirectionsLink from '../FacilityDirectionsLink';
 import Address from '../Address';
 import AddToCalendarButton from '../AddToCalendarButton';
 import NewTabAnchor from '../NewTabAnchor';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function InPersonLayout({ data: appointment }) {
   const {
@@ -51,6 +55,10 @@ export default function InPersonLayout({ data: appointment }) {
   if (isPastAppointment) heading = 'Past in-person appointment';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled in-person appointment';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layout/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/InPersonLayout.unit.spec.js
@@ -192,7 +192,21 @@ describe('VAOS Component: InPersonLayout', () => {
           );
         }),
       );
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
+
     it('should display facility phone when clinic phone is missing', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -379,6 +393,19 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).to.be.ok;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
 
     it('should display in-person layout without cancel button', async () => {

--- a/src/applications/vaos/components/layout/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layout/PhoneLayout.jsx
@@ -20,6 +20,10 @@ import {
 import AddToCalendarButton from '../AddToCalendarButton';
 import Address from '../Address';
 import NewTabAnchor from '../NewTabAnchor';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function PhoneLayout({ data: appointment }) {
   const {
@@ -44,6 +48,10 @@ export default function PhoneLayout({ data: appointment }) {
   if (isPastAppointment) heading = 'Past phone appointment';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled phone appointment';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layout/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/PhoneLayout.unit.spec.js
@@ -105,7 +105,21 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(screen.getByText(/Clinic: Not available/i));
       expect(screen.getByText(/Reason: Not available/i));
       expect(screen.getByText(/Other details: Not available/i));
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
+
     it('should display facility phone when clinic phone is missing', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -298,6 +312,19 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).to.be.ok;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
     it('should display phone layout without cancel button', async () => {
       // Arrange

--- a/src/applications/vaos/components/layout/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layout/VARequestLayout.jsx
@@ -14,6 +14,10 @@ import Address from '../Address';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
 import FacilityPhone from '../FacilityPhone';
 import NewTabAnchor from '../NewTabAnchor';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function VARequestLayout({ data: appointment }) {
   const { search } = useLocation();
@@ -41,6 +45,10 @@ export default function VARequestLayout({ data: appointment }) {
     heading = 'Request for appointment';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled request for appointment';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <PageLayout isDetailPage showNeedHelp>

--- a/src/applications/vaos/components/layout/VARequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/VARequestLayout.unit.spec.js
@@ -167,6 +167,19 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /After visit summary/i,
         }),
       ).to.be.null;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
   });
 

--- a/src/applications/vaos/components/layout/VideoLayout.jsx
+++ b/src/applications/vaos/components/layout/VideoLayout.jsx
@@ -26,6 +26,10 @@ import {
 import AddToCalendarButton from '../AddToCalendarButton';
 import VideoInstructions from '../VideoInstructions';
 import State from '../State';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function VideoLayout({ data: appointment }) {
   const {
@@ -57,6 +61,10 @@ export default function VideoLayout({ data: appointment }) {
   if (isPastAppointment) heading = 'Past video appointment';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layout/VideoLayout.unit.spec.js
+++ b/src/applications/vaos/components/layout/VideoLayout.unit.spec.js
@@ -98,7 +98,21 @@ describe('VAOS Component: VideoLayout', () => {
 
       expect(screen.getByText(/Clinic not available/i));
       expect(screen.getByText(/Facility not available/i));
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
+
     it('should display facility phone when clinic phone is missing', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -325,6 +339,19 @@ describe('VAOS Component: VideoLayout', () => {
           'va-additional-info[trigger="How to setup your device"]',
         ),
       ).to.be.ok;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
   });
 

--- a/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
@@ -23,6 +23,10 @@ import NewTabAnchor from '../NewTabAnchor';
 import Address from '../Address';
 import VideoInstructions from '../VideoInstructions';
 import State from '../State';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function VideoLayoutAtlas({ data: appointment }) {
   const {
@@ -49,6 +53,10 @@ export default function VideoLayoutAtlas({ data: appointment }) {
     heading = 'Past video appointment at an ATLAS location';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment at an ATLAS location';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layout/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/layout/VideoLayoutAtlas.unit.spec.js
@@ -113,6 +113,19 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
 
       expect(screen.getByText(/Clinic not available/i));
       expect(screen.getByText(/Facility not available/i));
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -406,6 +419,19 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
           'va-additional-info[trigger="How to setup your device"]',
         ),
       ).to.be.ok;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
   });
 

--- a/src/applications/vaos/components/layout/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutVA.jsx
@@ -21,6 +21,10 @@ import AddToCalendarButton from '../AddToCalendarButton';
 import NewTabAnchor from '../NewTabAnchor';
 import Address from '../Address';
 import FacilityDirectionsLink from '../FacilityDirectionsLink';
+import {
+  NULL_STATE_FIELD,
+  recordAppointmentDetailsNullStates,
+} from '../../utils/events';
 
 export default function VideoLayoutVA({ data: appointment }) {
   const {
@@ -46,6 +50,10 @@ export default function VideoLayoutVA({ data: appointment }) {
   if (isPastAppointment) heading = 'Past video appointment at VA location';
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment at VA location';
+
+  recordAppointmentDetailsNullStates({
+    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+  });
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layout/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/layout/VideoLayoutVA.unit.spec.js
@@ -203,7 +203,21 @@ describe('VAOS Component: VideoLayoutVA', () => {
           name: /What/i,
         }),
       ).not.to.exist;
+
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-total',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-any',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-type-of-care',
+      });
     });
+
     it('should display facility phone when clinic phone is missing', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -429,6 +443,19 @@ describe('VAOS Component: VideoLayoutVA', () => {
             'va-link[text="Find a full list of things to bring to your appointment"]',
           ),
         ).to.be.ok;
+
+        expect(window.dataLayer).to.deep.include({
+          event: 'vaos-null-states-expected-total',
+        });
+        expect(window.dataLayer).not.to.deep.include({
+          event: 'vaos-null-states-missing-any',
+        });
+        expect(window.dataLayer).to.deep.include({
+          event: 'vaos-null-states-expected-type-of-care',
+        });
+        expect(window.dataLayer).not.to.deep.include({
+          event: 'vaos-null-states-missing-type-of-care',
+        });
       });
     });
 

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -45,3 +45,54 @@ export function recordItemsRetrieved(type, count) {
   });
   resetDataLayer();
 }
+
+export const NULL_STATE_FIELD = {
+  TYPE_OF_CARE: 'type-of-care',
+  PROVIDER: 'provider',
+};
+
+/**
+ * Records events for appointment details null states
+ *
+ * @export
+ * @param {Object} nullStates This is the dictionary containing the null state
+ *   details to be logged. The keys are the keys of NULL_STATE_TYPE and the
+ *   values are booleans indicating whether that field is missing in the
+ *   appointment details (i.e. true for missing, false for not missing). If an
+ *   information type is not applicable for the appointment type (e.g. Provider
+ *   for Claim Exam) do not include an entry for the field in the dictionary.
+ */
+export function recordAppointmentDetailsNullStates(nullStates) {
+  const nullStateEventPrefix = `${GA_PREFIX}-null-states`;
+  let anyNullState = false;
+
+  // Always increment total expected count
+  recordEvent({ event: `${nullStateEventPrefix}-expected-total` });
+  // eslint-disable-next-line no-console
+  console.log(`incrementing ${nullStateEventPrefix}-expected-total`);
+
+  // Examine each field type and determine which events should be logged
+  Object.values(NULL_STATE_FIELD).forEach(key => {
+    // Only log events if a field exists in the input dictionary, otherwise ignore it
+    if (key in nullStates) {
+      // Record the expected event
+      recordEvent({ event: `${nullStateEventPrefix}-expected-${key}` });
+      // eslint-disable-next-line no-console
+      console.log(`incrementing ${nullStateEventPrefix}-expected-${key}`);
+      // Record the missing event if needed and updated anyNullState
+      if (nullStates[key]) {
+        recordEvent({ event: `${nullStateEventPrefix}-missing-${key}` });
+        // eslint-disable-next-line no-console
+        console.log(`incrementing ${nullStateEventPrefix}-missing-${key}`);
+        anyNullState = true;
+      }
+    }
+  });
+
+  //  Increment if any null states were present
+  if (anyNullState) {
+    recordEvent({ event: `${nullStateEventPrefix}-missing-any` });
+    // eslint-disable-next-line no-console
+    console.log(`incrementing ${nullStateEventPrefix}-missing-any`);
+  }
+}

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -48,7 +48,6 @@ export function recordItemsRetrieved(type, count) {
 
 export const NULL_STATE_FIELD = {
   TYPE_OF_CARE: 'type-of-care',
-  PROVIDER: 'provider',
 };
 
 /**
@@ -68,8 +67,6 @@ export function recordAppointmentDetailsNullStates(nullStates) {
 
   // Always increment total expected count
   recordEvent({ event: `${nullStateEventPrefix}-expected-total` });
-  // eslint-disable-next-line no-console
-  console.log(`incrementing ${nullStateEventPrefix}-expected-total`);
 
   // Examine each field type and determine which events should be logged
   Object.values(NULL_STATE_FIELD).forEach(key => {
@@ -77,13 +74,9 @@ export function recordAppointmentDetailsNullStates(nullStates) {
     if (key in nullStates) {
       // Record the expected event
       recordEvent({ event: `${nullStateEventPrefix}-expected-${key}` });
-      // eslint-disable-next-line no-console
-      console.log(`incrementing ${nullStateEventPrefix}-expected-${key}`);
       // Record the missing event if needed and updated anyNullState
       if (nullStates[key]) {
         recordEvent({ event: `${nullStateEventPrefix}-missing-${key}` });
-        // eslint-disable-next-line no-console
-        console.log(`incrementing ${nullStateEventPrefix}-missing-${key}`);
         anyNullState = true;
       }
     }
@@ -92,7 +85,5 @@ export function recordAppointmentDetailsNullStates(nullStates) {
   //  Increment if any null states were present
   if (anyNullState) {
     recordEvent({ event: `${nullStateEventPrefix}-missing-any` });
-    // eslint-disable-next-line no-console
-    console.log(`incrementing ${nullStateEventPrefix}-missing-any`);
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR adds appointment details null state recording. While specifically this only adds the null state tracking for type of care and any null state for review and evaluation, the same function and approach will be used for the other fields as well.
- I included two tickets in this PR to demonstrate the approach. The other fields will be added in followup PR(s) once we agree on the approach.
- Appointments (VAOS) Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98976
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99006

## Testing done

- I tested locally using `console.log` and a dummy field type. See https://github.com/department-of-veterans-affairs/vets-website/commit/64777390a00de4aee704f8e8d5907b60182ea21c for details on the code I used for testing.
- I tested the following scenarios
  - Missing type of care
  - Not missing type of care
  - Provider not applicable
  - Expected total and missing any for the above scenarios
- I updated our layout unit tests to account for the new messages

## Screenshots

N/A

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
