### PR TITLE
VACMS-20175: DUW Updates to remove bold text

### DIFF
--- a/src/applications/discharge-wizard/components/v2/Homepage.jsx
+++ b/src/applications/discharge-wizard/components/v2/Homepage.jsx
@@ -72,10 +72,9 @@ const HomePage = ({ router, setIntroPageViewed }) => {
             <p>
               If your previous upgrade application was denied, you can apply
               again, but you may have to follow a different process. Select the{' '}
-              <strong>Get Started</strong> link above. When you’re asked if
-              you’ve applied before, select <strong>Yes</strong>. After you’ve
-              answered all the questions, you’ll see application instructions
-              specific to your situation.
+              Get Started link above. When you’re asked if you’ve applied
+              before, select Yes. After you’ve answered all the questions,
+              you’ll see application instructions specific to your situation.
             </p>
             <p>
               Applying again is most likely to be successful if your application
@@ -124,12 +123,12 @@ const HomePage = ({ router, setIntroPageViewed }) => {
             <p>
               You can also apply to the Department of Defense (DOD) or the Coast
               Guard for a second DD214 only for that honorable period of
-              service. Select the <strong>Get Started</strong> link above and
-              answer the questions based on your most recent discharge. When
-              you’re asked if you completed a period of service in which your
-              character of service was honorable or general under honorable
-              conditions, select: “Yes, I completed a prior period of service,
-              but I did not receive discharge paperwork from that period.”
+              service. Select the Get Started link above and answer the
+              questions based on your most recent discharge. When you’re asked
+              if you completed a period of service in which your character of
+              service was honorable or general under honorable conditions,
+              select: “Yes, I completed a prior period of service, but I did not
+              receive discharge paperwork from that period.”
             </p>
           </va-accordion-item>
           <va-accordion-item header="What if I have a DD215 showing an upgraded discharge, but my DD214 still isn’t correct?">
@@ -143,12 +142,12 @@ const HomePage = ({ router, setIntroPageViewed }) => {
               record of their earlier characterization of discharge.
             </p>
             <p>
-              If you have a DD215 and want an updated DD214, select the{' '}
-              <strong>Get Started</strong> link above. On the next page, select:
-              “I received a discharge upgrade or correction, but my upgrade came
-              in the form of a DD215, and I want an updated DD214.” After you’ve
-              answered all the questions, you’ll see instructions for how to
-              request a new DD214.
+              If you have a DD215 and want an updated DD214, select the Get
+              Started link above. On the next page, select: “I received a
+              discharge upgrade or correction, but my upgrade came in the form
+              of a DD215, and I want an updated DD214.” After you’ve answered
+              all the questions, you’ll see instructions for how to request a
+              new DD214.
             </p>
           </va-accordion-item>
         </va-accordion>

--- a/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/v2/resultsComponents/StepOne.jsx
@@ -143,10 +143,10 @@ const StepOne = ({ formResponses }) => {
           <li>
             You can request either a Documentary Review or Personal Appearance
             Review from the Discharge Review Board (DRB). If your case is
-            especially complicated and requires detailed explanation, you{' '}
-            <strong>may</strong> have more success with a Personal Appearance
-            Review. Note that you’ll have to pay your travel costs if you make a
-            personal appearance. Documentary Reviews are generally faster, so we
+            especially complicated and requires detailed explanation, you may
+            have more success with a Personal Appearance Review. Note that
+            you’ll have to pay your travel costs if you make a personal
+            appearance. Documentary Reviews are generally faster, so we
             recommend you begin with this type of review. Also, if you’re denied
             in a Documentary Review, you can then appeal through a Personal
             Appearance Review. But you can’t request Documentary Review after a

--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -733,39 +733,31 @@ export const renderMedicalRecordInfo = formResponses => {
     if (reason === RESPONSES.REASON_PTSD) {
       providerStatement = (
         <li>
-          <strong>
-            If you’ve seen a non-VA health care provider for diagnosis or
-            treatment of PTSD or another mental health condition,
-          </strong>{' '}
-          you should also submit private medical treatment records that can
-          provide information about your condition. You’ll need to contact your
-          provider to request copies of your records.
+          If you’ve seen a non-VA health care provider for diagnosis or
+          treatment of PTSD or another mental health condition, you should also
+          submit private medical treatment records that can provide information
+          about your condition. You’ll need to contact your provider to request
+          copies of your records.
         </li>
       );
     }
     if (reason === RESPONSES.REASON_TBI) {
       providerStatement = (
         <li>
-          <strong>
-            If you’ve seen a non-VA health care provider for diagnosis or
-            treatment of TBI,
-          </strong>{' '}
-          you should also submit private medical treatment records that can
-          provide information about your condition. You’ll need to contact your
-          provider to request copies of your records.
+          If you’ve seen a non-VA health care provider for diagnosis or
+          treatment of TBI, you should also submit private medical treatment
+          records that can provide information about your condition. You’ll need
+          to contact your provider to request copies of your records.
         </li>
       );
     }
     if (reason === RESPONSES.REASON_SEXUAL_ASSAULT) {
       providerStatement = (
         <li>
-          <strong>
-            If you’ve seen a non-VA health care provider for for treatment after
-            your assault or harassment,
-          </strong>{' '}
-          you should also submit records from a non-VA health care provider.
-          You’ll need to contact your provider to request copies of your
-          records.
+          If you’ve seen a non-VA health care provider for for treatment after
+          your assault or harassment, you should also submit records from a
+          non-VA health care provider. You’ll need to contact your provider to
+          request copies of your records.
         </li>
       );
     }
@@ -776,12 +768,9 @@ export const renderMedicalRecordInfo = formResponses => {
         <ul>
           <li>You’ll need to submit copies of your medical records.</li>
           <li>
-            <strong>
-              If you need to request copies of your VA medical records,
-            </strong>{' '}
-            fill out and submit a Request for and Authorization to Release
-            Health Information (VA Form 10-5345) to your local VA medical
-            center.
+            If you need to request copies of your VA medical records, fill out
+            and submit a Request for and Authorization to Release Health
+            Information (VA Form 10-5345) to your local VA medical center.
           </li>
           <li>
             {requestQuestion}

--- a/src/applications/discharge-wizard/tests/v2/helpers/index.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/v2/helpers/index.unit.spec.js
@@ -567,6 +567,7 @@ describe('Discharge Wizard helpers', () => {
       expect(
         getByText(
           'If you’ve seen a non-VA health care provider for diagnosis or treatment of PTSD or another mental health condition,',
+          { exact: false },
         ),
       ).to.exist;
     });
@@ -582,6 +583,7 @@ describe('Discharge Wizard helpers', () => {
       expect(
         getByText(
           'If you’ve seen a non-VA health care provider for diagnosis or treatment of TBI,',
+          { exact: false },
         ),
       ).to.exist;
     });
@@ -597,6 +599,7 @@ describe('Discharge Wizard helpers', () => {
       expect(
         getByText(
           'If you’ve seen a non-VA health care provider for for treatment after your assault or harassment,',
+          { exact: false },
         ),
       ).to.exist;
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Remove bold text from various locations in DUW that are no longer needed

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20175

## Testing done
Tested all text to ensure no more bold using the flows in the ticket.

## Screenshots

**SCENARIO 1 AC:**
- [ ] The text on the Results screen, in Section 1 'Download and fill out DOD Form 293', in the second bullet has no bold text:
<img width="587" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/cea98046-3a20-41ea-a8ad-38a51cf0cb6e" />


**SCENARIO 2 AC AND ITS VARIABLES:**

_Scenario 2 AC:_
- [ ]  In the Medical Records sub-section of Step 2, second bullet's text, no text is bold:
<img width="558" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/671cc2af-0853-4624-b4c0-9db457f810aa" />


- [ ] In the Medical Records sub-section of Step 2, in the last bullet, no text in the sentence is bold (this text is specific to the PTSD answer for reason)_:
<img width="558" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/06d65956-982a-472b-b767-146d2aa016c1" />

 
_Scenario 2a AC:_
- [ ] In the Medical Records sub-section of Step 2, in the last bullet, no text in the first sentence is bold _(this text is specific to the TBI answer for reason)_:
<img width="561" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/fe00fa13-b10c-455e-a9da-34ee59614f8c" />


_Scenario 2b AC:_
- [ ] In the Medical Records sub-section of Step 2, in the last bullet, no text in the sentence is bold (this text is specific to the sexual assault or harassment answer for reason)_:
<img width="571" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/2d96f415-bff1-4ed1-807b-7f0c8adcfb5b" />


**SCENARIO 3 AC**

- [ ] There is no bold text under the second accordion : What if I already applied for an upgrade or correction and was denied? \ (e.g. Get Started and Yes are no longer bold)
<img width="582" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/485bf62b-b83f-4227-8531-2a361fd86f4d" />

- [ ] There is no bold text under the fourth accordion: What if I served honorably, but didn't receive discharge paperwork? (e.g. Get Started is no longer bold)
<img width="600" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/9f11572f-c3bc-4df8-b0a2-3987da148f72" />

- [ ] There is no bold text under the fifth accordion: What if I have a DD215 showing an upgraded discharge, but my DD214 still isn't correct? (e.g. Get Started is no longer bold)
<img width="586" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs" src="https://github.com/user-attachments/assets/e41ae086-3d5f-4435-a031-121adf29159f" />


## What areas of the site does it impact?
DUW
## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


