### PR TITLE
Fix e2e tests for Income Limits and Search

### DIFF
--- a/src/applications/income-limits/tests/cypress/standard-flow.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/standard-flow.cypress.spec.js
@@ -35,10 +35,10 @@ describe('standard flow', () => {
 
     // Results
     h.verifyElement(h.RESULTSPAGE);
-    h.checkAccordionValue(h.RESULTS_1, '$24,505 or less', 0);
-    h.checkAccordionValue(h.RESULTS_2, '$24,506 - $52,180', 1);
-    h.checkAccordionValue(h.RESULTS_3, '$52,181 - $101,800', 2);
-    h.checkAccordionValue(h.RESULTS_4, '$101,801 - $111,980', 3);
-    h.checkAccordionValue(h.RESULTS_5, '$111,981 or more', 4);
+    h.checkAccordionValue(h.RESULTS_1, '$16,037 or less', 0);
+    h.checkAccordionValue(h.RESULTS_2, '$16,038 - $39,849', 1);
+    h.checkAccordionValue(h.RESULTS_3, '$39,850 - $46,450', 2);
+    h.checkAccordionValue(h.RESULTS_4, '$46,451 - $51,095', 3);
+    h.checkAccordionValue(h.RESULTS_5, '$51,096 or more', 4);
   });
 });

--- a/src/applications/search/tests/e2e/helpers.js
+++ b/src/applications/search/tests/e2e/helpers.js
@@ -10,7 +10,7 @@ export const SELECTORS = {
   TYPEAHEAD_DROPDOWN: '#va-search-listbox',
   TYPEAHEAD_OPTIONS: '#va-search-listbox li',
   ERROR_ALERT_BOX: '[data-e2e-id="alert-box"]',
-  MAINT_BOX: 'va-maintenance-banner',
+  MAINT_BOX: '[banner-id="search-gov-maintenance-banner"]',
   OUTAGE_BOX: 'va-banner',
   PAGINATION: 'va-pagination',
   HEADER_SEARCH_TRIGGER: 'button.sitewide-search-drop-down-panel-button',


### PR DESCRIPTION
## Summary
Fixes end-to-end tests for Income Limits and Search.

We have new Income Limits data for 2025 so this test has to be manually updated each year. For Search, it seems the test started picking up the generic `<va-maintenance-banner>` that is present (and usually empty) in production. I made the check for the Search maintenance banner more specific so it wouldn't get tripped up on the generic one.

Ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20195