### PR TITLE
[VI-1004] Remove QueryParams from Verify Page

### DIFF
--- a/src/applications/verify/components/UnifiedVerify.jsx
+++ b/src/applications/verify/components/UnifiedVerify.jsx
@@ -20,45 +20,21 @@ const Verify = () => {
 
   if (isAuthenticated) {
     <>
-      <VerifyLogingovButton
-        queryParams={{ operation: 'authenticated_verify_page' }}
-      />
-      <VerifyIdmeButton
-        queryParams={{ operation: 'authenticated_verify_page' }}
-      />
+      <VerifyLogingovButton />
+      <VerifyIdmeButton />
     </>;
   } else if (isAuthenticatedOAuth) {
     // Use the loginServiceName to determine which button to show
     if (loginServiceName === 'idme') {
-      buttonContent = (
-        <VerifyIdmeButton
-          useOAuth
-          queryParams={{ operation: 'authenticated_verify_page' }}
-        />
-      );
+      buttonContent = <VerifyIdmeButton useOAuth />;
     } else if (loginServiceName === 'logingov') {
-      buttonContent = (
-        <VerifyLogingovButton
-          useOAuth
-          queryParams={{ operation: 'authenticated_verify_page' }}
-        />
-      );
+      buttonContent = <VerifyLogingovButton useOAuth />;
     }
   } else {
     buttonContent = (
       <>
-        <VerifyLogingovButton
-          useOAuth
-          queryParams={{
-            operation: 'unauthenticated_verify_page',
-          }}
-        />
-        <VerifyIdmeButton
-          useOAuth
-          queryParams={{
-            operation: 'unauthenticated_verify_page',
-          }}
-        />
+        <VerifyLogingovButton useOAuth />
+        <VerifyIdmeButton useOAuth />
       </>
     );
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removed unneeded `queryParams` from `src/applications/verify/components/UnifiedVerify.jsx`.

## Related issue(s)

[Jira Ticket VI-1004](https://jira.devops.va.gov/browse/VI-1004)

## Testing done

No additional tests added. Ran all `applications/verify` tests locally to ensure no breaking changes.

## What areas of the site does it impact?

This only impacts `UnifiedVerify.jsx`.

## Acceptance criteria

- [x] Remove `queryParams` from `UnifiedVerify.jsx`
