### PR TITLE
[10-10CG] - Change Facility VaSearchInput label

### DIFF
--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -305,16 +305,16 @@ const FacilitySearch = props => {
               searchInputError ? 'caregiver-facilities-search-input-error' : ''
             }`}
           >
-            <label
-              htmlFor="facility-search"
+            <p
               className="vads-u-margin-top--0 vads-u-margin-bottom--1"
+              aria-hidden="true"
             >
               {content['form-facilities-search-label']}
               <span className="vads-u-color--secondary-dark"> (*Required)</span>
-            </label>
+            </p>
             {searchInputError && searchError()}
             <VaSearchInput
-              label={content['form-facilities-search-label']}
+              label={`${content['form-facilities-search-label']} (*Required)`}
               value={query}
               onInput={handleChange}
               onSubmit={handleSearch}

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -309,12 +309,16 @@ const FacilitySearch = props => {
               className="vads-u-margin-top--0 vads-u-margin-bottom--1"
               aria-hidden="true"
             >
-              {content['form-facilities-search-label']}
-              <span className="vads-u-color--secondary-dark"> (*Required)</span>
+              {content['form-facilities-search-label']}{' '}
+              <span className="vads-u-color--secondary-dark">
+                {content['validation-required-label']}
+              </span>
             </p>
             {searchInputError && searchError()}
             <VaSearchInput
-              label={`${content['form-facilities-search-label']} (*Required)`}
+              label={`${content['form-facilities-search-label']} ${
+                content['validation-required-label']
+              }}`}
               value={query}
               onInput={handleChange}
               onSubmit={handleSearch}

--- a/src/applications/caregivers/locales/en/content.json
+++ b/src/applications/caregivers/locales/en/content.json
@@ -142,6 +142,7 @@
   "validation-facilities--search-required": "Enter a city, state or postal code",
   "validation-facilities--submit-search-required": "Select the search button",
   "validation-facilities--default-required": "Select a medical center or clinic",
+  "validation-required-label": "(*Required)",
   "validation-signature-required": "Must certify by checking box",
   "validation-sign-as-rep": "You must sign as representative.",
   "validation-sign-as-rep--vet-name": "Your signature must match previously entered name: %s",

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
@@ -106,7 +106,7 @@ describe('CG <FacilitySearch>', () => {
       expect(selectors().moreFacilities).not.to.exist;
       expect(selectors().ariaLiveStatus).not.to.exist;
       expect(queryByText(content['form-facilities-search-label'])).to.exist;
-      expect(queryByText('(*Required)')).to.exist;
+      expect(queryByText(content['validation-required-label'])).to.exist;
     });
   });
 
@@ -699,7 +699,7 @@ describe('CG <FacilitySearch>', () => {
           expect(selectors().searchInputError.parentElement).to.have.class(
             'caregiver-facilities-search-input-error',
           );
-          expect(getByText('(*Required)')).to.exist;
+          expect(getByText(content['validation-required-label'])).to.exist;
         });
 
         it('renders error when trying to click goForward when no search value is present', () => {
@@ -713,7 +713,7 @@ describe('CG <FacilitySearch>', () => {
           expect(selectors().searchInputError.parentElement).to.have.class(
             'caregiver-facilities-search-input-error',
           );
-          expect(getByText('(*Required)')).to.exist;
+          expect(getByText(content['validation-required-label'])).to.exist;
         });
       });
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updating facility search input label. The `VaSearchInput` component has a hidden label, and we added a visible label to the page. This caused screen readers to read the same label text twice. This PR changes the visible label to a `p` and sets `aria-hidden` to true to prevent the duplication for screen readers.
- Added new `(*Required)` label to content.json and replaced usages of it. 
- 1010 Health apps
- This work is behind the `caregiver_use_facilities_API` toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99046

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

No visible UI changes. The only changes are for screen readers.

## What areas of the site does it impact?

10-10CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
