### PR TITLE
Pilot station filter for community care self scheduling

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
@@ -8,7 +8,6 @@ import DowntimeNotification, {
 import PropTypes from 'prop-types';
 import {
   selectFeatureBreadcrumbUrlUpdate,
-  selectFeatureCCDirectScheduling,
   // selectFeatureBookingExclusion,
 } from '../../../redux/selectors';
 import UpcomingAppointmentsList from '../UpcomingAppointmentsList';
@@ -30,6 +29,7 @@ import CernerAlert from '../../../components/CernerAlert';
 import ReferralTaskCardWithReferral from '../../../referral-appointments/components/ReferralTaskCardWithReferral';
 import { setFormCurrentPage } from '../../../referral-appointments/redux/actions';
 import { routeToCCPage } from '../../../referral-appointments/flow';
+import { useIsInCCPilot } from '../../../referral-appointments/hooks/useIsInCCPilot';
 
 function renderWarningNotification() {
   return (props, childContent) => {
@@ -52,10 +52,7 @@ export default function AppointmentsPage() {
   const dispatch = useDispatch();
   const [hasTypeChanged, setHasTypeChanged] = useState(false);
   let [pageTitle] = useState('VA online scheduling');
-
-  const featureCCDirectScheduling = useSelector(state =>
-    selectFeatureCCDirectScheduling(state),
-  );
+  const { isInCCPilot } = useIsInCCPilot();
 
   const pendingAppointments = useSelector(state =>
     selectPendingAppointments(state),
@@ -166,8 +163,8 @@ export default function AppointmentsPage() {
       />
       {/* {!hideScheduleLink() && <ScheduleNewAppointment />} */}
       <ScheduleNewAppointment />
-      {featureCCDirectScheduling && <ReferralTaskCardWithReferral />}
-      {featureCCDirectScheduling && (
+      {isInCCPilot && <ReferralTaskCardWithReferral />}
+      {isInCCPilot && (
         <div
           className={classNames(
             'vads-u-padding-y--3',
@@ -189,7 +186,7 @@ export default function AppointmentsPage() {
         </div>
       )}
       <AppointmentListNavigation
-        hidePendingTab={featureCCDirectScheduling}
+        hidePendingTab={isInCCPilot}
         count={count}
         callback={setHasTypeChanged}
       />

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentsListGroup.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentsListGroup.jsx
@@ -19,7 +19,6 @@ import InfoAlert from '../../components/InfoAlert';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
 import RequestAppointmentLayout from './AppointmentsPage/RequestAppointmentLayout';
 import BackendAppointmentServiceAlert from './BackendAppointmentServiceAlert';
-import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
 
 export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
   const {
@@ -32,10 +31,6 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
   );
 
   const dispatch = useDispatch();
-
-  const featureCCDirectScheduling = useSelector(
-    selectFeatureCCDirectScheduling,
-  );
 
   useEffect(
     () => {
@@ -100,10 +95,6 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
     return 0;
   });
 
-  const paragraphText = featureCCDirectScheduling
-    ? "These requests and referrals haven't been scheduled yet."
-    : 'Appointments that you request will show here until staff review and schedule them.';
-
   return (
     <>
       <div aria-live="polite" className="sr-only">
@@ -130,7 +121,8 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
         )}
         {appointmentsByStatus.flat().includes(APPOINTMENT_STATUS.proposed) && (
           <p className="vaos-hide-for-print mobile:vads-u-margin-bottom--1 mobile-lg:vads-u-margin-bottom--2">
-            {paragraphText}
+            Appointments that you request will show here until staff review and
+            schedule them.
           </p>
         )}
         {appointmentsByStatus.map(statusBucket => {

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -6,10 +6,8 @@ import AppointmentsPage from './components/AppointmentsPage/index';
 import RequestedAppointmentDetailsPage from './components/RequestedAppointmentDetailsPage';
 import ConfirmedAppointmentDetailsPage from './components/ConfirmedAppointmentDetailsPage';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
-import {
-  selectFeatureBreadcrumbUrlUpdate,
-  selectFeatureCCDirectScheduling,
-} from '../redux/selectors';
+import { selectFeatureBreadcrumbUrlUpdate } from '../redux/selectors';
+import { useIsInCCPilot } from '../referral-appointments/hooks/useIsInCCPilot';
 import ReferralsAndRequests from '../referral-appointments/ReferralsAndRequests';
 
 function AppointmentListSection() {
@@ -18,11 +16,7 @@ function AppointmentListSection() {
   const featureBreadcrumbUrlUpdate = useSelector(state =>
     selectFeatureBreadcrumbUrlUpdate(state),
   );
-
-  const featureCCDirectScheduling = useSelector(state =>
-    selectFeatureCCDirectScheduling(state),
-  );
-
+  const { isInCCPilot } = useIsInCCPilot();
   return (
     <>
       {!featureBreadcrumbUrlUpdate && (
@@ -49,7 +43,7 @@ function AppointmentListSection() {
             component={RequestedAppointmentDetailsPage}
           />
           <Route path="/pending" component={AppointmentsPage} />
-          {featureCCDirectScheduling && (
+          {isInCCPilot && (
             <Route
               path="/referrals-requests"
               component={ReferralsAndRequests}

--- a/src/applications/vaos/referral-appointments/components/ReferralAppLink.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralAppLink.jsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useLocation, useHistory } from 'react-router-dom';
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import { GA_PREFIX } from 'applications/vaos/utils/constants';
-import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
+import { useIsInCCPilot } from '../hooks/useIsInCCPilot';
 import { routeToNextReferralPage } from '../flow';
 import { selectCurrentPage } from '../redux/selectors';
 
@@ -21,12 +21,9 @@ function ReferralAppLinkComponent({ linkText, id }) {
       routeToNextReferralPage(history, currentPage, id);
     };
   };
+  const { isInCCPilot } = useIsInCCPilot();
 
-  const featureCCDirectScheduling = useSelector(
-    selectFeatureCCDirectScheduling,
-  );
-
-  return featureCCDirectScheduling ? (
+  return isInCCPilot ? (
     // eslint-disable-next-line jsx-a11y/anchor-is-valid
     <a
       className="vads-c-action-link--green vaos-hide-for-print"

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -22,6 +22,11 @@ const initialState = {
     ],
     referralFetchStatus: FETCH_STATUS.succeeded,
   },
+  user: {
+    profile: {
+      facilities: [{ facilityId: '983' }],
+    },
+  },
 };
 
 describe('VAOS Component: ReferralTaskCardWithReferral', () => {

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
@@ -3,15 +3,13 @@ import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { getReferral } from '../redux/selectors';
 import { fetchReferralById } from '../redux/actions';
 import { FETCH_STATUS } from '../../utils/constants';
-import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
+import { useIsInCCPilot } from './useIsInCCPilot';
 
 const useGetReferralById = id => {
   const [referralNotFound, setReferralNotFound] = useState(false);
   const [currentReferral, setCurrentReferral] = useState(null);
   const dispatch = useDispatch();
-  const featureCCDirectScheduling = useSelector(
-    selectFeatureCCDirectScheduling,
-  );
+  const { isInCCPilot } = useIsInCCPilot();
   const { referrals, referralFetchStatus } = useSelector(
     state => getReferral(state),
     shallowEqual,
@@ -19,17 +17,17 @@ const useGetReferralById = id => {
   useEffect(
     () => {
       if (
-        featureCCDirectScheduling &&
+        isInCCPilot &&
         (referralFetchStatus === FETCH_STATUS.succeeded && !referrals.length)
       ) {
         setReferralNotFound(true);
       }
     },
-    [featureCCDirectScheduling, referralFetchStatus, referrals],
+    [isInCCPilot, referralFetchStatus, referrals],
   );
   useEffect(
     () => {
-      if (featureCCDirectScheduling && (referrals.length && id)) {
+      if (isInCCPilot && (referrals.length && id)) {
         const referralFromParam = referrals.find(ref => ref.UUID === id);
         if (referralFromParam) {
           setCurrentReferral(referralFromParam);
@@ -38,19 +36,19 @@ const useGetReferralById = id => {
         }
       }
     },
-    [id, referrals, referralFetchStatus, featureCCDirectScheduling],
+    [id, referrals, referralFetchStatus, isInCCPilot],
   );
   useEffect(
     () => {
       if (
-        featureCCDirectScheduling &&
+        isInCCPilot &&
         !referrals.length &&
         referralFetchStatus === FETCH_STATUS.notStarted
       ) {
         dispatch(fetchReferralById(id));
       }
     },
-    [dispatch, featureCCDirectScheduling, id, referralFetchStatus, referrals],
+    [dispatch, isInCCPilot, id, referralFetchStatus, referrals],
   );
   return {
     currentReferral,

--- a/src/applications/vaos/referral-appointments/hooks/useIsInCCPilot.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useIsInCCPilot.jsx
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+import { selectPatientFacilities } from '@department-of-veterans-affairs/platform-user/cerner-dsot/selectors';
+import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
+
+const useIsInCCPilot = () => {
+  let isInCCPilot = false;
+  const pilotStations = ['984', '983'];
+  const featureCCDirectScheduling = useSelector(
+    selectFeatureCCDirectScheduling,
+  );
+  const patentFacilities = useSelector(selectPatientFacilities);
+
+  if (featureCCDirectScheduling) {
+    isInCCPilot = patentFacilities.some(station =>
+      pilotStations.includes(station.facilityId),
+    );
+  }
+
+  return { isInCCPilot };
+};
+
+export { useIsInCCPilot };

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -6,15 +6,14 @@ import {
   Redirect,
   useLocation,
 } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import ScheduleReferral from './ScheduleReferral';
 import ReviewAndConfirm from './ReviewAndConfirm';
 import ConfirmReferral from './ConfirmReferral';
 import ChooseDateAndTime from './ChooseDateAndTime';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
-import { selectFeatureCCDirectScheduling } from '../redux/selectors';
 import { useGetReferralById } from './hooks/useGetReferralById';
+import { useIsInCCPilot } from './hooks/useIsInCCPilot';
 import { FETCH_STATUS } from '../utils/constants';
 import FormLayout from '../new-appointment/components/FormLayout';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
@@ -22,9 +21,7 @@ import { scrollAndFocus } from '../utils/scrollAndFocus';
 export default function ReferralAppointments() {
   useManualScrollRestoration();
   const basePath = useRouteMatch();
-  const featureCCDirectScheduling = useSelector(
-    selectFeatureCCDirectScheduling,
-  );
+  const { isInCCPilot } = useIsInCCPilot();
   const { search } = useLocation();
 
   const params = new URLSearchParams(search);
@@ -51,7 +48,7 @@ export default function ReferralAppointments() {
     },
     [referralFetchStatus],
   );
-  if (referralNotFound || !featureCCDirectScheduling) {
+  if (referralNotFound || !isInCCPilot) {
     return <Redirect from={basePath.url} to="/" />;
   }
   if (

--- a/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
@@ -32,6 +32,11 @@ describe('Community Care Referrals', () => {
           referrals: [],
           referralFetchStatus: FETCH_STATUS.notStarted,
         },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '983' }],
+          },
+        },
       };
       const screen = renderWithStoreAndRouter(<TestComponent />, {
         initialState,
@@ -55,6 +60,11 @@ describe('Community Care Referrals', () => {
             createReferral(now, 'add2f0f4-a1ea-4dea-a504-a54ab57c6800'),
           ],
           referralFetchStatus: FETCH_STATUS.notStarted,
+        },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '983' }],
+          },
         },
       };
       const screen = renderWithStoreAndRouter(<TestComponent />, {
@@ -80,6 +90,11 @@ describe('Community Care Referrals', () => {
           ],
           referralFetchStatus: FETCH_STATUS.notStarted,
         },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '983' }],
+          },
+        },
       };
       const screen = renderWithStoreAndRouter(<TestComponent />, {
         initialState,
@@ -101,6 +116,11 @@ describe('Community Care Referrals', () => {
           facility: null,
           referrals: [],
           referralFetchStatus: FETCH_STATUS.notStarted,
+        },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '983' }],
+          },
         },
       };
       const screen = renderWithStoreAndRouter(<TestComponent />, {

--- a/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/TestComponent.jsx
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/TestComponent.jsx
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+import React from 'react';
+import { useIsInCCPilot } from '../../../hooks/useIsInCCPilot';
+
+export default function TestComponent() {
+  const { isInCCPilot } = useIsInCCPilot();
+  return (
+    <div>
+      <p>Test component</p>
+      <p data-testid="pilot-value">{isInCCPilot.toString()}</p>
+    </div>
+  );
+}

--- a/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/useIsInCCPilot.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/useIsInCCPilot.unit.spec.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderWithStoreAndRouter } from '../../../../tests/mocks/setup';
+
+import TestComponent from './TestComponent';
+
+describe('Community Care Referrals', () => {
+  describe('useIsInCCPilot hook', () => {
+    it('Returns true when the user has a facility within the pilot list', () => {
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: true,
+        },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '983' }],
+          },
+        },
+      };
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      expect(screen.getByTestId('pilot-value')).to.have.text('true');
+    });
+    it('Returns true when the user has a facility within the pilot list as well as some outside', () => {
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: true,
+        },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '983' }, { facilityId: '400' }],
+          },
+        },
+      };
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      expect(screen.getByTestId('pilot-value')).to.have.text('true');
+    });
+    it('Returns false when the user has no facilities in the pilot list', () => {
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: true,
+        },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '400' }],
+          },
+        },
+      };
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      expect(screen.getByTestId('pilot-value')).to.have.text('false');
+    });
+    it('Returns false when the user has a facility within the pilot list but the feature is off', () => {
+      const initialState = {
+        featureToggles: {
+          vaOnlineSchedulingCCDirectScheduling: false,
+        },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '983' }],
+          },
+        },
+      };
+      const screen = renderWithStoreAndRouter(<TestComponent />, {
+        initialState,
+      });
+      expect(screen.getByTestId('pilot-value')).to.have.text('false');
+    });
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Adds a hook to check feature flag state along with a hardcoded list of facilities that are to be piloted. Returns true if feature is on and the user object in redux contains a facility in the list. Replaces areas where we were using the feature toggle to determine if the schedule CC appointment flow is available. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#99589

## Testing done

Adds unit tests, and tested locally.

## What areas of the site does it impact?

Self scheduling community care referrals feature in VAOS.

## Acceptance criteria
 - [ ] Application flow is only available if feature is on and the patient is associated with facility 983 or 984
  
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Testing steps

 - [ ] Turn on the mocks
 - [ ] Run the app locally
 - [ ] verify that the `vaOnlineSchedulingCCDirectScheduling` feature toggle still works as expected
 - [ ] Remove `984` from the pilotStations array in `/vaos/referral-appointments/hooks/useIsInCCPilot.jsx`
 - [ ] verify that the CC flow is unavailable

