### PR TITLE
adds margin-top to downtime banners

### DIFF
--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -16,6 +16,14 @@ const routes = {
             path: 'mocked-auth',
             component: MockAuth,
           },
+          {
+            path: 'access-myhealthevet-test-account',
+            component: MhvSignIn,
+          },
+          {
+            path: 'mhv',
+            component: MhvAccess,
+          },
         ]
       : [
           {

--- a/src/platform/user/authentication/components/DowntimeBanner.js
+++ b/src/platform/user/authentication/components/DowntimeBanner.js
@@ -26,7 +26,7 @@ export default function DowntimeBanners() {
     !isLocalhost && !loading && (!statuses || statuses?.length === 0);
 
   return (
-    <div className="downtime-notification row">
+    <div className="downtime-notification row vads-u-margin-top--2">
       <div className="sign-in-wrapper">
         <div className="form-warning-banner fed-warning--v2">
           {isApiDown() ? renderServiceDown('mvi') : null}

--- a/src/platform/user/authentication/components/DowntimeBanner.js
+++ b/src/platform/user/authentication/components/DowntimeBanner.js
@@ -28,7 +28,7 @@ export default function DowntimeBanners() {
   return (
     <div className="downtime-notification row vads-u-margin-top--2">
       <div className="sign-in-wrapper">
-        <div className="form-warning-banner fed-warning--v2">
+        <div className="form-warning-banner fed-warning--v2 vads-u-margin-left--0">
           {isApiDown() ? renderServiceDown('mvi') : null}
           {renderMaintenanceWindow(maintenanceWindows)}
           {renderDowntimeBanner(statuses)}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- adds ```vads-u-margin-top--2``` class to Downtime Banner
- adds pro

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
![Screenshot 2025-01-27 at 9 49 05 AM](https://github.com/user-attachments/assets/afdb22e0-65dd-41b6-92cc-12563cc41ebf)

## What areas of the site does it impact?

- ```<LoginModal />```


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

