### PR TITLE
Add null state tracking for facility info

### DIFF
--- a/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
@@ -58,6 +58,9 @@ export default function ClaimExamLayout({ data: appointment }) {
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
     [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.js
@@ -146,9 +146,6 @@ describe('VAOS Component: ClaimExamLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        location: {
-          stationId: '983',
-        },
         videoData: {},
         vaos: {
           isCommunityCare: false,
@@ -177,15 +174,7 @@ describe('VAOS Component: ClaimExamLayout', () => {
         screen.getByText((content, element) => {
           return (
             element.tagName.toLowerCase() === 'span' &&
-            content === 'Location: Not available'
-          );
-        }),
-      );
-      expect(
-        screen.getByText((content, element) => {
-          return (
-            element.tagName.toLowerCase() === 'span' &&
-            content === 'Clinic: Not available'
+            content === 'Facility details not available'
           );
         }),
       );
@@ -207,6 +196,24 @@ describe('VAOS Component: ClaimExamLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
 
@@ -419,6 +426,24 @@ describe('VAOS Component: ClaimExamLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-id',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.jsx
@@ -60,6 +60,9 @@ export default function InPersonLayout({ data: appointment }) {
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
     [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
     [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.js
@@ -132,9 +132,6 @@ describe('VAOS Component: InPersonLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        location: {
-          stationId: '983',
-        },
         videoData: {},
         vaos: {
           isCommunityCare: false,
@@ -164,15 +161,7 @@ describe('VAOS Component: InPersonLayout', () => {
         screen.getByText((content, element) => {
           return (
             element.tagName.toLowerCase() === 'span' &&
-            content === 'Location: Not available'
-          );
-        }),
-      );
-      expect(
-        screen.getByText((content, element) => {
-          return (
-            element.tagName.toLowerCase() === 'span' &&
-            content === 'Clinic: Not available'
+            content === 'Facility details not available'
           );
         }),
       );
@@ -216,6 +205,24 @@ describe('VAOS Component: InPersonLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
 
@@ -429,6 +436,24 @@ describe('VAOS Component: InPersonLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-id',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
 

--- a/src/applications/vaos/components/layouts/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.jsx
@@ -53,6 +53,8 @@ export default function PhoneLayout({ data: appointment }) {
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
     [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
     [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.js
@@ -37,9 +37,6 @@ describe('VAOS Component: PhoneLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        location: {
-          stationId: '983',
-        },
         videoData: {},
         practitioners: [
           {
@@ -102,7 +99,6 @@ describe('VAOS Component: PhoneLayout', () => {
         }),
       );
 
-      expect(screen.getByText(/Clinic: Not available/i));
       expect(screen.getByText(/Reason: Not available/i));
       expect(screen.getByText(/Other details: Not available/i));
 
@@ -129,6 +125,18 @@ describe('VAOS Component: PhoneLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
 
@@ -348,6 +356,18 @@ describe('VAOS Component: PhoneLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
     it('should display phone layout without cancel button', async () => {

--- a/src/applications/vaos/components/layouts/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.jsx
@@ -48,6 +48,9 @@ export default function VARequestLayout({ data: appointment }) {
 
   recordAppointmentDetailsNullStates({
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.js
@@ -180,6 +180,24 @@ describe('VAOS Component: VARequestLayout', () => {
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-id',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
+      });
     });
   });
 

--- a/src/applications/vaos/components/layouts/VideoLayout.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.jsx
@@ -66,6 +66,8 @@ export default function VideoLayout({ data: appointment }) {
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
     [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
     [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/VideoLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayout.unit.spec.js
@@ -123,6 +123,18 @@ describe('VAOS Component: VideoLayout', () => {
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
       });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
+      });
     });
 
     it('should display facility phone when clinic phone is missing', async () => {
@@ -375,6 +387,18 @@ describe('VAOS Component: VideoLayout', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
@@ -58,6 +58,8 @@ export default function VideoLayoutAtlas({ data: appointment }) {
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
     [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
     [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.js
@@ -44,9 +44,6 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
 
       const store = createTestStore(state);
       const appointment = {
-        location: {
-          stationId: '983',
-        },
         videoData: {
           atlasConfirmationCode: '1234',
           atlasLocation: {
@@ -137,6 +134,18 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
 
@@ -455,6 +464,18 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       });
       expect(window.dataLayer).not.to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).not.to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
   });

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
@@ -55,6 +55,9 @@ export default function VideoLayoutVA({ data: appointment }) {
     [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
     [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
     [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
   });
 
   return (

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.js
@@ -149,11 +149,6 @@ describe('VAOS Component: VideoLayoutVA', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        location: {
-          stationId: '983',
-          clinicName: 'Clinic 1',
-          clinicPhysicalLocation: 'CHEYENNE',
-        },
         videoData: {
           isVideo: true,
           facilityId: '983',
@@ -227,6 +222,24 @@ describe('VAOS Component: VideoLayoutVA', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-id',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-details',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-expected-facility-phone',
+      });
+      expect(window.dataLayer).to.deep.include({
+        event: 'vaos-null-states-missing-facility-phone',
       });
     });
 
@@ -479,6 +492,24 @@ describe('VAOS Component: VideoLayoutVA', () => {
         });
         expect(window.dataLayer).not.to.deep.include({
           event: 'vaos-null-states-missing-clinic-phone',
+        });
+        expect(window.dataLayer).to.deep.include({
+          event: 'vaos-null-states-expected-facility-id',
+        });
+        expect(window.dataLayer).not.to.deep.include({
+          event: 'vaos-null-states-missing-facility-id',
+        });
+        expect(window.dataLayer).to.deep.include({
+          event: 'vaos-null-states-expected-facility-details',
+        });
+        expect(window.dataLayer).not.to.deep.include({
+          event: 'vaos-null-states-missing-facility-details',
+        });
+        expect(window.dataLayer).to.deep.include({
+          event: 'vaos-null-states-expected-facility-phone',
+        });
+        expect(window.dataLayer).not.to.deep.include({
+          event: 'vaos-null-states-missing-facility-phone',
         });
       });
     });

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.unit.spec.js
@@ -53,9 +53,12 @@ describe('VAOS Page: ContactInfoPage', () => {
       ),
     ).to.be.ok;
     userEvent.click(screen.getByText(/^Continue/));
-    await waitFor(() => {
-      expect(screen.history.push.called).to.be.true;
-    });
+    await waitFor(
+      () => {
+        expect(screen.history.push.called).to.be.true;
+      },
+      { timeout: 3000 },
+    );
 
     expect(window.dataLayer).to.deep.include({
       event: 'vaos-contact-info-email-not-populated',

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -279,10 +279,10 @@ export function getVAAppointmentLocationId(appointment) {
       return '612A4';
     }
 
-    return appointment?.location.vistaId;
+    return appointment?.location?.vistaId;
   }
 
-  return appointment?.location.stationId;
+  return appointment?.location?.stationId;
 }
 /**
  * Returns the patient telecom info in a VA appointment

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -50,6 +50,9 @@ export const NULL_STATE_FIELD = {
   TYPE_OF_CARE: 'type-of-care',
   PROVIDER: 'provider',
   CLINIC_PHONE: 'clinic-phone',
+  FACILITY_ID: 'facility-id',
+  FACILITY_DETAILS: 'facility-details',
+  FACILITY_PHONE: 'facility-phone',
 };
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds additional fields for null state tracking, similar to the previous PR: https://github.com/department-of-veterans-affairs/vets-website/pull/34180
- This PR adds tracking for facility id, facility details and facility phone
- Appointments (VAOS) Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98978
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98979
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98980

## Testing done

- Updated unit tests to account for the new behaviors

## Screenshots

N/A

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


