### PR TITLE
VACMS-11597 remove CC pagination flipper

### DIFF
--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -2,7 +2,6 @@ import { VaPagination } from '@department-of-veterans-affairs/component-library/
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { LocationType } from '../constants';
-import { facilityLocatorRestoreCommunityCarePagination } from '../utils/featureFlagSelectors';
 
 export class PaginationWrapper extends Component {
   shouldComponentUpdate = nextProps =>
@@ -40,17 +39,6 @@ export class PaginationWrapper extends Component {
 
 const mapStateToProps = state => {
   let shouldHidePagination = false;
-
-  if (
-    [
-      LocationType.CC_PROVIDER,
-      LocationType.URGENT_CARE_PHARMACIES,
-      LocationType.EMERGENCY_CARE,
-    ].includes(state.searchQuery.facilityType) &&
-    !facilityLocatorRestoreCommunityCarePagination(state)
-  ) {
-    shouldHidePagination = true;
-  }
 
   // pagination not yet supported for PPMS urgent care
   if (

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -11,8 +11,3 @@ export const facilityLocatorPredictiveLocationSearch = state =>
   toggleValues(state)[
     FEATURE_FLAG_NAMES.facilityLocatorPredictiveLocationSearch
   ];
-
-export const facilityLocatorRestoreCommunityCarePagination = state =>
-  toggleValues(state)[
-    FEATURE_FLAG_NAMES.facilityLocatorRestoreCommunityCarePagination
-  ];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -72,7 +72,6 @@
   "facilitiesPpmsSuppressAll": "facilities_ppms_suppress_all",
   "facilitiesPpmsSuppressPharmacies": "facilities_ppms_suppress_pharmacies",
   "facilityLocatorPredictiveLocationSearch": "facility_locator_predictive_location_search",
-  "facilityLocatorRestoreCommunityCarePagination": "facility_locator_restore_community_care_pagination",
   "facilityLocatorShowCommunityCares": "facility_locator_show_community_cares",
   "facilityLocatorShowOperationalHoursSpecialInstructions": "facility_locator_show_operational_hours_special_instructions",
   "fileUploadShortWorkflowEnabled": "file_upload_short_workflow_enabled",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Remove `facility_locator_restore_community_care_pagination` flipper. It is **on** in staging and production, but the only logic that uses it checks if it is **off**.

Flipper admin in staging and prod:
<img width="785" alt="Screenshot 2025-01-23 at 5 08 53 PM" src="https://github.com/user-attachments/assets/f1cec6e3-a7c3-4031-98cd-cc43e17567ed" />

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11597

## Testing & screenshots
Checked CC provider search in local vs. prod - same behavior:

### Local
<img width="587" alt="Screenshot 2025-01-23 at 5 16 23 PM" src="https://github.com/user-attachments/assets/3e666585-1ccf-412e-999c-b611690e4829" />
<img width="690" alt="Screenshot 2025-01-23 at 5 16 32 PM" src="https://github.com/user-attachments/assets/35b42ec3-6bb6-4b4c-838d-f7297c6f488e" />

### Prod
<img width="668" alt="Screenshot 2025-01-23 at 5 16 43 PM" src="https://github.com/user-attachments/assets/c59586b4-393e-4e96-8a05-68607f377851" />
<img width="635" alt="Screenshot 2025-01-23 at 5 16 51 PM" src="https://github.com/user-attachments/assets/2c3182ec-2c2a-429e-9843-a486e174f830" />
