### PR TITLE
[SIMPLE-FORMS] fix: update statement type page styling to match mockups

### DIFF
--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -56,7 +56,8 @@ export const STATEMENT_TYPES = Object.freeze({
 });
 
 export const STATEMENT_TYPE_LABELS = Object.freeze({
-  [STATEMENT_TYPES.NEW_EVIDENCE]: 'I have new evidence to submit.',
+  [STATEMENT_TYPES.NEW_EVIDENCE]:
+    'I have new evidence to submit for an open claim.',
   [STATEMENT_TYPES.DECISION_REVIEW]:
     "I disagree with VA's decision on my benefit or claim, and I'd like to request a decision review.",
   [STATEMENT_TYPES.BUDDY_STATEMENT]:
@@ -78,6 +79,12 @@ export const STATEMENT_TYPE_DESCRIPTIONS = Object.freeze({
   [STATEMENT_TYPES.PERSONAL_RECORDS]:
     'You can request your DD214, benefit records, and more.',
   [STATEMENT_TYPES.NOT_LISTED]: '',
+});
+
+export const STATEMENT_TYPE_PAGE = Object.freeze({
+  title: 'What would you like to do?',
+  description:
+    "We’ve improved how we process certain types of statements and requests. Before you continue with VA Form 21-4138, tell us what you’re trying to do and we'll check if there's a quicker way to help you.",
 });
 
 export const DECISION_REVIEW_TYPES = Object.freeze({

--- a/src/applications/simple-forms/21-4138/pages/statementType.js
+++ b/src/applications/simple-forms/21-4138/pages/statementType.js
@@ -24,7 +24,6 @@ export const statementTypePage = {
         errorMessages: {
           required: "Select the kind of statement you'd like to submit",
         },
-        labelHeaderLevel: 'p',
       }),
     },
     'view:additionalInfoStatementType': { 'ui:description': ESCAPE_HATCH },

--- a/src/applications/simple-forms/21-4138/pages/statementType.js
+++ b/src/applications/simple-forms/21-4138/pages/statementType.js
@@ -1,4 +1,5 @@
 import {
+  titleUI,
   radioUI,
   radioSchema,
 } from '~/platform/forms-system/src/js/web-component-patterns';
@@ -7,38 +8,32 @@ import {
   STATEMENT_TYPES,
   STATEMENT_TYPE_LABELS,
   STATEMENT_TYPE_DESCRIPTIONS,
+  STATEMENT_TYPE_PAGE,
 } from '../config/constants';
 
 /** @type {PageSchema} */
 export const statementTypePage = {
   uiSchema: {
+    ...titleUI(STATEMENT_TYPE_PAGE.title, STATEMENT_TYPE_PAGE.description),
     statementType: {
       ...radioUI({
-        title: 'What would you like to do?',
-        description:
-          "We’ve improved how we process certain types of statements and requests. Before you continue with VA Form 21-4138, tell us what you’re trying to do and we'll check if there's a quicker way to help you.",
-        label: 'Select the option that describes what you want to do',
+        title: 'Select the option that describes what you want to do',
         labels: STATEMENT_TYPE_LABELS,
         descriptions: STATEMENT_TYPE_DESCRIPTIONS,
         tile: true,
         errorMessages: {
           required: "Select the kind of statement you'd like to submit",
         },
-        labelHeaderLevel: '1',
+        labelHeaderLevel: 'p',
       }),
     },
-    'view:additionalInfoStatementType': {
-      'ui:description': ESCAPE_HATCH,
-    },
+    'view:additionalInfoStatementType': { 'ui:description': ESCAPE_HATCH },
   },
   schema: {
     type: 'object',
     properties: {
       statementType: radioSchema(Object.values(STATEMENT_TYPES)),
-      'view:additionalInfoStatementType': {
-        type: 'object',
-        properties: {},
-      },
+      'view:additionalInfoStatementType': { type: 'object', properties: {} },
     },
     required: ['statementType'],
   },


### PR DESCRIPTION
## Summary

- This work updates the statement type page for form 4138 to display the radio group label correctly and updates the wording of one of the options presented to the user.
- I work for the Veteran Facing Forms team

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1640

## Testing done

- Browser testing successful
- Unit tests pass
- E2E tests pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2025-01-31 at 10 20 12 AM](https://github.com/user-attachments/assets/4c0f1c5c-6092-4365-b027-601d6725eca5) | ![Screenshot 2025-01-31 at 10 19 32 AM](https://github.com/user-attachments/assets/67657a83-f8c2-4720-91e6-571a3ab4e69a) |

## Requested Feedback

Any