### PR TITLE
Form Upload, change Zip code to Postal code in field

### DIFF
--- a/src/applications/simple-forms/form-upload/pages/nameAndZipCode.jsx
+++ b/src/applications/simple-forms/form-upload/pages/nameAndZipCode.jsx
@@ -21,7 +21,7 @@ export const nameAndZipCodePage = {
     fullName: firstNameLastNameNoSuffixUI(),
     address: addressUI({
       labels: {
-        postalCode: 'Zip code',
+        postalCode: 'Postal code',
       },
       omit: [
         'country',


### PR DESCRIPTION
## Summary
This PR changes a field label from "Zip code" to "Postal code". That's all.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=92481615&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1952
