### PR TITLE
Remove checks for maintenance banners in search e2e tests

### DIFF
--- a/src/applications/search/tests/e2e/error-states.cypress.spec.js
+++ b/src/applications/search/tests/e2e/error-states.cypress.spec.js
@@ -1,6 +1,6 @@
 import { SELECTORS as s } from './helpers';
 
-describe('Error states', () => {
+xdescribe('Error states', () => {
   it('shows an error when no search term is given', () => {
     cy.visit('/search');
     cy.injectAxeThenAxeCheck();

--- a/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
+++ b/src/applications/search/tests/e2e/search-and-pagination.cypress.spec.js
@@ -49,8 +49,6 @@ describe('Global search', () => {
       );
 
       cy.get(s.ERROR_ALERT_BOX).should('not.exist');
-      cy.get(s.MAINT_BOX).should('not.exist');
-      cy.get(s.OUTAGE_BOX).should('not.exist');
 
       cy.get(s.PAGINATION)
         .should('exist')
@@ -112,8 +110,6 @@ describe('Global search', () => {
       );
 
       cy.get(s.ERROR_ALERT_BOX).should('not.exist');
-      cy.get(s.MAINT_BOX).should('not.exist');
-      cy.get(s.OUTAGE_BOX).should('not.exist');
     });
 
     cy.axeCheck();
@@ -135,8 +131,6 @@ describe('Global search', () => {
         .should('be.visible')
         .should('contain.text', `We didn’t find any results for "benefits."`);
       cy.get(s.ERROR_ALERT_BOX).should('not.exist');
-      cy.get(s.MAINT_BOX).should('not.exist');
-      cy.get(s.OUTAGE_BOX).should('not.exist');
       cy.get(s.TOP_RECOMMENDATIONS).should('not.exist');
       cy.get(s.SEARCH_RESULTS).should('not.exist');
     });
@@ -158,8 +152,6 @@ describe('Global search', () => {
         .should('be.visible')
         .should('contain.text', `We didn’t find any results.`);
       cy.get(s.ERROR_ALERT_BOX).should('not.exist');
-      cy.get(s.MAINT_BOX).should('not.exist');
-      cy.get(s.OUTAGE_BOX).should('not.exist');
       cy.get(s.TOP_RECOMMENDATIONS).should('not.exist');
       cy.get(s.SEARCH_RESULTS).should('not.exist');
     });

--- a/src/applications/search/tests/e2e/typeahead-behavior.cypress.spec.js
+++ b/src/applications/search/tests/e2e/typeahead-behavior.cypress.spec.js
@@ -45,8 +45,6 @@ describe('Global search typeahead behavior', () => {
       verifyTAResult(4, 'benefits letter');
 
       cy.get(s.ERROR_ALERT_BOX).should('not.exist');
-      cy.get(s.MAINT_BOX).should('not.exist');
-      cy.get(s.OUTAGE_BOX).should('not.exist');
 
       cy.get(s.TYPEAHEAD_OPTIONS)
         .eq(3)


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
In the Search Cypress tests for standard searches / typeahead, we are checking that the Search.gov planned maintenance banner and the Search.gov UNplanned maintenance banners are not visible when conducting searches. This isn't really necessary, and certainly isn't always true as those banners come and go and can randomly fail the e2e tests. 

I removed those checks in the standard tests. We will continue to check for those banners in their specific e2e tests where the API calls and times are mocked to intentionally show the banners and won't have unpredictable results.

Also skipped the error e2e tests for now because we need to iron out some product questions and fix the display of error messages and maintenance banners together, and then update the e2e tests. This will be addressed in this PR: https://github.com/department-of-veterans-affairs/vets-website/pull/34007/files

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20198