### PR TITLE
[SIMPLE-FORMS] fix: Important instructions may be missed by screen reader users

### DIFF
--- a/src/applications/simple-forms/form-upload/config/constants.js
+++ b/src/applications/simple-forms/form-upload/config/constants.js
@@ -55,14 +55,16 @@ export const MUST_MATCH_ALERT = (variant, onCloseEvent, formData) => {
 };
 
 export const UPLOAD_GUIDELINES = Object.freeze(
-  <>
-    <h3 className="vads-u-margin-bottom--3">Your file</h3>
-    <p>
-      <span className="vads-u-font-weight--bold">Note:</span> After you upload
-      your file, you’ll need to continue to the next screen to submit it. If you
-      leave before you submit it, you’ll need to upload it again.
-    </p>
-  </>,
+  <fieldset>
+    <legend className="vads-u-font-weight--normal vads-u-padding-bottom--0">
+      <h3 className="vads-u-margin-bottom--3">Your file</h3>
+      <p>
+        <span className="vads-u-font-weight--bold">Note:</span> After you upload
+        your file, you’ll need to continue to the next screen to submit it. If
+        you leave before you submit it, you’ll need to upload it again.
+      </p>
+    </legend>
+  </fieldset>,
 );
 
 export const SAVE_IN_PROGRESS_CONFIG = {


### PR DESCRIPTION
## Summary

- This work adds a fieldset and legend to the upload component in the `UPLOAD_GUIDELINES` constant in `src/applications/simple-forms/form-upload/config/constants.js`.
- When using a screen reader, the field description was not read out loud
- Wrapping the description in a `fieldset` and `legend` will ensure that the description is read out loud by the screen reader
- I work for the Veteran Facing Forms team who owns this component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#101265

## Testing done

- Browser testing with a screen reader has been completed successfully

## What areas of the site does it impact?

- These changes impact the upload component in the simple forms application

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any