### PR TITLE
[96901] Appoint a Rep 21-22 and 21-22a: replace-rep page fixups

### DIFF
--- a/src/applications/representative-appoint/components/CurrentAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/CurrentAccreditedRepresentative.jsx
@@ -8,6 +8,7 @@ const CurrentAccreditedRepresentative = ({ repType, repAttributes }) => {
   const addressData = getEntityAddressAsObject(repAttributes);
   const repName = repAttributes.name || repAttributes.fullName;
   const { email, phone } = repAttributes;
+  const isOrgOrVSO = ['Organization', 'VSO Representative'].includes(repType);
 
   return (
     <va-card class="representative-result-card vads-u-padding--4 vads-u-background-color--gray-lightest vads-u-border--0">
@@ -27,10 +28,12 @@ const CurrentAccreditedRepresentative = ({ repType, repAttributes }) => {
             </>
           )}
         </div>
-        <p>
-          <strong>Note:</strong> You can work with any accredited VSO
-          representative at this organization.
-        </p>
+        {isOrgOrVSO && (
+          <p data-testid="work-with-any-VSO-note">
+            <strong>Note:</strong> You can work with any accredited VSO
+            representative at this organization.
+          </p>
+        )}
         <AddressEmailPhone
           addressData={addressData}
           email={email}

--- a/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
@@ -3,13 +3,19 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import CurrentAccreditedRepresentative from './CurrentAccreditedRepresentative';
 import ContactCard from './ContactCard';
-import { getEntityAddressAsObject, getRepType } from '../utilities/helpers';
+import {
+  getEntityAddressAsObject,
+  getOrgName,
+  getRepType,
+} from '../utilities/helpers';
 
 const ReplaceAccreditedRepresentative = props => {
   const { formData } = props;
   const currentRep = formData?.['view:representativeStatus'] || {};
   const selectedRepAttributes =
     formData?.['view:selectedRepresentative']?.attributes || {};
+  const repName = selectedRepAttributes?.fullName;
+  const orgName = getOrgName(formData);
 
   return (
     <div>
@@ -29,11 +35,11 @@ const ReplaceAccreditedRepresentative = props => {
         You’ve selected this new accredited representative:
       </h4>
       <ContactCard
-        repName={selectedRepAttributes.name || selectedRepAttributes.fullName}
-        orgName={selectedRepAttributes.name}
+        repName={repName}
+        orgName={orgName}
         addressData={getEntityAddressAsObject(selectedRepAttributes)}
-        phone={selectedRepAttributes.phone}
-        email={selectedRepAttributes.email}
+        phone={selectedRepAttributes?.phone}
+        email={selectedRepAttributes?.email}
       />
     </div>
   );

--- a/src/applications/representative-appoint/tests/components/ReplaceAccreditedRepresentative.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/ReplaceAccreditedRepresentative.unit.spec.jsx
@@ -45,39 +45,69 @@ const selectedRep = {
 };
 
 const oldRep = {
-  data: {
-    id: '074',
+  id: '074',
+  type: 'organization',
+  attributes: {
+    addressLine1: '1608 K St NW',
+    addressLine2: null,
+    addressLine3: null,
+    addressType: 'Domestic',
+    city: 'Washington',
+    countryName: null,
+    countryCodeIso3: null,
+    province: null,
+    internationalPostalCode: null,
+    stateCode: 'DC',
+    zipCode: '20006',
+    zipSuffix: '2801',
+    phone: '202-861-2700',
     type: 'organization',
-    attributes: {
-      addressLine1: '1608 K St NW',
-      addressLine2: null,
-      addressLine3: null,
-      addressType: 'Domestic',
-      city: 'Washington',
-      countryName: null,
-      countryCodeIso3: null,
-      province: null,
-      internationalPostalCode: null,
-      stateCode: 'DC',
-      zipCode: '20006',
-      zipSuffix: '2801',
-      phone: '202-861-2700',
-      type: 'organization',
-      name: 'American Legion',
+    name: 'American Legion',
+  },
+};
+
+const attorney = {
+  id: '20087',
+  type: 'representative',
+  attributes: {
+    firstName: 'John',
+    lastName: 'Adams',
+    fullName: 'John Adams',
+    addressLine1: '2342 Main St',
+    addressLine2: null,
+    addressLine3: null,
+    addressType: 'Domestic',
+    city: 'Anytown',
+    countryName: 'United States',
+    countryCodeIso3: 'USA',
+    province: 'Connecticut',
+    internationalPostalCode: null,
+    stateCode: 'CT',
+    zipCode: '54837',
+    zipSuffix: '2319',
+    email: 'attorney@law.com',
+    phone: '585-878-0710ext.321',
+    individualType: 'attorney',
+    accreditedOrganizations: {
+      data: [],
     },
   },
 };
 
 describe('<ReplaceAccreditedRepresentative>', () => {
-  const getProps = ({ submitted = false, setFormData = () => {} } = {}) => {
+  const getProps = ({
+    submitted = false,
+    setFormData = () => {},
+    currentRep = oldRep,
+  } = {}) => {
     return {
       props: {
         formContext: {
           submitted,
         },
         formData: {
-          'view:representativeStatus': selectedRep, // Add necessary mock data here
-          'view:selectedRepresentative': oldRep, // Add necessary mock data here },
+          'view:representativeStatus': currentRep, // Add necessary mock data here
+          'view:selectedRepresentative': selectedRep, // Add necessary mock data here },
         },
         setFormData,
       },
@@ -85,8 +115,8 @@ describe('<ReplaceAccreditedRepresentative>', () => {
         getState: () => ({
           form: {
             data: {
-              'view:representativeStatus': selectedRep, // Add necessary mock data here
-              'view:selectedRepresentative': oldRep, // Add necessary mock data here
+              'view:representativeStatus': currentRep, // Add necessary mock data here
+              'view:selectedRepresentative': selectedRep, // Add necessary mock data here
             },
           },
         }),
@@ -124,6 +154,7 @@ describe('<ReplaceAccreditedRepresentative>', () => {
       'You’ll replace your current accredited representative with the new one you’ve selected.',
     );
   });
+
   it('should render selected rep address', () => {
     const { props, mockStore } = getProps();
     const { container } = render(
@@ -133,7 +164,41 @@ describe('<ReplaceAccreditedRepresentative>', () => {
     );
 
     expect(container.querySelector('a')).to.contain.text(
-      'Franklin County Service officer8389 Dinah Shore BlvdWinchester, TN 37398',
+      '1608 K St NWWashington, DC 20006',
     );
+  });
+
+  context('when the current rep is an org or VSO', () => {
+    it('should render the work with any rep note', () => {
+      const { props, mockStore } = getProps();
+      const { container } = render(
+        <Provider store={mockStore}>
+          <ReplaceAccreditedRepresentative {...props} />
+        </Provider>,
+      );
+
+      const usedPolicy = container.querySelector(
+        '[data-testid="work-with-any-VSO-note"]',
+      );
+
+      expect(usedPolicy).to.exist;
+    });
+  });
+
+  context('when the current rep is an attorney or claims agent', () => {
+    it('should not render the work with any rep note', () => {
+      const { props, mockStore } = getProps({ currentRep: attorney });
+      const { container } = render(
+        <Provider store={mockStore}>
+          <ReplaceAccreditedRepresentative {...props} />
+        </Provider>,
+      );
+
+      const usedPolicy = container.querySelector(
+        '[data-testid="work-with-any-VSO-note"]',
+      );
+
+      expect(usedPolicy).not.to.exist;
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds conditional logic for the "work with any accredited VSO" note so that is only appears for organizations and VSOs
- This pr aligns the selected rep contact card with how it appears on next-steps by using the same rep and org name attribute logic

## Related issue(s)

- [96901](https://github.com/department-of-veterans-affairs/va.gov-team/issues/96901)

## Testing done

- Went through the flow locally with authed user

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/168dd49f-53c7-479a-8fa6-bf0ada073a5f)

### After
![image](https://github.com/user-attachments/assets/04d6d11a-edb4-4bdf-8d32-1bf6c19365d7)

## What areas of the site does it impact?
Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user