### PR TITLE
99724 treat the AC-API response's code attribute as if it were an integer

### DIFF
--- a/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.jsx
@@ -66,7 +66,7 @@ const AlertAccountApiAlert = ({
             page. Or check back later.
           </p>
 
-          {errorCode.length > 0 ? (
+          {errorCode > 0 ? (
             <p>
               If the problem persists, call the My HealtheVet helpdesk at
               877-327-0022 (TTY: 711). We’re here Monday through Friday, 8:00
@@ -96,13 +96,13 @@ const AlertAccountApiAlert = ({
 
 AlertAccountApiAlert.defaultProps = {
   title: 'Error code 000: Contact the My HealtheVet help desk',
-  errorCode: '',
+  errorCode: 0,
   recordEvent: recordEventFn,
   testId: 'mhv-alert--mhv-registration',
 };
 
 AlertAccountApiAlert.propTypes = {
-  errorCode: PropTypes.string,
+  errorCode: PropTypes.number,
   title: PropTypes.string,
   headline: PropTypes.string,
   recordEvent: PropTypes.func,

--- a/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
+++ b/src/applications/mhv-landing-page/mocks/api/user/mhvAccountStatus.js
@@ -21,7 +21,7 @@ const eightZeroOne = (req, res) => {
       {
         title: 'The server responded with status 422',
         detail: 'things fall apart',
-        code: '801',
+        code: 801,
       },
     ],
   });
@@ -33,7 +33,7 @@ const eightZeroFive = (req, res) => {
       {
         title: 'The server responded with status 422',
         detail: 'things fall apart',
-        code: '805',
+        code: 805,
       },
     ],
   });
@@ -45,7 +45,7 @@ const eightZeroSix = (req, res) => {
       {
         title: 'The server responded with status 422',
         detail: 'things fall apart',
-        code: '802',
+        code: 802,
       },
     ],
   });
@@ -57,7 +57,7 @@ const fiveZeroZero = (req, res) => {
       {
         title: 'The server responded with status 500',
         detail: 'things fall apart',
-        code: '500',
+        code: 500,
       },
     ],
   });
@@ -69,22 +69,22 @@ const multiError = (req, res) => {
       {
         title: 'The server responded with status 422',
         detail: 'things fall apart',
-        code: '802',
+        code: 802,
       },
       {
         title: 'The server responded with status 500',
         detail: 'things fall apart',
-        code: '500',
+        code: 500,
       },
       {
         title: 'The server responded with status 422',
         detail: 'things fall apart',
-        code: '805',
+        code: 805,
       },
       {
         title: 'The server responded with status 422',
         detail: 'things fall apart',
-        code: '801',
+        code: 801,
       },
     ],
   });
@@ -110,7 +110,7 @@ const accountStatusEightZeroOne = {
     {
       title: 'The server responded with status 422',
       detail: 'things fall apart',
-      code: '801',
+      code: 801,
     },
   ],
 };
@@ -120,7 +120,7 @@ const accountStatusFiveZeroZero = {
     {
       title: 'The server responded with status 500',
       detail: 'things fall apart',
-      code: '500',
+      code: 500,
     },
   ],
 };
@@ -139,22 +139,22 @@ const accountStatusMultiError = {
     {
       title: 'The server responded with status 422',
       detail: 'things fall apart',
-      code: '802',
+      code: 802,
     },
     {
       title: 'The server responded with status 500',
       detail: 'things fall apart',
-      code: '500',
+      code: 500,
     },
     {
       title: 'The server responded with status 422',
       detail: 'things fall apart',
-      code: '805',
+      code: 805,
     },
     {
       title: 'The server responded with status 422',
       detail: 'things fall apart',
-      code: '801',
+      code: 801,
     },
   ],
 };

--- a/src/applications/mhv-landing-page/selectors/mhvAccountStatus.js
+++ b/src/applications/mhv-landing-page/selectors/mhvAccountStatus.js
@@ -1,4 +1,4 @@
-const userActionErrorCodes = ['801', '805', '806', '807'];
+const userActionErrorCodes = [801, 805, 806, 807];
 
 export const mhvAccountStatusLoading = state => {
   return state?.myHealth?.accountStatus?.loading;

--- a/src/applications/mhv-landing-page/tests/e2e/alerts/no-mhv-account.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/alerts/no-mhv-account.cypress.spec.js
@@ -64,8 +64,6 @@ describe(`${appName} - MHV Registration Alert - `, () => {
     });
 
     it('should reference a specific error', () => {
-      'Tell the representative that you received';
-
       cy.injectAxeThenAxeCheck();
       cy.findByText('Tell the representative that you received', {
         exact: false,

--- a/src/applications/mhv-landing-page/tests/selectors/mhvAccountStatus.unit.spec.js
+++ b/src/applications/mhv-landing-page/tests/selectors/mhvAccountStatus.unit.spec.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import {
+  mhvAccountStatusUsersuccess,
+  mhvAccountStatusErrorsSorted,
+  mhvAccountStatusUserError,
+} from '../../selectors';
+import { accountStatusMultiError } from '../../mocks/api/user/mhvAccountStatus';
+
+describe('mhvAccountStatusUsersuccess', () => {
+  it('returns false when loading', () => {
+    const loadingState = {
+      myHealth: {
+        accountStatus: {
+          loading: true,
+        },
+      },
+    };
+    const result = mhvAccountStatusUsersuccess(loadingState);
+    expect(result).to.be.false;
+  });
+
+  it('returns false when errors', () => {
+    const errorState = {
+      myHealth: {
+        accountStatus: {
+          data: {
+            errors: [
+              {
+                title: 'The server responded with status 422',
+                detail: 'things fall apart',
+                code: 801,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const result = mhvAccountStatusUsersuccess(errorState);
+    expect(result).to.be.false;
+  });
+
+  it('returns true not loading and no errors', () => {
+    const state = {
+      myHealth: {
+        accountStatus: {
+          data: {},
+        },
+      },
+    };
+    const result = mhvAccountStatusUsersuccess(state);
+    expect(result).to.be.true;
+  });
+});
+
+describe('mhvAccountStatusErrorsSorted', () => {
+  it('prioritizes user errors', () => {
+    const state = {
+      myHealth: {
+        accountStatus: {
+          data: accountStatusMultiError,
+        },
+      },
+    };
+    const result = mhvAccountStatusErrorsSorted(state);
+    expect(result[0].code).to.eq(805);
+  });
+});
+
+describe('mhvAccountStatusUserError', () => {
+  it('returns user error code', () => {
+    const state = {
+      myHealth: {
+        accountStatus: {
+          data: accountStatusMultiError,
+        },
+      },
+    };
+    const result = mhvAccountStatusUserError(state);
+    expect(result[0].code).to.eq(805);
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
A small change to the expected schema of an API response the MHV landing page ingests 

## Related issue(s)
[99724](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99724)

## Testing done
Specs green

## What areas of the site does it impact?
MHV landing page

## Acceptance criteria
When the AC-API returns an error response the MHV landing page serves the correct alert based on the related error code.
