### PR TITLE
21-0966, replace fullName with veteranFullName upon submission

### DIFF
--- a/src/applications/simple-forms/21-0966/config/submit-transformer.js
+++ b/src/applications/simple-forms/21-0966/config/submit-transformer.js
@@ -9,6 +9,11 @@ export default function transformForSubmit(formConfig, form) {
     sharedTransformForSubmit(formConfig, form),
   );
 
+  if (transformedData.fullName) {
+    transformedData.veteranFullName = transformedData.fullName;
+    delete transformedData.fullName;
+  }
+
   return JSON.stringify({
     ...transformedData,
     benefitSelection: {


### PR DESCRIPTION
## Summary
This PR changes a key which occurs on a particular occasion (when the user is logged in and has prefill) where a `fullName` field gets populated. We're actually expecting `veteranFullName` on the backend (and elsewhere in our fixtures in the `vets-website` repo), so I thought it would be best to change it here (rather than on the backend).

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=93326260&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1967
