### PR TITLE
Disable flaky test

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-
 import {
   mockFetch,
   setFetchJSONFailure,
@@ -147,7 +146,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
       );
     });
 
-    it('should show request limits message when not eligible for direct, requests are supported, over request limit', async () => {
+    it.skip('should show request limits message when not eligible for direct, requests are supported, over request limit', async () => {
       mockSchedulingConfigurations([
         getSchedulingConfigurationMock({
           id: '983',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR disables a flaky test that seems to fail at the end of the calendar year, but might also fail at the end of each month.
- An investigation ticket has been filed but this PR disable the test to unblock CI.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99920

## Testing done

- N/A this PR only disables a test

## Screenshots

N/A

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

