### PR TITLE
MHV-66892 RUM logging for loading spinner

### DIFF
--- a/src/applications/mhv-medical-records/actions/common.js
+++ b/src/applications/mhv-medical-records/actions/common.js
@@ -84,13 +84,13 @@ export const getListWithRetry = async (
       status = STATUS_SUCCESS;
     }
     return response;
-  } catch (e) {
+  } catch (error) {
     if (error.message === TIMEOUT_ERROR) {
       status = STATUS_TIMEDOUT;
     } else {
       status = STATUS_ERROR;
     }
-    throw e;
+    throw error;
   } finally {
     const totalDuration = Math.round((Date.now() - startTime) / 1000);
     datadogRum.addAction(rumActions.INITIAL_FHIR_LOAD_DURATION, {

--- a/src/applications/mhv-medical-records/actions/common.js
+++ b/src/applications/mhv-medical-records/actions/common.js
@@ -1,7 +1,14 @@
+import { datadogRum } from '@datadog/browser-rum';
 import { Actions } from '../util/actionTypes';
 import { INITIAL_FHIR_LOAD_DURATION } from '../util/constants';
+import * as rumActions from '../util/rumConstants';
 
 const defaultRetryInterval = 2000;
+
+const TIMEOUT_ERROR = 'Timed out while waiting for response';
+const STATUS_SUCCESS = 'success';
+const STATUS_ERROR = 'error';
+const STATUS_TIMEDOUT = 'timedout';
 
 /**
  * Helper function to create a delay
@@ -31,7 +38,7 @@ export const getListWithRetryRecursively = async (
     endTimeParam === null ? now + INITIAL_FHIR_LOAD_DURATION : endTimeParam;
 
   if (now >= endTime) {
-    throw new Error('Timed out while waiting for response');
+    throw new Error(TIMEOUT_ERROR);
   }
 
   let response = await getList();
@@ -52,8 +59,8 @@ export const getListWithRetryRecursively = async (
 };
 
 /**
- * Wrapper for getListWithRetryRecursively(). Its sole function is to make sure the
- * CLEAR_INITIAL_FHIR_LOAD action is called only once.
+ * Wrapper for getListWithRetryRecursively(). Its function is to make sure the
+ * CLEAR_INITIAL_FHIR_LOAD action is called only once, as well as handle logging.
  */
 export const getListWithRetry = async (
   dispatch,
@@ -61,16 +68,34 @@ export const getListWithRetry = async (
   retryInterval = defaultRetryInterval,
   endTimeParam = null,
 ) => {
-  const response = await getListWithRetryRecursively(
-    dispatch,
-    getList,
-    retryInterval,
-    endTimeParam,
-  );
-  if (response?.id) {
-    // All successful FHIR calls should have an id, so this indicates a successful response, and we
-    // clear the initialFhirLoad.
-    dispatch({ type: Actions.Refresh.CLEAR_INITIAL_FHIR_LOAD });
+  const startTime = Date.now();
+  let status = null;
+  try {
+    const response = await getListWithRetryRecursively(
+      dispatch,
+      getList,
+      retryInterval,
+      endTimeParam,
+    );
+    if (response?.id) {
+      // All successful FHIR calls should have an id, so this indicates a successful response, and we
+      // clear the initialFhirLoad.
+      dispatch({ type: Actions.Refresh.CLEAR_INITIAL_FHIR_LOAD });
+      status = STATUS_SUCCESS;
+    }
+    return response;
+  } catch (e) {
+    if (error.message === TIMEOUT_ERROR) {
+      status = STATUS_TIMEDOUT;
+    } else {
+      status = STATUS_ERROR;
+    }
+    throw e;
+  } finally {
+    const totalDuration = Math.round((Date.now() - startTime) / 1000);
+    datadogRum.addAction(rumActions.INITIAL_FHIR_LOAD_DURATION, {
+      duration: totalDuration,
+      status,
+    });
   }
-  return response;
 };

--- a/src/applications/mhv-medical-records/util/rumConstants.js
+++ b/src/applications/mhv-medical-records/util/rumConstants.js
@@ -1,0 +1,1 @@
+export const INITIAL_FHIR_LOAD_DURATION = 'initial_fhir_polling_duration';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added some DD RUM logging around the Initial FHIR Load experience.

## Related issue(s)

### [MHV-66892](https://jira.devops.va.gov/browse/MHV-66892) - ###

> We need to track behavior around the "2 minute spinner" as some users are reporting that it spins indefinitely. Add logging to help diagnose the general behavior, as well as when issues happen.


## Testing done

- Added logging so test will be to pull the new actions into a chart in Datadog.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
