### PR TITLE
Fix refresh not working

### DIFF
--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
@@ -25,6 +25,7 @@ export default function ReferralTaskCardWithReferral() {
   const { currentReferral, referralFetchStatus } = useGetReferralById(id);
 
   if (
+    id &&
     !currentReferral &&
     (referralFetchStatus === FETCH_STATUS.succeeded ||
       referralFetchStatus === FETCH_STATUS.failed)

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -132,4 +132,5 @@ module.exports = {
   createReferrals,
   getReferralSlotKey,
   filterReferrals,
+  expiredUUIDBase,
 };

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -328,10 +328,19 @@ const responses = {
     });
   },
   'GET /vaos/v2/epsApi/referralDetails/:referralId': (req, res) => {
+    let expiredReferrals = 0;
     if (req.params.referralId === 'error') {
       return res.status(500).json({ error: true });
     }
-    const referrals = referralUtils.createReferrals(3, '2024-12-02', 1);
+
+    if (req.params.referralId?.startsWith(referralUtils.expiredUUIDBase)) {
+      expiredReferrals = 1;
+    }
+    const referrals = referralUtils.createReferrals(
+      3,
+      '2024-12-02',
+      expiredReferrals,
+    );
     const singleReferral = referrals.find(
       referral => referral?.UUID === req.params.referralId,
     );


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- updates `/vaos/v2/epsApi/referralDetails/:referralId` mock to only return an expired referral when the UUID starts with the specified expired UUID. The default was to always return one expired referral and when re-loading the single referral requested would always be expired. 
- Fixes error alert showing when going back to appointments from the complete page

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#101448

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### Before


https://github.com/user-attachments/assets/45dec822-f44a-4d43-abe4-fe0910cdd6a4


https://github.com/user-attachments/assets/919fcec0-20b1-495f-bc7a-b1ef2c05e73d



### After
https://github.com/user-attachments/assets/82d3329b-2220-4dc5-9818-32b2a6d49617

https://github.com/user-attachments/assets/eeaf68dd-e8fc-4916-8f9e-45d84fd4c0a5



## What areas of the site does it impact?

- VAOS

## Acceptance criteria

- [ ] When in a referral page flow and a user reloads the page should reload to the same state and not error out

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
