### PR TITLE
Renamed all pciu variables as formProfile variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,7 +335,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#35ca8ea9a798407936e20ccf76a4be0fd75a8f76",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#75b0a0dd78b479e230867e89989bf3e8262d850c",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -1,7 +1,7 @@
 import constants from 'vets-json-schema/dist/constants.json';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
-const { pciuStates: PCIU_STATES } = constants;
+const { formProfileStates: FORM_PROFILE_STATES } = constants;
 
 import {
   VA_FORM_IDS,
@@ -38,10 +38,10 @@ export const RESERVE_GUARD_TYPES = {
   reserve: 'Reserve',
 };
 
-export { PCIU_STATES };
+export { FORM_PROFILE_STATES };
 
-export const STATE_LABELS = PCIU_STATES.map(state => state.label);
-export const STATE_VALUES = PCIU_STATES.map(state => state.value);
+export const STATE_LABELS = FORM_PROFILE_STATES.map(state => state.label);
+export const STATE_VALUES = FORM_PROFILE_STATES.map(state => state.value);
 
 export const MILITARY_STATE_VALUES = ['AA', 'AE', 'AP'];
 export const MILITARY_STATE_LABELS = [

--- a/src/applications/disability-benefits/all-claims/migrations/02-convert-country-code.js
+++ b/src/applications/disability-benefits/all-claims/migrations/02-convert-country-code.js
@@ -33,7 +33,7 @@ export default function convertCountryCode(savedData) {
     },
   ];
 
-  // If they've got a 3-letter country code, try to match it to the list of PCIU countries
+  // If they've got a 3-letter country code, try to match it to the list of form data countries
   let earliestReturnUrl = '';
   let { formData: newData } = savedData;
   addressPaths.forEach(({ path, returnUrl }) => {

--- a/src/applications/financial-status-report/constants/index.js
+++ b/src/applications/financial-status-report/constants/index.js
@@ -3,8 +3,12 @@ import constants from 'vets-json-schema/dist/constants.json';
 export const COUNTRY_LABELS = constants.countries.map(country => country.label);
 export const COUNTRY_VALUES = constants.countries.map(country => country.value);
 
-export const STATE_LABELS = constants.pciuStates.map(state => state.label);
-export const STATE_VALUES = constants.pciuStates.map(state => state.value);
+export const STATE_LABELS = constants.formProfileStates.map(
+  state => state.label,
+);
+export const STATE_VALUES = constants.formProfileStates.map(
+  state => state.value,
+);
 
 export const MILITARY_CITY_CODES = ['APO', 'DPO', 'FPO'];
 export const MILITARY_STATE_CODES = ['AA', 'AE', 'AP'];

--- a/src/platform/forms/tests/address.unit.spec.js
+++ b/src/platform/forms/tests/address.unit.spec.js
@@ -1,9 +1,6 @@
 import { expect } from 'chai';
 import * as addressUtils from '../address/helpers';
 
-// Examples from:
-// https://github.com/department-of-veterans-affairs/vets-api/blob/1efd2c206859b1a261e762a50cdb44dc8b66462d/spec/factories/pciu_address.rb#L34
-
 const domestic = {
   addressType: 'DOMESTIC',
   countryName: 'USA',

--- a/yarn.lock
+++ b/yarn.lock
@@ -21520,9 +21520,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#35ca8ea9a798407936e20ccf76a4be0fd75a8f76":
-  version "24.7.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#35ca8ea9a798407936e20ccf76a4be0fd75a8f76"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#75b0a0dd78b479e230867e89989bf3e8262d850c":
+  version "24.7.4"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#75b0a0dd78b479e230867e89989bf3e8262d850c"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

All PCIU variables appropriately renamed. Vets-Website PCIU variables are imported from the hardcoded PCIU Vets-Json-schema variables. 

## Related issue(s)

- department-of-veterans-affairs/va.gov-team/issues/99359
- [vets-json-schema pr](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/970)
- [vets-api pr](https://github.com/department-of-veterans-affairs/vets-api/pull/20265)

## Testing done

Contact Information for a test user was tested locally with the new schema version.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
