### PR TITLE
Remove sign in alert verbiage from all simple forms

### DIFF
--- a/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
@@ -78,13 +78,6 @@ export const IntroductionPage = ({ route, userIdVerified, userLoggedIn }) => {
       </ul>
 
       <h2 id="start-your-request">Start your request</h2>
-      <p>
-        <strong>Note</strong>: You’ll need to sign in with a verified{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account or a
-        Premium <strong>DS Logon</strong> or <strong>My HealtheVet</strong>{' '}
-        account. If you don’t have any of those accounts, you can create a free{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account now.
-      </p>
       {userLoggedIn &&
       !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
           <div className="id-not-verified-content vads-u-margin-top--4">

--- a/src/applications/simple-forms/20-10207/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/20-10207/containers/IntroductionPage.jsx
@@ -206,14 +206,6 @@ const IntroductionPage = props => {
         </p>
       </va-additional-info>
       <h2 id="start-your-request">Start your request</h2>
-      <p>
-        <strong>Note</strong>: You’ll need to sign in with a verified{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account or a
-        Premium <strong>DS Logon</strong> or <strong>My HealtheVet</strong>{' '}
-        account. If you don’t have any of those accounts, you can create a free{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account when you
-        sign in to start filling out your form.
-      </p>
       {userLoggedIn &&
       !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
           <div

--- a/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
@@ -72,14 +72,6 @@ class IntroductionPage extends React.Component {
           ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
         </p>
         <h2 id="start-your-request">Start your authorization</h2>
-        <p>
-          <strong>Note</strong>: You’ll need to sign in with a verified{' '}
-          <strong>Login.gov</strong> or <strong>ID.me</strong> account or a
-          Premium <strong>DS Logon</strong> or <strong>My HealtheVet</strong>{' '}
-          account. If you don’t have any of those accounts, you can create a
-          free <strong>Login.gov</strong> or <strong>ID.me</strong> account when
-          you sign in to start filling out your form.
-        </p>
         {userLoggedIn &&
         !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
             <div className="id-not-verified-content vads-u-margin-top--4">

--- a/src/applications/simple-forms/21-0966/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0966/containers/IntroductionPage.jsx
@@ -118,13 +118,6 @@ class IntroductionPage extends React.Component {
           </li>
         </ul>
         <h2 id="start-your-request">Start your intent to file</h2>
-        <p>
-          <strong>Note</strong>: You’ll need to sign in with a verified{' '}
-          <strong>Login.gov</strong> or <strong>ID.me</strong> account or a
-          Premium <strong>DS Logon</strong> or <strong>My HealtheVet</strong>{' '}
-          account. If you don’t have any of those accounts, you can create a
-          free <strong>Login.gov</strong> or <strong>ID.me</strong> account now.
-        </p>
         {userLoggedIn &&
         !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
             <div className="id-not-verified-content vads-u-margin-top--4">

--- a/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
@@ -33,12 +33,6 @@ const IntroductionPage = props => {
         </a>
       </p>
       <h2>Start your form</h2>
-      <p>
-        <b>Note:</b> You’ll need to sign in with a verified <b>Login.gov</b> or{' '}
-        <b>ID.me</b> account or a Premium <b>DS Logon</b> or{' '}
-        <b>My HealtheVet</b> account. If you don’t have any of those accounts,
-        you can create a free <b>Login.gov</b> or <b>ID.me</b> account now.
-      </p>
     </>
   );
 

--- a/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
@@ -52,14 +52,6 @@ export const IntroductionPage = ({ route, userIdVerified, userLoggedIn }) => {
         </li>
       </ul>
       <h2 id="start-your-request">Start your authorization</h2>
-      <p>
-        <strong>Note</strong>: You’ll need to sign in with a verified{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account or a
-        Premium <strong>DS Logon</strong> or <strong>My HealtheVet</strong>{' '}
-        account. If you don’t have any of those accounts, you can create a free{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account when you
-        sign in to start filling out your form.
-      </p>
       {userLoggedIn &&
       !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
           <div className="id-not-verified-content vads-u-margin-top--4">


### PR DESCRIPTION
## Summary
This removes all of the specific sign in verbiage from all of the simple forms that were displaying custom text.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1956