### PR TITLE
Fix page title in Form Upload

### DIFF
--- a/src/applications/simple-forms/form-upload/containers/App.jsx
+++ b/src/applications/simple-forms/form-upload/containers/App.jsx
@@ -2,10 +2,14 @@ import React from 'react';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
+import { getFormContent } from '../helpers';
 
 const config = formConfig();
 
 const App = ({ location, children }) => {
+  const { formNumber } = getFormContent();
+  document.title = `Upload form ${formNumber}`;
+
   return (
     <RoutedSavableApp formConfig={config} currentLocation={location}>
       {children}


### PR DESCRIPTION
## Summary
This PR adds a `<title />` to the `<head />` of all Form Upload pages, to be in line with our requirements that it be dynamic.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=94053329&issue=department-of-veterans-affairs%7Cva.gov-team%7C101254
