### PR TITLE
Launch injected header on mirecc.va.gov

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -103,12 +103,12 @@
     {
       "hostname": "www.mirecc.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "mirecc.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.move.va.gov",


### PR DESCRIPTION
Enabling the proxy-rewrite cookie for header/footer injection on Team site.

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20330