### PR TITLE
MHV-66087 Ensure we are displaying appropriate precision in ChemHem

### DIFF
--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -85,11 +85,7 @@ export const convertChemHemObservation = record => {
         observationValue,
         observationUnit,
       } = getObservationValueWithUnits(result);
-      const fixedObservationValue =
-        typeof observationValue === 'number'
-          ? observationValue.toFixed(1)
-          : observationValue;
-      finalObservationValue = `${fixedObservationValue} ${observationUnit}`;
+      finalObservationValue = `${observationValue} ${observationUnit}`;
       standardRange = isArrayAndHasItems(result.referenceRange)
         ? `${result.referenceRange[0].text} ${observationUnit}`.trim()
         : null;

--- a/src/applications/mhv-medical-records/tests/components/ChemHemDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/ChemHemDetails.unit.spec.jsx
@@ -105,7 +105,7 @@ describe('Chem Hem details component', () => {
 
   it('should display the result and interpretation in parentheses', () => {
     expect(screen.getAllByText('Result', { selector: 'h4' }).length).to.eq(2);
-    expect(screen.getByText('138.0 mEq/L (Low)', { selector: 'p' })).to.exist;
+    expect(screen.getByText('138 mEq/L (Low)', { selector: 'p' })).to.exist;
   });
 
   it('should display the reference range with units', () => {

--- a/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
@@ -166,7 +166,65 @@ describe('convertChemHemObservation', () => {
     expect(convertChemHemObservation(record)).to.deep.equal([
       {
         name: 'Name',
-        result: '138.0 mEq/L (Low)',
+        result: '138 mEq/L (Low)',
+        standardRange: EMPTY_FIELD,
+        status: 'final',
+        labComments: EMPTY_FIELD,
+        labLocation: EMPTY_FIELD,
+      },
+    ]);
+  });
+
+  it('should retain significant digits in small numbers', () => {
+    const record = {
+      contained: [
+        {
+          resourceType: 'Observation',
+          id: 'test-1',
+          code: { text: 'Name' },
+          valueQuantity: {
+            value: 0.0007,
+            unit: 'mEq/L',
+          },
+          status: 'final',
+        },
+      ],
+      result: [{ reference: '#test-1' }],
+    };
+
+    expect(convertChemHemObservation(record)).to.deep.equal([
+      {
+        name: 'Name',
+        result: '0.0007 mEq/L',
+        standardRange: EMPTY_FIELD,
+        status: 'final',
+        labComments: EMPTY_FIELD,
+        labLocation: EMPTY_FIELD,
+      },
+    ]);
+  });
+
+  it('should display string values as-is', () => {
+    const record = {
+      contained: [
+        {
+          resourceType: 'Observation',
+          id: 'test-1',
+          code: { text: 'Name' },
+          valueQuantity: {
+            value: '0.0007000',
+            unit: 'mEq/L',
+          },
+          status: 'final',
+        },
+      ],
+      result: [{ reference: '#test-1' }],
+    };
+
+    expect(convertChemHemObservation(record)).to.deep.equal([
+      {
+        name: 'Name',
+        result: '0.0007000 mEq/L',
         standardRange: EMPTY_FIELD,
         status: 'final',
         labComments: EMPTY_FIELD,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We are now displaying the appropriate precision for Chem/Hem Observation values.

## Related issue(s)

### [MHV-66087](https://jira.devops.va.gov/browse/MHV-66087) - Do not round Chem/Hem quantity values ###

> We are currently rounding to the nearest tenth for all observations. This is causing wrong values to appear for users. See [this Slack thread](https://dsva.slack.com/archives/C03Q2UQL1AS/p1736527547614809).


## Testing done

- Added new unit tests specifically for precision.

## Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/99b88439-93c9-46e6-b993-07f611efd445" />


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
