### PR TITLE
Appoint a rep phone validation bug

### DIFF
--- a/src/applications/representative-appoint/api/generatePDF.js
+++ b/src/applications/representative-appoint/api/generatePDF.js
@@ -2,7 +2,7 @@ import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/a
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import * as Sentry from '@sentry/browser';
 import { pdfTransform } from '../utilities/pdfTransform';
-import { isAttorneyOrClaimsAgent } from '../utilities/helpers';
+import { formIs2122A } from '../utilities/helpers';
 import manifest from '../manifest.json';
 
 export const generatePDF = async formData => {
@@ -20,7 +20,7 @@ export const generatePDF = async formData => {
     body: JSON.stringify(transformedFormData),
   };
 
-  const formType = isAttorneyOrClaimsAgent(formData) ? '2122a' : '2122';
+  const formType = formIs2122A(formData) ? '2122a' : '2122';
 
   const requestUrl = `${
     environment.API_URL

--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -12,7 +12,7 @@ import SearchResult from './SearchResult';
 import SearchInput from './SearchInput';
 import { useReviewPage } from '../hooks/useReviewPage';
 import { SearchResultsHeader } from './SearchResultsHeader';
-import { isAttorneyOrClaimsAgent } from '../utilities/helpers';
+import { isVSORepresentative } from '../utilities/helpers';
 
 const SelectAccreditedRepresentative = props => {
   const {
@@ -73,8 +73,8 @@ const SelectAccreditedRepresentative = props => {
     const selection = formData['view:selectedRepresentative'];
 
     const repTypeChanged =
-      isAttorneyOrClaimsAgent(currentSelectedRep) !==
-      isAttorneyOrClaimsAgent(newSelection);
+      isVSORepresentative(currentSelectedRep.current) !==
+      isVSORepresentative(newSelection);
     const noSelectionExists = !selection && !selectionMade;
     const noNewSelection =
       !newSelection || newSelection === currentSelectedRep.current;

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -9,10 +9,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import { generatePDF } from '../api/generatePDF';
 import NextStepsPage from '../containers/NextStepsPage';
 import PreSubmitInfo from '../containers/PreSubmitInfo';
-import {
-  preparerIsVeteran,
-  isAttorneyOrClaimsAgent,
-} from '../utilities/helpers';
+import { preparerIsVeteran, formIs2122A } from '../utilities/helpers';
 import {
   authorizeMedical,
   authorizeMedicalSelect,
@@ -240,10 +237,7 @@ const formConfig = {
           path: 'veteran-service-information',
           title: `Your service information`,
           depends: formData => {
-            return (
-              isAttorneyOrClaimsAgent(formData) &&
-              preparerIsVeteran({ formData })
-            );
+            return formIs2122A(formData) && preparerIsVeteran({ formData });
           },
           uiSchema: veteranServiceInformation.uiSchema,
           schema: veteranServiceInformation.schema,
@@ -286,10 +280,7 @@ const formConfig = {
           path: 'veteran-service-information',
           title: `Veteran's service information`,
           depends: formData => {
-            return (
-              isAttorneyOrClaimsAgent(formData) &&
-              !preparerIsVeteran({ formData })
-            );
+            return formIs2122A(formData) && !preparerIsVeteran({ formData });
           },
           uiSchema: veteranServiceInformation.uiSchema,
           schema: veteranServiceInformation.schema,
@@ -326,7 +317,7 @@ const formConfig = {
         authorizeInsideVA: {
           path: 'authorize-inside-va',
           depends: formData => {
-            return isAttorneyOrClaimsAgent(formData);
+            return formIs2122A(formData);
           },
           title: 'Authorization for Access Inside VA Systems',
           uiSchema: authorizeInsideVA.uiSchema,
@@ -335,7 +326,7 @@ const formConfig = {
         authorizeOutsideVA: {
           path: 'authorize-outside-va',
           depends: formData => {
-            return isAttorneyOrClaimsAgent(formData);
+            return formIs2122A(formData);
           },
           title: 'Authorization for Access Outside VA Systems',
           uiSchema: authorizeOutsideVA.uiSchema,
@@ -345,7 +336,7 @@ const formConfig = {
           path: 'authorize-outside-va/names',
           depends: formData => {
             return (
-              isAttorneyOrClaimsAgent(formData) &&
+              formIs2122A(formData) &&
               formData.authorizeOutsideVARadio === 'Yes'
             );
           },

--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -18,7 +18,7 @@ export default function prefillTransformer(formData) {
       street: formData?.contactInformation?.address?.street,
     };
     newFormData.veteranEmail = formData?.contactInformation?.email;
-    newFormData['Primary phone'] = formData?.contactInformation?.primaryPhone;
+    newFormData.primaryPhone = formData?.contactInformation?.primaryPhone;
     newFormData['Branch of Service'] =
       formData?.militaryInformation?.serviceBranch;
     // reset the applicant information in case of claimant type change

--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -58,7 +58,7 @@ export default function prefillTransformer(formData) {
       street: undefined,
     };
     newFormData.veteranEmail = undefined;
-    newFormData['Primary phone'] = undefined;
+    newFormData.primaryPhone = undefined;
     newFormData['Branch of Service'] = undefined;
   }
 

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
@@ -22,7 +22,7 @@ export const uiSchema = {
       />
     ),
   },
-  'Primary phone': phoneUI({
+  primaryPhone: phoneUI({
     required: true,
   }),
   veteranEmail: emailUI(),
@@ -30,11 +30,11 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
-  required: ['Primary phone'],
+  required: ['primaryPhone'],
   properties: {
     titleSchema,
     profileNotUpdatedNote: { type: 'object', properties: {} },
-    'Primary phone': phoneSchema,
+    primaryPhone: phoneSchema,
     veteranEmail: emailSchema,
   },
 };

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailClaimant.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailClaimant.js
@@ -16,7 +16,7 @@ export const uiSchema = {
   profileNotUpdatedNote: {
     'ui:description': () => <ProfileNotUpdatedNote includePhone />,
   },
-  'Primary phone': phoneUI({}),
+  primaryPhone: phoneUI({}),
   veteranEmail: emailUI(),
 };
 
@@ -26,7 +26,7 @@ export const schema = {
   properties: {
     titleSchema,
     profileNotUpdatedNote: { type: 'object', properties: {} },
-    'Primary phone': phoneSchema,
+    primaryPhone: phoneSchema,
     veteranEmail: emailSchema,
   },
 };

--- a/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
+++ b/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
@@ -24,7 +24,7 @@ describe('prefillTransformer', () => {
         postalCode: '75014',
       });
       expect(result.veteranEmail).to.eql('test2@test1.net');
-      expect(result['Primary phone']).to.eql('4445551212');
+      expect(result.primaryPhone).to.eql('4445551212');
       expect(result['Branch of Service']).to.eql('Army');
     });
 
@@ -91,7 +91,7 @@ describe('prefillTransformer', () => {
         veteranFullName: 'test',
         veteranDateOfBirth: 'test',
         veteranEmail: 'test',
-        'Primary phone': 'test',
+        primaryPhone: 'test',
         veteranHomeAddress: {
           city: 'test',
           country: 'test',
@@ -108,7 +108,7 @@ describe('prefillTransformer', () => {
       expect(result.veteranFullName).to.be.undefined;
       expect(result.veteranDateOfBirth).to.be.undefined;
       expect(result.veteranEmail).to.be.undefined;
-      expect(result['Primary phone']).to.be.undefined;
+      expect(result.primaryPhone).to.be.undefined;
       expect(result.veteranHomeAddress).to.eql({
         city: undefined,
         country: undefined,

--- a/src/applications/representative-appoint/tests/e2e/navigation/2122.cypress.spec.js
+++ b/src/applications/representative-appoint/tests/e2e/navigation/2122.cypress.spec.js
@@ -108,7 +108,7 @@ describe('Authenticated', () => {
       h.verifyUrl(ROUTES.VETERAN_CONTACT_PHONE_EMAIL);
       cy.injectAxeThenAxeCheck();
 
-      cy.get('input[name="root_Primary phone"]').type('5467364732');
+      cy.get('input[name="root_primaryPhone"]').type('5467364732');
 
       h.clickContinue();
 

--- a/src/applications/representative-appoint/tests/e2e/navigation/2122a.cypress.spec.js
+++ b/src/applications/representative-appoint/tests/e2e/navigation/2122a.cypress.spec.js
@@ -155,7 +155,7 @@ describe('Unauthenticated', () => {
       h.verifyUrl(ROUTES.VETERAN_CONTACT_PHONE_EMAIL);
       cy.injectAxeThenAxeCheck();
 
-      cy.get('input[name="root_Primary phone"]').type('5467364732');
+      cy.get('input[name="root_primaryPhone"]').type('5467364732');
 
       h.clickContinue();
 

--- a/src/applications/representative-appoint/tests/fixtures/data/21-22a/form-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/21-22a/form-data.json
@@ -242,7 +242,7 @@
     "postalCode": "01050"
   },
   "veteranEmail": "test@example.com",
-  "Primary phone": "5551234567",
+  "primaryPhone": "5551234567",
   "mobilePhone": "5551234567",
   "internationalPhone": "001-555-123-4567",
   "view:aidAttendance": true,

--- a/src/applications/representative-appoint/tests/fixtures/data/form-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/form-data.json
@@ -241,7 +241,7 @@
     "postalCode": "01050"
   },
   "veteranEmail": "test@example.com",
-  "Primary phone": "5551234567",
+  "primaryPhone": "5551234567",
   "mobilePhone": "5551234567",
   "internationalPhone": "001-555-123-4567",
   "view:aidAttendance": true,

--- a/src/applications/representative-appoint/tests/fixtures/data/initial-form-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/initial-form-data.json
@@ -46,7 +46,7 @@
     "postalCode": "01050"
   },
   "veteranEmail": "test@example.com",
-  "'Primary phone'": "5551234567",
+  "primaryPhone": "5551234567",
   "mobilePhone": "5551234567",
   "internationalPhone": "001-555-123-4567",
   "homeAddress": {

--- a/src/applications/representative-appoint/tests/fixtures/data/test-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/test-data.json
@@ -261,7 +261,7 @@
     "postalCode": "01050"
   },
   "veteranEmail": "test@example.com",
-  "Primary phone": "5551234567",
+  "primaryPhone": "5551234567",
   "mobilePhone": "5551234567",
   "internationalPhone": "001-555-123-4567",
   "view:aidAttendance": true,

--- a/src/applications/representative-appoint/tests/utilities/isAttorneyOrClaimsAgent.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/utilities/isAttorneyOrClaimsAgent.unit.spec.jsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { isAttorneyOrClaimsAgent } from '../../utilities/helpers';
+import { formIs2122A } from '../../utilities/helpers';
 
-describe('isAttorneyOrClaimsAgent', () => {
+describe('formIs2122A', () => {
   it('should return true when the selected rep has an individualType of attorney', () => {
     const mockFormData = {
       'view:selectedRepresentative': {
@@ -10,7 +10,7 @@ describe('isAttorneyOrClaimsAgent', () => {
         },
       },
     };
-    const result = isAttorneyOrClaimsAgent(mockFormData);
+    const result = formIs2122A(mockFormData);
     expect(result).to.be.true;
   });
 
@@ -22,7 +22,7 @@ describe('isAttorneyOrClaimsAgent', () => {
         },
       },
     };
-    const result = isAttorneyOrClaimsAgent(mockFormData);
+    const result = formIs2122A(mockFormData);
     expect(result).to.be.true;
   });
 
@@ -34,7 +34,7 @@ describe('isAttorneyOrClaimsAgent', () => {
         },
       },
     };
-    const result = isAttorneyOrClaimsAgent(mockFormData);
+    const result = formIs2122A(mockFormData);
     expect(result).to.be.true;
   });
 
@@ -46,7 +46,7 @@ describe('isAttorneyOrClaimsAgent', () => {
         },
       },
     };
-    const result = isAttorneyOrClaimsAgent(mockFormData);
+    const result = formIs2122A(mockFormData);
     expect(result).to.be.true;
   });
 
@@ -58,7 +58,7 @@ describe('isAttorneyOrClaimsAgent', () => {
         },
       },
     };
-    const result = isAttorneyOrClaimsAgent(mockFormData);
+    const result = formIs2122A(mockFormData);
     expect(result).to.not.be.ok;
   });
 
@@ -68,7 +68,7 @@ describe('isAttorneyOrClaimsAgent', () => {
         attributes: {},
       },
     };
-    const result = isAttorneyOrClaimsAgent(mockFormData);
+    const result = formIs2122A(mockFormData);
     expect(result).to.not.be.ok;
   });
 });

