### PR TITLE
VACMS 20206 - allow numbers of more patterns to process as phone numbers in FL results

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
@@ -15,8 +15,13 @@ export const renderPhoneNumber = (
     return null;
   }
 
-  const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(phone);
-
+  const {
+    extension,
+    contact,
+    processed,
+    international,
+    countryCode,
+  } = parsePhoneNumber(phone);
   // The Telephone component will throw an error if passed an invalid phone number.
   // Since we can't use try/catch or componentDidCatch here, we'll just do this:
   if (contact.length !== 10) {
@@ -30,17 +35,23 @@ export const renderPhoneNumber = (
       {from === 'FacilityDetail' && <va-icon icon="phone" size="3" />}
       {title && <strong id={phoneNumberId}>{title}: </strong>}
       {subTitle}
-      <va-telephone
-        className={
-          subTitle ? 'vads-u-margin-left--0p5' : 'vads-u-margin-left--0p25'
-        }
-        contact={contact}
-        extension={extension}
-        aria-describedby={phoneNumberId}
-        message-aria-describedby={title}
-      >
-        {formattedPhoneNumber}
-      </va-telephone>
+      {processed ? (
+        <va-telephone
+          className={
+            subTitle ? 'vads-u-margin-left--0p5' : 'vads-u-margin-left--0p25'
+          }
+          contact={contact}
+          extension={extension}
+          message-aria-describedby={title}
+          country-code={countryCode}
+          international={international}
+        />
+      ) : (
+        // eslint-disable-next-line @department-of-veterans-affairs/prefer-telephone-component
+        <a href={`tel:${contact}`} aria-describedby={phoneNumberId}>
+          {contact}
+        </a>
+      )}
     </p>
   );
 };

--- a/src/applications/facility-locator/tests/components/search-results/common/Covid19PhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/common/Covid19PhoneLink.unit.spec.jsx
@@ -16,7 +16,7 @@ describe('Covid19PhoneLink', () => {
         .trim(),
     ).to.equal('Call to schedule:');
     expect(wrapper.find('va-telephone').html()).to.equal(
-      '<va-telephone className="vads-u-margin-left--0p25" contact="9994567890" extension="" message-aria-describedby="Call to schedule"></va-telephone>',
+      '<va-telephone className="vads-u-margin-left--0p25" contact="9994567890" message-aria-describedby="Call to schedule"></va-telephone>',
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
@@ -4,51 +4,113 @@ import { parsePhoneNumber } from '../../utils/phoneNumbers';
 describe('parsePhoneNumber', () => {
   it('without extension, without dashes', () => {
     const phone = '1234567890';
-    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
-      phone,
-    );
-    expect(formattedPhoneNumber).to.equal('123-456-7890');
-    expect(extension).to.equal('');
+    const {
+      contact,
+      extension,
+      processed,
+      international,
+      countryCode,
+    } = parsePhoneNumber(phone);
+    expect(processed).to.equal(true);
+    expect(extension).to.equal(undefined);
     expect(contact).to.equal('1234567890');
+    expect(international).to.equal(false);
+    expect(countryCode).to.equal(undefined);
   });
 
   it('with extension, without dashes', () => {
     const phone = '1234567890 x123';
-    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
-      phone,
-    );
-    expect(formattedPhoneNumber).to.equal('123-456-7890 x123');
+    const {
+      contact,
+      extension,
+      processed,
+      international,
+      countryCode,
+    } = parsePhoneNumber(phone);
     expect(extension).to.equal('123');
     expect(contact).to.equal('1234567890');
+    expect(processed).to.equal(true);
+    expect(international).to.equal(false);
+    expect(countryCode).to.equal(undefined);
   });
 
   it('with dashes', () => {
     const phone = '123-456--7890';
-    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
-      phone,
-    );
-    expect(formattedPhoneNumber).to.equal('123-456-7890');
-    expect(extension).to.equal('');
+    const {
+      contact,
+      extension,
+      processed,
+      international,
+      countryCode,
+    } = parsePhoneNumber(phone);
+    expect(extension).to.equal(undefined);
     expect(contact).to.equal('1234567890');
+    expect(processed).to.equal(true);
+    expect(international).to.equal(false);
+    expect(countryCode).to.equal(undefined);
   });
 
   it('with spaces and extension', () => {
     const phone = '123  456 7890 Extension 123';
-    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
-      phone,
-    );
-    expect(formattedPhoneNumber).to.equal('123-456-7890 x123');
+    const {
+      contact,
+      extension,
+      processed,
+      international,
+      countryCode,
+    } = parsePhoneNumber(phone);
     expect(extension).to.equal('123');
     expect(contact).to.equal('1234567890');
+    expect(processed).to.equal(true);
+    expect(international).to.equal(false);
+    expect(countryCode).to.equal(undefined);
   });
 
   it('with 800 numbers', () => {
     const phone = '1-800-827-1000';
-    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
-      phone,
-    );
-    expect(formattedPhoneNumber).to.equal('800-827-1000');
-    expect(extension).to.equal('');
+    const {
+      processed,
+      extension,
+      contact,
+      countryCode,
+      international,
+    } = parsePhoneNumber(phone);
+    expect(extension).to.equal(undefined);
     expect(contact).to.equal('8008271000');
+    expect(processed).to.equal(true);
+    expect(international).to.equal(true);
+    expect(countryCode).to.equal(undefined); // because it is 1
+  });
+
+  it('with +1-877 numbers', () => {
+    const phone = '+1-877-222-8387 ext. 123';
+    const {
+      processed,
+      extension,
+      contact,
+      countryCode,
+      international,
+    } = parsePhoneNumber(phone);
+    expect(extension).to.equal('123');
+    expect(contact).to.equal('8772228387');
+    expect(processed).to.equal(true);
+    expect(international).to.equal(true);
+    expect(countryCode).to.equal(undefined); // because it is 1
+  });
+
+  it('with +1(877) numbers', () => {
+    const phone = '+1(877) 222-8387 ext 123';
+    const {
+      processed,
+      extension,
+      contact,
+      countryCode,
+      international,
+    } = parsePhoneNumber(phone);
+    expect(extension).to.equal('123');
+    expect(contact).to.equal('8772228387');
+    expect(processed).to.equal(true);
+    expect(international).to.equal(true);
+    expect(countryCode).to.equal(undefined); // because it is 1
   });
 });

