### PR TITLE
Add util for screen readers and numeric formatting

### DIFF
--- a/src/platform/forms-system/src/js/utilities/ui/mask-string.jsx
+++ b/src/platform/forms-system/src/js/utilities/ui/mask-string.jsx
@@ -33,3 +33,20 @@ export default function mask(string, unmaskedLength) {
     </span>
   );
 }
+
+/**
+ * Format a number with spaces between digits for screen readers while maintaining
+ * visual display without spaces.
+ *
+ * @param {string|number} number - The number to format
+ * @returns {ReactElement} - Formatted number with screen reader spacing
+ */
+export const formatNumberForScreenReader = number => {
+  if (!number && number !== 0) return null;
+
+  const numberString = number.toString();
+  const visualDisplay = numberString;
+  const screenReaderText = numberString.split('').join(' ');
+
+  return srSubstitute(visualDisplay, screenReaderText);
+};

--- a/src/platform/forms-system/test/js/utilities/mask-string.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/mask-string.unit.spec.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { formatNumberForScreenReader } from '../../../src/js/utilities/ui/mask-string';
+
+describe('formatNumberForScreenReader', () => {
+  it('should return null for undefined input', () => {
+    const result = formatNumberForScreenReader(undefined);
+    expect(result).to.be.null;
+  });
+
+  it('should return null for null input', () => {
+    const result = formatNumberForScreenReader(null);
+    expect(result).to.be.null;
+  });
+
+  it('should return null for empty string', () => {
+    const result = formatNumberForScreenReader('');
+    expect(result).to.be.null;
+  });
+
+  it('should handle zero correctly', () => {
+    const { container } = render(formatNumberForScreenReader(0));
+
+    // Check visual display
+    const visualElement = container.querySelector('[aria-hidden="true"]');
+    expect(visualElement).to.exist;
+    expect(visualElement.textContent).to.equal('0');
+
+    // Check screen reader text
+    const srElement = container.querySelector('.sr-only');
+    expect(srElement).to.exist;
+    expect(srElement.textContent).to.equal('0');
+  });
+
+  it('should format multiple digit numbers correctly', () => {
+    const { container } = render(formatNumberForScreenReader(123));
+
+    const visualElement = container.querySelector('[aria-hidden="true"]');
+    expect(visualElement.textContent).to.equal('123');
+
+    const srElement = container.querySelector('.sr-only');
+    expect(srElement.textContent).to.equal('1 2 3');
+  });
+
+  it('should handle string number inputs correctly', () => {
+    const { container } = render(formatNumberForScreenReader('456'));
+
+    const visualElement = container.querySelector('[aria-hidden="true"]');
+    expect(visualElement.textContent).to.equal('456');
+
+    const srElement = container.querySelector('.sr-only');
+    expect(srElement.textContent).to.equal('4 5 6');
+  });
+
+  it('should render with correct ARIA attributes', () => {
+    const { container } = render(formatNumberForScreenReader(42));
+
+    // Check that visual content is hidden from screen readers
+    const visualElement = container.querySelector('[aria-hidden="true"]');
+    expect(visualElement).to.exist;
+    expect(visualElement.getAttribute('aria-hidden')).to.equal('true');
+
+    // Check that screen reader text is properly classed
+    const srElement = container.querySelector('.sr-only');
+    expect(srElement).to.exist;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds a utility to use `srSubstitute` in a common way to represent numbers like last four digits of SSN
- Will be using this util in documentation about SSN masking that our team is in the process of updating.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/165

## Testing done

- Added unit test suite for this utility

## Screenshots

No UI changes specific for this util as it adds a screen reader specific utility

## What areas of the site does it impact?

Just adding the util right now, and not updating any specific production apps with it's usage.

## Acceptance criteria

- util added
- tests covering util

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

