### PR TITLE
VACMS-20324: Remove check for answer before 1992

### DIFF
--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -22,10 +22,6 @@ export const answerReviewLabel = (key, formValues) => {
     case SHORT_NAME_MAP.SERVICE_BRANCH:
       return `I served in the ${formValues[key]}.`;
     case SHORT_NAME_MAP.DISCHARGE_YEAR:
-      if (answer < 1992 && !formValues[SHORT_NAME_MAP.DISCHARGE_MONTH]) {
-        return 'I was discharged before 1992.';
-      }
-
       return `I was discharged in ${formValues[key]}.`;
     case SHORT_NAME_MAP.DISCHARGE_MONTH:
       return dischargeMonth;

--- a/src/applications/discharge-wizard/tests/helpers/index.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/helpers/index.unit.spec.js
@@ -126,11 +126,6 @@ describe('Discharge Wizard helpers', () => {
       formResponses,
     );
 
-    const oldDischargeYearLabel = answerReviewLabel(
-      SHORT_NAME_MAP.DISCHARGE_YEAR,
-      { [SHORT_NAME_MAP.DISCHARGE_YEAR]: '1990' },
-    );
-
     const notSureCourtMartialLabel = answerReviewLabel(
       SHORT_NAME_MAP.COURT_MARTIAL,
       { [SHORT_NAME_MAP.COURT_MARTIAL]: RESPONSES.NOT_SURE },
@@ -151,7 +146,6 @@ describe('Discharge Wizard helpers', () => {
 
     expect(serviceBranchLabel).to.equal('I served in the Army.');
     expect(dischargeYearLabel).to.equal('I was discharged in 2022.');
-    expect(oldDischargeYearLabel).to.equal('I was discharged before 1992.');
     expect(notSureCourtMartialLabel).to.equal(
       `I'm not sure if my discharge was the outcome of a general court-martial.`,
     );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR removes the custom logic we had for before 1992 for discharge year

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20324

## Testing done
Test with any year in the discharge year input field and it will show `I was discharged in {discharge_year}`

## Screenshots
![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/user-attachments/assets/ad9e0d8d-9b8a-47bd-85e2-d6a275e5206a)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
