### PR TITLE
[100908] Appoint a Rep truncate middle name for prefill

### DIFF
--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -6,7 +6,11 @@ export default function prefillTransformer(formData) {
   };
 
   if (preparerIsVeteran({ formData })) {
-    newFormData.veteranFullName = formData?.personalInformation?.fullName;
+    newFormData.veteranFullName = {
+      first: formData?.personalInformation?.fullName?.first,
+      middle: formData?.personalInformation?.fullName?.middle?.substring(0, 1),
+      last: formData?.personalInformation?.fullName?.last,
+    };
     newFormData.veteranDateOfBirth = formData?.personalInformation?.dateOfBirth;
     newFormData.veteranSocialSecurityNumber =
       formData?.personalInformation?.ssn;
@@ -34,7 +38,11 @@ export default function prefillTransformer(formData) {
       street: undefined,
     };
   } else {
-    newFormData.applicantName = formData?.personalInformation?.fullName;
+    newFormData.applicantName = {
+      first: formData?.personalInformation?.fullName?.first,
+      middle: formData?.personalInformation?.fullName?.middle?.substring(0, 1),
+      last: formData?.personalInformation?.fullName?.last,
+    };
     newFormData.applicantDOB = formData?.personalInformation?.dateOfBirth;
     newFormData.applicantEmail = formData?.contactInformation?.email;
     newFormData.applicantPhone = formData?.contactInformation?.primaryPhone;

--- a/src/applications/representative-appoint/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -37,13 +37,13 @@ describe('ConfirmationPage', () => {
     selectedAccreditedOrganizationId: '1',
     applicantName: {
       first: 'John',
-      middle: 'Edmund',
+      middle: 'E',
       last: 'Doe',
       suffix: 'Sr.',
     },
     veteranFullName: {
       first: 'John',
-      middle: 'Edmund',
+      middle: 'E',
       last: 'Doe',
       suffix: 'Sr.',
     },

--- a/src/applications/representative-appoint/tests/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/containers/PreSubmitInfo.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('<PreSubmitInfo>', () => {
         formData: {
           veteranFullName: {
             first: 'John',
-            middle: 'Edmund',
+            middle: 'E',
             last: 'Doe',
             suffix: 'Sr.',
           },
@@ -63,7 +63,7 @@ describe('<PreSubmitInfo>', () => {
     const { container } = renderContainer(props, mockStore);
     const content = $('va-accordion-item', container);
 
-    expect(content.textContent).to.contain('John Edmund Doe Sr.');
+    expect(content.textContent).to.contain('John E Doe Sr.');
   });
 
   it('should include the representative name', () => {

--- a/src/applications/representative-appoint/tests/e2e/navigation/2122.cypress.spec.js
+++ b/src/applications/representative-appoint/tests/e2e/navigation/2122.cypress.spec.js
@@ -67,7 +67,7 @@ describe('Authenticated', () => {
       h.verifyUrl(ROUTES.VETERAN_PERSONAL_INFORMATION);
       cy.injectAxeThenAxeCheck();
       cy.get('input[name="root_veteranFullName_first"]').type('John');
-      cy.get('input[name="root_veteranFullName_middle"]').type('Edmund');
+      cy.get('input[name="root_veteranFullName_middle"]').type('E');
       cy.get('input[name="root_veteranFullName_last"]').type('Doe');
 
       cy.get('va-select.usa-form-group--month-select')

--- a/src/applications/representative-appoint/tests/e2e/navigation/2122a.cypress.spec.js
+++ b/src/applications/representative-appoint/tests/e2e/navigation/2122a.cypress.spec.js
@@ -69,7 +69,7 @@ describe('Unauthenticated', () => {
       cy.injectAxeThenAxeCheck();
 
       cy.get('input[name="root_applicantName_first"]').type('Adam');
-      cy.get('input[name="root_applicantName_middle"]').type('James');
+      cy.get('input[name="root_applicantName_middle"]').type('J');
       cy.get('input[name="root_applicantName_last"]').type('Friedman');
 
       cy.get('va-select.usa-form-group--month-select')
@@ -114,7 +114,7 @@ describe('Unauthenticated', () => {
       // VETERAN_PERSONAL_INFORMATION;
       h.verifyUrl(ROUTES.VETERAN_PERSONAL_INFORMATION);
       cy.get('input[name="root_veteranFullName_first"]').type('John');
-      cy.get('input[name="root_veteranFullName_middle"]').type('Edmund');
+      cy.get('input[name="root_veteranFullName_middle"]').type('E');
       cy.get('input[name="root_veteranFullName_last"]').type('Doe');
 
       cy.get('va-select.usa-form-group--month-select')

--- a/src/applications/representative-appoint/tests/fixtures/data/21-22a/form-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/21-22a/form-data.json
@@ -27,7 +27,7 @@
   "claimantRelationship": "CHILD",
   "veteranFullName": {
     "first": "John",
-    "middle": "Edmund",
+    "middle": "E",
     "last": "Doe",
     "suffix": "Sr."
   },

--- a/src/applications/representative-appoint/tests/fixtures/data/form-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/form-data.json
@@ -26,7 +26,7 @@
   "claimantRelationship": "CHILD",
   "veteranFullName": {
     "first": "John",
-    "middle": "Edmund",
+    "middle": "E",
     "last": "Doe",
     "suffix": "Sr."
   },

--- a/src/applications/representative-appoint/tests/fixtures/data/initial-form-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/initial-form-data.json
@@ -4,7 +4,7 @@
   "applicantName": {},
   "veteranFullName": {
     "first": "John",
-    "middle": "Edmund",
+    "middle": "E",
     "last": "Doe",
     "suffix": "Sr."
   },

--- a/src/applications/representative-appoint/tests/fixtures/data/pdf-transformed-form-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/pdf-transformed-form-data.json
@@ -2,7 +2,7 @@
   "veteran": {
     "name": {
       "first": "John",
-      "middle": "Edmund",
+      "middle": "E",
       "last": "Doe"
     },
     "ssn": "333224444",

--- a/src/applications/representative-appoint/tests/fixtures/data/prefill.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/prefill.json
@@ -3,7 +3,7 @@
     "fullName": {
       "first": "Greg",
       "last": "Anderson",
-      "middle": "A"
+      "middle": "Alex"
     },
     "dateOfBirth": "1933-04-05",
     "ssn": "796121200"

--- a/src/applications/representative-appoint/tests/fixtures/data/test-data.json
+++ b/src/applications/representative-appoint/tests/fixtures/data/test-data.json
@@ -1,7 +1,7 @@
 {
   "veteranFullName": {
     "first": "John",
-    "middle": "Edmund",
+    "middle": "E",
     "last": "Doe",
     "suffix": "Sr."
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr truncates middle name in the prefill transformer to only the first character so that prefill aligns with the maxLength of 1 for middle initial in the personal information screens. Otherwise, prefilled users can be automatically set into an error state.

## Related issue(s)

- [100908](https://github.com/department-of-veterans-affairs/va.gov-team/issues/100908)

## Testing done

- logged into local build and went through flow with users that have and do not have middle names.

## Screenshots

### Before

https://github.com/user-attachments/assets/d5331c2b-b9e1-44f1-8b3c-c0cb78932b3d

### After

https://github.com/user-attachments/assets/6ac3ed0c-db6b-4ff9-83cd-919f59e075e8

## What areas of the site does it impact?

Appoint a Rep 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user