### PR TITLE
VACMS-20329 Add new Teamsites for injected assets

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -96,6 +96,21 @@
       "cookieOnly": true
     },
     {
+      "hostname": "mentalhealth.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
+      "hostname": "www.mirecc.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
+      "hostname": "mirecc.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
       "hostname": "www.move.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": true
@@ -142,6 +157,11 @@
     },
     {
       "hostname": "www.ptsd.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
+      "hostname": "ptsd.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": true
     },


### PR DESCRIPTION
## Summary
Add new TeamSites domains to enable injected header/footer to appear. We have the `cookieOnly` value as a temporary testing flag (the injected H/F will only show when the correct cookie is passed to the browser). Once we have confirmed everything is working as expected with the cookie on, we can make code changes to remove that.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20329

## Testing done & screenshots
Confirmed the header and footer shows up on all 3 new domains (with and without the `www` appended):

### https://www.mentalhealth.va.gov/
<img width="1576" alt="Screenshot 2025-01-22 at 1 44 55 PM" src="https://github.com/user-attachments/assets/4bb26a9b-62ae-49ef-b552-dff7b55f41da" />
<img width="1555" alt="Screenshot 2025-01-22 at 1 49 27 PM" src="https://github.com/user-attachments/assets/0fa88731-80bf-4d28-b7d3-73a2fcede77e" />

### https://mentalhealth.va.gov/
<img width="1575" alt="Screenshot 2025-01-22 at 1 44 45 PM" src="https://github.com/user-attachments/assets/fab09d8f-8cc2-45af-a0d4-982922c437d4" />
<img width="1557" alt="Screenshot 2025-01-22 at 1 49 17 PM" src="https://github.com/user-attachments/assets/6a7ae9b6-5cbd-417b-b43f-fa6f90cc4472" />

### https://www.mirecc.va.gov/
<img width="1576" alt="Screenshot 2025-01-22 at 1 44 03 PM" src="https://github.com/user-attachments/assets/4a57c870-0687-459e-ab84-abb173aab684" />
<img width="1557" alt="Screenshot 2025-01-22 at 1 48 37 PM" src="https://github.com/user-attachments/assets/a33cd797-ebc9-4e06-a6a3-f1cb29c6d593" />

### https://mirecc.va.gov/
<img width="1576" alt="Screenshot 2025-01-22 at 1 44 13 PM" src="https://github.com/user-attachments/assets/ad1a6c6b-f8fc-44ea-8193-4effc0983d44" />
<img width="1559" alt="Screenshot 2025-01-22 at 1 48 27 PM" src="https://github.com/user-attachments/assets/a0cf8d3d-5dd0-4f34-8547-45c93e827ed1" />

### https://www.ptsd.va.gov/
<img width="1575" alt="Screenshot 2025-01-22 at 1 43 47 PM" src="https://github.com/user-attachments/assets/fe2cc302-70d4-4642-ac35-b87d1871bbef" />
<img width="1555" alt="Screenshot 2025-01-22 at 1 48 59 PM" src="https://github.com/user-attachments/assets/57659e03-7d62-4034-939d-9b92d34a7eee" />

### https://ptsd.va.gov/
<img width="1579" alt="Screenshot 2025-01-22 at 1 43 29 PM" src="https://github.com/user-attachments/assets/17d7eb1a-6d72-41f4-8ef1-1a29f8b7a39d" />
<img width="1556" alt="Screenshot 2025-01-22 at 1 48 49 PM" src="https://github.com/user-attachments/assets/e5e4e934-325e-4c1f-8b03-4c377b4b9754" />