### PR TITLE
VACMS-20198 Maintenance banner hour adjustments

### DIFF
--- a/src/applications/search/components/SearchMaintenance.jsx
+++ b/src/applications/search/components/SearchMaintenance.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getDay, getHours, setHours, setMinutes, setSeconds } from 'date-fns';
+import {
+  add,
+  getDay,
+  getHours,
+  setHours,
+  setMinutes,
+  setSeconds,
+} from 'date-fns';
 import { utcToZonedTime, format as tzFormat } from 'date-fns-tz';
 
 const maintenanceDays = [2, 4]; // Days: 2 for Tuesday, 4 for Thursday
@@ -29,11 +36,7 @@ const calculateCurrentMaintenanceWindow = () => {
   start = setSeconds(start, 0);
 
   // Calculate end time by adding the duration to the start time
-  let end = new Date(
-    start.getTime() + maintenanceDurationHours * 60 * 60 * 1000,
-  );
-
-  end = utcToZonedTime(end, maintenanceTimezone); // Ensure the end time is also adjusted to the specified timezone
+  const end = add(start, { hours: maintenanceDurationHours });
 
   // Format start and end dates to include timezone offset correctly
   const startFormatted = tzFormat(start, "EEE MMM d yyyy HH:mm:ss 'GMT'XXXX", {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
I inadvertently introduced a defect in the way the maintenance hours were calculated in my previous PR for this ticket: https://github.com/department-of-veterans-affairs/vets-website/pull/34007. The logic was taking a start time, then converting it into the Eastern time zone, then adding hours for the end time, and converting that to the Eastern time zone too. It seemed to be working fine until I moved the variable definitions out of the function, and then it broke. I simplified the logic here.

(The maintenance window is 3-6pm ET, so it should only show 3 hours).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20198

## Testing done
Tested at `/search`.

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1006" alt="Screenshot 2025-01-14 at 4 42 18 PM" src="https://github.com/user-attachments/assets/f5f70fbe-982a-4e27-8a86-7c0edf7c68ab" /> | <img width="1003" alt="Screenshot 2025-01-14 at 4 42 06 PM" src="https://github.com/user-attachments/assets/4df7485d-f6ca-4c03-9888-358b5721129f" /> |