### PR TITLE
100465 Update title tag to match app name - form 10-7959f-2

### DIFF
--- a/src/applications/ivc-champva/10-7959f-2/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/containers/App.jsx
@@ -8,8 +8,11 @@ import {
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import WIP from '../../shared/components/WIP';
 import formConfig from '../config/form';
+import manifest from '../manifest.json';
 
 export default function App({ location, children }) {
+  document.title = `${manifest.appName} | Veterans Affairs`;
+
   const breadcrumbs = [
     { href: '/', label: 'Home' },
     { href: '/health-care', label: 'Health care' },

--- a/src/applications/ivc-champva/10-7959f-2/manifest.json
+++ b/src/applications/ivc-champva/10-7959f-2/manifest.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Foreign Medical Program  Cover Sheet",
+  "appName": "Foreign Medical Program Cover Sheet",
   "entryFile": "./app-entry.jsx",
   "entryName": "fmp-cover-sheet",
   "rootUrl": "/health-care/foreign-medical-program/file-claim-form-10-7959f-2",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates `<title/>` tag to match the app name contained in the manifest.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/100465

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="538" alt="Screenshot 2025-01-08 at 11 10 36" src="https://github.com/user-attachments/assets/56a0f107-cb19-46fa-8cce-125e1e9c1bea" />|<img width="552" alt="Screenshot 2025-01-08 at 11 14 44" src="https://github.com/user-attachments/assets/298e24d5-bc3b-431c-9452-81de00f2d5f4" />|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA