### PR TITLE
Redirect to signin for unauthenticated users on the Review information form

### DIFF
--- a/src/applications/personalization/review-information/containers/App.jsx
+++ b/src/applications/personalization/review-information/containers/App.jsx
@@ -1,12 +1,35 @@
 import React from 'react';
-
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
+import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import formConfig from '../config/form';
 
-export default function App({ location, children }) {
+export const App = ({ location, children, user }) => {
+  const serviceRequired = [backendServices.USER_PROFILE];
+
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
+      <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
+        {children}
+      </RequiredLoginView>
     </RoutedSavableApp>
   );
-}
+};
+App.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+  location: PropTypes.object,
+  user: PropTypes.shape({
+    profile: PropTypes.shape({}),
+  }),
+};
+
+const mapStateToProps = state => ({
+  user: state.user,
+});
+
+export default connect(mapStateToProps)(App);


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Wrapped this application in the `<RequiredLoginView>` component which causes unauthenticated users to be routed to a sign-in flow before returning
- - I work for VA IIR and we own this application

## Related issue(s)

- [VA IIR ticket #1321](https://github.com/department-of-veterans-affairs/va-iir/issues/1321)

## Testing done

The old behavior: the user sees a broken version of the page with red text indicating that sign-in is required. 

To verify that this is working
1. Run the entire stack with `yarn watch`.
2. In another console run a mock api: `yarn mock-api --responses src/applications/personalization/profile/mocks/server.js`
3. Visit http://localhost:3001/my-va/welcome-va-setup/review-information/contact-information
4. If you are already signed-in, open the JavaScript console and sign out with`localStorage.setItem('hasSession', false)`
5. Refresh the site. You should see that you are redirected to the sign-in form
6. Don't forget to sign in again using the JS console: `localStorage.setItem('hasSession', true)`

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="431" alt="m-before" src="https://github.com/user-attachments/assets/c6de801b-df1b-42aa-a2ff-7774e1f0a7dd" />|<img width="436" alt="m-after" src="https://github.com/user-attachments/assets/a23e7901-6900-42cc-ac85-43aa2eeff231" />|
| Desktop |<img width="702" alt="d-before" src="https://github.com/user-attachments/assets/8b79fe36-75f1-47e7-ba61-7e55cebceef8" />|<img width="1194" alt="d-after" src="https://github.com/user-attachments/assets/204e517b-9139-460f-b1e4-f1994113b29e" />|

## What areas of the site does it impact?

This only impacts the Review Information form.

## Acceptance criteria
- [ ] When unauthenticated, the user is redirected to the sign-in form.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
