### PR TITLE
[99972] Appoint a Rep Show digital submission eligibility

### DIFF
--- a/src/applications/representative-appoint/components/SearchResult.jsx
+++ b/src/applications/representative-appoint/components/SearchResult.jsx
@@ -4,7 +4,10 @@ import { connect } from 'react-redux';
 import { setData } from '~/platform/forms-system/src/js/actions';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { parsePhoneNumber } from '../utilities/parsePhoneNumber';
-import { getFormNumberFromEntity } from '../utilities/helpers';
+import {
+  getFormNumberFromEntity,
+  entityAcceptsDigitalPoaRequests,
+} from '../utilities/helpers';
 import useV2FeatureToggle from '../hooks/useV2FeatureVisibility';
 
 const SearchResult = ({
@@ -31,6 +34,7 @@ const SearchResult = ({
 
   const formNumber = getFormNumberFromEntity(representative.data);
   const v2IsEnabled = useV2FeatureToggle();
+  const showSubmissionContent = v2IsEnabled && userIsDigitalSubmitEligible;
 
   const representativeName = name || fullName;
 
@@ -49,12 +53,28 @@ const SearchResult = ({
     (stateCode ? ` ${stateCode}` : '') +
     (zipCode ? ` ${zipCode}` : '');
 
-  const submissionTypeContent = v2IsEnabled &&
-    userIsDigitalSubmitEligible && (
-      <p data-testid="submission-methods">
-        Accepts VA Form {formNumber} online, by mail, and in person
+  function submissionTypeContent() {
+    if (!showSubmissionContent) {
+      return null;
+    }
+
+    const digitalSubmission = entityAcceptsDigitalPoaRequests(
+      representative?.data,
+    );
+
+    if (digitalSubmission) {
+      return (
+        <p data-testid="submission-methods-with-digital">
+          Accepts VA Form {formNumber} online, by mail, and in person
+        </p>
+      );
+    }
+    return (
+      <p data-testid="submission-methods-without-digital">
+        Accepts VA Form {formNumber} by mail and in person
       </p>
     );
+  }
 
   return (
     <va-card class="vads-u-padding--4 vads-u-margin-bottom--4">
@@ -95,7 +115,7 @@ const SearchResult = ({
             </va-additional-info>
           </div>
         )}
-        {submissionTypeContent}
+        {submissionTypeContent()}
         <div className="representative-contact-section vads-u-margin-top--3">
           {addressExists && (
             <div className="address-link vads-u-display--flex">

--- a/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
@@ -107,44 +107,108 @@ describe('SearchResult Component', () => {
 
   context('when v2 is enabled', () => {
     context('when the user is userIsDigitalSubmitEligible', () => {
-      it('displays submission methods', () => {
-        const representative = {
-          data: {
-            id: 1,
-            type: 'individual',
-            attributes: {
-              addressLine1: '123 Main St',
-              city: '',
-              stateCode: '',
-              zipCode: '',
-              fullName: 'Robert Smith',
-              individualType: 'representative',
+      context('when the representative accepts digital submission', () => {
+        it('displays digital submission methods', () => {
+          const representative = {
+            data: {
+              id: 1,
+              type: 'individual',
+              attributes: {
+                addressLine1: '123 Main St',
+                city: '',
+                stateCode: '',
+                zipCode: '',
+                fullName: 'Robert Smith',
+                individualType: 'representative',
+                accreditedOrganizations: {
+                  data: [{ attributes: { canAcceptDigitalPoaRequests: true } }],
+                },
+              },
             },
-          },
-        };
+          };
 
-        const useV2FeatureVisibilityStub = sinon
-          .stub(useV2FeatureToggle, 'default')
-          .returns(true);
+          const useV2FeatureVisibilityStub = sinon
+            .stub(useV2FeatureToggle, 'default')
+            .returns(true);
 
-        const { container } = render(
-          <SearchResult
-            representative={representative}
-            query={{}}
-            handleSelectRepresentative={() => {}}
-            loadingPOA={false}
-            userIsDigitalSubmitEligible
-          />,
-        );
+          const { container } = render(
+            <SearchResult
+              representative={representative}
+              query={{}}
+              handleSelectRepresentative={() => {}}
+              loadingPOA={false}
+              userIsDigitalSubmitEligible
+            />,
+          );
 
-        const submissionMethods = container.querySelector(
-          '[data-testid="submission-methods"]',
-        );
+          const digitalSubmissionMethods = container.querySelector(
+            '[data-testid="submission-methods-with-digital"]',
+          );
 
-        expect(submissionMethods).to.exist;
+          const nonDigitalSubmissionMethods = container.querySelector(
+            '[data-testid="submission-methods-without-digital"]',
+          );
 
-        useV2FeatureVisibilityStub.restore();
+          expect(digitalSubmissionMethods).to.exist;
+          expect(nonDigitalSubmissionMethods).not.to.exist;
+
+          useV2FeatureVisibilityStub.restore();
+        });
       });
+
+      context(
+        'when the representative does not accept digital submission',
+        () => {
+          it('displays non digital submission methods', () => {
+            const representative = {
+              data: {
+                id: 1,
+                type: 'individual',
+                attributes: {
+                  addressLine1: '123 Main St',
+                  city: '',
+                  stateCode: '',
+                  zipCode: '',
+                  fullName: 'Robert Smith',
+                  individualType: 'representative',
+                  accreditedOrganizations: {
+                    data: [
+                      { attributes: { canAcceptDigitalPoaRequests: false } },
+                    ],
+                  },
+                },
+              },
+            };
+
+            const useV2FeatureVisibilityStub = sinon
+              .stub(useV2FeatureToggle, 'default')
+              .returns(true);
+
+            const { container } = render(
+              <SearchResult
+                representative={representative}
+                query={{}}
+                handleSelectRepresentative={() => {}}
+                loadingPOA={false}
+                userIsDigitalSubmitEligible
+              />,
+            );
+
+            const digitalSubmissionMethods = container.querySelector(
+              '[data-testid="submission-methods-with-digital"]',
+            );
+
+            const nonDigitalSubmissionMethods = container.querySelector(
+              '[data-testid="submission-methods-without-digital"]',
+            );
+
+            expect(digitalSubmissionMethods).not.to.exist;
+            expect(nonDigitalSubmissionMethods).to.exist;
+
+            useV2FeatureVisibilityStub.restore();
+          });
+        },
+      );
     });
 
     context('when the user is not userIsDigitalSubmitEligible', () => {
@@ -178,11 +242,16 @@ describe('SearchResult Component', () => {
           />,
         );
 
-        const submissionMethods = container.querySelector(
-          '[data-testid="submission-methods"]',
+        const digitalSubmissionMethods = container.querySelector(
+          '[data-testid="submission-methods-with-digital"]',
         );
 
-        expect(submissionMethods).not.to.exist;
+        const nonDigitalSubmissionMethods = container.querySelector(
+          '[data-testid="submission-methods-without-digital"]',
+        );
+
+        expect(digitalSubmissionMethods).not.to.exist;
+        expect(nonDigitalSubmissionMethods).not.to.exist;
 
         useV2FeatureVisibilityStub.restore();
       });
@@ -220,11 +289,16 @@ describe('SearchResult Component', () => {
         />,
       );
 
-      const submissionMethods = container.querySelector(
-        '[data-testid="submission-methods"]',
+      const digitalSubmissionMethods = container.querySelector(
+        '[data-testid="submission-methods-with-digital"]',
       );
 
-      expect(submissionMethods).not.to.exist;
+      const nonDigitalSubmissionMethods = container.querySelector(
+        '[data-testid="submission-methods-without-digital"]',
+      );
+
+      expect(digitalSubmissionMethods).not.to.exist;
+      expect(nonDigitalSubmissionMethods).not.to.exist;
 
       useV2FeatureVisibilityStub.restore();
     });

--- a/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/SearchResult.unit.spec.jsx
@@ -6,6 +6,12 @@ import { SearchResult } from '../../components/SearchResult';
 import * as useV2FeatureToggle from '../../hooks/useV2FeatureVisibility';
 
 describe('SearchResult Component', () => {
+  let useV2FeatureVisibilityStub;
+
+  afterEach(() => {
+    useV2FeatureVisibilityStub.restore();
+  });
+
   it('evaluates addressExists correctly', () => {
     const representative = {
       data: {
@@ -18,7 +24,7 @@ describe('SearchResult Component', () => {
       },
     };
 
-    const useV2FeatureVisibilityStub = sinon
+    useV2FeatureVisibilityStub = sinon
       .stub(useV2FeatureToggle, 'default')
       .returns(false);
 
@@ -34,8 +40,6 @@ describe('SearchResult Component', () => {
     const addressAnchor = container.querySelector('.address-anchor');
     expect(addressAnchor).to.exist;
     expect(addressAnchor.textContent).to.contain('123 Main St');
-
-    useV2FeatureVisibilityStub.restore();
   });
 
   it('evaluates addressExists correctly when only city, stateCode, and zipCode exist', () => {
@@ -49,7 +53,7 @@ describe('SearchResult Component', () => {
       },
     };
 
-    const useV2FeatureVisibilityStub = sinon
+    useV2FeatureVisibilityStub = sinon
       .stub(useV2FeatureToggle, 'default')
       .returns(false);
 
@@ -65,8 +69,6 @@ describe('SearchResult Component', () => {
     const addressAnchor = container.querySelector('.address-anchor');
     expect(addressAnchor).to.exist;
     expect(addressAnchor.textContent).to.contain('Anytown, CT');
-
-    useV2FeatureVisibilityStub.restore();
   });
 
   it('includes the representative name in the select button text', () => {
@@ -83,7 +85,7 @@ describe('SearchResult Component', () => {
       },
     };
 
-    const useV2FeatureVisibilityStub = sinon
+    useV2FeatureVisibilityStub = sinon
       .stub(useV2FeatureToggle, 'default')
       .returns(false);
 
@@ -101,11 +103,15 @@ describe('SearchResult Component', () => {
     );
     expect(selectButton).to.exist;
     expect(selectButton.getAttribute('text')).to.contain('Robert Smith');
-
-    useV2FeatureVisibilityStub.restore();
   });
 
   context('when v2 is enabled', () => {
+    beforeEach(() => {
+      useV2FeatureVisibilityStub = sinon
+        .stub(useV2FeatureToggle, 'default')
+        .returns(true);
+    });
+
     context('when the user is userIsDigitalSubmitEligible', () => {
       context('when the representative accepts digital submission', () => {
         it('displays digital submission methods', () => {
@@ -127,10 +133,6 @@ describe('SearchResult Component', () => {
             },
           };
 
-          const useV2FeatureVisibilityStub = sinon
-            .stub(useV2FeatureToggle, 'default')
-            .returns(true);
-
           const { container } = render(
             <SearchResult
               representative={representative}
@@ -151,8 +153,6 @@ describe('SearchResult Component', () => {
 
           expect(digitalSubmissionMethods).to.exist;
           expect(nonDigitalSubmissionMethods).not.to.exist;
-
-          useV2FeatureVisibilityStub.restore();
         });
       });
 
@@ -180,10 +180,6 @@ describe('SearchResult Component', () => {
               },
             };
 
-            const useV2FeatureVisibilityStub = sinon
-              .stub(useV2FeatureToggle, 'default')
-              .returns(true);
-
             const { container } = render(
               <SearchResult
                 representative={representative}
@@ -204,8 +200,6 @@ describe('SearchResult Component', () => {
 
             expect(digitalSubmissionMethods).not.to.exist;
             expect(nonDigitalSubmissionMethods).to.exist;
-
-            useV2FeatureVisibilityStub.restore();
           });
         },
       );
@@ -228,10 +222,6 @@ describe('SearchResult Component', () => {
           },
         };
 
-        const useV2FeatureVisibilityStub = sinon
-          .stub(useV2FeatureToggle, 'default')
-          .returns(true);
-
         const { container } = render(
           <SearchResult
             representative={representative}
@@ -252,8 +242,6 @@ describe('SearchResult Component', () => {
 
         expect(digitalSubmissionMethods).not.to.exist;
         expect(nonDigitalSubmissionMethods).not.to.exist;
-
-        useV2FeatureVisibilityStub.restore();
       });
     });
   });
@@ -275,7 +263,7 @@ describe('SearchResult Component', () => {
         },
       };
 
-      const useV2FeatureVisibilityStub = sinon
+      useV2FeatureVisibilityStub = sinon
         .stub(useV2FeatureToggle, 'default')
         .returns(false);
 
@@ -299,8 +287,6 @@ describe('SearchResult Component', () => {
 
       expect(digitalSubmissionMethods).not.to.exist;
       expect(nonDigitalSubmissionMethods).not.to.exist;
-
-      useV2FeatureVisibilityStub.restore();
     });
   });
 });

--- a/src/applications/representative-appoint/tests/utilities/entityAcceptsDigitalPoaRequests.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/utilities/entityAcceptsDigitalPoaRequests.unit.spec.jsx
@@ -1,0 +1,108 @@
+import { expect } from 'chai';
+
+import { entityAcceptsDigitalPoaRequests } from '../../utilities/helpers';
+
+describe('entityAcceptsDigitalPoaRequests', () => {
+  context('when the representative is an organization', () => {
+    context('when the organization accepts digital submissions', () => {
+      it('returns true', () => {
+        const mockEntity = {
+          type: 'organization',
+          attributes: { canAcceptDigitalPoaRequests: true },
+        };
+        const result = entityAcceptsDigitalPoaRequests(mockEntity);
+        expect(result).to.be.true;
+      });
+    });
+    context('when the organization does not accept digital submissions', () => {
+      it('returns false', () => {
+        const mockEntity = {
+          type: 'organization',
+          attributes: { canAcceptDigitalPoaRequests: false },
+        };
+        const result = entityAcceptsDigitalPoaRequests(mockEntity);
+        expect(result).to.be.false;
+      });
+    });
+  });
+
+  context('when the representative is a vso representative', () => {
+    context(
+      'when at least one organization accepts digital submissions',
+      () => {
+        it('returns true', () => {
+          const mockEntity = {
+            type: 'representative',
+            attributes: {
+              accreditedOrganizations: {
+                data: [
+                  { attributes: { canAcceptDigitalPoaRequests: true } },
+                  { attributes: { canAcceptDigitalPoaRequests: true } },
+                  { attributes: { canAcceptDigitalPoaRequests: false } },
+                ],
+              },
+            },
+          };
+          const result = entityAcceptsDigitalPoaRequests(mockEntity);
+          expect(result).to.be.true;
+        });
+      },
+    );
+
+    context('when no organization accepts digital submissions', () => {
+      it('returns false', () => {
+        const mockEntity = {
+          type: 'representative',
+          attributes: {
+            accreditedOrganizations: {
+              data: [
+                { attributes: { canAcceptDigitalPoaRequests: false } },
+                { attributes: { canAcceptDigitalPoaRequests: false } },
+                { attributes: { canAcceptDigitalPoaRequests: false } },
+              ],
+            },
+          },
+        };
+        const result = entityAcceptsDigitalPoaRequests(mockEntity);
+        expect(result).to.be.false;
+      });
+    });
+
+    context('when there are no organizations', () => {
+      it('returns false', () => {
+        const mockEntity = {
+          type: 'representative',
+          attributes: {
+            accreditedOrganizations: {
+              data: [],
+            },
+          },
+        };
+        const result = entityAcceptsDigitalPoaRequests(mockEntity);
+        expect(result).to.be.false;
+      });
+    });
+  });
+
+  context('when the representative is an attorney', () => {
+    it('returns false', () => {
+      const mockEntity = {
+        type: 'representative',
+        attributes: { individualType: 'attorney' },
+      };
+      const result = entityAcceptsDigitalPoaRequests(mockEntity);
+      expect(result).to.be.false;
+    });
+  });
+
+  context('when the representative is a claims agent', () => {
+    it('returns false', () => {
+      const mockEntity = {
+        type: 'representative',
+        attributes: { individualType: 'claims_agent' },
+      };
+      const result = entityAcceptsDigitalPoaRequests(mockEntity);
+      expect(result).to.be.false;
+    });
+  });
+});

--- a/src/applications/representative-appoint/utilities/helpers.js
+++ b/src/applications/representative-appoint/utilities/helpers.js
@@ -247,3 +247,26 @@ export const addressExists = address =>
     address?.stateCode?.trim() &&
     address?.zipCode?.trim()
   );
+
+export const entityAcceptsDigitalPoaRequests = entity => {
+  const repType = getRepType(entity);
+
+  if (repType === 'Organization') {
+    return !!entity?.attributes?.canAcceptDigitalPoaRequests;
+  }
+  if (repType === 'VSO Representative') {
+    const accreditedOrganizations = entity?.attributes?.accreditedOrganizations;
+
+    if (
+      !accreditedOrganizations ||
+      accreditedOrganizations?.data?.length === 0
+    ) {
+      return false;
+    }
+
+    return accreditedOrganizations.data.some(
+      org => org?.attributes?.canAcceptDigitalPoaRequests === true,
+    );
+  }
+  return false;
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr uses the new organization level attribute `canAcceptDigitalPoaRequests` to correctly show when organizations and VSO representatives can accept digital submissions.

## Related issue(s)

- [99972](https://github.com/department-of-veterans-affairs/va.gov-team/issues/99972)

## Testing done

- Went through the flow with authed and unauthed users to ensure base behavior unchanged
- Did several rep searches to ensure search result card content was correct

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![image](https://github.com/user-attachments/assets/79aa49c3-e122-4d56-82d6-441cf00a7dd3)|![image](https://github.com/user-attachments/assets/b07c9fc5-c857-4508-8702-f596caf1f690)|
| Desktop |![image](https://github.com/user-attachments/assets/cd6b4092-4e5b-4ffd-a185-79941441cbe9)|![image](https://github.com/user-attachments/assets/a33ad01c-4a2f-41d9-8b7d-55be99d1f7cb)|

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a version 2 - this work is protected by a feature flag in production

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user