--- a/src/applications/representative-appoint/tests/utilities/isVSORepresentative.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/utilities/isVSORepresentative.unit.spec.jsx
@@ -3,28 +3,25 @@ import { isVSORepresentative } from '../../utilities/helpers';
 
 describe('isVSORepresentative', () => {
   it('should return true when the selected rep has at least one organization', () => {
-    const mockFormData = {
-      'view:selectedRepresentative': {
-        type: 'individual',
-        attributes: {
-          accreditedOrganizations: { data: [{ id: 1 }, { id: 2 }] },
-        },
+    const mockRep = {
+      type: 'individual',
+      attributes: {
+        accreditedOrganizations: { data: [{ id: 1 }, { id: 2 }] },
       },
     };
-    const result = isVSORepresentative(mockFormData);
+    const result = isVSORepresentative(mockRep);
     expect(result).to.be.true;
   });
 
   it('should return false when the selected rep has no organizations', () => {
-    const mockFormData = {
-      'view:selectedRepresentative': {
-        type: 'individual',
-        attributes: {
-          accreditedOrganizations: { data: [] },
-        },
+    const mockRep = {
+      type: 'individual',
+      attributes: {
+        accreditedOrganizations: { data: [] },
       },
     };
-    const result = isVSORepresentative(mockFormData);
+
+    const result = isVSORepresentative(mockRep);
     expect(result).to.be.false;
   });
 });

--- a/src/applications/representative-appoint/utilities/helpers.js
+++ b/src/applications/representative-appoint/utilities/helpers.js
@@ -140,12 +140,14 @@ export const getFormName = formData => {
   return "Appointment of Individual As Claimant's Representative";
 };
 
-export const isVSORepresentative = formData => {
-  const rep = formData['view:selectedRepresentative'];
-
-  if (rep.attributes?.accreditedOrganizations?.data?.length > 0) {
+/**
+ * Takes rep object (rather than form object)
+ */
+export const isVSORepresentative = rep => {
+  if (rep?.attributes?.accreditedOrganizations?.data?.length > 0) {
     return true;
   }
+
   return false;
 };
 

--- a/src/applications/representative-appoint/utilities/helpers.js
+++ b/src/applications/representative-appoint/utilities/helpers.js
@@ -141,7 +141,7 @@ export const getFormName = formData => {
 };
 
 /**
- * Takes rep object (rather than form object)
+ * Takes representative object (rather than formData object)
  */
 export const isVSORepresentative = rep => {
   if (rep?.attributes?.accreditedOrganizations?.data?.length > 0) {
@@ -151,7 +151,10 @@ export const isVSORepresentative = rep => {
   return false;
 };
 
-export const isAttorneyOrClaimsAgent = formData =>
+/**
+ * If the representative is a claims agent or attorney, user will fill out 21-22A
+ */
+export const formIs2122A = formData =>
   ['attorney', 'claimsAgent', 'claims_agent', 'claim_agents'].includes(
     formData?.['view:selectedRepresentative']?.attributes?.individualType,
   ) || null;
@@ -164,7 +167,7 @@ export const getOrgName = formData => {
     return formData['view:selectedRepresentative']?.attributes?.name;
   }
 
-  if (isAttorneyOrClaimsAgent(formData)) {
+  if (formIs2122A(formData)) {
     return null;
   }
 
@@ -192,7 +195,8 @@ export const getRepresentativeName = formData => {
   if (isOrg(formData)) {
     return formData['view:selectedRepresentative']?.attributes?.name;
   }
-  return isVSORepresentative(formData)
+
+  return isVSORepresentative(formData['view:selectedRepresentative'])
     ? formData.selectedAccreditedOrganizationName
     : rep.attributes.fullName;
 };

--- a/src/applications/representative-appoint/utilities/pdfTransform.js
+++ b/src/applications/representative-appoint/utilities/pdfTransform.js
@@ -30,7 +30,7 @@ export function pdfTransform(formData) {
     veteranDateOfBirth: dateOfBirth,
     serviceNumber,
     veteranHomeAddress: homeAddress,
-    'Primary phone': phone,
+    primaryPhone: phone,
     veteranEmail: email,
     'view:selectedRepresentative': selectedRep,
     applicantName,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Renamed 'Primary phone' property to primaryPhone to avoid display bug
- Adjusted helper method being used to compare old and new rep selections

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96854
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97215

## Testing done

- Updated tests to reflect new function arguments

