### PR TITLE
task: VACMS-100246 Redirect Boston RO teamsites to the modernized page

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1567,5 +1567,17 @@
     "src": "/ROLITTLEROCK",
     "dest": "/little-rock-va-regional-benefit-office-at-eugene-j-towbin-healthcare-center/",
     "catchAll": true
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/ROBOSTON",
+    "dest": "/boston-va-regional-benefit-office/",
+    "catchAll": true
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/boston",
+    "dest": "/boston-va-regional-benefit-office/",
+    "catchAll": true
   }
 ]


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
Redirecting the Boston RO sites to the new modernized page

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/100246