--- a/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
@@ -113,4 +113,20 @@ describe('parsePhoneNumber', () => {
     expect(international).to.equal(true);
     expect(countryCode).to.equal(undefined); // because it is 1
   });
+
+  it('should process with extension from result', () => {
+    const phone = '573-475-4108 ext 1008';
+    const {
+      processed,
+      extension,
+      contact,
+      countryCode,
+      international,
+    } = parsePhoneNumber(phone);
+    expect(extension).to.equal('1008');
+    expect(contact).to.equal('5734754108');
+    expect(processed).to.equal(true);
+    expect(international).to.equal(false);
+    expect(countryCode).to.equal(undefined);
+  });
 });

--- a/src/applications/facility-locator/utils/phoneNumbers.js
+++ b/src/applications/facility-locator/utils/phoneNumbers.js
@@ -14,13 +14,25 @@
  */
 
 export const parsePhoneNumber = phone => {
-  const phoneUS = phone.replace(/^1-/, '');
-  const re = /^(\d{3})[ -]*?(\d{3})[ -]*?(\d{4})\s?(\D*)?[ ]?(\d*)?/;
-  const extension = phoneUS.replace(re, '$5').replace(/\D/g, '');
-  const formattedPhoneNumber = extension
-    ? phoneUS.replace(re, '$1-$2-$3 x$5').replace(/x$/, '')
-    : phoneUS.replace(re, '$1-$2-$3');
-  const contact = phoneUS.replace(re, '$1$2$3');
+  const phoneRegex = /^(?:\+?(?<intl>\d{1,}?)[ -.]*)?\(?(?<ac>\d{3})\)?[- .]*(?<pfx>\d{3})[- .]*(?<linenum>\d{4}),?(?: ?e?xt?e?n?s?i?o?n?\.? ?(?<ext>\d*))?$/i;
+  const match = phoneRegex.exec(phone);
+  const { intl, ac, pfx, linenum, ext } = match?.groups;
+  // must have at least ac, pfx, and linenum
+  if (!match || !ac || !pfx || !linenum) {
+    return {
+      contact: phone,
+      extension: '',
+      processed: false,
+      international: false,
+      countryCode: '',
+    };
+  }
 
-  return { formattedPhoneNumber, extension, contact };
+  return {
+    contact: `${ac}${pfx}${linenum}`,
+    extension: ext,
+    processed: true,
+    international: !!intl,
+    countryCode: intl && intl !== '1' ? intl : undefined,
+  };
 };

