### PR TITLE
Conditions 688 Prototype Summary Hint Update to Null

### DIFF
--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/causeFollowUp.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/causeFollowUp.js
@@ -28,8 +28,8 @@ export const createCauseFollowUpTitles = formData => {
   return causeTitle[formData.cause];
 };
 
-// TODO: Fix formData so that shape is consistent
-// formData changes shape between add and edit which results in the need for the conditional below
+// TODO: [Fix the formData prop on edit so that it contains all form data](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/689)
+// formData contains all form data on add and only item data on edit which results in the need for the conditional below
 const createCauseFollowUpConditional = (formData, index, causeType) => {
   const cause = formData?.[arrayBuilderOptions.arrayPath]
     ? formData?.[arrayBuilderOptions.arrayPath][index]?.cause
@@ -37,9 +37,9 @@ const createCauseFollowUpConditional = (formData, index, causeType) => {
   return cause !== causeType;
 };
 
-// TODO: Fix causedByCondition functionality on edit
-// formData on add { "conditionByCondition": [{ "condition": "migraines (headaches)"... }] }
-// formData on edit { "condition": "migraines (headaches)"... } - does not include ratedDisabilities or other new conditions
+// TODO: [Fix the formData prop on edit so that it contains all form data](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/689)
+// formData on add contains all form data { "conditionByCondition": [{ "condition": "migraines (headaches)"... }] }
+// formData on edit contains only item data { "condition": "migraines (headaches)"... } which does not include ratedDisabilities or other new conditions
 // TODO: If causedByCondition is 'asthma' asthma is updated to 'emphysema' ensure 'asthma' is cleared as potential cause
 const getOtherConditions = (formData, currentIndex) => {
   const ratedDisabilities =

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/index.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/index.js
@@ -39,7 +39,8 @@ const conditionByConditionPages = arrayBuilderPages(
         const { formData, index } = props;
         const item = formData?.[arrayBuilderOptions.arrayPath]?.[index];
 
-        // TODO: This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
+        // TODO: [Depends should clear the data of the dependent pages when the condition is no longer true](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/691)
+        // This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
         // However, with this fix, when user doesn't change condition, side of body is still cleared which could confuse users
         // The depends should potentially clear the data of the dependent pages when the condition is no longer true
         // TODO: use setFormData instead of mutating formData directly.

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/summary.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/summary.js
@@ -17,7 +17,9 @@ const summaryPage = {
       arrayBuilderOptions,
       {},
       {
-        hint: null, // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
+        // Because there is maxItems: 100 in the arrayBuilderOptions,
+        // if this null value is not present the hint will count down from 100 which is a confusing user experience
+        hint: null,
       },
     ),
   },

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/summary.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/summary.js
@@ -16,9 +16,8 @@ const summaryPage = {
     'view:hasConditions': arrayBuilderYesNoUI(
       arrayBuilderOptions,
       {},
-      // TODO: Is this the best way to handle hiding the hint?
       {
-        hint: ' ', // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
+        hint: null, // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
       },
     ),
   },

--- a/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/utils.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionByConditionPages/utils.js
@@ -66,8 +66,8 @@ export const arrayBuilderOptions = {
   },
 };
 
-// TODO: Fix formData so that shape is consistent
-// formData changes shape between add and edit which results in the need for the conditional below
+// TODO: [Fix the formData prop on edit so that it contains all form data](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/689)
+// formData contains all form data on add and only item data on edit which results in the need for the conditional below
 export const hasSideOfBody = (formData, index) => {
   const condition = formData?.[arrayBuilderOptions.arrayPath]
     ? formData?.[arrayBuilderOptions.arrayPath][index]?.condition

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/index.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/index.js
@@ -36,10 +36,11 @@ const conditionsFirstPages = arrayBuilderPages(
         const { formData, index } = props;
         const item = formData?.[arrayBuilderOptions.arrayPath]?.[index];
 
-        // TODO: This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
+        // TODO: [Depends should clear the data of the dependent pages when the condition is no longer true](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/691)
+        // This fixed bug where side of body was not being cleared when condition was edited which could result in 'Asthma, right'
         // However, with this fix, when user doesn't change condition, side of body is still cleared which could confuse users
         // The depends should potentially clear the data of the dependent pages when the condition is no longer true
-        // TODO: use setFormData instead of mutating formData directly
+        // TODO: use setFormData instead of mutating formData directly.
         if (item) {
           item.sideOfBody = undefined;
         }

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/summary.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/summary.js
@@ -17,7 +17,9 @@ const summaryPage = {
       arrayBuilderOptions,
       {},
       {
-        hint: null, // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
+        // Because there is maxItems: 100 in the arrayBuilderOptions,
+        // if this null value is not present the hint will count down from 100 which is a confusing user experience
+        hint: null,
       },
     ),
   },

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/summary.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/summary.js
@@ -17,7 +17,7 @@ const summaryPage = {
       arrayBuilderOptions,
       {},
       {
-        hint: ' ', // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
+        hint: null, // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
       },
     ),
   },

--- a/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
+++ b/src/applications/user-testing/new-conditions/pages/conditionsFirstPages/utils.js
@@ -42,8 +42,8 @@ export const arrayBuilderOptions = {
   },
 };
 
