### PR TITLE
Update forms-config-validator.unit.spec.js

### DIFF
--- a/src/platform/forms/tests/forms-config-validator.unit.spec.js
+++ b/src/platform/forms/tests/forms-config-validator.unit.spec.js
@@ -67,6 +67,7 @@ const formConfigKeys = [
   'CustomTopContent',
   'defaultDefinitions',
   'dev',
+  'disableSave',
   'downtime',
   'errorText',
   'footerContent',

--- a/src/platform/forms/tests/forms-config-validator.unit.spec.js
+++ b/src/platform/forms/tests/forms-config-validator.unit.spec.js
@@ -280,6 +280,7 @@ const validateForm = async formConfigParam => {
   const optionalProps = {
     ariaDescribedBySubmit: 'string',
     dev: 'object',
+    disableSave: 'boolean',
     introduction: 'component',
     prefillEnabled: 'boolean',
     prefillTransformer: 'function',


### PR DESCRIPTION
Patches an issue causing form configuration tests to fail.