### PR TITLE
Fix Clinic Choice Page flaky test

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.unit.spec.js
@@ -293,12 +293,11 @@ describe('VAOS Page: ClinicChoicePage', () => {
     await cleanup();
   });
 
-  // Flaky test: https://github.com/department-of-veterans-affairs/va.gov-team/issues/82977
-  it.skip('should show the correct clinic name when filtered to matching', async () => {
+  it('should show the correct clinic name when filtered to matching', async () => {
     // Given two available clinics
     const clinics = [
       getV2ClinicMock({
-        id: '309',
+        id: '333',
         serviceName: 'Filtered out clinic',
         stationId: '983',
       }),
@@ -341,8 +340,10 @@ describe('VAOS Page: ClinicChoicePage', () => {
     );
 
     // And the user is asked if they want an appt at matching clinic
-    expect(screen.baseElement).to.contain.text(
-      'Would you like to make an appointment at Green team clinic',
-    );
+    expect(
+      screen.container.querySelector(
+        'va-radio[label="Would you like to make an appointment at Green team clinic?"',
+      ),
+    ).to.be.ok;
   });
 });


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder



### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes the flaky test for ClinicChoicePage

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#82977


## Testing done

unit test

## Screenshots

n/a

## What areas of the site does it impact?

Clinic Choice Page unit test

## Acceptance criteria

- [ ] unit test is fixed

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
