### PR TITLE
[DBX-97082] Add Behavioral Changes Pages for 0781 Paper Sync

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form0781/index.js
+++ b/src/applications/disability-benefits/all-claims/config/form0781/index.js
@@ -50,12 +50,6 @@ export const form0781PagesConfig = {
     uiSchema: eventType.uiSchema,
     schema: eventType.schema,
   },
-  consentPage: {
-    path: 'additional-forms/mental-health-statement/consent',
-    depends: formData => isRelatedToMST(formData),
-    uiSchema: consentPage.uiSchema,
-    schema: consentPage.schema,
-  },
   additionalInformationPage: {
     path: 'additional-forms/mental-health-statement/additional-information',
     depends: formData => showForm0781Pages(formData),
@@ -80,5 +74,11 @@ export const form0781PagesConfig = {
     depends: formData => showBehaviorListPage(formData),
     uiSchema: behaviorListPage.uiSchema,
     schema: behaviorListPage.schema,
+  },
+  consentPage: {
+    path: 'additional-forms/mental-health-statement/consent',
+    depends: formData => isRelatedToMST(formData),
+    uiSchema: consentPage.uiSchema,
+    schema: consentPage.schema,
   },
 };

--- a/src/applications/disability-benefits/all-claims/config/form0781/index.js
+++ b/src/applications/disability-benefits/all-claims/config/form0781/index.js
@@ -2,13 +2,20 @@ import * as workflowChoicePage from '../../pages/form0781/workflowChoicePage';
 import * as mentalHealthSupport from '../../pages/form0781/mentalHealthSupport';
 import * as traumaticEventsIntro from '../../pages/form0781/traumaticEventsIntro';
 import * as eventType from '../../pages/form0781/traumaticEventTypes';
-import {
-  showForm0781Pages,
-  isCompletingForm0781,
-  isRelatedToMST,
-} from '../../utils/form0781';
 import * as consentPage from '../../pages/form0781/consentPage';
 import * as additionalInformationPage from '../../pages/form0781/additionalInformationPage';
