### PR TITLE
[SIMPLE-FORMS] fix: update va link to download PDF to open in new tab

### DIFF
--- a/src/applications/simple-forms/form-upload/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/IntroductionPage.jsx
@@ -35,7 +35,7 @@ const IntroductionPage = ({ route }) => {
         <VaProcessListItem header="Download the form">
           <p>Download the official VA Form {formNumber} from VA.gov.</p>
           <VaLink
-            download
+            external
             filetype="PDF"
             href={pdfDownloadUrl}
             text={`Download VA Form ${formNumber}`}


### PR DESCRIPTION
## Summary

- This work updates the pdf download link on the introduction page of the form upload flow to open in a new tab.
- This solution was suggested by the CAIA team.
- I work for the Veteran Facing Forms team who owns this component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#101257

## Testing done

- Browser testing successful

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any