### PR TITLE
Preload maintenance windows

### DIFF
--- a/src/applications/mhv-medications/app-entry.jsx
+++ b/src/applications/mhv-medications/app-entry.jsx
@@ -13,4 +13,5 @@ startApp({
   reducer,
   routes,
   entryName: manifest.entryName,
+  preloadScheduledDowntimes: true,
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Preloads maintenance windows at initial load to improve page load performance. Without this change, the maintenance windows endpoint is not called until the `DowntimeNotification` component is loaded, delaying the app load. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/33797

## Testing done

tested locally + automated testing

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    ![image](https://github.com/user-attachments/assets/4e906e70-2fea-4470-8f65-7890cd5fd061)    |    ![image](https://github.com/user-attachments/assets/d6171310-14c2-48c5-b95e-bfc8b1624db4)   |