+import * as behaviorIntroPage from '../../pages/form0781/behaviorIntroPage';
+import * as behaviorIntroCombatPage from '../../pages/form0781/behaviorIntroCombatPage';
+import * as behaviorListPage from '../../pages/form0781/behaviorListPage';
+
+import {
+  isCompletingForm0781,
+  showForm0781Pages,
+  isRelatedToMST,
+  showBehaviorIntroPage,
+  showBehaviorIntroCombatPage,
+  showBehaviorListPage,
+} from '../../utils/form0781';
 
 /**
  * Configuration for our modern 0781 paper sync (2024/2025)
@@ -54,5 +61,24 @@ export const form0781PagesConfig = {
     depends: formData => showForm0781Pages(formData),
     uiSchema: additionalInformationPage.uiSchema,
     schema: additionalInformationPage.schema,
+  },
+  // Behavioral Changes Pages
+  behaviorIntroPage: {
+    path: 'additional-forms/mental-health-statement/behavior-changes',
+    depends: formData => showBehaviorIntroPage(formData),
+    uiSchema: behaviorIntroPage.uiSchema,
+    schema: behaviorIntroPage.schema,
+  },
+  behaviorIntroCombatPage: {
+    path: 'additional-forms/mental-health-statement/behavior-changes-combat',
+    depends: formData => showBehaviorIntroCombatPage(formData),
+    uiSchema: behaviorIntroCombatPage.uiSchema,
+    schema: behaviorIntroCombatPage.schema,
+  },
+  behaviorListPage: {
+    path: 'additional-forms/mental-health-statement/behavior-changes-list',
+    depends: formData => showBehaviorListPage(formData),
+    uiSchema: behaviorListPage.uiSchema,
+    schema: behaviorListPage.schema,
   },
 };

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -411,3 +411,29 @@ export const TRAUMATIC_EVENT_TYPES = Object.freeze({
   nonMst: 'Traumatic events related to other personal interactions',
   other: 'Other traumatic events',
 });
+
+export const BEHAVIOR_CHANGES_WORK = Object.freeze({
+  reassignment:
+    'Request for a change in occupational series or duty assignment',
+  absences: 'Increased or decreased use of leave',
+  performance: 'Changes in performance or performance evaluations',
+});
+
+export const BEHAVIOR_CHANGES_HEALTH = Object.freeze({
+  consultations:
+    'Increased or decreased visits to a healthcare professional, counselor, or treatment facility',
+  episodes: 'Episodes of depression, panic attacks, or anxiety',
+  medications: 'Increased or decreased use of prescription medications',
+  selfMedication: 'Increased or decreased use of over-the-counter medications',
+  substances: 'Increased or decreased use of alcohol or drugs',
+  appetite:
+    'Changes in eating habits, such as overeating or undereating, or significant changes in weight',
+  pregnancy: 'Pregnancy tests around the time of the traumatic experiences',
+  screenings: 'Tests for sexually transmitted infections',
+});
+
+export const BEHAVIOR_CHANGES_OTHER = Object.freeze({
+  socialEconomic: 'Economic or social behavioral changes',
+  relationships: 'Changes in or breakup of a significant relationship',
+  misconduct: 'Disciplinary or legal difficulties',
+});

--- a/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const BEHAVIOR_LIST_DESCRIPTION = (
+  <p>
+    Did you experience any of these behavioral changes after your traumatic
+    experiences? It’s also okay if you don’t report any behavioral changes. You
+    can skip this question if you don’t feel comfortable answering.
+  </p>
+);
+
+export const BEHAVIOR_LIST_BEHAVIORS_TITLE =
+  'Behavioral changes related to work';
+
+export const BEHAVIOR_INTRO_COMBAT_DESCRIPTION = (
+  <p>Placholder content for combat intro description</p>
+);

--- a/src/applications/disability-benefits/all-claims/pages/form0781/behaviorIntroCombatPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/behaviorIntroCombatPage.js
@@ -1,0 +1,27 @@
+import {
+  radioUI,
+  radioSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+import { BEHAVIOR_INTRO_COMBAT_DESCRIPTION } from '../../content/form0781/behaviorListPages';
+
+export const uiSchema = {
+  'ui:description': BEHAVIOR_INTRO_COMBAT_DESCRIPTION,
+  'view:answerCombatBehaviorQuestions': {
+    ...radioUI({
+      title: 'Do you want to answer additional questions?',
+      required: () => true,
+      labels: {
+        true: 'true',
+        false: 'false',
+      },
+    }),
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    'view:answerCombatBehaviorQuestions': radioSchema(['true', 'false']),
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/form0781/behaviorIntroPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/behaviorIntroPage.js
@@ -1,0 +1,8 @@
+export const uiSchema = {
+  'ui:description': 'Placeholder Text for Behavior Intro',
+};
+
+export const schema = {
+  type: 'object',
+  properties: {},
+};

--- a/src/applications/disability-benefits/all-claims/pages/form0781/behaviorListPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/behaviorListPage.js
@@ -1,0 +1,79 @@
+import {
+  checkboxGroupSchema,
+  checkboxGroupUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import {
+  BEHAVIOR_LIST_DESCRIPTION,
+  BEHAVIOR_LIST_BEHAVIORS_TITLE,
+} from '../../content/form0781/behaviorListPages';
+import {
+  BEHAVIOR_CHANGES_WORK,
+  BEHAVIOR_CHANGES_HEALTH,
+  BEHAVIOR_CHANGES_OTHER,
+} from '../../constants';
+
+const schemaKeys = Object.keys(BEHAVIOR_CHANGES_WORK).concat(
+  Object.keys(BEHAVIOR_CHANGES_HEALTH),
+  Object.keys(BEHAVIOR_CHANGES_OTHER),
+);
+
+export const uiSchema = {
+  'ui:description': BEHAVIOR_LIST_DESCRIPTION,
+  behaviors: checkboxGroupUI({
+    title: BEHAVIOR_LIST_BEHAVIORS_TITLE,
+    labels: {
+      ...BEHAVIOR_CHANGES_WORK,
+      ...BEHAVIOR_CHANGES_HEALTH,
+      ...BEHAVIOR_CHANGES_OTHER,
+    },
+    required: false,
+  }),
+  otherBehaviors: {
+    'ui:title': 'placeholder title',
+    'ui:description': 'placeholde description',
+  },
+  'view:optOut': checkboxGroupUI({
+    title: 'None',
+    labels: {
+      none: 'no selection placeholder',
+    },
+    required: false,
+  }),
+  'ui:validations': [
+    (errors, field) => {
+      const behaviorSelected = Object.values(field.behaviors || {}).some(
+        selected => selected,
+      );
+      const otherProvided = Object.values(field.otherBehaviors || {}).some(
+        entry => !!entry,
+      );
+      const optedOut = !!Object.values(field['view:optOut'] || {}).some(
+        entry => !!entry,
+      );
+
+      if (!behaviorSelected && !otherProvided && !optedOut) {
+        // when a user has not selected options nor opted out
+        errors['view:optOut'].addError(
+          'selection required Error message placehoder',
+        );
+      } else if (optedOut && (behaviorSelected || otherProvided)) {
+        // when a user has selected options and opted out
+        errors['view:optOut'].addError(
+          'conflicting selections Error message placehoder',
+        );
+      }
+    },
+  ],
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    behaviors: checkboxGroupSchema(schemaKeys),
+    otherBehaviors: {
+      type: 'string',
+      properties: {},
+    },
+    'view:optOut': checkboxGroupSchema(['none']),
+  },
+};

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorIntroCombatPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorIntroCombatPage.unit.spec.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as behaviorIntroCombatPage from '../../../pages/form0781/behaviorIntroCombatPage';
+
+describe('Behavior Intro Page when Combat is the only type selected', () => {
+  it('should define a uiSchema object', () => {
+    expect(behaviorIntroCombatPage.uiSchema).to.be.an('object');
+  });
+
+  it('should define a schema object', () => {
+    expect(behaviorIntroCombatPage.schema).to.be.an('object');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorIntroPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorIntroPage.unit.spec.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as behaviorIntroPage from '../../../pages/form0781/behaviorIntroPage';
+
+describe('Behavior Intro Page', () => {
+  it('should define a uiSchema object', () => {
+    expect(behaviorIntroPage.uiSchema).to.be.an('object');
+  });
+
+  it('should define a schema object', () => {
+    expect(behaviorIntroPage.schema).to.be.an('object');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import * as behaviorListPage from '../../../pages/form0781/behaviorListPage';
+
+describe('Behavior List Page', () => {
+  it('should define a uiSchema object', () => {
+    expect(behaviorListPage.uiSchema).to.be.an('object');
+  });
+
+  it('should define a schema object', () => {
+    expect(behaviorListPage.schema).to.be.an('object');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/utils/form0781.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/utils/form0781.unit.spec.js
@@ -207,8 +207,6 @@ describe('showBehaviorListPage', () => {
           conditions: {
             someCondition: true,
           },
-        },
-        form0781: {
           eventTypes: {
             combat: true,
             nonMst: true,

--- a/src/applications/disability-benefits/all-claims/tests/utils/form0781.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/utils/form0781.unit.spec.js
@@ -1,0 +1,221 @@
+import { expect } from 'chai';
+
+import {
+  showForm0781Pages,
+  showBehaviorIntroPage,
+  showBehaviorIntroCombatPage,
+  showBehaviorListPage,
+} from '../../utils/form0781';
+
+describe('showForm0781Pages', () => {
+  describe('when the flipper is on and a user is claiming a new condition', () => {
+    it('should should return true', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+        },
+      };
+      expect(showForm0781Pages(formData)).to.eq(true);
+    });
+  });
+
+  describe('when the flipper is off and a user is claiming a new condition', () => {
+    it('should should return false', () => {
+      const formData = {
+        syncModern0781Flow: false,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+        },
+      };
+      expect(showForm0781Pages(formData)).to.eq(false);
+    });
+  });
+
+  describe('when the flipper is on and a user is not claiming a new condition', () => {
+    it('should should return false', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            none: true,
+          },
+        },
+      };
+      expect(showForm0781Pages(formData)).to.eq(false);
+    });
+
+    it('should should return false', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: false,
+          },
+        },
+      };
+      expect(showForm0781Pages(formData)).to.eq(false);
+    });
+  });
+});
+
+describe('showBehaviorIntroCombatPage', () => {
+  describe('when a user has selected ONLY combat related events', () => {
+    it('should should return true', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+          eventTypes: {
+            combat: true,
+            nonMst: false,
+          },
+        },
+      };
+
+      expect(showBehaviorIntroCombatPage(formData)).to.eq(true);
+    });
+  });
+
+  describe('when a user has selected combat related AND non-combat related events', () => {
+    it('should should return false', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+          eventTypes: {
+            combat: true,
+            nonMst: true,
+          },
+        },
+      };
+
+      expect(showBehaviorIntroCombatPage(formData)).to.eq(false);
+    });
+  });
+
+  describe('when a user has not selected combat related events', () => {
+    it('should should return false', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+          eventTypes: {
+            combat: false,
+            nonMst: true,
+          },
+        },
+      };
+
+      expect(showBehaviorIntroCombatPage(formData)).to.eq(false);
+    });
+  });
+});
+
+describe('showBehaviorIntroPage', () => {
+  describe('when a user has not selected ONLY combat related events', () => {
+    it('should should return true', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+          eventTypes: {
+            combat: true,
+            nonMst: true,
+          },
+        },
+      };
+      expect(showBehaviorIntroPage(formData)).to.eq(true);
+    });
+  });
+
+  describe('when a user has selected ONLY combat related events', () => {
+    it('should should return false', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+          eventTypes: {
+            combat: true,
+            nonMst: false,
+          },
+        },
+      };
+      expect(showBehaviorIntroPage(formData)).to.eq(false);
+    });
+  });
+});
+
+describe('showBehaviorListPage', () => {
+  describe('when a user has selected ONLY combat related events and opted in', () => {
+    it('should should return true', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        'view:answerCombatBehaviorQuestions': 'true',
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+          eventTypes: {
+            combat: true,
+            nonMst: false,
+          },
+        },
+      };
+      expect(showBehaviorListPage(formData)).to.eq(true);
+    });
+  });
+
+  describe('when a user has selected ONLY combat related events and opted OUT', () => {
+    it('should should return false', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        'view:answerCombatBehaviorQuestions': 'false',
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+          eventTypes: {
+            combat: true,
+            nonMst: false,
+          },
+        },
+      };
+      expect(showBehaviorListPage(formData)).to.eq(false);
+    });
+  });
+
+  describe('when a user has not selected ONLY combat related events', () => {
+    it('should should return true', () => {
+      const formData = {
+        syncModern0781Flow: true,
+        mentalHealth: {
+          conditions: {
+            someCondition: true,
+          },
+        },
+        form0781: {
+          eventTypes: {
+            combat: true,
+            nonMst: true,
+          },
+        },
+      };
+      expect(showBehaviorListPage(formData)).to.eq(true);
+    });
+  });
+});

--- a/src/applications/disability-benefits/all-claims/utils/form0781.js
+++ b/src/applications/disability-benefits/all-claims/utils/form0781.js
@@ -99,8 +99,8 @@ export function showBehaviorListPage(formData) {
     _.get('view:answerCombatBehaviorQuestions', formData, 'false') === 'true';
 
   return (
-    (showForm0781Pages(formData) &&
-      (showBehaviorIntroCombatPage(formData) && answerQuestions)) ||
-    !combatOnlySelection(formData)
+    showForm0781Pages(formData) &&
+    ((showBehaviorIntroCombatPage(formData) && answerQuestions) ||
+      !combatOnlySelection(formData))
   );
 }

--- a/src/applications/disability-benefits/all-claims/utils/form0781.js
+++ b/src/applications/disability-benefits/all-claims/utils/form0781.js
@@ -1,6 +1,21 @@
 // All flippers for the 0781 Papersync should be added to this file
+import _ from 'platform/utilities/data';
 import { isClaimingNew } from '.';
 import { form0781WorkflowChoices } from '../content/form0781';
+
+/**
+ * Helper method to determin if a series of veteran selections match ONLY
+ * the condition of type === combat
+ */
+function combatOnlySelection(formData) {
+  const eventTypes = formData?.mentalHealth?.eventTypes || {};
+  // ensure the Vet has only selected the 'combat' event type
+  const combatSelected = eventTypes.combat;
+  const nonCombatSelections = Object.keys(eventTypes)
+    .filter(key => key !== 'combat')
+    .some(key => eventTypes[key]);
+  return combatSelected && !nonCombatSelections;
+}
 
 /**
  * Checks if the modern 0781 flow should be shown if the flipper is active for this veteran
@@ -45,5 +60,47 @@ export function isRelatedToMST(formData) {
   return (
     isCompletingForm0781(formData) &&
     formData?.mentalHealth?.eventTypes?.mst === true
+  );
+}
+/*
+ * @returns
+ *   TRUE
+ *     - IF Vetern should see 0781 pages
+ *       - AND is not seeing the 'Combat Only' version of this page
+ */
+export function showBehaviorIntroPage(formData) {
+  return showForm0781Pages(formData) && !combatOnlySelection(formData);
+}
+
+/*
+ * @returns
+ *   FALSE
+ *     - IF Vetern has ONLY selected "Traumatic Events Related To Comabt"
+ *       - AND has explicitly opted out of providing more info
+ *     - ELSE IF Veteran should not see 0781 pages
+ *   TRUE
+ *     - in all other cases
+ */
+export function showBehaviorIntroCombatPage(formData) {
+  return showForm0781Pages(formData) && combatOnlySelection(formData);
+}
+
+/*
+ * @returns
+ *   FALSE
+ *     - IF Vetern has ONLY selected "Traumatic Events Related To Comabt"
+ *       - AND has explicitly opted out of providing more info
+ *     - ELSE IF Veteran should not see 0781 pages
+ *   TRUE
+ *     - in all other cases
+ */
+export function showBehaviorListPage(formData) {
+  const answerQuestions =
+    _.get('view:answerCombatBehaviorQuestions', formData, 'false') === 'true';
+
+  return (
+    (showForm0781Pages(formData) &&
+      (showBehaviorIntroCombatPage(formData) && answerQuestions)) ||
+    !combatOnlySelection(formData)
   );
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adding 'skeleton' pages (data / navigation only) for the 'behavioral changes' section of the new 0781 flow. [See tiles 3.11 - 3.12 in the design doc](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=8144-135894&p=f&t=9OFz94er2hIJJv3l-0)
- NB: placeholder text is intentional. Typos are not important. Content added is not considered final, that work will be done in ticket [97083](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97083)

## Related issue(s)

- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97082)

