### PR TITLE
Use uploadedFile prop instead of saving file locally for form upload

### DIFF
--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -40,7 +40,7 @@ const CustomReviewTopContent = () => {
           <div className="vads-u-display--flex vads-u-flex-direction--column">
             <span
               className="vads-u-font-weight--bold"
-              style={{ wordBreak: 'break-all' }}
+              style={{ 'word-break': 'break-all' }}
             >
               {file.name}
             </span>

--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -40,7 +40,7 @@ const CustomReviewTopContent = () => {
           <div className="vads-u-display--flex vads-u-flex-direction--column">
             <span
               className="vads-u-font-weight--bold"
-              style={{ 'word-break': 'break-all' }}
+              style={{ wordBreak: 'break-all' }}
             >
               {file.name}
             </span>

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
@@ -5,8 +5,6 @@ import PropTypes from 'prop-types';
 import vaFileInputFieldMapping from './vaFileInputFieldMapping';
 import { getFileSize, uploadScannedForm } from './vaFileInputFieldHelpers';
 
-let file = null;
-
 /**
  * Usage uiSchema:
  * ```
@@ -54,7 +52,6 @@ const VaFileInputField = props => {
         errorMessage,
       } = uploadedFile;
       setError(errorMessage);
-      file = uploadedFile.file;
       props.childrenProps.onChange({
         confirmationCode,
         isEncrypted,
@@ -68,17 +65,8 @@ const VaFileInputField = props => {
   const handleVaChange = e => {
     const fileFromEvent = e.detail.files[0];
     if (!fileFromEvent) {
-      file = null;
       setError(mappedProps.error);
       props.childrenProps.onChange({});
-      return;
-    }
-
-    if (
-      file?.lastModified === fileFromEvent.lastModified &&
-      file?.size === fileFromEvent.size
-    ) {
-      // This guard clause protects against infinite looping/updating if the localFile and fileFromEvent are identical
       return;
     }
 
@@ -104,7 +92,7 @@ const VaFileInputField = props => {
     <VaFileInput
       {...mappedProps}
       error={error}
-      value={file}
+      uploadedFile={mappedProps.uploadedFile}
       onVaChange={handleVaChange}
     />
   );

--- a/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldHelpers.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldHelpers.jsx
@@ -46,3 +46,5 @@ export const getFileSize = num => {
   }
   return `${num} B`;
 };
+
+export const allKeysAreEmpty = obj => Object.keys(obj).every(key => !obj[key]);

--- a/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldMapping.jsx
@@ -1,5 +1,6 @@
 import commonFieldMapping from './commonFieldMapping';
 import formsPatternFieldMapping from './formsPatternFieldMapping';
+import { allKeysAreEmpty } from './vaFileInputFieldHelpers';
 
 /** @param {WebComponentFieldProps} props */
 const vaFileInputFieldMapping = props => {
@@ -18,6 +19,9 @@ const vaFileInputFieldMapping = props => {
       commonFieldProps.messageAriaDescribedby || textDescription || undefined,
     name,
     onBlur: () => childrenProps.onBlur(childrenProps.idSchema.$id),
+    uploadedFile: allKeysAreEmpty(childrenProps.formData)
+      ? null
+      : childrenProps.formData,
   };
 };
 


### PR DESCRIPTION
## Summary
This PR uses the new `uploadedFile` prop in `va-file-input` instead of our hacky workaround of saving the file to the browser.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=95703397&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1989
