### PR TITLE
Update Cypress keyboard commands

### DIFF
--- a/src/applications/lgy/coe/form/tests/coe-keyboard-only.cypress.spec.js
+++ b/src/applications/lgy/coe/form/tests/coe-keyboard-only.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Certificate of Eligibility keyboard only navigation', () => {
       chapters.applicantInformationChapter.pages.applicantInformationSummary
         .path,
     );
-    cy.typeInFullName('root_fullName_', data.fullName);
+    cy.typeInFullName('root_fullName', data.fullName);
     cy.typeInDate('root_dateOfBirth', data.dateOfBirth);
     cy.tabToContinueForm();
 

--- a/src/platform/testing/e2e/cypress/support/commands/getMany.js
+++ b/src/platform/testing/e2e/cypress/support/commands/getMany.js
@@ -1,0 +1,15 @@
+/**
+ * @callback getMany
+ * @param {Array} selectors - an array of aliases/elements/etc to retrieve
+ */
+/**
+ * This command will get multiple elements at once without individual callbacks
+ * @param {String} name - Name of the new command
+ * @param {getMany} callbackFunction - The callback that handles focusing & checking or unchecking a checkbox based on the checkbox state
+ */
+Cypress.Commands.add('getMany', selectors => {
+  const values = Promise.all(
+    selectors.map(name => cy.get(name).then($el => $el)),
+  );
+  return cy.wrap(values);
+});

--- a/src/platform/testing/e2e/cypress/support/commands/index.js
+++ b/src/platform/testing/e2e/cypress/support/commands/index.js
@@ -9,6 +9,7 @@ import './upload';
 import './keyboardNavigation';
 import './injectAxeThenAxeCheck';
 import './viewportPreset';
