### PR TITLE
VACMS-14112 Remove show community cares flipper

### DIFF
--- a/src/applications/post-911-gib-status/mocks/server.js
+++ b/src/applications/post-911-gib-status/mocks/server.js
@@ -133,7 +133,6 @@ const responses = {
       type: 'feature_toggles',
       features: [
         { name: 'showExpandableVamcAlert', value: true },
-        { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },
         { name: 'vaOnlineScheduling', value: true },
         { name: 'vaOnlineSchedulingCancel', value: true },

--- a/src/applications/simple-forms/20-10206/tests/e2e/fixtures/mocks/featureToggles.json
+++ b/src/applications/simple-forms/20-10206/tests/e2e/fixtures/mocks/featureToggles.json
@@ -4,7 +4,6 @@
     "features": [
       { "name": "form210845", "value": true },
       { "name": "showExpandableVamcAlert", "value": true },
-      { "name": "facilityLocatorShowCommunityCares", "value": true },
       { "name": "profile_show_profile_2.0", "value": false },
       { "name": "vaOnlineScheduling", "value": true },
       { "name": "vaOnlineSchedulingCancel", "value": true },

--- a/src/applications/simple-forms/21-0845/tests/e2e/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/simple-forms/21-0845/tests/e2e/fixtures/mocks/local-mock-responses.js
@@ -16,7 +16,6 @@ const responses = {
       features: [
         { name: 'form210845', value: true },
         { name: 'showExpandableVamcAlert', value: true },
-        { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },
         { name: 'vaOnlineScheduling', value: true },
         { name: 'vaOnlineSchedulingCancel', value: true },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -7,10 +7,6 @@
         "value": false
       },
       {
-        "name": "facilityLocatorShowCommunityCares",
-        "value": false
-      },
-      {
         "name": "facilitiesPpmsSuppressPharmacies",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "facilityLocatorShowCommunityCares",
-        "value": true
-      },
-      {
         "name": "facilitiesPpmsSuppressPharmacies",
         "value": true
       },

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -1,5 +1,4 @@
 module.exports = [
-  { name: 'facilityLocatorShowCommunityCares', value: true },
   { name: 'profile_show_profile_2.0', value: false },
   { name: 'vaOnlineScheduling', value: true },
   { name: 'vaOnlineSchedulingCancel', value: true },

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -65,7 +65,6 @@ const responses = {
       type: 'feature_toggles',
       features: [
         { name: 'showExpandableVamcAlert', value: true },
-        { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },
         { name: 'vaOnlineScheduling', value: true },
         { name: 'vaOnlineSchedulingCancel', value: true },

--- a/src/platform/utilities/tests/header-footer/mocks/features.js
+++ b/src/platform/utilities/tests/header-footer/mocks/features.js
@@ -2,7 +2,6 @@ const features = {
   data: {
     type: 'feature_toggles',
     features: [
-      { name: 'facilityLocatorShowCommunityCares', value: true },
       { name: 'profile_show_profile_2.0', value: false },
       { name: 'vaOnlineScheduling', value: true },
       { name: 'vaOnlineSchedulingCancel', value: true },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Remove unused `facility_locator_show_community_cares` flipper. It is **on** in staging and production, but the code isn't using it.

<img width="896" alt="Screenshot 2025-01-23 at 5 56 01 PM" src="https://github.com/user-attachments/assets/3cc534f3-3f37-40e4-90ad-186455c7afd3" />

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14112