### PR TITLE
Update form title to not be focusable for form upload

### DIFF
--- a/src/applications/simple-forms/form-upload/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/IntroductionPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { isLoggedIn } from 'platform/user/selectors';
 import SaveInProgressIntro from '~/platform/forms/save-in-progress/SaveInProgressIntro';
-import { FormTitle } from '@department-of-veterans-affairs/va-forms-system-core';
+import FormTitle from '~/platform/forms-system/src/js/components/FormTitle';
 import {
   VaAlert,
   VaButton,

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/containers/IntroductionPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
-import { FormTitle } from '@department-of-veterans-affairs/va-forms-system-core';
+import FormTitle from '~/platform/forms-system/src/js/components/FormTitle';
 
 const childContent = (
   <>


### PR DESCRIPTION
## Summary

- Remove tabIndex from title (by using the other `FormTitle` component`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#101263

## Testing done

- keyboard testing

## Screenshots

![image](https://github.com/user-attachments/assets/61708bd2-0137-4c7e-834a-6a446c172319)

## What areas of the site does it impact?

form-upload tool
mock form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
