### PR TITLE
Update breadcrumbs and H1 on Form Upload

### DIFF
--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -34,7 +34,7 @@ export const getFormContent = (pathname = null) => {
     ombInfo,
     subTitle,
     pdfDownloadUrl,
-    title: `Upload Form ${formNumber}`,
+    title: `Upload form ${formNumber}`,
   };
 };
 

--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -34,7 +34,7 @@ export const getFormContent = (pathname = null) => {
     ombInfo,
     subTitle,
     pdfDownloadUrl,
-    title: `Upload VA Form ${formNumber}`,
+    title: `Upload Form ${formNumber}`,
   };
 };
 

--- a/src/applications/simple-forms/form-upload/manifest.json
+++ b/src/applications/simple-forms/form-upload/manifest.json
@@ -2,6 +2,6 @@
   "appName": "Form Upload",
   "entryFile": "./app-entry.jsx",
   "entryName": "form-upload-flow",
-  "rootUrl": "/form-upload",
+  "rootUrl": "/find-forms/upload",
   "productId": "88558f52-5c6c-447f-ab78-e006b01a32db"
 }

--- a/src/applications/simple-forms/form-upload/pages/helpers.jsx
+++ b/src/applications/simple-forms/form-upload/pages/helpers.jsx
@@ -7,14 +7,14 @@ export const CustomTopContent = () => {
   const formNumber = getFormNumber();
   const breadcrumbs = [
     { href: '/', label: 'VA.gov home' },
-    { href: '/find-forms', label: 'Find a Form' },
+    { href: '/find-forms', label: 'Find a VA form' },
     {
       href: `/find-forms/upload`,
-      label: `Upload VA Forms`,
+      label: `Upload VA forms`,
     },
     {
       href: `/find-forms/upload/${formNumber}/introduction`,
-      label: `Upload Form ${formNumber}`,
+      label: `Upload form ${formNumber}`,
     },
   ];
   const bcString = JSON.stringify(breadcrumbs);

--- a/src/applications/simple-forms/form-upload/pages/helpers.jsx
+++ b/src/applications/simple-forms/form-upload/pages/helpers.jsx
@@ -9,11 +9,11 @@ export const CustomTopContent = () => {
     { href: '/', label: 'VA.gov home' },
     { href: '/find-forms', label: 'Find a Form' },
     {
-      href: `/find-forms/about-form-${formNumber}`,
-      label: `About Form ${formNumber}`,
+      href: `/find-forms/upload`,
+      label: `Upload VA Forms`,
     },
     {
-      href: `/form-upload/${formNumber}/introduction`,
+      href: `/find-forms/upload/${formNumber}/introduction`,
       label: `Upload Form ${formNumber}`,
     },
   ];

--- a/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
+++ b/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
@@ -40,14 +40,14 @@ describe('Helpers', () => {
       global.window.location = {
         pathname: '/form-upload/21-0779/upload',
       };
-      expect(getFormContent()).to.include({ title: 'Upload VA Form 21-0779' });
+      expect(getFormContent()).to.include({ title: 'Upload form 21-0779' });
     });
 
     it('returns default content when the form number is not mapped', () => {
       global.window.location = {
         pathname: '/form-upload/99-9999/upload',
       };
-      expect(getFormContent()).to.include({ title: 'Upload VA Form 99-9999' });
+      expect(getFormContent()).to.include({ title: 'Upload form 99-9999' });
     });
   });
 

--- a/src/applications/simple-forms/form-upload/tests/unit/pages/UploadPage.unit.spec.jsx
+++ b/src/applications/simple-forms/form-upload/tests/unit/pages/UploadPage.unit.spec.jsx
@@ -18,7 +18,7 @@ describe('UploadPage', () => {
     const result = uiSchema.uploadedFile['ui:options'].updateUiSchema({});
 
     expect(result).to.deep.equal({
-      'ui:title': 'Upload VA Form ',
+      'ui:title': 'Upload form ',
     });
   });
 
@@ -31,7 +31,7 @@ describe('UploadPage', () => {
     const result = uiSchema.uploadedFile['ui:options'].updateUiSchema(formData);
 
     expect(result).to.deep.equal({
-      'ui:title': 'VA Form ',
+      'ui:title': 'form ',
     });
   });
 });

--- a/src/applications/simple-forms/form-upload/tests/unit/pages/helpers.unit.spec.jsx
+++ b/src/applications/simple-forms/form-upload/tests/unit/pages/helpers.unit.spec.jsx
@@ -79,7 +79,7 @@ describe('CustomTopContent', () => {
     expect(breadcrumbs).to.exist;
     expect(breadcrumbs).to.have.attr(
       'breadcrumb-list',
-      '[{"href":"/","label":"VA.gov home"},{"href":"/find-forms","label":"Find a Form"},{"href":"/find-forms/about-form-21-0779","label":"About Form 21-0779"},{"href":"/form-upload/21-0779/introduction","label":"Upload Form 21-0779"}]',
+      '[{"href":"/","label":"VA.gov home"},{"href":"/find-forms","label":"Find a VA form"},{"href":"/find-forms/upload","label":"Upload VA forms"},{"href":"/find-forms/upload/21-0779/introduction","label":"Upload form 21-0779"}]',
     );
   });
 });


### PR DESCRIPTION
## Summary
This PR makes slight changes to align page H1s and the breadcrumbs on the Form Upload tool.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=94053329&issue=department-of-veterans-affairs%7Cva.gov-team%7C101254

## Screenshots
![image](https://github.com/user-attachments/assets/ade4960d-3507-49c2-a592-7ee9471cd0bb)