## Testing done

- Local click through with user 228. **NB**: If testing locally, note that the `showBehaviorIntroCombatPage` relies on form data that is not organically populated yet. You will need to manually add the appropriate data, or simply manually return true from the utility method.

## Screenshots

### Intro page
#### Conditions
- Flipper turned on

#### Image
<img width="583" alt="Screenshot 2025-01-03 at 12 37 08 PM" src="https://github.com/user-attachments/assets/45ddcc44-64d3-4215-9959-a3b6ccbe0444" />

### 'Combat Only' intro page w/ question
#### Image
<img width="435" alt="Screenshot 2025-01-08 at 12 04 49 PM" src="https://github.com/user-attachments/assets/b8a9b89e-f87b-4002-a616-3a3d58f46af3" />

#### Conditions
- Flipper turned on
- User has selected ONLY the 'Combat related' option (stubbed)
  - AND they have opted on the previous page to answer these questions
  - OR (they have not selected 'combat related' only) 

### Behavior List Page
#### Conditions
- Flipper turned on

#### Image
<img width="522" alt="Screenshot 2025-01-03 at 12 37 48 PM" src="https://github.com/user-attachments/assets/396cee2d-f33e-4f5f-b9cd-e3f15651d602" />

## Error States
### User has not made a selection
<img width="435" alt="Screenshot 2025-01-08 at 12 00 21 PM" src="https://github.com/user-attachments/assets/645d09a1-d6af-4a23-8ae4-0ac39d0838b5" />

### User has selected incompatible options
NOTE: not sure if this is going to be it's own error, but that consideration can be handled in the content ticket

#### With checkbox selections
<img width="412" alt="Screenshot 2025-01-08 at 12 00 00 PM" src="https://github.com/user-attachments/assets/1ea4c7bf-0fc1-4e0f-8748-44d9f542c801" />

#### With text field input
<img width="408" alt="Screenshot 2025-01-08 at 12 00 09 PM" src="https://github.com/user-attachments/assets/98171df3-1eda-43ac-a580-c1f5b3f2b61d" />


## Acceptance criteria

- Pages exist at the appropriate endpoints
- Pages can be navigated with the appropriate show / hide logic
- selections are saved into the form data

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated (see ticket / epic)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (N/A - this is behind a flipper. This will be done when the content is added)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
