### PR TITLE
VACMS-20198 Fix search maintenance banner display

### DIFF
--- a/src/applications/search/components/SearchMaintenance.jsx
+++ b/src/applications/search/components/SearchMaintenance.jsx
@@ -3,15 +3,15 @@ import PropTypes from 'prop-types';
 import { getDay, getHours, setHours, setMinutes, setSeconds } from 'date-fns';
 import { utcToZonedTime, format as tzFormat } from 'date-fns-tz';
 
-export const isWithinMaintenanceWindow = () => {
-  const maintenanceDays = [2, 4]; // Days: 2 for Tuesday, 4 for Thursday
-  const maintenanceStartHour = 10; // DUMMY - remove this
-  // const maintenanceStartHour = 15; // Start time: 3 PM in 24-hour format
-  const maintenanceEndHour = 18; // End time: 6 PM in 24-hour format
-  const timeZone = 'America/New_York';
+const maintenanceStartHour = 15; // Start time: 3 PM in 24-hour format
+const maintenanceDays = [2, 4]; // Days: 2 for Tuesday, 4 for Thursday
+const maintenanceEndHour = 18; // End time: 6 PM in 24-hour format
+const maintenanceDurationHours = maintenanceEndHour - maintenanceStartHour;
+const maintenanceTimezone = 'America/New_York';
 
+export const isWithinMaintenanceWindow = () => {
   const now = new Date();
-  const zonedNow = utcToZonedTime(now, timeZone);
+  const zonedNow = utcToZonedTime(now, maintenanceTimezone);
 
   return (
     maintenanceDays.includes(getDay(zonedNow)) &&
@@ -21,14 +21,9 @@ export const isWithinMaintenanceWindow = () => {
 };
 
 const calculateCurrentMaintenanceWindow = () => {
-  const maintenanceStartHour = 10; // DUMMY - remove this
-  // const maintenanceStartHour = 15; // 3 PM in 24-hour format
-  const maintenanceDurationHours = 3; // Duration of the maintenance window in hours
-  const timeZone = 'America/New_York';
-
   // Current date and time in the specified timezone
   let start = new Date();
-  start = utcToZonedTime(start, timeZone);
+  start = utcToZonedTime(start, maintenanceTimezone);
   start = setHours(start, maintenanceStartHour);
   start = setMinutes(start, 0);
   start = setSeconds(start, 0);
@@ -37,14 +32,16 @@ const calculateCurrentMaintenanceWindow = () => {
   let end = new Date(
     start.getTime() + maintenanceDurationHours * 60 * 60 * 1000,
   );
-  end = utcToZonedTime(end, timeZone); // Ensure the end time is also adjusted to the specified timezone
+
+  end = utcToZonedTime(end, maintenanceTimezone); // Ensure the end time is also adjusted to the specified timezone
 
   // Format start and end dates to include timezone offset correctly
   const startFormatted = tzFormat(start, "EEE MMM d yyyy HH:mm:ss 'GMT'XXXX", {
-    timeZone,
+    maintenanceTimezone,
   });
+
   const endFormatted = tzFormat(end, "EEE MMM d yyyy HH:mm:ss 'GMT'XXXX", {
-    timeZone,
+    maintenanceTimezone,
   });
 
   return {

--- a/src/applications/search/components/SearchMaintenance.jsx
+++ b/src/applications/search/components/SearchMaintenance.jsx
@@ -5,7 +5,8 @@ import { utcToZonedTime, format as tzFormat } from 'date-fns-tz';
 
 export const isWithinMaintenanceWindow = () => {
   const maintenanceDays = [2, 4]; // Days: 2 for Tuesday, 4 for Thursday
-  const maintenanceStartHour = 15; // Start time: 3 PM in 24-hour format
+  const maintenanceStartHour = 10; // DUMMY - remove this
+  // const maintenanceStartHour = 15; // Start time: 3 PM in 24-hour format
   const maintenanceEndHour = 18; // End time: 6 PM in 24-hour format
   const timeZone = 'America/New_York';
 
@@ -20,7 +21,8 @@ export const isWithinMaintenanceWindow = () => {
 };
 
 const calculateCurrentMaintenanceWindow = () => {
-  const maintenanceStartHour = 15; // 3 PM in 24-hour format
+  const maintenanceStartHour = 10; // DUMMY - remove this
+  // const maintenanceStartHour = 15; // 3 PM in 24-hour format
   const maintenanceDurationHours = 3; // Duration of the maintenance window in hours
   const timeZone = 'America/New_York';
 
@@ -60,7 +62,7 @@ const SearchMaintenance = ({ unexpectedMaintenance }) => {
         <va-banner
           data-label="Error banner"
           headline="Search Maintenance"
-          type="error"
+          type="warning"
         >
           We’re working on Search VA.gov right now. If you have trouble using
           the search tool, check back later. Thank you for your patience.

--- a/src/applications/search/components/SearchMaintenance.jsx
+++ b/src/applications/search/components/SearchMaintenance.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { getDay, getHours, setHours, setMinutes, setSeconds } from 'date-fns';
 import { utcToZonedTime, format as tzFormat } from 'date-fns-tz';
 
-const maintenanceStartHour = 15; // Start time: 3 PM in 24-hour format
 const maintenanceDays = [2, 4]; // Days: 2 for Tuesday, 4 for Thursday
+const maintenanceStartHour = 15; // Start time: 3 PM in 24-hour format
 const maintenanceEndHour = 18; // End time: 6 PM in 24-hour format
 const maintenanceDurationHours = maintenanceEndHour - maintenanceStartHour;
 const maintenanceTimezone = 'America/New_York';

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -395,15 +395,14 @@ const SearchApp = ({
             appTitle="Search App"
             dependencies={[externalServices.search]}
           >
-            {// Search API returned errors OR errors with user input before
-            //  submitting AND the maintenance banner is NOT going to be displayed
-            shouldShowErrorMessage &&
-              !shouldShowMaintenanceBanner && <Errors userInput={userInput} />}
             {// Search API is either within the maintenance window AND has returned
             //  no results OR the search_gov_maintenance Flipper has been enabled
             shouldShowMaintenanceBanner && (
               <SearchMaintenance unexpectedMaintenance={searchGovMaintenance} />
             )}
+            {// Search API returned errors OR errors with user input before
+            //  submitting AND the maintenance banner is NOT going to be displayed
+            shouldShowErrorMessage && <Errors userInput={userInput} />}
             <div className="vads-u-background-color--gray-lightest vads-u-padding-x--3 vads-u-padding-bottom--3 vads-u-padding-top--1p5 vads-u-margin-bottom--4">
               <p className="vads-u-margin-top--0">
                 Enter a keyword, phrase, or question
@@ -439,7 +438,6 @@ const SearchApp = ({
 
 const mapStateToProps = state => ({
   search: state.search,
-  // searchGovMaintenance: true
   searchGovMaintenance: toggleValues(state)[
     FEATURE_FLAG_NAMES.searchGovMaintenance
   ],

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -376,15 +376,8 @@ const SearchApp = ({
   // 1. Search.gov errors during their maintenance windows (Tues & Thurs 3-6pm EST)
   // 2. Sitewide team using the search_gov_maintenance feature flipper
   //    when Search.gov is experiencing major outages
-  const searchGovIssuesWithinMaintenanceWindow =
-    isWithinMaintenanceWindow() &&
-    results &&
-    results.length === 0 &&
-    !hasErrors &&
-    !searchIsLoading;
-
   const shouldShowMaintenanceBanner =
-    searchGovIssuesWithinMaintenanceWindow || searchGovMaintenance;
+    isWithinMaintenanceWindow() || searchGovMaintenance;
 
   return (
     <div className="search-app" data-e2e-id="search-app">
@@ -446,6 +439,7 @@ const SearchApp = ({
 
 const mapStateToProps = state => ({
   search: state.search,
+  // searchGovMaintenance: true
   searchGovMaintenance: toggleValues(state)[
     FEATURE_FLAG_NAMES.searchGovMaintenance
   ],

--- a/src/applications/search/tests/e2e/error-states.cypress.spec.js
+++ b/src/applications/search/tests/e2e/error-states.cypress.spec.js
@@ -41,7 +41,7 @@ xdescribe('Error states', () => {
     });
   });
 
-  it('fails to search and has an error', () => {
+  it('shows an error when the search service fails', () => {
     cy.intercept('GET', '/v0/search?query=benefits', {
       body: [],
       statusCode: 500,

--- a/src/applications/search/tests/e2e/maintenance-window.cypress.spec.js
+++ b/src/applications/search/tests/e2e/maintenance-window.cypress.spec.js
@@ -55,43 +55,7 @@ describe('Search.gov maintenance window message', () => {
     });
   };
 
-  it('should display maintenance message during maintenance window when 0 results on Tuesday at 4 PM EST', () => {
-    mockResultsEmpty();
-    setClockAndSearch('2021-03-16T20:00:00.000Z');
-    verifyBanner();
-    verifyNoResults();
-
-    cy.axeCheck();
-  });
-
-  it('should display maintenance message during maintenance window when 0 results on Thursday at 4 PM EST', () => {
-    mockResultsEmpty();
-    setClockAndSearch('2021-03-18T20:00:00.000Z');
-    verifyBanner();
-    verifyNoResults();
-
-    cy.axeCheck();
-  });
-
-  it('should display maintenance message during maintenance window when 0 results on Tuesday at 5 PM EST', () => {
-    mockResultsEmpty();
-    setClockAndSearch('2021-03-16T21:00:00.000Z');
-    verifyBanner();
-    verifyNoResults();
-
-    cy.axeCheck();
-  });
-
-  it('should display maintenance message during maintenance window when 0 results on Thursday at 5 PM EST', () => {
-    mockResultsEmpty();
-    setClockAndSearch('2021-03-18T21:00:00.000Z');
-    verifyBanner();
-    verifyNoResults();
-
-    cy.axeCheck();
-  });
-
-  it('should display message if returns with search results at 4 PM EST on a Tuesday', () => {
+  it('should display maintenance message during maintenance window on Tuesday at 4 PM EST', () => {
     mockResults();
     setClockAndSearch('2021-03-16T20:00:00.000Z');
     verifyBanner();
@@ -100,27 +64,45 @@ describe('Search.gov maintenance window message', () => {
     cy.axeCheck();
   });
 
-  it('should NOT display maintenance message when 0 results on Monday at 2 PM EST', () => {
+  it('should display maintenance message during maintenance window on Thursday at 4 PM EST', () => {
+    mockResults();
+    setClockAndSearch('2021-03-18T20:00:00.000Z');
+    verifyBanner();
+    checkForResults();
+
+    cy.axeCheck();
+  });
+
+  it('should display maintenance message during maintenance window on Tuesday at 5 PM EST', () => {
     mockResultsEmpty();
+    setClockAndSearch('2021-03-16T21:00:00.000Z');
+    verifyBanner();
+    verifyNoResults();
+
+    cy.axeCheck();
+  });
+
+  it('should display maintenance message during maintenance window on Thursday at 5 PM EST', () => {
+    mockResultsEmpty();
+    setClockAndSearch('2021-03-18T21:00:00.000Z');
+    verifyBanner();
+    verifyNoResults();
+
+    cy.axeCheck();
+  });
+
+  it('should NOT display maintenance message on Monday at 2 PM EST', () => {
+    mockResults();
     setClockAndSearch('2021-03-15T18:00:00.000Z');
     verifyNoBanner();
-    verifyNoResults();
+    checkForResults();
 
     cy.axeCheck();
   });
 
-  it('should NOT display maintenance message when 0 results on Saturday at 6 PM EST', () => {
+  it('should NOT display maintenance message on Saturday at 6 PM EST', () => {
     mockResultsEmpty();
     setClockAndSearch('2021-03-20T22:00:00.000Z');
-    verifyNoBanner();
-    verifyNoResults();
-
-    cy.axeCheck();
-  });
-
-  it('should NOT display maintenance message when 0 results on Sunday at 9 AM EST', () => {
-    mockResultsEmpty();
-    setClockAndSearch('2021-03-21T13:00:00.000Z');
     verifyNoBanner();
     verifyNoResults();
 

--- a/src/applications/search/tests/e2e/maintenance-window.cypress.spec.js
+++ b/src/applications/search/tests/e2e/maintenance-window.cypress.spec.js
@@ -91,10 +91,10 @@ describe('Search.gov maintenance window message', () => {
     cy.axeCheck();
   });
 
-  it('should NOT display message if returns with search results at 4 PM EST on a Tuesday', () => {
+  it('should display message if returns with search results at 4 PM EST on a Tuesday', () => {
     mockResults();
     setClockAndSearch('2021-03-16T20:00:00.000Z');
-    verifyNoBanner();
+    verifyBanner();
     checkForResults();
 
     cy.axeCheck();

--- a/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
+++ b/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
@@ -66,12 +66,11 @@ describe('Unexpected outage from Search.gov', () => {
     });
   };
 
-  const verifyMaintanenceBanner = () => {
+  const verifyMaintenanceBanner = () => {
     cy.get(s.APP).within(() => {
       cy.get(s.OUTAGE_BOX)
         .should('exist')
         .and('contain', 'We’re working on Search VA.gov right now.');
-      cy.get(s.ERROR_ALERT_BOX).should('not.exist');
     });
   };
 
@@ -96,7 +95,7 @@ describe('Unexpected outage from Search.gov', () => {
     mockResults();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyMaintanenceBanner();
+    verifyMaintenanceBanner();
     checkForResults();
   });
 
@@ -105,7 +104,7 @@ describe('Unexpected outage from Search.gov', () => {
     mockResultsEmpty();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyMaintanenceBanner();
+    verifyMaintenanceBanner();
     verifyNoResults();
   });
 
@@ -114,7 +113,7 @@ describe('Unexpected outage from Search.gov', () => {
     mockResultsFailure();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyMaintanenceBanner();
+    verifyMaintenanceBanner();
     verifyNoResults();
   });
 

--- a/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
+++ b/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
@@ -16,19 +16,6 @@ describe('Unexpected outage from Search.gov', () => {
     });
   };
 
-  const disableToggle = () => {
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        features: [
-          {
-            name: 'search_gov_maintenance',
-            value: false,
-          },
-        ],
-      },
-    });
-  };
-
   const mockResultsEmpty = () => {
     cy.intercept('GET', '/v0/search?query=benefits', {
       body: zeroResultsStub,
@@ -66,7 +53,7 @@ describe('Unexpected outage from Search.gov', () => {
     });
   };
 
-  const verifyMaintenanceBanner = () => {
+  const verifyOutageBanner = () => {
     cy.get(s.APP).within(() => {
       cy.get(s.OUTAGE_BOX)
         .should('exist')
@@ -86,7 +73,12 @@ describe('Unexpected outage from Search.gov', () => {
       cy.get(s.ERROR_ALERT_BOX)
         .should('exist')
         .and('contain', 'Something went wrong on our end,');
-      cy.get(s.OUTAGE_BOX).should('not.exist');
+    });
+  };
+
+  const verifySearchFailureBannerIsNotVisible = () => {
+    cy.get(s.APP).within(() => {
+      cy.get(s.ERROR_ALERT_BOX).should('not.exist');
     });
   };
 
@@ -95,7 +87,8 @@ describe('Unexpected outage from Search.gov', () => {
     mockResults();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyMaintenanceBanner();
+    verifyOutageBanner();
+    verifySearchFailureBannerIsNotVisible();
     checkForResults();
   });
 
@@ -104,24 +97,17 @@ describe('Unexpected outage from Search.gov', () => {
     mockResultsEmpty();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyMaintenanceBanner();
+    verifyOutageBanner();
+    verifySearchFailureBannerIsNotVisible();
     verifyNoResults();
   });
 
-  it('should show the outage banner and no results when the toggle is on and the search call fails', () => {
+  it('should show an error message, the outage banner and no results when the toggle is on and the search call fails', () => {
     enableToggle();
     mockResultsFailure();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyMaintenanceBanner();
-    verifyNoResults();
-  });
-
-  it('should show an error message and no results when the API encounters an error', () => {
-    disableToggle();
-    mockResultsFailure();
-    cy.visit('/search?query=benefits');
-    cy.injectAxeThenAxeCheck();
+    verifyOutageBanner();
     verifySearchFailureBanner();
     verifyNoResults();
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
We had a bug reported that, during the Search.gov maintenance windows, the search maintenance banner is only visible if you go to `/search` with no search term. In production during the maintenance window, if you search via another method like the VA header or the homepage, you land on `/search` and don't see the maintenance banner then or in subsequent searches.

In poking around to fix this defect, I referred to [the last Slack thread in October](https://dsva.slack.com/archives/C52CL1PKQ/p1729686502971359) discussing unexpected UX where two red banners were stacked. This happened because we had unexpected Search.gov maintenance/outages and turned on the flipper, which turned on a red banner. **And** the search service also failed, so a red banner appeared to explain that.

In addressing that issue, we didn't address the UX recommendations that Amanda gave in the thread, so I revived the thread and proposed a number of scenarios for maintenance banners in combination with error banners. Those were approved by Fran, so they have been implemented here.

Going forward:

- The unplanned Search.gov maintenance banner (flipper-controlled) is now yellow as it is a warning and **does not** mean the search service will not work at all
- The planned Search.gov maintenance banner UX remains the same and will appear above the search input regardless of method of entry into the `/search` application **and** regardless of the outcome of the search service. Previously its display hinged on whether we had results -- this is not relevant anymore.
- The input's error banner, which shows when there is invalid user input or when the search service fails, will show regardless of maintenance status. We will still have scenarios where the banners stack, and the screenshots below illustrate those.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20198

## Testing done / Screenshots

Note that showing these maintenance banners requires running this locally and forcing them to appear, so I've provided screenshots to reflect the changes.

**To get the flipper banner to show up locally**:
1. go to `src/applications/search/containers/SearchApp.jsx`
2. in the `mapStateToProps` function, change `searchGovMaintenance` to `true`

**To get the maintenance banner to show up locally**:
1. go to `src/applications/search/components/SearchMaintenance.jsx`
2. change `maintenanceDays` at the top of the file to include `5`
3. change `maintenanceStartHour` to something much earlier, like `10`

### Unplanned maintenance

<img width="1059" alt="Screenshot 2025-01-09 at 2 13 51 PM" src="https://github.com/user-attachments/assets/1ce35159-11d8-4f9a-a6f2-4a8ea4269b44" />
<img width="1037" alt="Screenshot 2025-01-09 at 2 13 24 PM" src="https://github.com/user-attachments/assets/950f15a3-5b73-444e-9629-bfe22ebbd950" />
<img width="1044" alt="Screenshot 2025-01-09 at 2 13 44 PM" src="https://github.com/user-attachments/assets/09798e61-4129-4cf6-9685-cca98ed211b1" />

### Planned maintenance

<img width="1047" alt="Screenshot 2025-01-09 at 2 01 42 PM" src="https://github.com/user-attachments/assets/763977a8-b129-4029-8c18-e0fde57ea848" />
<img width="1045" alt="Screenshot 2025-01-09 at 2 01 27 PM" src="https://github.com/user-attachments/assets/7e49f1b3-4d6a-427a-8bdd-9b1b87531e07" />
<img width="1038" alt="Screenshot 2025-01-09 at 2 01 06 PM" src="https://github.com/user-attachments/assets/442be4b2-98dd-4359-8d60-817f55fc5680" />

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed