### PR TITLE
added error state for referral card

### DIFF
--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 
 import { useGetReferralById } from '../hooks/useGetReferralById';
 import ReferralTaskCard from './ReferralTaskCard';
+import { FETCH_STATUS } from '../../utils/constants';
 
 export default function ReferralTaskCardWithReferral() {
   const { search } = useLocation();
@@ -10,10 +11,26 @@ export default function ReferralTaskCardWithReferral() {
   const params = new URLSearchParams(search);
   const id = params.get('id');
 
-  const { currentReferral } = useGetReferralById(id);
+  const { currentReferral, referralFetchStatus } = useGetReferralById(id);
 
-  if (!currentReferral) {
-    return null;
+  if (
+    !currentReferral &&
+    (referralFetchStatus === FETCH_STATUS.succeeded ||
+      referralFetchStatus === FETCH_STATUS.failed)
+  ) {
+    return (
+      <va-alert
+        data-testid="referral-error"
+        status="error"
+        class="vads-u-margin-y--3"
+      >
+        <h2>We’re sorry. We’ve run into a problem</h2>
+        <p>
+          We’re having trouble getting your referral information. Please try
+          again later.
+        </p>
+      </va-alert>
+    );
   }
 
   return <ReferralTaskCard data={currentReferral} />;

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -86,4 +86,28 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
     const taskCard = screen.queryByTestId('referral-task-card');
     expect(taskCard).to.be.null;
   });
+
+  it('should display the error alert when referral is not found', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=thisisareferralthatwontbefound',
+    });
+    expect(await screen.getByTestId('referral-error')).to.exist;
+  });
+
+  it('should display the error alert when fetch fails', async () => {
+    const store = createTestStore({
+      ...initialState,
+      referral: {
+        referrals: [],
+        referralFetchStatus: FETCH_STATUS.failed,
+      },
+    });
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801',
+    });
+    expect(await screen.getByTestId('referral-error')).to.exist;
+  });
 });

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
@@ -41,6 +41,7 @@ const useGetReferralById = id => {
   useEffect(
     () => {
       if (
+        id &&
         isInCCPilot &&
         !referrals.length &&
         referralFetchStatus === FETCH_STATUS.notStarted


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds an error state for when a referral can't be found or if the fetch fails.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#95285

## Testing done

Visual and unit tests

## Screenshots

![localhost_3001_my-health_appointments__id=add2f0f4-a1ea-4dea-a50](https://github.com/user-attachments/assets/b8c02986-76f3-4cd2-8f6b-67469ff6740d)


## What areas of the site does it impact?

Community care referral self scheduling feature in VAOS

## Acceptance criteria
 - [x] When there is an `id` query param value in the URL that doesn't match redux, show an error.
 - [ ] Error matches the [figma file](https://www.figma.com/design/DsRXEFiYLCFnY5nBkp9Dc4/CC-Referral-%7C-Appointments-FE?node-id=5844-9118&t=D3Pr1ORsYomTdZ4S-0)
   
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Testing steps

 - [ ] run local mocks for vaos
 - [ ] start app locally
 - [ ] visit http://localhost:3001/my-health/appointments/?id=add2f0f4-a1ea-4dea-a504-abbab57c6800
 - [ ] verify that the error alert is shown
