### PR TITLE
Facility Locator: remove flippers that came back due to merge conflicts

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -72,8 +72,6 @@
   "facilitiesPpmsSuppressAll": "facilities_ppms_suppress_all",
   "facilitiesPpmsSuppressPharmacies": "facilities_ppms_suppress_pharmacies",
   "facilityLocatorPredictiveLocationSearch": "facility_locator_predictive_location_search",
-  "facilityLocatorShowCommunityCares": "facility_locator_show_community_cares",
-  "facilityLocatorShowOperationalHoursSpecialInstructions": "facility_locator_show_operational_hours_special_instructions",
   "fileUploadShortWorkflowEnabled": "file_upload_short_workflow_enabled",
   "financialStatusReportDebtsApiModule": "financial_status_report_debts_api_module",
   "financialStatusReportExpensesUpdate": "financial_status_report_expenses_update",


### PR DESCRIPTION
## Summary

`facility_locator_show_community_cares` and `facility_locator_show_operational_hours_special_instructions` should have been removed in previous PRs but due to merge conflicts of trying to get 7-8 flipper PRs through, the actual flipper removals ended up getting removed from the diffs.

- PR for `facility_locator_show_community_cares`: https://github.com/department-of-veterans-affairs/vets-website/pull/34251/files
- PR for `facility_locator_show_operational_hours_special_instructions`: https://github.com/department-of-veterans-affairs/vets-website/pull/34255/files

The code that uses these flippers has already been removed and merged; this is all that's left.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14112
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20290