### PR TITLE
edit commit

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -70,6 +70,8 @@ export const FETCH_LC_RESULTS_SUCCEEDED = 'FETCH_LC_RESULTS_SUCCEEDED';
 export const FETCH_LC_RESULT_FAILED = 'FETCH_LC_RESULT_FAILED';
 export const FETCH_LC_RESULT_STARTED = 'FETCH_LC_RESULT_STARTED';
 export const FETCH_LC_RESULT_SUCCEEDED = 'FETCH_LC_RESULT_SUCCEEDED';
+export const FILTER_LC_RESULTS = 'FILTER_LC_RESULTS';
+
 export const FETCH_INSTITUTION_PROGRAMS_FAILED =
   'FETCH_INSTITUTION_PROGRAMS_FAILED';
 export const FETCH_INSTITUTION_PROGRAMS_STARTED =
@@ -163,6 +165,49 @@ export const fetchInstitutionPrograms = (facilityCode, programType) => {
     }
   };
 };
+
+export function fetchAndFilterLacpResults( // new action for ss filter
+  name,
+  lacpType = 'all',
+  location = 'all',
+) {
+  const url = `${
+    api.url
+  }/lcpe/lacs?type=${lacpType}&location=${location}&name=${name}`; //
+
+  return dispatch => {
+    dispatch({ type: FETCH_LC_RESULTS_STARTED });
+
+    return fetch(url, api.settings)
+      .then(res => {
+        if (res.ok) {
+          return res.json();
+        }
+        throw new Error(res.statusText);
+      })
+      .then(results => {
+        const { lacs } = results;
+
+        dispatch({
+          type: FETCH_LC_RESULTS_SUCCEEDED,
+          payload: lacs, // this list of lacps will be filtered based on the query parameters in the above url
+        });
+      })
+      .catch(err => {
+        dispatch({
+          type: FETCH_LC_RESULTS_FAILED,
+          payload: err.message,
+        });
+      });
+  };
+}
+
+export function filterLcResults(name, category, location) {
+  return {
+    type: FILTER_LC_RESULTS,
+    payload: { name, category, location },
+  };
+}
 
 export function fetchLicenseCertificationResults() {
   const url = `${api.url}/lcpe/lacs`;

--- a/src/applications/gi/components/LicenseCertificationKeywordSearch.jsx
+++ b/src/applications/gi/components/LicenseCertificationKeywordSearch.jsx
@@ -19,7 +19,6 @@ export default function LicenseCertificationKeywordSearch({
   };
 
   const handleSuggestionSelected = selected => {
-    // console.log('selected', selected);
     const { name, type, state } = selected;
 
     onSelection({

--- a/src/applications/gi/containers/LicenseCertificationSearchPage.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchPage.jsx
@@ -3,7 +3,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import LicenseCertificationSearchForm from '../components/LicenseCertificationSearchForm';
+import LicenseCertificationSearchForm from './LicenseCertificationSearchForm';
 import { handleLcResultsSearch, updateQueryParam } from '../utils/helpers';
 import { fetchLicenseCertificationResults } from '../actions';
 

--- a/src/applications/gi/reducers/licenseCertificationSearch.js
+++ b/src/applications/gi/reducers/licenseCertificationSearch.js
@@ -5,11 +5,14 @@ import {
   FETCH_LC_RESULT_STARTED,
   FETCH_LC_RESULT_SUCCEEDED,
   FETCH_LC_RESULT_FAILED,
+  FILTER_LC_RESULTS,
 } from '../actions';
+import { filterSuggestions } from '../utils/helpers';
 
 export const INITIAL_STATE = {
   fetchingLc: true,
   lcResults: [],
+  filteredResults: [],
   hasFetchedOnce: false,
   fetchingLcResult: false,
   hasFetchedResult: false,
@@ -35,6 +38,7 @@ export default function(state = INITIAL_STATE, action) {
         lcResults: action.payload,
         hasFetchedOnce: true,
         error: false,
+        filteredResults: action.payload,
       };
     case FETCH_LC_RESULTS_FAILED:
       return {
@@ -47,19 +51,42 @@ export default function(state = INITIAL_STATE, action) {
         ...newState,
         fetchingLcResult: true,
       };
-    case FETCH_LC_RESULT_SUCCEEDED:
+    case FETCH_LC_RESULT_SUCCEEDED: {
       return {
         ...newState,
         fetchingLcResult: false,
         lcResultInfo: action.payload,
         hasFetchedResult: true,
       };
+    }
     case FETCH_LC_RESULT_FAILED:
       return {
         ...newState,
         fetchingLcResult: false,
         error: action.payload,
       };
+    case FILTER_LC_RESULTS: {
+      const { name, category, location } = action.payload;
+
+      const newSuggestions = filterSuggestions(
+        newState.lcResults,
+        name,
+        category,
+        location,
+      );
+
+      if (name.trim() !== '') {
+        newSuggestions.unshift({
+          lacNm: name,
+          type: 'all',
+        });
+      }
+
+      return {
+        ...newState,
+        filteredResults: newSuggestions,
+      };
+    }
     default:
       return { ...state };
   }

--- a/src/applications/gi/tests/reducers/licenseCertificationSearch.unit.spec.jsx
+++ b/src/applications/gi/tests/reducers/licenseCertificationSearch.unit.spec.jsx
@@ -30,6 +30,7 @@ describe('License Certification Reducer', () => {
     });
     expect(result).to.deep.equal({
       ...INITIAL_STATE,
+      filteredResults: payload,
       fetchingLc: false,
       lcResults: payload,
       hasFetchedOnce: true,

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -529,9 +529,12 @@ export const getGIBillHeaderText = (automatedTest = false) => {
     : 'Learn about and compare your GI Bill benefits at approved schools and employers.';
 };
 
-export const filterLcResults = (results, nameInput, filters) => {
-  const { type: typeFilter, state: stateFilter } = filters;
-
+export const filterSuggestions = (
+  results,
+  nameInput,
+  typeFilter,
+  stateFilter,
+) => {
   if (typeFilter === 'all' && stateFilter === 'all' && nameInput === '')
     return results;
 
@@ -587,10 +590,9 @@ export const handleLcResultsSearch = (history, category, name, state) => {
 };
 
 export const formatResultCount = (results, currentPage, itemsPerPage) => {
-  if (currentPage * itemsPerPage > results.length) {
-    return `${currentPage * itemsPerPage - (itemsPerPage - 1)} - ${
-      results.length
-    }  `;
+  if (currentPage * itemsPerPage > results.length - 1) {
+    return `${currentPage * itemsPerPage -
+      (itemsPerPage - 1)} - ${results.length - 1}  `;
   }
 
   return `${currentPage * itemsPerPage - (itemsPerPage - 1)} - ${currentPage *
@@ -621,9 +623,30 @@ export function capitalizeFirstLetter(string) {
     .join(' ');
 }
 
-export const mappedStates = Object.entries(ADDRESS_DATA.states).map(state => {
-  return { optionValue: state[0], optionLabel: state[1] };
-});
+export const mappedStates = Object.entries(ADDRESS_DATA.states)
+  .map(state => {
+    return { optionValue: state[0], optionLabel: state[1] };
+  })
+  .filter(state => {
+    const exceptions = [
+      'AS',
+      'AA',
+      'AE',
+      'AP',
+      'DC',
+      'FM',
+      'GU',
+      'MH',
+      'MP',
+      'PW',
+      'PR',
+      'VI',
+    ];
+
+    if (exceptions.includes(state.optionValue)) return false;
+
+    return true;
+  });
 
 export const updateDropdowns = (
   category = 'all',

--- a/src/applications/gi/utils/useLcpFilter.js
+++ b/src/applications/gi/utils/useLcpFilter.js
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  filterLcResults,
+  fetchAndFilterLacpResults,
+  fetchLicenseCertificationResults,
+} from '../actions';
+
+export const useLcpFilter = ({ flag, name, categoryValue, locationValue }) => {
+  const dispatch = useDispatch();
+  const { hasFetchedOnce } = useSelector(
+    state => state.licenseCertificationSearch,
+  );
+
+  // initial fetch
+  useEffect(() => {
+    if (!hasFetchedOnce) {
+      if (flag === 'singleFetch') {
+        dispatch(fetchLicenseCertificationResults());
+      }
+
+      if (flag === 'serverSideFilter') {
+        dispatch(fetchAndFilterLacpResults());
+      }
+    }
+  }, []);
+
+  // filter when dropdowns or input value changes
+  useEffect(
+    () => {
+      if (flag === 'singleFetch') {
+        dispatch(filterLcResults(name, categoryValue, locationValue));
+      }
+
+      if (flag === 'serverSideFilter') {
+        dispatch(fetchAndFilterLacpResults(name, categoryValue, locationValue));
+      }
+    },
+    [flag, name, categoryValue, locationValue],
+  );
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- First of 2 PRs ( [second PR](https://github.com/department-of-veterans-affairs/vets-website/pull/34202) ) updating the fetch and filter logic for License and Certifications Search to account for different scenarios: 
    - fetching then filtering on the front end
    - fetching and filtering on the server
    - querying indexedDb 
- This includes a new custom react hook as well as updated redux syntax for easier readability.
- I work for Education Data Migration (EDM)
- A feature toggle is currently in use and will be lifted when the contract expires in Aprl

## Related issue(s)

- EDM-478: implement browser side storage for L&C

## Testing done

- This is a new app with limited test unit coverage. Code is being finalized, so expanding unit test coverage is the next order of business

## Screenshots

## What areas of the site does it impact?

Comparison Tool

## Acceptance criteria

### Quality Assurance & Testing

- Full QA testing will be performed in the midst of, and following, upcoming usability research 

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

No authentication required for these changes

## Requested Feedback
