### PR TITLE
[99786] Appoint a Rep add submission types to search results

### DIFF
--- a/src/applications/representative-appoint/components/SearchResult.jsx
+++ b/src/applications/representative-appoint/components/SearchResult.jsx
@@ -4,12 +4,15 @@ import { connect } from 'react-redux';
 import { setData } from '~/platform/forms-system/src/js/actions';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { parsePhoneNumber } from '../utilities/parsePhoneNumber';
+import { getFormNumberFromEntity } from '../utilities/helpers';
+import useV2FeatureToggle from '../hooks/useV2FeatureVisibility';
 
 const SearchResult = ({
   representative,
   query,
   handleSelectRepresentative,
   loadingPOA,
+  userIsDigitalSubmitEligible,
 }) => {
   const { id } = representative.data;
   const {
@@ -25,6 +28,9 @@ const SearchResult = ({
     email,
     accreditedOrganizations,
   } = representative.data.attributes;
+
+  const formNumber = getFormNumberFromEntity(representative.data);
+  const v2IsEnabled = useV2FeatureToggle();
 
   const representativeName = name || fullName;
 
@@ -42,6 +48,13 @@ const SearchResult = ({
     (city ? ` ${city},` : '') +
     (stateCode ? ` ${stateCode}` : '') +
     (zipCode ? ` ${zipCode}` : '');
+
+  const submissionTypeContent = v2IsEnabled &&
+    userIsDigitalSubmitEligible && (
+      <p data-testid="submission-methods">
+        Accepts VA Form {formNumber} online, by mail, and in person
+      </p>
+    );
 
   return (
     <va-card class="vads-u-padding--4 vads-u-margin-bottom--4">
@@ -82,7 +95,7 @@ const SearchResult = ({
             </va-additional-info>
           </div>
         )}
-
+        {submissionTypeContent}
         <div className="representative-contact-section vads-u-margin-top--3">
           {addressExists && (
             <div className="address-link vads-u-display--flex">
@@ -181,6 +194,7 @@ SearchResult.propTypes = {
   router: PropTypes.object,
   routes: PropTypes.array,
   stateCode: PropTypes.string,
+  userIsDigitalSubmitEligible: PropTypes.bool,
   zipCode: PropTypes.string,
 };
 

--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -204,6 +204,7 @@ const SelectAccreditedRepresentative = props => {
             currentSelectedRep={currentSelectedRep.current}
             goToPath={goToPath}
             handleSelectRepresentative={handleSelectRepresentative}
+            userIsDigitalSubmitEligible={formData?.userIsDigitalSubmitEligible}
           />
         ))}
       <p className="vads-u-margin-y--4">

--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -70,5 +70,9 @@ export default function prefillTransformer(formData) {
     newFormData['Branch of Service'] = undefined;
   }
 
+  newFormData.userIsDigitalSubmitEligible =
+    formData?.identityValidation?.hasIcn &&
+    formData?.identityValidation?.hasParticipantId;
+
   return newFormData;
 }

--- a/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
@@ -191,44 +191,42 @@ describe('SearchResult Component', () => {
 
   context('when v2 is not enabled', () => {
     it('does not display submission methods', () => {
-      it('does not display submission methods', () => {
-        const representative = {
-          data: {
-            id: 1,
-            type: 'individual',
-            attributes: {
-              addressLine1: '123 Main St',
-              city: '',
-              stateCode: '',
-              zipCode: '',
-              fullName: 'Robert Smith',
-              individualType: 'representative',
-            },
+      const representative = {
+        data: {
+          id: 1,
+          type: 'individual',
+          attributes: {
+            addressLine1: '123 Main St',
+            city: '',
+            stateCode: '',
+            zipCode: '',
+            fullName: 'Robert Smith',
+            individualType: 'representative',
           },
-        };
+        },
+      };
 
-        const useV2FeatureVisibilityStub = sinon
-          .stub(useV2FeatureToggle, 'default')
-          .returns(false);
+      const useV2FeatureVisibilityStub = sinon
+        .stub(useV2FeatureToggle, 'default')
+        .returns(false);
 
-        const { container } = render(
-          <SearchResult
-            representative={representative}
-            query={{}}
-            handleSelectRepresentative={() => {}}
-            loadingPOA={false}
-            userIsDigitalSubmitEligible
-          />,
-        );
+      const { container } = render(
+        <SearchResult
+          representative={representative}
+          query={{}}
+          handleSelectRepresentative={() => {}}
+          loadingPOA={false}
+          userIsDigitalSubmitEligible
+        />,
+      );
 
-        const submissionMethods = container.querySelector(
-          '[data-testid="submission-methods"]',
-        );
+      const submissionMethods = container.querySelector(
+        '[data-testid="submission-methods"]',
+      );
 
-        expect(submissionMethods).not.to.exist;
+      expect(submissionMethods).not.to.exist;
 
-        useV2FeatureVisibilityStub.restore();
-      });
+      useV2FeatureVisibilityStub.restore();
     });
   });
 });

--- a/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { SearchResult } from '../../components/SearchResult';
+import * as useV2FeatureToggle from '../../hooks/useV2FeatureVisibility';
 
 describe('SearchResult Component', () => {
   it('evaluates addressExists correctly', () => {
@@ -16,6 +18,10 @@ describe('SearchResult Component', () => {
       },
     };
 
+    const useV2FeatureVisibilityStub = sinon
+      .stub(useV2FeatureToggle, 'default')
+      .returns(false);
+
     const { container } = render(
       <SearchResult
         representative={representative}
@@ -28,6 +34,8 @@ describe('SearchResult Component', () => {
     const addressAnchor = container.querySelector('.address-anchor');
     expect(addressAnchor).to.exist;
     expect(addressAnchor.textContent).to.contain('123 Main St');
+
+    useV2FeatureVisibilityStub.restore();
   });
 
   it('evaluates addressExists correctly when only city, stateCode, and zipCode exist', () => {
@@ -41,6 +49,10 @@ describe('SearchResult Component', () => {
       },
     };
 
+    const useV2FeatureVisibilityStub = sinon
+      .stub(useV2FeatureToggle, 'default')
+      .returns(false);
+
     const { container } = render(
       <SearchResult
         representative={representative}
@@ -53,6 +65,8 @@ describe('SearchResult Component', () => {
     const addressAnchor = container.querySelector('.address-anchor');
     expect(addressAnchor).to.exist;
     expect(addressAnchor.textContent).to.contain('Anytown, CT');
+
+    useV2FeatureVisibilityStub.restore();
   });
 
   it('includes the representative name in the select button text', () => {
@@ -69,6 +83,10 @@ describe('SearchResult Component', () => {
       },
     };
 
+    const useV2FeatureVisibilityStub = sinon
+      .stub(useV2FeatureToggle, 'default')
+      .returns(false);
+
     const { container } = render(
       <SearchResult
         representative={representative}
@@ -83,5 +101,134 @@ describe('SearchResult Component', () => {
     );
     expect(selectButton).to.exist;
     expect(selectButton.getAttribute('text')).to.contain('Robert Smith');
+
+    useV2FeatureVisibilityStub.restore();
+  });
+
+  context('when v2 is enabled', () => {
+    context('when the user is userIsDigitalSubmitEligible', () => {
+      it('displays submission methods', () => {
+        const representative = {
+          data: {
+            id: 1,
+            type: 'individual',
+            attributes: {
+              addressLine1: '123 Main St',
+              city: '',
+              stateCode: '',
+              zipCode: '',
+              fullName: 'Robert Smith',
+              individualType: 'representative',
+            },
+          },
+        };
+
+        const useV2FeatureVisibilityStub = sinon
+          .stub(useV2FeatureToggle, 'default')
+          .returns(true);
+
+        const { container } = render(
+          <SearchResult
+            representative={representative}
+            query={{}}
+            handleSelectRepresentative={() => {}}
+            loadingPOA={false}
+            userIsDigitalSubmitEligible
+          />,
+        );
+
+        const submissionMethods = container.querySelector(
+          '[data-testid="submission-methods"]',
+        );
+
+        expect(submissionMethods).to.exist;
+
+        useV2FeatureVisibilityStub.restore();
+      });
+    });
+
+    context('when the user is not userIsDigitalSubmitEligible', () => {
+      it('does not display submission methods', () => {
+        const representative = {
+          data: {
+            id: 1,
+            type: 'individual',
+            attributes: {
+              addressLine1: '123 Main St',
+              city: '',
+              stateCode: '',
+              zipCode: '',
+              fullName: 'Robert Smith',
+              individualType: 'representative',
+            },
+          },
+        };
+
+        const useV2FeatureVisibilityStub = sinon
+          .stub(useV2FeatureToggle, 'default')
+          .returns(true);
+
+        const { container } = render(
+          <SearchResult
+            representative={representative}
+            query={{}}
+            handleSelectRepresentative={() => {}}
+            loadingPOA={false}
+            userIsDigitalSubmitEligible={false}
+          />,
+        );
+
+        const submissionMethods = container.querySelector(
+          '[data-testid="submission-methods"]',
+        );
+
+        expect(submissionMethods).not.to.exist;
+
+        useV2FeatureVisibilityStub.restore();
+      });
+    });
+  });
+
+  context('when v2 is not enabled', () => {
+    it('does not display submission methods', () => {
+      it('does not display submission methods', () => {
+        const representative = {
+          data: {
+            id: 1,
+            type: 'individual',
+            attributes: {
+              addressLine1: '123 Main St',
+              city: '',
+              stateCode: '',
+              zipCode: '',
+              fullName: 'Robert Smith',
+              individualType: 'representative',
+            },
+          },
+        };
+
+        const useV2FeatureVisibilityStub = sinon
+          .stub(useV2FeatureToggle, 'default')
+          .returns(false);
+
+        const { container } = render(
+          <SearchResult
+            representative={representative}
+            query={{}}
+            handleSelectRepresentative={() => {}}
+            loadingPOA={false}
+            userIsDigitalSubmitEligible
+          />,
+        );
+
+        const submissionMethods = container.querySelector(
+          '[data-testid="submission-methods"]',
+        );
+
+        expect(submissionMethods).not.to.exist;
+
+        useV2FeatureVisibilityStub.restore();
+      });
+    });
   });
 });

--- a/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
+++ b/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
@@ -120,4 +120,40 @@ describe('prefillTransformer', () => {
       expect(result.veteranSocialSecurityNumber).to.be.undefined;
     });
   });
+
+  context('when the user does not have an ICN', () => {
+    it('sets userIsDigitalSubmitEligible to false', () => {
+      const data = {
+        ...prefill,
+        identityValidation: { hasIcn: false, hasParticipantId: true },
+      };
+
+      const result = prefillTransformer(data);
+
+      expect(result.userIsDigitalSubmitEligible).to.be.false;
+    });
+  });
+
+  context('when the user does not have a participant id', () => {
+    it('sets userIsDigitalSubmitEligible to false', () => {
+      const data = {
+        ...prefill,
+        identityValidation: { hasIcn: true, hasParticipantId: false },
+      };
+
+      const result = prefillTransformer(data);
+
+      expect(result.userIsDigitalSubmitEligible).to.be.false;
+    });
+  });
+
+  context('when the user has an ICN and a participant id', () => {
+    it('sets userIsDigitalSubmitEligible to true', () => {
+      const data = { ...prefill };
+
+      const result = prefillTransformer(data);
+
+      expect(result.userIsDigitalSubmitEligible).to.be.true;
+    });
+  });
 });

--- a/src/applications/representative-appoint/tests/utilities/getFormNumberFromEntity.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/utilities/getFormNumberFromEntity.unit.spec.jsx
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+
+import { getFormNumberFromEntity } from '../../utilities/helpers';
+
+describe('getFormNumberFromEntity', () => {
+  it('should return "21-22" when entity type is organization', () => {
+    const mockFormData = { type: 'organization' };
+    const result = getFormNumberFromEntity(mockFormData);
+    expect(result).to.equal('21-22');
+  });
+
+  it('should return "21-22a" when individual type is attorney', () => {
+    const mockFormData = {
+      type: 'individual',
+      attributes: { individualType: 'attorney' },
+    };
+    const result = getFormNumberFromEntity(mockFormData);
+    expect(result).to.equal('21-22a');
+  });
+
+  it('should return "21-22a" when individual type is claimsAgent', () => {
+    const mockFormData = {
+      type: 'individual',
+      attributes: { individualType: 'claimsAgent' },
+    };
+    const result = getFormNumberFromEntity(mockFormData);
+    expect(result).to.equal('21-22a');
+  });
+
+  it('should return "21-22" when individual type is representative', () => {
+    const mockFormData = {
+      type: 'individual',
+      attributes: { individualType: 'representative' },
+    };
+    const result = getFormNumberFromEntity(mockFormData);
+    expect(result).to.equal('21-22');
+  });
+});

--- a/src/applications/representative-appoint/utilities/helpers.js
+++ b/src/applications/representative-appoint/utilities/helpers.js
@@ -115,6 +115,14 @@ export const getRepType = entity => {
   return 'VSO Representative';
 };
 
+export const getFormNumberFromEntity = entity => {
+  const repType = getRepType(entity);
+
+  return ['Organization', 'VSO Representative'].includes(repType)
+    ? '21-22'
+    : '21-22a';
+};
+
 export const getFormNumber = formData => {
   const entity = formData['view:selectedRepresentative'];
   const entityType = entity?.type;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds a submission types sentence to search results in Appoint a Rep
- This new content should only show when V2 is enabled AND the user has an ICN AND the user has a participant id


## Related issue(s)

- [99786](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99786)

## Testing done

- Went through flow with authed and unauthed users. Also used the local constant to turn V2 on/off.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![image](https://github.com/user-attachments/assets/30df5e1b-039b-422f-b78e-a1c6f617d86c)|![image](https://github.com/user-attachments/assets/38d157cd-f0a0-4c39-a024-0a82ab6d9c35)|
| Desktop |![image](https://github.com/user-attachments/assets/98497279-6394-499f-820d-583909fc4377)|![image](https://github.com/user-attachments/assets/dc61c541-1311-4ad2-a19a-72e4b64a3a64)|

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user