### PR TITLE
92996 Update forms to use VaStatementOfTruth component - 10-7959F-1, 10-10D

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/tests/e2e/10-7959f-1-FMP-statement-of-truth.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959f-1/tests/e2e/10-7959f-1-FMP-statement-of-truth.cypress.spec.js
@@ -1,0 +1,138 @@
+import path from 'path';
+
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+
+import formConfig from '../../config/form';
+import manifest from '../../manifest.json';
+import {
+  fillAddressWebComponentPattern,
+  verifyAllDataWasSubmitted,
+  getAllPages,
+} from '../../../shared/tests/helpers';
+
+import mockFeatureToggles from './fixtures/mocks/featureToggles.json';
+
+const ALL_PAGES = getAllPages(formConfig);
+
+function getSotInput() {
+  return cy
+    .get('va-statement-of-truth')
+    .shadow()
+    .get('va-text-input')
+    .shadow()
+    .get('#inputField');
+}
+
+function typeInStatementOfTruthAndSubmit(text) {
+  getSotInput().clear();
+  getSotInput().type(`${text}`, { force: true });
+}
+
+const testConfig = createTestConfig(
+  {
+    dataPrefix: 'data',
+    dataDir: path.join(__dirname, 'fixtures', 'data'),
+    // Rename and modify the test data as needed.
+    dataSets: ['test-data'],
+    pageHooks: {
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.findAllByText(/start/i, { selector: 'a' })
+            .first()
+            .click();
+        });
+      },
+      [ALL_PAGES.page3.path]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            fillAddressWebComponentPattern(
+              'veteranAddress',
+              data.veteranAddress,
+            );
+            cy.axeCheck();
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
+      [ALL_PAGES.page4a.path]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            fillAddressWebComponentPattern(
+              'physicalAddress',
+              data.physicalAddress,
+            );
+            cy.axeCheck();
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            // Type wrong value in the signature to trigger an error
+            typeInStatementOfTruthAndSubmit(
+              `${data.statementOfTruthSignature}FALSE`,
+            );
+
+            // Check the checkbox, which invokes onblur on signature input and shows
+            // the error message we want to verify:
+            cy.get(`va-statement-of-truth`)
+              .shadow()
+              .find('va-checkbox')
+              .shadow()
+              .get('#checkbox-element')
+              .click({ force: true });
+
+            // Expect an error
+            cy.get('va-statement-of-truth')
+              .shadow()
+              .get('va-text-input')
+              .shadow()
+              .findByText(
+                /Please enter your name exactly as it appears on your application/i,
+              )
+              .should('exist');
+
+            // Type the proper name in to clear the errror
+            typeInStatementOfTruthAndSubmit(data.statementOfTruthSignature);
+
+            cy.findByText('Submit', {
+              selector: 'button',
+            }).click();
+          });
+        });
+      },
+    },
+
+    setupPerTest: () => {
+      cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+      cy.intercept('POST', formConfig.submitUrl, req => {
+        cy.get('@testData').then(dataPreTransform => {
+          // Runs the test-data through transformForSubmit and compares it
+          // to the submitted form data to make sure that all outputs are present:
+          verifyAllDataWasSubmitted(
+            JSON.parse(
+              formConfig.transformForSubmit(formConfig, {
+                data: dataPreTransform,
+              }),
+            ),
+            req.body,
+          );
+        });
+        // Mock response
+        req.reply({ status: 200 });
+      });
+      cy.config('includeShadowDom', true);
+    },
+    // Skip tests in CI until the form is released.
+    // Remove this setting when the form has a content page in production.
+    // skip: Cypress.env('CI'),
+  },
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);

