### PR TITLE
Add Ask Questions section to Burials Confirmation

### DIFF
--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -274,6 +274,26 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
     </>
   );
 
+  const askQuestions = (
+    <>
+      <h2>How to contact us if you have questions</h2>
+      <p>
+        Call us at <va-telephone contact="8008271000" international /> (
+        <va-telephone contact="711" tty />
+        ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+      </p>
+      <p>
+        Or you can ask us a question online through Ask VA. Select the category
+        and topic for the VA benefit this form is related to.
+      </p>
+      <va-link
+        text="Contact us online through Ask VA"
+        label="Contact us online through Ask VA"
+        href="ask.va.gov"
+      />
+    </>
+  );
+
   if (burialsConfirmationPage) {
     return (
       <ConfirmationView
@@ -298,6 +318,7 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
           item2Content={item2Content}
         />
         {submitAdditionalDocuments}
+        {askQuestions}
         <ConfirmationView.GoBackLink />
         <ConfirmationView.NeedHelp />
       </ConfirmationView>

--- a/src/applications/burials-ez/containers/ConfirmationPage.jsx
+++ b/src/applications/burials-ez/containers/ConfirmationPage.jsx
@@ -289,7 +289,7 @@ const ConfirmationPage = ({ form, isLoggedIn, route }) => {
       <va-link
         text="Contact us online through Ask VA"
         label="Contact us online through Ask VA"
-        href="ask.va.gov"
+        href="https://ask.va.gov/"
       />
     </>
   );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds a section to the Burials confirmation page explaining what to do if you have questions

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99540

## Testing done

- Verified the new section matches the wireframes and all links work as expected

## Screenshots

<img width="710" alt="Screenshot 2025-01-09 at 10 35 08 AM" src="https://github.com/user-attachments/assets/22120149-9088-4376-88f5-e52dab941dc6" />

## What areas of the site does it impact?

Burials

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

