### PR TITLE
[art/98327] - POA request details page update + mock data update

### DIFF
--- a/src/applications/accredited-representative-portal/components/POARequestCard/POARequestCard.jsx
+++ b/src/applications/accredited-representative-portal/components/POARequestCard/POARequestCard.jsx
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { differenceInDays } from 'date-fns';
-
 import {
   formatDateParsedZoneLong,
   timeFromNow,
 } from 'platform/utilities/date/index';
 
-const expiresSoon = expDate => {
-  const EXPIRES_SOON_THRESHOLD_DURATION = 7 * 24 * 60 * 60 * 1000;
+export const expiresSoon = expDate => {
+  const EXPIRES_SOON_THRESHOLD_DURATION = 7;
   const now = new Date();
   const expiresAt = new Date(expDate);
   const daysLeft = timeFromNow(expiresAt, now);
@@ -22,7 +21,35 @@ const expiresSoon = expDate => {
   return null;
 };
 
+export const formatStatus = x => {
+  if (x === 'declination') {
+    return 'Declined';
+  }
+  if (x === 'acceptance') {
+    return 'Accepted';
+  }
+  if (x === 'expiration') {
+    return 'Expired';
+  }
+  return 'Pending';
+};
+export const resolutionDate = (date, requestId) => {
+  return (
+    <span data-testid={`poa-request-card-${requestId}`}>
+      {formatDateParsedZoneLong(date)}
+    </span>
+  );
+};
 const POARequestCard = ({ poaRequest, id }) => {
+  const lastName = poaRequest?.power_of_attorney_form?.claimant?.name?.last;
+  const firstName = poaRequest?.power_of_attorney_form?.claimant?.name?.first;
+  const city = poaRequest?.power_of_attorney_form?.claimant?.address.city;
+  const state =
+    poaRequest?.power_of_attorney_form?.claimant?.address.state_code;
+  const zipCode =
+    poaRequest?.power_of_attorney_form?.claimant?.address.zip_code;
+  const poaStatus =
+    poaRequest.resolution?.decision_type || poaRequest.resolution?.type;
   return (
     <li>
       <va-card class="poa-request__card">
@@ -30,62 +57,59 @@ const POARequestCard = ({ poaRequest, id }) => {
           data-testid={`poa-request-card-${id}-status`}
           className="usa-label poa-request__card-field poa-request__card-field--status"
         >
-          {poaRequest.status}
+          {formatStatus(poaStatus)}
         </span>
-        <Link to={id}>
+        <Link to={`/poa-requests/${poaRequest.id}`}>
           <span className="sr-only">View details for </span>
           <h3
             data-testid={`poa-request-card-${id}-name`}
             className="poa-request__card-title vads-u-font-size--h4"
           >
-            {`${poaRequest.claimant.lastName}, ${
-              poaRequest.claimant.firstName
-            }`}
+            {`${lastName}, ${firstName}`}
           </h3>
         </Link>
 
         <p className="poa-request__card-field poa-request__card-field--location">
-          <span data-testid={`poa-request-card-${id}-city`}>
-            {poaRequest.claimantAddress.city}
-          </span>
+          <span data-testid={`poa-request-card-${id}-city`}>{city}</span>
           {', '}
-          <span data-testid={`poa-request-card-${id}-state`}>
-            {poaRequest.claimantAddress.state}
-          </span>
+          <span data-testid={`poa-request-card-${id}-state`}>{state}</span>
           {', '}
-          <span data-testid={`poa-request-card-${id}-zip`}>
-            {poaRequest.claimantAddress.zip}
-          </span>
+          <span data-testid={`poa-request-card-${id}-zip`}>{zipCode}</span>
         </p>
 
         <p
           data-testid="poa-request-card-field-received"
           className="poa-request__card-field poa-request__card-field--request"
         >
-          {poaRequest.status === 'Declined' && (
+          {poaStatus === 'declination' && (
             <>
               <span className="poa-request__card-field--label">
                 POA request declined on:
               </span>
-              <span data-testid={`poa-request-card-${id}-declined`}>
-                {formatDateParsedZoneLong(poaRequest.acceptedOrDeclinedAt)}
-              </span>
+              {resolutionDate(poaRequest.resolution?.created_at, id)}
             </>
           )}
-          {poaRequest.status === 'Accepted' && (
+          {poaStatus === 'acceptance' && (
             <>
               <span className="poa-request__card-field--label">
                 POA request accepted on:
               </span>
-              <span data-testid={`poa-request-card-${id}-accepted`}>
-                {formatDateParsedZoneLong(poaRequest.acceptedOrDeclinedAt)}
-              </span>
+              {resolutionDate(poaRequest.resolution?.created_at, id)}
             </>
           )}
 
-          {poaRequest.status === 'Pending' && (
+          {poaStatus === 'expiration' && (
             <>
-              {expiresSoon(poaRequest.expiresAt) && (
+              <span className="poa-request__card-field--label">
+                POA request expired on:
+              </span>
+              {resolutionDate(poaRequest.resolution?.created_at, id)}
+            </>
+          )}
+
+          {!poaRequest.resolution && (
+            <>
+              {expiresSoon(poaRequest.expires_at) && (
                 <va-icon
                   class="poa-request__card-icon"
                   icon="warning"
@@ -97,11 +121,9 @@ const POARequestCard = ({ poaRequest, id }) => {
               <span className="poa-request__card-field--label">
                 POA request expires on:
               </span>
-              <span data-testid={`poa-request-card-${id}-received`}>
-                {formatDateParsedZoneLong(poaRequest.expiresAt)}
-              </span>
+              {resolutionDate(poaRequest.expires_at, id)}
               <span className="poa-request__card-field--expiry">
-                {expiresSoon(poaRequest.expiresAt)}
+                {expiresSoon(poaRequest.expires_at)}
               </span>
             </>
           )}
@@ -113,6 +135,8 @@ const POARequestCard = ({ poaRequest, id }) => {
 
 POARequestCard.propTypes = {
   cssClass: PropTypes.string,
+  id: PropTypes.string,
+  poaRequest: PropTypes.object,
 };
 
 export default POARequestCard;

--- a/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
@@ -1,27 +1,61 @@
 import React, { useState } from 'react';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
-import { Link, useLoaderData } from 'react-router-dom';
-import { formatDateShort } from 'platform/utilities/date/index';
+import { useLoaderData } from 'react-router-dom';
 import {
   VaRadio,
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  expiresSoon,
+  formatStatus,
+  resolutionDate,
+} from '../components/POARequestCard/POARequestCard';
 import mockPOARequestsResponse from '../mocks/mockPOARequestsResponse.json';
 
-const checkAuthorizations = (
-  isTreatmentDisclosureAuthorized,
-  isAddressChangingAuthorized,
-  status,
-) => {
-  const authorizations = [];
-  if (isTreatmentDisclosureAuthorized === status) {
-    authorizations.push('Health');
-  }
+const Authorized = () => {
+  return (
+    <span>
+      <va-icon
+        icon="check_circle"
+        class="vads-u-color--success poa-request__card-icon"
+      />
+      Authorized
+    </span>
+  );
+};
 
-  if (isAddressChangingAuthorized === status) {
-    authorizations.push('Address');
+const NoAccess = () => {
+  return (
+    <span>
+      <va-icon
+        icon="warning"
+        class="vads-u-color--error poa-request__card-icon"
+      />
+      No Access
+    </span>
+  );
+};
+
+const AccessToSome = () => {
+  return (
+    <span>
+      <va-icon
+        icon="warning"
+        class="vads-u-color--error poa-request__card-icon"
+      />
+      Access to some
+    </span>
+  );
+};
+const checkAuthorizations = x => {
+  if (x) {
+    return <Authorized />;
   }
-  return authorizations.length > 0 ? authorizations.join(', ') : 'None';
+  return <NoAccess />;
+};
+const checkLimitations = (limitations, limit) => {
+  const checkLimitation = limitations.includes(limit);
+  return checkAuthorizations(checkLimitation);
 };
 
 const POARequestDetailsPage = () => {
@@ -36,207 +70,306 @@ const POARequestDetailsPage = () => {
       setError(true);
     }
   };
+
+  const poaStatus =
+    poaRequest.resolution?.decision_type ||
+    poaRequest.resolution?.type ||
+    'Pending';
+
+  const relationship =
+    poaRequest?.power_of_attorney_form.claimant?.relationship || 'Self';
+  const city =
+    poaRequest?.power_of_attorney_form.claimant?.address.city ||
+    poaRequest?.power_of_attorney_form.veteran.address.city;
+  const state =
+    poaRequest?.power_of_attorney_form.claimant?.address.state_code ||
+    poaRequest?.power_of_attorney_form.veteran.address.state_code;
+  const zipCode =
+    poaRequest?.power_of_attorney_form.claimant?.address.zip_code ||
+    poaRequest?.power_of_attorney_form.veteran.address.zip_code;
+  const phone =
+    poaRequest?.power_of_attorney_form.claimant?.phone ||
+    poaRequest?.power_of_attorney_form.veteran.phone;
+  const email =
+    poaRequest?.power_of_attorney_form.claimant?.email ||
+    poaRequest?.power_of_attorney_form.veteran.email;
+  const claimantFirstName =
+    poaRequest?.power_of_attorney_form?.claimant?.name?.first;
+  const claimantLastName =
+    poaRequest?.power_of_attorney_form?.claimant?.name?.last;
+  const recordDisclosureLimitations =
+    poaRequest.power_of_attorney_form.authorizations
+      .record_disclosure_limitations;
   return (
     <section className="poa-request-details">
-      <h1>
-        <span data-testid="poa-request-details-header">POA request:</span>
-        {poaRequest?.claimant?.firstName} {poaRequest?.claimant?.lastName}
-      </h1>
+      <h1 data-testid="poa-request-details-header">POA request</h1>
+      <h2 className="poa-request-details__name">
+        {claimantLastName}, {claimantFirstName}
+        <span
+          className={`usa-label vads-u-font-family--sans poa-request-details__status ${poaStatus}`}
+        >
+          {formatStatus(poaStatus)}
+        </span>
+      </h2>
+
+      <ul className="poa-request-details__list">
+        <li className="poa-request-details__list-item">
+          <p className="poa-request-details__title">
+            Requesting representation through
+          </p>
+          <p className="poa-request-details__subtitle">
+            {poaRequest?.power_of_attorney_holder?.name}
+          </p>
+        </li>
+        <li className="poa-request-details__list-item">
+          {poaRequest?.created_at && (
+            <>
+              <p className="poa-request-details__title">Request submitted on</p>
+              {resolutionDate(poaRequest?.created_at, poaStatus.id)}
+            </>
+          )}
+        </li>
+        <li className="poa-request-details__list-item">
+          {poaStatus === 'declination' && (
+            <>
+              <p className="poa-request-details__title">
+                POA request declined on
+              </p>
+              {resolutionDate(poaRequest.resolution?.created_at, poaStatus.id)}
+            </>
+          )}
+          {poaStatus === 'acceptance' && (
+            <>
+              <p className="poa-request-details__title">
+                <va-icon
+                  icon="check_circle"
+                  class="vads-u-color--success poa-request__card-icon"
+                />{' '}
+                POA request accepted on
+              </p>
+              {resolutionDate(poaRequest.resolution?.created_at, poaStatus.id)}
+            </>
+          )}
+          {poaStatus === 'expiration' && (
+            <>
+              <p className="poa-request-details__title">
+                <va-icon
+                  icon="warning"
+                  class="vads-u-color--error poa-request__card-icon"
+                />{' '}
+                POA request expired on
+              </p>
+              {resolutionDate(poaRequest.resolution?.created_at, poaStatus.id)}
+            </>
+          )}
+          {poaStatus === 'Pending' && (
+            <>
+              <p className="poa-request-details__title">
+                {expiresSoon(poaRequest.expires_at) && (
+                  <va-icon
+                    class="poa-request__card-icon"
+                    icon="warning"
+                    size={2}
+                    srtext="warning"
+                    aria-hidden="true"
+                  />
+                )}
+                POA request expires on
+              </p>
+              {resolutionDate(poaRequest?.expires_at, poaStatus.id)}
+            </>
+          )}
+        </li>
+      </ul>
+
       <span
         className="poa-request-details__divider"
         aria-hidden="true"
         tabIndex={-1}
       />
 
-      <h2>Veteran information</h2>
-      <ul className="poa-request-details__list">
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Name</p>
-          <p className="poa-request-details__subtitle">
-            {poaRequest?.veteran?.lastName}, {poaRequest?.veteran?.firstName}
-          </p>
-        </li>
-
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">VA file number</p>
-          <p className="poa-request-details__subtitle">xxx-xxx-1111</p>
-        </li>
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Social security number</p>
-          <p className="poa-request-details__subtitle">xxx-xx-1234</p>
-        </li>
-      </ul>
-
-      <h2>POA request information</h2>
-      <ul className="poa-request-details__list">
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">POA submission date</p>
-          <p className="poa-request-details__subtitle">
-            {poaRequest?.submittedAt &&
-              formatDateShort(poaRequest?.submittedAt)}
-          </p>
-        </li>
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">
-            {poaRequest?.status === 'Declined' && (
-              <va-icon
-                icon="close"
-                class="vads-u-color--error poa-request__card-icon"
-              />
-            )}
-            {poaRequest?.status === 'Accepted' && (
-              <va-icon
-                icon="check_circle"
-                class="vads-u-color--success poa-request__card-icon"
-              />
-            )}
-            <span>POA status</span>
-          </p>
-          <p className="poa-request-details__subtitle">{poaRequest?.status}</p>
-        </li>
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Represented through</p>
-          <p className="poa-request-details__subtitle">
-            Disabled American Veterans
-          </p>
-        </li>
-      </ul>
-
-      <h2>Claimant information</h2>
-      <ul className="poa-request-details__list">
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Claimant name</p>
-          <p className="poa-request-details__subtitle">
-            {poaRequest?.claimant.lastName}, {poaRequest?.claimant.firstName}
-          </p>
-        </li>
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Relationship to Veteran</p>
-          <p className="poa-request-details__subtitle">
-            {poaRequest?.claimant.relationshipToVeteran}
-          </p>
-        </li>
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Address</p>
-          <p className="poa-request-details__subtitle">
-            {poaRequest?.claimantAddress.city},{' '}
-            {poaRequest?.claimantAddress.state}
-            <br />
-            {poaRequest?.claimantAddress.zip}
-          </p>
-        </li>
-
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Email</p>
-          <p className="poa-request-details__subtitle">email</p>
-        </li>
-
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">Phone</p>
-          <p className="poa-request-details__subtitle">1231231234</p>
-        </li>
-      </ul>
-
-      <h2>Limitations of consent</h2>
-      <ul className="poa-request-details__list">
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">
-            <va-icon
-              icon="check_circle"
-              class="vads-u-color--success poa-request__card-icon"
-            />
-            Approves
-          </p>
-          {checkAuthorizations(
-            poaRequest?.isTreatmentDisclosureAuthorized,
-            poaRequest?.isAddressChangingAuthorized,
-            true,
+      <div className="poa-request-details__info">
+        <h2>Claimant information</h2>
+        <table className="poa-request-details__table">
+          <tr>
+            <th scope="row">Relationship to veteran</th>
+            <td>{relationship}</td>
+          </tr>
+          <tr>
+            <th scope="row">Address</th>
+            <td>
+              {city}, {state}, {zipCode}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Phone</th>
+            <td>{phone}</td>
+          </tr>
+          <tr>
+            <th scope="row">Email</th>
+            <td>{email}</td>
+          </tr>
+          {relationship === 'Self' && (
+            <>
+              <tr>
+                <th scope="row">Social security number</th>
+                <td>{poaRequest?.power_of_attorney_form?.claimant?.ssn}</td>
+              </tr>
+              <tr>
+                <th scope="row">VA file number</th>
+                <td>
+                  {poaRequest?.power_of_attorney_form?.claimant?.va_file_number}
+                </td>
+              </tr>
+            </>
           )}
-        </li>
-        <li className="poa-request-details__list-item">
-          <p className="poa-request-details__title">
-            <va-icon
-              icon="warning"
-              class="vads-u-color--error poa-request__card-icon"
-            />
-            Declines
-          </p>
+        </table>
 
-          {checkAuthorizations(
-            poaRequest?.isTreatmentDisclosureAuthorized,
-            poaRequest?.isAddressChangingAuthorized,
-            false,
-          )}
-        </li>
-      </ul>
-      <Link to="/poa-requests/">Back to power of attorney list</Link>
+        {/* if there is a claimant that is a relative/friend to the veteran, their information will populate in the previous table under claimant,
+        and the veteran information will show up here. if the veteran is filing themselves, they will appear as the claimant */}
+        {poaRequest.power_of_attorney_form.veteran && (
+          <>
+            <h2>Veteran information</h2>
+            <table className="poa-request-details__table">
+              <tr>
+                <th scope="row">Name</th>
+                <td>
+                  {poaRequest?.power_of_attorney_form?.veteran?.name?.last},{' '}
+                  {poaRequest?.power_of_attorney_form?.veteran?.name?.first}
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Social security number</th>
+                <td>{poaRequest?.power_of_attorney_form?.veteran?.ssn}</td>
+              </tr>
+              <tr>
+                <th scope="row">VA file number</th>
+                <td>
+                  {poaRequest?.power_of_attorney_form?.veteran?.va_file_number}
+                </td>
+              </tr>
+            </table>
+          </>
+        )}
 
-      <form
-        method="post"
-        className={
-          error
-            ? `poa-request-details__form poa-request-details__form--error`
-            : `poa-request-details__form`
-        }
-        onSubmit={handleChange}
-      >
-        <VaRadio
-          header-aria-describedby={null}
-          hint=""
-          label="Do you accept or decline this POA request?"
-          label-header-level="4"
-          class="poa-request-details__form-label"
-          onVaValueChange={handleChange}
-          required
-        >
-          <VaRadioOption label="I accept the request" name="group" value="1" />
-          <VaRadioOption
-            label="I decline the request, because the claimant didn't provide access to health records"
-            name="group"
-            value="2"
-          />
-          <VaRadioOption
-            label="I decline the request, because the claimant didn't allow me to change their address"
-            name="group"
-            value="3"
-          />
-          <VaRadioOption
-            label="I decline the request, because the claimant did not provide access to change address and to health records"
-            name="group"
-            value="4"
-          />
-          <VaRadioOption
-            label="I decline the request, because the VSO is not currently accepting new clients"
-            name="group"
-            value="5"
-          />
-          <VaRadioOption
-            label="I decline for another reason"
-            name="group"
-            value="6"
-            onVaValueChange={handleChange}
-          />
-        </VaRadio>
+        <h2>Authorization information</h2>
+        <table className="poa-request-details__table">
+          <tr>
+            <th scope="row">Change of address</th>
+            <td>
+              {checkAuthorizations(
+                poaRequest?.power_of_attorney_form.authorizations
+                  .address_change,
+              )}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Protected medical records</th>
+            <td>
+              {recordDisclosureLimitations.length === 0 && <NoAccess />}
+              {recordDisclosureLimitations.length < 4 &&
+                recordDisclosureLimitations.length > 0 && <AccessToSome />}
+              {recordDisclosureLimitations.length === 4 && <Authorized />}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Alcoholism or alcohol abuse records</th>
+            <td>
+              {checkLimitations(recordDisclosureLimitations, 'ALCOHOLISM')}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Drug abuse records</th>
+            <td>
+              {checkLimitations(recordDisclosureLimitations, 'DRUG_ABUSE')}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">HIV records</th>
+            <td>{checkLimitations(recordDisclosureLimitations, 'HIV')}</td>
+          </tr>
+          <tr>
+            <th scope="row">Sickle cell anemia records</th>
+            <td>
+              {checkLimitations(recordDisclosureLimitations, 'SICKLE_CELL')}
+            </td>
+          </tr>
+        </table>
 
-        <va-alert
-          status="info"
-          class="poa-request-details__form-alert"
-          visible
-          aria-live="polite"
-          slim
-        >
-          <p className="vads-u-margin-y--0">
-            We will send the claimant an email letting them know your decision.
-          </p>
-        </va-alert>
-        {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component */}
-        <button
-          type="submit"
-          className="usa-button poa-request-details__form-submit"
-        >
-          Submit decision
-        </button>
-      </form>
+        {poaStatus === 'Pending' && (
+          <form
+            method="post"
+            className={
+              error
+                ? `poa-request-details__form poa-request-details__form--error`
+                : `poa-request-details__form`
+            }
+            onSubmit={handleChange}
+          >
+            <VaRadio
+              header-aria-describedby={null}
+              hint=""
+              label="Do you accept or decline this POA request?"
+              label-header-level="4"
+              class="poa-request-details__form-label"
+              onVaValueChange={handleChange}
+              required
+            >
+              <VaRadioOption
+                label="I accept the request"
+                name="group"
+                value="1"
+              />
+              <VaRadioOption
+                label="I decline the request, because the claimant didn't provide access to health records"
+                name="group"
+                value="2"
+              />
+              <VaRadioOption
+                label="I decline the request, because the claimant didn't allow me to change their address"
+                name="group"
+                value="3"
+              />
+              <VaRadioOption
+                label="I decline the request, because the claimant did not provide access to change address and to health records"
+                name="group"
+                value="4"
+              />
+              <VaRadioOption
+                label="I decline the request, because the VSO is not currently accepting new clients"
+                name="group"
+                value="5"
+              />
+              <VaRadioOption
+                label="I decline for another reason"
+                name="group"
+                value="6"
+                onVaValueChange={handleChange}
+              />
+            </VaRadio>
+
+            <va-alert
+              status="info"
+              class="poa-request-details__form-alert"
+              visible
+              aria-live="polite"
+              slim
+            >
+              <p className="vads-u-margin-y--0">
+                We will send the claimant an email letting them know your
+                decision.
+              </p>
+            </va-alert>
+            {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component */}
+            <button
+              type="submit"
+              className="usa-button poa-request-details__form-submit"
+            >
+              Submit decision
+            </button>
+          </form>
+        )}
+      </div>
     </section>
   );
 };
@@ -254,8 +387,7 @@ export async function poaRequestLoader({ params }) {
   } catch (error) {
     // Return mock data if API fails (TODO: remove this before pilot and replace with commented throw below)
     // throwing the error will cause the app to show the error message configured in routes.jsx
-    return mockPOARequestsResponse.data.find(r => r.id === Number(id))
-      ?.attributes;
+    return mockPOARequestsResponse.data.find(r => r.id === id);
     // throw error;
   }
 }

--- a/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
@@ -125,7 +125,7 @@ const POARequestDetailsPage = () => {
           {poaRequest?.created_at && (
             <>
               <p className="poa-request-details__title">Request submitted on</p>
-              {resolutionDate(poaRequest?.created_at, poaStatus.id)}
+              {resolutionDate(poaRequest?.created_at, poaRequest.id)}
             </>
           )}
         </li>
@@ -135,7 +135,7 @@ const POARequestDetailsPage = () => {
               <p className="poa-request-details__title">
                 POA request declined on
               </p>
-              {resolutionDate(poaRequest.resolution?.created_at, poaStatus.id)}
+              {resolutionDate(poaRequest.resolution?.created_at, poaRequest.id)}
             </>
           )}
           {poaStatus === 'acceptance' && (
@@ -147,7 +147,7 @@ const POARequestDetailsPage = () => {
                 />{' '}
                 POA request accepted on
               </p>
-              {resolutionDate(poaRequest.resolution?.created_at, poaStatus.id)}
+              {resolutionDate(poaRequest.resolution?.created_at, poaRequest.id)}
             </>
           )}
           {poaStatus === 'expiration' && (
@@ -159,7 +159,7 @@ const POARequestDetailsPage = () => {
                 />{' '}
                 POA request expired on
               </p>
-              {resolutionDate(poaRequest.resolution?.created_at, poaStatus.id)}
+              {resolutionDate(poaRequest.resolution?.created_at, poaRequest.id)}
             </>
           )}
           {poaStatus === 'Pending' && (
@@ -176,7 +176,7 @@ const POARequestDetailsPage = () => {
                 )}
                 POA request expires on
               </p>
-              {resolutionDate(poaRequest?.expires_at, poaStatus.id)}
+              {resolutionDate(poaRequest?.expires_at, poaRequest.id)}
             </>
           )}
         </li>

--- a/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
@@ -32,8 +32,8 @@ const SearchResults = ({ poaRequests }) => {
       className="poa-request__list"
       sort-column={1}
     >
-      {poaRequests.map(({ id, attributes: poaRequest }) => {
-        return <POARequestCard poaRequest={poaRequest} key={id} id={id} />;
+      {poaRequests.map((request, index) => {
+        return <POARequestCard poaRequest={request} key={index} />;
       })}
     </ul>
   );
@@ -54,7 +54,6 @@ const StatusTabLink = ({ status, searchStatus, children }) => {
 const POARequestSearchPage = () => {
   const poaRequests = useLoaderData();
   const searchStatus = useSearchParams()[0].get('status');
-
   return (
     <>
       <h1 data-testid="poa-requests-heading">Power of attorney requests</h1>
@@ -123,10 +122,10 @@ export async function poaRequestsLoader({ request }) {
     // TODO: Remove mock data before pilot and uncomment throw statement
     const requests = mockPOARequestsResponse?.data?.map(req => req);
     return requests?.filter(x => {
-      if (status === 'completed') {
-        return x.attributes.status !== 'Pending';
+      if (status === 'pending') {
+        return x.resolution === null;
       }
-      return x.attributes.status === 'Pending';
+      return x.resolution !== null;
     });
     // throw error;
   }

--- a/src/applications/accredited-representative-portal/mocks/mockPOARequestsResponse.json
+++ b/src/applications/accredited-representative-portal/mocks/mockPOARequestsResponse.json
@@ -1,224 +1,5458 @@
 {
   "data": [
     {
-      "id": 12345,
-      "type": "powerOfAttorneyRequest",
-      "attributes": {
-        "status": "Declined",
-        "declinedReason": "Refused to disclose health information",
-        "powerOfAttorneyCode": "012",
-        "submittedAt": "2024-04-10T04:51:12Z",
-        "expiresAt": "2024-11-31T15:20:00Z",
-        "acceptedOrDeclinedAt": "2024-04-10T04:51:12Z",
-        "isAddressChangingAuthorized": true,
-        "isTreatmentDisclosureAuthorized": false,
-        "representative": {
-          "firstName": "John",
-          "lastName": "Smith",
-          "email": "john.smith@vsorg.org"
+      "claimant_id": "7de8ce1e-af1c-4c5d-8caf-4002593dac69",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-27T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
         },
+        "dependent": null,
         "claimant": {
-          "firstName": "Morgan",
-          "lastName": "Fox",
-          "participantId": 23456,
-          "relationshipToVeteran": "Child"
-        },
-        "claimantAddress": {
-          "city": "Baltimore",
-          "state": "MD",
-          "zip": "21218",
-          "country": "US",
-          "militaryPostOffice": null,
-          "militaryPostalCode": null
+          "name": {
+            "first": "Racquel",
+            "middle": null,
+            "last": "Cornell"
+          },
+          "address": {
+            "address_line1": "7805 Wintheiser Flats",
+            "address_line2": null,
+            "city": "Port Idella",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "21317",
+            "zip_code_suffix": null
+          },
+          "ssn": "808470130",
+          "va_file_number": "225762772",
+          "date_of_birth": "1982-03-29",
+          "service_number": "888606132",
+          "service_branch": "ARMY",
+          "phone": "(973) 688-6630",
+          "email": "rochel@deckow-bernhard.test"
         }
-      }
+      },
+      "resolution": {
+        "created_at": "2024-11-28T17:51:27.455Z",
+        "type": "expiration",
+        "id": "e35c2787-cd86-4b69-a714-707a424d70bb"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Bob Representative",
+        "id": "d9d7e941-7156-4eca-827c-bcabe731d7ea"
+      },
+      "id": "345dd27a-db3f-4e8f-8588-e0d589026e44"
     },
     {
-      "id": 67890,
-      "type": "powerOfAttorneyRequest",
-      "attributes": {
-        "status": "Pending",
-        "powerOfAttorneyCode": "034",
-        "submittedAt": "2024-03-29T15:20:00Z",
-        "expiresAt": "2024-12-07T12:15:47Z",
-        "acceptedOrDeclinedAt": null,
-        "isAddressChangingAuthorized": false,
-        "isTreatmentDisclosureAuthorized": true,
-        "representative": {
-          "firstName": "Michael",
-          "lastName": "Johnson",
-          "email": "michael.johnson@vsorg.org"
+      "claimant_id": "7de8ce1e-af1c-4c5d-8caf-4002593dac69",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-07T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
         },
+        "dependent": null,
         "claimant": {
-          "firstName": "Emily",
-          "lastName": "Wells",
-          "participantId": 56789,
-          "relationshipToVeteran": "Parent"
-        },
-        "claimantAddress": {
-          "city": "New York",
-          "state": "NY",
-          "zip": "10001",
-          "country": "US",
-          "militaryPostOffice": null,
-          "militaryPostalCode": null
+          "name": {
+            "first": "Racquel",
+            "middle": null,
+            "last": "Cornell"
+          },
+          "address": {
+            "address_line1": "7805 Wintheiser Flats",
+            "address_line2": null,
+            "city": "Port Idella",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "21317",
+            "zip_code_suffix": null
+          },
+          "ssn": "808470130",
+          "va_file_number": "225762772",
+          "date_of_birth": "1982-03-29",
+          "service_number": "888606132",
+          "service_branch": "ARMY",
+          "phone": "(973) 688-6630",
+          "email": "rochel@deckow-bernhard.test"
         }
-      }
+      },
+      "resolution": {
+        "created_at": "2024-12-08T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "37f4491b-5cf2-42b1-93c6-bc329c935c51",
+        "id": "1d86c16e-19be-4344-b4f6-06c22d9496cb"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Bob Representative",
+        "id": "d9d7e941-7156-4eca-827c-bcabe731d7ea"
+      },
+      "id": "0b255a94-b9e0-45c8-b313-3c1179178b4f"
     },
     {
-      "id": 54321,
-      "type": "powerOfAttorneyRequest",
-      "attributes": {
-        "status": "Accepted",
-        "powerOfAttorneyCode": "056",
-        "submittedAt": "2024-04-20T09:22:33Z",
-        "expiresAt": "2024-12-31T15:20:00Z",
-        "acceptedOrDeclinedAt": "2024-10-31T15:20:00Z",
-        "isAddressChangingAuthorized": true,
-        "isTreatmentDisclosureAuthorized": false,
+      "claimant_id": "7de8ce1e-af1c-4c5d-8caf-4002593dac69",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-17T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Racquel",
+            "middle": null,
+            "last": "Cornell"
+          },
+          "address": {
+            "address_line1": "7805 Wintheiser Flats",
+            "address_line2": null,
+            "city": "Port Idella",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "21317",
+            "zip_code_suffix": null
+          },
+          "ssn": "808470130",
+          "va_file_number": "225762772",
+          "date_of_birth": "1982-03-29",
+          "service_number": "888606132",
+          "service_branch": "ARMY",
+          "phone": "(973) 688-6630",
+          "email": "rochel@deckow-bernhard.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-18T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "e6438b18-28ab-43a7-854f-4c27c7daa23c",
+        "id": "7f33a272-afc8-47cc-bbaa-cf5d6771f8a1"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "521ea854-2dee-4b52-b681-401c6c8542f5"
+    },
+    {
+      "claimant_id": "3e6f543c-1d24-456e-be14-49e0a0d6eeb1",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-27T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Morgan",
+            "middle": null,
+            "last": "Tiffany"
+          },
+          "address": {
+            "address_line1": "3186 Yundt Estate",
+            "address_line2": null,
+            "city": "Erneststad",
+            "state_code": "NY",
+            "country": "US",
+            "zip_code": "10739-6818",
+            "zip_code_suffix": null
+          },
+          "ssn": "135456143",
+          "va_file_number": "193891177",
+          "date_of_birth": "1976-10-16",
+          "service_number": "333731267",
+          "service_branch": "USPHS",
+          "phone": "670-453-4163",
+          "email": "clarence.vonrueden@adams.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-28T23:51:27.455Z",
+        "type": "expiration",
+        "id": "043a6d05-549e-4a13-bb30-8cdda34b6f40"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "6cb8c41a-7ede-4124-91e3-aeb31932207a"
+    },
+    {
+      "claimant_id": "3e6f543c-1d24-456e-be14-49e0a0d6eeb1",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-07T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Morgan",
+            "middle": null,
+            "last": "Tiffany"
+          },
+          "address": {
+            "address_line1": "3186 Yundt Estate",
+            "address_line2": null,
+            "city": "Erneststad",
+            "state_code": "NY",
+            "country": "US",
+            "zip_code": "10739-6818",
+            "zip_code_suffix": null
+          },
+          "ssn": "135456143",
+          "va_file_number": "193891177",
+          "date_of_birth": "1976-10-16",
+          "service_number": "333731267",
+          "service_branch": "USPHS",
+          "phone": "670-453-4163",
+          "email": "clarence.vonrueden@adams.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-08T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "2b4a721f-0882-433f-bb51-b0f30270555e",
+        "id": "73fdf18e-6fac-44a3-9b69-0e7c3149e8d1"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "53a1c8f1-0ac2-442b-b6df-768a5324fd78"
+    },
+    {
+      "claimant_id": "3e6f543c-1d24-456e-be14-49e0a0d6eeb1",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-17T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Morgan",
+            "middle": null,
+            "last": "Tiffany"
+          },
+          "address": {
+            "address_line1": "3186 Yundt Estate",
+            "address_line2": null,
+            "city": "Erneststad",
+            "state_code": "NY",
+            "country": "US",
+            "zip_code": "10739-6818",
+            "zip_code_suffix": null
+          },
+          "ssn": "135456143",
+          "va_file_number": "193891177",
+          "date_of_birth": "1976-10-16",
+          "service_number": "333731267",
+          "service_branch": "USPHS",
+          "phone": "670-453-4163",
+          "email": "clarence.vonrueden@adams.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-18T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "f31cb32a-23bf-48ca-995a-db20e6bdf951",
+        "id": "3580e76b-33b5-408e-b925-b6c308fa0003"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "0657aca0-a8d2-4d09-bf60-114fe0fe468d"
+    },
+    {
+      "claimant_id": "1e6f8e10-3515-498c-b241-00f110ead8e3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-28T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Larhonda",
+            "middle": null,
+            "last": "Reginald"
+          },
+          "address": {
+            "address_line1": "781 Botsford Coves",
+            "address_line2": null,
+            "city": "Port Tori",
+            "state_code": "AL",
+            "country": "US",
+            "zip_code": "25448-3277",
+            "zip_code_suffix": null
+          },
+          "ssn": "600043621",
+          "va_file_number": "534553389",
+          "date_of_birth": "1999-05-24",
+          "service_number": "500280763",
+          "service_branch": "SPACE_FORCE",
+          "phone": "617 924 1842",
+          "email": "bertram@fahey-dooley.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-29T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "4778ee12-f278-42ec-ba2f-9b67542fb590",
+        "id": "bb23f046-3153-463a-bdbc-1453559df470"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "9d9f3880-5ee4-4617-a044-3b1bce8dfb83"
+    },
+    {
+      "claimant_id": "1e6f8e10-3515-498c-b241-00f110ead8e3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-08T05:51:27.455Z",
+      "expires_at": "2025-01-30T22:14:49Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Larhonda",
+            "middle": null,
+            "last": "Reginald"
+          },
+          "address": {
+            "address_line1": "781 Botsford Coves",
+            "address_line2": null,
+            "city": "Port Tori",
+            "state_code": "AL",
+            "country": "US",
+            "zip_code": "25448-3277",
+            "zip_code_suffix": null
+          },
+          "ssn": "600043621",
+          "va_file_number": "534553389",
+          "date_of_birth": "1999-05-24",
+          "service_number": "500280763",
+          "service_branch": "SPACE_FORCE",
+          "phone": "617 924 1842",
+          "email": "bertram@fahey-dooley.test"
+        }
+      },
+      "resolution": null,
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "a31040b6-0099-492a-822f-d56e0c0f4762"
+    },
+    {
+      "claimant_id": "1e6f8e10-3515-498c-b241-00f110ead8e3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-18T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Larhonda",
+            "middle": null,
+            "last": "Reginald"
+          },
+          "address": {
+            "address_line1": "781 Botsford Coves",
+            "address_line2": null,
+            "city": "Port Tori",
+            "state_code": "AL",
+            "country": "US",
+            "zip_code": "25448-3277",
+            "zip_code_suffix": null
+          },
+          "ssn": "600043621",
+          "va_file_number": "534553389",
+          "date_of_birth": "1999-05-24",
+          "service_number": "500280763",
+          "service_branch": "SPACE_FORCE",
+          "phone": "617 924 1842",
+          "email": "bertram@fahey-dooley.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-19T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "220b19a7-7d1d-4343-983f-ebc1d3b0d9a7",
+        "id": "b59e41fe-81c2-4080-accf-f82de35945b1"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "f09dd1b1-a4ef-42a4-82da-055f36ffb410"
+    },
+    {
+      "claimant_id": "fe09af3c-d408-40b2-88e4-b3d78d05a88b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-28T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jonathan",
+            "middle": null,
+            "last": "Renaldo"
+          },
+          "address": {
+            "address_line1": "4327 Renato Harbor",
+            "address_line2": null,
+            "city": "East Jonie",
+            "state_code": "CA",
+            "country": "US",
+            "zip_code": "11172",
+            "zip_code_suffix": null
+          },
+          "ssn": "489185725",
+          "va_file_number": "858003927",
+          "date_of_birth": "1937-07-21",
+          "service_number": "686539598",
+          "service_branch": "NOAA",
+          "phone": "734-623-4085",
+          "email": "della@schulist.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-29T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "c82978e1-9140-4262-9f05-e5cdfd5f8305",
+        "id": "68ed3374-0c87-4a4f-bb9a-64766af03fbd"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "3f087751-8938-4215-b8dc-ab67cf729ad1"
+    },
+    {
+      "claimant_id": "fe09af3c-d408-40b2-88e4-b3d78d05a88b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-08T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jonathan",
+            "middle": null,
+            "last": "Renaldo"
+          },
+          "address": {
+            "address_line1": "4327 Renato Harbor",
+            "address_line2": null,
+            "city": "East Jonie",
+            "state_code": "CA",
+            "country": "US",
+            "zip_code": "11172",
+            "zip_code_suffix": null
+          },
+          "ssn": "489185725",
+          "va_file_number": "858003927",
+          "date_of_birth": "1937-07-21",
+          "service_number": "686539598",
+          "service_branch": "NOAA",
+          "phone": "734-623-4085",
+          "email": "della@schulist.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-09T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "66c9c4c1-c8b9-4683-94a6-355aea18e475",
+        "id": "bb8fc6c5-a310-4e4c-983f-4a083cd8e75e"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "b9bebdd0-2723-49ad-b809-60ae19264d14"
+    },
+    {
+      "claimant_id": "fe09af3c-d408-40b2-88e4-b3d78d05a88b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-18T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jonathan",
+            "middle": null,
+            "last": "Renaldo"
+          },
+          "address": {
+            "address_line1": "4327 Renato Harbor",
+            "address_line2": null,
+            "city": "East Jonie",
+            "state_code": "CA",
+            "country": "US",
+            "zip_code": "11172",
+            "zip_code_suffix": null
+          },
+          "ssn": "489185725",
+          "va_file_number": "858003927",
+          "date_of_birth": "1937-07-21",
+          "service_number": "686539598",
+          "service_branch": "NOAA",
+          "phone": "734-623-4085",
+          "email": "della@schulist.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-19T11:51:27.455Z",
+        "type": "expiration",
+        "id": "7c9b6720-b7c0-4eaa-9024-2da3759b1cbc"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "28e253a5-9355-4e05-9a84-c8c37c9cf78d"
+    },
+    {
+      "claimant_id": "8da29bdb-29e3-4b8a-a462-e640d34fdc76",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-28T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Shu",
+            "middle": null,
+            "last": "Liberty"
+          },
+          "address": {
+            "address_line1": "71616 Wintheiser Spring",
+            "address_line2": null,
+            "city": "Lake Yesenia",
+            "state_code": "CT",
+            "country": "US",
+            "zip_code": "54601",
+            "zip_code_suffix": null
+          },
+          "ssn": "737011798",
+          "va_file_number": "892801527",
+          "date_of_birth": "1989-09-14",
+          "service_number": "657761640",
+          "service_branch": "SPACE_FORCE",
+          "phone": "(164) 599 8240",
+          "email": "amanda_white@lang-krajcik.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-29T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "a2ef7fa9-b350-48bb-b64f-8fd15db8d2a9",
+        "id": "d206fdf1-f407-4277-b7e7-6bfa7d311bba"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "1c3d503b-9f18-4eba-828f-dcba2a1d2047"
+    },
+    {
+      "claimant_id": "8da29bdb-29e3-4b8a-a462-e640d34fdc76",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-08T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Shu",
+            "middle": null,
+            "last": "Liberty"
+          },
+          "address": {
+            "address_line1": "71616 Wintheiser Spring",
+            "address_line2": null,
+            "city": "Lake Yesenia",
+            "state_code": "CT",
+            "country": "US",
+            "zip_code": "54601",
+            "zip_code_suffix": null
+          },
+          "ssn": "737011798",
+          "va_file_number": "892801527",
+          "date_of_birth": "1989-09-14",
+          "service_number": "657761640",
+          "service_branch": "SPACE_FORCE",
+          "phone": "(164) 599 8240",
+          "email": "amanda_white@lang-krajcik.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-09T17:51:27.455Z",
+        "type": "expiration",
+        "id": "30f75114-217b-47d7-b6ff-9f79b487ce95"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "c4e49da5-20bc-4ed3-80fa-e3f2540e1c8e"
+    },
+    {
+      "claimant_id": "8da29bdb-29e3-4b8a-a462-e640d34fdc76",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-18T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Shu",
+            "middle": null,
+            "last": "Liberty"
+          },
+          "address": {
+            "address_line1": "71616 Wintheiser Spring",
+            "address_line2": null,
+            "city": "Lake Yesenia",
+            "state_code": "CT",
+            "country": "US",
+            "zip_code": "54601",
+            "zip_code_suffix": null
+          },
+          "ssn": "737011798",
+          "va_file_number": "892801527",
+          "date_of_birth": "1989-09-14",
+          "service_number": "657761640",
+          "service_branch": "SPACE_FORCE",
+          "phone": "(164) 599 8240",
+          "email": "amanda_white@lang-krajcik.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-19T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "f5794e56-aa4f-400c-bd7d-b54354465bc0",
+        "id": "d081bce6-9961-4371-8c68-f777a418a93b"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Odis Cruickshank",
+        "id": "96dc6994-1949-4f83-a6ad-a3bd9fd728e0"
+      },
+      "id": "83326cd5-c349-4939-a4da-ef58f5d8932f"
+    },
+    {
+      "claimant_id": "dfe94d0f-4c19-4105-9bf3-eec850b651ac",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-28T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Felton",
+            "middle": null,
+            "last": "Dena"
+          },
+          "address": {
+            "address_line1": "725 Schinner Lights",
+            "address_line2": null,
+            "city": "Micahberg",
+            "state_code": "VA",
+            "country": "US",
+            "zip_code": "66449",
+            "zip_code_suffix": null
+          },
+          "ssn": "656313470",
+          "va_file_number": "892297030",
+          "date_of_birth": "1944-03-17",
+          "service_number": "237139754",
+          "service_branch": "COAST_GUARD",
+          "phone": "248.373.6401",
+          "email": "gilberto@shields.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-29T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "9345f892-e779-456b-aa92-fa4d4bd10996",
+        "id": "db517993-9927-4e85-9fc8-66034db9bf1b"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Odis Cruickshank",
+        "id": "96dc6994-1949-4f83-a6ad-a3bd9fd728e0"
+      },
+      "id": "f854d559-325c-4134-8faa-505c0a234b85"
+    },
+    {
+      "claimant_id": "dfe94d0f-4c19-4105-9bf3-eec850b651ac",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-08T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Felton",
+            "middle": null,
+            "last": "Dena"
+          },
+          "address": {
+            "address_line1": "725 Schinner Lights",
+            "address_line2": null,
+            "city": "Micahberg",
+            "state_code": "VA",
+            "country": "US",
+            "zip_code": "66449",
+            "zip_code_suffix": null
+          },
+          "ssn": "656313470",
+          "va_file_number": "892297030",
+          "date_of_birth": "1944-03-17",
+          "service_number": "237139754",
+          "service_branch": "COAST_GUARD",
+          "phone": "248.373.6401",
+          "email": "gilberto@shields.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-09T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "52ad4c63-e141-4cac-a1ca-24f854f9421f",
+        "id": "9d7de606-6d13-4c39-a56b-6ccfc504c2e5"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Catheryn Baumbach",
+        "id": "3205b046-ee94-4b3f-8ef5-f081b4f60e79"
+      },
+      "id": "62dff33f-239e-4f75-b895-6b3540306cfb"
+    },
+    {
+      "claimant_id": "dfe94d0f-4c19-4105-9bf3-eec850b651ac",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-18T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Felton",
+            "middle": null,
+            "last": "Dena"
+          },
+          "address": {
+            "address_line1": "725 Schinner Lights",
+            "address_line2": null,
+            "city": "Micahberg",
+            "state_code": "VA",
+            "country": "US",
+            "zip_code": "66449",
+            "zip_code_suffix": null
+          },
+          "ssn": "656313470",
+          "va_file_number": "892297030",
+          "date_of_birth": "1944-03-17",
+          "service_number": "237139754",
+          "service_branch": "COAST_GUARD",
+          "phone": "248.373.6401",
+          "email": "gilberto@shields.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-19T23:51:27.455Z",
+        "type": "expiration",
+        "id": "db5cdefc-3447-46ca-9a92-9613db988103"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Erica Representative",
+        "id": "c50410bb-7341-4d95-9a2f-aed22178ff08"
+      },
+      "id": "824c5ddc-be9a-4fdb-9bf9-b0a2fc07aa11"
+    },
+    {
+      "claimant_id": "6f1c7f54-46ce-4336-9c4e-103263457cf5",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-29T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Melanie",
+            "middle": null,
+            "last": "Sean"
+          },
+          "address": {
+            "address_line1": "1500 Hirthe Pass",
+            "address_line2": null,
+            "city": "Wilburnton",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "12480-3163",
+            "zip_code_suffix": null
+          },
+          "ssn": "655065659",
+          "va_file_number": "312739227",
+          "date_of_birth": "1978-08-10",
+          "service_number": "481431002",
+          "service_branch": "COAST_GUARD",
+          "phone": "941 589 2434",
+          "email": "theron.goodwin@welch-oberbrunner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-30T05:51:27.455Z",
+        "type": "expiration",
+        "id": "504dfd79-314a-462c-b317-c51c5651739f"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Erica Representative",
+        "id": "c50410bb-7341-4d95-9a2f-aed22178ff08"
+      },
+      "id": "87c21b4f-1354-4357-bef9-2878ebb9891e"
+    },
+    {
+      "claimant_id": "6f1c7f54-46ce-4336-9c4e-103263457cf5",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-09T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Melanie",
+            "middle": null,
+            "last": "Sean"
+          },
+          "address": {
+            "address_line1": "1500 Hirthe Pass",
+            "address_line2": null,
+            "city": "Wilburnton",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "12480-3163",
+            "zip_code_suffix": null
+          },
+          "ssn": "655065659",
+          "va_file_number": "312739227",
+          "date_of_birth": "1978-08-10",
+          "service_number": "481431002",
+          "service_branch": "COAST_GUARD",
+          "phone": "941 589 2434",
+          "email": "theron.goodwin@welch-oberbrunner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-10T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "cb30657e-8480-43f8-b67b-07c9c1194877",
+        "id": "192d092d-7424-4f2e-9e31-81bc619abaa1"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "c15725e4-dad7-4f31-86b2-59d86a789fbd"
+    },
+    {
+      "claimant_id": "6f1c7f54-46ce-4336-9c4e-103263457cf5",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-19T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Melanie",
+            "middle": null,
+            "last": "Sean"
+          },
+          "address": {
+            "address_line1": "1500 Hirthe Pass",
+            "address_line2": null,
+            "city": "Wilburnton",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "12480-3163",
+            "zip_code_suffix": null
+          },
+          "ssn": "655065659",
+          "va_file_number": "312739227",
+          "date_of_birth": "1978-08-10",
+          "service_number": "481431002",
+          "service_branch": "COAST_GUARD",
+          "phone": "941 589 2434",
+          "email": "theron.goodwin@welch-oberbrunner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-20T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "8d51dad0-7e15-403b-8a91-7396aeda9a69",
+        "id": "8fea7314-ea5f-44d5-9001-7ed528c97676"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "6bbce2ba-11db-4896-a4a2-d73284281758"
+    },
+    {
+      "claimant_id": "77d8f6f9-326d-4304-a61c-f74f68f2d533",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-29T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Huey",
+            "middle": null,
+            "last": "Mindy"
+          },
+          "address": {
+            "address_line1": "4283 Moore Ford",
+            "address_line2": null,
+            "city": "North Dannieland",
+            "state_code": "WY",
+            "country": "US",
+            "zip_code": "98421-4418",
+            "zip_code_suffix": null
+          },
+          "ssn": "673777761",
+          "va_file_number": "841860726",
+          "date_of_birth": "1994-08-16",
+          "service_number": "100838830",
+          "service_branch": "AIR_FORCE",
+          "phone": "928.687.9286",
+          "email": "calvin@goodwin-collier.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-30T11:51:27.455Z",
+        "type": "expiration",
+        "id": "d3b90d0f-fbbe-4b62-9158-3980bcfd1240"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "15c5cdb4-1689-4def-b7f6-0f7134a081b2"
+    },
+    {
+      "claimant_id": "77d8f6f9-326d-4304-a61c-f74f68f2d533",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-09T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Huey",
+            "middle": null,
+            "last": "Mindy"
+          },
+          "address": {
+            "address_line1": "4283 Moore Ford",
+            "address_line2": null,
+            "city": "North Dannieland",
+            "state_code": "WY",
+            "country": "US",
+            "zip_code": "98421-4418",
+            "zip_code_suffix": null
+          },
+          "ssn": "673777761",
+          "va_file_number": "841860726",
+          "date_of_birth": "1994-08-16",
+          "service_number": "100838830",
+          "service_branch": "AIR_FORCE",
+          "phone": "928.687.9286",
+          "email": "calvin@goodwin-collier.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-10T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "2b56871b-b95a-4cb2-ae77-ea9bbabe44e7",
+        "id": "31586c78-0fcc-4cdd-8f79-b304b56e80a1"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "7942b09f-b05a-4a43-81d6-11d32a40538b"
+    },
+    {
+      "claimant_id": "77d8f6f9-326d-4304-a61c-f74f68f2d533",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-19T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Huey",
+            "middle": null,
+            "last": "Mindy"
+          },
+          "address": {
+            "address_line1": "4283 Moore Ford",
+            "address_line2": null,
+            "city": "North Dannieland",
+            "state_code": "WY",
+            "country": "US",
+            "zip_code": "98421-4418",
+            "zip_code_suffix": null
+          },
+          "ssn": "673777761",
+          "va_file_number": "841860726",
+          "date_of_birth": "1994-08-16",
+          "service_number": "100838830",
+          "service_branch": "AIR_FORCE",
+          "phone": "928.687.9286",
+          "email": "calvin@goodwin-collier.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-20T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "fed38d16-fb4b-4265-8158-b586649b0089",
+        "id": "2db70845-c3dd-41e8-b860-413c7c1dcfbd"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Eric Good",
+        "id": "c3063f49-f751-4b94-9d18-4a98f08c2926"
+      },
+      "id": "257656df-41d3-4077-a73e-ada9b5d34b3f"
+    },
+    {
+      "claimant_id": "04f6698b-68c8-40ff-ab82-07899e09eaa8",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-29T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Gerry",
+            "middle": null,
+            "last": "Kennith"
+          },
+          "address": {
+            "address_line1": "643 Batz Knoll",
+            "address_line2": null,
+            "city": "Mosestown",
+            "state_code": "MA",
+            "country": "US",
+            "zip_code": "17905",
+            "zip_code_suffix": null
+          },
+          "ssn": "519730202",
+          "va_file_number": "589665114",
+          "date_of_birth": "1930-12-25",
+          "service_number": "260914234",
+          "service_branch": "SPACE_FORCE",
+          "phone": "546.710.4433",
+          "email": "lang@pfeffer-bergnaum.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-30T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "a43fc36a-91da-4714-b55f-06e9db2bf98e",
+        "id": "a09ef9df-7b73-45f1-9e1f-edde72c4ef0f"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Eric Good",
+        "id": "c3063f49-f751-4b94-9d18-4a98f08c2926"
+      },
+      "id": "e31ade63-11ae-4fde-ba97-7db1c94642fc"
+    },
+    {
+      "claimant_id": "04f6698b-68c8-40ff-ab82-07899e09eaa8",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-09T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Gerry",
+            "middle": null,
+            "last": "Kennith"
+          },
+          "address": {
+            "address_line1": "643 Batz Knoll",
+            "address_line2": null,
+            "city": "Mosestown",
+            "state_code": "MA",
+            "country": "US",
+            "zip_code": "17905",
+            "zip_code_suffix": null
+          },
+          "ssn": "519730202",
+          "va_file_number": "589665114",
+          "date_of_birth": "1930-12-25",
+          "service_number": "260914234",
+          "service_branch": "SPACE_FORCE",
+          "phone": "546.710.4433",
+          "email": "lang@pfeffer-bergnaum.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-10T17:51:27.455Z",
+        "type": "expiration",
+        "id": "ba6ebc78-d4ac-46d4-b97a-0efbc46bc2a5"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "4a7024c3-71e6-4fc3-8346-e44bb6dcd57b"
+    },
+    {
+      "claimant_id": "04f6698b-68c8-40ff-ab82-07899e09eaa8",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-19T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Gerry",
+            "middle": null,
+            "last": "Kennith"
+          },
+          "address": {
+            "address_line1": "643 Batz Knoll",
+            "address_line2": null,
+            "city": "Mosestown",
+            "state_code": "MA",
+            "country": "US",
+            "zip_code": "17905",
+            "zip_code_suffix": null
+          },
+          "ssn": "519730202",
+          "va_file_number": "589665114",
+          "date_of_birth": "1930-12-25",
+          "service_number": "260914234",
+          "service_branch": "SPACE_FORCE",
+          "phone": "546.710.4433",
+          "email": "lang@pfeffer-bergnaum.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-20T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "c29826eb-1332-41d0-be0a-f0bb2093972c",
+        "id": "96d40621-cc5f-4c54-ae82-5826ff51f95a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "1af6f9fe-0650-41bc-a068-2d35e201b414"
+    },
+    {
+      "claimant_id": "7f26a96a-713c-4780-befe-339b30c98ba9",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-29T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Gustavo",
+            "middle": null,
+            "last": "Bryon"
+          },
+          "address": {
+            "address_line1": "90135 Morton Fork",
+            "address_line2": null,
+            "city": "New Angelena",
+            "state_code": "MO",
+            "country": "US",
+            "zip_code": "24490",
+            "zip_code_suffix": null
+          },
+          "ssn": "970026581",
+          "va_file_number": "555718456",
+          "date_of_birth": "1962-02-16",
+          "service_number": "601724237",
+          "service_branch": "USPHS",
+          "phone": "728 550 4054",
+          "email": "myron_schoen@hintz-mills.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-11-30T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "8d0dc5bc-cdf6-4f54-878e-52b6dfa92ad0",
+        "id": "c3d3eb44-9c0e-4ad6-8839-78d983bb7d0e"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "b8aaabfe-4594-4944-92b2-2bb9d60f5296"
+    },
+    {
+      "claimant_id": "7f26a96a-713c-4780-befe-339b30c98ba9",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-09T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Gustavo",
+            "middle": null,
+            "last": "Bryon"
+          },
+          "address": {
+            "address_line1": "90135 Morton Fork",
+            "address_line2": null,
+            "city": "New Angelena",
+            "state_code": "MO",
+            "country": "US",
+            "zip_code": "24490",
+            "zip_code_suffix": null
+          },
+          "ssn": "970026581",
+          "va_file_number": "555718456",
+          "date_of_birth": "1962-02-16",
+          "service_number": "601724237",
+          "service_branch": "USPHS",
+          "phone": "728 550 4054",
+          "email": "myron_schoen@hintz-mills.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-10T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "1cc5daa6-74f3-474c-beb7-5001e636ca69",
+        "id": "3975abe6-f0a0-4ebc-9255-84897b7870c6"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "cad1914b-9069-4765-bf19-2e75505ed566"
+    },
+    {
+      "claimant_id": "7f26a96a-713c-4780-befe-339b30c98ba9",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-19T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Gustavo",
+            "middle": null,
+            "last": "Bryon"
+          },
+          "address": {
+            "address_line1": "90135 Morton Fork",
+            "address_line2": null,
+            "city": "New Angelena",
+            "state_code": "MO",
+            "country": "US",
+            "zip_code": "24490",
+            "zip_code_suffix": null
+          },
+          "ssn": "970026581",
+          "va_file_number": "555718456",
+          "date_of_birth": "1962-02-16",
+          "service_number": "601724237",
+          "service_branch": "USPHS",
+          "phone": "728 550 4054",
+          "email": "myron_schoen@hintz-mills.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-20T23:51:27.455Z",
+        "type": "expiration",
+        "id": "c14fd0a2-4520-4b6e-9236-b65072cf1c79"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "2cff8566-e385-49ac-a031-a08da90bd6ff"
+    },
+    {
+      "claimant_id": "9c86e2f5-a4de-4b91-8822-66ccf560db7b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-30T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Joel",
+            "middle": null,
+            "last": "Tyson"
+          },
+          "address": {
+            "address_line1": "58702 Hermann Stream",
+            "address_line2": null,
+            "city": "Weberfort",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "64617",
+            "zip_code_suffix": null
+          },
+          "ssn": "521084792",
+          "va_file_number": "366848431",
+          "date_of_birth": "1986-05-04",
+          "service_number": "710659117",
+          "service_branch": "ARMY",
+          "phone": "382-704-9759",
+          "email": "jospeh_cummings@rath.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-01T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "a6f6dadb-9acd-4f49-b4aa-935e17209965",
+        "id": "f44466c1-479c-4768-977e-6d96da8d3fcf"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "890e1aa6-22dd-4742-879b-a5b421fc3323"
+    },
+    {
+      "claimant_id": "9c86e2f5-a4de-4b91-8822-66ccf560db7b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-10T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Joel",
+            "middle": null,
+            "last": "Tyson"
+          },
+          "address": {
+            "address_line1": "58702 Hermann Stream",
+            "address_line2": null,
+            "city": "Weberfort",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "64617",
+            "zip_code_suffix": null
+          },
+          "ssn": "521084792",
+          "va_file_number": "366848431",
+          "date_of_birth": "1986-05-04",
+          "service_number": "710659117",
+          "service_branch": "ARMY",
+          "phone": "382-704-9759",
+          "email": "jospeh_cummings@rath.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-11T05:51:27.455Z",
+        "type": "expiration",
+        "id": "f6026b2e-316b-4e06-a4b4-8a444847ac64"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "67e0feca-4029-448f-b2c3-4fd48a548434"
+    },
+    {
+      "claimant_id": "9c86e2f5-a4de-4b91-8822-66ccf560db7b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-20T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Joel",
+            "middle": null,
+            "last": "Tyson"
+          },
+          "address": {
+            "address_line1": "58702 Hermann Stream",
+            "address_line2": null,
+            "city": "Weberfort",
+            "state_code": "IA",
+            "country": "US",
+            "zip_code": "64617",
+            "zip_code_suffix": null
+          },
+          "ssn": "521084792",
+          "va_file_number": "366848431",
+          "date_of_birth": "1986-05-04",
+          "service_number": "710659117",
+          "service_branch": "ARMY",
+          "phone": "382-704-9759",
+          "email": "jospeh_cummings@rath.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-21T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "85285d28-1505-41fc-931e-022c39a9d15f",
+        "id": "4bac54d9-c716-4233-910f-f8b724a4ee17"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "9a0ab6dc-4941-41c5-b3d4-a145cef73656"
+    },
+    {
+      "claimant_id": "3a764877-02b3-4b8d-b5e7-66204ef67cc3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-30T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Tajuana",
+            "middle": null,
+            "last": "Hallie"
+          },
+          "address": {
+            "address_line1": "7902 Bogan Forks",
+            "address_line2": null,
+            "city": "New Vitostad",
+            "state_code": "MI",
+            "country": "US",
+            "zip_code": "37893-7920",
+            "zip_code_suffix": null
+          },
+          "ssn": "378410967",
+          "va_file_number": "211264946",
+          "date_of_birth": "1962-12-04",
+          "service_number": "912417854",
+          "service_branch": "MARINE_CORPS",
+          "phone": "953-642-9866",
+          "email": "delbert@reynolds.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-01T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "9fa7faee-9543-46cb-9ada-2e5be2cb8706",
+        "id": "031fc9a1-e6b9-4e2c-a23a-6aceadabb693"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "a03b20ce-12bd-47af-bd31-a39e5a00cf48"
+    },
+    {
+      "claimant_id": "3a764877-02b3-4b8d-b5e7-66204ef67cc3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-10T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Tajuana",
+            "middle": null,
+            "last": "Hallie"
+          },
+          "address": {
+            "address_line1": "7902 Bogan Forks",
+            "address_line2": null,
+            "city": "New Vitostad",
+            "state_code": "MI",
+            "country": "US",
+            "zip_code": "37893-7920",
+            "zip_code_suffix": null
+          },
+          "ssn": "378410967",
+          "va_file_number": "211264946",
+          "date_of_birth": "1962-12-04",
+          "service_number": "912417854",
+          "service_branch": "MARINE_CORPS",
+          "phone": "953-642-9866",
+          "email": "delbert@reynolds.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-11T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "7711057c-320e-4413-a618-b99904b72298",
+        "id": "4671f063-4e2e-4375-b310-6053d3850865"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "968db5ff-78c5-4ac0-820c-53df32ef399f"
+    },
+    {
+      "claimant_id": "3a764877-02b3-4b8d-b5e7-66204ef67cc3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-20T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Tajuana",
+            "middle": null,
+            "last": "Hallie"
+          },
+          "address": {
+            "address_line1": "7902 Bogan Forks",
+            "address_line2": null,
+            "city": "New Vitostad",
+            "state_code": "MI",
+            "country": "US",
+            "zip_code": "37893-7920",
+            "zip_code_suffix": null
+          },
+          "ssn": "378410967",
+          "va_file_number": "211264946",
+          "date_of_birth": "1962-12-04",
+          "service_number": "912417854",
+          "service_branch": "MARINE_CORPS",
+          "phone": "953-642-9866",
+          "email": "delbert@reynolds.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-21T11:51:27.455Z",
+        "type": "expiration",
+        "id": "a2946a83-9793-44a7-b536-4dcabfeb5ede"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Horacio Schultz",
+        "id": "0ea9df23-a0b9-42bc-9629-b6ad66704825"
+      },
+      "id": "7169b6ca-fc68-4b29-9520-d6ce3196a094"
+    },
+    {
+      "claimant_id": "ca2ec8b1-0733-42eb-9e10-6a5ff2c077e2",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-30T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Veda",
+            "middle": null,
+            "last": "Cliff"
+          },
+          "address": {
+            "address_line1": "84966 Adan Flat",
+            "address_line2": null,
+            "city": "North Louisaville",
+            "state_code": "MT",
+            "country": "US",
+            "zip_code": "17209",
+            "zip_code_suffix": null
+          },
+          "ssn": "680787975",
+          "va_file_number": "174394713",
+          "date_of_birth": "1935-07-02",
+          "service_number": "680109330",
+          "service_branch": "AIR_FORCE",
+          "phone": "(673) 952-9279",
+          "email": "wilbert@okuneva.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-01T17:51:27.455Z",
+        "type": "expiration",
+        "id": "d9d1e634-44ab-4c8b-8118-208ffdccb871"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Horacio Schultz",
+        "id": "0ea9df23-a0b9-42bc-9629-b6ad66704825"
+      },
+      "id": "4dd04d51-1ba3-4e03-b60b-590c80b5b1c9"
+    },
+    {
+      "claimant_id": "ca2ec8b1-0733-42eb-9e10-6a5ff2c077e2",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-10T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Veda",
+            "middle": null,
+            "last": "Cliff"
+          },
+          "address": {
+            "address_line1": "84966 Adan Flat",
+            "address_line2": null,
+            "city": "North Louisaville",
+            "state_code": "MT",
+            "country": "US",
+            "zip_code": "17209",
+            "zip_code_suffix": null
+          },
+          "ssn": "680787975",
+          "va_file_number": "174394713",
+          "date_of_birth": "1935-07-02",
+          "service_number": "680109330",
+          "service_branch": "AIR_FORCE",
+          "phone": "(673) 952-9279",
+          "email": "wilbert@okuneva.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-11T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "777c3ad5-977b-4327-94c4-201b904d344c",
+        "id": "a56f2848-8663-446e-820a-aec6b41962cd"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Bob Representative",
+        "id": "d9d7e941-7156-4eca-827c-bcabe731d7ea"
+      },
+      "id": "6d4fcfb0-84d6-4d71-b2d4-9507e87c81f0"
+    },
+    {
+      "claimant_id": "ca2ec8b1-0733-42eb-9e10-6a5ff2c077e2",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-20T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Veda",
+            "middle": null,
+            "last": "Cliff"
+          },
+          "address": {
+            "address_line1": "84966 Adan Flat",
+            "address_line2": null,
+            "city": "North Louisaville",
+            "state_code": "MT",
+            "country": "US",
+            "zip_code": "17209",
+            "zip_code_suffix": null
+          },
+          "ssn": "680787975",
+          "va_file_number": "174394713",
+          "date_of_birth": "1935-07-02",
+          "service_number": "680109330",
+          "service_branch": "AIR_FORCE",
+          "phone": "(673) 952-9279",
+          "email": "wilbert@okuneva.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-21T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "0d0e96d7-4274-4311-bf66-3b8b2e5f45fc",
+        "id": "3c5bd5c5-91f8-4bfc-a16f-215e6fcc72ae"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Bob Representative",
+        "id": "d9d7e941-7156-4eca-827c-bcabe731d7ea"
+      },
+      "id": "ad59327d-0976-41b7-8d94-b4becdc5d4bf"
+    },
+    {
+      "claimant_id": "09d1b85a-8e1b-48b3-b16c-b6b6d1fc8521",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-11-30T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Lino",
+            "middle": null,
+            "last": "Walker"
+          },
+          "address": {
+            "address_line1": "487 Mante Forge",
+            "address_line2": null,
+            "city": "New Jeramy",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "95451-6458",
+            "zip_code_suffix": null
+          },
+          "ssn": "752707017",
+          "va_file_number": "955609588",
+          "date_of_birth": "1942-02-28",
+          "service_number": "436504500",
+          "service_branch": "AIR_FORCE",
+          "phone": "838-983-5363",
+          "email": "roman.runte@roob-corwin.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-01T23:51:27.455Z",
+        "type": "expiration",
+        "id": "7722230f-606b-4e3b-830e-86d54d020407"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "4b48bfc3-2ba7-427d-ac14-70da34bf44fd"
+    },
+    {
+      "claimant_id": "09d1b85a-8e1b-48b3-b16c-b6b6d1fc8521",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-10T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Lino",
+            "middle": null,
+            "last": "Walker"
+          },
+          "address": {
+            "address_line1": "487 Mante Forge",
+            "address_line2": null,
+            "city": "New Jeramy",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "95451-6458",
+            "zip_code_suffix": null
+          },
+          "ssn": "752707017",
+          "va_file_number": "955609588",
+          "date_of_birth": "1942-02-28",
+          "service_number": "436504500",
+          "service_branch": "AIR_FORCE",
+          "phone": "838-983-5363",
+          "email": "roman.runte@roob-corwin.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-11T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "d018a5a0-48a7-487f-bfa8-6516ee40549e",
+        "id": "003f2b94-74be-452b-9684-ab08a0bffe12"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "4b83510c-06a9-4149-8440-e00c532c5b7a"
+    },
+    {
+      "claimant_id": "09d1b85a-8e1b-48b3-b16c-b6b6d1fc8521",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-20T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Lino",
+            "middle": null,
+            "last": "Walker"
+          },
+          "address": {
+            "address_line1": "487 Mante Forge",
+            "address_line2": null,
+            "city": "New Jeramy",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "95451-6458",
+            "zip_code_suffix": null
+          },
+          "ssn": "752707017",
+          "va_file_number": "955609588",
+          "date_of_birth": "1942-02-28",
+          "service_number": "436504500",
+          "service_branch": "AIR_FORCE",
+          "phone": "838-983-5363",
+          "email": "roman.runte@roob-corwin.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-21T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "c6a5988e-7f8d-4d1a-b10a-7e03559e01c4",
+        "id": "26803260-6a2a-4203-960d-e30b4af64bfc"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "bb2631d2-56c2-4f7d-a8a9-851c020193bd"
+    },
+    {
+      "claimant_id": "6febeedd-a134-4317-85d1-3bad378de80e",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-01T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Larissa",
+            "middle": null,
+            "last": "Darlene"
+          },
+          "address": {
+            "address_line1": "515 Rigoberto Ridge",
+            "address_line2": null,
+            "city": "Tyrellport",
+            "state_code": "MA",
+            "country": "US",
+            "zip_code": "05720",
+            "zip_code_suffix": null
+          },
+          "ssn": "354620409",
+          "va_file_number": "487805857",
+          "date_of_birth": "1934-05-31",
+          "service_number": "336195311",
+          "service_branch": "NAVY",
+          "phone": "(604) 994 2824",
+          "email": "stacy.schuppe@lehner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-02T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "10025381-fd4f-4f12-ba1c-ad3396199b72",
+        "id": "3c9f2e68-f798-44a6-8d24-e1ed049eb4f7"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "40c9ffbc-ae32-49c9-ab11-ff9c49105d5b"
+    },
+    {
+      "claimant_id": "6febeedd-a134-4317-85d1-3bad378de80e",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-11T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Larissa",
+            "middle": null,
+            "last": "Darlene"
+          },
+          "address": {
+            "address_line1": "515 Rigoberto Ridge",
+            "address_line2": null,
+            "city": "Tyrellport",
+            "state_code": "MA",
+            "country": "US",
+            "zip_code": "05720",
+            "zip_code_suffix": null
+          },
+          "ssn": "354620409",
+          "va_file_number": "487805857",
+          "date_of_birth": "1934-05-31",
+          "service_number": "336195311",
+          "service_branch": "NAVY",
+          "phone": "(604) 994 2824",
+          "email": "stacy.schuppe@lehner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-12T05:51:27.455Z",
+        "type": "expiration",
+        "id": "8133a6ca-18a9-4409-bb2c-ab8f105f9403"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "b3d8beb5-af82-4819-a6af-34d9497a52e4"
+    },
+    {
+      "claimant_id": "6febeedd-a134-4317-85d1-3bad378de80e",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-21T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Larissa",
+            "middle": null,
+            "last": "Darlene"
+          },
+          "address": {
+            "address_line1": "515 Rigoberto Ridge",
+            "address_line2": null,
+            "city": "Tyrellport",
+            "state_code": "MA",
+            "country": "US",
+            "zip_code": "05720",
+            "zip_code_suffix": null
+          },
+          "ssn": "354620409",
+          "va_file_number": "487805857",
+          "date_of_birth": "1934-05-31",
+          "service_number": "336195311",
+          "service_branch": "NAVY",
+          "phone": "(604) 994 2824",
+          "email": "stacy.schuppe@lehner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-22T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "bca65048-4d70-4146-adf6-eab74c3b3234",
+        "id": "f4b01627-9ddb-487a-9676-592865253c97"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "6c322870-b994-4d0f-aaa0-3e1212af0b42"
+    },
+    {
+      "claimant_id": "1b879de8-2e8e-4a3f-8f7a-72edcb97ce30",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-01T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Xavier",
+            "middle": null,
+            "last": "Blake"
+          },
+          "address": {
+            "address_line1": "796 Cheree Route",
+            "address_line2": null,
+            "city": "East Sookshire",
+            "state_code": "MO",
+            "country": "US",
+            "zip_code": "75206",
+            "zip_code_suffix": null
+          },
+          "ssn": "929405460",
+          "va_file_number": "560122662",
+          "date_of_birth": "1970-07-31",
+          "service_number": "250876526",
+          "service_branch": "SPACE_FORCE",
+          "phone": "790-598-4317",
+          "email": "dean.paucek@schuster.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-02T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "b50098ae-ac96-49e3-b85c-a0867157f302",
+        "id": "3a31528e-3e0b-418e-aed6-75d78a23793a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "13e27d16-dbc2-4625-8514-f40a9fe8caaf"
+    },
+    {
+      "claimant_id": "1b879de8-2e8e-4a3f-8f7a-72edcb97ce30",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-11T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Xavier",
+            "middle": null,
+            "last": "Blake"
+          },
+          "address": {
+            "address_line1": "796 Cheree Route",
+            "address_line2": null,
+            "city": "East Sookshire",
+            "state_code": "MO",
+            "country": "US",
+            "zip_code": "75206",
+            "zip_code_suffix": null
+          },
+          "ssn": "929405460",
+          "va_file_number": "560122662",
+          "date_of_birth": "1970-07-31",
+          "service_number": "250876526",
+          "service_branch": "SPACE_FORCE",
+          "phone": "790-598-4317",
+          "email": "dean.paucek@schuster.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-12T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "beb19262-f956-4a32-a4c6-6c4f1800e0f7",
+        "id": "39a82af5-f241-46ea-9797-8014e07f3b44"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "38c24e31-2df2-4a5d-bdfe-ac009432f6c3"
+    },
+    {
+      "claimant_id": "1b879de8-2e8e-4a3f-8f7a-72edcb97ce30",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-21T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Xavier",
+            "middle": null,
+            "last": "Blake"
+          },
+          "address": {
+            "address_line1": "796 Cheree Route",
+            "address_line2": null,
+            "city": "East Sookshire",
+            "state_code": "MO",
+            "country": "US",
+            "zip_code": "75206",
+            "zip_code_suffix": null
+          },
+          "ssn": "929405460",
+          "va_file_number": "560122662",
+          "date_of_birth": "1970-07-31",
+          "service_number": "250876526",
+          "service_branch": "SPACE_FORCE",
+          "phone": "790-598-4317",
+          "email": "dean.paucek@schuster.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-22T11:51:27.455Z",
+        "type": "expiration",
+        "id": "987f9ebf-2b21-477a-8960-f8b4dd63e08a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "43f64e87-f58d-402d-99b4-e71284cf7c81"
+    },
+    {
+      "claimant_id": "a763d926-33d0-47ad-87d2-cfad63b74132",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-01T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Guy",
+            "middle": null,
+            "last": "Sharon"
+          },
+          "address": {
+            "address_line1": "99173 Georgene Row",
+            "address_line2": null,
+            "city": "South Bobbybury",
+            "state_code": "TX",
+            "country": "US",
+            "zip_code": "02256",
+            "zip_code_suffix": null
+          },
+          "ssn": "579790197",
+          "va_file_number": "600233753",
+          "date_of_birth": "2000-03-19",
+          "service_number": "111516225",
+          "service_branch": "SPACE_FORCE",
+          "phone": "551.077.7169",
+          "email": "martine.langworth@thompson.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-02T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "1d6ba31e-5499-4dee-95d4-be20dd0210f5",
+        "id": "1208b921-9d15-4edf-9235-1378c8dcf78e"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "fbe2ab6a-bf82-4227-9da8-9e59a8a1c757"
+    },
+    {
+      "claimant_id": "a763d926-33d0-47ad-87d2-cfad63b74132",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-11T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Guy",
+            "middle": null,
+            "last": "Sharon"
+          },
+          "address": {
+            "address_line1": "99173 Georgene Row",
+            "address_line2": null,
+            "city": "South Bobbybury",
+            "state_code": "TX",
+            "country": "US",
+            "zip_code": "02256",
+            "zip_code_suffix": null
+          },
+          "ssn": "579790197",
+          "va_file_number": "600233753",
+          "date_of_birth": "2000-03-19",
+          "service_number": "111516225",
+          "service_branch": "SPACE_FORCE",
+          "phone": "551.077.7169",
+          "email": "martine.langworth@thompson.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-12T17:51:27.455Z",
+        "type": "expiration",
+        "id": "a4e6b02a-110f-442c-aaf9-2803bf298aeb"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "85071f62-af98-4843-a360-122c172c8974"
+    },
+    {
+      "claimant_id": "a763d926-33d0-47ad-87d2-cfad63b74132",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-21T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Guy",
+            "middle": null,
+            "last": "Sharon"
+          },
+          "address": {
+            "address_line1": "99173 Georgene Row",
+            "address_line2": null,
+            "city": "South Bobbybury",
+            "state_code": "TX",
+            "country": "US",
+            "zip_code": "02256",
+            "zip_code_suffix": null
+          },
+          "ssn": "579790197",
+          "va_file_number": "600233753",
+          "date_of_birth": "2000-03-19",
+          "service_number": "111516225",
+          "service_branch": "SPACE_FORCE",
+          "phone": "551.077.7169",
+          "email": "martine.langworth@thompson.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-22T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "76fce996-d5c9-43ad-8dc9-fcfebe8c7ff9",
+        "id": "152f1e07-4e52-4f4a-bd29-6da0b7a27c1a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "c83f382f-b026-4819-8d51-a4230cab11d9"
+    },
+    {
+      "claimant_id": "9529f8f9-9d28-4a8e-bef6-d9b47d6adf08",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-01T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Suzanna",
+            "middle": null,
+            "last": "Fletcher"
+          },
+          "address": {
+            "address_line1": "32401 Hubert Spur",
+            "address_line2": null,
+            "city": "Murazikborough",
+            "state_code": "OR",
+            "country": "US",
+            "zip_code": "50167",
+            "zip_code_suffix": null
+          },
+          "ssn": "966356377",
+          "va_file_number": "132927375",
+          "date_of_birth": "1986-03-05",
+          "service_number": "657579155",
+          "service_branch": "NOAA",
+          "phone": "245-603-2981",
+          "email": "aliza_berge@pacocha.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-02T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "f3ea6d76-7565-40cb-a37e-c27f01c3a2a8",
+        "id": "ac068397-9d55-49f6-a962-16616ce5f8a9"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Odis Cruickshank",
+        "id": "96dc6994-1949-4f83-a6ad-a3bd9fd728e0"
+      },
+      "id": "7c979ac1-d0c7-4de8-9483-a66ac88611b0"
+    },
+    {
+      "claimant_id": "9529f8f9-9d28-4a8e-bef6-d9b47d6adf08",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-11T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Suzanna",
+            "middle": null,
+            "last": "Fletcher"
+          },
+          "address": {
+            "address_line1": "32401 Hubert Spur",
+            "address_line2": null,
+            "city": "Murazikborough",
+            "state_code": "OR",
+            "country": "US",
+            "zip_code": "50167",
+            "zip_code_suffix": null
+          },
+          "ssn": "966356377",
+          "va_file_number": "132927375",
+          "date_of_birth": "1986-03-05",
+          "service_number": "657579155",
+          "service_branch": "NOAA",
+          "phone": "245-603-2981",
+          "email": "aliza_berge@pacocha.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-12T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "d7c5c080-842b-477a-8828-2b4e9e3871ba",
+        "id": "b53795de-821e-4618-b921-2e1fb632df82"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Odis Cruickshank",
+        "id": "96dc6994-1949-4f83-a6ad-a3bd9fd728e0"
+      },
+      "id": "8e516a07-10bd-4150-8527-c5f194595b92"
+    },
+    {
+      "claimant_id": "9529f8f9-9d28-4a8e-bef6-d9b47d6adf08",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-21T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Suzanna",
+            "middle": null,
+            "last": "Fletcher"
+          },
+          "address": {
+            "address_line1": "32401 Hubert Spur",
+            "address_line2": null,
+            "city": "Murazikborough",
+            "state_code": "OR",
+            "country": "US",
+            "zip_code": "50167",
+            "zip_code_suffix": null
+          },
+          "ssn": "966356377",
+          "va_file_number": "132927375",
+          "date_of_birth": "1986-03-05",
+          "service_number": "657579155",
+          "service_branch": "NOAA",
+          "phone": "245-603-2981",
+          "email": "aliza_berge@pacocha.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-22T23:51:27.455Z",
+        "type": "expiration",
+        "id": "b3c95593-e6a4-4bcf-97c7-e82c9d69e021"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Catheryn Baumbach",
+        "id": "3205b046-ee94-4b3f-8ef5-f081b4f60e79"
+      },
+      "id": "d5e1766d-8112-47e1-86e9-5252bb42cb1d"
+    },
+    {
+      "claimant_id": "7c1236f0-ba8c-4d0c-be76-7dab86150757",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-02T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Dell",
+            "middle": null,
+            "last": "Krystin"
+          },
+          "address": {
+            "address_line1": "7237 Jannie Spurs",
+            "address_line2": null,
+            "city": "Lake Creola",
+            "state_code": "NM",
+            "country": "US",
+            "zip_code": "40750-7319",
+            "zip_code_suffix": null
+          },
+          "ssn": "773768245",
+          "va_file_number": "204475931",
+          "date_of_birth": "1947-03-06",
+          "service_number": "579550588",
+          "service_branch": "NOAA",
+          "phone": "180 969 5477",
+          "email": "karina@quigley.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-03T05:51:27.455Z",
+        "type": "expiration",
+        "id": "b6569479-0a43-40ba-9ce9-3a5d51f87a00"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Erica Representative",
+        "id": "c50410bb-7341-4d95-9a2f-aed22178ff08"
+      },
+      "id": "aa8badb2-487d-4c0b-bb61-0a7f682cd09c"
+    },
+    {
+      "claimant_id": "7c1236f0-ba8c-4d0c-be76-7dab86150757",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-12T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Dell",
+            "middle": null,
+            "last": "Krystin"
+          },
+          "address": {
+            "address_line1": "7237 Jannie Spurs",
+            "address_line2": null,
+            "city": "Lake Creola",
+            "state_code": "NM",
+            "country": "US",
+            "zip_code": "40750-7319",
+            "zip_code_suffix": null
+          },
+          "ssn": "773768245",
+          "va_file_number": "204475931",
+          "date_of_birth": "1947-03-06",
+          "service_number": "579550588",
+          "service_branch": "NOAA",
+          "phone": "180 969 5477",
+          "email": "karina@quigley.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-13T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "09cb059d-3624-4a3d-9905-b9ebe0542206",
+        "id": "ba572ca6-bdd7-4453-96c4-607d96e0511a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Erica Representative",
+        "id": "c50410bb-7341-4d95-9a2f-aed22178ff08"
+      },
+      "id": "883d4d0e-3740-4762-9d31-c3e712974366"
+    },
+    {
+      "claimant_id": "7c1236f0-ba8c-4d0c-be76-7dab86150757",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-22T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Dell",
+            "middle": null,
+            "last": "Krystin"
+          },
+          "address": {
+            "address_line1": "7237 Jannie Spurs",
+            "address_line2": null,
+            "city": "Lake Creola",
+            "state_code": "NM",
+            "country": "US",
+            "zip_code": "40750-7319",
+            "zip_code_suffix": null
+          },
+          "ssn": "773768245",
+          "va_file_number": "204475931",
+          "date_of_birth": "1947-03-06",
+          "service_number": "579550588",
+          "service_branch": "NOAA",
+          "phone": "180 969 5477",
+          "email": "karina@quigley.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-23T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "8c48a548-bf4c-438f-b89e-c1bf3a2c3da2",
+        "id": "f867ff27-4b58-42bd-af84-4877cce8d104"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "b944a0eb-5a90-4562-afa5-60ca38b73079"
+    },
+    {
+      "claimant_id": "e7930f8c-23be-4b97-b4b1-4c006f034a9c",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-02T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Sebastian",
+            "middle": null,
+            "last": "Agueda"
+          },
+          "address": {
+            "address_line1": "7172 Hilll Mill",
+            "address_line2": null,
+            "city": "South Greg",
+            "state_code": "CO",
+            "country": "US",
+            "zip_code": "73868-9518",
+            "zip_code_suffix": null
+          },
+          "ssn": "381826687",
+          "va_file_number": "262395450",
+          "date_of_birth": "1967-11-09",
+          "service_number": "578535415",
+          "service_branch": "NAVY",
+          "phone": "559.250.4660",
+          "email": "homer_considine@lebsack.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-03T11:51:27.455Z",
+        "type": "expiration",
+        "id": "6d6cf905-23cc-4739-a69a-4c1771bf0dc1"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "69b800fe-2472-40be-af7f-2af57e39ebdd"
+    },
+    {
+      "claimant_id": "e7930f8c-23be-4b97-b4b1-4c006f034a9c",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-12T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Sebastian",
+            "middle": null,
+            "last": "Agueda"
+          },
+          "address": {
+            "address_line1": "7172 Hilll Mill",
+            "address_line2": null,
+            "city": "South Greg",
+            "state_code": "CO",
+            "country": "US",
+            "zip_code": "73868-9518",
+            "zip_code_suffix": null
+          },
+          "ssn": "381826687",
+          "va_file_number": "262395450",
+          "date_of_birth": "1967-11-09",
+          "service_number": "578535415",
+          "service_branch": "NAVY",
+          "phone": "559.250.4660",
+          "email": "homer_considine@lebsack.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-13T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "29cd5a12-f9d4-47ed-8d56-a47386f2775d",
+        "id": "841e8d3f-cb9e-4ec1-bba9-53d194a121ba"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "65c75f04-83ea-41b2-9777-0955acbcab83"
+    },
+    {
+      "claimant_id": "e7930f8c-23be-4b97-b4b1-4c006f034a9c",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-22T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Sebastian",
+            "middle": null,
+            "last": "Agueda"
+          },
+          "address": {
+            "address_line1": "7172 Hilll Mill",
+            "address_line2": null,
+            "city": "South Greg",
+            "state_code": "CO",
+            "country": "US",
+            "zip_code": "73868-9518",
+            "zip_code_suffix": null
+          },
+          "ssn": "381826687",
+          "va_file_number": "262395450",
+          "date_of_birth": "1967-11-09",
+          "service_number": "578535415",
+          "service_branch": "NAVY",
+          "phone": "559.250.4660",
+          "email": "homer_considine@lebsack.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-23T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "79bf90b1-18cb-4be3-b31d-f34ab4ec4437",
+        "id": "13c947ca-36bd-4eda-afe2-0f5737016ca7"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "c9ade6fa-9364-4df4-a72b-6e950a94c60c"
+    },
+    {
+      "claimant_id": "40407704-aee4-4c66-998f-1ab9f8d2aa3f",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-02T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Heidy",
+            "middle": null,
+            "last": "Kristine"
+          },
+          "address": {
+            "address_line1": "67974 Schuster Burg",
+            "address_line2": null,
+            "city": "West Jeniborough",
+            "state_code": "HI",
+            "country": "US",
+            "zip_code": "75488-5618",
+            "zip_code_suffix": null
+          },
+          "ssn": "360343145",
+          "va_file_number": "200247006",
+          "date_of_birth": "1959-04-24",
+          "service_number": "765445726",
+          "service_branch": "AIR_FORCE",
+          "phone": "233-549-9180",
+          "email": "treasa.baumbach@grady.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-03T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "73fa0fb1-568c-4635-a8cb-cc6a7602246b",
+        "id": "bc23bf0c-13d6-445b-bf85-fca6e5340445"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Eric Good",
+        "id": "c3063f49-f751-4b94-9d18-4a98f08c2926"
+      },
+      "id": "7f83f738-fbdf-4ba2-b538-17986557995a"
+    },
+    {
+      "claimant_id": "40407704-aee4-4c66-998f-1ab9f8d2aa3f",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-12T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Heidy",
+            "middle": null,
+            "last": "Kristine"
+          },
+          "address": {
+            "address_line1": "67974 Schuster Burg",
+            "address_line2": null,
+            "city": "West Jeniborough",
+            "state_code": "HI",
+            "country": "US",
+            "zip_code": "75488-5618",
+            "zip_code_suffix": null
+          },
+          "ssn": "360343145",
+          "va_file_number": "200247006",
+          "date_of_birth": "1959-04-24",
+          "service_number": "765445726",
+          "service_branch": "AIR_FORCE",
+          "phone": "233-549-9180",
+          "email": "treasa.baumbach@grady.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-13T17:51:27.455Z",
+        "type": "expiration",
+        "id": "332bc831-cdb7-41dd-adaf-17aeb831496b"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Eric Good",
+        "id": "c3063f49-f751-4b94-9d18-4a98f08c2926"
+      },
+      "id": "8d8805e3-4fc5-4e18-b092-7b81b528e57c"
+    },
+    {
+      "claimant_id": "40407704-aee4-4c66-998f-1ab9f8d2aa3f",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-22T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Heidy",
+            "middle": null,
+            "last": "Kristine"
+          },
+          "address": {
+            "address_line1": "67974 Schuster Burg",
+            "address_line2": null,
+            "city": "West Jeniborough",
+            "state_code": "HI",
+            "country": "US",
+            "zip_code": "75488-5618",
+            "zip_code_suffix": null
+          },
+          "ssn": "360343145",
+          "va_file_number": "200247006",
+          "date_of_birth": "1959-04-24",
+          "service_number": "765445726",
+          "service_branch": "AIR_FORCE",
+          "phone": "233-549-9180",
+          "email": "treasa.baumbach@grady.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-23T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "17864051-ff05-4ad4-ac49-b07d83e2ddcd",
+        "id": "84661529-aa8f-441e-854c-f0aedaa940dc"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "3ec95049-0afb-427f-b26c-3b8212b8979d"
+    },
+    {
+      "claimant_id": "eda90664-4002-44b0-9028-e99156a0f2f1",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-02T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Torri",
+            "middle": null,
+            "last": "Lilliam"
+          },
+          "address": {
+            "address_line1": "560 Rogahn Corners",
+            "address_line2": null,
+            "city": "Keeblerchester",
+            "state_code": "WI",
+            "country": "US",
+            "zip_code": "05526",
+            "zip_code_suffix": null
+          },
+          "ssn": "938988268",
+          "va_file_number": "211296774",
+          "date_of_birth": "1983-01-31",
+          "service_number": "714947082",
+          "service_branch": "NOAA",
+          "phone": "268-881-5766",
+          "email": "karri@tremblay-rippin.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-03T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "cfd6de86-af6e-4f41-a347-12c88c6bdb1a",
+        "id": "16116d36-ef54-4795-839d-870f1c5f594e"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "7c9253ec-b598-4c0c-9da1-fd25e8d6c6e3"
+    },
+    {
+      "claimant_id": "eda90664-4002-44b0-9028-e99156a0f2f1",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-12T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Torri",
+            "middle": null,
+            "last": "Lilliam"
+          },
+          "address": {
+            "address_line1": "560 Rogahn Corners",
+            "address_line2": null,
+            "city": "Keeblerchester",
+            "state_code": "WI",
+            "country": "US",
+            "zip_code": "05526",
+            "zip_code_suffix": null
+          },
+          "ssn": "938988268",
+          "va_file_number": "211296774",
+          "date_of_birth": "1983-01-31",
+          "service_number": "714947082",
+          "service_branch": "NOAA",
+          "phone": "268-881-5766",
+          "email": "karri@tremblay-rippin.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-13T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "d47b88b2-8efc-4631-84f2-e850db7d2181",
+        "id": "ec79ddf4-6c89-4cb3-a644-9add783c702a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "72b56a69-7037-4db9-8596-d2153187b81e"
+    },
+    {
+      "claimant_id": "eda90664-4002-44b0-9028-e99156a0f2f1",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-22T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Torri",
+            "middle": null,
+            "last": "Lilliam"
+          },
+          "address": {
+            "address_line1": "560 Rogahn Corners",
+            "address_line2": null,
+            "city": "Keeblerchester",
+            "state_code": "WI",
+            "country": "US",
+            "zip_code": "05526",
+            "zip_code_suffix": null
+          },
+          "ssn": "938988268",
+          "va_file_number": "211296774",
+          "date_of_birth": "1983-01-31",
+          "service_number": "714947082",
+          "service_branch": "NOAA",
+          "phone": "268-881-5766",
+          "email": "karri@tremblay-rippin.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-23T23:51:27.455Z",
+        "type": "expiration",
+        "id": "fc27fb71-7cbd-4b64-b184-628bb593bb4a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "651750f4-45bd-4b86-9db5-8b046ad061dd"
+    },
+    {
+      "claimant_id": "c93694ce-d64d-4eab-b0a9-4e8da9d6cb0e",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-03T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Dorsey",
+            "middle": null,
+            "last": "Ewa"
+          },
+          "address": {
+            "address_line1": "31404 Mariel Road",
+            "address_line2": null,
+            "city": "Jastville",
+            "state_code": "IN",
+            "country": "US",
+            "zip_code": "36566-8723",
+            "zip_code_suffix": null
+          },
+          "ssn": "727851961",
+          "va_file_number": "851132083",
+          "date_of_birth": "1972-08-13",
+          "service_number": "796221328",
+          "service_branch": "COAST_GUARD",
+          "phone": "(437) 874-1964",
+          "email": "verlie.klocko@haley-schroeder.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-04T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "e061c893-225a-4da3-896e-694687270c64",
+        "id": "ae78e338-93a6-4590-bc70-1c3f1162b959"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "4fd9a335-e257-4d3b-98ab-2f0aaa26b54f"
+    },
+    {
+      "claimant_id": "c93694ce-d64d-4eab-b0a9-4e8da9d6cb0e",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-13T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Dorsey",
+            "middle": null,
+            "last": "Ewa"
+          },
+          "address": {
+            "address_line1": "31404 Mariel Road",
+            "address_line2": null,
+            "city": "Jastville",
+            "state_code": "IN",
+            "country": "US",
+            "zip_code": "36566-8723",
+            "zip_code_suffix": null
+          },
+          "ssn": "727851961",
+          "va_file_number": "851132083",
+          "date_of_birth": "1972-08-13",
+          "service_number": "796221328",
+          "service_branch": "COAST_GUARD",
+          "phone": "(437) 874-1964",
+          "email": "verlie.klocko@haley-schroeder.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-14T05:51:27.455Z",
+        "type": "expiration",
+        "id": "23d8a29c-e934-4cec-a7b6-ac40e6266ea6"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "c4c640f8-b41a-4900-bd12-3fbd3eadf036"
+    },
+    {
+      "claimant_id": "c93694ce-d64d-4eab-b0a9-4e8da9d6cb0e",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-23T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Dorsey",
+            "middle": null,
+            "last": "Ewa"
+          },
+          "address": {
+            "address_line1": "31404 Mariel Road",
+            "address_line2": null,
+            "city": "Jastville",
+            "state_code": "IN",
+            "country": "US",
+            "zip_code": "36566-8723",
+            "zip_code_suffix": null
+          },
+          "ssn": "727851961",
+          "va_file_number": "851132083",
+          "date_of_birth": "1972-08-13",
+          "service_number": "796221328",
+          "service_branch": "COAST_GUARD",
+          "phone": "(437) 874-1964",
+          "email": "verlie.klocko@haley-schroeder.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-24T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "57a276a3-8f30-4b89-89de-632353e3c582",
+        "id": "19792399-05b5-4e4f-b7be-10c6c0be6329"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "7cdbf77f-1d1d-4e18-8586-30788e451faf"
+    },
+    {
+      "claimant_id": "8bea4d28-da9f-43eb-836f-6d24b4bb5061",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-03T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Christin",
+            "middle": null,
+            "last": "Lindsey"
+          },
+          "address": {
+            "address_line1": "35400 Kreiger Haven",
+            "address_line2": null,
+            "city": "East Meagan",
+            "state_code": "TX",
+            "country": "US",
+            "zip_code": "44607",
+            "zip_code_suffix": null
+          },
+          "ssn": "532154340",
+          "va_file_number": "635326512",
+          "date_of_birth": "1970-09-24",
+          "service_number": "329651309",
+          "service_branch": "USPHS",
+          "phone": "845-380-1169",
+          "email": "claude.collins@mertz-johnson.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-04T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "f19adbc9-8f50-4444-b4e5-a725a10aabcb",
+        "id": "817c68d3-3357-43ee-89c4-af505c1b455f"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "69e6138c-56cc-4f9f-95fa-1b40271e5a0a"
+    },
+    {
+      "claimant_id": "8bea4d28-da9f-43eb-836f-6d24b4bb5061",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-13T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Christin",
+            "middle": null,
+            "last": "Lindsey"
+          },
+          "address": {
+            "address_line1": "35400 Kreiger Haven",
+            "address_line2": null,
+            "city": "East Meagan",
+            "state_code": "TX",
+            "country": "US",
+            "zip_code": "44607",
+            "zip_code_suffix": null
+          },
+          "ssn": "532154340",
+          "va_file_number": "635326512",
+          "date_of_birth": "1970-09-24",
+          "service_number": "329651309",
+          "service_branch": "USPHS",
+          "phone": "845-380-1169",
+          "email": "claude.collins@mertz-johnson.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-14T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "ecf8cc66-f5d6-4b81-98da-a90ab8a462fd",
+        "id": "86f91f42-87d6-42e2-9ee6-4e13b5a782dd"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "fe90f71e-0786-49aa-b784-a0153ac90cd0"
+    },
+    {
+      "claimant_id": "8bea4d28-da9f-43eb-836f-6d24b4bb5061",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-23T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["DRUG_ABUSE", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Christin",
+            "middle": null,
+            "last": "Lindsey"
+          },
+          "address": {
+            "address_line1": "35400 Kreiger Haven",
+            "address_line2": null,
+            "city": "East Meagan",
+            "state_code": "TX",
+            "country": "US",
+            "zip_code": "44607",
+            "zip_code_suffix": null
+          },
+          "ssn": "532154340",
+          "va_file_number": "635326512",
+          "date_of_birth": "1970-09-24",
+          "service_number": "329651309",
+          "service_branch": "USPHS",
+          "phone": "845-380-1169",
+          "email": "claude.collins@mertz-johnson.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-24T11:51:27.455Z",
+        "type": "expiration",
+        "id": "d416ed0f-683f-4916-b536-828bbbaf390d"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Georgetta Roob",
+        "id": "c6999376-28ca-45b9-a840-40c6c7c4edef"
+      },
+      "id": "040aaf1a-7f37-413a-874c-a7dedacea424"
+    },
+    {
+      "claimant_id": "ce02c3d8-412f-43af-9711-05771224f09d",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-03T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Mitch",
+            "middle": null,
+            "last": "Jeanine"
+          },
+          "address": {
+            "address_line1": "96811 Zieme Harbor",
+            "address_line2": null,
+            "city": "South Arnold",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "89386",
+            "zip_code_suffix": null
+          },
+          "ssn": "360798744",
+          "va_file_number": "225416966",
+          "date_of_birth": "1963-03-17",
+          "service_number": "904847494",
+          "service_branch": "NOAA",
+          "phone": "(289) 121-3155",
+          "email": "micki@stark-bergstrom.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-04T17:51:27.455Z",
+        "type": "expiration",
+        "id": "978c6f9d-72ff-4ad7-aae5-956ae956a821"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Horacio Schultz",
+        "id": "0ea9df23-a0b9-42bc-9629-b6ad66704825"
+      },
+      "id": "0ab6a1b6-1ac2-4aec-acd7-c007ccd59305"
+    },
+    {
+      "claimant_id": "ce02c3d8-412f-43af-9711-05771224f09d",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-13T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Mitch",
+            "middle": null,
+            "last": "Jeanine"
+          },
+          "address": {
+            "address_line1": "96811 Zieme Harbor",
+            "address_line2": null,
+            "city": "South Arnold",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "89386",
+            "zip_code_suffix": null
+          },
+          "ssn": "360798744",
+          "va_file_number": "225416966",
+          "date_of_birth": "1963-03-17",
+          "service_number": "904847494",
+          "service_branch": "NOAA",
+          "phone": "(289) 121-3155",
+          "email": "micki@stark-bergstrom.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-14T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "7e3a0f21-9131-45f8-b33d-348a5fdc1d4d",
+        "id": "52f600fc-e90f-40d6-a60d-197afa25cd0e"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Horacio Schultz",
+        "id": "0ea9df23-a0b9-42bc-9629-b6ad66704825"
+      },
+      "id": "b7e2ea23-9744-4cdb-8fb3-2701afd36cee"
+    },
+    {
+      "claimant_id": "ce02c3d8-412f-43af-9711-05771224f09d",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-23T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Mitch",
+            "middle": null,
+            "last": "Jeanine"
+          },
+          "address": {
+            "address_line1": "96811 Zieme Harbor",
+            "address_line2": null,
+            "city": "South Arnold",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "89386",
+            "zip_code_suffix": null
+          },
+          "ssn": "360798744",
+          "va_file_number": "225416966",
+          "date_of_birth": "1963-03-17",
+          "service_number": "904847494",
+          "service_branch": "NOAA",
+          "phone": "(289) 121-3155",
+          "email": "micki@stark-bergstrom.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-24T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "1116d91c-9c72-4379-9165-0018ffbb0760",
+        "id": "1c0ac013-d3d6-4b44-a35d-5027179ffe26"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Bob Representative",
+        "id": "d9d7e941-7156-4eca-827c-bcabe731d7ea"
+      },
+      "id": "7da21967-9145-420c-af6f-6b56406d66de"
+    },
+    {
+      "claimant_id": "40ff03e4-19b6-4f70-bdb7-8d6ebe14b11b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-03T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Orval",
+            "middle": null,
+            "last": "Walton"
+          },
+          "address": {
+            "address_line1": "928 Perry Ridges",
+            "address_line2": null,
+            "city": "Lake Jonebury",
+            "state_code": "LA",
+            "country": "US",
+            "zip_code": "68561",
+            "zip_code_suffix": null
+          },
+          "ssn": "140388039",
+          "va_file_number": "604083390",
+          "date_of_birth": "1932-12-11",
+          "service_number": "264282994",
+          "service_branch": "ARMY",
+          "phone": "650.105.2060",
+          "email": "roxy@volkman-lueilwitz.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-04T23:51:27.455Z",
+        "type": "expiration",
+        "id": "5414fd64-c032-4ecb-90a5-59e67fcbbe1a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Bob Representative",
+        "id": "d9d7e941-7156-4eca-827c-bcabe731d7ea"
+      },
+      "id": "8971e86f-efe9-41a1-b5ad-36cc20e8d372"
+    },
+    {
+      "claimant_id": "40ff03e4-19b6-4f70-bdb7-8d6ebe14b11b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-13T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Orval",
+            "middle": null,
+            "last": "Walton"
+          },
+          "address": {
+            "address_line1": "928 Perry Ridges",
+            "address_line2": null,
+            "city": "Lake Jonebury",
+            "state_code": "LA",
+            "country": "US",
+            "zip_code": "68561",
+            "zip_code_suffix": null
+          },
+          "ssn": "140388039",
+          "va_file_number": "604083390",
+          "date_of_birth": "1932-12-11",
+          "service_number": "264282994",
+          "service_branch": "ARMY",
+          "phone": "650.105.2060",
+          "email": "roxy@volkman-lueilwitz.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-14T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "06c30448-a286-4303-9613-846af2809df3",
+        "id": "b3780085-07bf-42c2-8f2e-4ed93af73838"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "96312b2f-c699-4960-ac25-68ca3f952386"
+    },
+    {
+      "claimant_id": "40ff03e4-19b6-4f70-bdb7-8d6ebe14b11b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-23T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Orval",
+            "middle": null,
+            "last": "Walton"
+          },
+          "address": {
+            "address_line1": "928 Perry Ridges",
+            "address_line2": null,
+            "city": "Lake Jonebury",
+            "state_code": "LA",
+            "country": "US",
+            "zip_code": "68561",
+            "zip_code_suffix": null
+          },
+          "ssn": "140388039",
+          "va_file_number": "604083390",
+          "date_of_birth": "1932-12-11",
+          "service_number": "264282994",
+          "service_branch": "ARMY",
+          "phone": "650.105.2060",
+          "email": "roxy@volkman-lueilwitz.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-24T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "ba708264-4b83-4fa4-bb36-32a1401a4865",
+        "id": "49e83c49-2bd3-4bb6-8e8c-a6f4dd77a7b6"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "c27d1eb7-781e-4c18-9ffb-0797401dc95e"
+    },
+    {
+      "claimant_id": "427f8301-3c37-4311-a318-b71be231de38",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-04T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Fe",
+            "middle": null,
+            "last": "Johnson"
+          },
+          "address": {
+            "address_line1": "6051 Madaline Crest",
+            "address_line2": null,
+            "city": "Lubowitzfurt",
+            "state_code": "IN",
+            "country": "US",
+            "zip_code": "67966",
+            "zip_code_suffix": null
+          },
+          "ssn": "564944620",
+          "va_file_number": "916922396",
+          "date_of_birth": "1996-02-12",
+          "service_number": "433501327",
+          "service_branch": "COAST_GUARD",
+          "phone": "(236) 410 0878",
+          "email": "vaughn@bailey-larson.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-05T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "b7b9a5be-87e5-4757-b13f-b1cb4621fdc8",
+        "id": "fb9de19c-641a-42e9-9582-597af98f3246"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Robert Lowe",
+        "id": "3f47a6c7-ce14-4ab5-9567-6e3803336fe1"
+      },
+      "id": "14ea6796-9fbe-4456-a96d-2919bac8141b"
+    },
+    {
+      "claimant_id": "427f8301-3c37-4311-a318-b71be231de38",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-14T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Fe",
+            "middle": null,
+            "last": "Johnson"
+          },
+          "address": {
+            "address_line1": "6051 Madaline Crest",
+            "address_line2": null,
+            "city": "Lubowitzfurt",
+            "state_code": "IN",
+            "country": "US",
+            "zip_code": "67966",
+            "zip_code_suffix": null
+          },
+          "ssn": "564944620",
+          "va_file_number": "916922396",
+          "date_of_birth": "1996-02-12",
+          "service_number": "433501327",
+          "service_branch": "COAST_GUARD",
+          "phone": "(236) 410 0878",
+          "email": "vaughn@bailey-larson.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-15T05:51:27.455Z",
+        "type": "expiration",
+        "id": "7f0c650d-482f-4f37-ae1d-a05d1f4e876e"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "4b42c686-e997-4c3b-8cd9-0bfe45bae839"
+    },
+    {
+      "claimant_id": "427f8301-3c37-4311-a318-b71be231de38",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-24T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Fe",
+            "middle": null,
+            "last": "Johnson"
+          },
+          "address": {
+            "address_line1": "6051 Madaline Crest",
+            "address_line2": null,
+            "city": "Lubowitzfurt",
+            "state_code": "IN",
+            "country": "US",
+            "zip_code": "67966",
+            "zip_code_suffix": null
+          },
+          "ssn": "564944620",
+          "va_file_number": "916922396",
+          "date_of_birth": "1996-02-12",
+          "service_number": "433501327",
+          "service_branch": "COAST_GUARD",
+          "phone": "(236) 410 0878",
+          "email": "vaughn@bailey-larson.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-25T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "78ba7030-b75b-4bcd-8248-5f9dd360ab7b",
+        "id": "2a2b3d99-eba6-4b17-9b15-3bac33b0c68b"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "ecb0befa-0a45-4d77-a702-bf4b983f8adf"
+    },
+    {
+      "claimant_id": "9c1eef4b-6f43-42c6-8361-9d197ece3d37",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-04T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jame",
+            "middle": null,
+            "last": "Saundra"
+          },
+          "address": {
+            "address_line1": "911 Margit Drive",
+            "address_line2": null,
+            "city": "Walterfort",
+            "state_code": "CT",
+            "country": "US",
+            "zip_code": "98157",
+            "zip_code_suffix": null
+          },
+          "ssn": "291732209",
+          "va_file_number": "281338343",
+          "date_of_birth": "1937-05-23",
+          "service_number": "752019205",
+          "service_branch": "NOAA",
+          "phone": "151 404 7241",
+          "email": "neil@wyman.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-05T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "aa873b7f-43b6-47d9-ad2b-9fcc7adf8bbd",
+        "id": "8fd8a53b-a374-4bc7-ae55-279e3de18108"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "54973318-d456-49a4-bd7d-8b99ea5f9d29"
+    },
+    {
+      "claimant_id": "9c1eef4b-6f43-42c6-8361-9d197ece3d37",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-14T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jame",
+            "middle": null,
+            "last": "Saundra"
+          },
+          "address": {
+            "address_line1": "911 Margit Drive",
+            "address_line2": null,
+            "city": "Walterfort",
+            "state_code": "CT",
+            "country": "US",
+            "zip_code": "98157",
+            "zip_code_suffix": null
+          },
+          "ssn": "291732209",
+          "va_file_number": "281338343",
+          "date_of_birth": "1937-05-23",
+          "service_number": "752019205",
+          "service_branch": "NOAA",
+          "phone": "151 404 7241",
+          "email": "neil@wyman.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-15T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "05f45199-ac2e-4555-b0c3-3b495f1ce9be",
+        "id": "0e193b21-c790-44fb-adda-f10f4ffec436"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Suzie Lowe",
+        "id": "90e83d10-8ce1-482b-8f06-45bea0cc7f3c"
+      },
+      "id": "f3d93fb3-3683-4874-a9f5-727d5123b72b"
+    },
+    {
+      "claimant_id": "9c1eef4b-6f43-42c6-8361-9d197ece3d37",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-24T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jame",
+            "middle": null,
+            "last": "Saundra"
+          },
+          "address": {
+            "address_line1": "911 Margit Drive",
+            "address_line2": null,
+            "city": "Walterfort",
+            "state_code": "CT",
+            "country": "US",
+            "zip_code": "98157",
+            "zip_code_suffix": null
+          },
+          "ssn": "291732209",
+          "va_file_number": "281338343",
+          "date_of_birth": "1937-05-23",
+          "service_number": "752019205",
+          "service_branch": "NOAA",
+          "phone": "151 404 7241",
+          "email": "neil@wyman.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-25T11:51:27.455Z",
+        "type": "expiration",
+        "id": "46bf4255-e0cd-4927-ba79-2e66b897fd72"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "a56a3070-c272-46f6-8887-8bc948180acc"
+    },
+    {
+      "claimant_id": "dbce479d-88cd-4467-a771-4fab184425f3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-04T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jefferey",
+            "middle": null,
+            "last": "Van"
+          },
+          "address": {
+            "address_line1": "11090 Feest Streets",
+            "address_line2": null,
+            "city": "Stantonland",
+            "state_code": "ID",
+            "country": "US",
+            "zip_code": "92374-5866",
+            "zip_code_suffix": null
+          },
+          "ssn": "551830191",
+          "va_file_number": "529029766",
+          "date_of_birth": "1965-06-05",
+          "service_number": "320542382",
+          "service_branch": "USPHS",
+          "phone": "904.349.9018",
+          "email": "roselle_turner@senger.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-05T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "9865afaa-70eb-4845-8c0e-ef95c1990941",
+        "id": "62bc4df9-2d62-4bb4-80ca-7ebe8560d331"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Good Representatives R Us",
+        "id": "41d36596-67d1-4b23-ab58-927447e88d07"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "0f5dab09-4025-4e4c-bc3c-46b9097615ad"
+    },
+    {
+      "claimant_id": "dbce479d-88cd-4467-a771-4fab184425f3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-14T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jefferey",
+            "middle": null,
+            "last": "Van"
+          },
+          "address": {
+            "address_line1": "11090 Feest Streets",
+            "address_line2": null,
+            "city": "Stantonland",
+            "state_code": "ID",
+            "country": "US",
+            "zip_code": "92374-5866",
+            "zip_code_suffix": null
+          },
+          "ssn": "551830191",
+          "va_file_number": "529029766",
+          "date_of_birth": "1965-06-05",
+          "service_number": "320542382",
+          "service_branch": "USPHS",
+          "phone": "904.349.9018",
+          "email": "roselle_turner@senger.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-15T17:51:27.455Z",
+        "type": "expiration",
+        "id": "d924b48c-b682-430e-a914-2e0235729fe7"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "536ada6c-a158-40a0-bf8d-a580b4d9c2cd"
+    },
+    {
+      "claimant_id": "dbce479d-88cd-4467-a771-4fab184425f3",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-24T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [
+            "ALCOHOLISM",
+            "DRUG_ABUSE",
+            "HIV",
+            "SICKLE_CELL"
+          ],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Jefferey",
+            "middle": null,
+            "last": "Van"
+          },
+          "address": {
+            "address_line1": "11090 Feest Streets",
+            "address_line2": null,
+            "city": "Stantonland",
+            "state_code": "ID",
+            "country": "US",
+            "zip_code": "92374-5866",
+            "zip_code_suffix": null
+          },
+          "ssn": "551830191",
+          "va_file_number": "529029766",
+          "date_of_birth": "1965-06-05",
+          "service_number": "320542382",
+          "service_branch": "USPHS",
+          "phone": "904.349.9018",
+          "email": "roselle_turner@senger.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-25T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "ba12fc09-acdc-4772-a079-756918fb2bab",
+        "id": "d41e75ca-5499-4337-8009-831cc464feb3"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "f751ccd3-5ef5-4fd6-8020-ab1160addc3c"
+    },
+    {
+      "claimant_id": "0ec8246c-259e-41d5-a6fc-d4e12a7f3bad",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-04T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Bernardine",
+            "middle": null,
+            "last": "Merlin"
+          },
+          "address": {
+            "address_line1": "9252 Kamala Fork",
+            "address_line2": null,
+            "city": "North Charlynside",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "26138-2845",
+            "zip_code_suffix": null
+          },
+          "ssn": "943057460",
+          "va_file_number": "860181311",
+          "date_of_birth": "1993-07-31",
+          "service_number": "844087243",
+          "service_branch": "NAVY",
+          "phone": "686-235-0592",
+          "email": "annemarie@ledner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-05T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "4ab659d3-d288-49cf-ba0d-ae359862d131",
+        "id": "8d2861fe-3a97-42c1-9774-070111983279"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Jewell Armstrong",
+        "id": "a1e66cea-bd2d-4997-8b08-42770fc0ebce"
+      },
+      "id": "c7397103-59e4-4757-bca0-8af18594d490"
+    },
+    {
+      "claimant_id": "0ec8246c-259e-41d5-a6fc-d4e12a7f3bad",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-14T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Bernardine",
+            "middle": null,
+            "last": "Merlin"
+          },
+          "address": {
+            "address_line1": "9252 Kamala Fork",
+            "address_line2": null,
+            "city": "North Charlynside",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "26138-2845",
+            "zip_code_suffix": null
+          },
+          "ssn": "943057460",
+          "va_file_number": "860181311",
+          "date_of_birth": "1993-07-31",
+          "service_number": "844087243",
+          "service_branch": "NAVY",
+          "phone": "686-235-0592",
+          "email": "annemarie@ledner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-15T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "4b7d5184-eff8-4568-976e-a83d4b42e05d",
+        "id": "5e13e5b6-8ff9-4928-b453-ebc80d675ead"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Odis Cruickshank",
+        "id": "96dc6994-1949-4f83-a6ad-a3bd9fd728e0"
+      },
+      "id": "f41edbbd-cf43-4984-978f-f2f5d68529c6"
+    },
+    {
+      "claimant_id": "0ec8246c-259e-41d5-a6fc-d4e12a7f3bad",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-24T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "DRUG_ABUSE"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Bernardine",
+            "middle": null,
+            "last": "Merlin"
+          },
+          "address": {
+            "address_line1": "9252 Kamala Fork",
+            "address_line2": null,
+            "city": "North Charlynside",
+            "state_code": "RI",
+            "country": "US",
+            "zip_code": "26138-2845",
+            "zip_code_suffix": null
+          },
+          "ssn": "943057460",
+          "va_file_number": "860181311",
+          "date_of_birth": "1993-07-31",
+          "service_number": "844087243",
+          "service_branch": "NAVY",
+          "phone": "686-235-0592",
+          "email": "annemarie@ledner.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-25T23:51:27.455Z",
+        "type": "expiration",
+        "id": "4bd29834-04a0-4cb0-88be-1fe10533c628"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Odis Cruickshank",
+        "id": "96dc6994-1949-4f83-a6ad-a3bd9fd728e0"
+      },
+      "id": "3e2c1bac-c548-4453-894c-cf84cfd9986d"
+    },
+    {
+      "claimant_id": "4cdad2aa-87b9-4879-96fe-3effd6a13d83",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-05T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Kelly",
+            "middle": null,
+            "last": "Miguel"
+          },
+          "address": {
+            "address_line1": "5266 Minh Coves",
+            "address_line2": null,
+            "city": "Port America",
+            "state_code": "NC",
+            "country": "US",
+            "zip_code": "63751",
+            "zip_code_suffix": null
+          },
+          "ssn": "254457366",
+          "va_file_number": "639106878",
+          "date_of_birth": "1944-02-11",
+          "service_number": "342545363",
+          "service_branch": "ARMY",
+          "phone": "(802) 806-8772",
+          "email": "darryl.hayes@morissette-schaden.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-06T05:51:27.455Z",
+        "type": "expiration",
+        "id": "38bbf3fc-43aa-4018-aaff-d73c16db642a"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Catheryn Baumbach",
+        "id": "3205b046-ee94-4b3f-8ef5-f081b4f60e79"
+      },
+      "id": "f596d10b-4e29-4a93-85c0-280811b24dd3"
+    },
+    {
+      "claimant_id": "4cdad2aa-87b9-4879-96fe-3effd6a13d83",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-15T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Kelly",
+            "middle": null,
+            "last": "Miguel"
+          },
+          "address": {
+            "address_line1": "5266 Minh Coves",
+            "address_line2": null,
+            "city": "Port America",
+            "state_code": "NC",
+            "country": "US",
+            "zip_code": "63751",
+            "zip_code_suffix": null
+          },
+          "ssn": "254457366",
+          "va_file_number": "639106878",
+          "date_of_birth": "1944-02-11",
+          "service_number": "342545363",
+          "service_branch": "ARMY",
+          "phone": "(802) 806-8772",
+          "email": "darryl.hayes@morissette-schaden.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-16T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "56e5779a-5827-4cd0-962b-888137795feb",
+        "id": "8cd0f7f9-44e9-4ffc-a076-7e5ebbbe1ec5"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Erica Representative",
+        "id": "c50410bb-7341-4d95-9a2f-aed22178ff08"
+      },
+      "id": "beb394d6-006a-4f2a-918c-6d35355f3d41"
+    },
+    {
+      "claimant_id": "4cdad2aa-87b9-4879-96fe-3effd6a13d83",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-25T05:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Kelly",
+            "middle": null,
+            "last": "Miguel"
+          },
+          "address": {
+            "address_line1": "5266 Minh Coves",
+            "address_line2": null,
+            "city": "Port America",
+            "state_code": "NC",
+            "country": "US",
+            "zip_code": "63751",
+            "zip_code_suffix": null
+          },
+          "ssn": "254457366",
+          "va_file_number": "639106878",
+          "date_of_birth": "1944-02-11",
+          "service_number": "342545363",
+          "service_branch": "ARMY",
+          "phone": "(802) 806-8772",
+          "email": "darryl.hayes@morissette-schaden.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-26T05:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "d47ff27a-dcac-465e-aafd-86791d533b11",
+        "id": "feb522ec-0a43-463c-9fa1-f6652091bd00"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Erica Representative",
+        "id": "c50410bb-7341-4d95-9a2f-aed22178ff08"
+      },
+      "id": "e2a0785d-c92e-4442-9668-4097a1362bfb"
+    },
+    {
+      "claimant_id": "e61c1158-7d2b-43f3-8a9f-046ffdf1df37",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-05T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Lexie",
+            "middle": null,
+            "last": "Cathie"
+          },
+          "address": {
+            "address_line1": "353 Effie Locks",
+            "address_line2": null,
+            "city": "Kimberliechester",
+            "state_code": "HI",
+            "country": "US",
+            "zip_code": "28894",
+            "zip_code_suffix": null
+          },
+          "ssn": "744322753",
+          "va_file_number": "808732366",
+          "date_of_birth": "1996-04-27",
+          "service_number": "562978418",
+          "service_branch": "COAST_GUARD",
+          "phone": "821-717-0750",
+          "email": "edison@roberts-wunsch.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-06T11:51:27.455Z",
+        "type": "expiration",
+        "id": "e0e9e43d-06ac-4d50-8bda-62f5412b3aec"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "bf3c11a2-ba34-41f0-b9d6-b73bda4b1438"
+    },
+    {
+      "claimant_id": "e61c1158-7d2b-43f3-8a9f-046ffdf1df37",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-15T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Lexie",
+            "middle": null,
+            "last": "Cathie"
+          },
+          "address": {
+            "address_line1": "353 Effie Locks",
+            "address_line2": null,
+            "city": "Kimberliechester",
+            "state_code": "HI",
+            "country": "US",
+            "zip_code": "28894",
+            "zip_code_suffix": null
+          },
+          "ssn": "744322753",
+          "va_file_number": "808732366",
+          "date_of_birth": "1996-04-27",
+          "service_number": "562978418",
+          "service_branch": "COAST_GUARD",
+          "phone": "821-717-0750",
+          "email": "edison@roberts-wunsch.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-16T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "993c5014-30a3-4e19-be92-9f951e0774fd",
+        "id": "8244ba20-70fe-4057-962c-e9f5c3114b40"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "d52be790-a17a-4bf9-b8fe-30dca9078112"
+    },
+    {
+      "claimant_id": "e61c1158-7d2b-43f3-8a9f-046ffdf1df37",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-25T11:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["ALCOHOLISM", "HIV"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Lexie",
+            "middle": null,
+            "last": "Cathie"
+          },
+          "address": {
+            "address_line1": "353 Effie Locks",
+            "address_line2": null,
+            "city": "Kimberliechester",
+            "state_code": "HI",
+            "country": "US",
+            "zip_code": "28894",
+            "zip_code_suffix": null
+          },
+          "ssn": "744322753",
+          "va_file_number": "808732366",
+          "date_of_birth": "1996-04-27",
+          "service_number": "562978418",
+          "service_branch": "COAST_GUARD",
+          "phone": "821-717-0750",
+          "email": "edison@roberts-wunsch.example"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-26T11:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "8b67ed9e-4e1a-4211-9acf-50cd5d9d07fe",
+        "id": "59a084e9-3b83-4032-8602-2fc7c7037ebc"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "6b5ef4bc-d475-4d6f-ad2d-f5e265a613fe"
+    },
+    {
+      "claimant_id": "80a37238-7f0d-426f-ba14-e76e089fd24b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-05T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Clyde",
+            "middle": null,
+            "last": "Fidel"
+          },
+          "address": {
+            "address_line1": "936 Corine Meadows",
+            "address_line2": null,
+            "city": "Pastyville",
+            "state_code": "AL",
+            "country": "US",
+            "zip_code": "59204",
+            "zip_code_suffix": null
+          },
+          "ssn": "390637839",
+          "va_file_number": "814934408",
+          "date_of_birth": "1969-08-03",
+          "service_number": "442391727",
+          "service_branch": "SPACE_FORCE",
+          "phone": "906 148 9013",
+          "email": "dylan@aufderhar.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-06T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "1328b6fb-5fc3-4b65-9583-53a064ab1e7d",
+        "id": "ff108663-70d8-4a44-9b66-72578aeb0dd2"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Department of Veterans Fake Data",
+        "id": "4e21e4b2-02e5-4a96-ace3-8b56b97a275c"
+      },
+      "accredited_individual": {
+        "full_name": "Erin Trust",
+        "id": "595e4651-4bd0-4094-8007-f3711001efe5"
+      },
+      "id": "cf234722-6e63-4b5e-a648-2026328de0e4"
+    },
+    {
+      "claimant_id": "80a37238-7f0d-426f-ba14-e76e089fd24b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-15T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Clyde",
+            "middle": null,
+            "last": "Fidel"
+          },
+          "address": {
+            "address_line1": "936 Corine Meadows",
+            "address_line2": null,
+            "city": "Pastyville",
+            "state_code": "AL",
+            "country": "US",
+            "zip_code": "59204",
+            "zip_code_suffix": null
+          },
+          "ssn": "390637839",
+          "va_file_number": "814934408",
+          "date_of_birth": "1969-08-03",
+          "service_number": "442391727",
+          "service_branch": "SPACE_FORCE",
+          "phone": "906 148 9013",
+          "email": "dylan@aufderhar.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-16T17:51:27.455Z",
+        "type": "expiration",
+        "id": "d4f90462-de80-4464-a052-d7d6fca74d0f"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "We Help Vets",
+        "id": "83b7de4d-a2cd-4b15-9e32-af48804c3e31"
+      },
+      "accredited_individual": {
+        "full_name": "Eric Good",
+        "id": "c3063f49-f751-4b94-9d18-4a98f08c2926"
+      },
+      "id": "520fcf79-68b1-498d-b502-c5eccd51a15f"
+    },
+    {
+      "claimant_id": "80a37238-7f0d-426f-ba14-e76e089fd24b",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-25T17:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": ["HIV"],
+          "address_change": true
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Clyde",
+            "middle": null,
+            "last": "Fidel"
+          },
+          "address": {
+            "address_line1": "936 Corine Meadows",
+            "address_line2": null,
+            "city": "Pastyville",
+            "state_code": "AL",
+            "country": "US",
+            "zip_code": "59204",
+            "zip_code_suffix": null
+          },
+          "ssn": "390637839",
+          "va_file_number": "814934408",
+          "date_of_birth": "1969-08-03",
+          "service_number": "442391727",
+          "service_branch": "SPACE_FORCE",
+          "phone": "906 148 9013",
+          "email": "dylan@aufderhar.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-26T17:51:27.455Z",
+        "type": "decision",
+        "decision_type": "acceptance",
+        "creator_id": "3b7e40e1-3ad9-4b31-b505-70bd5499409d",
+        "id": "62aa73a5-68ff-48af-b94d-704d8815c969"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "The Swift Reps",
+        "id": "31f61e0f-8993-4c57-86f2-7f22e9ca9e68"
+      },
+      "accredited_individual": {
+        "full_name": "Eric Good",
+        "id": "c3063f49-f751-4b94-9d18-4a98f08c2926"
+      },
+      "id": "ba85f4d1-97fd-4c35-a051-cdeb5bd8df3c"
+    },
+    {
+      "claimant_id": "fcfd3511-2427-4ebd-bc73-8f88e12e6339",
+      "claimant_type": "veteran","expires_at": "2025-01-02T22:14:49Z",
+      "created_at": "2024-12-05T23:51:27.455Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": false,
+          "record_disclosure_limitations": ["HIV", "SICKLE_CELL"],
+          "address_change": false
+        },
+        "dependent": null,
+        "claimant": {
+          "name": {
+            "first": "Willis",
+            "middle": null,
+            "last": "Corey"
+          },
+          "address": {
+            "address_line1": "3135 Hermiston Greens",
+            "address_line2": null,
+            "city": "Nienowhaven",
+            "state_code": "MI",
+            "country": "US",
+            "zip_code": "48335",
+            "zip_code_suffix": null
+          },
+          "ssn": "740992993",
+          "va_file_number": "465430839",
+          "date_of_birth": "1998-04-04",
+          "service_number": "477613865",
+          "service_branch": "COAST_GUARD",
+          "phone": "700.286.0915",
+          "email": "rolanda@donnelly-larson.test"
+        }
+      },
+      "resolution": {
+        "created_at": "2024-12-06T23:51:27.455Z",
+        "type": "decision",
+        "decision_type": "declination",
+        "reason": "Didn't authorize treatment record disclosure",
+        "creator_id": "46cfc996-cbb4-40d0-9302-435622fe019d",
+        "id": "ed371211-79f1-4ab2-be92-ab48f9a6149c"
+      },
+      "power_of_attorney_holder": {
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization",
+        "id": "23563963-e31c-4797-a259-e26b727072e1"
+      },
+      "accredited_individual": {
+        "full_name": "Hershel Kertzmann",
+        "id": "9e68bca2-10e1-48cc-be75-b1ce64d07ef4"
+      },
+      "id": "bdca8125-98cd-4b37-a395-ff1f1eadc9b1"
+    },
+    {
+      "id": "921350ac-6dd6-4d31-bc4b-94be655ebb92",
+      "claimant_id": "110de1bc-f379-4104-a96a-b6edb2d3336e",
+      "created_at": "2024-12-30T22:14:49Z",
+      "expires_at": null,
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [],
+          "address_change": true
+        },
+        "claimant": {
+          "name": {
+            "first": "John",
+            "middle": "Middle",
+            "last": "Doe"
+          },
+          "address": {
+            "address_line1": "123 Main St",
+            "address_line2": "Apt 1",
+            "city": "Springfield",
+            "state_code": "IL",
+            "country": "US",
+            "zip_code": "62704",
+            "zip_code_suffix": "6789"
+          },
+          "date_of_birth": "1980-12-31",
+          "relationship": "Spouse",
+          "phone": "1234567890",
+          "email": "veteran@example.com"
+        },
         "veteran": {
-          "firstName": "Bob",
-          "middleName": "G",
-          "lastName": "Norris",
-          "participantId": 800067890
-        },
-        "representative": {
-          "firstName": "Christopher",
-          "lastName": "Lee",
-          "email": "christopher.lee@vsorg.org"
-        },
-        "claimant": {
-          "firstName": "Gamma",
-          "lastName": "Theta",
-          "participantId": 34567,
-          "relationshipToVeteran": "Child"
-        },
-        "claimantAddress": {
-          "city": "San Francisco",
-          "state": "CA",
-          "zip": "94102",
-          "country": "US",
-          "militaryPostOffice": null,
-          "militaryPostalCode": null
+          "name": {
+            "first": "John",
+            "middle": "Middle",
+            "last": "Doe"
+          },
+          "address": {
+            "address_line1": "123 Main St",
+            "address_line2": "Apt 1",
+            "city": "Springfield",
+            "state_code": "IL",
+            "country": "US",
+            "zip_code": "62704",
+            "zip_code_suffix": "6789"
+          },
+          "ssn": "123456789",
+          "va_file_number": "123456789",
+          "date_of_birth": "1980-12-31",
+          "service_number": "123456789",
+          "service_branch": "ARMY",
+          "phone": "1234567890",
+          "email": "veteran@example.com"
         }
