### PR TITLE
Supply Reordering: Adds instructions for viewing test reports in dev

### DIFF
--- a/src/applications/mhv-supply-reordering/README.md
+++ b/src/applications/mhv-supply-reordering/README.md
@@ -36,6 +36,15 @@ Run Cypress from command line:
 - Run all `yarn cy:run --spec "src/applications/mhv-supply-reordering/**/**/*"`
 - Specify browser `-b electron`
 
+### Test coverage
+
+```bash
+$ yarn test:unit --app-folder mhv-supply-reordering --coverage --coverage-html
+$ cd ./coverage
+$ npx http-server
+$ open http://localhost:8080
+```
+
 ## VA Forms - Web Component Fields and Patterns
 
 [[docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-web-component-fields-and-patterns)]

--- a/src/applications/mhv-supply-reordering/components/SuppliesUnavailable.jsx
+++ b/src/applications/mhv-supply-reordering/components/SuppliesUnavailable.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { VaCard } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import DlcTelephoneLink from './DlcTelephoneLink';
 import { HEALTH_FACILITIES_URL } from '../constants';
 import { formatDate, sortSupplies } from '../utils/helpers';
@@ -8,7 +9,7 @@ import { formatDate, sortSupplies } from '../utils/helpers';
 const SuppliesUnavailable = ({ supplies = [] }) => {
   const cards = sortSupplies(supplies).map((supply, index) => (
     <div key={`mhv-supply-unavailable-${index}`}>
-      <va-card
+      <VaCard
         class={classNames({
           'mhv-c-reorder-unavail-card': true,
           'vads-u-margin-bottom--1p5': index < supplies.length - 1,
@@ -37,7 +38,7 @@ const SuppliesUnavailable = ({ supplies = [] }) => {
             .
           </p>
         )}
-      </va-card>
+      </VaCard>
     </div>
   ));
 

--- a/src/applications/mhv-supply-reordering/tests/components/Help.unit.spec.jsx
+++ b/src/applications/mhv-supply-reordering/tests/components/Help.unit.spec.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import Help from '../../components/Help';
+
+describe('<SuppliesAvailable />', () => {
+  it('renders', () => {
+    const { container } = render(<Help />);
+    expect(container.textContent).to.contain('Denver Logistics Center');
+  });
+});

--- a/src/applications/mhv-supply-reordering/tests/components/SuppliesAvailable.unit.spec.jsx
+++ b/src/applications/mhv-supply-reordering/tests/components/SuppliesAvailable.unit.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SuppliesAvailable from '../../components/SuppliesAvailable';
+
+const supplies = [
+  { productId: '1', productName: 'Product #1' },
+  { productId: '2', productName: 'Product #2' },
+];
+
+const setup = (props = {}) => render(<SuppliesAvailable {...props} />);
+
+describe('<SuppliesAvailable />', () => {
+  it('renders', () => {
+    const { container } = setup({ supplies });
+    expect(container).to.not.be.empty;
+  });
+});

--- a/src/applications/mhv-supply-reordering/tests/components/SuppliesUnavailable.unit.spec.jsx
+++ b/src/applications/mhv-supply-reordering/tests/components/SuppliesUnavailable.unit.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SuppliesUnavailable from '../../components/SuppliesUnavailable';
+
+const supplyAccessory = {
+  productName: 'Widget thing',
+  deviceName: 'Widget consumer',
+  productGroup: 'Accessory',
+  productId: 6584,
+  availableForReorder: false,
+  lastOrderDate: '2022-05-16',
+  nextAvailabilityDate: '2022-10-16',
+  quantity: 5,
+};
+
+const setup = (props = {}) => render(<SuppliesUnavailable {...props} />);
+
+describe('<SuppliesUnavailable />', () => {
+  it('renders', () => {
+    const { container } = setup({ supplies: [supplyAccessory] });
+    expect(container).to.not.be.empty;
+  });
+});

--- a/src/applications/mhv-supply-reordering/tests/components/UnsavedFieldNote.unit.spec.jsx
+++ b/src/applications/mhv-supply-reordering/tests/components/UnsavedFieldNote.unit.spec.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import UnsavedFieldNote from '../../components/UnsavedFieldNote';
+
+const setup = (props = {}) => render(<UnsavedFieldNote {...props} />);
+
+describe('<UnsavedFieldNote />', () => {
+  it('renders', () => {
+    const { container } = setup({ fieldName: 'location' });
+    const note = 'Any updates you make to your location';
+    expect(container.textContent).to.contain(note);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds instructions for viewing mocha test reports in local development
- Adds more unit specs to boost test coverage
