### PR TITLE
Only show profile reference if user is a logged in veteran

### DIFF
--- a/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
+++ b/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
@@ -7,11 +7,18 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 import { isLoggedIn } from 'platform/user/selectors';
 
 function ProfileNotUpdatedNote(props) {
-  const { loggedIn, includePrefix, includeLink, includePhone } = props;
+  const {
+    includeLink,
+    includePhone,
+    includePrefix,
+    loggedIn,
+    preparerIsVeteran,
+  } = props;
+  const isLoggedInVeteran = loggedIn && preparerIsVeteran;
 
   return (
     <>
-      {loggedIn && (
+      {isLoggedInVeteran && (
         <>
           <p>
             {includePrefix && <strong>Note: </strong>}
@@ -45,11 +52,11 @@ function ProfileNotUpdatedNote(props) {
 }
 
 ProfileNotUpdatedNote.propTypes = {
-  formData: PropTypes.object,
   includeLink: PropTypes.bool,
   includePhone: PropTypes.bool,
   includePrefix: PropTypes.bool,
   loggedIn: PropTypes.bool,
+  preparerIsVeteran: PropTypes.bool,
 };
 
 function mapStateToProps(state) {

--- a/src/applications/representative-appoint/pages/claimant/claimantContactMailing.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantContactMailing.js
@@ -13,9 +13,7 @@ export const uiSchema = {
     'We’ll send any important information about your form to this address.',
   ),
   profileNotUpdatedNote: {
-    'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePrefix includeLink />
-    ),
+    'ui:description': () => <ProfileNotUpdatedNote includeLink includePrefix />,
   },
   homeAddress: addressUI({
     labels: {

--- a/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
@@ -13,9 +13,7 @@ import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 export const uiSchema = {
   ...titleUI('Your phone number and email address'),
   profileNotUpdatedNote: {
-    'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePhone />
-    ),
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
   },
   applicantPhone: phoneUI({
     required: true,

--- a/src/applications/representative-appoint/pages/claimant/claimantPersonalInformation.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantPersonalInformation.js
@@ -17,9 +17,7 @@ fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 export const uiSchema = {
   ...titleUI('Your personal information'),
   profileNotUpdatedNote: {
-    'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePhone />
-    ),
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
   },
   applicantName: fullNameMiddleInitialUI,
   applicantDOB: dateOfBirthUI({

--- a/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
@@ -7,12 +7,17 @@ import {
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
+import { preparerIsVeteran } from '../../utilities/helpers';
 
 export const uiSchema = {
   ...titleUI('Your mailing address'),
   profileNotUpdatedNote: {
     'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePrefix includeLink />
+      <ProfileNotUpdatedNote
+        includePrefix
+        includeLink
+        preparerIsVeteran={preparerIsVeteran({ formData })}
+      />
     ),
   },
   veteranHomeAddress: addressUI({

--- a/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
@@ -14,8 +14,8 @@ export const uiSchema = {
   profileNotUpdatedNote: {
     'ui:description': formData => (
       <ProfileNotUpdatedNote
-        includePrefix
         includeLink
+        includePrefix
         preparerIsVeteran={preparerIsVeteran({ formData })}
       />
     ),

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
@@ -10,12 +10,16 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
+import { preparerIsVeteran } from '../../utilities/helpers';
 
 export const uiSchema = {
   ...titleUI(() => 'Your phone number and email address'),
   profileNotUpdatedNote: {
     'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePhone />
+      <ProfileNotUpdatedNote
+        includePhone
+        preparerIsVeteran={preparerIsVeteran({ formData })}
+      />
     ),
   },
   'Primary phone': phoneUI({

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailClaimant.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailClaimant.js
@@ -14,9 +14,7 @@ import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 export const uiSchema = {
   ...titleUI(() => 'Veteran’s phone number and email address'),
   profileNotUpdatedNote: {
-    'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePhone />
-    ),
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
   },
   'Primary phone': phoneUI({}),
   veteranEmail: emailUI(),

--- a/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
@@ -34,8 +34,8 @@ export const uiSchema = {
   profileNotUpdatedNote: {
     'ui:description': formData => (
       <ProfileNotUpdatedNote
-        includePrefix
         includePhone
+        includePrefix
         preparerIsVeteran={preparerIsVeteran({ formData })}
       />
     ),

--- a/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
@@ -33,7 +33,11 @@ export const uiSchema = {
   ),
   profileNotUpdatedNote: {
     'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePrefix includePhone />
+      <ProfileNotUpdatedNote
+        includePrefix
+        includePhone
+        preparerIsVeteran={preparerIsVeteran({ formData })}
+      />
     ),
   },
   veteranSocialSecurityNumber: ssnUI('Social Security number'),

--- a/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
@@ -10,8 +10,8 @@ import {
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
-import { preparerIsVeteran } from '../../utilities/helpers';
 import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
+import { preparerIsVeteran } from '../../utilities/helpers';
 
 const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
 fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
@@ -25,7 +25,10 @@ export const uiSchema = {
   ),
   profileNotUpdatedNote: {
     'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePhone />
+      <ProfileNotUpdatedNote
+        includePhone
+        preparerIsVeteran={preparerIsVeteran({ formData })}
+      />
     ),
   },
   veteranFullName: fullNameMiddleInitialUI,

--- a/src/applications/representative-appoint/pages/veteran/veteranServiceInformation.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranServiceInformation.js
@@ -19,7 +19,10 @@ export const uiSchema = {
   ),
   profileNotUpdatedNote: {
     'ui:description': formData => (
-      <ProfileNotUpdatedNote formData={formData} includePhone />
+      <ProfileNotUpdatedNote
+        includePhone
+        preparerIsVeteran={preparerIsVeteran({ formData })}
+      />
     ),
   },
   'Branch of Service': radioUI('Branch of service'),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR resolves the following issue:

Actual: As a non-Veteran authenticated user, on the Claimant AND Veteran chapter I'm seeing the note that information being pre-populated from Profile, with information on how to change Profile information. This should not be showing for the Veteran chapter, which includes:

- veteran-personal-information
- veteran-contact-mailing
- veteran-contact-phone-email
- veteran-identification
- veteran-service

Expected: I should only see the note that information is from my profile for the Claimant chapter.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96946

## Testing done
All tests pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
