### PR TITLE
MHV-65416 Hash only the date portion of a CVIX timestamp

### DIFF
--- a/src/applications/mhv-medical-records/tests/util/radiologyUtil.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/util/radiologyUtil.unit.spec.js
@@ -4,6 +4,7 @@ import {
   findMatchingCvixReport,
   findMatchingPhrAndCvixStudies,
   parseRadiologyReport,
+  radiologyRecordHash,
   radiologyReportsMatch,
 } from '../../util/radiologyUtil';
 
@@ -265,7 +266,7 @@ describe('findMatchingPhrAndCvixStudies', () => {
     const cvixResponse = [{ id: '12345', performedDatePrecise: 1712264604902 }];
 
     const record = await findMatchingPhrAndCvixStudies(
-      'rXXXXX-5c4d0c86',
+      'rXXXXX-4ec8b4e4',
       null,
       cvixResponse,
     );
@@ -313,5 +314,47 @@ describe('findMatchingPhrAndCvixStudies', () => {
     );
     expect(record.phrDetails).to.be.null;
     expect(record.cvixDetails).to.be.null;
+  });
+});
+
+describe('radiologyRecordHash', () => {
+  const record = {
+    procedureName: 'CT THORAX W/O CONT',
+    radiologist: 'JOHNSON,JOHN',
+    stationNumber: '660',
+  };
+
+  it('returns the different hashes for timestamps on different days', () => {
+    const record1 = {
+      ...record,
+      performedDatePrecise: 1296052117949, // January 26, 2011 9:28:37.949 AM ET
+    };
+
+    const record2 = {
+      ...record,
+      performedDatePrecise: 1296138517949, // January 27, 2011 9:28:37.949 AM ET (one day later)
+    };
+
+    const hash1 = radiologyRecordHash(record1);
+    const hash2 = radiologyRecordHash(record2);
+
+    expect(hash1).to.not.eq(hash2); // Assert that the hashes are different.
+  });
+
+  it('returns the same hash for slightly differing timestamps', () => {
+    const record1 = {
+      ...record,
+      performedDatePrecise: 1296052117949, // January 26, 2011 9:28:37.949 AM ET
+    };
+
+    const record2 = {
+      ...record,
+      performedDatePrecise: 1296052177949, // January 26, 2011 9:29:37.949 AM ET (one minute later)
+    };
+
+    const hash1 = radiologyRecordHash(record1);
+    const hash2 = radiologyRecordHash(record2);
+
+    expect(hash1).to.eq(hash2); // Assert that the hashes are the same.
   });
 });

--- a/src/applications/mhv-medical-records/util/radiologyUtil.js
+++ b/src/applications/mhv-medical-records/util/radiologyUtil.js
@@ -184,11 +184,21 @@ const generateHash = data => {
   return hash.toString(16).padStart(8, '0'); // Convert to hexadecimal, pad to 8 chars
 };
 
-export const radiologyRecordHash = async record => {
+export const radiologyRecordHash = record => {
   const { procedureName, radiologist, stationNumber } = record;
-  const date = record.eventDate || record.performedDatePrecise;
+  let date = record.eventDate || record.performedDatePrecise;
+
+  if (!Number.isNaN(Number(date))) {
+    // If the date is a timestamp, convert it to a date (with no time). This is because subsequent
+    // fetches of the same study from CVIX can have timestamps that differ by a few seconds. This
+    // ensures the hash will remain consistent across fetches.
+    const timestamp = parseInt(date, 10);
+    const dateObj = new Date(timestamp);
+    [date] = dateObj.toISOString().split('T'); // Extract the date part
+  }
+
   const dataString = `${procedureName}|${radiologist}|${stationNumber}|${date}`;
-  return (await generateHash(dataString)).substring(0, 8);
+  return generateHash(dataString).substring(0, 8);
 };
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Because the CVIX dates can vary, even for the same record, only use the date portion of the timestamp when generating a hash.

## Related issue(s)

### [MHV-65416](https://jira.devops.va.gov/browse/MHV-65416) - Backup hash ID not working for CVIX records ###

> We implemented a hash ID for radiology records due to the wipe-and-replace which can replace the underlying MHV IDs. The hash is based on some fields that are supposed to be consistent across time.
> 
> However for CVIX records, the performedDatePrecise is changing when the record is regenerated. For example, here is the value for the SAME RECORD at different times:
> 
> "performedDatePrecise":1296052133029 (January 26, 2011 9:28:53.029 AM)
> "performedDatePrecise":1296052110789 (January 26, 2011 9:28:30.789 AM)
> 
> The hash is currently generated from these fields:
> 
> constdate = record.eventDate || record.performedDatePrecise;
> constdataString = ${procedureName}|${radiologist}|${stationNumber}|${date}`;
> 
> Possible solutions, keeping in mind that it would be a very good idea to keep a date as part of the hash:
> 
> Use only the first X digits of performedDatePrecise (I'm leaning towards this option)
> Pull a date from the text blob
> 
> Acceptance Criteria:
> 
> Ensure that hashes are consistent across time, accounting for slightly different dates
> Ensure that the page displays an error if the recordDetails cannot be found. (Currently it's an infinite spinner)

## Testing done

- Added a unit test for new functionality.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
