### PR TITLE
VACMS-20289 Remove lat long flipper

### DIFF
--- a/src/applications/facility-locator/api/LocatorApi.js
+++ b/src/applications/facility-locator/api/LocatorApi.js
@@ -24,9 +24,7 @@ class LocatorApi {
     page,
     center,
     radius,
-    allUrgentCare,
   ) {
-    const reduxStore = require('../facility-locator-entry');
     const { params, url, postParams } = resolveParamsWithUrl({
       address,
       locationType,
@@ -35,8 +33,6 @@ class LocatorApi {
       bounds,
       center,
       radius,
-      allUrgentCare,
-      reduxStore,
     });
 
     const api = getAPI();

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -6,7 +6,6 @@ import {
   EMERGENCY_CARE_SERVICES,
 } from './constants';
 import manifest from './manifest.json';
-import { facilityLocatorLatLongOnly } from './utils/featureFlagSelectors';
 
 const apiSettings = {
   credentials: 'include',
@@ -41,19 +40,8 @@ export const resolveParamsWithUrl = ({
   bounds,
   center,
   radius,
-  store,
 }) => {
   const filterableLocations = ['health', 'benefits', 'provider'];
-  const reduxStore = store || require('./facility-locator-entry');
-  let latLongOnly = false;
-
-  try {
-    latLongOnly = facilityLocatorLatLongOnly(reduxStore.default.getState());
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.warn('error getting redux state from store', reduxStore, e);
-  }
-
   const api = getAPI();
 
   let facility;
@@ -120,20 +108,12 @@ export const resolveParamsWithUrl = ({
     }&${sNchar}${EMERGENCY_CARE_SERVICES[4]}`;
   }
 
-  let locationParams;
-  if (latLongOnly) {
-    locationParams = [
-      center && center.length > 0 ? `lat=${center[0]}` : null,
-      center && center.length > 0 ? `long=${center[1]}` : null,
-    ];
-  } else {
-    locationParams = [
-      address ? `address=${address}` : null,
-      ...bounds.map(c => `bbox[]=${c}`),
-      center && center.length > 0 ? `latitude=${center[0]}` : null,
-      center && center.length > 0 ? `longitude=${center[1]}` : null,
-    ];
-  }
+  const locationParams = [
+    address ? `address=${address}` : null,
+    ...bounds.map(c => `bbox[]=${c}`),
+    center && center.length > 0 ? `latitude=${center[0]}` : null,
+    center && center.length > 0 ? `longitude=${center[1]}` : null,
+  ];
 
   const postLocationParams = {};
   locationParams.forEach(param => {

--- a/src/applications/facility-locator/tests/api-url-parameters.latLongOnly.unit.spec.js
+++ b/src/applications/facility-locator/tests/api-url-parameters.latLongOnly.unit.spec.js
@@ -4,6 +4,7 @@ import environment from 'platform/utilities/environment';
 import { resolveParamsWithUrl } from '../config';
 
 const center = [35.78, -78.68];
+const bounds = [];
 
 describe('Locator url and parameters builder - latLong only', () => {
   const page = 1;
@@ -16,12 +17,13 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: 'NonVAUrgentCare',
       center,
       page,
+      bounds,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/facilities_api/v2/ccp/urgent_care?page=1&per_page=10&lat=35.78&long=-78.68`,
+      }/facilities_api/v2/ccp/urgent_care?page=1&per_page=10&latitude=35.78&longitude=-78.68`,
     );
   });
 
@@ -33,12 +35,13 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'pharmacy',
       page,
       center,
+      bounds,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/facilities_api/v2/ccp/pharmacy?page=1&per_page=15&lat=35.78&long=-78.68`,
+      }/facilities_api/v2/ccp/pharmacy?page=1&per_page=15&latitude=35.78&longitude=-78.68`,
     );
   });
 
@@ -50,8 +53,11 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'health',
       page,
       center,
+      bounds,
     });
+
     const url = `${environment.API_URL}/facilities_api/v2/va`;
+
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
       type: 'health',
@@ -59,15 +65,18 @@ describe('Locator url and parameters builder - latLong only', () => {
       // eslint-disable-next-line camelcase
       per_page: 10,
       mobile: false,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
     });
+
     result = resolveParamsWithUrl({
       locationType: 'health',
       serviceType: 'PrimaryCare',
       page,
       center,
+      bounds,
     });
+
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
       type: 'health',
@@ -75,8 +84,8 @@ describe('Locator url and parameters builder - latLong only', () => {
       // eslint-disable-next-line camelcase
       per_page: 10,
       mobile: false,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
       services: ['PrimaryCare'],
     });
   });
@@ -90,7 +99,9 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: 'UrgentCare',
       page,
       center,
+      bounds,
     });
+
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
       type: 'health',
@@ -98,8 +109,8 @@ describe('Locator url and parameters builder - latLong only', () => {
       // eslint-disable-next-line camelcase
       per_page: 10,
       mobile: false,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
       services: ['UrgentCare'],
     });
   });
@@ -112,47 +123,56 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'benefits',
       page,
       center,
+      bounds,
     });
+
     const url = `${environment.API_URL}/facilities_api/v2/va`;
+
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
       type: 'benefits',
       page: 1,
       // eslint-disable-next-line camelcase
       per_page: 10,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
     });
+
     result = resolveParamsWithUrl({
       locationType: 'benefits',
       serviceType: 'VAHomeLoanAssistance',
       page,
       center,
+      bounds,
     });
+
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
       type: 'benefits',
       page: 1,
       // eslint-disable-next-line camelcase
       per_page: 10,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
       services: ['VAHomeLoanAssistance'],
     });
+
     result = resolveParamsWithUrl({
       locationType: 'benefits',
       serviceType: 'ApplyingForBenefits',
       page,
       center,
+      bounds,
     });
+
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
       type: 'benefits',
       page: 1,
       // eslint-disable-next-line camelcase
       per_page: 10,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
       services: ['ApplyingForBenefits'],
     });
   });
@@ -165,15 +185,17 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'cemetery',
       page,
       center,
+      bounds,
     });
+
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
       type: 'cemetery',
       page: 1,
       // eslint-disable-next-line camelcase
       per_page: 10,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
     });
   });
 
@@ -189,12 +211,14 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: '122300000X', // Dentist
       page,
       center,
+      bounds,
     });
+
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/facilities_api/v2/ccp/provider?specialties[]=122300000X&page=1&per_page=15&lat=35.78&long=-78.68`,
+      }/facilities_api/v2/ccp/provider?specialties[]=122300000X&page=1&per_page=15&address=I%2035%20Frontage%20Road,%20Austin,%20Texas%2078753,%20United%20States&latitude=35.78&longitude=-78.68`,
     );
   });
 
@@ -206,7 +230,9 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'vet_center',
       page,
       center,
+      bounds,
     });
+
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
       type: 'vet_center',
@@ -214,8 +240,8 @@ describe('Locator url and parameters builder - latLong only', () => {
       // eslint-disable-next-line camelcase
       per_page: 10,
       mobile: false,
-      lat: '35.78',
-      long: '-78.68',
+      latitude: '35.78',
+      longitude: '-78.68',
     });
   });
 
@@ -228,12 +254,14 @@ describe('Locator url and parameters builder - latLong only', () => {
       page,
       center: [33.32464, -97.18077],
       radius: 40,
+      bounds,
     });
+
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/facilities_api/v2/ccp/provider?specialties[]=122300000X&page=1&per_page=15&radius=40&lat=33.32464&long=-97.18077`,
+      }/facilities_api/v2/ccp/provider?specialties[]=122300000X&page=1&per_page=15&radius=40&latitude=33.32464&longitude=-97.18077`,
     );
   });
 });

--- a/src/applications/facility-locator/tests/api-url-parameters.latLongOnly.unit.spec.js
+++ b/src/applications/facility-locator/tests/api-url-parameters.latLongOnly.unit.spec.js
@@ -3,15 +3,6 @@ import { expect } from 'chai';
 import environment from 'platform/utilities/environment';
 import { resolveParamsWithUrl } from '../config';
 
-const store = {
-  default: {
-    getState: () => ({
-      // eslint-disable-next-line camelcase
-      featureToggles: { facility_locator_lat_long_only: true },
-    }),
-  },
-};
-
 const center = [35.78, -78.68];
 
 describe('Locator url and parameters builder - latLong only', () => {
@@ -25,7 +16,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: 'NonVAUrgentCare',
       center,
       page,
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
@@ -43,7 +33,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'pharmacy',
       page,
       center,
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
@@ -61,7 +50,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'health',
       page,
       center,
-      store,
     });
     const url = `${environment.API_URL}/facilities_api/v2/va`;
     expect(result.url).to.eql(url);
@@ -79,7 +67,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: 'PrimaryCare',
       page,
       center,
-      store,
     });
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
@@ -103,7 +90,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: 'UrgentCare',
       page,
       center,
-      store,
     });
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
@@ -126,7 +112,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'benefits',
       page,
       center,
-      store,
     });
     const url = `${environment.API_URL}/facilities_api/v2/va`;
     expect(result.url).to.eql(url);
@@ -143,7 +128,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: 'VAHomeLoanAssistance',
       page,
       center,
-      store,
     });
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
@@ -160,7 +144,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: 'ApplyingForBenefits',
       page,
       center,
-      store,
     });
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
@@ -182,7 +165,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'cemetery',
       page,
       center,
-      store,
     });
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
@@ -207,7 +189,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       serviceType: '122300000X', // Dentist
       page,
       center,
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
@@ -225,7 +206,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       locationType: 'vet_center',
       page,
       center,
-      store,
     });
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
@@ -248,7 +228,6 @@ describe('Locator url and parameters builder - latLong only', () => {
       page,
       center: [33.32464, -97.18077],
       radius: 40,
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(

--- a/src/applications/facility-locator/tests/api-url-parameters.railsEngine.unit.spec.js
+++ b/src/applications/facility-locator/tests/api-url-parameters.railsEngine.unit.spec.js
@@ -3,15 +3,6 @@ import { expect } from 'chai';
 import environment from 'platform/utilities/environment';
 import { resolveParamsWithUrl } from '../config';
 
-const store = {
-  default: {
-    getState: () => ({
-      // eslint-disable-next-line camelcase
-      featureToggles: { facility_locator_lat_long_only: false },
-    }),
-  },
-};
-
 describe('Locator url and parameters builder', () => {
   const page = 1;
   /**
@@ -26,7 +17,6 @@ describe('Locator url and parameters builder', () => {
       serviceType: 'NonVAUrgentCare',
       page,
       bounds: [-98.52, 29.74, -97.02, 31.24],
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
@@ -47,7 +37,6 @@ describe('Locator url and parameters builder', () => {
       locationType: 'pharmacy',
       page,
       bounds: [-98.45, 29.59, -96.95, 31.09],
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
@@ -65,7 +54,6 @@ describe('Locator url and parameters builder', () => {
       locationType: 'health',
       page,
       bounds: [-118.9939, 33.3044, -117.4939, 34.8044],
-      store,
     });
     const url = `${environment.API_URL}/facilities_api/v2/va`;
     expect(result.url).to.eql(url);
@@ -82,7 +70,6 @@ describe('Locator url and parameters builder', () => {
       serviceType: 'PrimaryCare',
       page,
       bounds: [-98.52, 29.74, -97.02, 31.24],
-      store,
     });
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
@@ -106,7 +93,6 @@ describe('Locator url and parameters builder', () => {
       serviceType: 'UrgentCare',
       page,
       bounds,
-      store,
     });
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
@@ -128,7 +114,6 @@ describe('Locator url and parameters builder', () => {
       locationType: 'benefits',
       page,
       bounds: [-98.52, 29.74, -97.02, 31.24],
-      store,
     });
     const url = `${environment.API_URL}/facilities_api/v2/va`;
     expect(result.url).to.eql(url);
@@ -144,7 +129,6 @@ describe('Locator url and parameters builder', () => {
       serviceType: 'VAHomeLoanAssistance',
       page,
       bounds: [-98.52, 29.74, -97.02, 31.24],
-      store,
     });
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
@@ -160,7 +144,6 @@ describe('Locator url and parameters builder', () => {
       serviceType: 'ApplyingForBenefits',
       page,
       bounds: [-98.52, 29.74, -97.02, 31.24],
-      store,
     });
     expect(result.url).to.eql(url);
     expect(result.postParams).to.eql({
@@ -181,7 +164,6 @@ describe('Locator url and parameters builder', () => {
       locationType: 'cemetery',
       page,
       bounds: [-98.52, 29.74, -97.02, 31.24],
-      store,
     });
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
@@ -205,7 +187,6 @@ describe('Locator url and parameters builder', () => {
       serviceType: '122300000X', // Dentist
       page,
       bounds: [-98.45, 29.59, -96.95, 31.09],
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(
@@ -223,7 +204,6 @@ describe('Locator url and parameters builder', () => {
       locationType: 'vet_center',
       page,
       bounds: [-98.45, 29.59, -96.95, 31.09],
-      store,
     });
     expect(result.url).to.eql(`${environment.API_URL}/facilities_api/v2/va`);
     expect(result.postParams).to.eql({
@@ -249,7 +229,6 @@ describe('Locator url and parameters builder', () => {
       bounds: [-98.45, 29.59, -96.95, 31.09],
       center: [33.32464, -97.18077],
       radius: 40,
-      store,
     });
     const test = `${result.url}?${result.params}`;
     expect(test).to.eql(

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -12,9 +12,6 @@ export const facilityLocatorPredictiveLocationSearch = state =>
     FEATURE_FLAG_NAMES.facilityLocatorPredictiveLocationSearch
   ];
 
-export const facilityLocatorLatLongOnly = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.facilityLocatorLatLongOnly];
-
 export const facilityLocatorRestoreCommunityCarePagination = state =>
   toggleValues(state)[
     FEATURE_FLAG_NAMES.facilityLocatorRestoreCommunityCarePagination

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -71,7 +71,6 @@
   "ezrUploadEnabled": "ezr_upload_enabled",
   "facilitiesPpmsSuppressAll": "facilities_ppms_suppress_all",
   "facilitiesPpmsSuppressPharmacies": "facilities_ppms_suppress_pharmacies",
-  "facilityLocatorLatLongOnly": "facility_locator_lat_long_only",
   "facilityLocatorPredictiveLocationSearch": "facility_locator_predictive_location_search",
   "facilityLocatorRestoreCommunityCarePagination": "facility_locator_restore_community_care_pagination",
   "facilityLocatorShowCommunityCares": "facility_locator_show_community_cares",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removes unused `facility_locator_lat_long_only` flipper. It is **off** in staging and production, and the only code that uses it requires it to be **on**.

<img width="658" alt="Screenshot 2025-01-23 at 6 04 32 PM" src="https://github.com/user-attachments/assets/38c0492e-6023-49d0-9597-f12e88fba8ea" />

### Testing done

Verified that the CCP calls matched production after the changes:

| Before | After |
| --- | --- |
| <img width="888" alt="Screenshot 2025-01-27 at 11 20 32 AM" src="https://github.com/user-attachments/assets/bc6bdcca-3eb1-46a9-b450-a2877dd97b2c" /> | <img width="889" alt="Screenshot 2025-01-27 at 11 20 39 AM" src="https://github.com/user-attachments/assets/62b4fb7f-4245-4c63-afca-6dc984fd8a9b" /> |
| <img width="907" alt="Screenshot 2025-01-27 at 11 23 23 AM" src="https://github.com/user-attachments/assets/d5d24c9a-4c58-434d-acc1-84ebbc2b1823" /> | <img width="902" alt="Screenshot 2025-01-27 at 11 23 35 AM" src="https://github.com/user-attachments/assets/7ec0f832-fdc9-4884-9312-0af4d538fc8c" /> |
| (GET) https://api.va.gov/facilities_api/v2/ccp/specialties | (GET) https://api.va.gov/facilities_api/v2/ccp/specialties |
| (GET) https://api.va.gov/facilities_api/v2/ccp/provider?specialties[]=152W00000X&page=1&per_page=15&radius=20&address=19185%20Stone%20Oak%20Parkway,%20San%20Antonio,%20Texas%2078258,%20United%20States&bbox[]=-99.245114&bbox[]=28.8767&bbox[]=-97.745114&bbox[]=30.3767&latitude=29.6267&longitude=-98.495114 | (GET) https://api.va.gov/facilities_api/v2/ccp/provider?specialties[]=152W00000X&page=1&per_page=15&radius=20&address=19185%20Stone%20Oak%20Parkway,%20San%20Antonio,%20Texas%2078258,%20United%20States&bbox[]=-99.245114&bbox[]=28.8767&bbox[]=-97.745114&bbox[]=30.3767&latitude=29.6267&longitude=-98.495114 |


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20289