-// TODO: Fix formData so that shape is consistent
-// formData changes shape between add and edit which results in the need for the conditional below
+// TODO: [Fix the formData prop on edit so that it contains all form data](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/689)
+// formData contains all form data on add and only item data on edit which results in the need for the conditional below
 export const hasSideOfBody = (formData, index) => {
   const condition = formData?.[arrayBuilderOptions.arrayPath]
     ? formData?.[arrayBuilderOptions.arrayPath][index]?.condition


### PR DESCRIPTION
## Summary

- Summarize the changes that have been made to the platform
  - It is necessary to omit the hint in the prototypes summary page because there is `maxItems: 100` in the arrayBuilderOptions and if the hint is present it will count down from 100 which is a confusing user experience
  - That a user would add 100 conditions is definitely an edge case so a static hint would not be needed either
  - In previous work, setting the arrayBuilder yes/no hint to null did not omit the hint with only `hint: ' '` omitting the hint
  - There was an issue created to update the code so that `hint: null` would hide the hint
  - This PR was meant to do that update, however after initial testing it was determined `hint: null` did omit the hint
  - It was attempted to determine if there was a fix that solved this issue or if this was a testing issue in the original implementation, but it could not be determined
  - Before: The empty space creates an empty div in the html for the empty space hint and this is not a clean implementation
    ```
    'view:hasConditions': arrayBuilderYesNoUI(
      arrayBuilderOptions,
      {},
      {
        hint: ' ', // Because there is maxItems: 100 if this empty string is not present the hint will count down from 100 which is a confusing user experience
      },
    ), 
    ```
  - After: no div is created for the hint (it is just omitted) and the code is easier to read
    ```
    'view:hasConditions': arrayBuilderYesNoUI(
      arrayBuilderOptions,
      {},
      {
        // Because there is maxItems: 100 in the arrayBuilderOptions,
        // if this null value is not present the hint will count down from 100 which is a confusing user experience
        hint: null,
      },
    ),
    ```
  - This change also updates TODOs to contain the newly created issue numbers
- Which team do you work for, does your team own the maintenance of this component? Conditions Team and Yes

## Related issue(s)


- [Add better way of omitting hint from multi-page yes/no than hint: ' ' (string with space) #688](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/688)

## Screenshots

### No Hint Hiding Code
<img width="646" alt="Screenshot 2025-01-28 at 10 58 34 AM" src="https://github.com/user-attachments/assets/f71d59ec-47e7-462a-9120-0949ba9c10bf" />
<img width="528" alt="Screenshot 2025-01-28 at 10 58 24 AM" src="https://github.com/user-attachments/assets/279dc437-3562-49c3-a4c3-83252890c30b" />

### Before
<img width="1314" alt="Screenshot 2025-01-28 at 11 00 00 AM" src="https://github.com/user-attachments/assets/ca13333e-256f-402b-9967-76e05f04f6a5" />
<img width="530" alt="Screenshot 2025-01-28 at 10 59 51 AM" src="https://github.com/user-attachments/assets/eee0ac80-af61-4b9d-a124-14fd32835e92" />

### After
<img width="635" alt="Screenshot 2025-01-28 at 11 21 31 AM" src="https://github.com/user-attachments/assets/72aa2da9-a87c-42d3-a2d1-0bfdb575ebd7" />
<img width="529" alt="Screenshot 2025-01-28 at 11 22 29 AM" src="https://github.com/user-attachments/assets/7f6d889b-4b06-4057-bcb0-0f46d3df0bfb" />


