### PR TITLE
Conditions 616 Add Input Transformers Functionality to Autocomplete

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -21,6 +21,7 @@ const Autocomplete = ({
   const [results, setResults] = useState([]);
   const [activeIndex, setActiveIndex] = useState(null);
   const [ariaLiveText, setAriaLiveText] = useState('');
+  const [isScrolling, setIsScrolling] = useState(false);
 
   const containerRef = useRef(null);
   const inputRef = useRef(null);
@@ -75,13 +76,26 @@ const Autocomplete = ({
     debouncedSearch(inputValue);
   };
 
+  const isElementVisible = (element, container) => {
+    const { top, bottom } = element?.getBoundingClientRect();
+    const containerRect = container?.getBoundingClientRect();
+
+    return top >= containerRect.top && bottom <= containerRect.bottom;
+  };
+
   const activateScrollToAndFocus = index => {
     setActiveIndex(index);
 
     const activeResult = resultsRef.current[index];
-    activeResult?.scrollIntoView({
-      block: 'nearest',
-    });
+    const container = activeResult?.parentNode;
+
+    if (!isElementVisible(activeResult, container)) {
+      activeResult?.scrollIntoView({
+        block: 'nearest',
+      });
+      setIsScrolling(true);
+    }
+
     activeResult?.focus();
   };
 
@@ -158,6 +172,13 @@ const Autocomplete = ({
     }
   };
 
+  const handleMouseEnter = index => {
+    if (!isScrolling) {
+      activateScrollToAndFocus(index);
+    }
+    setIsScrolling(false);
+  };
+
   return (
     <div className="cc-autocomplete" ref={containerRef}>
       <VaTextInput
@@ -196,7 +217,7 @@ const Autocomplete = ({
               tabIndex={-1}
               onClick={() => selectResult(result)}
               onKeyDown={handleKeyDown} // Keydown is handled on the input; this is never fired and prevents eslint error
-              onMouseEnter={() => activateScrollToAndFocus(index)}
+              onMouseEnter={() => handleMouseEnter(index)}
             >
               {result}
             </li>

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -29,11 +29,11 @@ const Autocomplete = ({
 
   // Delays screen reader result count reading to avoid interruption by input content reading
   const debouncedSetAriaLiveText = useRef(
-    debounce((resultCount, freeTextResult) => {
+    debounce((resultCount, inputValue) => {
       const makePlural = resultCount > 1 ? 's' : '';
 
       setAriaLiveText(
-        `${resultCount} result${makePlural}. ${freeTextResult}, (1 of ${resultCount})`,
+        `${resultCount} result${makePlural}. ${inputValue}, (1 of ${resultCount})`,
       );
     }, 700),
   ).current;
@@ -49,7 +49,7 @@ const Autocomplete = ({
       setResults(updatedResults);
       setActiveIndex(0);
 
-      debouncedSetAriaLiveText(updatedResults.length, freeTextResult);
+      debouncedSetAriaLiveText(updatedResults.length, inputValue);
     }, debounceDelay),
   ).current;
 

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -14,6 +14,7 @@ const Autocomplete = ({
   debounceDelay,
   formData,
   id,
+  inputTransformers = [],
   label,
   onChange,
 }) => {
@@ -27,7 +28,16 @@ const Autocomplete = ({
   const inputRef = useRef(null);
   const resultsRef = useRef([]);
 
-  // Delays screen reader result count reading to avoid interruption by input content reading
+  const transformInput = useCallback(
+    inputValue => {
+      return inputTransformers.reduce(
+        (currentValue, transformer) => transformer(currentValue),
+        inputValue,
+      );
+    },
+    [inputTransformers],
+  );
+
   const debouncedSetAriaLiveText = useRef(
     debounce((resultCount, inputValue) => {
       const makePlural = resultCount > 1 ? 's' : '';
@@ -64,16 +74,17 @@ const Autocomplete = ({
   );
 
   const handleInputChange = inputValue => {
-    setValue(inputValue);
-    onChange(inputValue);
+    const transformedValue = transformInput(inputValue);
+    setValue(transformedValue);
+    onChange(transformedValue);
 
-    if (!inputValue) {
+    if (!transformedValue) {
       closeList();
       setAriaLiveText('Input is empty. Please enter a condition.');
       return;
     }
 
-    debouncedSearch(inputValue);
+    debouncedSearch(transformedValue);
   };
 
   const isElementVisible = (element, container) => {
@@ -241,6 +252,7 @@ Autocomplete.propTypes = {
   debounceDelay: PropTypes.number,
   formData: PropTypes.string,
   id: PropTypes.string,
+  inputTransformers: PropTypes.array,
   label: PropTypes.string,
   onChange: PropTypes.func,
 };

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -170,12 +170,17 @@ const Autocomplete = ({
     if (value && results.length === 0) {
       debouncedSearch(value);
     }
+
+    const labelElement = inputRef.current.shadowRoot.querySelector('label');
+
+    labelElement.scrollIntoView({ block: 'start', behavior: 'smooth' });
   };
 
   const handleMouseEnter = index => {
     if (!isScrolling) {
       activateScrollToAndFocus(index);
     }
+
     setIsScrolling(false);
   };
 

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -74,17 +74,16 @@ const Autocomplete = ({
   );
 
   const handleInputChange = inputValue => {
-    const transformedValue = transformInput(inputValue);
-    setValue(transformedValue);
-    onChange(transformedValue);
+    setValue(inputValue);
+    onChange(inputValue);
 
-    if (!transformedValue) {
+    if (!inputValue) {
       closeList();
       setAriaLiveText('Input is empty. Please enter a condition.');
       return;
     }
 
-    debouncedSearch(transformedValue);
+    debouncedSearch(inputValue);
   };
 
   const isElementVisible = (element, container) => {
@@ -195,6 +194,12 @@ const Autocomplete = ({
     setIsScrolling(false);
   };
 
+  const handleBlur = () => {
+    const transformedValue = transformInput(value);
+    setValue(transformedValue);
+    onChange(transformedValue);
+  };
+
   return (
     <div className="cc-autocomplete" ref={containerRef}>
       <VaTextInput
@@ -206,6 +211,7 @@ const Autocomplete = ({
         ref={inputRef}
         required
         value={value}
+        onBlur={handleBlur}
         onFocus={handleFocus}
         onInput={e => handleInputChange(e.target.value)}
         onKeyDown={handleKeyDown}

--- a/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
+++ b/src/applications/disability-benefits/all-claims/components/Autocomplete.jsx
@@ -161,6 +161,7 @@ const Autocomplete = ({
   return (
     <div className="cc-autocomplete" ref={containerRef}>
       <VaTextInput
+        autocomplete="off"
         data-testid="autocomplete-input"
         id={id}
         label={label}

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -47,6 +47,9 @@ const autocompleteUiSchema = {
   'ui:errorMessages': {
     required: missingConditionMessage,
   },
+  'ui:options': {
+    hideLabelText: true,
+  },
 };
 
 const comboboxUiSchema = combobox.uiSchema('Enter your condition', {

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -56,6 +56,10 @@ const inputTransformers = [
   // Example: Input: 'Hello @World!' => Output: 'Hello World'
   input => input.replace(/([^a-zA-Z0-9\-',/() ]+)/g, ''),
 
+  // Remove leading and trailing whitespace
+  // Example: Input: '  Hello World  ' => Output: 'Hello World'
+  input => input.trim(),
+
   // Replace multiple spaces with a single space
   // Example: Input: 'Hello    World' => Output: 'Hello World'
   input => input.replace(/\s{2,}/g, ' '),

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -31,12 +31,43 @@ import {
 
 const { condition } = fullSchema.definitions.newDisabilities.items.properties;
 
+const inputTransformers = [
+  // Replace double quotes and smart quotes with single quotes
+  // Example: Input: 'Hello “world”!' => Output: 'Hello 'world'!'
+  input => input.replace(/["”’]/g, `'`),
+
+  // Replace semicolons and en-dashes with a double dash
+  // Example: Input: 'A; B – C' => Output: 'A -- B -- C'
+  input => input.replace(/[;–]/g, ' -- '),
+
+  // Replace ampersands with the word 'and'
+  // Example: Input: 'Rock & Roll' => Output: 'Rock and Roll'
+  input => input.replace(/[&]/g, ' and '),
+
+  // Replace backslashes with forward slashes
+  // Example: Input: 'C:\\Users\\Documents' => Output: 'C:/Users/Documents'
+  input => input.replace(/[\\]/g, '/'),
+
+  // Replace periods with spaces
+  // Example: Input: 'Mr. Smith is here.' => Output: 'Mr Smith is here '
+  input => input.replace(/[.]/g, ' '),
+
+  // Remove anything not a letter, number, dash, single quote, comma, forward slash, parenthesis, or space
+  // Example: Input: 'Hello @World!' => Output: 'Hello World'
+  input => input.replace(/([^a-zA-Z0-9\-',/() ]+)/g, ''),
+
+  // Replace multiple spaces with a single space
+  // Example: Input: 'Hello    World' => Output: 'Hello World'
+  input => input.replace(/\s{2,}/g, ' '),
+];
+
 const autocompleteUiSchema = {
   'ui:field': data => (
     <Autocomplete
       availableResults={Object.values(disabilityLabelsRevised)}
       debounceDelay={200}
       id={data.idSchema.$id}
+      inputTransformers={inputTransformers}
       formData={data.formData}
       label="Enter your condition"
       onChange={data.onChange}

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -297,11 +297,6 @@ article[data-location="supporting-evidence/evidence-types-bdd"] {
   }
 }
 
-// Hides the ArrayField label since using the VaTextInput label in the Autocomplete is more accessible
-[id^="root_newDisabilities_"][id$="_condition-label"] {
-  display: none !important;
-}
-
 // Hides the "New condition" h3 that appears on the last item of the platform ArrayField.
 // Cannot add a class to the ArrayField like we could with the allClaims arrayField
 [id^="root_newDisabilities_"] h3.vads-u-font-size--h5 {

--- a/src/applications/user-testing/new-conditions/components/Autocomplete.jsx
+++ b/src/applications/user-testing/new-conditions/components/Autocomplete.jsx
@@ -21,6 +21,7 @@ const Autocomplete = ({
   const [results, setResults] = useState([]);
   const [activeIndex, setActiveIndex] = useState(null);
   const [ariaLiveText, setAriaLiveText] = useState('');
+  const [isScrolling, setIsScrolling] = useState(false);
 
   const containerRef = useRef(null);
   const inputRef = useRef(null);
@@ -28,11 +29,11 @@ const Autocomplete = ({
 
   // Delays screen reader result count reading to avoid interruption by input content reading
   const debouncedSetAriaLiveText = useRef(
-    debounce((resultCount, freeTextResult) => {
+    debounce((resultCount, inputValue) => {
       const makePlural = resultCount > 1 ? 's' : '';
 
       setAriaLiveText(
-        `${resultCount} result${makePlural}. ${freeTextResult}, (1 of ${resultCount})`,
+        `${resultCount} result${makePlural}. ${inputValue}, (1 of ${resultCount})`,
       );
     }, 700),
   ).current;
@@ -48,7 +49,7 @@ const Autocomplete = ({
       setResults(updatedResults);
       setActiveIndex(0);
 
-      debouncedSetAriaLiveText(updatedResults.length, freeTextResult);
+      debouncedSetAriaLiveText(updatedResults.length, inputValue);
     }, debounceDelay),
   ).current;
 
@@ -75,13 +76,26 @@ const Autocomplete = ({
     debouncedSearch(inputValue);
   };
 
+  const isElementVisible = (element, container) => {
+    const { top, bottom } = element?.getBoundingClientRect();
+    const containerRect = container?.getBoundingClientRect();
+
+    return top >= containerRect.top && bottom <= containerRect.bottom;
+  };
+
   const activateScrollToAndFocus = index => {
     setActiveIndex(index);
 
     const activeResult = resultsRef.current[index];
-    activeResult?.scrollIntoView({
-      block: 'nearest',
-    });
+    const container = activeResult?.parentNode;
+
+    if (!isElementVisible(activeResult, container)) {
+      activeResult?.scrollIntoView({
+        block: 'nearest',
+      });
+      setIsScrolling(true);
+    }
+
     activeResult?.focus();
   };
 
@@ -158,6 +172,13 @@ const Autocomplete = ({
     }
   };
 
+  const handleMouseEnter = index => {
+    if (!isScrolling) {
+      activateScrollToAndFocus(index);
+    }
+    setIsScrolling(false);
+  };
+
   return (
     <div className="cc-autocomplete" ref={containerRef}>
       <VaTextInput
@@ -196,7 +217,7 @@ const Autocomplete = ({
               tabIndex={-1}
               onClick={() => selectResult(result)}
               onKeyDown={handleKeyDown} // Keydown is handled on the input; this is never fired and prevents eslint error
-              onMouseEnter={() => activateScrollToAndFocus(index)}
+              onMouseEnter={() => handleMouseEnter(index)}
             >
               {result}
             </li>


### PR DESCRIPTION
## Summary

- Summarize the changes that have been made to the platform:
  - This PR 6 years ago added "input transformer" functionality to the Autosuggest component and then used that functionality on the `addDisabilities` page: https://github.com/department-of-veterans-affairs/vets-website/pull/9674
  - This PR replaced Autosuggest with Combobox  on the `addDisabilities` page and included the input transformers. However, they were not having any effect because the Combobox did not have logic to handle the input transformers.
  - This PR adds the logic to handle the input transformers to the Autocomplete component (that will soon be replacing the Combobox in production). 
  - However, after discussion with the team, without messaging to users it would be confusing and disorienting (potentially especially to screen reader users) to change the users input without notify them. It was determined it would be best to handle this on the backend rather then nitpick their input content on the frontend. 
- Which team do you work for, does your team own the maintenance of this component? Condition Team and Yes

## Related issue(s)

- [Update Add Conditions Page to use Platform ArrayField #630](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/630)

## Screenshots

### Before (reimplemented in our current code to try to demo functionality before Combobox update removed it)
https://dsva.slack.com/archives/C04AZ8T7XN1/p1736199360446419?thread_ts=1736195692.542319&cid=C04AZ8T7XN1
### After
https://dsva.slack.com/archives/C04AZ8T7XN1/p1736199623059679?thread_ts=1736195692.542319&cid=C04AZ8T7XN1