### PR TITLE
MHV-66203: CCD generate polling throttled with backoff

### DIFF
--- a/src/applications/mhv-medical-records/actions/downloads.js
+++ b/src/applications/mhv-medical-records/actions/downloads.js
@@ -73,8 +73,7 @@ export const genAndDownloadCCD = (
     }
   } catch (error) {
     dispatch({ type: Actions.Downloads.CANCEL_CCD });
-    dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
-    throw error;
+    dispatch(addAlert(Constants.ALERT_TYPE_CCD_ERROR, error));
   }
 };
 

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -241,6 +241,17 @@ const DownloadReportPage = ({ runningUnitTest }) => {
     [refreshStatus],
   );
 
+  const handleDownloadCCD = e => {
+    e.preventDefault();
+    dispatch(
+      genAndDownloadCCD(
+        userProfile?.userFullName?.first,
+        userProfile?.userFullName?.last,
+      ),
+    );
+    sendDataDogAction('Download Continuity of Care Document xml Link');
+  };
+
   return (
     <div>
       <h1>Download your medical records reports</h1>
@@ -343,18 +354,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
             <va-link
               download
               href="#"
-              onClick={e => {
-                e.preventDefault();
-                dispatch(
-                  genAndDownloadCCD(
-                    userProfile.userFullName.first,
-                    userProfile.userFullName.last,
-                  ),
-                );
-                sendDataDogAction(
-                  'Download Continuity of Care Document xml Link',
-                );
-              }}
+              onClick={handleDownloadCCD}
               text="Download .xml file"
               data-testid="generateCcdButton"
             />

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -29,6 +29,7 @@ import {
   accessAlertTypes,
   ALERT_TYPE_BB_ERROR,
   ALERT_TYPE_SEI_ERROR,
+  ALERT_TYPE_CCD_ERROR,
   BB_DOMAIN_DISPLAY_MAP,
   documentTypes,
   pageTitles,
@@ -204,7 +205,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
   );
 
   const accessErrors = () => {
-    // CCD Access Error
+    // CCD generation Error
     if (CCDRetryTimestamp) {
       return (
         <AccessTroubleAlertBox
@@ -270,7 +271,6 @@ const DownloadReportPage = ({ runningUnitTest }) => {
           on {lastSuccessfulUpdate.date}
         </va-card>
       )}
-
       {activeAlert?.type === ALERT_TYPE_BB_ERROR && (
         <AccessTroubleAlertBox
           alertType={accessAlertTypes.DOCUMENT}
@@ -278,15 +278,6 @@ const DownloadReportPage = ({ runningUnitTest }) => {
           className="vads-u-margin-bottom--1"
         />
       )}
-
-      {activeAlert?.type === ALERT_TYPE_SEI_ERROR && (
-        <AccessTroubleAlertBox
-          alertType={accessAlertTypes.DOCUMENT}
-          documentType={documentTypes.SEI}
-          className="vads-u-margin-bottom--1"
-        />
-      )}
-
       {successfulBBDownload === true && (
         <>
           <MissingRecordsError
@@ -294,19 +285,6 @@ const DownloadReportPage = ({ runningUnitTest }) => {
             recordTypes={getFailedDomainList(
               failedBBDomains,
               BB_DOMAIN_DISPLAY_MAP,
-            )}
-          />
-          <DownloadSuccessAlert className="vads-u-margin-bottom--1" />
-        </>
-      )}
-
-      {successfulSeiDownload === true && (
-        <>
-          <MissingRecordsError
-            documentType="Self-entered health information report"
-            recordTypes={getFailedDomainList(
-              failedSeiDomains,
-              SEI_DOMAIN_DISPLAY_MAP,
             )}
           />
           <DownloadSuccessAlert className="vads-u-margin-bottom--1" />
@@ -327,7 +305,37 @@ const DownloadReportPage = ({ runningUnitTest }) => {
         data-testid="go-to-download-all"
       />
       <h2>Other reports you can download</h2>
+
       {accessErrors()}
+
+      {/* redux action/server errors */}
+      {activeAlert?.type === ALERT_TYPE_CCD_ERROR && (
+        <AccessTroubleAlertBox
+          alertType={accessAlertTypes.DOCUMENT}
+          documentType={documentTypes.CCD}
+          className="vads-u-margin-bottom--1"
+        />
+      )}
+      {activeAlert?.type === ALERT_TYPE_SEI_ERROR && (
+        <AccessTroubleAlertBox
+          alertType={accessAlertTypes.DOCUMENT}
+          documentType={documentTypes.SEI}
+          className="vads-u-margin-bottom--1"
+        />
+      )}
+
+      {successfulSeiDownload === true && (
+        <>
+          <MissingRecordsError
+            documentType="Self-entered health information report"
+            recordTypes={getFailedDomainList(
+              failedSeiDomains,
+              SEI_DOMAIN_DISPLAY_MAP,
+            )}
+          />
+          <DownloadSuccessAlert className="vads-u-margin-bottom--1" />
+        </>
+      )}
       <va-accordion bordered>
         <va-accordion-item bordered data-testid="ccdAccordionItem">
           <h3 slot="headline">

--- a/src/applications/mhv-medical-records/tests/actions/download.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/actions/download.unit.spec.js
@@ -4,6 +4,7 @@ import {
   mockMultipleApiRequests,
 } from '@department-of-veterans-affairs/platform-testing/helpers';
 import sinon from 'sinon';
+import { waitFor } from '@testing-library/dom';
 import {
   updateReportRecordType,
   updateReportDateRange,
@@ -65,18 +66,24 @@ describe('Download Actions', () => {
       const firstName = 'first';
       const lastName = 'last';
       const dateGenerated = '2024-10-30T10:00:40.000-0400';
-      const completeRequest = {
+      const inProcessRequest = {
         shouldResolve: true,
         response: [{ status: 'IN_PROCESS', dateGenerated }],
       };
+      const completeRequest = {
+        shouldResolve: true,
+        response: [{ status: 'COMPLETE', dateGenerated }],
+      };
 
-      mockMultipleApiRequests([completeRequest]);
+      mockMultipleApiRequests([inProcessRequest, completeRequest]);
       await genAndDownloadCCD(firstName, lastName)(dispatch);
-      expect(dispatch.callCount).to.be.equal(2);
-      expect(dispatch.calledWith({ type: Actions.Downloads.GENERATE_CCD })).to
-        .be.true;
-      // expect dispatch to be called with a function
-      expect(dispatch.secondCall.args[0]).to.be.a('function');
+      waitFor(() => {
+        expect(dispatch.callCount).to.be.equal(2);
+        expect(dispatch.calledWith({ type: Actions.Downloads.GENERATE_CCD })).to
+          .be.true;
+        // expect dispatch to be called with a function
+        expect(dispatch.secondCall.args[0]).to.be.a('function');
+      });
     });
   });
 

--- a/src/applications/mhv-medical-records/util/constants.js
+++ b/src/applications/mhv-medical-records/util/constants.js
@@ -221,6 +221,8 @@ export const ALERT_TYPE_IMAGE_STATUS_ERROR = 'images status error';
 export const ALERT_TYPE_SUCCESS = 'success';
 export const ALERT_TYPE_BB_ERROR = 'blue button download error';
 export const ALERT_TYPE_SEI_ERROR = 'self-entered download error';
+export const ALERT_TYPE_CCD_ERROR =
+  'continuity of care document download error';
 
 export const pageTitles = {
   MEDICAL_RECORDS_PAGE_TITLE: 'Medical Records | Veterans Affairs',


### PR DESCRIPTION
## Summary
- Generate CCD polling throttled with a 5% backoff. It will poll for up to 60 seconds and then return a timeout error. 
- Added error handling for generate CCD redux action errors.
- Moved the SEI error to it's appropriate place (same spot as CCD error).

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-66203

> ### Download CCD occasionally generates a 404 error
> Description
> Our monitor for Download endpoints occasionally trips because the Download CCD endpoint generates a 404. [Here is a list of such errors](https://vagov.ddog-gov.com/apm/traces?query=service%3Amhv-medical-records%20-status%3Aok%20resource_name%3A%22MyHealth%3A%3AV1%3A%3AMedicalRecords%3A%3ACcdController%23download%22%20%40http.status_code%3A404&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=all&storage=hot&traceQuery=&view=spans&viz=stream&start=1735582477635&end=1736792077635&paused=false).
> 
> Understand why these are happening and fix if necessary.
> 
> [Linked GitHub issue](https://github.com/department-of-veterans-affairs/octo_watchofficer/issues/475).

## Testing done
CCD tests adjusted for changes. 

## Screenshots
<img width="1261" alt="Screenshot 2025-02-03 at 11 45 14 AM" src="https://github.com/user-attachments/assets/a2b53466-232e-4e71-a2fc-4b83861fb8f7" />

## What areas of the site does it impact?
MHV medical records - CCD download

## Acceptance criteria
AC1 Research and understand why error is happening

AC2 Fix any issues found

AC3 Add a backoff throttle for the generate polling, start w/ 1 second and back off 5-10% every call up to some max

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
