### PR TITLE
MHV-66893 Vital-Print-View-Content-Needs-To-be-Updated-To-Match-With-Download-PDF-And-TXT-File

### DIFF
--- a/src/applications/mhv-medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VitalDetails.jsx
@@ -228,11 +228,11 @@ const VitalDetails = props => {
   const generateVitalsPdf = async () => {
     setDownloadStarted(true);
 
-    const { subject, subtitles } = generateVitalsIntro(
+    const { title, subject, subtitles } = generateVitalsIntro(
       records,
       lastUpdatedText,
     );
-    const scaffold = generatePdfScaffold(user, subject);
+    const scaffold = generatePdfScaffold(user, title, subject);
     const pdfData = {
       ...scaffold,
       subtitles,
@@ -388,7 +388,7 @@ Provider notes: ${vital.notes}\n\n`,
           data-dd-privacy="mask"
           data-dd-action-name="[vitals detail - name - Print]"
         >
-          Vitals: {vitalTypeDisplayNames[records[0].type]}
+          {vitalTypeDisplayNames[records[0].type]}
         </h1>
         <ul className="vital-records-list vads-u-margin--0 vads-u-padding--0 print-only">
           {records?.length > 0 &&

--- a/src/applications/mhv-medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VitalDetails.jsx
@@ -228,11 +228,11 @@ const VitalDetails = props => {
   const generateVitalsPdf = async () => {
     setDownloadStarted(true);
 
-    const { title, subject, subtitles } = generateVitalsIntro(
+    const { subject, subtitles } = generateVitalsIntro(
       records,
       lastUpdatedText,
     );
-    const scaffold = generatePdfScaffold(user, title, subject);
+    const scaffold = generatePdfScaffold(user, subject);
     const pdfData = {
       ...scaffold,
       subtitles,
@@ -250,7 +250,7 @@ ${vitalTypeDisplayNames[records[0].type]}\n
 ${formatNameFirstLast(user.userFullName)}\n
 Date of birth: ${formatUserDob(user)}\n
 ${reportGeneratedBy}\n
-Showing ${records.length} from newest to oldest
+Showing ${records.length} records from newest to oldest
 ${records
       .map(
         vital => `${txtLine}\n\n

--- a/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
@@ -43,7 +43,7 @@ describe('Vital details container', () => {
       selector: 'h1',
     });
 
-    expect(vitalNames).to.have.lengthOf(1);
+    expect(vitalNames).to.have.lengthOf(2);
   });
 
   it('displays a print button', () => {

--- a/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/VitalDetails.unit.spec.jsx
@@ -38,11 +38,12 @@ describe('Vital details container', () => {
   });
 
   it('displays the vital name inside an h1 as a span', () => {
-    const vitalName = screen.getByText('Blood pressure', {
+    const vitalNames = screen.getAllByText('Blood pressure', {
       exact: true,
       selector: 'h1',
     });
-    expect(vitalName).to.exist;
+
+    expect(vitalNames).to.have.lengthOf(1);
   });
 
   it('displays a print button', () => {

--- a/src/applications/mhv-medical-records/util/pdfHelpers/vitals.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/vitals.js
@@ -2,7 +2,7 @@ import { vitalTypeDisplayNames } from '../constants';
 
 export const generateVitalsIntro = (records, lastUpdated) => {
   return {
-    title: vitalTypeDisplayNames[records[0].type],
+    typeDisplayName: vitalTypeDisplayNames[records[0].type], // Assigning a key for display name
     subject: 'VA Medical Record',
     subtitles: [
       lastUpdated,

--- a/src/applications/mhv-medical-records/util/pdfHelpers/vitals.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/vitals.js
@@ -2,7 +2,7 @@ import { vitalTypeDisplayNames } from '../constants';
 
 export const generateVitalsIntro = (records, lastUpdated) => {
   return {
-    typeDisplayName: vitalTypeDisplayNames[records[0].type], // Assigning a key for display name
+    title: vitalTypeDisplayNames[records[0].type],
     subject: 'VA Medical Record',
     subtitles: [
       lastUpdated,


### PR DESCRIPTION
## Summary
Removed Prefix from TXT doc and added 'records' to the count string.

## Related issue(s)
[MHV-66889](https://jira.devops.va.gov/browse/MHV-66893) - Vital: Print view content needs to be updated to match with download pdf and txt file

Replace existing label/value pairs with the new LabelValue component. This has already been done for some existing domains. [See here for examples](https://github.com/department-of-veterans-affairs/vets-website/pull/33846/files).

## Testing done
Tested to verify that TXT document has prefix removed and "record" added to count string. 

## Screenshots
<img width="1512" alt="Screenshot 2025-01-31 at 12 22 25 PM" src="https://github.com/user-attachments/assets/69a4e9f7-9bf9-4a89-bce2-a35cd97dd344" />



## What areas of the site does it impact?
Vital PDF print view section in medical records. 

## Acceptance criteria
PDF and PDF print view match

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


