### PR TITLE
93008 Update 'update' and 'remove' buttons - Array Field

### DIFF
--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -458,31 +458,29 @@ export default class ArrayField extends React.Component {
                         <div className="row small-collapse">
                           <div className="small-6 left columns">
                             {(!isLast || showSave) && (
-                              <button
-                                type="button"
+                              <VaButton
                                 className="float-left"
-                                aria-label={`${updateText} ${ariaItemName}`}
+                                label={`${updateText} ${ariaItemName} ${index +
+                                  1}`}
                                 onClick={() => this.handleUpdate(index)}
-                              >
-                                {updateText}
-                              </button>
+                                text={updateText}
+                              />
                             )}
                           </div>
                           <div className="small-6 right columns">
                             {multipleRows && (
-                              <button
-                                type="button"
-                                className="usa-button-secondary float-right"
-                                aria-label={`Remove ${ariaItemName}`}
+                              <VaButton
+                                secondary
+                                className="float-right"
+                                label={`Remove ${ariaItemName} ${index + 1}`}
                                 onClick={() =>
                                   this.handleRemove(
                                     index,
                                     uiOptions.confirmRemove,
                                   )
                                 }
-                              >
-                                Remove
-                              </button>
+                                text="Remove"
+                              />
                             )}
                           </div>
                         </div>

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -139,9 +139,10 @@ describe('Schemaform <ArrayField>', () => {
     expect(tree.everySubTree('.va-growable-background').length).to.equal(1);
     const button = tree.everySubTree('button');
     // no remove button
-    expect(button.length).to.equal(2);
-    expect(button[0].text()).to.equal('Save');
-    expect(button[1].text()).to.contain('Add another');
+    expect(button.length).to.equal(1);
+    // expect(button[0].text()).to.equal('Save');
+    expect(tree.toString()).to.contain('text="Save"'); // SkinDeep doesn't handle VaButton, so can't directly query for this edit button.
+    expect(button[0].text()).to.contain('Add another');
   });
   it('should render save button with showSave option', () => {
     const idSchema = {
@@ -184,11 +185,14 @@ describe('Schemaform <ArrayField>', () => {
     expect(tree.everySubTree('SchemaField').length).to.equal(1);
     expect(tree.everySubTree('.va-growable-background').length).to.equal(2);
     const button = tree.everySubTree('button');
-    expect(button.length).to.equal(3);
-    expect(tree.toString()).to.contain('text="Edit"'); // SkinDeep doesn't handle VaButton, so can't directly query for this edit button.
-    expect(button[0].text()).to.equal('Save');
-    expect(button[1].text()).to.equal('Remove');
-    expect(button[2].text()).to.contain('Add another');
+    expect(button.length).to.equal(1);
+
+    // SkinDeep doesn't handle VaButton, so can't directly query for these three buttons directly:
+    expect(tree.toString()).to.contain('text="Edit"');
+    expect(tree.toString()).to.contain('text="Remove"');
+    expect(tree.toString()).to.contain('text="Save"');
+
+    expect(button[0].text()).to.contain('Add another');
   });
 
   it('should render unique aria-labels on buttons from ui option key in item', () => {
@@ -259,13 +263,14 @@ describe('Schemaform <ArrayField>', () => {
     expect(tree.everySubTree('SchemaField').length).to.equal(1);
     expect(tree.everySubTree('.va-growable-background').length).to.equal(2);
     const button = tree.everySubTree('button');
-    expect(button.length).to.equal(3);
-    expect(tree.toString()).to.contain('Edit foo'); // SkinDeep doesn't handle VaButton, so can't directly query for this edit button.
-    expect(button[0].text()).to.equal('Save');
-    expect(button[0].props['aria-label']).to.equal('Save bar');
-    expect(button[1].text()).to.equal('Remove');
-    expect(button[1].props['aria-label']).to.equal('Remove bar');
-    expect(button[2].text()).to.contain('Add another');
+    expect(button.length).to.equal(1);
+
+    // SkinDeep doesn't handle VaButton, so can't directly query for these three buttons directly.
+    expect(tree.toString()).to.contain('label="Edit foo');
+    expect(tree.toString()).to.contain('label="Save bar');
+    expect(tree.toString()).to.contain('label="Remove bar');
+
+    expect(button[0].text()).to.contain('Add another');
   });
 
   it('should render invalid items', () => {
@@ -394,11 +399,12 @@ describe('Schemaform <ArrayField>', () => {
       expect(tree.getMountedInstance().state.editing[2]).to.be.false;
     });
     it('enforces max items by hiding add and displaying an alert', () => {
-      const buttons = tree.everySubTree('button');
       const alerts = tree.everySubTree('va-alert');
-      expect(buttons.length).to.equal(1);
-      expect(tree.toString()).to.contain('Edit item'); // SkinDeep doesn't handle VaButton, so can't directly query for this edit button.
-      expect(buttons[0].text()).to.contain('Remove');
+
+      // SkinDeep doesn't handle VaButton, so can't directly query for these two buttons directly.
+      expect(tree.toString()).to.contain('label="Edit item');
+      expect(tree.toString()).to.contain('label="Remove');
+
       expect(alerts.length).to.equal(1);
       expect(alerts[0].text()).to.equal(
         'You’ve entered the maximum number of items allowed.',

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -140,8 +140,7 @@ describe('Schemaform <ArrayField>', () => {
     const button = tree.everySubTree('button');
     // no remove button
     expect(button.length).to.equal(1);
-    // expect(button[0].text()).to.equal('Save');
-    expect(tree.toString()).to.contain('text="Save"'); // SkinDeep doesn't handle VaButton, so can't directly query for this edit button.
+    expect(tree.toString()).to.contain('text="Save"'); // SkinDeep doesn't handle VaButton, so can't directly query for this save button.
     expect(button[0].text()).to.contain('Add another');
   });
   it('should render save button with showSave option', () => {
@@ -265,7 +264,7 @@ describe('Schemaform <ArrayField>', () => {
     const button = tree.everySubTree('button');
     expect(button.length).to.equal(1);
 
-    // SkinDeep doesn't handle VaButton, so can't directly query for these three buttons directly.
+    // SkinDeep doesn't handle VaButton, so can't directly query for these three buttons directly:
     expect(tree.toString()).to.contain('label="Edit foo');
     expect(tree.toString()).to.contain('label="Save bar');
     expect(tree.toString()).to.contain('label="Remove bar');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This is a continuation of the work done in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/33886). 

- The `ArrayField.jsx` Update and Remove buttons have been switched over to `<VaButton/>` 
- Associated aria labels with the index of the particular list item

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93013

## Testing done

- Unit

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Remove button |![remove_before](https://github.com/user-attachments/assets/9170315d-4610-42b2-99d5-5be1d8ff7d2c)|![remove_after](https://github.com/user-attachments/assets/8d7f0cba-c6e5-4143-abf4-d5d830bdcf15)|
|Button styles|![before](https://github.com/user-attachments/assets/70dc959e-9f53-4358-b2bf-ef5fcb607416)|![after](https://github.com/user-attachments/assets/569902d3-fc9d-4387-8028-00be65d8fd03)|

## What areas of the site does it impact?

Forms that use v1 list loop

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA