### PR TITLE
[SIMPLE-FORMS] fix: update error check to properly determine alert should be displayed

### DIFF
--- a/src/applications/simple-forms/form-upload/pages/upload.jsx
+++ b/src/applications/simple-forms/form-upload/pages/upload.jsx
@@ -62,14 +62,15 @@ export const uploadPage = {
 /** @type {CustomPageType} */
 export function UploadPage(props) {
   const warnings = props.data?.uploadedFile?.warnings;
-  const alert = warnings
-    ? FORM_UPLOAD_OCR_ALERT(
-        formNumber,
-        getPdfDownloadUrl(formNumber),
-        onCloseAlert,
-        warnings,
-      )
-    : FORM_UPLOAD_INSTRUCTION_ALERT(onCloseAlert);
+  const alert =
+    warnings?.length > 0
+      ? FORM_UPLOAD_OCR_ALERT(
+          formNumber,
+          getPdfDownloadUrl(formNumber),
+          onCloseAlert,
+          warnings,
+        )
+      : FORM_UPLOAD_INSTRUCTION_ALERT(onCloseAlert);
   return <CustomAlertPage {...props} alert={alert} />;
 }
 


### PR DESCRIPTION
## Summary

- This work fixes logic which displays an error alert when file uploads contain an error
- To reproduce: Choose to upload a file, no matter what file you upload, it displays the error alert on the top of the page.
- The logic to determine if the alert should be displayed was incorrect, causing the alert to display when it should not have
- This change updates the logic to properly determine if the alert should be displayed
- I work for the Veteran Facing Forms team which owns this module

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#101256

## Testing done

- Browser testing successful

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any
