### PR TITLE
99422 cache preferred name to local storage

### DIFF
--- a/src/platform/site-wide/user-nav/selectors.js
+++ b/src/platform/site-wide/user-nav/selectors.js
@@ -8,17 +8,25 @@ import { selectProfile } from '../../user/selectors';
 export const selectUserGreeting = createSelector(
   state => selectProfile(state)?.userFullName,
   state => selectProfile(state)?.email,
+  () => localStorage.getItem('preferredName'),
   () => localStorage.getItem('userFirstName'),
   state => selectProfile(state)?.preferredName,
-  (name, email, sessionFirstName, preferredName) => {
-    if (preferredName || name.first || sessionFirstName) {
+  (name, email, sessionPreferredName, sessionFirstName, preferredName) => {
+    if (
+      preferredName ||
+      sessionPreferredName ||
+      name.first ||
+      sessionFirstName
+    ) {
       return (
         <span
           className="user-dropdown-email"
           data-dd-privacy="mask"
           data-dd-action-name="First Name"
         >
-          {preferredName || startCase(toLower(name.first || sessionFirstName))}
+          {preferredName ||
+            sessionPreferredName ||
+            startCase(toLower(name.first || sessionFirstName))}
         </span>
       );
     }

--- a/src/platform/site-wide/user-nav/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/user-nav/tests/selectors.unit.spec.js
@@ -30,6 +30,13 @@ describe('User navigation selectors', () => {
       expect(result.props.children).to.equal('Joe');
     });
 
+    it('should return session preferred name', () => {
+      localStorage.setItem('userFirstName', 'Joe');
+      localStorage.setItem('preferredName', 'Joey');
+      const result = selectUserGreeting(state);
+      expect(result.props.children).to.equal('Joey');
+    });
+
     it('should return profile name', () => {
       localStorage.setItem('userFirstName', 'Joe');
       const result = selectUserGreeting(
@@ -40,6 +47,15 @@ describe('User navigation selectors', () => {
 
     it('should return preferred name', () => {
       localStorage.setItem('userFirstName', 'Joe');
+      let stateObj = set('user.profile.userFullName.first', 'Jain');
+      stateObj = set('user.profile.preferredName', 'JJ', stateObj);
+      const result = selectUserGreeting(stateObj);
+      expect(result.props.children).to.equal('JJ');
+    });
+
+    it('should prioritize preferred name over cached preferred name', () => {
+      localStorage.setItem('userFirstName', 'Joe');
+      localStorage.setItem('preferredName', 'Joey');
       let stateObj = set('user.profile.userFullName.first', 'Jain');
       stateObj = set('user.profile.preferredName', 'JJ', stateObj);
       const result = selectUserGreeting(stateObj);

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -136,7 +136,7 @@ export const hasSessionSSO = () =>
   JSON.parse(localStorage.getItem('hasSessionSSO'));
 
 export function setupProfileSession(userProfile) {
-  const { firstName, signIn } = userProfile;
+  const { firstName, signIn, preferredName } = userProfile;
   const loginType = signIn?.serviceName || null;
   localStorage.setItem('hasSession', true);
   if (signIn?.ssoe) {
@@ -146,6 +146,7 @@ export function setupProfileSession(userProfile) {
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
+  if (preferredName) localStorage.setItem('preferredName', preferredName);
 
   // Set Sentry Tag so we can associate errors with the login policy
   setSentryLoginType(loginType);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Cache user's preferred name so that the auth menu doesn't have this nasty pop-in effect
https://github.com/user-attachments/assets/f642c8e3-f443-4dc6-8280-3b8298979c83

## Related issue(s)
[99422](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99422)

## Testing done
Specs added

## What areas of the site does it impact?
site-wide 😭 

## Acceptance criteria
vets-website caches user's preferred name at login and serves that cached value from the auth menu.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
