### PR TITLE
VACMS-11599 Remove health connect flipper

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 import DelayedRender from 'platform/utilities/ui/DelayedRender';
 import { facilityTypes } from '../config';
@@ -308,9 +306,6 @@ function mapStateToProps(state) {
     searchString,
     selectedResult: state.searchResult.selectedResult,
     resultTime: state.searchResult.resultTime,
-    facilityLocatorShowHealthConnectNumber: toggleValues(state)[
-      FEATURE_FLAG_NAMES.facilityLocatorShowHealthConnectNumber
-    ],
   };
 }
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -76,7 +76,6 @@
   "facilityLocatorRailsEngine": "facility_locator_rails_engine",
   "facilityLocatorRestoreCommunityCarePagination": "facility_locator_restore_community_care_pagination",
   "facilityLocatorShowCommunityCares": "facility_locator_show_community_cares",
-  "facilityLocatorShowHealthConnectNumber": "facility_locator_show_health_connect_number",
   "facilityLocatorShowOperationalHoursSpecialInstructions": "facility_locator_show_operational_hours_special_instructions",
   "fileUploadShortWorkflowEnabled": "file_upload_short_workflow_enabled",
   "financialStatusReportDebtsApiModule": "financial_status_report_debts_api_module",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Remove the `facility_locator_show_health_connect_number` flipper. It is **on** in staging and production, but the code isn't using this flipper.

Flipper admin in staging and prod:
<img width="625" alt="Screenshot 2025-01-23 at 5 33 54 PM" src="https://github.com/user-attachments/assets/b27e62d8-08ea-437d-9773-c69cd2c51072" />

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11599