### PR TITLE
Disable Prefill for the My VA Review Contact Information form

### DIFF
--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatus.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatus.jsx
@@ -133,32 +133,37 @@ const ProofOfVeteranStatus = ({
     }
   };
 
-  const componentizedMessage = vetStatusEligibility.message.map(item => {
-    const contactNumber = `${CONTACTS.DS_LOGON.slice(
-      0,
-      3,
-    )}-${CONTACTS.DS_LOGON.slice(3, 6)}-${CONTACTS.DS_LOGON.slice(6)}`;
-    const startIndex = item.indexOf(contactNumber);
+  const isVetStatusEligibilityPopulated =
+    Object.keys(vetStatusEligibility).length !== 0;
 
-    if (startIndex === -1) {
-      return item;
-    }
+  const componentizedMessage = isVetStatusEligibilityPopulated
+    ? vetStatusEligibility.message.map(item => {
+        const contactNumber = `${CONTACTS.DS_LOGON.slice(
+          0,
+          3,
+        )}-${CONTACTS.DS_LOGON.slice(3, 6)}-${CONTACTS.DS_LOGON.slice(6)}`;
+        const startIndex = item.indexOf(contactNumber);
 
-    const before = item.slice(0, startIndex);
-    const telephone = item.slice(
-      startIndex,
-      startIndex + contactNumber.length + 11,
-    );
-    const after = item.slice(startIndex + telephone.length);
+        if (startIndex === -1) {
+          return item;
+        }
 
-    return (
-      <>
-        {before}
-        <va-telephone contact={contactNumber} /> (
-        <va-telephone contact={CONTACTS[711]} tty />){after}
-      </>
-    );
-  });
+        const before = item.slice(0, startIndex);
+        const telephone = item.slice(
+          startIndex,
+          startIndex + contactNumber.length + 11,
+        );
+        const after = item.slice(startIndex + telephone.length);
+
+        return (
+          <>
+            {before}
+            <va-telephone contact={contactNumber} /> (
+            <va-telephone contact={CONTACTS[711]} tty />){after}
+          </>
+        );
+      })
+    : null;
 
   const contactInfoElements = data?.attributes?.message?.map(item => {
     const contactNumber = `${CONTACTS.DS_LOGON.slice(
@@ -345,7 +350,8 @@ const ProofOfVeteranStatus = ({
             </>
           ) : null}
 
-          {!vetStatusEligibility.confirmed &&
+          {isVetStatusEligibilityPopulated &&
+          !vetStatusEligibility.confirmed &&
           vetStatusEligibility.message.length > 0 ? (
             <>
               <div>

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
@@ -151,32 +151,37 @@ const ProofOfVeteranStatusNew = ({
     }
   };
 
-  const componentizedMessage = vetStatusEligibility.message.map(item => {
-    const contactNumber = `${CONTACTS.DS_LOGON.slice(
-      0,
-      3,
-    )}-${CONTACTS.DS_LOGON.slice(3, 6)}-${CONTACTS.DS_LOGON.slice(6)}`;
-    const startIndex = item.indexOf(contactNumber);
+  const isVetStatusEligibilityPopulated =
+    Object.keys(vetStatusEligibility).length !== 0;
 
-    if (startIndex === -1) {
-      return item;
-    }
+  const componentizedMessage = isVetStatusEligibilityPopulated
+    ? vetStatusEligibility?.message.map(item => {
+        const contactNumber = `${CONTACTS.DS_LOGON.slice(
+          0,
+          3,
+        )}-${CONTACTS.DS_LOGON.slice(3, 6)}-${CONTACTS.DS_LOGON.slice(6)}`;
+        const startIndex = item.indexOf(contactNumber);
 
-    const before = item.slice(0, startIndex);
-    const telephone = item.slice(
-      startIndex,
-      startIndex + contactNumber.length + 11,
-    );
-    const after = item.slice(startIndex + telephone.length);
+        if (startIndex === -1) {
+          return item;
+        }
 
-    return (
-      <>
-        {before}
-        <va-telephone contact={contactNumber} /> (
-        <va-telephone contact={CONTACTS[711]} tty />){after}
-      </>
-    );
-  });
+        const before = item.slice(0, startIndex);
+        const telephone = item.slice(
+          startIndex,
+          startIndex + contactNumber.length + 11,
+        );
+        const after = item.slice(startIndex + telephone.length);
+
+        return (
+          <>
+            {before}
+            <va-telephone contact={contactNumber} /> (
+            <va-telephone contact={CONTACTS[711]} tty />){after}
+          </>
+        );
+      })
+    : null;
 
   const contactInfoElements = data?.attributes?.message?.map(item => {
     const contactNumber = `${CONTACTS.DS_LOGON.slice(
@@ -338,7 +343,8 @@ const ProofOfVeteranStatusNew = ({
                   </>
                 ) : null}
 
-                {data?.attributes?.veteranStatus !== 'confirmed' &&
+                {isVetStatusEligibilityPopulated &&
+                data?.attributes?.veteranStatus !== 'confirmed' &&
                 data?.attributes?.message.length > 0 ? (
                   <>
                     <div>

--- a/src/applications/personalization/review-information/config/form.js
+++ b/src/applications/personalization/review-information/config/form.js
@@ -78,7 +78,7 @@ const formConfig = {
     // },
   },
   version: 0,
-  prefillEnabled: true,
+  prefillEnabled: false,
   savedFormMessages: {
     notFound:
       'Please start over to apply for welcome va setup review information form.',

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -462,12 +462,6 @@ export const MY_VA_SIP_FORMS = [
     trackingPrefix: '',
   },
   {
-    benefit: 'welcome va setup review information form',
-    title: 'Welcome VA Setup Review Information Form',
-    description: 'welcome va setup review information form',
-    trackingPrefix: 'welcome-va-setup-review-information-',
-  },
-  {
     id: VA_FORM_IDS.FORM_DISPUTE_DEBT,
     benefit: 'digital dispute for debts',
     title: 'Dispute your VA debt',

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -462,7 +462,6 @@ export const MY_VA_SIP_FORMS = [
     trackingPrefix: '',
   },
   {
-    id: VA_FORM_IDS.FORM_WELCOME_VA_SETUP_REVIEW_INFORMATION,
     benefit: 'welcome va setup review information form',
     title: 'Welcome VA Setup Review Information Form',
     description: 'welcome va setup review information form',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Changes a config property on the My VA Review Contact Information form, and removes the ID of the same form from a file. Both of these changes are a attempt to prevent our form from appearing on the list of draft forms on the My VA page.
- `prefillEnabled` is not [documented](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-form-config-options) thoroughly enough for me to be confident that this change will work. This is an experiment.
- I work for VA IIR and we own this form.

## Related issue(s)

[VA IIR issue 1385](https://github.com/department-of-veterans-affairs/va-iir/issues/1385)

## Testing done

If this is working as intended, we will see in staging that a draft form is not created after one or more changes have been made using our form.

## Screenshots


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
