### PR TITLE
93006 Removed unclear reference to 'other' insurance - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
@@ -61,7 +61,7 @@ const IntroductionPage = props => {
           <br />
           <br />
           You may also need to submit supporting documents, like copies of your
-          other health insurance cards or proof of school enrollment.
+          health insurance cards or proof of school enrollment.
           <p>
             <va-link
               href="https://www.va.gov/family-and-caregiver-benefits/health-and-disability/champva/#supporting-documents-for-your-"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removed the word 'other' from the intro page per this [recommendation](https://github.com/department-of-veterans-affairs/va.gov-team/issues/93006) from staging review.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93006

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![before11](https://github.com/user-attachments/assets/7ce6713c-d0c2-4ec3-ac7d-58d15ef0c407)|![after11](https://github.com/user-attachments/assets/b451e156-1b16-4d5c-b698-2aa6c280d7af)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA