### PR TITLE
MHV-64553 Audit: Update PDF and TXT for Health Conditions

### DIFF
--- a/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
@@ -95,7 +95,7 @@ const ConditionDetails = props => {
 
   const generateConditionDetailsPdf = async () => {
     setDownloadStarted(true);
-    const title = `Health conditions: ${record.name}`;
+    const title = `${record.name}`;
     const subject = 'VA Medical Record';
     const scaffold = generatePdfScaffold(user, title, subject);
     const pdfData = { ...scaffold, ...generateConditionContent(record) };
@@ -111,8 +111,8 @@ ${record.name} \n
 ${formatNameFirstLast(user.userFullName)}\n
 Date of birth: ${formatUserDob(user)}\n
 ${reportGeneratedBy}\n
-Date entered: ${record.date}\n
 ${txtLine}\n
+Date entered: ${record.date}\n
 Provider: ${record.provider}\n
 Location: ${record.facility}\n
 Provider Notes: ${processList(record.comments)}\n`;

--- a/src/applications/mhv-medical-records/util/pdfHelpers/conditions.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/conditions.js
@@ -21,6 +21,12 @@ export const generateConditionContent = record => ({
         value: record.comments,
         inline: true,
       },
+      {
+        title: 'About the code in this condition name',
+        value:
+          'Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.',
+        inline: false,
+      },
     ],
   },
 });


### PR DESCRIPTION
## Summary

- PDF and TXT for Care Summary and Notes (Consult Note) [audit](https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1685987646356/dde9adf5fd24b6e5d2431a77cb13ea15bf4b6cab). 
  - Removed "Care summaries and notes" from TXT.
  - Changed field to "date entered" for PDF. 
- This is not a bug.
- Updated the JSX and already existing functions. 
 
- MHV Medical Records.

## Related issue(s)
### [MHV-64554](https://jira.devops.va.gov/browse/MHV-64554) Audit update vitals list page ###
![Screenshot 2025-01-29 at 5 29 33 PM](https://github.com/user-attachments/assets/069341aa-1ec1-48ad-ada6-eee516ec5cda)

## Screenshot
![Screenshot 2025-01-29 at 4 40 48 PM](https://github.com/user-attachments/assets/62b39b14-d171-44d6-a53d-26e586a53e24)
![Screenshot 2025-01-29 at 4 23 41 PM](https://github.com/user-attachments/assets/b326ee1f-727f-40d7-b764-332f9d132cb1)


## Testing done

-  Tests are passing.

## What areas of the site does it impact?
MHV Medical Records
