### PR TITLE
100539 Only hit AC-API if user is verified

### DIFF
--- a/src/applications/mhv-landing-page/containers/LandingPageContainer.jsx
+++ b/src/applications/mhv-landing-page/containers/LandingPageContainer.jsx
@@ -12,6 +12,7 @@ import {
 } from '../utilities/data';
 import {
   isAuthenticatedWithSSOe,
+  isLOA3,
   isVAPatient,
   selectProfile,
   signInServiceEnabled,
@@ -32,6 +33,7 @@ const LandingPageContainer = () => {
   const profile = useSelector(selectProfile);
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const useSiS = useSelector(signInServiceEnabled);
+  const userVerified = useSelector(isLOA3);
   const registered = useSelector(isVAPatient);
   const unreadMessageAriaLabel = resolveUnreadMessageAriaLabel(
     unreadMessageCount,
@@ -77,7 +79,7 @@ const LandingPageContainer = () => {
 
   useEffect(
     () => {
-      if (!profile.loading) {
+      if (!profile.loading && userVerified) {
         if (userHasMhvAccount) {
           dispatch({
             type: fetchAccountStatusSuccess,
@@ -95,7 +97,7 @@ const LandingPageContainer = () => {
         }
       }
     },
-    [userHasMhvAccount, profile.loading, dispatch],
+    [userHasMhvAccount, profile.loading, userVerified, dispatch],
   );
 
   if (loading)


### PR DESCRIPTION
Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Only hit AC-API if current user is verified

## Related issue(s)
[100539](https://github.com/department-of-veterans-affairs/va.gov-team/issues/100539)

## Testing done
Specs green

## What areas of the site does it impact?
MHV landing page

## Acceptance criteria
If the current user is not LOA3, the landingpage will not hit the mhv_user_account endpoint.
