### PR TITLE
[VA-IIR 1383] update URL based on feeback

### DIFF
--- a/src/applications/personalization/review-information/README.md
+++ b/src/applications/personalization/review-information/README.md
@@ -12,7 +12,7 @@ yarn watch --env entry=welcome-va-setup-review-information
 The form runs at this location:
 
 ```
-http://localhost:3001/my-va/welcome-va-setup/review-information/contact-information
+http://localhost:3001/my-va/welcome-va-setup/contact-information
 ```
 
 ## Testing

--- a/src/applications/personalization/review-information/manifest.json
+++ b/src/applications/personalization/review-information/manifest.json
@@ -2,6 +2,6 @@
   "appName": "Welcome VA Setup Review Information Form",
   "entryFile": "./app-entry.jsx",
   "entryName": "welcome-va-setup-review-information",
-  "rootUrl": "/my-va/welcome-va-setup/review-information",
+  "rootUrl": "/my-va/welcome-va-setup",
   "productId": "c1a00d88-ead0-46d4-94ab-e72baba100c6"
 }

--- a/src/applications/personalization/review-information/tests/welcome-va-setup-review-information.cypress.spec.js
+++ b/src/applications/personalization/review-information/tests/welcome-va-setup-review-information.cypress.spec.js
@@ -1,7 +1,9 @@
+import manifest from '../manifest.json';
 import { cypressSetup } from './utils';
 import mockUser from './fixtures/mocks/user.json';
 
 describe.skip('Welcome to My VA Review Contact Information form', () => {
+  const formURL = `${manifest.rootUrl}/contact-information`;
   const editMobileNumber = () => {
     cy.get('#edit-mobile-phone').click();
     cy.location('pathname').should('include', '/edit-mobile-phone');
@@ -69,9 +71,7 @@ describe.skip('Welcome to My VA Review Contact Information form', () => {
     beforeEach(() => {
       cypressSetup();
       cy.login(mockUser);
-      cy.visit(
-        '/my-va/welcome-va-setup/review-information/contact-information',
-      );
+      cy.visit(formURL);
       cy.wait(['@mockUser', '@features', '@mockVamc']);
     });
 
@@ -94,9 +94,7 @@ describe.skip('Welcome to My VA Review Contact Information form', () => {
   context('when not signed in', () => {
     beforeEach(() => {
       cypressSetup();
-      cy.visit(
-        '/my-va/welcome-va-setup/review-information/contact-information',
-      );
+      cy.visit(formURL);
       cy.wait(['@features']);
     });
 
@@ -105,7 +103,7 @@ describe.skip('Welcome to My VA Review Contact Information form', () => {
     it('should redirect to sign in', () => {
       cy.location().should(loc => {
         expect(loc.search).to.eq(
-          '?next=%2Fmy-va%2Fwelcome-va-setup%2Freview-information%2Fcontact-information',
+          '?next=%2Fmy-va%2Fwelcome-va-setup%2Fcontact-information',
         );
       });
     });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This is work for the VA-IIR team.
- Our team owns this form/application, the Welcome VA Setup Review Information form.
- It completes a portion of the work required for ticket [1383](https://github.com/orgs/department-of-veterans-affairs/projects/1360/views/3?pane=issue&itemId=94058094&issue=department-of-veterans-affairs%7Cva-iir%7C1383), which is being completed in coordination with ticket [1384](https://github.com/orgs/department-of-veterans-affairs/projects/1360/views/3?pane=issue&itemId=94058167&issue=department-of-veterans-affairs%7Cva-iir%7C1384) (see [1384 PR](https://github.com/department-of-veterans-affairs/content-build/pull/2425)).
- It updates (shortens) the URL for our form, which is not yet in production.

## Related issue(s)

- Related work is being completed in [1383]([1383](https://github.com/orgs/department-of-veterans-affairs/projects/1360/views/3?pane=issue&itemId=94058094&issue=department-of-veterans-affairs%7Cva-iir%7C1383)) on vets-website.

## What areas of the site does it impact?

No other areas beyond our own application.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

