### PR TITLE
[VI-956] Removed Unnecessary '/v0'

### DIFF
--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -18,7 +18,7 @@ export default function MhvSignIn() {
   };
 
   const handleButtonClick = () => {
-    apiRequest('/v0/test_account_user_email', {
+    apiRequest('/test_account_user_email', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removed the `/v0` from the `/test_account_user_email` api request in `MhvSignIn.jsx` as it was causing the test account user email form to not work properly.

## Related issue(s)

[Jira Ticket VI-956](https://jira.devops.va.gov/browse/VI-956)

## Testing done

No additional tests added. Ran all `applications/login` tests locally to ensure no breaking changes.

## What areas of the site does it impact?

This only impacts `MhvSignIn.jsx`.

## Acceptance criteria

- [x] Remove the unnecessary '/v0' present in the `/test_account_user_email` api request in `MhvSignIn.jsx`.
