### PR TITLE
update aria labels related to minimal header

### DIFF
--- a/src/platform/forms-system/src/js/components/BackLink.jsx
+++ b/src/platform/forms-system/src/js/components/BackLink.jsx
@@ -70,7 +70,10 @@ const BackLink = ({ router, routes, location, form, setData }) => {
   }
 
   return (
-    <nav className="vads-u-margin-top--2 vads-u-margin-bottom--4">
+    <nav
+      className="vads-u-margin-top--2 vads-u-margin-bottom--4"
+      aria-label="Previous page"
+    >
       <a href={link} onClick={onClick} className="vads-u-padding--1">
         <va-icon icon="navigate_before" size={3} />
         Back

--- a/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
@@ -22,13 +22,10 @@ export const Title = ({
   const className =
     classNames || `vads-u-color--${color} vads-u-margin-top--0${style}`;
 
-  // If the header is an h1, it's intended to also be the focus,
-  // in which case we need an aria-describedby attribute to point to the
-  // stepper to read out the step and chapter after reading the title
+  // If the header is an h1, it's intended to also be the focus
   const focusHeaderProps =
     headerLevel === 1
       ? {
-          'aria-describedby': 'nav-form-header',
           tabIndex: '-1',
         }
       : {};


### PR DESCRIPTION
## Summary

When using minimal header:
- H1 no longer reads out chapter stepper (intentional decision from UX after discussion/research)
- Add additional aria label on nav back

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1540
department-of-veterans-affairs/va.gov-team-forms#1521

## Testing done

- Screen reader testing using NVDA

## Screenshots

n/a

## What areas of the site does it impact?

minimal header mock form and 4138

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
