### PR TITLE
VACMS-20288 Update print view without Back and Print buttons

### DIFF
--- a/src/applications/discharge-wizard/components/resultsComponents/StepThree.jsx
+++ b/src/applications/discharge-wizard/components/resultsComponents/StepThree.jsx
@@ -40,21 +40,7 @@ const StepThree = ({ formResponses }) => {
 
   const handlePrint = () => {
     if (window.print) {
-      const printButton = document.querySelector(
-        'va-button[data-testid="duw-print"]',
-      );
-      const backButton = document.querySelector(
-        'va-button[data-testid="duw-results-back"]',
-      );
-      if (printButton) printButton.style.display = 'none';
-      if (backButton) backButton.style.display = 'none';
-
       window.print();
-
-      setTimeout(() => {
-        if (printButton) printButton.style.display = '';
-        if (backButton) backButton.style.display = '';
-      }, 500);
     }
   };
 

--- a/src/applications/discharge-wizard/components/resultsComponents/StepThree.jsx
+++ b/src/applications/discharge-wizard/components/resultsComponents/StepThree.jsx
@@ -40,7 +40,21 @@ const StepThree = ({ formResponses }) => {
 
   const handlePrint = () => {
     if (window.print) {
+      const printButton = document.querySelector(
+        'va-button[data-testid="duw-print"]',
+      );
+      const backButton = document.querySelector(
+        'va-button[data-testid="duw-results-back"]',
+      );
+      if (printButton) printButton.style.display = 'none';
+      if (backButton) backButton.style.display = 'none';
+
       window.print();
+
+      setTimeout(() => {
+        if (printButton) printButton.style.display = '';
+        if (backButton) backButton.style.display = '';
+      }, 500);
     }
   };
 
@@ -109,7 +123,11 @@ const StepThree = ({ formResponses }) => {
           {onlineSubmissionMsg}
         </>
       )}
-      <va-button onClick={handlePrint} text="Print this page" />
+      <va-button
+        data-testid="duw-print"
+        onClick={handlePrint}
+        text="Print this page"
+      />
     </va-process-list-item>
   );
 };

--- a/src/applications/discharge-wizard/sass/discharge-wizard.scss
+++ b/src/applications/discharge-wizard/sass/discharge-wizard.scss
@@ -30,4 +30,12 @@
     margin-right: -4px;
     margin-left: -4px;
   }
+
+  @media print {
+
+    [data-testid=duw-print],
+    [data-testid=duw-results-back] {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR removes the Back and Print buttons for the print view screen and adds them back once printing has completed.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20288

## Testing done
Go to the results page of any flow and click Print this page. There should be no buttons present in the print view.

## Screenshots
![Screenshot_1_24_25__10_22 AM](https://github.com/user-attachments/assets/5e3cf5f7-bff9-4b74-9ed1-e2b3cf843b5d)

## What areas of the site does it impact?
DUW
## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

