### PR TITLE
Improve radiology images test

### DIFF
--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-view-labs-radiology-images.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-view-labs-radiology-images.cypress.spec.js
@@ -1,24 +1,25 @@
 import MedicalRecordsSite from './mr_site/MedicalRecordsSite';
 import RadiologyDetailsPage from './pages/RadiologyDetailsPage';
 import LabsAndTestsListPage from './pages/LabsAndTestsListPage';
+import defaultLabsAndTests from './fixtures/labs-and-tests/labsAndTests.json';
 import statusResponseComplete from './fixtures/labs-and-tests/imaging-status-response-complete.json';
 import viewImagesResponse from './fixtures/labs-and-tests/imaging-view-images-response.json';
 import imagingStudies from './fixtures/labs-and-tests/radiologyCvix.json';
 
-describe('Medical Records Redirect Users to MHV Classic to view images', () => {
+describe('Medical Records - Radiology images are shown when requested', () => {
   const site = new MedicalRecordsSite();
 
   before(() => {
     site.login();
-    // cy.visit('my-health/medical-records/labs-and-tests');
-    LabsAndTestsListPage.goToLabsAndTests();
+    LabsAndTestsListPage.goToLabsAndTests(
+      defaultLabsAndTests,
+      imagingStudies,
+      statusResponseComplete,
+      true,
+    );
   });
 
   it('View Radiology Images On Radiology Details Page', () => {
-    RadiologyDetailsPage.interceptImagingEndpoint(imagingStudies);
-
-    RadiologyDetailsPage.interceptImagingStatus(statusResponseComplete);
-
     LabsAndTestsListPage.clickRadiologyDetailsLink(0);
 
     const studyId = statusResponseComplete[0].studyIdUrn;
@@ -29,10 +30,6 @@ describe('Medical Records Redirect Users to MHV Classic to view images', () => {
     RadiologyDetailsPage.verifyRadiologyImageCount(10);
 
     RadiologyDetailsPage.verifyPaginationVisible();
-
-    // RadiologyDetailsPage.verifyRadiologyImageLink(
-    //   'Request images on the My HealtheVet website',
-    // );
 
     cy.injectAxe();
     cy.axeCheck('main', {});

--- a/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
+++ b/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
@@ -11,7 +11,6 @@ class MedicalRecordsSite {
     }
     this.mockVamcEhr();
     this.mockMaintenanceWindow();
-    cy.login(userFixture);
     cy.intercept('POST', '/my_health/v1/medical_records/session', {
       statusCode: 204,
       body: {},
@@ -20,9 +19,7 @@ class MedicalRecordsSite {
       statusCode: 200,
       body: sessionStatus, // status response copied from staging
     }).as('status');
-    // src/platform/testing/e2e/cypress/support/commands/login.js handles the next two lines
-    // window.localStorage.setItem('isLoggedIn', true);
-    // cy.intercept('GET', '/v0/user', mockUser).as('mockUser');
+    cy.login(userFixture);
   };
 
   mockFeatureToggles = ({

--- a/src/applications/mhv-medical-records/tests/e2e/pages/LabsAndTestsListPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/LabsAndTestsListPage.js
@@ -1,11 +1,12 @@
 import defaultLabsAndTests from '../fixtures/labs-and-tests/labsAndTests.json';
 import radiologyRecordsMhv from '../fixtures/labs-and-tests/radiologyRecordsMhv.json';
-// import radiologyRecordsMhv from '../../tests/fixtures/labs-and-tests/radiologyRecordsMhv.json';
 import BaseListPage from './BaseListPage';
 
 class LabsAndTestsListPage extends BaseListPage {
   goToLabsAndTests = (
     labsAndTests = defaultLabsAndTests,
+    imaging = [],
+    imagingStatus = [],
     waitForLabsAndTests = false,
   ) => {
     cy.intercept(
@@ -18,12 +19,14 @@ class LabsAndTestsListPage extends BaseListPage {
       '/my_health/v1/medical_records/radiology',
       radiologyRecordsMhv,
     ).as('RadiologyRecordsMhv');
-    cy.intercept('GET', '/my_health/v1/medical_records/imaging', []).as(
+    cy.intercept('GET', '/my_health/v1/medical_records/imaging', imaging).as(
       'CvixRadiologyRecordsMhv',
     );
-    cy.intercept('GET', '/my_health/v1/medical_records/imaging/status', []).as(
-      'CvixRadiologyRecordsMhv',
-    );
+    cy.intercept(
+      'GET',
+      '/my_health/v1/medical_records/imaging/status',
+      imagingStatus,
+    ).as('CvixRadiologyRecordsMhv');
     cy.intercept(
       'GET',
       '/my_health/v1/medical_records/bbmi_notification/status',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Improves the radiology test by only using the fixtures needed. I'm pulling this out of the user load performance PR because there's a weird testing-only interaction between the MR and site wide unit tests.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/33809