+import './getMany';
 import './hasCount';
 import './testStatus';
 import 'cy-mobile-commands';

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -242,6 +242,40 @@ Cypress.Commands.add('setCheckboxFromData', (selector, isChecked = false) => {
 });
 
 /**
+ * @callback selectDropdownFromData
+ * @param {String} selector - The element selector
+ * @param {String} value - the option value to select
+ */
+/**
+ * This command will find and select a dropdown option if the data is true
+ * @param {String} name - Name of the new command
+ * @param {selectDropdownFromData} callbackFunction - The callback that handles focusing & checking or unchecking a checkbox based on the checkbox state
+ */
+Cypress.Commands.add('selectDropdownFromData', (selector, value) => {
+  if (value) {
+    cy.tabToElement(selector);
+    cy.chooseSelectOptionUsingValue(value);
+  }
+});
+
+/**
+ * @callback selectRadioFromData
+ * @param {String} selector - The element selector
+ * @param {String} value - the input value to select
+ */
+/**
+ * This command will find and select a radio option if the data is true
+ * @param {String} name - Name of the new command
+ * @param {selectRadioFromData} callbackFunction - The callback that handles focusing & checking or unchecking a checkbox based on the checkbox state
+ */
+Cypress.Commands.add('selectRadioFromData', (selector, value) => {
+  if (value) {
+    cy.tabToElement(selector);
+    cy.chooseRadio(value);
+  }
+});
+
+/**
  * FullName
  * @typedef {Object}
  * @property {String} prefix - Prefix
@@ -261,17 +295,17 @@ Cypress.Commands.add('setCheckboxFromData', (selector, isChecked = false) => {
  * @param {typeInFullName} callbackFunction - The callback that handles moving the focus to an element and then select or type in the text
  */
 Cypress.Commands.add('typeInFullName', (fieldName, data) => {
-  const name = removeLeadingHash(fieldName);
-  if (data.prefix) {
-    cy.tabToElement(`#${name}prefix`);
-    cy.chooseSelectOptionByTyping(data.prefix);
-  }
-  cy.typeInIfDataExists(`#${name}first`, data.first);
-  cy.typeInIfDataExists(`#${name}middle`, data.middle);
-  cy.typeInIfDataExists(`#${name}last`, data.last);
-  if (data.suffix) {
-    cy.tabToElement(`#${name}suffix`);
-    cy.chooseSelectOptionByTyping(data.suffix);
+  if (data) {
+    const name = removeLeadingHash(fieldName);
+    if (data.prefix) {
+      cy.selectDropdownFromData(`[name="${name}_prefix"]`, data.prefix);
+    }
+    cy.typeInIfDataExists(`[name="${name}_first"]`, data.first);
+    cy.typeInIfDataExists(`[name="${name}_middle"]`, data.middle);
+    cy.typeInIfDataExists(`[name="${name}_last"]`, data.last);
+    if (data.suffix) {
+      cy.selectDropdownFromData(`[name="${name}_suffix"]`, data.suffix);
+    }
   }
 });
 
@@ -286,13 +320,49 @@ Cypress.Commands.add('typeInFullName', (fieldName, data) => {
  * @param {typeInDate} callbackFunction - The callback that handles making the month & day selections and typing in the year
  */
 Cypress.Commands.add('typeInDate', (fieldName, dateString) => {
-  // Remove leading zeros
-  const date = dateString.split('-').map(v => parseInt(v, 10).toString());
-  const name = removeLeadingHash(fieldName);
-  cy.tabToElement(`#${name}Month`);
-  cy.chooseSelectOptionUsingValue(date[1]);
-  cy.tabToElement(`#${name}Day`);
-  cy.chooseSelectOptionUsingValue(date[2]);
-  cy.tabToElement(`input[name="${name}Year"]`);
-  cy.typeInFocused(date[0]);
+  if (dateString) {
+    const [year, month, day] = dateString
+      .split('-')
+      .map(v => parseInt(v, 10).toString());
+    const name = removeLeadingHash(fieldName);
+    cy.selectDropdownFromData(`[name="${name}Month"]`, month);
+    cy.selectDropdownFromData(`[name="${name}Day"]`, day);
+    cy.typeInIfDataExists(`[name="${name}Year"]`, year);
+  }
+});
+
+/**
+ * Address
+ * @typedef {Object}
+ * @property {String} country - Country
+ * @property {String} street - Street
+ * @property {String} street2 - Street 2
+ * @property {String} street3 - Street 3
+ * @property {String} city - City
+ * @property {String} state - State
+ * @property {String} postalCode - Postal Code
+ */
+/**
+ * @callback typeInAddress
+ * @param {String} fieldName - The group of elements ID prefix
+ * @param {Address} data - Address object
+ */
+/**
+ * This command will check if the data portion of the value is truthy, before tabbing to the name part. If found, it will then select or type in the address part
+ * @param {String} address - Name of the new command
+ * @param {typeInAddress} callbackFunction - The callback that handles moving the focus to an element and then select or type in the text
+ */
+Cypress.Commands.add('typeInAddress', (fieldName, data) => {
+  if (data) {
+    const name = removeLeadingHash(fieldName);
+    if (data.country) {
+      cy.selectDropdownFromData(`[name="${name}_country"]`, data.country);
+    }
+    cy.typeInIfDataExists(`[name="${name}_street"]`, data.street);
+    cy.typeInIfDataExists(`[name="${name}_street2"]`, data.street2);
+    cy.typeInIfDataExists(`[name="${name}_street3"]`, data.street3);
+    cy.typeInIfDataExists(`[name="${name}_city"]`, data.city);
+    cy.selectDropdownFromData(`[name="${name}_state"]`, data.state);
+    cy.typeInIfDataExists(`[name="${name}_postalCode"]`, data.postalCode);
+  }
 });

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -326,7 +326,10 @@ Cypress.Commands.add('typeInDate', (fieldName, dateString) => {
       .map(v => parseInt(v, 10).toString());
     const name = removeLeadingHash(fieldName);
     cy.selectDropdownFromData(`[name="${name}Month"]`, month);
-    cy.selectDropdownFromData(`[name="${name}Day"]`, day);
+    // eslint-disable-next-line no-restricted-globals
+    if (!isNaN(day)) {
+      cy.selectDropdownFromData(`[name="${name}Day"]`, day);
+    }
     cy.typeInIfDataExists(`[name="${name}Year"]`, year);
   }
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds new commands to Cypress to fill in an address pattern and select both radio inputs and select options using a keyboard. The PR also updates existing commands to be more consistent with selectors and utilize the added commands. 

## Related issue(s)

department-of-veterans-affairs/va.gov-team#100726

## What areas of the site does it impact?

This PR updates the COE keyboard only test to adjust a selector string.

## Acceptance criteria

- Commands utilize consistent selector patterns
- Commands can successfully handle input data

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution