### PR TITLE
VACMS-11596 Remove Facility Locator rails flipper

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -73,7 +73,6 @@
   "facilitiesPpmsSuppressPharmacies": "facilities_ppms_suppress_pharmacies",
   "facilityLocatorLatLongOnly": "facility_locator_lat_long_only",
   "facilityLocatorPredictiveLocationSearch": "facility_locator_predictive_location_search",
-  "facilityLocatorRailsEngine": "facility_locator_rails_engine",
   "facilityLocatorRestoreCommunityCarePagination": "facility_locator_restore_community_care_pagination",
   "facilityLocatorShowCommunityCares": "facility_locator_show_community_cares",
   "facilityLocatorShowHealthConnectNumber": "facility_locator_show_health_connect_number",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Remove unused `facility_locator_rails_engine` flipper. Flipper is currently **on** in staging and production but not being used in the code:

<img width="428" alt="Screenshot 2025-01-23 at 5 42 57 PM" src="https://github.com/user-attachments/assets/f8430cba-721c-4a73-855b-c627d889d8d9" />


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11596