### PR TITLE
Update card for file upload

### DIFF
--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -25,25 +25,32 @@ const CustomReviewTopContent = () => {
   } = form?.data;
 
   const renderFileInfo = file => (
-    <VaCard style={{ maxWidth: '75%' }}>
-      <div className="vads-u-display--flex vads-u-flex-direction--row">
-        <span className="vads-u-color--primary">
-          <VaIcon
-            size={6}
-            icon="file_present"
-            className="vads-u-margin-right--1"
-            srtext="icon representing a file"
-            aria-hidden="true"
-          />
-        </span>
-        <div className="vads-u-display--flex vads-u-flex-direction--column">
-          <span className="vads-u-font-weight--bold">{file.name}</span>
-          <span className="vads-u-color--gray-darker">
-            {getFileSize(file.size)}
+    <div className="vads-l-col--12 medium-screen:vads-l-col--12 small-desktop-screen:vads-l-col--8">
+      <VaCard>
+        <div className="vads-u-display--flex vads-u-flex-direction--row">
+          <span className="vads-u-color--primary">
+            <VaIcon
+              size={6}
+              icon="file_present"
+              className="vads-u-margin-right--1"
+              srtext="icon representing a file"
+              aria-hidden="true"
+            />
           </span>
+          <div className="vads-u-display--flex vads-u-flex-direction--column">
+            <span
+              className="vads-u-font-weight--bold"
+              style={{ 'word-break': 'break-all' }}
+            >
+              {file.name}
+            </span>
+            <span className="vads-u-color--gray-darker">
+              {getFileSize(file.size)}
+            </span>
+          </div>
         </div>
-      </div>
-    </VaCard>
+      </VaCard>
+    </div>
   );
 
   const renderPersonalInfo = () => (


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

In the accessibility audit of the [form upload](https://staging.va.gov/form-upload/21-0779/introduction) I found that long file names with underscores break the bounding box of the card. 

This only applies to the form-upload project maintained by the Veteran Facing Forms team.

There's two fixes for this.
1. Add word-break:break-all to the file name
2. Adjust the width of the container for the card that adjusts to 100% for smaller screen sizes (and zoom at 400%)

## Related issue(s)
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1950

## Testing done

Tested in browser and confirmed with code inspection and Axe and various zoom sizes, and file name lengths.


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile | <img width="323" alt="image" src="https://github.com/user-attachments/assets/0ade43cd-48e0-48ab-96d0-e6950fe849f1" /> | <img width="319" alt="image" src="https://github.com/user-attachments/assets/6b7f822f-7c45-41eb-b32a-e99e12a34dc4" />  |
| Desktop |  <img width="500" alt="image" src="https://github.com/user-attachments/assets/9105b463-fd54-4999-96fa-ffd907a3026d" />    |  <img width="500" alt="Screenshot 2025-01-03 at 10 04 33 AM" src="https://github.com/user-attachments/assets/f3b0e03a-eedb-4799-9adc-c1784cf60f04" /> |

## What areas of the site does it impact?

Only `/vets-website/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

