### PR TITLE
Make copy changes for Pension confirmation page

### DIFF
--- a/src/applications/pensions/containers/ConfirmationPage.jsx
+++ b/src/applications/pensions/containers/ConfirmationPage.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { utcToZonedTime, format } from 'date-fns-tz';
 import { useSelector } from 'react-redux';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
-import { isLoggedIn } from 'platform/user/selectors';
 
 import { focusElement } from 'platform/utilities/ui';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
@@ -19,7 +18,6 @@ const centralTz = 'America/Chicago';
 
 const ConfirmationPage = ({ route }) => {
   const form = useSelector(state => state.form);
-  const loggedIn = useSelector(isLoggedIn);
   const { formConfig } = route;
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const showUpdatedConfirmation = useToggleValue(
@@ -37,6 +35,18 @@ const ConfirmationPage = ({ route }) => {
     timeZone: centralTz,
   });
 
+  const confirmationNumber = response?.confirmationNumber;
+  const submissionAlertContent = (
+    <>
+      <p>Your submission is in progress.</p>
+      <p>
+        It can take up to 10 days for us to receive your form.
+        {confirmationNumber &&
+          ` Your confirmation number is ${confirmationNumber}.`}
+      </p>
+    </>
+  );
+
   useEffect(() => {
     focusElement('h2');
     scrollToTop();
@@ -46,11 +56,14 @@ const ConfirmationPage = ({ route }) => {
     <div className="vads-u-margin-bottom--9">
       <ConfirmationView
         submitDate={submission?.timestamp}
-        confirmationNumber={response?.confirmationNumber}
+        confirmationNumber={confirmationNumber}
         formConfig={formConfig}
       >
         {showUpdatedConfirmation ? (
-          <ConfirmationView.SubmissionAlert actions={!loggedIn && <p />} />
+          <ConfirmationView.SubmissionAlert
+            content={submissionAlertContent}
+            actions={<p />}
+          />
         ) : (
           <>
             <h2 className="vads-u-margin-bottom--3">
@@ -68,12 +81,12 @@ const ConfirmationPage = ({ route }) => {
           <p>{fullName}</p>
           <h4>Date you submitted your application</h4>
           <p>{submittedAt}</p>
-          {response?.confirmationNumber && (
+          {confirmationNumber && (
             <>
               <h4 id="pension_527ez_submission_confirmation">
                 Confirmation number
               </h4>
-              <p>{response?.confirmationNumber}</p>
+              <p>{confirmationNumber}</p>
             </>
           )}
           {!showUpdatedConfirmation && (
@@ -90,12 +103,10 @@ const ConfirmationPage = ({ route }) => {
           <>
             <ConfirmationView.PrintThisPage />
             <ConfirmationView.WhatsNextProcessList
-              item1Content={`This can take up to 10 days. When we receive your form, ${
-                loggedIn
-                  ? 'we’ll update the status on My VA.'
-                  : 'we’ll send you an email.'
-              }`}
-              item1Actions={!loggedIn && <p />}
+              item1Header="We’ll confirm when we receive your form"
+              item1Content="This can take up to 10 days. When we receive your form, we'll send you an email."
+              item1Actions={<p />}
+              item2Content="If we have questions or need more information after reviewing your form, we'll contact you by phone, email, or mail."
             />
             <p className="vads-u-padding-left--7">
               <strong>Note:</strong> If we send you a request for more


### PR DESCRIPTION
## Summary

- Updated copy on the Pensions confirmation page to reflect CAIA feedback

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99181

## Testing done

- Complete the Pensions form while authenticated and confirm the confirmation page matches the [updated wires](https://www.figma.com/design/9JKK5Eo43uJWEr66JPiebc/WIP---21P-527EZ---Pension-Benefits?node-id=9779-167359&t=ZqtLydopJL19Wxto-0)

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Confirmation Page  |   <img width="521" alt="Screenshot 2025-01-06 at 10 56 02 AM" src="https://github.com/user-attachments/assets/dcf76ed7-f8a0-4d4b-bd7d-044cd5d1b6b2" />   <img width="538" alt="Screenshot 2025-01-06 at 10 56 08 AM" src="https://github.com/user-attachments/assets/3a81fdc4-abad-4d23-ba53-c7d2210f3b8e" />  |    <img width="529" alt="Screenshot 2025-01-06 at 10 54 45 AM" src="https://github.com/user-attachments/assets/3c2d9069-9b7f-4b8a-a806-154c770067d7" /> <img width="536" alt="Screenshot 2025-01-06 at 10 50 16 AM" src="https://github.com/user-attachments/assets/2e7a5136-48b3-43c3-a9f1-03f80aa6d811" />    |

## What areas of the site does it impact?

Pensions

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

