### PR TITLE
Fix flaky ReasonForAppointmentPage unit test

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.unit.spec.js
@@ -28,13 +28,13 @@ const initialState = {
 describe('VAOS Page: ReasonForAppointmentPage', () => {
   beforeEach(() => mockFetch());
 
-  // Flaky test: https://github.com/department-of-veterans-affairs/va.gov-team/issues/94470
-  describe.skip('VA requests', () => {
+  describe('VA requests', () => {
     it('should show page for VA medical request', async () => {
       const store = createTestStore(initialState);
       const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
         store,
       });
+      await screen.findByText(/Continue/i);
 
       const radioSelector = screen.container.querySelector('va-radio');
       await waitFor(() => {
@@ -66,6 +66,8 @@ describe('VAOS Page: ReasonForAppointmentPage', () => {
       const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
         store,
       });
+      await screen.findByText(/Continue/i);
+
       const radioSelector = screen.container.querySelector('va-radio');
       await waitFor(() => {
         expect(radioSelector).to.exist;
@@ -101,6 +103,7 @@ describe('VAOS Page: ReasonForAppointmentPage', () => {
       const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
         store,
       });
+      await screen.findByText(/Continue/i);
 
       const radioOptions = screen.container.querySelectorAll('va-radio-option');
       await waitFor(() => {
@@ -123,6 +126,8 @@ describe('VAOS Page: ReasonForAppointmentPage', () => {
       const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
         store,
       });
+      await screen.findByText(/Continue/i);
+
       expect(
         await screen.findByTestId('reason-comment-field'),
       ).to.have.attribute(
@@ -151,6 +156,7 @@ describe('VAOS Page: ReasonForAppointmentPage', () => {
           store,
         },
       );
+      await screen.findByText(/Continue/i);
 
       const radioOptions = screen.container.querySelectorAll('va-radio-option');
       const radioSelector = screen.container.querySelector('va-radio');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixing a flaky unit test for Appointments

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94470

## Testing done

- Ensured the unit test passes locally and on the CI

## Screenshots

N/A

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
