### PR TITLE
Fix error message displayed when API error returned

### DIFF
--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
@@ -370,7 +370,7 @@ const ProofOfVeteranStatusNew = ({
                 ) : null}
 
                 {isVetStatusEligibilityPopulated &&
-                data?.attributes?.veteranStatus !== 'confirmed' &&
+                data?.attributes?.veteranStatus === 'not confirmed' &&
                 data?.message?.length > 0 ? (
                   <>{lighthouseApiErrorMessage}</>
                 ) : null}
@@ -389,11 +389,22 @@ const ProofOfVeteranStatusNew = ({
 
             {useLighthouseApi ? (
               <>
+                {errors?.length > 0 ? (
+                  <>
+                    <div className="vet-status-pdf-download-error vads-u-padding-y--2">
+                      <va-alert status="error" uswds>
+                        {errors[0]}
+                      </va-alert>
+                    </div>
+                  </>
+                ) : null}
+
                 {data?.attributes?.veteranStatus === 'confirmed' ? (
                   <>{profileApiErrorMessage}</>
-                ) : (
+                ) : null}
+                {data?.attributes?.veteranStatus === 'not confirmed' ? (
                   <>{lighthouseApiErrorMessage}</>
-                )}
+                ) : null}
               </>
             ) : null}
           </>

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.unit.spec.jsx
@@ -237,6 +237,56 @@ describe('ProofOfVeteranStatusNew', () => {
       });
     });
 
+    it('handles a 504 API error with service history', async () => {
+      const mockData = {
+        errors: [
+          {
+            title: 'Gateway Timeout',
+            detail: 'Did not receive a timely response.',
+            code: '504',
+            status: '504',
+          },
+        ],
+      };
+      apiRequestStub.rejects(mockData);
+      const view = renderWithProfileReducers(<ProofOfVeteranStatusNew />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        expect(
+          view.queryByText(
+            'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later.',
+          ),
+        ).to.exist;
+      });
+    });
+
+    it('handles a 403 API error with service history', async () => {
+      const mockData = {
+        errors: [
+          {
+            title: 'Forbidden',
+            detail: 'User does not have access to the requested resource',
+            code: '403',
+            status: '403',
+          },
+        ],
+      };
+      apiRequestStub.rejects(mockData);
+      const view = renderWithProfileReducers(<ProofOfVeteranStatusNew />, {
+        initialState,
+      });
+
+      await waitFor(() => {
+        expect(
+          view.queryByText(
+            'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later.',
+          ),
+        ).to.exist;
+      });
+    });
+
     it('displays not confirmed message if confirmed with no service history', async () => {
       const mockData = {
         data: {

--- a/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
@@ -38,8 +38,20 @@ const notConfirmedIneligible = {
   },
 };
 
+const apiError = {
+  errors: [
+    {
+      title: 'Gateway Timeout',
+      detail: 'Did not receive a timely response from an upstream server.',
+      code: '504',
+      status: '504',
+    },
+  ],
+};
+
 module.exports = {
   confirmed,
   notConfirmedProblem,
   notConfirmedIneligible,
+  apiError,
 };

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -242,6 +242,7 @@ const responses = {
     return res.status(200).json(vetVerificationStatus.confirmed);
     // return res.status(200).json(vetVerificationStatus.notConfirmedProblem);
     // return res.status(200).json(vetVerificationStatus.notConfirmedIneligible);
+    // return res.status(504).json(vetVerificationStatus.apiError);
   },
   'GET /v0/disability_compensation_form/rating_info': (_req, res) => {
     // return res.status(200).json(ratingInfo.success.serviceConnected0);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- These changes fix a bug with the wrong error message showing for veterans that visit the Proof of Status card app and anything but a "success" status is returned from the API. It was showing a blank yellow alert to the user when it should show the red "system error" message.
- I work on the IIR Product team and we currently own this feature.
- The entire implementation of the confirmation statuses is behind a feature toggle. The success criteria targeted for the flipper is to make sure that we receive the same access rate or better for known test users when trying to view their Vet Status card. Additional testing will also be done with veterans on production to further solidify our test cases.

## Related issue(s)

- [1406](https://github.com/department-of-veterans-affairs/va-iir/issues/1406)

## Testing done

- Old behavior showed an empty yellow alert on the page under the "Proof of Veteran status" section when anything but "success" is returned by the API. The new and expected behavior is to see a red "system error" alert.
- Testing has been completed locally to mock the response for both feature toggles involved and handling both "confirmed" and "not confirmed" return values (as the Lighthouse API will do) to make sure the UI shows either the proof of status card or error messages, accordingly.


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop | ![image](https://github.com/user-attachments/assets/7e077d2f-0845-4fe0-bd98-7950fef6831c) | ![image](https://github.com/user-attachments/assets/d62fbf83-c5e9-4f4f-b3d9-133407408d8a) |

## What areas of the site does it impact?

These changes only impact the Proof of Status app.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
