### PR TITLE
Allow scrollAndFocusTarget without useCustomScrollAndFocus

### DIFF
--- a/src/applications/pre-need-integration/tests/utils/cypress-preneed-integration-helpers.js
+++ b/src/applications/pre-need-integration/tests/utils/cypress-preneed-integration-helpers.js
@@ -265,6 +265,7 @@ function fillServicePeriods(serviceRecord) {
   clickContinue();
 
   serviceRecord.forEach((tour, index) => {
+    cy.get('.schemaform-block-title', { timeout: 10000 }).should('be.visible');
     autoSuggestFirstResult(
       '#root_serviceBranch',
       serviceLabels[tour.serviceBranch],

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -29,11 +29,14 @@ import { DevModeNavLinks } from '../components/dev/DevModeNavLinks';
 import { stringifyUrlParams } from '../helpers';
 
 function focusForm(route, index) {
-  // Check main toggle to enable custom focus
-  if (route.formConfig?.useCustomScrollAndFocus) {
-    const scrollAndFocusTarget =
-      route.pageConfig?.scrollAndFocusTarget ||
-      route.formConfig?.scrollAndFocusTarget;
+  const useCustomScrollAndFocus = route.formConfig?.useCustomScrollAndFocus;
+  const scrollAndFocusTarget =
+    route.pageConfig?.scrollAndFocusTarget ||
+    route.formConfig?.scrollAndFocusTarget;
+
+  if (useCustomScrollAndFocus === false) {
+    focusElement(defaultFocusSelector);
+  } else if (useCustomScrollAndFocus || scrollAndFocusTarget) {
     customScrollAndFocus(scrollAndFocusTarget, index);
   } else {
     focusElement(defaultFocusSelector);

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -975,6 +975,58 @@ describe('Schemaform <FormPage>', () => {
       });
     });
 
+    it('should use a page’s scrollAndFocusTarget even if useCustomScrollAndFocus is undefined', async () => {
+      const CustomPage = () => (
+        <div id="main">
+          <div name="topScrollElement" />
+          <h2>H2</h2>
+          <div name="topContentElement" />
+          <h3>H3</h3>
+          <h4>H4</h4>
+        </div>
+      );
+      const route = makeBypassRoute(CustomPage)();
+      route.pageConfig.scrollAndFocusTarget = '#main h4';
+      route.formConfig = { useCustomScrollAndFocus: undefined };
+      render(
+        <FormPage
+          form={makeBypassForm(CustomPage)()}
+          route={route}
+          location={location}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(document.activeElement.tagName).to.eq('H4');
+      });
+    });
+
+    it('should not use a page’s scrollAndFocusTarget if useCustomScrollAndFocus is explicitly false', async () => {
+      const CustomPage = () => (
+        <div id="main" className="nav-header">
+          <div name="topScrollElement" />
+          <h2>H2</h2>
+          <div name="topContentElement" />
+          <h3>H3</h3>
+          <h4>H4</h4>
+        </div>
+      );
+      const route = makeBypassRoute(CustomPage)();
+      route.pageConfig.scrollAndFocusTarget = '#main h4';
+      route.formConfig = { useCustomScrollAndFocus: false };
+      render(
+        <FormPage
+          form={makeBypassForm(CustomPage)()}
+          route={route}
+          location={location}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(document.activeElement.tagName).to.eq('H2');
+      });
+    });
+
     it('can receive ContentBeforeButtons that has access to setFormData and router', () => {
       const setData = sinon.spy();
       const router = {


### PR DESCRIPTION
## Summary

- Allow `scrollAndFocusTarget` without `useCustomScrollAndFocus`
- For example if array builder defines its own `scrollAndFocusTarget`, it won't work today unless the user specifically enables `useCustomScrollAndFocus` on their `formConfig`. This PR changes that so if any page defines a `scrollAndFocusTarget`, then it will respect that unless `useCustomScrollAndFocus` is explicitly `false`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1538

## Testing done

- Browser testing

## Screenshots

n/a

## What areas of the site does it impact?

forms that specify useCustomScrollAndFocus and/or scrollAndFocusTarget

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
