### PR TITLE
Iir 1397 fix confirmation error messages

### DIFF
--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
@@ -183,7 +183,7 @@ const ProofOfVeteranStatusNew = ({
       })
     : null;
 
-  const contactInfoElements = data?.attributes?.message?.map(item => {
+  const contactInfoElements = data?.message?.map(item => {
     const contactNumber = `${CONTACTS.DS_LOGON.slice(
       0,
       3,
@@ -345,7 +345,7 @@ const ProofOfVeteranStatusNew = ({
 
                 {isVetStatusEligibilityPopulated &&
                 data?.attributes?.veteranStatus !== 'confirmed' &&
-                data?.attributes?.message.length > 0 ? (
+                data?.message?.length > 0 ? (
                   <>
                     <div>
                       <va-alert

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
@@ -62,9 +62,7 @@ const ProofOfVeteranStatusNew = ({
   const userHasRequiredCardData = !!(
     serviceHistory.length && formattedFullName
   );
-
   const hasConfirmationData = !!(data && data.attributes);
-
   const pdfData = {
     title: `Veteran status card for ${formattedFullName}`,
     details: {
@@ -383,18 +381,51 @@ const ProofOfVeteranStatusNew = ({
               </va-alert>
             ) : null}
           </>
-        ) : (
-          <va-alert
-            close-btn-aria-label="Close notification"
-            status="error"
-            visible
-          >
-            <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-              We’re sorry. There’s a problem with our system. We can’t show your
-              Veteran status card right now. Try again later.
-            </p>
-          </va-alert>
-        )}
+        ) : null}
+
+        {!userHasRequiredCardData ? (
+          <>
+            {!useLighthouseApi ? (
+              <va-alert
+                close-btn-aria-label="Close notification"
+                status="error"
+                visible
+              >
+                <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+                  We’re sorry. There’s a problem with our system. We can’t show
+                  your Veteran status card right now. Try again later.
+                </p>
+              </va-alert>
+            ) : null}
+
+            {useLighthouseApi ? (
+              <>
+                {data?.attributes?.veteranStatus === 'confirmed' ? (
+                  <>
+                    <div>
+                      <va-alert
+                        close-btn-aria-label="Close notification"
+                        status="warning"
+                        visible
+                      >
+                        {componentizedMessage.map((message, i) => {
+                          if (i === 0) {
+                            return (
+                              <p key={i} className="vads-u-margin-top--0">
+                                {message}
+                              </p>
+                            );
+                          }
+                          return <p key={i}>{message}</p>;
+                        })}
+                      </va-alert>
+                    </div>
+                  </>
+                ) : null}
+              </>
+            ) : null}
+          </>
+        ) : null}
       </div>
     </>
   );

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
@@ -208,6 +208,53 @@ const ProofOfVeteranStatusNew = ({
     );
   });
 
+  const systemErrrorAlert = (
+    <va-alert close-btn-aria-label="Close notification" status="error" visible>
+      <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+        We’re sorry. There’s a problem with our system. We can’t show your
+        Veteran status card right now. Try again later.
+      </p>
+    </va-alert>
+  );
+
+  const lighthouseApiErrorMessage = (
+    <va-alert
+      close-btn-aria-label="Close notification"
+      status="warning"
+      visible
+    >
+      {contactInfoElements?.map((message, i) => {
+        if (i === 0) {
+          return (
+            <p key={i} className="vads-u-margin-top--0">
+              {message}
+            </p>
+          );
+        }
+        return <p key={i}>{message}</p>;
+      })}
+    </va-alert>
+  );
+
+  const profileApiErrorMessage = (
+    <va-alert
+      close-btn-aria-label="Close notification"
+      status="warning"
+      visible
+    >
+      {componentizedMessage.map((message, i) => {
+        if (i === 0) {
+          return (
+            <p key={i} className="vads-u-margin-top--0">
+              {message}
+            </p>
+          );
+        }
+        return <p key={i}>{message}</p>;
+      })}
+    </va-alert>
+  );
+
   return (
     <>
       <div id="proof-of-veteran-status">
@@ -269,26 +316,7 @@ const ProofOfVeteranStatusNew = ({
                 ) : null}
                 {!vetStatusEligibility.confirmed &&
                 vetStatusEligibility.message.length > 0 ? (
-                  <>
-                    <div>
-                      <va-alert
-                        close-btn-aria-label="Close notification"
-                        status="warning"
-                        visible
-                      >
-                        {componentizedMessage.map((message, i) => {
-                          if (i === 0) {
-                            return (
-                              <p key={i} className="vads-u-margin-top--0">
-                                {message}
-                              </p>
-                            );
-                          }
-                          return <p key={i}>{message}</p>;
-                        })}
-                      </va-alert>
-                    </div>
-                  </>
+                  <>{profileApiErrorMessage}</>
                 ) : null}
               </>
             ) : null}
@@ -344,84 +372,28 @@ const ProofOfVeteranStatusNew = ({
                 {isVetStatusEligibilityPopulated &&
                 data?.attributes?.veteranStatus !== 'confirmed' &&
                 data?.message?.length > 0 ? (
-                  <>
-                    <div>
-                      <va-alert
-                        close-btn-aria-label="Close notification"
-                        status="warning"
-                        visible
-                      >
-                        {contactInfoElements.map((message, i) => {
-                          if (i === 0) {
-                            return (
-                              <p key={i} className="vads-u-margin-top--0">
-                                {message}
-                              </p>
-                            );
-                          }
-                          return <p key={i}>{message}</p>;
-                        })}
-                      </va-alert>
-                    </div>
-                  </>
+                  <>{lighthouseApiErrorMessage}</>
                 ) : null}
               </>
             ) : null}
 
             {useLighthouseApi && !hasConfirmationData ? (
-              <va-alert
-                close-btn-aria-label="Close notification"
-                status="error"
-                visible
-              >
-                <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-                  We’re sorry. There’s a problem with our system. We can’t show
-                  your Veteran status card right now. Try again later.
-                </p>
-              </va-alert>
+              <>{systemErrrorAlert}</>
             ) : null}
           </>
         ) : null}
 
         {!userHasRequiredCardData ? (
           <>
-            {!useLighthouseApi ? (
-              <va-alert
-                close-btn-aria-label="Close notification"
-                status="error"
-                visible
-              >
-                <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-                  We’re sorry. There’s a problem with our system. We can’t show
-                  your Veteran status card right now. Try again later.
-                </p>
-              </va-alert>
-            ) : null}
+            {!useLighthouseApi ? <>{systemErrrorAlert}</> : null}
 
             {useLighthouseApi ? (
               <>
                 {data?.attributes?.veteranStatus === 'confirmed' ? (
-                  <>
-                    <div>
-                      <va-alert
-                        close-btn-aria-label="Close notification"
-                        status="warning"
-                        visible
-                      >
-                        {componentizedMessage.map((message, i) => {
-                          if (i === 0) {
-                            return (
-                              <p key={i} className="vads-u-margin-top--0">
-                                {message}
-                              </p>
-                            );
-                          }
-                          return <p key={i}>{message}</p>;
-                        })}
-                      </va-alert>
-                    </div>
-                  </>
-                ) : null}
+                  <>{profileApiErrorMessage}</>
+                ) : (
+                  <>{lighthouseApiErrorMessage}</>
+                )}
               </>
             ) : null}
           </>

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
@@ -180,8 +180,8 @@ describe('ProofOfVeteranStatusNew', () => {
           attributes: {
             veteranStatus: 'not confirmed',
             notConfirmedReason: 'PERSON_NOT_FOUND',
-            message: problematicEligibility.message,
           },
+          message: problematicEligibility.message,
         },
       };
 

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
@@ -237,7 +237,7 @@ describe('ProofOfVeteranStatusNew', () => {
       });
     });
 
-    it('displays error message when confirmed without service history', async () => {
+    it('confirmed and no service history displays not confirmed message', async () => {
       const mockData = {
         data: {
           id: '',
@@ -257,6 +257,38 @@ describe('ProofOfVeteranStatusNew', () => {
         '/profile/vet_verification_status',
       );
       await waitFor(() => {
+        expect(
+          view.queryByText(
+            /We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now./,
+          ),
+        ).to.exist;
+      });
+    });
+
+    it('not confirmed and no service history displays the returned not confirmed message', async () => {
+      const mockData = {
+        data: {
+          id: '',
+          type: 'veteran_status_confirmations',
+          attributes: {
+            veteranStatus: 'not confirmed',
+            notConfirmedReason: 'PERSON_NOT_FOUND',
+          },
+          message: problematicEligibility.message,
+        },
+      };
+      apiRequestStub.resolves(mockData);
+      initialState = createBasicInitialState([], problematicEligibility, true);
+      const view = renderWithProfileReducers(<ProofOfVeteranStatusNew />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        expect(
+          view.queryByText(
+            /Get proof of Veteran Status on your mobile device/i,
+          ),
+        ).to.not.exist;
         expect(
           view.queryByText(
             /We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now./,

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
@@ -125,7 +125,7 @@ describe('ProofOfVeteranStatusNew', () => {
 
   describe('should fetch verification status on render', () => {
     let apiRequestStub;
-    const initialState = createBasicInitialState(
+    let initialState = createBasicInitialState(
       [eligibleServiceHistoryItem],
       confirmedEligibility,
       true,
@@ -232,6 +232,34 @@ describe('ProofOfVeteranStatusNew', () => {
         expect(
           view.getByText(
             'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later.',
+          ),
+        ).to.exist;
+      });
+    });
+
+    it('displays error message when confirmed without service history', async () => {
+      const mockData = {
+        data: {
+          id: '',
+          type: 'veteran_status_confirmations',
+          attributes: { veteranStatus: 'confirmed' },
+        },
+      };
+      apiRequestStub.resolves(mockData);
+
+      initialState = createBasicInitialState([], problematicEligibility, true);
+      const view = renderWithProfileReducers(<ProofOfVeteranStatusNew />, {
+        initialState,
+      });
+
+      sinon.assert.calledWith(
+        apiRequestStub,
+        '/profile/vet_verification_status',
+      );
+      await waitFor(() => {
+        expect(
+          view.queryByText(
+            /We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now./,
           ),
         ).to.exist;
       });

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
@@ -237,7 +237,7 @@ describe('ProofOfVeteranStatusNew', () => {
       });
     });
 
-    it('confirmed and no service history displays not confirmed message', async () => {
+    it('displays not confirmed message if confirmed with no service history', async () => {
       const mockData = {
         data: {
           id: '',
@@ -265,7 +265,7 @@ describe('ProofOfVeteranStatusNew', () => {
       });
     });
 
-    it('not confirmed and no service history displays the returned not confirmed message', async () => {
+    it('displays not confirmed message if not confirmed and no service history', async () => {
       const mockData = {
         data: {
           id: '',

--- a/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
@@ -8,22 +8,38 @@ const confirmed = {
   },
 };
 
-const notConfirmed = {
+const notConfirmedProblem = {
   data: {
     id: null,
     type: 'veteran_status_confirmations',
     attributes: {
       veteranStatus: 'not confirmed',
       notConfirmedReason: 'PERSON_NOT_FOUND',
-      message: [
-        'We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now.',
-        'To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
-      ],
     },
+    message: [
+      'We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now.',
+      'To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
+    ],
+  },
+};
+
+const notConfirmedIneligible = {
+  data: {
+    id: '',
+    type: 'veteran_status_confirmations',
+    attributes: {
+      veteranStatus: 'not confirmed',
+      notConfirmedReason: 'NOT_TITLE_38',
+    },
+    message: [
+      'Our records show that you’re not eligible for a Veteran status card. To get a Veteran status card, you must have received an honorable discharge for at least one period of service.',
+      'If you think your discharge status is incorrect, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
+    ],
   },
 };
 
 module.exports = {
   confirmed,
-  notConfirmed,
+  notConfirmedProblem,
+  notConfirmedIneligible,
 };

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -240,7 +240,8 @@ const responses = {
   },
   'GET /v0/profile/vet_verification_status': (_req, res) => {
     return res.status(200).json(vetVerificationStatus.confirmed);
-    // return res.status(200).json(vetVerificationStatus.notConfirmed);
+    // return res.status(200).json(vetVerificationStatus.notConfirmedProblem);
+    // return res.status(200).json(vetVerificationStatus.notConfirmedIneligible);
   },
   'GET /v0/disability_compensation_form/rating_info': (_req, res) => {
     // return res.status(200).json(ratingInfo.success.serviceConnected0);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- These changes fix a bug with the wrong error message showing for veterans that have a "not confirmed" status and visit the Proof of Status card app. It was possible to see the “We’re sorry. There’s a problem with our system…” error when users should have received either a) "We’re sorry. There’s a problem with your discharge status records…” or b) “Our records show that you’re not eligible for Veteran Status card…” warnings. Additionally, this fixes a problem where users that are "confirmed" but don't have service history see the “We’re sorry. There’s a problem with our system…” error when they should be seeing the “We’re sorry. There’s a problem with your discharge status records…” warning.
- I work on the IIR Product team and we currently own this feature.
- The entire implementation of the confirmation statuses is behind a feature toggle. The success criteria targeted for the flipper is to make sure that we receive the same access rate or better for known test users when trying to view their Vet Status card. Additional testing will also be done with veterans on production to further solidify our test cases.

## Related issue(s)

- [1397](https://github.com/department-of-veterans-affairs/va-iir/issues/1397)

## Testing done

- Old behavior and new behavior, as witnessed by users should more or less be the same, just with the caveat of increased access rates. The old behavior used Profile API data and custom logic from vets-api to determine eligibility. This new API endpoint makes a request the the Lighthouse Veteran Service History and Eligibility API and determines whether or not to show the proof of status card based on the confirmation value returned from LH.
- Testing has been completed locally to mock the response for both feature toggles involved and handling both "confirmed" and "not confirmed" return values (as the Lighthouse API will do) to make sure the UI shows either the proof of status card or error messages, accordingly.


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |     
![Screenshot 2025-01-14 at 12 10 32 PM](https://github.com/user-attachments/assets/99597521-60ff-4cbb-ad00-a3c6ff90b3f7)
   |     
![Screenshot 2025-01-14 at 12 10 32 PM](https://github.com/user-attachments/assets/80c54af9-38fc-4687-bb02-b5a2cbd11330)
  |

## What areas of the site does it impact?

These changes only impact the Proof of Status app.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