+      },
+      "resolution": {
+        "id": "e4683c77-f1b8-400d-a2a0-12cab1155169",
+        "type": "decision",
+        "created_at": "2024-12-31T22:14:49Z",
+        "creator_id": "51664ff1-3ec0-4361-a39e-12418e9a9a88",
+        "reason": "Didn't authorize treatment record disclosure",
+        "decision_type": "declination"
+      },
+      "power_of_attorney_holder": {
+        "id": "69af0f61-2a9c-4eaf-a1cd-2e7a08330025",
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization"
+      },
+      "accredited_individual": {
+        "id": "d0fd88c1-4568-4d7e-9983-33bbc45b0224",
+        "full_name": "Alanna Smith"
       }
     },
     {
-      "id": 24680,
-      "type": "powerOfAttorneyRequest",
-      "attributes": {
-        "status": "Accepted",
-        "powerOfAttorneyCode": "077",
-        "submittedAt": "2024-02-14T10:30:00Z",
-        "expiresAt": "2024-11-31T15:20:00Z",
-        "acceptedOrDeclinedAt": "2024-02-15T14:45:22Z",
-        "isAddressChangingAuthorized": false,
-        "isTreatmentDisclosureAuthorized": false,
-        "veteran": {
-          "firstName": "Larry",
-          "middleName": "David",
-          "lastName": "Allen",
-          "participantId": 900077600
-        },
-        "representative": {
-          "firstName": "Alexander",
-          "lastName": "Williams",
-          "email": "alexander.williams@vsorg.org"
+      "id": "921350ac-6dd6-4d31-bc4b-94be655ebb92q",
+      "claimant_id": "110de1bc-f379-4104-a96a-b6edb2d3336e",
+      "created_at": "2024-12-30T22:14:49Z",
+      "expires_at": "2025-01-14T22:14:49Z",
+      "power_of_attorney_form": {
+        "authorizations": {
+          "record_disclosure": true,
+          "record_disclosure_limitations": [],
+          "address_change": true
         },
         "claimant": {
-          "firstName": "Jacob",
-          "lastName": "Parker",
-          "participantId": 45678,
-          "relationshipToVeteran": "Brother"
-        },
-        "claimantAddress": {
-          "city": "Chicago",
-          "state": "IL",
-          "zip": "60607",
-          "country": "US",
-          "militaryPostOffice": null,
-          "militaryPostalCode": null
+          "name": {
+            "first": "John",
+            "middle": "Middle",
+            "last": "Doe"
+          },
+          "address": {
+            "address_line1": "123 Main St",
+            "address_line2": "Apt 1",
+            "city": "Springfield",
+            "state_code": "IL",
+            "country": "US",
+            "zip_code": "62704",
+            "zip_code_suffix": "6789"
+          },
+          "ssn": "123456789",
+          "va_file_number": "123456789",
+          "date_of_birth": "1980-12-31",
+          "service_number": "123456789",
+          "service_branch": "ARMY",
+          "phone": "1234567890",
+          "email": "veteran@example.com",
+          "relationship": "Self"
         }
-      }
-    },
-    {
-      "id": 13579,
-      "type": "powerOfAttorneyRequest",
-      "attributes": {
-        "status": "Pending",
-        "powerOfAttorneyCode": "089",
-        "submittedAt": "2024-05-01T12:15:47Z",
-        "expiresAt": "2024-05-01T12:15:47Z",
-        "acceptedOrDeclinedAt": null,
-        "isAddressChangingAuthorized": true,
-        "isTreatmentDisclosureAuthorized": true,
-        "veteran": {
-          "firstName": "Suzanne",
-          "middleName": "Jane",
-          "lastName": "Baker",
-          "participantId": 101112130
-        },
-        "representative": {
-          "firstName": "Benjamin",
-          "lastName": "Davis",
-          "email": "benjamin.davis@vsorg.org"
-        },
-        "claimant": {
-          "firstName": "Samantha",
-          "lastName": "Jones",
-          "participantId": 98765,
-          "relationshipToVeteran": "Sister"
-        },
-        "claimantAddress": {
-          "city": "Miami",
-          "state": "FL",
-          "zip": "33101",
-          "country": "US",
-          "militaryPostOffice": null,
-          "militaryPostalCode": null
-        }
-      }
-    },
-    {
-      "id": 97531,
-      "type": "powerOfAttorneyRequest",
-      "attributes": {
-        "status": "Pending",
-        "powerOfAttorneyCode": "102",
-        "submittedAt": "2024-03-20T08:00:00Z",
-        "expiresAt": "2024-05-01T12:15:47Z",
-        "acceptedOrDeclinedAt": null,
-        "isAddressChangingAuthorized": false,
-        "isTreatmentDisclosureAuthorized": false,
-        "veteran": {
-          "firstName": "Michael",
-          "middleName": "Karl",
-          "lastName": "Sage",
-          "participantId": 111213140
-        },
-        "representative": {
-          "firstName": "Nicholas",
-          "lastName": "Brown",
-          "email": "nicholas.brown@vsorg.org"
-        },
-        "claimant": {
-          "firstName": "Lucas",
-          "lastName": "Brown",
-          "participantId": 65432,
-          "relationshipToVeteran": "Child"
-        },
-        "claimantAddress": {
-          "city": "Los Angeles",
-          "state": "CA",
-          "zip": "90001",
-          "country": "US",
-          "militaryPostOffice": null,
-          "militaryPostalCode": null
-        }
+      },
+      "resolution": null,
+      "power_of_attorney_holder": {
+        "id": "69af0f61-2a9c-4eaf-a1cd-2e7a08330025",
+        "type": "veteran_service_organization",
+        "name": "Trustworthy Organization"
+      },
+      "accredited_individual": {
+        "id": "d0fd88c1-4568-4d7e-9983-33bbc45b0224",
+        "full_name": "Alanna Smith"
       }
     }
-  ],
-  "meta": {
-    "totalRecords": "6"
-  }
+  ]
 }

