### PR TITLE
Fix required span font size

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/SelectDate1Page.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/SelectDate1Page.jsx
@@ -155,7 +155,7 @@ export default function SelectDate1Page({ changeCrumb }) {
     <div>
       <h1 className="vads-u-font-size--h2">
         {pageTitle}
-        <span className="schemaform-required-span vaos-calendar__page_header vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal">
+        <span className="schemaform-required-span vaos-calendar__page_header vads-u-font-family--sans vads-u-font-weight--normal">
           (*Required)
         </span>
       </h1>

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/VA.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/VA.jsx
@@ -86,7 +86,7 @@ export default function VARequest({ changeCrumb }) {
     <div className="vaos-form__detailed-radio">
       <h1 className="vads-u-font-size--h2">
         {pageTitle}
-        <span className="schemaform-required-span vaos-calendar__page_header vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal">
+        <span className="schemaform-required-span vaos-calendar__page_header vads-u-font-family--sans vads-u-font-weight--normal">
           (*Required)
         </span>
       </h1>

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -107,7 +107,7 @@ export default function TypeOfCarePage() {
     <div className="vaos-form__radio-field">
       <h1 className="vads-u-font-size--h2">
         {pageTitle}
-        <span className="schemaform-required-span vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal">
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
           (*Required)
         </span>
       </h1>

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -92,6 +92,7 @@ va-radio::part(legend) {
   margin-top: 16px;
 }
 
+.schemaform-required-span,
 body {
   font-size: 1.06rem; // same as 16.96px
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fix the font size of the "(*Required)" spans from 16px => 16.96px
- Appointments (VAOS) Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96063

## Testing done

- Tested locally, see screenshots

## Screenshots

|Before | After |
| ------ | ----- |
|   <img width="423" alt="image" src="https://github.com/user-attachments/assets/4e65d638-edfa-4a47-be22-011ef9996f95" />    |   <img width="421" alt="image" src="https://github.com/user-attachments/assets/d224536f-12ef-400c-ab02-04d10b5925a6" />   |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

