### PR TITLE
Remove 'Stay on this page until your records load' from PHR refresh l…

### DIFF
--- a/src/applications/mhv-medical-records/components/shared/RecordListSection.jsx
+++ b/src/applications/mhv-medical-records/components/shared/RecordListSection.jsx
@@ -25,7 +25,7 @@ const RecordListSection = ({
       <div className="vads-u-margin-y--8">
         <va-loading-indicator
           class="hydrated initial-fhir-load"
-          message="We're loading your records for the first time. This can take up to 2 minutes. Stay on this page until your records load."
+          message="We're loading your records for the first time. This can take up to 2 minutes."
           setFocus
           data-testid="initial-fhir-loading-indicator"
         />

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -172,7 +172,7 @@ const Vitals = () => {
         <div className="vads-u-margin-y--8">
           <va-loading-indicator
             class="hydrated initial-fhir-load"
-            message="We're loading your records for the first time. This can take up to 2 minutes. Stay on this page until your records load."
+            message="We're loading your records for the first time. This can take up to 2 minutes."
             setFocus
             data-testid="initial-fhir-loading-indicator"
           />


### PR DESCRIPTION
## Summary
Remove 'Stay on this page until your records load' from PHR refresh load state

## Related issue(s)
[MHV-65243](https://jira.devops.va.gov/browse/MHV-65243) - Remove 'Stay on this page until your records load' from PHR refresh load state

Remove 'Stay on this page until your records load' from PHR refresh load state

GIVEN:

WHEN:

THEN:


Feature Flag Y/N ?

DataDog Analytics  Y/N ?

Manual Testing Y/N ? 

Automated Testing Y/N ?

Accessibility Testing Y/N ?

UCD Validation Y/N

Acceptance Criteria:

AC1 'Stay on this page until your records load' has been removed from PHR refresh load state

AC2

AC3

AC4

Links to UCD:

Figma Link:

Other Design Notes:


## Testing done
Tested affected page by the refactor 

## What areas of the site does it impact?
RecordListSection.jsx and Vitals.jsx.

## Acceptance criteria
All refactored pages now utilize the LabelValue component.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


