### PR TITLE
(feature) hiding OH warning for accelerated users

### DIFF
--- a/src/applications/mhv-medical-records/components/shared/CernerFacilityAlert.jsx
+++ b/src/applications/mhv-medical-records/components/shared/CernerFacilityAlert.jsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { getVamcSystemNameFromVhaId } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/utils';
 import { selectCernerFacilities } from 'platform/site-wide/drupal-static-data/source-files/vamc-ehr/selectors';
 import { getCernerURL } from 'platform/utilities/cerner';
+import useAcceleratedData from '../../hooks/useAcceleratedData';
 
 const CernerFacilityAlert = ({ linkPath, pageName }) => {
   const ehrDataByVhaId = useSelector(
@@ -12,6 +13,8 @@ const CernerFacilityAlert = ({ linkPath, pageName }) => {
   const userFacilities = useSelector(state => state?.user?.profile?.facilities);
 
   const drupalCernerFacilities = useSelector(selectCernerFacilities);
+
+  const { isAccelerating } = useAcceleratedData();
 
   const cernerFacilities = useMemo(
     () => {
@@ -35,6 +38,10 @@ const CernerFacilityAlert = ({ linkPath, pageName }) => {
     },
     [cernerFacilities, ehrDataByVhaId],
   );
+
+  if (isAccelerating) {
+    return <></>;
+  }
 
   return (
     <>

--- a/src/applications/mhv-medical-records/containers/LandingPage.jsx
+++ b/src/applications/mhv-medical-records/containers/LandingPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
@@ -61,14 +61,11 @@ const LandingPage = () => {
   );
   const {
     isLoading,
+    isAccelerating,
     isAcceleratingAllergies,
     isAcceleratingVitals,
   } = useAcceleratedData();
 
-  const isAcceleratingEnabled = useMemo(
-    () => isAcceleratingAllergies || isAcceleratingVitals,
-    [isAcceleratingAllergies, isAcceleratingVitals],
-  );
   const accordionRef = useRef(null);
 
   useEffect(() => {
@@ -145,7 +142,7 @@ const LandingPage = () => {
                 Get results of your VA medical tests. This includes blood tests,
                 X-rays, and other imaging tests.
               </p>
-              {isAcceleratingEnabled ? (
+              {isAccelerating ? (
                 <a
                   className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
                   href={getCernerURL('/pages/health_record/results', true)}
@@ -179,7 +176,7 @@ const LandingPage = () => {
                 care. This includes summaries of your stays in health facilities
                 (called admission and discharge summaries).
               </p>
-              {isAcceleratingEnabled ? (
+              {isAccelerating ? (
                 <>
                   <a
                     className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
@@ -220,7 +217,7 @@ const LandingPage = () => {
                 Get a list of all vaccines (immunizations) in your VA medical
                 records.
               </p>
-              {isAcceleratingEnabled ? (
+              {isAccelerating ? (
                 <a
                   className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
                   href={getCernerURL(
@@ -256,7 +253,7 @@ const LandingPage = () => {
               VA medical records. This includes medication side effects (also
               called adverse drug reactions).
             </p>
-            {isAcceleratingEnabled && !isAcceleratingAllergies ? (
+            {isAccelerating && !isAcceleratingAllergies ? (
               <a
                 className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
                 href={getCernerURL(
@@ -291,7 +288,7 @@ const LandingPage = () => {
                 Get a list of health conditions your VA providers are helping
                 you manage.
               </p>
-              {isAcceleratingEnabled ? (
+              {isAccelerating ? (
                 <a
                   className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
                   href={getCernerURL('/pages/health_record/conditions', true)}
@@ -330,7 +327,7 @@ const LandingPage = () => {
                 <li>Height and weight</li>
                 <li>Temperature</li>
               </ul>
-              {isAcceleratingEnabled && !isAcceleratingVitals ? (
+              {isAccelerating && !isAcceleratingVitals ? (
                 <a
                   className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
                   href={getCernerURL('/pages/health_record/results', true)}

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -111,6 +111,13 @@ const Vitals = () => {
     [isAcceleratingVitals],
   );
 
+  const PER_PAGE = useMemo(
+    () => {
+      return Object.keys(VITAL_TYPES).length;
+    },
+    [VITAL_TYPES],
+  );
+
   useEffect(
     () => {
       if (vitals?.length) {
@@ -201,7 +208,7 @@ const Vitals = () => {
           <RecordList
             records={cards}
             type={recordType.VITALS}
-            perPage={7}
+            perPage={PER_PAGE}
             hidePagination
             domainOptions={{
               isAccelerating: isAcceleratingVitals,

--- a/src/applications/mhv-medical-records/hooks/useAcceleratedData.js
+++ b/src/applications/mhv-medical-records/hooks/useAcceleratedData.js
@@ -66,8 +66,14 @@ const useAcceleratedData = () => {
     [isAcceleratedDeliveryEnabled, isAcceleratingVitalsEnabled, isCerner],
   );
 
+  const isAccelerating = useMemo(
+    () => isAcceleratingAllergies || isAcceleratingVitals,
+    [isAcceleratingAllergies, isAcceleratingVitals],
+  );
+
   return {
     isLoading,
+    isAccelerating,
     isAcceleratingAllergies,
     isAcceleratingVitals,
   };

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.cypress.spec.js
@@ -25,6 +25,9 @@ describe('Medical Records View Vitals', () => {
 
     cy.injectAxeThenAxeCheck();
 
+    const CARDS_PER_PAGE = 16; // 8 per page * 2 for printing
+    cy.get('va-card').should('have.length', CARDS_PER_PAGE);
+
     cy.get("[data-testid='current-date-display']").should('be.visible');
     cy.get("[data-testid='current-date-display']").should('not.be.empty');
   });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.domain.pain-severity.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/vitals/view-vitals-list.oracle-health.domain.pain-severity.cypress.spec.js
@@ -27,9 +27,6 @@ describe('Medical Records View Pain Severity', () => {
     Vitals.selectMonthAndYear({ month: '3', year: 2024 });
     Vitals.verifySelectedDate({ dateString: 'March 2024' });
 
-    // go to second page
-    Vitals.viewNextPage();
-
     // check for latest id
     cy.get(
       '[data-testid="vital-pain-severity-0-10-verbal-numeric-rating-score-reported-measurement"]',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Hiding OH warning for accelerated users
- Updated Pagination count to display all items on 1 page

## Related issue(s)

Tracker in a slack canvas

## Testing done

- updated e2e tests
 
## Screenshots
Before:
![image](https://github.com/user-attachments/assets/0f9b4d69-7701-44d9-8896-ca3aa728d1d6)

After with both changes

![image](https://github.com/user-attachments/assets/a31eedc7-86ac-4194-b948-0acc5e791836)


## What areas of the site does it impact?

MHV- MR

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
