### PR TITLE
VACMS-20283: Add bold "Note:" to reason question

### DIFF
--- a/src/applications/discharge-wizard/components/questions/Reason.jsx
+++ b/src/applications/discharge-wizard/components/questions/Reason.jsx
@@ -16,8 +16,15 @@ const Reason = ({ formResponses, setReason, router, viewedIntroPage }) => {
   const shortName = SHORT_NAME_MAP.REASON;
   const H1 = QUESTION_MAP[shortName];
   const reason = formResponses[shortName];
-  const hint =
-    'Note: If more than one of these descriptions matches your situation, choose the one that started the events that led to your discharge. For example, if you sustained a traumatic brain injury (TBI), which led to posttraumatic stress disorder (PTSD), choose the option associated with TBI.';
+  const hint = (
+    <>
+      <strong>Note: </strong> If more than one of these descriptions matches
+      your situation, choose the one that started the events that led to your
+      discharge. For example, if you sustained a traumatic brain injury (TBI),
+      which led to posttraumatic stress disorder (PTSD), choose the option
+      associated with TBI.
+    </>
+  );
   const {
     REASON_PTSD,
     REASON_TBI,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Add the html markup of the hint for the reason question that was not part of the initial bolding of Note:

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20283

## Testing done
Tested the bold text on the reason question

## Screenshots
<img width="582" alt="How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs_and_Yahoo___Mail__Weather__Search__Politics__News__Finance__Sports___Videos_and_Sitewide_scrum_topics__List__-_Office_of_CTO___VA_-_Slack_and_Notes" src="https://github.com/user-attachments/assets/d7c24210-cc37-4b57-a5eb-8c82b1b33856" />

## What areas of the site does it impact?
DUW

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

