### PR TITLE
MHV-65436: bb medications sort date changed

### DIFF
--- a/src/applications/mhv-medical-records/reducers/blueButton.js
+++ b/src/applications/mhv-medical-records/reducers/blueButton.js
@@ -65,8 +65,8 @@ export const convertMedication = med => {
     id: med.id,
     type: medicationTypes.VA,
     prescriptionName: attributes.prescriptionName,
-    lastFilledOn: attributes.dispensedDate
-      ? formatDateLong(attributes.dispensedDate)
+    lastFilledOn: attributes.sortedDispensedDate
+      ? formatDateLong(attributes.sortedDispensedDate)
       : 'Not filled yet',
     status: attributes.refillStatus,
     refillsLeft: attributes.refillRemaining ?? UNKNOWN,

--- a/src/applications/mhv-medical-records/tests/reducers/blueButton.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/blueButton.unit.spec.js
@@ -20,7 +20,7 @@ describe('convertMedication', () => {
       id: '123',
       attributes: {
         prescriptionName: 'Aspirin',
-        dispensedDate: '2021-01-01',
+        sortedDispensedDate: '2021-01-01',
         refillStatus: 'Active',
         refillRemaining: 2,
         prescriptionNumber: 'RX123456',
@@ -347,7 +347,7 @@ describe('blueButtonReducer', () => {
             id: 'med1',
             attributes: {
               prescriptionName: 'Medication1',
-              dispensedDate: '2021-01-01',
+              sortedDispensedDate: '2021-01-01',
             },
           },
         ],


### PR DESCRIPTION
## Summary
Changed the Blue Button medications sort date based on advice from the medications team. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-65436

> ### For medications BB download, use sortedDispensedDate
> Description
> For medications BB download, use sortedDispensedDate
> 
> We are currently using dispensedDate, but according to Tony, "it doesn't include the latest refill information".
> Slack thread: https://dsva.slack.com/archives/C059Q28DV99/p1734645821601669

## Testing done
Unit tests fixed

## Screenshots
No UI changes.

## What areas of the site does it impact?
MHV medical records BB download

## Acceptance criteria
Medications sort date changed. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