--- a/src/applications/accredited-representative-portal/sass/POARequestCard.scss
+++ b/src/applications/accredited-representative-portal/sass/POARequestCard.scss
@@ -44,7 +44,7 @@
     }
 
     @media (min-width: $small-desktop-screen) {
-      max-width: 600px;
+      max-width: 660px;
     }
 
     &-icon {

--- a/src/applications/accredited-representative-portal/sass/POARequestDetails.scss
+++ b/src/applications/accredited-representative-portal/sass/POARequestDetails.scss
@@ -1,14 +1,15 @@
 @import "~@department-of-veterans-affairs/css-library/dist/tokens/scss/variables";
 
 .poa-request-details {
+  width: 100%;
   @media (min-width: $small-desktop-screen) {
-    width: 968px;
+    width: 1000px;
   }
 
   &__form {
     padding: 35px 14px;
     background-color: $vads-color-base-lightest;
-    margin-top: 35px;
+    margin-top: 66px;
 
     h4 {
       font-family: var(--font-source-sans);
@@ -79,5 +80,71 @@
 
   &__subtitle {
     margin-top: 0;
+  }
+
+  &__name {
+    font-weight: 400;
+    margin: 15px 0;
+    display: flex;
+    align-items: center;
+  }
+
+  &__status {
+    margin-left: 15px;
+    color: $vads-color-base;
+
+    &.pending {
+      background-color: $vads-color-warning-lighter;
+      border: 1px solid $vads-color-warning-darker;
+    }
+    &.acceptance {
+      background-color: $vads-color-success-lighter;
+      border: 1px solid $vads-color-success;
+    }
+    &.declination,
+    &.expiration {
+      background-color: $uswds-system-color-red-warm-10;
+      border: 1px solid $uswds-system-color-red-warm-vivid-50 ;
+    }
+    &.processing {
+      background-color: $uswds-system-color-gray-5;
+      border: 1px solid $uswds-system-color-gray-cool-60;
+    }
+  }
+
+  &__table {
+    border-collapse: collapse;
+
+    th {
+      font-weight: 700;
+    }
+    td, th {
+      border: none;
+      padding: 8px 15px;
+      width: 100%;
+      display: block;
+
+      @media (min-width: $small-desktop-screen) {
+        width: 50%;
+        display: table-cell;
+        padding: 15px;
+      }
+    }
+
+    tr {
+      display: block;
+      border-bottom: 1px solid $vads-color-base;
+      @media (min-width: $small-desktop-screen) {
+        display: table-row;
+      }
+
+      &:first-child {
+        border-top: 1px solid $vads-color-base;
+      }
+    }
+  }
+
+  &__info {
+    max-width: 650px;
   }
 }

--- a/src/applications/accredited-representative-portal/sass/POARequestDetails.scss
+++ b/src/applications/accredited-representative-portal/sass/POARequestDetails.scss
@@ -65,6 +65,10 @@
     }
 
     &-item {
+      span {
+        margin-bottom: 1em;
+        display: block;
+      }
       @media (min-width: $small-desktop-screen) {
         flex: 33%;
       }


### PR DESCRIPTION
Updating the details page to match the latest figma.
Some notes:
`va-table` is currently broken and being worked on - see [slack thread](https://dsva.slack.com/archives/C5HP4GN3F/p1733254701304129). Using the default html5 `table` element for now.

![image](https://github.com/user-attachments/assets/fa98537a-181e-4d88-8fad-93d34fb320fd)
![image](https://github.com/user-attachments/assets/9b2dc14d-da91-45fa-8915-4f532eb60f49)
![image](https://github.com/user-attachments/assets/f790debf-1e7f-4e74-aeb5-eb46e3bb34b7)