--- a/src/applications/ivc-champva/shared/tests/helpers.js
+++ b/src/applications/ivc-champva/shared/tests/helpers.js
@@ -118,7 +118,7 @@ export const reviewAndSubmitPageFlow = (
     .shadow()
     .get('#inputField')
     .type(veteranSignature);
-  cy.get(`va-checkbox[name="veteran-certify"]`)
+  cy.get(`va-checkbox[id="veteran-certify"]`)
     .shadow()
     .find('input')
     .click({ force: true });

--- a/src/applications/simple-forms/shared/tests/e2e/helpers.js
+++ b/src/applications/simple-forms/shared/tests/e2e/helpers.js
@@ -164,6 +164,20 @@ export const introductionPageFlow = () => {
     .click({ force: true });
 };
 
+export const fillStatementOfTruthSignature = veteranSignature => {
+  cy.get('#veteran-signature')
+    .shadow()
+    .get('#inputField')
+    .type(veteranSignature);
+};
+
+export const checkStatementOfTruthBox = () => {
+  cy.get(`va-checkbox[id="veteran-certify"]`)
+    .shadow()
+    .find('input')
+    .click({ force: true });
+};
+
 export const reviewAndSubmitPageFlow = (
   signerName,
   submitButtonText = 'Submit application',
@@ -176,8 +190,8 @@ export const reviewAndSubmitPageFlow = (
       : `${signerName.first} ${signerName.last}`;
   }
 
-  cy.fillVaTextInput('veteran-signature', veteranSignature);
-  cy.selectVaCheckbox('veteran-certify', true);
+  fillStatementOfTruthSignature(veteranSignature);
+  checkStatementOfTruthBox();
   cy.findByText(submitButtonText, {
     selector: 'button',
   }).click();

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -7,6 +7,7 @@ import { get } from 'lodash';
 import {
   VaCheckbox,
   VaPrivacyAgreement,
+  VaStatementOfTruth,
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
@@ -145,83 +146,40 @@ export function PreSubmitSection(props) {
   return (
     <>
       {statementOfTruth ? (
-        <>
-          <p className="vads-u-padding-x--3">
-            <strong>Note:</strong> According to federal law, there are criminal
-            penalties, including a fine and/or imprisonment for up to 5 years,
-            for withholding information or for providing incorrect information
-            (Reference: 18 U.S.C. 1001).
-          </p>
-          <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--3 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--3">
-            <h3>{statementOfTruth.heading || 'Statement of truth'}</h3>
-            {statementOfTruthBodyElement(form?.data, statementOfTruth.body)}
-            <p>
-              I have read and accept the{' '}
-              <a
-                href="/privacy-policy/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                privacy policy
-                <va-icon icon="launch" srtext="opens in a new window" />
-              </a>
-              .
-            </p>
-            <VaTextInput
-              id="veteran-signature"
-              name="veteran-signature"
-              label={statementOfTruth.textInputLabel || 'Your full name'}
-              class="signature-input"
-              value={form?.data.statementOfTruthSignature}
-              onInput={event =>
-                setPreSubmit('statementOfTruthSignature', event.target.value)
-              }
-              onBlur={() => setStatementOfTruthSignatureBlurred(true)}
-              type="text"
-              error={
-                (showPreSubmitError || statementOfTruthSignatureBlurred) &&
-                fullNameReducer(form?.data.statementOfTruthSignature) !==
-                  fullNameReducer(
-                    statementOfTruthFullName(
-                      form?.data,
-                      statementOfTruth,
-                      user?.profile?.userFullName,
-                    ),
-                  )
-                  ? `Please enter your name exactly as it appears on your application: ${statementOfTruthFullName(
-                      form?.data,
-                      statementOfTruth,
-                      user?.profile?.userFullName,
-                    )}`
-                  : undefined
-              }
-              message-aria-describedby={`${statementOfTruth.heading ||
-                'Statement of truth'}: ${
-                statementOfTruth.messageAriaDescribedby
-              }`}
-              required
-            />
-            <VaCheckbox
-              id="veteran-certify"
-              name="veteran-certify"
-              label={
-                statementOfTruth.checkboxLabel ||
-                'I certify the information above is correct and true to the best of my knowledge and belief.'
-              }
-              checked={form?.data.statementOfTruthCertified}
-              onVaChange={event =>
-                setPreSubmit('statementOfTruthCertified', event.target.checked)
-              }
-              error={
-                showPreSubmitError && !form?.data.statementOfTruthCertified
-                  ? 'You must certify by checking the box'
-                  : undefined
-              }
-              className="statement-of-truth-va-checkbox"
-              required
-            />
-          </article>
-        </>
+        <VaStatementOfTruth
+          inputLabel={statementOfTruth.textInputLabel || 'Your full name'}
+          inputValue={form?.data.statementOfTruthSignature}
+          inputError={
+            (showPreSubmitError || statementOfTruthSignatureBlurred) &&
+            fullNameReducer(form?.data.statementOfTruthSignature) !==
+              fullNameReducer(
+                statementOfTruthFullName(
+                  form?.data,
+                  statementOfTruth,
+                  user?.profile?.userFullName,
+                ),
+              )
+              ? `Please enter your name exactly as it appears on your application: ${statementOfTruthFullName(
+                  form?.data,
+                  statementOfTruth,
+                  user?.profile?.userFullName,
+                )}`
+              : undefined
+          }
+          checked={form?.data.statementOfTruthCertified}
+          onVaInputChange={event =>
+            setPreSubmit('statementOfTruthSignature', event.detail.value)
+          }
+          onVaInputBlur={() => setStatementOfTruthSignatureBlurred(true)}
+          onVaCheckboxChange={event =>
+            setPreSubmit('statementOfTruthCertified', event.detail.checked)
+          }
+          checkboxError={
+            showPreSubmitError && !form?.data.statementOfTruthCertified
+              ? 'You must certify by checking the box'
+              : undefined
+          }
+        />
       ) : (
         <div>
           {preSubmit.notice}

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -235,12 +235,24 @@ PreSubmitSection.propTypes = {
     submission: PropTypes.shape({
       hasAttemptedSubmit: PropTypes.bool,
     }),
+    data: PropTypes.object,
   }).isRequired,
   formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      finishAppLaterMessage: PropTypes.string,
+    }),
     preSubmitInfo: PropTypes.object,
   }).isRequired,
   setPreSubmit: PropTypes.func.isRequired,
+  // added by withRouter
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
+  preSubmit: PropTypes.object,
+  saveAndRedirectToReturnUrl: PropTypes.func,
+  showLoginModal: PropTypes.bool,
   showPreSubmitError: PropTypes.bool,
+  toggleLoginModal: PropTypes.func,
   user: PropTypes.shape({
     login: PropTypes.shape({
       currentlyLoggedIn: PropTypes.bool,
@@ -248,13 +260,6 @@ PreSubmitSection.propTypes = {
     profile: PropTypes.shape({
       userFullName: PropTypes.object,
     }),
-  }),
-  showLoginModal: PropTypes.bool,
-  saveAndRedirectToReturnUrl: PropTypes.func,
-  toggleLoginModal: PropTypes.func,
-  // added by withRouter
-  location: PropTypes.shape({
-    pathname: PropTypes.string,
   }),
 };
 

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -8,7 +8,6 @@ import {
   VaCheckbox,
   VaPrivacyAgreement,
   VaStatementOfTruth,
-  VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 // platform - forms - selectors
@@ -149,6 +148,8 @@ export function PreSubmitSection(props) {
         <VaStatementOfTruth
           inputLabel={statementOfTruth.textInputLabel || 'Your full name'}
           inputValue={form?.data.statementOfTruthSignature}
+          inputMessageAriaDescribedby={`${statementOfTruth.heading ||
+            'Statement of truth'}: ${statementOfTruth.messageAriaDescribedby}`}
           inputError={
             (showPreSubmitError || statementOfTruthSignatureBlurred) &&
             fullNameReducer(form?.data.statementOfTruthSignature) !==
@@ -179,7 +180,9 @@ export function PreSubmitSection(props) {
               ? 'You must certify by checking the box'
               : undefined
           }
-        />
+        >
+          {statementOfTruthBodyElement(form?.data, statementOfTruth.body)}
+        </VaStatementOfTruth>
       ) : (
         <div>
           {preSubmit.notice}

--- a/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
+++ b/src/platform/forms/tests/components/review/PreSubmitSection.unit.spec.jsx
@@ -9,9 +9,6 @@ import createSchemaFormReducer from 'platform/forms-system/src/js/state';
 import reducers from 'platform/forms-system/src/js/state/reducers';
 
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
-import ReactTestUtils from 'react-dom/test-utils';
-import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
-import { inputVaTextInput } from 'platform/testing/unit/helpers';
 
 const createForm = options => ({
   formId: 'test',
@@ -273,66 +270,7 @@ describe('Review PreSubmitSection component', () => {
       </Provider>,
     );
 
-    expect(tree.container.querySelector('h3').innerHTML).to.equal(
-      'Statement of truth',
-    );
-
-    tree.unmount();
-  });
-
-  it('should render statement of truth using user profile option when name mismatch error', () => {
-    const formConfig = getFormConfig({
-      preSubmitInfo: {
-        statementOfTruth: {
-          body: 'Test body',
-          heading: 'Test heading',
-          useProfileFullName: true,
-        },
-      },
-    });
-    const form = createForm({});
-    const store = {
-      getState: () => ({
-        form,
-        user: {
-          login: { currentlyLoggedIn: true },
-          profile: {
-            userFullName: {
-              first: 'Elphaba',
-              middle: '',
-              last: 'Thropp',
-            },
-          },
-        },
-        location: { pathname: '/review-and-submit' },
-        navigation: { showLoginModal: false },
-      }),
-      subscribe: () => {},
-      dispatch: () => {},
-    };
-
-    const tree = render(
-      <Provider store={store}>
-        <PreSubmitSection
-          form={form}
-          formConfig={formConfig}
-          location={{ pathname: '/review-and-submit' }}
-          setPreSubmit={() => {}}
-        />
-      </Provider>,
-    );
-
-    const nameInput = $('va-text-input', tree.container);
-    inputVaTextInput(tree.container, 'Elphie Thropp');
-    ReactTestUtils.Simulate.blur(nameInput);
-
-    expect(tree.container.querySelector('h3').innerHTML).to.equal(
-      'Test heading',
-    );
-    tree.getByText('Test body');
-    expect($('va-text-input').error).to.equal(
-      'Please enter your name exactly as it appears on your application: Elphaba Thropp',
-    );
+    expect(tree.container.querySelector('va-statement-of-truth')).to.exist;
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the PreSubmitSection component to replace the "impostor component" version of the Statement of Truth with the official [Statement Of Truth component](https://design.va.gov/components/form/statement-of-truth)

- Updates `PreSubmitSection` with newer platform statement of truth component
- Updates unit tests for `PreSubmitSection`
- Adds new E2E test in IVC CHAMPVA form 10-7959f-1 that checks error state of statement of truth during a form fill


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92996

## Testing done

- Manual
- Updated unit tests that applied to this component
- Added an E2E test under IVC CHAMPVA form 10-7959f-1 that tests the text error handling (previously done in a unit test, now that shadow dom is present had to use Cypress to check the behavior)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="708" alt="before" src="https://github.com/user-attachments/assets/2b42d9d6-400f-4073-92b3-235ab51c5d62" />|<img width="544" alt="after" src="https://github.com/user-attachments/assets/dcc50377-48c9-46da-8f78-56dc48e3c012" />|

## What areas of the site does it impact?

Form applications that use the default statement of truth configuration

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
