### PR TITLE
VACMS-20290 Remove unused flipper and clean up LocationHours component

### DIFF
--- a/src/applications/facility-locator/components/LocationHours.jsx
+++ b/src/applications/facility-locator/components/LocationHours.jsx
@@ -42,6 +42,10 @@ const LocationHours = ({ location }) => {
   const facilityType = get(location, 'attributes.facilityType');
   const isVetCenter = facilityType === LocationType.VET_CENTER;
 
+  if ((Array.isArray(hoursInfo) && !hoursInfo.length) || !hoursInfo) {
+    return null;
+  }
+
   return (
     <div id="hours-op">
       <h3 className="highlight">Hours of operation</h3>

--- a/src/applications/facility-locator/components/LocationHours.jsx
+++ b/src/applications/facility-locator/components/LocationHours.jsx
@@ -1,91 +1,51 @@
-// Dependencies
 import React from 'react';
 import { get } from 'lodash';
-// Relative
-import { LocationType, FacilityType } from '../constants';
+import { LocationForHoursTypes } from '../types';
+import { LocationType } from '../constants';
 import { formatOperatingHours } from '../utils/helpers';
 
-/**
- * VA Facility Known Operational Hours
- */
-const LocationHours = ({ location, showHoursSpecialInstructions }) => {
-  // Derive the formatted hours info.
+const LocationHours = ({ location }) => {
   const hoursInfo = get(location, 'attributes.hours');
-  // Derive the time ranges for each day.
-  const sunday = formatOperatingHours(get(hoursInfo, 'sunday'));
-  const monday = formatOperatingHours(get(hoursInfo, 'monday'));
-  const tuesday = formatOperatingHours(get(hoursInfo, 'tuesday'));
-  const wednesday = formatOperatingHours(get(hoursInfo, 'wednesday'));
-  const thursday = formatOperatingHours(get(hoursInfo, 'thursday'));
-  const friday = formatOperatingHours(get(hoursInfo, 'friday'));
-  const saturday = formatOperatingHours(get(hoursInfo, 'saturday'));
+  const days = [
+    'sunday',
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+  ];
 
-  // Derive if the facility is a vet center.
+  const renderHoursByDay = () => {
+    return days.map(day => {
+      const hours = formatOperatingHours(get(hoursInfo, day));
+      const dayToDisplay = day.charAt(0).toUpperCase() + day.slice(1);
+
+      if (hours) {
+        return (
+          <div className="row">
+            <p className="small-6 columns vads-u-margin--0">{dayToDisplay}:</p>
+            <p
+              data-testid={`${day}-hours`}
+              className="small-6 columns vads-u-margin--0"
+            >
+              {hours}
+            </p>
+          </div>
+        );
+      }
+
+      return null;
+    });
+  };
+
   const facilityType = get(location, 'attributes.facilityType');
   const isVetCenter = facilityType === LocationType.VET_CENTER;
-  const isVaHealth = facilityType === FacilityType.VA_HEALTH_FACILITY;
-  const { operationalHoursSpecialInstructions } = location.attributes;
 
   return (
     <div id="hours-op">
       <h3 className="highlight">Hours of operation</h3>
-
-      {/* Sunday */}
-      {sunday && (
-        <div className="row">
-          <div className="small-6 columns">Sunday:</div>
-          <div className="small-6 columns">{sunday}</div>
-        </div>
-      )}
-
-      {/* Monday */}
-      {monday && (
-        <div className="row">
-          <div className="small-6 columns">Monday:</div>
-          <div className="small-6 columns">{monday}</div>
-        </div>
-      )}
-
-      {/* Tuesday */}
-      {tuesday && (
-        <div className="row">
-          <div className="small-6 columns">Tuesday:</div>
-          <div className="small-6 columns">{tuesday}</div>
-        </div>
-      )}
-
-      {/* Wednesday */}
-      {wednesday && (
-        <div className="row">
-          <div className="small-6 columns">Wednesday:</div>
-          <div className="small-6 columns">{wednesday}</div>
-        </div>
-      )}
-
-      {/* Thursday */}
-      {thursday && (
-        <div className="row">
-          <div className="small-6 columns">Thursday:</div>
-          <div className="small-6 columns">{thursday}</div>
-        </div>
-      )}
-
-      {/* Friday */}
-      {friday && (
-        <div className="row">
-          <div className="small-6 columns">Friday:</div>
-          <div className="small-6 columns">{friday}</div>
-        </div>
-      )}
-
-      {/* Saturday */}
-      {saturday && (
-        <div className="row">
-          <div className="small-6 columns">Saturday:</div>
-          <div className="small-6 columns">{saturday}</div>
-        </div>
-      )}
-
+      {renderHoursByDay()}
       {isVetCenter && (
         <p>
           In addition to the hours listed above, all Vet Centers maintain
@@ -94,16 +54,10 @@ const LocationHours = ({ location, showHoursSpecialInstructions }) => {
           Please contact your Vet Center to obtain the current schedule.
         </p>
       )}
-
-      {isVaHealth &&
-        showHoursSpecialInstructions &&
-        operationalHoursSpecialInstructions && (
-          <p id="operational-special-p">
-            {operationalHoursSpecialInstructions}
-          </p>
-        )}
     </div>
   );
 };
+
+LocationHours.propTypes = LocationForHoursTypes;
 
 export default LocationHours;

--- a/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
@@ -17,6 +17,7 @@ function LocationDirectionsLink({ location, from }) {
     <p>
       {from === 'FacilityDetail' && <va-icon icon="directions" size="3" />}
       <va-link
+        class="vads-u-margin-left--0p5"
         href={`https://maps.google.com?saddr=${
           location.searchString
         }&daddr=${address}`}

--- a/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
@@ -32,7 +32,9 @@ export const renderPhoneNumber = (
 
   return (
     <p>
-      {from === 'FacilityDetail' && <va-icon icon="phone" size="3" />}
+      {from === 'FacilityDetail' && (
+        <va-icon class="vads-u-margin-right--0p5" icon="phone" size="3" />
+      )}
       {title && <strong id={phoneNumberId}>{title}: </strong>}
       {subTitle}
       {processed ? (

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -13,7 +13,6 @@ import LocationPhoneLink from '../components/search-results-items/common/Locatio
 import ServicesAtFacility from '../components/ServicesAtFacility';
 import { FacilityType } from '../constants';
 import VABenefitsCall from '../components/VABenefitsCall';
-import { facilityLocatorShowOperationalHoursSpecialInstructions } from '../utils/featureFlagSelectors';
 
 import OperationStatus from '../components/facility-details/OperationStatus';
 
@@ -92,7 +91,7 @@ class FacilityDetail extends Component {
   }
 
   render() {
-    const { facility, currentQuery, showHoursSpecialInstructions } = this.props;
+    const { facility, currentQuery } = this.props;
 
     if (!facility) {
       return null;
@@ -124,10 +123,7 @@ class FacilityDetail extends Component {
           <div>
             <LocationMap info={facility} />
             <div className="vads-u-margin-bottom--4">
-              <LocationHours
-                location={facility}
-                showHoursSpecialInstructions={showHoursSpecialInstructions}
-              />
+              <LocationHours location={facility} />
             </div>
           </div>
         </div>
@@ -144,9 +140,6 @@ function mapStateToProps(state) {
   return {
     facility: state.searchResult.selectedResult,
     currentQuery: state.searchQuery,
-    showHoursSpecialInstructions: facilityLocatorShowOperationalHoursSpecialInstructions(
-      state,
-    ),
   };
 }
 
@@ -160,5 +153,4 @@ FacilityDetail.propTypes = {
   facility: PropTypes.object,
   fetchVAFacility: PropTypes.func,
   params: PropTypes.object,
-  showHoursSpecialInstructions: PropTypes.bool,
 };

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -69,10 +69,14 @@ class FacilityDetail extends Component {
         </div>
         {website &&
           website !== 'NULL' && (
-            <>
+            <p className="vads-u-margin--0">
               <va-icon icon="language" size="3" />
-              <va-link href={website} text="Website" />
-            </>
+              <va-link
+                class="vads-u-margin-left--0p5"
+                href={website}
+                text="Website"
+              />
+            </p>
           )}
         <div>
           <LocationDirectionsLink location={facility} from="FacilityDetail" />

--- a/src/applications/facility-locator/tests/components/LocationHours.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/LocationHours.unit.spec.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import LocationHours from '../../components/LocationHours';
 
 describe('<LocationHours>', () => {
-  const makeTestFacility = (
-    operationalHoursSpecialInstructions,
-    facilityType,
-  ) => ({
+  const makeTestFacility = (facilityType, hours) => ({
     id: 'vha_549',
     type: 'facility',
     attributes: {
@@ -18,82 +15,118 @@ describe('<LocationHours>', () => {
       operatingStatus: {
         code: 'NORMAL',
       },
-      hours: {
-        monday: '24/7',
-        tuesday: '24/7',
-        wednesday: '24/7',
-        thursday: '24/7',
-        friday: '24/7',
-        saturday: '24/7',
-        sunday: '24/7',
-      },
-      operationalHoursSpecialInstructions,
+      hours,
       uniqueId: '549',
       visn: '17',
       website: 'https://www.northtexas.va.gov/locations/directions.asp',
     },
   });
 
-  const operationalHoursSpecialInstructions =
-    'Administrative hours are Monday-Friday 8:00 a.m. to 4:30 p.m. | Expanded or Nontraditional hours are available for some services on a ' +
-    'routine and or requested basis. Please call our main phone number for details. |';
+  it('should render LocationHours with the correct values given', () => {
+    const hours = {
+      monday: '24/7',
+      tuesday: '24/7',
+      wednesday: '24/7',
+      thursday: '24/7',
+      friday: '24/7',
+      saturday: '24/7',
+      sunday: '24/7',
+    };
 
-  it('Should render LocationHours with operationalHoursSpecialInstructions field with truthy values', () => {
-    const wrapper = shallow(
+    const screen = render(
       <LocationHours
-        location={makeTestFacility(
-          operationalHoursSpecialInstructions,
-          'va_health_facility',
-        )}
-        showHoursSpecialInstructions
+        location={makeTestFacility('va_health_facility', hours)}
       />,
     );
-    expect(wrapper.type()).to.not.equal(null);
-    expect(
-      wrapper
-        .render()
-        .find('#operational-special-p')
-        .text(),
-    ).to.equal(operationalHoursSpecialInstructions);
-    wrapper.unmount();
+
+    expect(screen.queryByText('Sunday:')).to.exist;
+    expect(screen.queryByText('Monday:')).to.exist;
+    expect(screen.queryByText('Tuesday:')).to.exist;
+    expect(screen.queryByText('Wednesday:')).to.exist;
+    expect(screen.queryByText('Thursday:')).to.exist;
+    expect(screen.queryByText('Friday:')).to.exist;
+    expect(screen.queryByText('Saturday:')).to.exist;
+
+    expect(screen.queryByTestId('sunday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('monday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('tuesday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('wednesday-hours').textContent).to.equal(
+      '24/7',
+    );
+    expect(screen.queryByTestId('thursday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('friday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('saturday-hours').textContent).to.equal('24/7');
   });
 
-  it('Should render LocationHours without operationalHoursSpecialInstructions field - showHoursSpecialInstructions false', () => {
-    const wrapper = shallow(
+  it('should render LocationHours with the correct values given', () => {
+    const hours = {
+      tuesday: '24/7',
+      wednesday: '24/7',
+      thursday: '24/7',
+      saturday: '24/7',
+      sunday: '24/7',
+    };
+
+    const screen = render(
       <LocationHours
-        location={makeTestFacility(
-          operationalHoursSpecialInstructions,
-          'va_health_facility',
-        )}
-        showHoursSpecialInstructions={false}
+        location={makeTestFacility('va_health_facility', hours)}
       />,
     );
-    expect(wrapper.find('#operational-special-p').length).to.equal(0);
-    wrapper.unmount();
+
+    expect(screen.queryByText('Sunday:')).to.exist;
+    expect(screen.queryByText('Monday:')).not.to.exist;
+    expect(screen.queryByText('Tuesday:')).to.exist;
+    expect(screen.queryByText('Wednesday:')).to.exist;
+    expect(screen.queryByText('Thursday:')).to.exist;
+    expect(screen.queryByText('Friday:')).not.to.exist;
+    expect(screen.queryByText('Saturday:')).to.exist;
+
+    expect(screen.queryByTestId('sunday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('monday-hours')).not.to.exist;
+    expect(screen.queryByTestId('tuesday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('wednesday-hours').textContent).to.equal(
+      '24/7',
+    );
+    expect(screen.queryByTestId('thursday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('friday-hours')).not.to.exist;
+    expect(screen.queryByTestId('saturday-hours').textContent).to.equal('24/7');
   });
 
-  it('Should render LocationHours without operationalHoursSpecialInstructions field - operationalHoursSpecialInstructions null', () => {
-    const wrapper = shallow(
-      <LocationHours
-        location={makeTestFacility(null, operationalHoursSpecialInstructions)}
-        showHoursSpecialInstructions
-      />,
-    );
-    expect(wrapper.find('#operational-special-p').length).to.equal(0);
-    wrapper.unmount();
-  });
+  it('should render LocationHours with the correct values given', () => {
+    const hours = {
+      monday: '8:00 a.m. - 4:30 p.m.',
+      wednesday: '24/7',
+      thursday: '24/7',
+      friday: '8:00 a.m. - 4:30 p.m.',
+      sunday: '24/7',
+    };
 
-  it('Should render LocationHours without operationalHoursSpecialInstructions field with no VA facilities', () => {
-    const wrapper = shallow(
+    const screen = render(
       <LocationHours
-        location={makeTestFacility(
-          operationalHoursSpecialInstructions,
-          'facility_other_type',
-        )}
-        showHoursSpecialInstructions
+        location={makeTestFacility('va_health_facility', hours)}
       />,
     );
-    expect(wrapper.find('#operational-special-p').length).to.equal(0);
-    wrapper.unmount();
+
+    expect(screen.queryByText('Sunday:')).to.exist;
+    expect(screen.queryByText('Monday:')).to.exist;
+    expect(screen.queryByText('Tuesday:')).not.to.exist;
+    expect(screen.queryByText('Wednesday:')).to.exist;
+    expect(screen.queryByText('Thursday:')).to.exist;
+    expect(screen.queryByText('Friday:')).to.exist;
+    expect(screen.queryByText('Saturday:')).not.to.exist;
+
+    expect(screen.queryByTestId('sunday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('monday-hours').textContent).to.equal(
+      '8:00 a.m. - 4:30 p.m.',
+    );
+    expect(screen.queryByTestId('tuesday-hours')).not.to.exist;
+    expect(screen.queryByTestId('wednesday-hours').textContent).to.equal(
+      '24/7',
+    );
+    expect(screen.queryByTestId('thursday-hours').textContent).to.equal('24/7');
+    expect(screen.queryByTestId('friday-hours').textContent).to.equal(
+      '8:00 a.m. - 4:30 p.m.',
+    );
+    expect(screen.queryByTestId('saturday-hours')).not.to.exist;
   });
 });

--- a/src/applications/facility-locator/types/index.js
+++ b/src/applications/facility-locator/types/index.js
@@ -121,6 +121,61 @@ export const LocationTypes = PropTypes.shape({
   search: PropTypes.string,
 });
 
+export const LocationForHoursTypes = PropTypes.shape({
+  attributes: {
+    access: {
+      effectiveDate: PropTypes.string,
+      health: PropTypes.arrayOf(PropTypes.string),
+    },
+    address: {
+      mailing: {
+        address1: PropTypes.string,
+        city: PropTypes.string,
+        state: PropTypes.string,
+        zip: PropTypes.string,
+      },
+      physical: {
+        address1: PropTypes.string,
+        city: PropTypes.string,
+        state: PropTypes.string,
+        zip: PropTypes.string,
+      },
+      classification: PropTypes.string,
+      distance: PropTypes.any,
+      facilityType: PropTypes.string,
+      feedback: PropTypes.arrayOf(PropTypes.string),
+      hours: {
+        sunday: PropTypes.string,
+        monday: PropTypes.string,
+        tuesday: PropTypes.string,
+        wednesday: PropTypes.string,
+        thursday: PropTypes.string,
+        friday: PropTypes.string,
+        saturday: PropTypes.string,
+      },
+      id: PropTypes.string,
+      LatLongAbbrTypes,
+      mobile: PropTypes.any,
+      name: PropTypes.string,
+      operatingStatus: {
+        code: PropTypes.string,
+      },
+      operationalHoursSpecialInstructions: PropTypes.string,
+      phone: {
+        fax: PropTypes.string,
+        main: PropTypes.string,
+      },
+      services: PropTypes.arrayOf(PropTypes.string),
+      tmpCovidOnlineScheduling: PropTypes.any,
+      uniqueId: PropTypes.string,
+      visn: PropTypes.string,
+      website: PropTypes.string,
+    },
+    id: PropTypes.string,
+    type: PropTypes.string,
+  },
+});
+
 export const RouterTypes = PropTypes.shape({
   createHref: PropTypes.func,
   createKey: PropTypes.func,

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -12,11 +12,6 @@ export const facilityLocatorPredictiveLocationSearch = state =>
     FEATURE_FLAG_NAMES.facilityLocatorPredictiveLocationSearch
   ];
 
-export const facilityLocatorShowOperationalHoursSpecialInstructions = state =>
-  toggleValues(state)[
-    FEATURE_FLAG_NAMES.facilityLocatorShowOperationalHoursSpecialInstructions
-  ];
-
 export const facilityLocatorLatLongOnly = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilityLocatorLatLongOnly];
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed unused `facility_locator_show_operational_hours_special_instructions` flipper and cleaned up the LocationHours component (used on vets-website Facilities pages such as cemeteries). Also cleaned up / refactored the unit tests to get better coverage. The flipper is **off** in staging and production currently:

<img width="500" alt="Screenshot 2025-01-23 at 6 58 20 PM" src="https://github.com/user-attachments/assets/3cc077b0-5d92-4b75-82e1-2251a82c548e" />

Improvements:
- Added some space between the icons for phone number, Google maps link and website
- Added a paragraph wrapper around the `Website` so it would scale with font size changes
- Removed the `Hours of operation` section for facilities that do not have this information yet


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20290

## Testing & screenshots

Functionally, nothing should change. The display for hours should only change slightly because I changed the text to `<p>` tags which made it pick up the 16.96px font size (it was 16px before).

Tested at these URLs:
- /find-locations/facility/nca_846
- /find-locations/facility/nca_054
- /find-locations/facility/nca_808
- /find-locations/facility/nca_947

Note that I was not running content-build for these screenshots so it is expected that the alert on the 4th one is not showing up locally.

| Before | After |
| --- | --- |
| <img width="1016" alt="Screenshot 2025-01-23 at 7 02 57 PM" src="https://github.com/user-attachments/assets/3800a6c3-a574-4ce4-9793-0a7a7842c5ff" /> | <img width="1020" alt="Screenshot 2025-01-23 at 7 22 10 PM" src="https://github.com/user-attachments/assets/480a037f-03e4-423d-942d-bb2085ddfe11" /> |
| <img width="1041" alt="Screenshot 2025-01-23 at 7 04 59 PM" src="https://github.com/user-attachments/assets/89332be9-b1c0-4b79-ab86-cc7604b8ef0a" /> | <img width="1014" alt="Screenshot 2025-01-23 at 7 22 20 PM" src="https://github.com/user-attachments/assets/588a52d4-1517-4a6b-aeb7-cad59d0c7aaa" /> |
| <img width="1046" alt="Screenshot 2025-01-23 at 7 06 44 PM" src="https://github.com/user-attachments/assets/408c9c64-28e8-4f5e-a65a-a3adf99c0c5b" /> | <img width="1048" alt="Screenshot 2025-01-23 at 7 27 11 PM" src="https://github.com/user-attachments/assets/b60bc4e3-e23d-4f85-8612-b539017e48a4" /> |
| <img width="1027" alt="Screenshot 2025-01-23 at 7 28 01 PM" src="https://github.com/user-attachments/assets/e085ff6d-c783-4093-94f9-9bdc28f04b83" /> | <img width="1014" alt="Screenshot 2025-01-23 at 7 28 05 PM" src="https://github.com/user-attachments/assets/286300b5-c685-41d2-99b0-1c5a1d13adac" /> |

Here's how things look when the font size is enlarged in the browser settings:

| Before | After |
| --- | --- |
| <img width="1080" alt="Screenshot 2025-01-27 at 10 38 06 AM" src="https://github.com/user-attachments/assets/da54c97f-b43c-44ac-bdfa-9687e47a0dd2" /> | <img width="1074" alt="Screenshot 2025-01-27 at 10 37 54 AM" src="https://github.com/user-attachments/assets/39ace7ac-55a3-4080-82fa-d2155993c9f7" /> |
