### PR TITLE
Add session storage for minimal header

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -808,19 +808,34 @@ export function getUrlPathIndex(url) {
   return indexString ? Number(indexString) : undefined;
 }
 
-export function isMinimalHeaderApplicable() {
-  // sessionStorage needs to be populated by header component before you
-  // can use this, which happens before all form code is loaded, but not
-  // necessarily before the .js files are served. Using it in any React
-  // component in the body is generally fine, but not in the initial
-  // load of a .js file.
-  const isApplicable = sessionStorage.getItem('MINIMAL_HEADER_APPLICABLE');
-  if (isApplicable !== 'true') {
+/**
+ * If the minimal header is applicable to the current app regardless of excluded paths.
+ *
+ * Note: Not reliable to use in a .js file load. Should be used in
+ * a component or function to allow for session storage to load first.
+ *
+ * @returns {boolean}
+ */
+export function isMinimalHeaderApp() {
+  return sessionStorage.getItem('MINIMAL_HEADER_APPLICABLE') === 'true';
+}
+
+/**
+ * If the minimal header is applicable to the current app and the
+ * current window path is not a excluded
+ *
+ * Note: Not reliable to use in a .js file load. Should be used in
+ * a component or function to allow for session storage to load first.
+ *
+ * @returns {boolean}
+ */
+export function isMinimalHeaderPath() {
+  if (!isMinimalHeaderApp()) {
     return false;
   }
 
   let excludePaths = sessionStorage.getItem('MINIMAL_HEADER_EXCLUDE_PATHS');
   excludePaths = excludePaths ? JSON.parse(excludePaths) : [];
   const isExcludedPath = excludePaths.includes(window?.location?.pathname);
-  return isApplicable && !isExcludedPath;
+  return !isExcludedPath;
 }

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -807,3 +807,20 @@ export function getUrlPathIndex(url) {
     .find(part => !Number.isNaN(Number(part)));
   return indexString ? Number(indexString) : undefined;
 }
+
+export function isMinimalHeaderApplicable() {
+  // sessionStorage needs to be populated by header component before you
+  // can use this, which happens before all form code is loaded, but not
+  // necessarily before the .js files are served. Using it in any React
+  // component in the body is generally fine, but not in the initial
+  // load of a .js file.
+  const isApplicable = sessionStorage.getItem('MINIMAL_HEADER_APPLICABLE');
+  if (isApplicable !== 'true') {
+    return false;
+  }
+
+  let excludePaths = sessionStorage.getItem('MINIMAL_HEADER_EXCLUDE_PATHS');
+  excludePaths = excludePaths ? JSON.parse(excludePaths) : [];
+  const isExcludedPath = excludePaths.includes(window?.location?.pathname);
+  return isApplicable && !isExcludedPath;
+}

--- a/src/platform/forms-system/test/js/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/helpers.unit.spec.js
@@ -16,7 +16,8 @@ import {
   showReviewField,
   stringifyUrlParams,
   getUrlPathIndex,
-  isMinimalHeaderApplicable,
+  isMinimalHeaderPath,
+  isMinimalHeaderApp,
 } from '../../src/js/helpers';
 
 describe('Schemaform helpers:', () => {
@@ -1303,7 +1304,7 @@ describe('getUrlPathIndex', () => {
   });
 });
 
-describe('isMinimalHeaderApplicable', () => {
+describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
   afterEach(() => {
     sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
     sessionStorage.removeItem('MINIMAL_HEADER_EXCLUDE_PATHS');
@@ -1322,9 +1323,11 @@ describe('isMinimalHeaderApplicable', () => {
   });
 
   it('should return a boolean if minimal header is applicable', () => {
-    expect(isMinimalHeaderApplicable()).to.eql(false);
+    expect(isMinimalHeaderApp()).to.eql(false);
+    expect(isMinimalHeaderPath()).to.eql(false);
     sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
-    expect(isMinimalHeaderApplicable()).to.eql(true);
+    expect(isMinimalHeaderApp()).to.eql(true);
+    expect(isMinimalHeaderPath()).to.eql(true);
   });
 
   it('should not be applicable on excluded paths', () => {
@@ -1338,12 +1341,14 @@ describe('isMinimalHeaderApplicable', () => {
     locationStub.value({
       pathname: '/introduction',
     });
-    expect(isMinimalHeaderApplicable()).to.eql(false);
+    expect(isMinimalHeaderApp()).to.eql(true);
+    expect(isMinimalHeaderPath()).to.eql(false);
 
     locationStub.value({
       pathname: '/middle-of-form',
     });
-    expect(isMinimalHeaderApplicable()).to.eql(true);
+    expect(isMinimalHeaderApp()).to.eql(true);
+    expect(isMinimalHeaderPath()).to.eql(true);
 
     locationStub.restore();
   });

--- a/src/platform/site-wide/header/index.js
+++ b/src/platform/site-wide/header/index.js
@@ -1,27 +1,52 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import environment from 'platform/utilities/environment';
 import './components/LogoRow/styles.scss';
 import './components/OfficialGovtWebsite/styles.scss';
 import './components/Search/styles.scss';
 import './containers/Menu/styles.scss';
 import App from './components/App';
 
+const setSessionStorage = (headerMinimal, excludePathsString) => {
+  if (!environment.isUnitTest()) {
+    // Set this manually if you want to unit test it - otherwise session
+    // storage could potentially leak to other tests
+    if (headerMinimal) {
+      sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
+    } else {
+      sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
+    }
+
+    if (excludePathsString) {
+      sessionStorage.setItem(
+        'MINIMAL_HEADER_EXCLUDE_PATHS',
+        excludePathsString,
+      );
+    } else {
+      sessionStorage.removeItem('MINIMAL_HEADER_EXCLUDE_PATHS');
+    }
+  }
+};
+
 const setupMinimalHeader = () => {
   let showMinimalHeader;
   // #header-minimal will not be in the DOM unless specified in content-build
   const headerMinimal = document.querySelector('#header-minimal');
+  let excludePathsString;
 
   if (headerMinimal) {
     showMinimalHeader = () => true;
     if (headerMinimal.dataset?.excludePaths) {
-      const excludePathsString = headerMinimal.dataset.excludePaths;
+      excludePathsString = headerMinimal.dataset.excludePaths;
       const excludePaths = JSON.parse(excludePathsString);
       // Remove the data attribute from the DOM since it's no longer needed
       headerMinimal.removeAttribute('data-exclude-paths');
       showMinimalHeader = path => path != null && !excludePaths.includes(path);
     }
   }
+
+  setSessionStorage(headerMinimal, excludePathsString);
 
   return showMinimalHeader;
 };

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -108,4 +108,8 @@ export default Object.freeze({
       process?.env?.NODE_ENV === 'test'
     );
   },
+
+  isUnitTest() {
+    return !!(window?.Mocha || process?.env?.NODE_ENV === 'test');
+  },
 });


### PR DESCRIPTION
## Summary

- Add session storage for minimal header so that various parts of form-system can utilize it without needing to hook into redux.
(for example titleUI, arrayBuilder, web component patterns)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1538

## Testing done

- Tested in minimal header form, array builder, simple forms, unit tests and cypress.
- Tested across multiple apps that do and don't use minimal header, and verified it resets the session storage value each time you cross apps.

## Screenshots

n/a

## What areas of the site does it impact?

populates sessionStorage for consumers to use

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
