### PR TITLE
adds approved access mhv sign in page

### DIFF
--- a/src/applications/login/containers/MhvAccess.jsx
+++ b/src/applications/login/containers/MhvAccess.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { login } from 'platform/user/authentication/utilities';
+
+export default function MhvAccess() {
+  return (
+    <section className="container row login vads-u-padding--3">
+      <div className="columns small-12 vads-u-padding--0">
+        <h1 id="signin-signup-modal-title">
+          Get temporary access to My HealtheVet
+        </h1>
+        <p className="vads-u-measure--5">
+          Some groups are approved to access the My HealtheVet sign-in option
+          until they create a new modern account. This sign-in process may
+          change in the future.
+        </p>
+      </div>
+      <div className="vads-u-margin-y--2">
+        <va-button
+          onClick={() => login({ policy: 'mhv' })}
+          text="Sign in with My HealtheVet"
+          data-testid="accessMhvBtn"
+        />
+      </div>
+      <div className="vads-u-margin-y--6">
+        <h2>Having trouble signing in?</h2>
+        <p>Contact the administrator who gave you access to this page.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/applications/login/containers/MhvSignIn.jsx
+++ b/src/applications/login/containers/MhvSignIn.jsx
@@ -31,7 +31,7 @@ export default function MhvSignIn() {
   const notDisable = isValidEmail || email.length === 0;
 
   return (
-    <section className="container row login">
+    <section className="container row login vads-u-padding--3">
       <div className="columns small-12 vads-u-padding--0">
         <h1 id="signin-signup-modal-title">
           Access My HealtheVet test account

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -3,6 +3,7 @@ import SignInApp from './containers/SignInApp';
 import SignInWrapper from './components/SignInWrapper';
 import MockAuth from './containers/MockAuth';
 import MhvSignIn from './containers/MhvSignIn';
+import MhvAccess from './containers/MhvAccess';
 
 const routes = {
   path: '/',
@@ -20,6 +21,10 @@ const routes = {
           {
             path: 'access-myhealthevet-test-account',
             component: MhvSignIn,
+          },
+          {
+            path: 'mhv',
+            component: MhvAccess,
           },
         ],
 };

--- a/src/applications/login/tests/containers/MhvAccess.unit.spec.js
+++ b/src/applications/login/tests/containers/MhvAccess.unit.spec.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { expect } from 'chai';
+import { fireEvent } from '@testing-library/react';
+import MhvAccess from '../../containers/MhvAccess';
+
+describe('MhvAccess', () => {
+  it('renders main title', () => {
+    const screen = renderInReduxProvider(<MhvAccess />);
+    const mainTitle = screen.getByRole('heading', {
+      name: /get temporary access to my healthevet/i,
+    });
+    expect(mainTitle).to.exist;
+  });
+
+  it('renders information paragraph', () => {
+    const screen = renderInReduxProvider(<MhvAccess />);
+    const description = screen.getByText(
+      /Some groups are approved to access the My HealtheVet sign-in option/i,
+    );
+    expect(description).to.exist;
+  });
+
+  it('renders button', () => {
+    const screen = renderInReduxProvider(<MhvAccess />);
+    const accessButton = screen.getByTestId('accessMhvBtn');
+    expect(accessButton).to.exist;
+    fireEvent.click(accessButton);
+  });
+
+  it('renders having trouble section', () => {
+    const screen = renderInReduxProvider(<MhvAccess />);
+    const troubleHeading = screen.getByRole('heading', {
+      name: /having trouble signing in/i,
+    });
+    expect(troubleHeading).to.exist;
+
+    const troubleParagraph = screen.getByText(
+      /contact the administrator who gave you access to this page/i,
+    );
+    expect(troubleParagraph).to.exist;
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Create a new ```/sign-in``` route that allows authorized and approved users continued access to My HealtheVet CSP

## Related issue(s)

[Jira Ticket]()

## Testing done

- unit tests at 100%

## Screenshots

![Screenshot 2025-01-08 at 12 06 54 PM](https://github.com/user-attachments/assets/d215462e-098c-4f8f-8c8a-1f050acb05fe)

## What areas of the site does it impact?

- staging.va.gov/sign-in/mhv

## Acceptance criteria

- Create new route for authorized mhv users
- Reference this [Figma](https://www.figma.com/design/d3fRL81XY4o9tncCOjmRNS/Sign-in-page---MHV-removal?node-id=473-160548&t=sC4ApCQC2elhGWL2-0) for design and content

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
