### PR TITLE
Simplify Form Upload setup for new forms

### DIFF
--- a/src/applications/simple-forms/form-upload/config/constants.js
+++ b/src/applications/simple-forms/form-upload/config/constants.js
@@ -76,17 +76,6 @@ export const SAVE_IN_PROGRESS_CONFIG = {
   },
 };
 
-export const SUBTITLE_0779 =
-  'Request for Nursing Home Information in Connection with Claim for Aid and Attendance';
-
-export const DOWNLOAD_URL_0779 =
-  'https://www.vba.va.gov/pubs/forms/VBA-21-0779-ARE.pdf';
-
-export const SUBTITLE_509 = 'Statement of Dependency of Parent(s)';
-
-export const DOWNLOAD_URL_509 =
-  'https://www.vba.va.gov/pubs/forms/VBA-21-509-ARE.pdf';
-
 export const FORM_UPLOAD_OCR_ALERT = (
   formNumber,
   pdfDownloadUrl,

--- a/src/applications/simple-forms/form-upload/config/submit-transformer.js
+++ b/src/applications/simple-forms/form-upload/config/submit-transformer.js
@@ -6,13 +6,14 @@ const transformForSubmit = (formConfig, form) => {
     sharedTransformForSubmit(formConfig, form),
   );
 
-  const { formNumber } = getFormContent();
+  const { formNumber, subTitle } = getFormContent();
   const { idNumber = {}, address = {}, fullName = {}, email } = transformedData;
   const { confirmationCode } = transformedData.uploadedFile;
 
   return JSON.stringify({
     confirmationCode,
     formNumber,
+    formName: subTitle,
     formData: {
       idNumber,
       postalCode: address.postalCode,

--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -1,12 +1,6 @@
 import { srSubstitute } from '~/platform/forms-system/src/js/utilities/ui/mask-string';
 import { focusByOrder, scrollTo } from 'platform/utilities/ui';
 
-export const getFormNumber = (pathname = null) => {
-  const path = pathname || window?.location?.pathname;
-  const regex = /upload\/([^/]+)/;
-  return path.match(regex)?.[1] || '';
-};
-
 const formMappings = {
   '21-0779': {
     subTitle:
@@ -17,6 +11,17 @@ const formMappings = {
     subTitle: 'Statement of Dependency of Parent(s)',
     pdfDownloadUrl: 'https://www.vba.va.gov/pubs/forms/VBA-21-509-ARE.pdf',
   },
+};
+
+export const getFormNumber = (pathname = null) => {
+  const path = pathname || window?.location?.pathname;
+  const regex = /upload\/([^/]+)/;
+  const match = path.match(regex)?.[1];
+  if (formMappings[match]) {
+    return match;
+  }
+
+  return '';
 };
 
 export const getFormContent = (pathname = null) => {

--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -1,26 +1,21 @@
 import { srSubstitute } from '~/platform/forms-system/src/js/utilities/ui/mask-string';
 import { focusByOrder, scrollTo } from 'platform/utilities/ui';
-import {
-  SUBTITLE_509,
-  DOWNLOAD_URL_509,
-  SUBTITLE_0779,
-  DOWNLOAD_URL_0779,
-} from '../config/constants';
 
 export const getFormNumber = (pathname = null) => {
   const path = pathname || window?.location?.pathname;
-  const regex = /\/(\d{2}-\d{3,4})/;
+  const regex = /upload\/([^/]+)/;
   return path.match(regex)?.[1] || '';
 };
 
 const formMappings = {
   '21-0779': {
-    subTitle: SUBTITLE_0779,
-    pdfDownloadUrl: DOWNLOAD_URL_0779,
+    subTitle:
+      'Request for Nursing Home Information in Connection with Claim for Aid and Attendance',
+    pdfDownloadUrl: 'https://www.vba.va.gov/pubs/forms/VBA-21-0779-ARE.pdf',
   },
   '21-509': {
-    subTitle: SUBTITLE_509,
-    pdfDownloadUrl: DOWNLOAD_URL_509,
+    subTitle: 'Statement of Dependency of Parent(s)',
+    pdfDownloadUrl: 'https://www.vba.va.gov/pubs/forms/VBA-21-509-ARE.pdf',
   },
 };
 

--- a/src/applications/simple-forms/form-upload/tests/e2e/fixtures/data/transformed/minimal-submit-transformer.json
+++ b/src/applications/simple-forms/form-upload/tests/e2e/fixtures/data/transformed/minimal-submit-transformer.json
@@ -1,6 +1,7 @@
 {
   "confirmationCode": "123456",
   "formNumber": "21-0779",
+  "formName": "Request for Nursing Home Information in Connection with Claim for Aid and Attendance",
   "formData": {
     "idNumber": {},
     "fullName": {}

--- a/src/applications/simple-forms/form-upload/tests/e2e/fixtures/data/transformed/submit-transformer.json
+++ b/src/applications/simple-forms/form-upload/tests/e2e/fixtures/data/transformed/submit-transformer.json
@@ -1,6 +1,7 @@
 {
   "confirmationCode": "123456",
   "formNumber": "21-0779",
+  "formName": "Request for Nursing Home Information in Connection with Claim for Aid and Attendance",
   "formData": {
     "idNumber": {
       "ssn": "234232345",

--- a/src/applications/simple-forms/form-upload/tests/unit/config/submit-transformer.unit.spec.js
+++ b/src/applications/simple-forms/form-upload/tests/unit/config/submit-transformer.unit.spec.js
@@ -11,7 +11,7 @@ describe('transformForSubmit', () => {
   it('should transform json correctly', () => {
     const windowLocationStub = sinon
       .stub(window, 'location')
-      .get(() => ({ pathname: '/21-0779' }));
+      .get(() => ({ pathname: 'upload/21-0779' }));
 
     const transformedResult = JSON.parse(transformForSubmit(formConfig, form));
     expect(transformedResult).to.deep.equal(transformedFixture);
@@ -22,7 +22,7 @@ describe('transformForSubmit', () => {
   it('handles empty transformedData', () => {
     const windowLocationStub = sinon
       .stub(window, 'location')
-      .get(() => ({ pathname: '/21-0779' }));
+      .get(() => ({ pathname: 'upload/21-0779' }));
 
     const transformedResult = JSON.parse(
       transformForSubmit(formConfig, minimalForm),

--- a/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
+++ b/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
@@ -21,14 +21,14 @@ describe('Helpers', () => {
   describe('getFormNumber', () => {
     it('returns correct path when formNumber matches', () => {
       global.window.location = {
-        pathname: '/form-upload/21-0779/upload',
+        pathname: '/find-forms/upload/21-0779/upload',
       };
       expect(getFormNumber()).to.eq('21-0779');
     });
 
     it('returns empty string when formNumber does not match', () => {
       global.window.location = {
-        pathname: '/form-upload/fake-form/upload',
+        pathname: 'find-forms/upload/fake-form/upload',
       };
       expect(getFormNumber()).to.eq('');
     });
@@ -37,14 +37,14 @@ describe('Helpers', () => {
   describe('getFormContent', () => {
     it('returns appropriate content when the form number is mapped', () => {
       global.window.location = {
-        pathname: '/form-upload/21-0779/upload',
+        pathname: 'find-forms/upload/21-0779/upload',
       };
       expect(getFormContent()).to.include({ title: 'Upload form 21-0779' });
     });
 
     it('returns default content when the form number is not mapped', () => {
       global.window.location = {
-        pathname: '/form-upload/99-9999/upload',
+        pathname: 'find-forms/upload/99-9999/upload',
       };
       expect(getFormContent()).to.include({ title: 'Upload form 99-9999' });
     });

--- a/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
+++ b/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
@@ -14,7 +14,6 @@ import {
   getMockData,
   formattedPhoneNumber,
 } from '../../../helpers';
-import { DOWNLOAD_URL_0779 } from '../../../config/constants';
 
 const { scroller } = Scroll;
 
@@ -53,7 +52,9 @@ describe('Helpers', () => {
 
   describe('getPdfDownloadUrl', () => {
     it('returns the url', () => {
-      expect(getPdfDownloadUrl('21-0779')).to.eq(DOWNLOAD_URL_0779);
+      expect(getPdfDownloadUrl('21-0779')).to.eq(
+        'https://www.vba.va.gov/pubs/forms/VBA-21-0779-ARE.pdf',
+      );
     });
 
     it('returns an empty string', () => {

--- a/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
+++ b/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
@@ -41,13 +41,6 @@ describe('Helpers', () => {
       };
       expect(getFormContent()).to.include({ title: 'Upload form 21-0779' });
     });
-
-    it('returns default content when the form number is not mapped', () => {
-      global.window.location = {
-        pathname: 'find-forms/upload/99-9999/upload',
-      };
-      expect(getFormContent()).to.include({ title: 'Upload form 99-9999' });
-    });
   });
 
   describe('getPdfDownloadUrl', () => {


### PR DESCRIPTION
## Summary
This small PR makes adding new forms to the Form Upload tool easier by reducing the spots where changes are needed and by loosening the regex a bit so that different form number shapes are allowed.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=94061666&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1974
e above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
