### PR TITLE
[DBEX] add mental health intro & events content

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { formTitleTag, formTitle } from '../utils';
 
+export const form0781HeadingTag = 'VA FORM 21-0781';
 export const additionalFormsTitle = 'Additional Forms';
 
 export const form0781WorkflowChoices = {
@@ -73,3 +75,118 @@ export const traumaticEventsExamples = (
     </va-accordion-item>
   </va-accordion>
 );
+
+export const mentalHealthSupportResources = (
+  <>
+    <strong>
+      Veterans Crisis Line responders are available 24 hours a day. You can
+      connect with a responder in any of these ways:
+    </strong>
+    <ul>
+      <li>
+        Dial <va-telephone contact="988" /> then select 1.
+      </li>
+      <li>
+        <va-link
+          external
+          href="https://www.veteranscrisisline.net/get-help-now/chat/"
+          text="Start a confidential chat."
+        />
+      </li>
+      <li>
+        Text <va-telephone contact="838255" />.
+      </li>
+      <li>
+        If you have hearing loss, call TTY: <va-telephone contact="711" />, then{' '}
+        <va-telephone contact="988" />.
+      </li>
+    </ul>
+    <strong>You can also get support in any of these ways:</strong>
+    <ul>
+      <li>
+        <va-link
+          external
+          href="https://www.va.gov/get-help-from-accredited-representative/"
+          text="Connect with a Veterans Service Officer (VSO) to assist you with your
+          application."
+        />
+      </li>
+      <li>
+        Call <va-telephone contact="911" />.
+      </li>
+      <li>Go to the nearest emergency room.</li>
+      <li>
+        Go directly to your nearest VA medical center. It doesn’t matter what
+        your discharge status is or if you’re enrolled in VA health care.
+        <va-link
+          external
+          href="https://www.va.gov/find-locations/?facilityType=health"
+          text="Find your nearest VA medical center"
+        />
+      </li>
+    </ul>
+    <strong>
+      If your claim is related to MST (military sexual trauma), you can also get
+      support in these ways:
+    </strong>
+    <ul>
+      <li>
+        <va-link
+          external
+          href="https://www.mentalhealth.va.gov/msthome/vha-mst-coordinators.asp"
+          text="Connect with a MST Outreach Coordinator."
+        />
+      </li>
+      <li>
+        <va-link
+          external
+          href="https://www.va.gov/health-care/health-needs-conditions/military-sexual-trauma/"
+          text="Learn more about our MST-related services."
+        />
+      </li>
+    </ul>
+  </>
+);
+
+export const mentalHealthSupportAlert = () => {
+  return (
+    <va-alert-expandable
+      status="info"
+      trigger="How do I get mental health support right now?"
+    >
+      <p>
+        We understand that some of the questions may be difficult to answer. If
+        you need to take a break and come back to your application, your
+        information will be saved.
+      </p>
+      <br />
+      <p>
+        If you’re a Veteran in crisis or concerned about one, connect with our
+        caring, qualified Veterans Crisis Line responders for confidential help.
+        Many of them are Veterans themselves. This service is private, free, and
+        available 24/7.
+      </p>
+      <br />
+      {mentalHealthSupportResources}
+    </va-alert-expandable>
+  );
+};
+
+/**
+ * Create a title and headingTag for a page which will be passed into ui:title so that
+ * they are grouped in the same legend
+ * @param {string} title - the title for the page, which displays below the stepper
+ * @param {string} headingTag - the headingTag for the page, which displays above the title
+ * @returns {JSX.Element} markup with title and headingTag. example below.
+ *
+ * <h3 class="...">VA FORM 21-0781</h3>
+ * <h3 class="...">Mental health support</h3>
+ */
+export function titleWithTag(title, headingTag) {
+  return (
+    <>
+      {formTitleTag(headingTag)}
+      {formTitle(title)}
+    </>
+  );
+}

--- a/src/applications/disability-benefits/all-claims/content/mentalHealthSupport.jsx
+++ b/src/applications/disability-benefits/all-claims/content/mentalHealthSupport.jsx
@@ -1,4 +1,21 @@
-// TODO: additional content will be added in ticket #97079
+import React from 'react';
+import { mentalHealthSupportResources } from './form0781';
 
-/* ---------- content ----------*/
 export const mentalHealthSupportPageTitle = 'Mental health support';
+
+export const mentalHealthSupportDescription = () => {
+  return (
+    <>
+      <p>
+        On the next screen, we’ll ask you about your mental health conditions.
+        <br />
+        <br />
+        First, we want you to know that you can get support for your mental
+        health any time, day or night.
+      </p>
+      <h4>Resources that may be helpful</h4>
+      <br />
+      {mentalHealthSupportResources}
+    </>
+  );
+};

--- a/src/applications/disability-benefits/all-claims/content/traumaticEventTypes.jsx
+++ b/src/applications/disability-benefits/all-claims/content/traumaticEventTypes.jsx
@@ -1,7 +1,6 @@
-// TODO: additional content will be added in ticket #97079
-
-/* ---------- content ----------*/
 export const eventTypesPageTitle = 'Types of traumatic events';
+export const eventTypesDescription =
+  'We may send your claim to a specific type of claim processor who specializes in reviewing claims related to the traumatic events you went through.';
 export const eventTypesQuestion =
   'Which of these did you experience during your military service? Select all that you experienced.';
 export const eventTypesHint =

--- a/src/applications/disability-benefits/all-claims/content/traumaticEventsIntro.jsx
+++ b/src/applications/disability-benefits/all-claims/content/traumaticEventsIntro.jsx
@@ -1,4 +1,42 @@
-// TODO: additional content will be added in ticket #97079
+import React from 'react';
 
-/* ---------- content ----------*/
 export const eventsPageTitle = 'Traumatic events';
+
+export const eventsIntroDescription = () => {
+  return (
+    <>
+      <p>
+        We want to know about any traumatic events during your military service.
+        <br />
+        <br />
+        Any information you provide will help us understand your situation and
+        identify evidence to support your claim. All the questions are optional.
+        You can provide only details that you’re comfortable sharing.
+      </p>
+      <h4>Information we’ll ask you for</h4>
+      <p>
+        We’ll ask you for this information:
+        <ul>
+          <li>
+            Whether your event was related to combat, personal interactions,
+            military sexual trauma (MST), something else, or any combination of
+            these
+          </li>
+          <li>
+            A brief description, location, and approximate time frame of your
+            event
+          </li>
+          <li>
+            Details about any official reports that were filed, if applicable
+          </li>
+        </ul>
+      </p>
+      <h4>You can take a break at any time</h4>
+      <p>
+        We understand that some of the questions may be difficult to answer. You
+        can take a break at any time and come back to continue your application
+        later. We’ll save the information you’ve entered so far.
+      </p>
+    </>
+  );
+};

--- a/src/applications/disability-benefits/all-claims/pages/form0781/mentalHealthSupport.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/mentalHealthSupport.js
@@ -1,10 +1,12 @@
-// TODO: this is a placeholder; structure will be added in ticket #97079
-import { mentalHealthSupportPageTitle } from '../../content/mentalHealthSupport';
-
-import { formTitle } from '../../utils';
+import {
+  mentalHealthSupportPageTitle,
+  mentalHealthSupportDescription,
+} from '../../content/mentalHealthSupport';
+import { titleWithTag, form0781HeadingTag } from '../../content/form0781';
 
 export const uiSchema = {
-  'ui:title': formTitle(mentalHealthSupportPageTitle),
+  'ui:title': titleWithTag(mentalHealthSupportPageTitle, form0781HeadingTag),
+  'ui:description': mentalHealthSupportDescription,
 };
 
 export const schema = {

--- a/src/applications/disability-benefits/all-claims/pages/form0781/traumaticEventTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/traumaticEventTypes.js
@@ -4,15 +4,21 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import {
   eventTypesPageTitle,
+  eventTypesDescription,
   eventTypesQuestion,
   eventTypesHint,
 } from '../../content/traumaticEventTypes';
-import { formTitle } from '../../utils';
+import {
+  titleWithTag,
+  form0781HeadingTag,
+  traumaticEventsExamples,
+  mentalHealthSupportAlert,
+} from '../../content/form0781';
 import { TRAUMATIC_EVENT_TYPES } from '../../constants';
-import { traumaticEventsExamples } from '../../content/form0781';
 
 export const uiSchema = {
-  'ui:title': formTitle(eventTypesPageTitle),
+  'ui:title': titleWithTag(eventTypesPageTitle, form0781HeadingTag),
+  'ui:description': eventTypesDescription,
   mentalHealth: {
     eventTypes: checkboxGroupUI({
       title: eventTypesQuestion,
@@ -23,6 +29,9 @@ export const uiSchema = {
   },
   'view:traumaticEventsInfo': {
     'ui:description': traumaticEventsExamples,
+  },
+  'view:mentalHealthSupportAlert': {
+    'ui:description': mentalHealthSupportAlert,
   },
 };
 
@@ -36,6 +45,10 @@ export const schema = {
       },
     },
     'view:traumaticEventsInfo': {
+      type: 'object',
+      properties: {},
+    },
+    'view:mentalHealthSupportAlert': {
       type: 'object',
       properties: {},
     },

--- a/src/applications/disability-benefits/all-claims/pages/form0781/traumaticEventsIntro.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/traumaticEventsIntro.js
@@ -1,13 +1,27 @@
-// TODO: this is a placeholder; structure will be added in ticket #97079
-import { eventsPageTitle } from '../../content/traumaticEventsIntro';
-
-import { formTitle } from '../../utils';
+import {
+  eventsPageTitle,
+  eventsIntroDescription,
+} from '../../content/traumaticEventsIntro';
+import {
+  titleWithTag,
+  form0781HeadingTag,
+  mentalHealthSupportAlert,
+} from '../../content/form0781';
 
 export const uiSchema = {
-  'ui:title': formTitle(eventsPageTitle),
+  'ui:title': titleWithTag(eventsPageTitle, form0781HeadingTag),
+  'ui:description': eventsIntroDescription,
+  'view:mentalHealthSupportAlert': {
+    'ui:description': mentalHealthSupportAlert,
+  },
 };
 
 export const schema = {
   type: 'object',
-  properties: {},
+  properties: {
+    'view:mentalHealthSupportAlert': {
+      type: 'object',
+      properties: {},
+    },
+  },
 };

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/mentalHealthSupport.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/mentalHealthSupport.unit.spec.js
@@ -1,12 +1,55 @@
+import React from 'react';
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import * as mentalHealthSupport from '../../../pages/form0781/mentalHealthSupport';
+import {
+  mentalHealthSupportPageTitle,
+  mentalHealthSupportDescription,
+} from '../../../content/mentalHealthSupport';
+import { titleWithTag, form0781HeadingTag } from '../../../content/form0781';
 
-describe('Mental health support', () => {
+describe('Mental health support page', () => {
   it('should define a uiSchema object', () => {
     expect(mentalHealthSupport.uiSchema).to.be.an('object');
   });
 
   it('should define a schema object', () => {
     expect(mentalHealthSupport.schema).to.be.an('object');
+  });
+
+  it('should have the correct title in uiSchema', () => {
+    const { container: uiTitleContainer } = render(
+      <div>{mentalHealthSupport.uiSchema['ui:title']}</div>,
+    );
+    const renderedUITitleText = uiTitleContainer.textContent.trim();
+
+    const { container: titleWithTagContainer } = render(
+      <div>
+        {titleWithTag(mentalHealthSupportPageTitle, form0781HeadingTag)}
+      </div>,
+    );
+    const expectedTitleText = titleWithTagContainer.textContent.trim();
+
+    expect(renderedUITitleText).to.equal(expectedTitleText);
+  });
+
+  it('should have the correct description in uiSchema', () => {
+    expect(mentalHealthSupport.uiSchema['ui:description']).to.equal(
+      mentalHealthSupportDescription,
+    );
+  });
+
+  it('should have correct schema structure', () => {
+    expect(mentalHealthSupport.schema)
+      .to.have.property('type')
+      .that.equals('object');
+    expect(mentalHealthSupport.schema)
+      .to.have.property('properties')
+      .that.is.an('object');
+  });
+
+  it('should not have additional properties in schema', () => {
+    const properties = Object.keys(mentalHealthSupport.schema.properties);
+    expect(properties).to.have.lengthOf(0);
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/traumaticEventTypes.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/traumaticEventTypes.unit.spec.js
@@ -13,9 +13,15 @@ import formConfig from '../../../config/form';
 import * as eventType from '../../../pages/form0781/traumaticEventTypes';
 import {
   eventTypesPageTitle,
+  eventTypesDescription,
   eventTypesQuestion,
 } from '../../../content/traumaticEventTypes';
 import { TRAUMATIC_EVENT_TYPES } from '../../../constants';
+import {
+  titleWithTag,
+  form0781HeadingTag,
+  mentalHealthSupportAlert,
+} from '../../../content/form0781';
 
 describe('Traumatic event types', () => {
   const {
@@ -29,6 +35,32 @@ describe('Traumatic event types', () => {
 
   it('should define a schema object', () => {
     expect(eventType.schema).to.be.an('object');
+  });
+
+  it('should have the correct title in uiSchema', () => {
+    const { container: uiTitleContainer } = render(
+      <div>{eventType.uiSchema['ui:title']}</div>,
+    );
+    const renderedUITitleText = uiTitleContainer.textContent.trim();
+
+    const { container: titleWithTagContainer } = render(
+      <div>{titleWithTag(eventTypesPageTitle, form0781HeadingTag)}</div>,
+    );
+    const expectedTitleText = titleWithTagContainer.textContent.trim();
+
+    expect(renderedUITitleText).to.equal(expectedTitleText);
+  });
+
+  it('should have the correct description in uiSchema', () => {
+    expect(eventType.uiSchema['ui:description']).to.equal(
+      eventTypesDescription,
+    );
+  });
+
+  it('should render the mental health support alert description in uiSchema', () => {
+    expect(
+      eventType.uiSchema['view:mentalHealthSupportAlert']['ui:description'],
+    ).to.equal(mentalHealthSupportAlert);
   });
 
   it('should render with all checkboxes', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/traumaticEventsIntro.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/traumaticEventsIntro.unit.spec.js
@@ -1,12 +1,69 @@
+import React from 'react';
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import * as traumaticEvents from '../../../pages/form0781/traumaticEventsIntro';
+import {
+  eventsPageTitle,
+  eventsIntroDescription,
+} from '../../../content/traumaticEventsIntro';
+import {
+  titleWithTag,
+  form0781HeadingTag,
+  mentalHealthSupportAlert,
+} from '../../../content/form0781';
 
-describe('Traumatic events', () => {
+describe('Traumatic events intro page', () => {
   it('should define a uiSchema object', () => {
     expect(traumaticEvents.uiSchema).to.be.an('object');
   });
 
   it('should define a schema object', () => {
     expect(traumaticEvents.schema).to.be.an('object');
+  });
+
+  it('should have the correct title in uiSchema', () => {
+    const { container: uiTitleContainer } = render(
+      <div>{traumaticEvents.uiSchema['ui:title']}</div>,
+    );
+    const renderedUITitleText = uiTitleContainer.textContent.trim();
+
+    const { container: titleWithTagContainer } = render(
+      <div>{titleWithTag(eventsPageTitle, form0781HeadingTag)}</div>,
+    );
+    const expectedTitleText = titleWithTagContainer.textContent.trim();
+
+    expect(renderedUITitleText).to.equal(expectedTitleText);
+  });
+
+  it('should have the correct description in uiSchema', () => {
+    expect(traumaticEvents.uiSchema['ui:description']).to.equal(
+      eventsIntroDescription,
+    );
+  });
+
+  it('should render the mental health support alert description in uiSchema', () => {
+    expect(
+      traumaticEvents.uiSchema['view:mentalHealthSupportAlert'][
+        'ui:description'
+      ],
+    ).to.equal(mentalHealthSupportAlert);
+  });
+
+  it('should have correct schema structure', () => {
+    expect(traumaticEvents.schema)
+      .to.have.property('type')
+      .that.equals('object');
+    expect(traumaticEvents.schema)
+      .to.have.property('properties')
+      .that.is.an('object');
+    expect(Object.keys(traumaticEvents.schema.properties)).to.have.lengthOf(1);
+    expect(traumaticEvents.schema.properties).to.have.property(
+      'view:mentalHealthSupportAlert',
+    );
+  });
+
+  it('should not have additional properties in schema', () => {
+    const properties = Object.keys(traumaticEvents.schema.properties);
+    expect(properties).to.have.lengthOf(1);
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -743,6 +743,17 @@ export const truncateDescriptions = data =>
   );
 
 /**
+ * Creates consistent form title tag
+ * @param {string} titleTag
+ * @returns {string} markup with h3 tag and consistent styling
+ */
+export const formTitleTag = titleTag => (
+  <h3 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+    {`${titleTag} `}
+  </h3>
+);
+
+/**
  * Creates consistent form title
  * @param {string} title
  * @returns {string} markup with h3 tag and consistent styling


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - In the ["Add event" section](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=9856-83462&t=ymVYrSth7bWoMpuD-4) of the new, digitized Form 0781 flow, add content (page name heading tags, descriptions, and alert content/component) to the following pages, placeholders for which were incorporated in https://github.com/department-of-veterans-affairs/vets-website/pull/33741:
    - ["Mental health support"](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=10498-213662&t=NszIlX2RqUx8XIU5-4)
    - ["Events intro"](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=10498-213692&t=NszIlX2RqUx8XIU5-4)
    - ["Event type"](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=10498-213692&t=NszIlX2RqUx8XIU5-4)
  - shared content:
    - page name heading tag: `VA FORM 21-0781` 
    - mental health support alert
- _(If bug, how to reproduce)_
  - n/a
- _(What is the solution, why is this the solution)_
  - Create a new flow and pages to align the digital form with the [VA Form 21-0781](https://www.vba.va.gov/pubs/forms/VBA-21-0781-ARE.pdf) paper version 
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - `sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97079
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97078

## Testing done

- _Describe what the old behavior was prior to the change_
 - These pages previously were placeholders, and do not yet exist on the digital form that informs generation of form 21-0781
- _Describe the steps required to verify your changes are working as expected_
  1. in the development environment, ensure that the [`sync_modern_0781_flow`](https://dev-api.va.gov/flipper/features#:~:text=disability_compensation_sync_modern_0781_flow) toggle is enabled 
  2. start a new claim
  3. claim at least 1 new condition
  4. select at least 1 of the new conditions on the [0781 screener page](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=9250-79794&t=NszIlX2RqUx8XIU5-4)
  5. once https://github.com/department-of-veterans-affairs/va.gov-team/issues/97067 is complete, the 3 pages should display after the new [0781 choice page](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=9442-72041&t=NszIlX2RqUx8XIU5-4), only if the option to complete the online form is selected on the preceding choice page (or force `isCompletingForm0781(formData)` to return **true**)
  6. the last of the new pages should continue to the "Supporting evidence" chapter, until additional pages are developed
- Describe the tests completed and the results
  - added unit tests to check for content
  - manually verified

## Screenshots

| Page | Before | After |
| ------- | ------ | ----- |
| Mental health support | <img width="300" alt="Screenshot 2024-12-20 at 11 52 21 AM" src="https://github.com/user-attachments/assets/f0bb9b85-a08e-4ae1-ab80-5c13f3860fdf" /> | <img width="300" alt="Screenshot 2024-12-30 at 2 48 51 PM" src="https://github.com/user-attachments/assets/4b46117d-fa73-4a8a-80b8-40bfb40a7fb8" /> |
| Events intro | <img width="300" alt="Screenshot 2024-12-20 at 12 05 52 PM" src="https://github.com/user-attachments/assets/56df8a3b-d807-4d9f-bde8-f1db82290e22" /> | <img width="300" alt="Screenshot 2024-12-30 at 2 49 23 PM" src="https://github.com/user-attachments/assets/9154eedd-68aa-4a8a-b05a-b7dddb52930a" /> |
| Event type | <img width="300" alt="Screenshot 2024-12-20 at 12 04 42 PM" src="https://github.com/user-attachments/assets/ae8b8914-9bc2-4da0-9bef-7375e352b833" /> | <img width="300" alt="Screenshot 2024-12-30 at 2 50 25 PM" src="https://github.com/user-attachments/assets/477e41dd-2d8e-4bdc-9a5f-82ca97453208" /> |

| Component | Expanded |
| ------- | ------ |
| alert | <img width="300" alt="Screenshot 2024-12-30 at 2 49 53 PM" src="https://github.com/user-attachments/assets/49067511-2a86-4d8f-bf31-3df58192d3d9" /> |
| event examples | <img width="300" alt="Screenshot 2024-12-31 at 10 09 05 AM" src="https://github.com/user-attachments/assets/302b0be3-18b5-4274-8cfe-6d21e3743c04" /> |

## What areas of the site does it impact?

- Only impacts 526 EZ (within a new "Additional Forms" chapter)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I ~fixed~|~updated~|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) ~has been performed~ **(linked page does not exist)**

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user