### PR TITLE
93009 Add definite article when referencing sponsor - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -422,12 +422,13 @@ const formConfig = {
             sponsorInfoTitle: titleUI('Sponsor status details'),
             sponsorDOD: dateOfDeathUI('When did the sponsor die?'),
             sponsorDeathConditions: yesNoUI({
-              title: 'Did sponsor die during active military service?',
+              title: 'Did the sponsor die during active military service?',
               hint: ADDITIONAL_FILES_HINT,
               labels: {
-                yes: 'Yes, sponsor passed away during active military service',
+                yes:
+                  'Yes, the sponsor passed away during active military service',
                 no:
-                  'No, sponsor did not pass away during active military service',
+                  'No, the sponsor did not pass away during active military service',
               },
             }),
           },
@@ -598,7 +599,7 @@ const formConfig = {
                     undefined,
                     false,
                   )}. This includes social security number, mailing address, 
-                          contact information, relationship to sponsor, and health 
+                          contact information, relationship to the sponsor, and health 
                           insurance information.`,
                 ),
               },
@@ -770,7 +771,8 @@ const formConfig = {
           path: 'applicant-relationship/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
-          title: item => `${applicantWording(item)} relationship to sponsor`,
+          title: item =>
+            `${applicantWording(item)} relationship to the sponsor`,
           CustomPage: ApplicantRelationshipPage,
           CustomPageReview: ApplicantRelationshipReviewPage,
           schema: applicantListSchema([], {

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
@@ -121,7 +121,7 @@ function marriageTitle(text, subtitle) {
 
 const dateOfMarriageToSponsor = {
   ...currentOrPastDateUI({
-    title: 'Date of marriage to sponsor',
+    title: 'Date of marriage to the sponsor',
     errorMessages: {
       pattern: 'Please provide a valid date',
       required: 'Please provide the date of marriage',
@@ -144,7 +144,7 @@ export const marriageDatesSchema = {
       'ui:options': { viewField: ApplicantField },
       items: {
         'ui:options': marriageTitle(
-          ' date of marriage to sponsor',
+          ' date of marriage to the sponsor',
           'If you don’t know the exact date, enter your best guess',
         ),
         dateOfMarriageToSponsor,

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -178,7 +178,7 @@ testNumberOfWebComponentFields(
   formConfig.chapters.applicantInformation.pages.page18c.schema,
   formConfig.chapters.applicantInformation.pages.page18c.uiSchema,
   0,
-  'Applicant - relationship to sponsor',
+  'Applicant - relationship to the sponsor',
   { ...mockData.data },
 );
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates copy across form 10-10d to use definite article "the" when referencing the sponsor (e.g., "Your relationship to _the_ sponsor").

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93009

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2025-01-06 at 14 03 30](https://github.com/user-attachments/assets/0f8aae6b-e075-4560-8133-726b2a13a6b9)|![Screenshot 2025-01-06 at 14 08 25](https://github.com/user-attachments/assets/2222c599-0ef2-43a0-800f-66f140a0bca7)|

## What areas of the site does it impact?

form 10-10d

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA