### PR TITLE
100524 If AC-API error is missing a code, don't display that empty code to the user

### DIFF
--- a/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.jsx
@@ -66,13 +66,20 @@ const AlertAccountApiAlert = ({
             page. Or check back later.
           </p>
 
-          <p>
-            If the problem persists, call the My HealtheVet helpdesk at
-            877-327-0022 (TTY: 711). We’re here Monday through Friday, 8:00 a.m.
-            to 8 p.m. ET. Tell the representative that you received{' '}
-            <b>error code {errorCode}</b>.
-          </p>
-
+          {errorCode.length > 0 ? (
+            <p>
+              If the problem persists, call the My HealtheVet helpdesk at
+              877-327-0022 (TTY: 711). We’re here Monday through Friday, 8:00
+              a.m. to 8 p.m. ET. Tell the representative that you received{' '}
+              <b>error code {errorCode}</b>.
+            </p>
+          ) : (
+            <p>
+              If the problem persists, call the My HealtheVet helpdesk at
+              877-327-0022 (TTY: 711). We’re here Monday through Friday, 8:00
+              a.m. to 8 p.m. ET.
+            </p>
+          )}
           <p>
             If you need to contact your care team now, call your VA health
             facility.
@@ -89,7 +96,7 @@ const AlertAccountApiAlert = ({
 
 AlertAccountApiAlert.defaultProps = {
   title: 'Error code 000: Contact the My HealtheVet help desk',
-  errorCode: 'unknown',
+  errorCode: '',
   recordEvent: recordEventFn,
   testId: 'mhv-alert--mhv-registration',
 };

--- a/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
+++ b/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
@@ -118,9 +118,18 @@ const accountStatusEightZeroOne = {
 const accountStatusFiveZeroZero = {
   errors: [
     {
-      title: 'The server responded with status 422',
+      title: 'The server responded with status 500',
       detail: 'things fall apart',
       code: '500',
+    },
+  ],
+};
+
+const accountStatusFourTwoTwo = {
+  errors: [
+    {
+      title: 'The server responded with status 422',
+      detail: 'this error never gets past vets-api so it has no code value',
     },
   ],
 };
@@ -160,5 +169,6 @@ module.exports = {
   accountStatusSuccessResponse,
   accountStatusEightZeroOne,
   accountStatusFiveZeroZero,
+  accountStatusFourTwoTwo,
   accountStatusMultiError,
 };

--- a/src/applications/mhv-landing-page/tests/e2e/alerts/no-mhv-account.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/alerts/no-mhv-account.cypress.spec.js
@@ -46,7 +46,7 @@ describe(`${appName} - MHV Registration Alert - `, () => {
     });
   });
 
-  context('for non-user api errors', () => {
+  context('for non-user api errors with error code', () => {
     beforeEach(() => {
       ApiInitializer.initializeAccountStatus.with500();
       LandingPage.visit({ mhvAccountState: 'NONE' });
@@ -55,6 +55,19 @@ describe(`${appName} - MHV Registration Alert - `, () => {
     it(`shows a 'try again later' alert`, () => {
       cy.injectAxeThenAxeCheck();
       cy.findByText(AlertMhvNoAction.defaultProps.title, {
+        exact: false,
+      }).should.exist;
+
+      // Check the cards and hubs are visible
+      cy.findAllByTestId(/^mhv-link-group-card-/).should.exist;
+      cy.findAllByTestId(/^mhv-link-group-hub-/).should.exist;
+    });
+
+    it('should reference a specific error', () => {
+      'Tell the representative that you received';
+
+      cy.injectAxeThenAxeCheck();
+      cy.findByText('Tell the representative that you received', {
         exact: false,
       }).should.exist;
 
@@ -86,6 +99,26 @@ describe(`${appName} - MHV Registration Alert - `, () => {
           exact: false,
         },
       ).should.exist;
+    });
+  });
+
+  context('for non-user api errors without error code', () => {
+    beforeEach(() => {
+      ApiInitializer.initializeAccountStatus.with422();
+      LandingPage.visit({ mhvAccountState: 'NONE' });
+    });
+
+    it('should not reference any specific error', () => {
+      'Tell the representative that you received';
+
+      cy.injectAxeThenAxeCheck();
+      cy.findByText('Tell the representative that you received', {
+        exact: false,
+      }).should('not.exist');
+
+      // Check the cards and hubs are visible
+      cy.findAllByTestId(/^mhv-link-group-card-/).should.exist;
+      cy.findAllByTestId(/^mhv-link-group-hub-/).should.exist;
     });
   });
 

--- a/src/applications/mhv-landing-page/tests/e2e/utilities/ApiInitializer.js
+++ b/src/applications/mhv-landing-page/tests/e2e/utilities/ApiInitializer.js
@@ -8,6 +8,7 @@ import {
   accountStatusSuccessResponse,
   accountStatusEightZeroOne,
   accountStatusFiveZeroZero,
+  accountStatusFourTwoTwo,
   accountStatusMultiError,
 } from '../../../mocks/api/user/mhvAccountStatus';
 
@@ -86,6 +87,9 @@ class ApiInitializer {
         '/v0/user/mhv_user_account',
         accountStatusFiveZeroZero,
       );
+    },
+    with422: () => {
+      cy.intercept('GET', '/v0/user/mhv_user_account', accountStatusFourTwoTwo);
     },
     withMultipleErrors: () => {
       cy.intercept('GET', '/v0/user/mhv_user_account', accountStatusMultiError);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
If we receive an error response without an explicit code, we don't want to render an alert informing the user that we don't know the error code.

## Related issue(s)
[100524](https://github.com/department-of-veterans-affairs/va.gov-team/issues/100524)

## Testing done
Specs added

## Screenshots
<img width="1030" alt="Screenshot 2025-01-09 at 4 41 55 PM" src="https://github.com/user-attachments/assets/98eff937-ea00-49ab-bc98-62d22875033b" />

## What areas of the site does it impact?
MHV landing page

## Acceptance criteria
when the AC-API returns an error without an explicit `code` attribute, render the corresponding alert without describing the error code as "unknown"
