### PR TITLE
[10-10CG] Update facility address formatting

### DIFF
--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -3,8 +3,18 @@ import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import content from '../locales/en/content.json';
 
-const joinAddressParts = (...parts) => {
-  return parts.filter(part => part != null).join(', ');
+const formatAddress = address => {
+  const joinAddressParts = (...parts) => {
+    const [city, state, zip] = parts;
+    const stateZip = state && zip ? `${state} ${zip}` : state || zip;
+    return [city, stateZip].filter(Boolean).join(', ');
+  };
+
+  return {
+    address1: address.address1,
+    address2: [address?.address2, address?.address3].filter(Boolean).join(', '),
+    address3: joinAddressParts(address?.city, address?.state, address?.zip),
+  };
 };
 
 const formatQueryParams = ({
@@ -75,25 +85,13 @@ export const fetchFacilities = async ({
       }
       const facilities = response.data.map(facility => {
         const attributes = facility?.attributes;
-        const { physical } = attributes?.address;
-
-        // Create a new address object without modifying the original facility
-        const newPhysicalAddress = {
-          address1: physical.address1,
-          address2: joinAddressParts(physical?.address2, physical?.address3),
-          address3: joinAddressParts(
-            physical.city,
-            physical.state,
-            physical.zip,
-          ),
-        };
 
         // Return a new facility object with the updated address
         return {
           ...attributes,
           id: facility.id,
           address: {
-            physical: newPhysicalAddress,
+            physical: formatAddress(attributes?.address.physical),
           },
         };
       });

--- a/src/applications/caregivers/tests/mocks/responses.js
+++ b/src/applications/caregivers/tests/mocks/responses.js
@@ -456,7 +456,7 @@ const fetchChildFacilityWithoutCaregiverSupport = {
     physical: {
       address1: '2720 Airport Drive',
       address2: 'Suite 100',
-      address3: 'Columbus, OH, 43219-2219',
+      address3: 'Columbus, OH 43219-2219',
     },
   },
   classification: 'Other Outpatient Services (OOS)',
@@ -514,7 +514,7 @@ const fetchChildFacilityWithCaregiverSupport = {
     physical: {
       address1: '2720 Airport Drive',
       address2: 'Suite 100',
-      address3: 'Columbus, OH, 43219-2219',
+      address3: 'Columbus, OH 43219-2219',
     },
   },
   classification: 'Other Outpatient Services (OOS)',
@@ -580,7 +580,7 @@ const fetchParentFacility = {
     physical: {
       address1: '420 North James Road',
       address2: '33',
-      address3: 'Columbus, OH, 43219-1834',
+      address3: 'Columbus, OH 43219-1834',
     },
   },
   classification: 'Health Care Center (HCC)',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated the address formatting on the facility list and facility confirmation page to not have a comma after the state. This change makes it consistent with VA address formatting standards.
- The date is formatted in the `fetchFacilities` function, so the formatted date is available anywhere we use the date returned on the facility object (we currently display it on the facilities list on the search page, the facility confirmation page, and the form review page in the facility section).
- 1010 Health Apps
- This work is behind the `caregiver_use_facilities_API` toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99040

## Testing done

- Updated unit tests

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
|   |![Screenshot 2024-12-30 at 4 42 31 PM](https://github.com/user-attachments/assets/84d4a42d-b00b-42e3-828b-90cc93419794)|![Screenshot 2024-12-30 at 4 41 22 PM](https://github.com/user-attachments/assets/64802d9e-11f5-4a7e-ae8a-135dc34fffb5)|


## What areas of the site does it impact?

10-10CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
