### PR TITLE
[100627] Appoint a Rep - only have consent limits when some records is selected

### DIFF
--- a/src/applications/representative-appoint/tests/utilities/pdfTransform.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/utilities/pdfTransform.unit.spec.jsx
@@ -5,13 +5,47 @@ import { pdfTransform } from '../../utilities/pdfTransform';
 const { expect } = require('chai');
 
 describe('transformData', () => {
-  it('should transform the input data into the expected output format', () => {
-    const input = formData;
+  let input;
 
+  beforeEach(() => {
+    input = { ...formData };
+  });
+
+  it('should transform the input data into the expected output format', () => {
     const expectedOutput = transformedData;
 
     const result = pdfTransform(input);
 
     expect(result).to.deep.equal(expectedOutput);
+  });
+
+  context('when authorizationRadio is all records', () => {
+    it('should ignore the previously selected consent limitations', () => {
+      input.authorizationRadio =
+        'Yes, they can access all of these types of records';
+
+      const result = pdfTransform(input);
+
+      expect(result.consentLimits).to.be.empty;
+    });
+  });
+
+  context('when authorizationRadio is some records', () => {
+    it('should include the previously selected consent limitations', () => {
+      const result = pdfTransform(input);
+
+      expect(result.consentLimits).to.deep.equal(['ALCOHOLISM', 'DRUG_ABUSE']);
+    });
+  });
+
+  context('when authorizationRadio is no records', () => {
+    it('should ignore the previously selected consent limitations', () => {
+      input.authorizationRadio =
+        "No, they can't access any of these types of records";
+
+      const result = pdfTransform(input);
+
+      expect(result.consentLimits).to.be.empty;
+    });
   });
 });

--- a/src/applications/representative-appoint/utilities/pdfTransform.js
+++ b/src/applications/representative-appoint/utilities/pdfTransform.js
@@ -1,7 +1,18 @@
 import { getRepType } from './helpers';
 
 function consentLimitsTransform(formData) {
-  const authorizeRecords = formData.authorizeMedicalSelectCheckbox || {};
+  const medicalAuthorization = formData.authorizationRadio;
+  let authorizeRecords;
+  if (
+    medicalAuthorization ===
+      'Yes, they can access all of these types of records' ||
+    medicalAuthorization ===
+      "No, they can't access any of these types of records"
+  ) {
+    authorizeRecords = {};
+  } else {
+    authorizeRecords = formData.authorizeMedicalSelectCheckbox || {};
+  }
 
   const conditionsMap = {
     alcoholRecords: 'ALCOHOLISM',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds a conditional check to the pdf data transform method to only send consent limitations when "some records" is the selected medical authorization.

## Related issue(s)

- [100627](https://github.com/department-of-veterans-affairs/va.gov-team/issues/100627)

## Testing done

- Went through 21-22 and 21-22a flow selecting various authorizations, navigating backwards, and selecting new authorizations with auth and unauth users.

## What areas of the site does it impact?

Appoint a Rep 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user