### PR TITLE
Add null state tracking for provider and clinic phone

### DIFF
--- a/src/applications/vaos/components/layouts/CCLayout.jsx
+++ b/src/applications/vaos/components/layouts/CCLayout.jsx
@@ -50,6 +50,7 @@ export default function CCLayout({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.PROVIDER]: !providerName,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/CCLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/CCLayout.unit.spec.js
@@ -77,6 +77,12 @@ describe('VAOS Component: CCLayout', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
     });
   });
 
@@ -209,6 +215,12 @@ describe('VAOS Component: CCLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-provider',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/CCRequestLayout.jsx
+++ b/src/applications/vaos/components/layouts/CCRequestLayout.jsx
@@ -48,6 +48,7 @@ export default function CCRequestLayout({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.PROVIDER]: !providerName,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/CCRequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/CCRequestLayout.unit.spec.js
@@ -6,8 +6,11 @@ import {
 } from '../../tests/mocks/setup';
 import CCRequestLayout from './CCRequestLayout';
 
-describe('VAOS Component: VARequestLayout', () => {
+describe('VAOS Component: CCRequestLayout', () => {
   const initialState = {
+    featureToggles: {
+      vaOnlineSchedulingVAOSServiceCCAppointments: true,
+    },
     appointments: {
       facilityData: {
         '983': {
@@ -52,6 +55,7 @@ describe('VAOS Component: VARequestLayout', () => {
           clinicName: 'Clinic 1',
           clinicPhysicalLocation: 'CHEYENNE',
         },
+        preferredProviderName: { providerName: 'Clinic 1' },
         preferredDates: [],
         videoData: {},
         vaos: {
@@ -175,6 +179,12 @@ describe('VAOS Component: VARequestLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-provider',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
@@ -57,6 +57,7 @@ export default function ClaimExamLayout({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.js
@@ -202,6 +202,12 @@ describe('VAOS Component: ClaimExamLayout', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -407,6 +413,12 @@ describe('VAOS Component: ClaimExamLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.jsx
@@ -58,6 +58,8 @@ export default function InPersonLayout({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
+    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.js
@@ -205,6 +205,18 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -405,6 +417,18 @@ describe('VAOS Component: InPersonLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
       });
     });
 

--- a/src/applications/vaos/components/layouts/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.jsx
@@ -51,6 +51,8 @@ export default function PhoneLayout({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
+    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.js
@@ -118,6 +118,18 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -324,6 +336,18 @@ describe('VAOS Component: PhoneLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
       });
     });
     it('should display phone layout without cancel button', async () => {

--- a/src/applications/vaos/components/layouts/VideoLayout.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.jsx
@@ -64,6 +64,8 @@ export default function VideoLayout({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
+    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/VideoLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayout.unit.spec.js
@@ -111,6 +111,18 @@ describe('VAOS Component: VideoLayout', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -351,6 +363,18 @@ describe('VAOS Component: VideoLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
@@ -56,6 +56,8 @@ export default function VideoLayoutAtlas({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
+    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.js
@@ -126,6 +126,18 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -431,6 +443,18 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
@@ -53,6 +53,8 @@ export default function VideoLayoutVA({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
+    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.js
@@ -216,6 +216,18 @@ describe('VAOS Component: VideoLayoutVA', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-provider',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-clinic-phone',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -455,6 +467,18 @@ describe('VAOS Component: VideoLayoutVA', () => {
         });
         expect(window.dataLayer).not.to.deep.include({
           event: 'vaos-null-states-missing-type-of-care',
+        });
+        expect(window.dataLayer).to.deep.include({
+          event: 'vaos-null-states-expected-provider',
+        });
+        expect(window.dataLayer).not.to.deep.include({
+          event: 'vaos-null-states-missing-provider',
+        });
+        expect(window.dataLayer).to.deep.include({
+          event: 'vaos-null-states-expected-clinic-phone',
+        });
+        expect(window.dataLayer).not.to.deep.include({
+          event: 'vaos-null-states-missing-clinic-phone',
         });
       });
     });

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -48,6 +48,8 @@ export function recordItemsRetrieved(type, count) {
 
 export const NULL_STATE_FIELD = {
   TYPE_OF_CARE: 'type-of-care',
+  PROVIDER: 'provider',
+  CLINIC_PHONE: 'clinic-phone',
 };
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds additional fields for null state tracking, similar to the previous PR: https://github.com/department-of-veterans-affairs/vets-website/pull/33798
- This PR adds tracking for providers and clinic phone fields
- Appointments (VAOS)
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98981
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98977

## Testing done

- Updated unit tests to account for the new behavior

## Screenshots

N/A this change does not impact UI/UX

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
