### PR TITLE
[10-10CG] Update Facility Confirmation Page

### DIFF
--- a/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
+++ b/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
@@ -32,9 +32,10 @@ const FacilityConfirmation = props => {
   const addressText = facility => {
     return (
       <>
-        <h5 className="vads-u-font-size--h4 vads-u-margin-top--0">
+        <strong className="vads-u-font-size--h4 vads-u-margin-top--0">
           {facility.name}
-        </h5>
+        </strong>
+        <br role="presentation" />
         {facility?.address?.physical?.address1 && (
           <>
             {facility.address.physical.address1}

--- a/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
+++ b/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
@@ -56,23 +56,25 @@ const FacilityConfirmation = props => {
 
   return (
     <div>
-      <h3>Confirm your health care facilities</h3>
-      <h4>The Veteran’s facility you selected</h4>
+      <h3>Caregiver support location</h3>
       <p>
-        This is the facility where you told us the Veteran receives or plans to
-        receive treatment.
-      </p>
-      <va-card>{addressText(selectedFacility)}</va-card>
-      <h4>Your assigned caregiver support facility</h4>
-      <p>
-        This is the facility we’ve assigned to support you in the application
-        process and has a caregiver support coordinator on staff. The
-        coordinator at this facility will support you through the application
-        process.
+        This is the location we’ve assigned to support the caregiver in the
+        application process:
       </p>
       <p className="va-address-block">
         {addressText(selectedCaregiverSupportFacility)}
       </p>
+      <p>
+        This VA health facility has a Caregiver Support Team coordinator. And
+        this facility is closest to where the Veteran receives or plans to
+        receive care.
+      </p>
+      <h4>The Veteran’s VA health facility</h4>
+      <p>
+        The Veteran will still receive their health care at the facility you
+        selected:
+      </p>
+      <p className="va-address-block">{addressText(selectedFacility)}</p>
       <FormNavButtons goBack={onGoBack} goForward={onGoForward} />
     </div>
   );

--- a/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
@@ -31,22 +31,8 @@ describe('CG <FacilityConfirmation>', () => {
     const { getByText, getByRole } = render(
       <FacilityConfirmation {...props} />,
     );
-    const selectedFacilityAddress = selectedFacility.address.physical;
-    const caregiverFacilityAddress = caregiverFacility.address.physical;
 
     const selectors = () => ({
-      selectedFacility: {
-        name: getByText(new RegExp(selectedFacility.name)),
-        address1: getByText(new RegExp(selectedFacilityAddress.address1)),
-        address2: getByText(new RegExp(selectedFacilityAddress.address2)),
-        address3: getByText(new RegExp(selectedFacilityAddress.address3)),
-      },
-      caregiverFacility: {
-        name: getByText(new RegExp(caregiverFacility.name)),
-        address1: getByText(new RegExp(caregiverFacilityAddress.address1)),
-        address2: getByText(new RegExp(caregiverFacilityAddress.address2)),
-        address3: getByText(new RegExp(caregiverFacilityAddress.address3)),
-      },
       formNavButtons: {
         back: getByText('Back'),
         forward: getByText('Continue'),
@@ -103,65 +89,23 @@ describe('CG <FacilityConfirmation>', () => {
     });
   });
 
-  it('renders selected facility description text', () => {
-    const { getByRole, getByText } = subject();
-    expect(
-      getByRole('heading', {
-        level: 3,
-        name: /Confirm your health care facilities/i,
-      }),
-    ).to.be.visible;
-    expect(
-      getByRole('heading', {
-        level: 4,
-        name: /The Veteran’s Facility you selected/i,
-      }),
-    ).to.be.visible;
-    expect(
-      getByText(
-        /This is the facility where you told us the Veteran receives or plans to receive treatment/i,
-      ),
-    ).to.be.visible;
+  it('should render caregiver facility name and address', () => {
+    const { getByText } = subject();
+    const caregiverFacilityAddress = caregiverFacility.address.physical;
+
+    expect(getByText(new RegExp(caregiverFacility.name))).to.exist;
+    expect(getByText(new RegExp(caregiverFacilityAddress.address1))).to.exist;
+    expect(getByText(new RegExp(caregiverFacilityAddress.address2))).to.exist;
+    expect(getByText(new RegExp(caregiverFacilityAddress.address3))).to.exist;
   });
 
-  it('should render veteran selected facility name', () => {
-    const { selectors } = subject();
-    expect(selectors().selectedFacility.name).to.exist;
-  });
+  it('should render veteran selected facility name and address', () => {
+    const { getByText } = subject();
+    const selectedFacilityAddress = selectedFacility.address.physical;
 
-  it('should render veteran selected facility address', () => {
-    const { selectors } = subject();
-
-    expect(selectors().selectedFacility.address1).to.exist;
-    expect(selectors().selectedFacility.address2).to.exist;
-    expect(selectors().selectedFacility.address3).to.exist;
-  });
-
-  it('renders caregive facility description text', () => {
-    const { getByRole, getByText } = subject();
-    expect(
-      getByRole('heading', {
-        level: 4,
-        name: /Your assigned caregiver support facility/i,
-      }),
-    ).to.be.visible;
-    expect(
-      getByText(
-        /This is the facility we’ve assigned to support you in the application process and has a caregiver support coordinator on staff. The coordinator at this facility will support you through the application process./i,
-      ),
-    ).to.be.visible;
-  });
-
-  it('should render caregiver facility name', () => {
-    const { selectors } = subject();
-    expect(selectors().caregiverFacility.name).to.exist;
-  });
-
-  it('should render caregiver facility address', () => {
-    const { selectors } = subject();
-
-    expect(selectors().caregiverFacility.address1).to.exist;
-    expect(selectors().caregiverFacility.address2).to.exist;
-    expect(selectors().caregiverFacility.address3).to.exist;
+    expect(getByText(new RegExp(selectedFacility.name))).to.exist;
+    expect(getByText(new RegExp(selectedFacilityAddress.address1))).to.exist;
+    expect(getByText(new RegExp(selectedFacilityAddress.address2))).to.exist;
+    expect(getByText(new RegExp(selectedFacilityAddress.address3))).to.exist;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated the 10-10CG Facility Confirmation screen per staging review and research feedback results.
- **Note: I noticed we have a comma after the state in the address display. This is due to formatting that we do in the fetch call, and I have a separate branch that I will open a PR for to fix it. I wanted to keep it separate. [PR here](https://github.com/department-of-veterans-affairs/vets-website/pull/33808)
- 1010 Health Apps
- This work is behind the `caregiver_use_facilities_API` toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99040

## Testing done

- Updated unit tests to match new design and refactored them a bit

## Screenshots


|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![Screenshot 2024-12-30 at 4 14 02 PM](https://github.com/user-attachments/assets/b124bde4-3b84-492a-b23c-cfc3beb3ce52)|![Screenshot 2024-12-30 at 4 17 46 PM](https://github.com/user-attachments/assets/4a15fa7e-56e6-4ce9-80f5-05664be7ba0b)|
| Desktop |![Screenshot 2024-12-30 at 4 13 51 PM](https://github.com/user-attachments/assets/6af850e3-4341-4298-be2f-1ced81271a0d)|![Screenshot 2024-12-30 at 4 11 09 PM](https://github.com/user-attachments/assets/e49225a6-c910-417d-bb65-81ac65ee2917)|

## What areas of the site does it impact?

10-10CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

