### PR TITLE
add tests to address coverage report

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/tests/DebtCopayActions.unit.spec.js
+++ b/src/applications/combined-debt-portal/debt-letters/tests/DebtCopayActions.unit.spec.js
@@ -1,0 +1,126 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
+import {
+  fetchDebtLetters,
+  DEBTS_FETCH_INITIATED,
+  DEBTS_FETCH_SUCCESS,
+  DEBTS_FETCH_FAILURE,
+  setActiveDebt,
+  DEBTS_SET_ACTIVE_DEBT,
+} from '../../combined/actions/debts';
+import {
+  getStatements,
+  MCP_STATEMENTS_FETCH_INIT,
+  MCP_STATEMENTS_FETCH_SUCCESS,
+} from '../../combined/actions/copays';
+
+describe('Debt Portal Actions', () => {
+  describe('fetchDebtLetters', () => {
+    let dispatch;
+
+    beforeEach(() => {
+      dispatch = sinon.spy();
+    });
+
+    it('should handle successful response', () => {
+      const mockResponse = {
+        debts: [
+          {
+            deductionCode: '30',
+            currentAr: 100,
+            debtHistory: [
+              {
+                date: '2024-01-01',
+              },
+            ],
+          },
+        ],
+        hasDependentDebts: false,
+      };
+
+      mockApiRequest(mockResponse);
+
+      return fetchDebtLetters(dispatch, true).then(() => {
+        const allCalls = dispatch.getCalls().map(call => call.args[0]);
+
+        // First call: DEBTS_FETCH_INITIATED
+        expect(allCalls[0]).to.eql({
+          type: DEBTS_FETCH_INITIATED,
+        });
+
+        // Last call: DEBTS_FETCH_SUCCESS with data
+        expect(allCalls[allCalls.length - 1]).to.eql({
+          type: DEBTS_FETCH_SUCCESS,
+          debts: mockResponse.debts,
+          hasDependentDebts: mockResponse.hasDependentDebts,
+        });
+      });
+    });
+
+    it('should handle error response', () => {
+      // Provide null response with `false` to indicate failure
+      mockApiRequest(null, false);
+
+      return fetchDebtLetters(dispatch, true).then(() => {
+        const allCalls = dispatch.getCalls().map(call => call.args[0]);
+
+        expect(allCalls[0]).to.eql({
+          type: DEBTS_FETCH_INITIATED,
+        });
+        // Next call: DEBTS_FETCH_FAILURE
+        expect(allCalls[1]).to.contain({
+          type: DEBTS_FETCH_FAILURE,
+        });
+      });
+    });
+  });
+
+  describe('setActiveDebt', () => {
+    it('should return the correct action', () => {
+      const debt = { id: 1, amount: 100 };
+      const action = setActiveDebt(debt);
+      expect(action).to.eql({
+        type: DEBTS_SET_ACTIVE_DEBT,
+        debt,
+      });
+    });
+  });
+});
+
+describe('Copay Actions', () => {
+  let dispatch;
+
+  beforeEach(() => {
+    dispatch = sinon.spy();
+  });
+
+  it('should handle successful copay statements fetch', () => {
+    const mockResponse = {
+      data: [
+        {
+          station: {
+            facilitYNum: '123',
+            city: 'Washington',
+            facilityName: '123',
+          },
+        },
+      ],
+    };
+    mockApiRequest(mockResponse);
+    return getStatements(dispatch).then(() => {
+      const allCalls = dispatch.getCalls().map(call => call.args[0]);
+
+      // First call to MCP_STATEMENTS_FETCH_INIT
+      expect(allCalls[0]).to.eql({
+        type: MCP_STATEMENTS_FETCH_INIT,
+      });
+
+      // Last call to MCP_STATEMENTS_FETCH_SUCCESS with response data
+      expect(allCalls[allCalls.length - 1]).to.eql({
+        type: MCP_STATEMENTS_FETCH_SUCCESS,
+        response: mockResponse.data,
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder



## Summary

- Update unit tests for actions to get coverage to the acceptable 80% range. Currently the Branches is below the threshold:
The following command opens the report above
yarn test:coverage-app combined-debt-portal




This is a follow on after our last staging review: https://github.com/department-of-veterans-affairs/va.gov-team/issues/92381. 
We met acceptable standards for the new feature/release, but this will make for smoother reviews moving forward.



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#95189

## Testing done

- _wrote unit tests_


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Coverage        | | |
| ------- | ------ | ----- |
|![image](https://github.com/user-attachments/assets/586dab29-d831-4604-a61c-043b35f24656)
| ![image](https://github.com/user-attachments/assets/9a97178e-f2df-4cff-89bb-9e07ea682b74)        |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added


### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
