### PR TITLE
Fix copy in form upload error message

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
@@ -85,7 +85,7 @@ const VaFileInputField = props => {
     const { maxFileSize } = props.uiOptions;
     if (fileFromEvent.size > maxFileSize) {
       const fileSizeString = getFileSize(maxFileSize);
-      setError(`file - size must not be greater than ${fileSizeString}`);
+      setError(`File size cannot be greater than ${fileSizeString}`);
       return;
     }
 


### PR DESCRIPTION
## Summary
This PR corrects some copy for the error message in Form Upload if the file is too large.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&filterQuery=-status%3AIcebox%2CEpic%2C%22Collab+Cycle%22&pane=issue&itemId=91271783&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1930
