### PR TITLE
Add headingLevel attribute to mhv sign-in widget

### DIFF
--- a/src/applications/static-pages/mhv-signin-cta/README.md
+++ b/src/applications/static-pages/mhv-signin-cta/README.md
@@ -9,8 +9,7 @@ The default alert content matches the global versions of sign-in alerts that wil
   - Custom content is defined under a child element with the `static-widget-content` class (see sample in Template section below). This allows the static content maintainers to update or change the content as needed. 
   - If there is no content specified then simply nothing is displayed. This allows this widget to be used with or without content. 
   - For security, custom content HTML is sanitized before being displayed.
-- The default alert header level is `2`. To overwrite the header level, static content maintainers may include a different level on the `data-heading-level` attribute
-- Alert heading will include the service description when one is provided on the `data-service-description` attribute
+- The default alert header level is `3`. To overwrite the header level, static content maintainers may include a different value on the `data-heading-level` attribute
 
 ## Template for Static Pages
 The template follows the existing established [template defined in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/cb8e27a144d78ab2b6f7d378468b6d14da4fcb5e/src/platform/landing-pages/dev-template.ejs#L195) and already used in other static pages like the [secure messaging static page](https://staging.va.gov/health-care/secure-messaging/).

--- a/src/applications/static-pages/mhv-signin-cta/README.md
+++ b/src/applications/static-pages/mhv-signin-cta/README.md
@@ -9,12 +9,16 @@ The default alert content matches the global versions of sign-in alerts that wil
   - Custom content is defined under a child element with the `static-widget-content` class (see sample in Template section below). This allows the static content maintainers to update or change the content as needed. 
   - If there is no content specified then simply nothing is displayed. This allows this widget to be used with or without content. 
   - For security, custom content HTML is sanitized before being displayed.
+- The default alert header level is `2`. To overwrite the header level, static content maintainers may include a different level on the `data-heading-level` attribute
+- Alert heading will include the service description when one is provided on the `data-service-description` attribute
 
 ## Template for Static Pages
-The template follows the already stablished [template defined in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/cb8e27a144d78ab2b6f7d378468b6d14da4fcb5e/src/platform/landing-pages/dev-template.ejs#L195) and already used in other static pages like the [secure messaging static page](https://staging.va.gov/health-care/secure-messaging/). Here is a specific template example to use this new widget:
+The template follows the existing established [template defined in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/cb8e27a144d78ab2b6f7d378468b6d14da4fcb5e/src/platform/landing-pages/dev-template.ejs#L195) and already used in other static pages like the [secure messaging static page](https://staging.va.gov/health-care/secure-messaging/).
+
+Here is a specific template example to use this new widget:
 ```html
 <div data-template="paragraphs/react_widget" data-entity-id="13348" data-widget-type="mhv-signin-cta"
-  data-widget-timeout="20" data-service-description="order medical supplies">
+  data-widget-timeout="20" data-heading-level="4" data-service-description="order medical supplies">
   <div class="loading-indicator-container">
     <div aria-label="Loading..." aria-valuetext="Loading your application..." class="loading-indicator" role="progressbar">
     </div>

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/CustomAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/CustomAlert.jsx
@@ -41,14 +41,18 @@ const CustomAlert = ({
     'mhv-u-reg-alert-success': status === 'continue' || status === 'success',
     'mhv-u-reg-alert-info': status === 'info',
   });
-
+  const headerClasses = classNames(
+    'vads-u-margin-top--0',
+    'vads-u-margin-bottom--1',
+    headerLevel > 3 && 'vads-u-font-size--h3',
+  );
   const CustomHeaderLevel = `h${headerLevel}`;
 
   return (
     <div className={alertClasses} data-testid="mhv-custom-alert">
       <va-icon icon={icon} size={4} data-testid="mhv-custom-alert-icon" />
       <div className="mhv-u-reg-alert-col vads-u-flex-direction--col">
-        <CustomHeaderLevel className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+        <CustomHeaderLevel className={headerClasses}>
           {headline}
         </CustomHeaderLevel>
         <div className="mhv-u-reg-alert-body" role="presentation">

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/CustomAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/CustomAlert.jsx
@@ -16,7 +16,7 @@ import classNames from 'classnames';
  */
 const CustomAlert = ({
   children,
-  headerLevel = 2,
+  headerLevel = 3,
   headline,
   recordEvent,
   status = 'info',

--- a/src/applications/static-pages/mhv-signin-cta/createMhvSigninCTA.js
+++ b/src/applications/static-pages/mhv-signin-cta/createMhvSigninCTA.js
@@ -23,9 +23,11 @@ export default async function createMhvSigninCallToAction(store, widgetType) {
         'static-widget-content',
       )[0];
       const serviceDescription = el.getAttribute('data-service-description');
+      const headingLevel = el.getAttribute('data-heading-level');
       ReactDOM.render(
         <Provider store={store}>
           <MhvSigninCallToAction
+            headingLevel={headingLevel}
             serviceDescription={serviceDescription}
             noAlertContent={widgetContent}
           />

--- a/src/applications/static-pages/mhv-signin-cta/index.js
+++ b/src/applications/static-pages/mhv-signin-cta/index.js
@@ -13,20 +13,23 @@ import UnverifiedAlert from './components/messages/UnverifiedAlert';
 /**
  * MHV Signin CTA widget. This widget displays an alert if the user is not authenticated or verified.
  * Otherwise, it displays provided HTML content.
- * @property {number} headerLevel the heading level
  * @property {HTMLElement} noAlertContent optional content to display if no alerts are shown
  * @property {String} signInServiceName the signin service name is available
  * @property {bool} userIsLoggedIn true if the user is logged in
  * @property {bool} userIsVerified true if the user is verified
+ * @property {string} headingLevel the heading level
+ * @property {string} serviceDescription the heading service description
  */
 export const MhvSigninCallToAction = ({
-  headerLevel,
   noAlertContent,
+  headingLevel,
   serviceDescription,
   serviceName,
   userIsLoggedIn = false,
   userIsVerified = false,
 }) => {
+  const headerLevel = parseInt(headingLevel, 10) || 2;
+
   if (!userIsLoggedIn) {
     return (
       <UnauthenticatedAlert
@@ -58,7 +61,7 @@ export const MhvSigninCallToAction = ({
 };
 
 MhvSigninCallToAction.propTypes = {
-  headerLevel: PropTypes.number,
+  headingLevel: PropTypes.string,
   noAlertContent: PropTypes.instanceOf(HTMLElement),
   serviceDescription: PropTypes.string,
   serviceName: PropTypes.string,

--- a/src/applications/static-pages/mhv-signin-cta/index.js
+++ b/src/applications/static-pages/mhv-signin-cta/index.js
@@ -28,7 +28,7 @@ export const MhvSigninCallToAction = ({
   userIsLoggedIn = false,
   userIsVerified = false,
 }) => {
-  const headerLevel = parseInt(headingLevel, 10) || 2;
+  const headerLevel = parseInt(headingLevel, 10) || 3;
 
   if (!userIsLoggedIn) {
     return (

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/CustomAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/CustomAlert.unit.spec.jsx
@@ -21,6 +21,21 @@ describe('Custom Alert component', () => {
       expect(alertEl.className).to.include('mhv-u-reg-alert-info');
     });
 
+    it('renders info alert with header level = 4', () => {
+      const contentText = 'Some text for content';
+      const { getByRole, getByText, getByTestId } = render(
+        <CustomAlert headline={headline} headerLevel={4}>
+          <p>{contentText}</p>
+        </CustomAlert>,
+      );
+      expect(getByRole('heading', { level: 4, name: headline })).to.exist;
+      expect(getByText(contentText)).to.exist;
+      const alertEl = getByTestId('mhv-custom-alert');
+      expect(alertEl.className).to.include('mhv-u-reg-alert-info');
+      const headingEl = getByRole('heading', { level: 4, name: headline });
+      expect(headingEl.className).to.include('vads-u-font-size--h3');
+    });
+
     it('renders warning alert', () => {
       const { getByTestId } = render(
         <CustomAlert headline={headline} status="warning" />,

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/CustomAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/CustomAlert.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('Custom Alert component', () => {
           <p>{contentText}</p>
         </CustomAlert>,
       );
-      expect(getByRole('heading', { level: 2, name: headline })).to.exist;
+      expect(getByRole('heading', { level: 3, name: headline })).to.exist;
       expect(getByText(contentText)).to.exist;
       const alertEl = getByTestId('mhv-custom-alert');
       expect(alertEl.className).to.include('mhv-u-reg-alert-info');

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnauthenticatedAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnauthenticatedAlert.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('Unauthenticated Alert component', () => {
         <UnauthenticatedAlert />
       </Provider>,
     );
-    expect(getByRole('heading', { level: 2, name: headingPrefix })).to.exist;
+    expect(getByRole('heading', { level: 3, name: headingPrefix })).to.exist;
   });
 
   it('with service description', () => {

--- a/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnverifiedAlert.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/components/messages/UnverifiedAlert.unit.spec.jsx
@@ -19,7 +19,7 @@ describe('Unverified Alert component', () => {
         <UnverifiedAlert />
       </Provider>,
     );
-    expect(getByRole('heading', { level: 2, name: headingPrefix })).to.exist;
+    expect(getByRole('heading', { level: 3, name: headingPrefix })).to.exist;
   });
 
   it('with service description', () => {
@@ -34,13 +34,13 @@ describe('Unverified Alert component', () => {
     expect(getByRole('heading', { name: expectedHeadline })).to.exist;
   });
 
-  it('with header level 3', () => {
+  it('with header level 4', () => {
     const { getByRole } = render(
       <Provider store={mockStore()}>
-        <UnverifiedAlert headerLevel={3} />
+        <UnverifiedAlert headerLevel={4} />
       </Provider>,
     );
-    expect(getByRole('heading', { level: 3, name: headingPrefix })).to.exist;
+    expect(getByRole('heading', { level: 4, name: headingPrefix })).to.exist;
   });
 
   it('renders MHV account alert', () => {
@@ -49,7 +49,7 @@ describe('Unverified Alert component', () => {
         <UnverifiedAlert signInService={CSP_IDS.MHV} />
       </Provider>,
     );
-    expect(getByRole('heading', { level: 2, name: mhvHeadingPrefix })).to.exist;
+    expect(getByRole('heading', { level: 3, name: mhvHeadingPrefix })).to.exist;
     expect(getByText(/You have 2 options/)).to.exist;
   });
 

--- a/src/applications/static-pages/mhv-signin-cta/test/createMhvSigninCallToAction.unit.spec.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/test/createMhvSigninCallToAction.unit.spec.jsx
@@ -31,6 +31,7 @@ describe('create MHV Signin Call To Action widget', () => {
     </a>
   </span>`;
   const serviceDescription = 'a description';
+  const headingLevel = '3';
   const divId = 'div1';
 
   beforeEach(() => {
@@ -52,18 +53,18 @@ describe('create MHV Signin Call To Action widget', () => {
     });
   });
 
-  it('widget rendered with no content', async () => {
+  it('widget rendered with no content, no serviceDescription and no headingLevel', async () => {
     const div = document.createElement('div');
     div.innerHTML = `
-    <div id="${divId}" data-widget-type=${widgetTypes.MHV_SIGNIN_CTA} 
-     data-service-description="${serviceDescription}" />`;
+    <div id="${divId}" data-widget-type=${widgetTypes.MHV_SIGNIN_CTA} />`;
     document.body.appendChild(div);
     createMhvSigninCallToAction(mockStore(state), widgetTypes.MHV_SIGNIN_CTA);
     await waitFor(() => {
       expect(ReactDOM.render.calledOnce).to.be.true;
       const components = ReactDOM.render.getCall(0).args[0].props.children;
       expect(components).to.exist;
-      expect(components.props.serviceDescription).to.eql(serviceDescription);
+      expect(components.props.headingLevel).to.eql(null);
+      expect(components.props.serviceDescription).to.eql(null);
       expect(components.props.noAlertContent).to.not.exist;
       const replacedEl = ReactDOM.render.getCall(0).args[1];
       expect(replacedEl).to.exist;
@@ -71,10 +72,11 @@ describe('create MHV Signin Call To Action widget', () => {
     });
   });
 
-  it('widget rendered with content', async () => {
+  it('widget rendered with content and data attributes', async () => {
     const div = document.createElement('div');
     div.innerHTML = `
     <div id="${divId}" data-widget-type=${widgetTypes.MHV_SIGNIN_CTA} 
+     data-heading-level="${headingLevel}"
      data-service-description="${serviceDescription}">
       ${noAlertContent}
     </div>`;
@@ -84,6 +86,7 @@ describe('create MHV Signin Call To Action widget', () => {
       expect(ReactDOM.render.calledOnce).to.be.true;
       const components = ReactDOM.render.getCall(0).args[0].props.children;
       expect(components).to.exist;
+      expect(components.props.headingLevel).to.eql(headingLevel);
       expect(components.props.serviceDescription).to.eql(serviceDescription);
       expect(components.props.noAlertContent).to.exist;
       expect(components.props.noAlertContent.innerHTML).to.include(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Modify mhv-signin-cta to add a 'data-heading-level' attribute so that static content maintainer can set a customized heading level for headings within the widget, for example `data-heading-level="4"`

## Related issue(s)
department-of-veterans-affairs/va.gov-team/issues/94862

## Testing done

- Add unit test coverage

- Manual testing of the mhv sign-in widget
  - Build this branch in `vets-website` repo with `yarn build --env --entry=static-pages`
  - Run a watch on `content-build` repo (`yarn watch`).
  - Edit the file `build/localhost/health-care/order-medical-supplies/index.html` within the `content-build` directory. Replace the `Order hearing aid and CPAP supplies online` link (`<a>` tag) with the template in the README.md file under directory `/src/application/static-pages/mhv-signin-cta`.
  - Save the file. DO NOT restart the content-build watch.
  - Build this branch in `vets-website` with `yarn build --env --entry=static-pages`
  - Open `http://localhost:3002/health-care/order-medical-supplies/ `and verify the widget is shown.

## Screenshots


|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    <img width="468" alt="Screenshot 2025-01-31 at 3 19 00 PM" src="https://github.com/user-attachments/assets/ae0b94a9-3698-4ea4-b2aa-4b71deed03f7" />    |   <img width="468" alt="Screenshot 2025-01-31 at 3 18 41 PM" src="https://github.com/user-attachments/assets/ad5785fe-ad48-48fa-96a5-6881073935bf" />    |
| Desktop |  <img width="740" alt="Screenshot 2025-01-31 at 3 19 15 PM" src="https://github.com/user-attachments/assets/01767331-9afb-497f-b417-d38afebe76eb" />       |    <img width="740" alt="Screenshot 2025-01-31 at 3 19 36 PM" src="https://github.com/user-attachments/assets/af4d4e22-8c43-4387-b912-bcb9417e205f" />   |

## What areas of the site does it impact?

/applications/static-pages/mhv-signin-cta

## Acceptance criteria
Content maintainer can change the widget's alert heading level

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
