### PR TITLE
SC | Add white-space above finish application link

### DIFF
--- a/src/applications/appeals/995/components/ITFBanner.jsx
+++ b/src/applications/appeals/995/components/ITFBanner.jsx
@@ -82,7 +82,9 @@ const ITFBanner = props => {
     <div className="itf-inner vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
       <div className="usa-content">
         {message}
-        <div className="vads-u-margin-top--2">{itfExpander}</div>
+        <div className="vads-u-margin-top--2 vads-u-padding-bottom--2">
+          {itfExpander}
+        </div>
         <VaButtonPair
           class="vads-u-margin-top--2"
           continue

--- a/src/applications/appeals/995/components/PrimaryPhone.jsx
+++ b/src/applications/appeals/995/components/PrimaryPhone.jsx
@@ -90,7 +90,7 @@ export const PrimaryPhone = ({
       <form onSubmit={handlers.onSubmit}>
         <div name="topScrollElement" />
         <VaRadio
-          class="vads-u-margin-y--2"
+          class="vads-u-margin-top--2 vads-u-margin-bottom--4"
           label={content.label}
           label-header-level={onReviewPage ? 4 : 3}
           hint="We may need to contact you if we have questions about your Supplemental Claim."

--- a/src/applications/appeals/995/content/evidencePrivateLimitation.js
+++ b/src/applications/appeals/995/content/evidencePrivateLimitation.js
@@ -7,7 +7,10 @@ export const content = {
     'If you want to limit what we can request from your non-VA medical provider(s), describe the limitation (for example, you want your doctor to release only treatment dates or certain types of disabilities)',
 
   info: (
-    <va-additional-info trigger="What does &quot;limiting consent&quot; mean?">
+    <va-additional-info
+      class="vads-u-margin-bottom--4"
+      trigger="What does &quot;limiting consent&quot; mean?"
+    >
       <p>
         If you choose to limit consent, you’re limiting the type or amount of
         information that your doctor or medical facility can release to us. It

--- a/src/applications/appeals/995/content/evidenceWillUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceWillUpload.jsx
@@ -6,7 +6,7 @@ export const evidenceWillUploadTitle =
 export const evidenceWillUploadInfo = (
   <va-additional-info
     trigger="Types of supporting evidence"
-    class="vads-u-margin-top--2"
+    class="vads-u-margin-top--2 vads-u-margin-bottom--4"
     uswds
   >
     <div>

--- a/src/applications/appeals/995/content/livingSituation.jsx
+++ b/src/applications/appeals/995/content/livingSituation.jsx
@@ -81,7 +81,7 @@ livingSituationReviewField.propTypes = {
 export const domesticViolenceInfo = (
   <va-additional-info
     trigger="Are you experiencing domestic violence?"
-    class="vads-u-margin-bottom--4"
+    class="vads-u-margin-y--4"
   >
     If you need help because of domestic violence, call the National Domestic
     Violence hotline <va-telephone contact="8007997233" /> (

--- a/src/applications/appeals/995/content/optIn.jsx
+++ b/src/applications/appeals/995/content/optIn.jsx
@@ -17,7 +17,7 @@ export const content = {
         appeals process for the issues you have selected. You’re likely to get a
         faster decision on your claim when you switch to the new process.
       </p>
-      <p>
+      <p className="vads-u-margin-bottom--4">
         If you want to continue your claim in the old appeals process, don’t
         submit a Supplemental Claim. Check your decision notice for more details
         about the appeals process.

--- a/src/applications/appeals/995/content/optionForMst.jsx
+++ b/src/applications/appeals/995/content/optionForMst.jsx
@@ -7,7 +7,10 @@ export const optionForMstHint =
   'This option is for an indicator on your health record and will not affect the status or decision for your claim.';
 
 export const supportInfo = (
-  <va-additional-info trigger="How can I find support?">
+  <va-additional-info
+    trigger="How can I find support?"
+    class="vads-u-margin-bottom--4"
+  >
     <div>
       <p className="vads-u-margin-top--0">
         <va-link

--- a/src/applications/appeals/995/pages/evidencePrivateLimitation.js
+++ b/src/applications/appeals/995/pages/evidencePrivateLimitation.js
@@ -8,6 +8,7 @@ export default {
       title: content.textAreaTitle,
       hint: content.textAreaHint,
       labelHeaderLevel: 3,
+      classNames: 'vads-u-margin-bottom--4',
       required: () => true,
       errorMessages: {
         required: content.errorMessage,

--- a/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
+++ b/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
@@ -19,6 +19,7 @@ export default {
     [EVIDENCE_VA]: yesNoUI({
       title: requestVaRecordsTitleOld,
       enableAnalytics: true,
+      classNames: 'vads-u-margin-bottom--4',
       labelHeaderLevel: '3',
       labels: {
         Y: 'Yes',

--- a/src/applications/appeals/995/pages/facilityTypes.js
+++ b/src/applications/appeals/995/pages/facilityTypes.js
@@ -22,6 +22,7 @@ export default {
       ...checkboxGroupUI({
         title: facilityTypeTitle,
         enableAnalytics: true,
+        classNames: 'vads-u-margin-bottom--6',
         required: true,
         labelHeaderLevel: '3',
         labels: facilityTypeChoices,

--- a/src/applications/appeals/995/pages/housingRisk.js
+++ b/src/applications/appeals/995/pages/housingRisk.js
@@ -11,6 +11,7 @@ export default {
   uiSchema: {
     housingRisk: yesNoUI({
       title: housingRiskTitle,
+      classNames: 'vads-u-margin-bottom--4',
       enableAnalytics: true,
       labelHeaderLevel: '3',
       labels: {

--- a/src/applications/appeals/995/pages/optionIndicator.js
+++ b/src/applications/appeals/995/pages/optionIndicator.js
@@ -22,6 +22,7 @@ export default {
       ...radioUI({
         title: optionIndicatorLabel,
         hint: optionIndicatorHint,
+        classNames: 'vads-u-margin-bottom--4',
         enableAnalytics: true,
         labelHeaderLevel: '3',
         labels: optionIndicatorChoices,

--- a/src/applications/appeals/995/pages/pointOfContact.js
+++ b/src/applications/appeals/995/pages/pointOfContact.js
@@ -17,7 +17,10 @@ export default {
       'ui:description': pointOfContactTitle,
     },
     pointOfContactName: textUI(pointOfContactNameLabel),
-    pointOfContactPhone: phoneUI(pointOfContactPhoneLabel),
+    pointOfContactPhone: phoneUI({
+      title: pointOfContactPhoneLabel,
+      classNames: 'vads-u-margin-bottom--4',
+    }),
   },
   schema: {
     type: 'object',

--- a/src/applications/appeals/shared/components/AddIssue.jsx
+++ b/src/applications/appeals/shared/components/AddIssue.jsx
@@ -180,6 +180,7 @@ const AddIssue = ({
         <VaTextInput
           id="issue-name"
           name="issue-name"
+          class="vads-u-margin-bottom--4"
           type="text"
           label={content.name.label}
           required
@@ -188,12 +189,9 @@ const AddIssue = ({
           onBlur={handlers.onInputBlur}
           error={((submitted || inputDirty) && showIssueNameError) || null}
           message-aria-describedby={content.name.hintText}
-          uswds
         >
           {content.name.hint}
         </VaTextInput>
-
-        <br role="presentation" />
 
         <VaMemorableDate
           name="decision-date"
@@ -211,7 +209,7 @@ const AddIssue = ({
           month-select={false}
           uswds
         />
-        <p>
+        <p className="vads-u-margin-top--6">
           <va-button
             id="cancel"
             secondary

--- a/src/applications/appeals/shared/components/FileField.jsx
+++ b/src/applications/appeals/shared/components/FileField.jsx
@@ -644,7 +644,9 @@ const FileField = props => {
       showButtons && (
         <div
           id="upload-wrap"
-          className={showUpload ? '' : 'vads-u-display--none'}
+          className={
+            showUpload ? 'vads-u-margin-bottom--2' : 'vads-u-display--none'
+          }
         >
           {/* eslint-disable jsx-a11y/label-has-associated-control */}
           <label

--- a/src/applications/appeals/shared/components/VeteranInformation.jsx
+++ b/src/applications/appeals/shared/components/VeteranInformation.jsx
@@ -88,9 +88,7 @@ const VeteranInformation = ({ formData }) => {
         </p>
       </div>
 
-      <br role="presentation" />
-
-      <p>
+      <p className="vads-u-margin-top--2 vads-u-margin-bottom--4">
         <strong>Note:</strong> If you need to update your personal information,
         you can call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />.
         We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.{' '}

--- a/src/applications/appeals/shared/content/contestableIssues.jsx
+++ b/src/applications/appeals/shared/content/contestableIssues.jsx
@@ -171,7 +171,10 @@ NoneSelectedAlert.propTypes = {
 };
 
 export const ContestableIssuesAdditionalInfo = (
-  <va-additional-info trigger="Why isn’t my issue listed here?" uswds>
+  <va-additional-info
+    trigger="Why isn’t my issue listed here?"
+    class="vads-u-margin-top--3 vads-u-margin-bottom--4"
+  >
     If you don’t see your issue or decision listed here, it may not be in our
     system yet. This can happen if it’s a more recent claim decision. If you
     have a decision date, you can add a new issue now.


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Increasing white space above the "Finish this application later" link on many pages within the Supplemental Claim flow. 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/102199

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Visual tests & screenshots
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| ITF | <img width="350" alt="itf-before" src="https://github.com/user-attachments/assets/04cf298e-ea88-464f-b7e1-37414958abfc" /> | <img width="336" alt="itf-after" src="https://github.com/user-attachments/assets/5635ba46-cb8d-4989-94b8-f2afec4f7a86" /> |
| Veteran info | <img width="568" alt="vet-info-before" src="https://github.com/user-attachments/assets/69ee8f11-56f4-45e1-83fd-e1776270bc20" /> | <img width="594" alt="vet-info-after" src="https://github.com/user-attachments/assets/98c6b078-9a9d-43fc-b02d-0384a3081018" /> |
| primary phone | <img width="528" alt="primary-phone-before" src="https://github.com/user-attachments/assets/b8e1b3ee-46a1-4475-a65c-03bdd8a4926b" /> | <img width="508" alt="primary-phone-after" src="https://github.com/user-attachments/assets/8e735bfd-de49-493a-8d43-350bb1481ebf" /> |
| homeless risk | <img width="527" alt="homeless-risk-before" src="https://github.com/user-attachments/assets/adc7d1a1-872d-47be-83dd-80a127f98cc0" /> | <img width="503" alt="homeless-risk-after" src="https://github.com/user-attachments/assets/fa90cae0-704c-49ac-a088-6c5e490b905b" /> |
| living situation | <img width="435" alt="living-situation-before" src="https://github.com/user-attachments/assets/76dee172-d063-4052-b70f-54f5bdbb46f1" /> | <img width="443" alt="living-situation-after" src="https://github.com/user-attachments/assets/8c89c563-bfdb-46f7-9324-9186bf6745a0" /> |
| point of contact | <img width="529" alt="point-of-contact-before" src="https://github.com/user-attachments/assets/26b1a932-df15-4bd3-9315-3d8d0dd66e68" /> | <img width="534" alt="point-of-contact-after" src="https://github.com/user-attachments/assets/2542ef8a-9004-4d63-8715-5d0fa3569b7d" /> |
| contestable issues | <img width="580" alt="contestable-issues-before" src="https://github.com/user-attachments/assets/731e7e53-3a37-4417-98d1-fd065055773b" /> | <img width="572" alt="contestable-issues-after" src="https://github.com/user-attachments/assets/f6a3a10f-f91d-4842-918b-e3a235aeb753" /> |
| add issue | <img width="556" alt="add-issue-before" src="https://github.com/user-attachments/assets/2a806773-6f76-4316-8c92-eaa95501e6b9" /> | <img width="545" alt="add-issue-after" src="https://github.com/user-attachments/assets/e381d402-e890-4f8e-88a7-0d1df5f139fc" /> |
| opt in | <img width="575" alt="opt-in-before" src="https://github.com/user-attachments/assets/d0972db9-cb84-4c4a-af84-c3c230bca734" /> | <img width="573" alt="opt-in-after" src="https://github.com/user-attachments/assets/2c48be6b-82a3-4d46-bdf8-7d056f11efb9" /> |
| facility type | <img width="536" alt="facility-type-before" src="https://github.com/user-attachments/assets/9e9d392d-19db-4e8d-801b-630846088d56" /> | <img width="525" alt="facility-type-after" src="https://github.com/user-attachments/assets/f69658f1-b6dc-49d7-9b7d-40e7ba38a2aa" /> |
| VA evidence request | <img width="533" alt="va-request-before" src="https://github.com/user-attachments/assets/5ad2b817-1f74-494d-b680-cf17ec32fbed" /> | <img width="541" alt="va-request-after" src="https://github.com/user-attachments/assets/c0e2c970-1037-43c3-8dbb-0ad49c60d924" /> |
| limit consent | <img width="553" alt="limit-consent-before" src="https://github.com/user-attachments/assets/a14b72ae-d137-4269-b7d9-11a4544a58b1" /> | <img width="534" alt="limit-consent-after" src="https://github.com/user-attachments/assets/e70318dc-67b2-4b98-a84f-7e8b547dd50e" /> |
| limitation reason | <img width="549" alt="limitation-before" src="https://github.com/user-attachments/assets/1d0baac9-e2b6-4581-af86-34701e8aae56" /> | <img width="535" alt="limitation-after" src="https://github.com/user-attachments/assets/486532f1-1298-4bae-8f50-72fc7ed2e427" /> |
| upload yes or no | <img width="532" alt="will-upload-before" src="https://github.com/user-attachments/assets/1fdf2890-384f-4480-9a40-564a53dce793" /> | <img width="536" alt="will-upload-after" src="https://github.com/user-attachments/assets/91c20835-9854-492a-beec-6452daf50a46" /> |
| upload | <img width="543" alt="upload-before" src="https://github.com/user-attachments/assets/dd06ca98-94fb-4ee6-929f-a00902a954f9" /> | <img width="529" alt="upload-after" src="https://github.com/user-attachments/assets/04a02730-80a2-454d-a9f7-b89ac1cf3814" /> |
| option claims | <img width="552" alt="option-claims-before" src="https://github.com/user-attachments/assets/2f5fc5d7-ec97-474f-b893-5edba530479c" /> | <img width="540" alt="option-claims-after" src="https://github.com/user-attachments/assets/06d331c6-d718-4bf9-8aa4-240ce9561803" /> |
| option indicator | <img width="534" alt="option-indicator-before" src="https://github.com/user-attachments/assets/3a8dda7c-33a3-4d75-8012-5a9b519c7c44" /> | <img width="528" alt="option-indicator-after" src="https://github.com/user-attachments/assets/fcd1029d-9d1f-4b20-baa0-239fe31d7865" /> |

## What areas of the site does it impact?

Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