--- a/src/applications/facility-locator/utils/phoneNumbers.js
+++ b/src/applications/facility-locator/utils/phoneNumbers.js
@@ -14,6 +14,21 @@
  */
 
 export const parsePhoneNumber = phone => {
+  // This regex has named capture groups for the international code (optional), area code, prefix, line number, and extension.
+  // The international code (intl) is optional. Someone may write +1 ac, +1 (ac), 1 (ac), 1-ac, 1.ac or 1ac or just ac, (ac), or ac.
+  // the intl need not be separated by space, dash or period from the ac
+  // The ac is the area code and is expected to be 3 digits exactly
+  // The pfx is the prefix and is expected to be 3 digits exactly
+  // The linenum is the line number and is expected to be 4 digits exactly
+  // ac/pfx/linenum _can_ be separated by space, dash or period or repeats of those characters
+  // The extension is optional and is expected to be a number after the required capture groups
+  // The extension is at least separated by an "x" or "ext" or "extension" or "ext." or "x." or "ext." or "extension."
+  // Since the intl group is greedy, if there is a number like +63285503888 (the Philippines VA Medical Center)
+  // it will be captured as intl=6, ac=328, pfx=550, linenum=3888 because the ac, pfx, and linenum are required to be a certain length
+  // However, if it is entered as +063285503888, it will be captured as intl=06, ac=328, pfx=550, linenum=3888
+  // This is because the intl group can expand to capture the 0, but the ac, pfx, and linenum groups are required to be a certain length
+  // Similarly if it is entered as: +01163285503888 it will be captured as intl=0116, ac=328, pfx=550, linenum=3888
+  // At some point we may wish to remove the 0 and 011 from the intl group, but it is unlikely to be entered
   const phoneRegex = /^(?:\+?(?<intl>\d{1,}?)[ -.]*)?\(?(?<ac>\d{3})\)?[- .]*(?<pfx>\d{3})[- .]*(?<linenum>\d{4}),?(?: ?e?xt?e?n?s?i?o?n?\.? ?(?<ext>\d*))?$/i;
   const match = phoneRegex.exec(phone);
 

--- a/src/applications/facility-locator/utils/phoneNumbers.js
+++ b/src/applications/facility-locator/utils/phoneNumbers.js
@@ -15,6 +15,7 @@
 
 export const parsePhoneNumber = phone => {
   // This regex has named capture groups for the international code (optional), area code, prefix, line number, and extension.
+  // in regular expressions (?<name>...) is a named capture group, therefore you can reference the group by its name
   // The international code (intl) is optional. Someone may write +1 ac, +1 (ac), 1 (ac), 1-ac, 1.ac or 1ac or just ac, (ac), or ac.
   // the intl need not be separated by space, dash or period from the ac
   // The ac is the area code and is expected to be 3 digits exactly

--- a/src/applications/facility-locator/utils/phoneNumbers.js
+++ b/src/applications/facility-locator/utils/phoneNumbers.js
@@ -16,16 +16,23 @@
 export const parsePhoneNumber = phone => {
   const phoneRegex = /^(?:\+?(?<intl>\d{1,}?)[ -.]*)?\(?(?<ac>\d{3})\)?[- .]*(?<pfx>\d{3})[- .]*(?<linenum>\d{4}),?(?: ?e?xt?e?n?s?i?o?n?\.? ?(?<ext>\d*))?$/i;
   const match = phoneRegex.exec(phone);
-  const { intl, ac, pfx, linenum, ext } = match?.groups;
-  // must have at least ac, pfx, and linenum
-  if (!match || !ac || !pfx || !linenum) {
-    return {
-      contact: phone,
-      extension: '',
-      processed: false,
-      international: false,
-      countryCode: '',
-    };
+
+  const errorObject = {
+    contact: phone,
+    extension: undefined,
+    processed: false,
+    international: false,
+    countryCode: '',
+  };
+
+  // must have at least match
+  if (!match) {
+    return errorObject;
+  }
+
+  const { intl, ac, pfx, linenum, ext } = match.groups;
+  if (!ac || !pfx || !linenum) {
+    return errorObject;
   }
 
   return {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Formerly processing of phone numbers for FL results was very rigid and didn't handle many edge cases including somewhat standard ones (especially from PPMS)
- Phone numbers with parentheses from PPMS/CCP would not display
- Modified the phone number parsing strategy... also left presentation to the component
- Sitewide team, We manage FL

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20206

## Testing done

- Added testing and coverage
- manually tested the failing facilities on PPMS searches in FL

## Screenshots

<details>
<summary>former (problem)</summary>
<img width="1100" alt="Screenshot 2025-01-03 at 4 59 12 PM" src="https://github.com/user-attachments/assets/6cda45fa-7f1f-4161-a844-565718291073" />

</details>

<details>
<summary>PR for result</summary>
<img width="1057" alt="Screenshot 2025-01-03 at 5 05 20 PM" src="https://github.com/user-attachments/assets/8f97c452-1357-4cd4-8364-950f42a948a1" />
</details>

## What areas of the site does it impact?

Facility Locator phone number display

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check
`/find-locations/?address=Alamogordo%2C%20nm&bounds%5B%5D%5B%5D=-106.710304&bounds%5B%5D%5B%5D=32.14977&bounds%5B%5D%5B%5D=-105.210304&bounds%5B%5D%5B%5D=33.64977&bounds%5B%5D%5B%5D%5B%5D=-106.710304&bounds%5B%5D%5B%5D%5B%5D=32.14977&bounds%5B%5D%5B%5D%5B%5D=-105.210304&bounds%5B%5D%5B%5D%5B%5D=33.64977&context=Alamogordo%2C%20New%20Mexico%2C%20United%20States&facilityType=provider&latitude=32.89977&longitude=-105.960304&page=1&radius=56&serviceType=253Z00000X&bounds%5B%5D=-106.710304&bounds%5B%5D=32.14977&bounds%5B%5D=-105.210304&bounds%5B%5D=33.64977`

Must be on v-w local deploy with prod vets-api as api endpoint, eg:
`yarn watch --env api=https://api.va.gov`

because RI will use dev PPMS data which is completely different than prod data