### PR TITLE
Review Contact Information form - set focus to h2 on confirmation page

### DIFF
--- a/src/applications/personalization/review-information/containers/ConfirmationPage.jsx
+++ b/src/applications/personalization/review-information/containers/ConfirmationPage.jsx
@@ -1,6 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { focusElement } from 'platform/utilities/ui';
 
 export const ConfirmationPage = () => {
+  // Set focus
+  useEffect(() => {
+    // Wait a moment before setting focus to avoid an issue where focus would otherwise reset to the body element
+    setTimeout(() => {
+      focusElement('#confirmation-heading');
+    }, 250);
+  }, []);
+
   return (
     <>
       <div className="vads-u-margin-bottom--4">
@@ -8,7 +17,9 @@ export const ConfirmationPage = () => {
           status="success"
           id="welcome-va-setup-review-information-confirmation-alert"
         >
-          <h2 slot="headline">Contact information added to your profile</h2>
+          <h2 id="confirmation-heading" slot="headline">
+            Contact information added to your profile
+          </h2>
           <p className="vads-u-margin-y--2">
             If you apply for VA benefits, we’ll use this information to contact
             you with important information about your benefits and how to manage


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- On the confirmation page of the Review Contact Information form focus is set to the H2
- Used the platform utility `focusElement` for consistency.
- I work for VA IIR and we own this form

## Related issue(s)

[VA IIR issue 1320](https://github.com/department-of-veterans-affairs/va-iir/issues/1320)

## Testing done

- Before this change the body element received focus, which is a bad user experience for users using a screenreader or navigating with the keyboard.

To verify this change is working as intended:
1. Run the mock-api `yarn mock-api --responses src/applications/personalization/profile/mocks/server.js`
2. In a new console run the app `yarn watch --env entry=welcome-va-setup-review-information`
3. Visit http://localhost:3001/my-va/welcome-va-setup/review-information/confirmation
4. Click the continue button and you'll be routed to the confirmation page
5. Ensure that the h2 is focused. You should see a glow around the element.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="438" alt="m-before" src="https://github.com/user-attachments/assets/3902b442-9618-42a7-8081-1068b1db9446" />|<img width="434" alt="m-after" src="https://github.com/user-attachments/assets/622c0061-8507-4da2-b2da-717a7a4a5c5f" />|
| Desktop |<img width="737" alt="d-before" src="https://github.com/user-attachments/assets/61261093-e22e-432e-918e-44e4d7cae470" />|<img width="732" alt="d-after" src="https://github.com/user-attachments/assets/aa9a10b7-45d9-4571-8a65-d2bd7ab924bc" />|

## What areas of the site does it impact?

This only impacts the Review Contact Information form.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
