### PR TITLE
VACMS-18480 Add TTY to all Facility Locator results

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/CCProviderPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/CCProviderPhoneLink.jsx
@@ -20,6 +20,10 @@ const CCProviderPhoneLink = ({ location, query }) => {
   return (
     <div>
       {renderPhoneNumber('Main number', null, phone, true, location)}
+      <p>
+        <strong>Telecommunications Relay Services (using TTY):</strong>{' '}
+        <va-telephone tty contact="711" />
+      </p>
       {isCCProvider && (
         <p className="referral-message">
           If you don’t have a referral, contact your local VA medical center.

--- a/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
@@ -17,7 +17,7 @@ function LocationDirectionsLink({ location, from }) {
     <p>
       {from === 'FacilityDetail' && <va-icon icon="directions" size="3" />}
       <va-link
-        class="vads-u-margin-left--0p5"
+        class={from === 'FacilityDetail' ? 'vads-u-margin-left--0p5' : ''}
         href={`https://maps.google.com?saddr=${
           location.searchString
         }&daddr=${address}`}

--- a/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
@@ -98,6 +98,10 @@ const LocationPhoneLink = ({
         from,
         location,
       )}
+      <p>
+        <strong>Telecommunications Relay Services (using TTY):</strong>{' '}
+        <va-telephone tty contact="711" />
+      </p>
     </div>
   );
 };

--- a/src/applications/facility-locator/tests/components/search-results/LocationPhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationPhoneLink.unit.spec.jsx
@@ -12,7 +12,9 @@ describe('LocationPhoneLink', () => {
     const wrapper = shallow(
       <LocationPhoneLink location={locationWithBadPhone} />,
     );
-    expect(wrapper.html()).to.equal('<div class="facility-phone-group"></div>');
+    expect(wrapper.html()).to.equal(
+      '<div class="facility-phone-group"><p><strong>Telecommunications Relay Services (using TTY):</strong> <va-telephone tty="true" contact="711"></va-telephone></p></div>',
+    );
     wrapper.unmount();
   });
 
@@ -24,8 +26,19 @@ describe('LocationPhoneLink', () => {
     const wrapper = shallow(
       <LocationPhoneLink location={locationWithGoodPhone} />,
     );
-    expect(wrapper.find('va-telephone').length).to.equal(1);
-    expect(wrapper.find('strong').text()).to.equal('Main number: ');
+    expect(wrapper.find('va-telephone').length).to.equal(2);
+    expect(
+      wrapper
+        .find('strong')
+        .at(0)
+        .text(),
+    ).to.equal('Main number: ');
+    expect(
+      wrapper
+        .find('strong')
+        .at(1)
+        .text(),
+    ).to.equal('Telecommunications Relay Services (using TTY):');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
We need to add the TTY number (711) to every type of Facility Locator search result. This also includes a tweak to the class name for the `Get directions on Google Maps`. In a previous PR I added left margin to that link because it has an icon on the facility detail page but I did not know it was shared with the FL search results.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18480

## Testing done / screenshots

1. Go to http://6289fac3dcd274e54b10cd6b92020027.review.vetsgov-internal/find-locations
2. Enter a zip code or city, state
3. Select one of the services options from the dropdown (i.e. VA health) and search
4. Validate that you can see the Telecommunications (TTY) number under each search result with a working link
5. Conduct the search again with the next service option from the dropdown (i.e. Urgent care)
6. Continue validation until all the services in the dropdown are checked

Tested all the FL search types. DOM example below.

<img width="494" alt="Screenshot 2025-01-27 at 3 23 51 PM" src="https://github.com/user-attachments/assets/2e9a4fd6-cb1c-4f14-a8d2-710a89822d0a" />

| Flow | Screenshot |
| ------ | ----- |
| VA health  |  <img width="848" alt="Screenshot 2025-01-27 at 3 28 48 PM" src="https://github.com/user-attachments/assets/a8dfc55e-8d4c-466c-bcbc-c69e564459fc" /> |  
| Emergency care | <img width="864" alt="Screenshot 2025-01-27 at 3 40 49 PM" src="https://github.com/user-attachments/assets/3838106b-6fd3-444c-8e1d-b29148429818" /> |
| Community providers | <img width="852" alt="Screenshot 2025-01-27 at 3 41 04 PM" src="https://github.com/user-attachments/assets/f426a75d-388f-4687-8c0c-3831aa07a5d1" /> |
| Community pharmacies | <img width="850" alt="Screenshot 2025-01-27 at 3 41 15 PM" src="https://github.com/user-attachments/assets/a7833a29-eed3-4b79-bb3c-aa502f68fc67" /> |
| VA benefits | <img width="417" alt="Screenshot 2025-01-27 at 3 41 24 PM" src="https://github.com/user-attachments/assets/a6015b4f-5447-47dc-8b40-b7bc8bec4fe9" /> |
| VA cemeteries | <img width="839" alt="Screenshot 2025-01-27 at 3 41 34 PM" src="https://github.com/user-attachments/assets/2fb8f7aa-d1f7-40e2-bf66-21089eea59d8" /> |
| Vet Centers | <img width="830" alt="Screenshot 2025-01-27 at 3 41 42 PM" src="https://github.com/user-attachments/assets/8d6c75cf-8132-4bca-afe4-3b7c7a57114b" /> |

Also tested the text across browser font sizes:

| Size | Screenshot |
| ------ | ----- |
| Very small | <img width="293" alt="Screenshot 2025-01-27 at 4 02 35 PM" src="https://github.com/user-attachments/assets/a2e9096e-e216-4712-a9d4-832267ec991d" /> |
| Small | <img width="295" alt="Screenshot 2025-01-27 at 4 02 25 PM" src="https://github.com/user-attachments/assets/eeb97a4a-cf7e-4dc4-bae9-8c84290b3357" /> |
| Large | <img width="295" alt="Screenshot 2025-01-27 at 4 02 43 PM" src="https://github.com/user-attachments/assets/9abc40ce-f31b-4859-84f8-ada26b130938" /> |
| Very large | <img width="297" alt="Screenshot 2025-01-27 at 4 02 55 PM" src="https://github.com/user-attachments/assets/56f72df6-ef4d-45ab-8f6c-5525c6ef554f" /> |

## Acceptance criteria
- [x] For each results listing on the Facility locator, the TTY number is added as the last phone number - as shown in the Figma file
- [ ] Requires design review
- [x] Requires accessibility review