### PR TITLE
 change the way the api calls and stores referrals and referallDetails

### DIFF
--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.js
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.js
@@ -17,7 +17,7 @@ import {
 import AppointmentsPage from '.';
 import { mockVAOSAppointmentsFetch } from '../../../tests/mocks/helpers';
 import { getVAOSRequestMock } from '../../../tests/mocks/mock';
-import { createReferral } from '../../../referral-appointments/utils/referrals';
+import { createReferralById } from '../../../referral-appointments/utils/referrals';
 import { FETCH_STATUS } from '../../../utils/constants';
 
 const initialState = {
@@ -553,8 +553,8 @@ describe('VAOS Page: AppointmentsPage', () => {
             ...defaultState,
             referral: {
               facility: null,
-              referrals: [
-                createReferral(
+              referralDetails: [
+                createReferralById(
                   moment().format('YYYY-MM-DD'),
                   'add2f0f4-a1ea-4dea-a504-a54ab57c6801',
                 ),

--- a/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.js
@@ -6,7 +6,7 @@ import {
   createTestStore,
 } from '../tests/mocks/setup';
 import ChooseDateAndTime from './ChooseDateAndTime';
-import { createReferral } from './utils/referrals';
+import { createReferralById } from './utils/referrals';
 import { createDraftAppointmentInfo } from './utils/provider';
 import confirmedV2 from '../services/mocks/v2/confirmed.json';
 import * as postDraftReferralAppointmentModule from '../services/referral';
@@ -147,7 +147,7 @@ describe('VAOS ChoseDateAndTime component', () => {
   it('should fetch provider or appointments from store if it exists and not call API', async () => {
     renderWithStoreAndRouter(
       <ChooseDateAndTime
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(initialFullState),
@@ -161,7 +161,7 @@ describe('VAOS ChoseDateAndTime component', () => {
   it('should call API for provider or appointment data if not in store', async () => {
     const screen = renderWithStoreAndRouter(
       <ChooseDateAndTime
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(initialEmptyState),
@@ -176,7 +176,7 @@ describe('VAOS ChoseDateAndTime component', () => {
   it('should show error if any fetch fails', async () => {
     const screen = renderWithStoreAndRouter(
       <ChooseDateAndTime
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(failedState),

--- a/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.js
@@ -10,7 +10,7 @@ import {
   createTestStore,
   renderWithStoreAndRouter,
 } from '../tests/mocks/setup';
-import { createReferral, getReferralSlotKey } from './utils/referrals';
+import { createReferralById, getReferralSlotKey } from './utils/referrals';
 import { FETCH_STATUS } from '../utils/constants';
 import { createProviderDetails } from './utils/provider';
 import * as getProviderByIdModule from '../services/referral';
@@ -48,7 +48,7 @@ describe('CompleteReferral', () => {
     it('should render review and schedule links', () => {
       const { getByTestId } = renderWithStoreAndRouter(
         <CompleteReferral
-          currentReferral={createReferral('2024-11-29', 'UUID', '111')}
+          currentReferral={createReferralById('2024-11-29', 'UUID', '111')}
         />,
         {
           store: createTestStore(initialState),
@@ -63,7 +63,7 @@ describe('CompleteReferral', () => {
 
       const { getByTestId } = renderWithStoreAndRouter(
         <CompleteReferral
-          currentReferral={createReferral('2024-11-29', 'UUID', '111')}
+          currentReferral={createReferralById('2024-11-29', 'UUID', '111')}
         />,
         {
           store: createTestStore(initialState),
@@ -79,7 +79,7 @@ describe('CompleteReferral', () => {
   it('should render error alert when provider loading fails', () => {
     const { getByTestId } = renderWithStoreAndRouter(
       <CompleteReferral
-        currentReferral={createReferral('2024-11-29', 'UUID', '111')}
+        currentReferral={createReferralById('2024-11-29', 'UUID', '111')}
       />,
       {
         store: createTestStore({
@@ -102,7 +102,7 @@ describe('CompleteReferral', () => {
 
     const { history } = renderWithStoreAndRouter(
       <CompleteReferral
-        currentReferral={createReferral('2024-11-29', 'UUID', '111')}
+        currentReferral={createReferralById('2024-11-29', 'UUID', '111')}
       />,
       {
         store: createTestStore(initialState),
@@ -118,7 +118,7 @@ describe('CompleteReferral', () => {
     providerDetails.slots[0].start = '2024-11-29T16:00:00.000Z';
     const { getByTestId } = renderWithStoreAndRouter(
       <CompleteReferral
-        currentReferral={createReferral('2024-11-29', 'UUID', '111')}
+        currentReferral={createReferralById('2024-11-29', 'UUID', '111')}
       />,
       {
         store: createTestStore({
@@ -159,7 +159,7 @@ describe('CompleteReferral', () => {
     };
     const { history } = renderWithStoreAndRouter(
       <CompleteReferral
-        currentReferral={createReferral('2024-11-29', 'UUID')}
+        currentReferral={createReferralById('2024-11-29', 'UUID')}
       />,
       {
         store: createTestStore(noSelectState),

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.js
@@ -160,7 +160,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
 
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(initialFullState),
@@ -192,7 +192,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
 
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(initialFullState),

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.js
@@ -9,8 +9,8 @@ import {
   createTestStore,
   renderWithStoreAndRouter,
 } from '../tests/mocks/setup';
-import { createReferral, getReferralSlotKey } from './utils/referrals';
 import { createReferralAppointment } from './utils/appointment';
+import { createReferralById, getReferralSlotKey } from './utils/referrals';
 import { FETCH_STATUS } from '../utils/constants';
 import { createDraftAppointmentInfo } from './utils/provider';
 import * as postDraftReferralAppointmentModule from '../services/referral';
@@ -57,7 +57,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
   it('should not fetch provider if in redux', async () => {
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(initialFullState),
@@ -76,7 +76,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     );
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(initialEmptyState),
@@ -99,7 +99,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     };
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(noSelectState),
@@ -125,7 +125,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     };
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
-        currentReferral={createReferral('2024-09-09', 'UUID')}
+        currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
         store: createTestStore(noSelectState),

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.js
@@ -6,7 +6,7 @@ import {
   createTestStore,
   renderWithStoreAndRouter,
 } from '../tests/mocks/setup';
-import { createReferral, getReferralSlotKey } from './utils/referrals';
+import { createReferralById, getReferralSlotKey } from './utils/referrals';
 
 describe('VAOS Component: ScheduleReferral', () => {
   afterEach(() => {
@@ -14,7 +14,7 @@ describe('VAOS Component: ScheduleReferral', () => {
   });
   const referralDate = '2024-09-09';
   it('should display the subtitle correctly given different numbers of appointments', async () => {
-    const referralOne = createReferral(referralDate, '111');
+    const referralOne = createReferralById(referralDate, '111');
     const store = createTestStore();
     const screen = renderWithStoreAndRouter(
       <ScheduleReferral currentReferral={referralOne} />,
@@ -26,7 +26,7 @@ describe('VAOS Component: ScheduleReferral', () => {
     expect(subtitle).to.contain.text('1 appointment');
   });
   it('should display the subtitle correctly given 2 appointments', async () => {
-    const referralTwo = createReferral(referralDate, '222');
+    const referralTwo = createReferralById(referralDate, '222');
     const store = createTestStore();
     referralTwo.numberOfAppointments = 2;
     const screen = renderWithStoreAndRouter(
@@ -40,7 +40,7 @@ describe('VAOS Component: ScheduleReferral', () => {
   });
 
   it('should render with default data', async () => {
-    const referral = createReferral(referralDate, '111');
+    const referral = createReferralById(referralDate, '111');
 
     const store = createTestStore();
 
@@ -71,7 +71,7 @@ describe('VAOS Component: ScheduleReferral', () => {
     expect(facility).to.exist;
   });
   it('should reset slot selection', async () => {
-    const referral = createReferral(referralDate, '222');
+    const referral = createReferralById(referralDate, '222');
     const selectedSlotKey = getReferralSlotKey(referral.UUID);
     sessionStorage.setItem(selectedSlotKey, '0');
     const initialState = {

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.js
@@ -3,7 +3,7 @@ import { fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import MockDate from 'mockdate';
 import DateAndTimeContent from './DateAndTimeContent';
-import { createReferral, getReferralSlotKey } from '../utils/referrals';
+import { createReferralById, getReferralSlotKey } from '../utils/referrals';
 import { createDraftAppointmentInfo } from '../utils/provider';
 import { renderWithStoreAndRouter } from '../../tests/mocks/setup';
 
@@ -17,7 +17,7 @@ describe('VAOS Component: DateAndTimeContent', () => {
       selectedSlot: null,
     },
   };
-  const referral = createReferral(
+  const referral = createReferralById(
     '2024-12-05',
     'add2f0f4-a1ea-4dea-a504-a54ab57c68',
   );

--- a/src/applications/vaos/referral-appointments/components/PendingReferralCard.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/PendingReferralCard.unit.spec.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import MockDate from 'mockdate';
 import sinon from 'sinon';
 import PendingReferralCard from './PendingReferralCard';
-import { createReferral } from '../utils/referrals';
+import { createReferralById } from '../utils/referrals';
 
 describe('VAOS Component: PendingReferralCard', () => {
   beforeEach(() => {
@@ -14,7 +14,7 @@ describe('VAOS Component: PendingReferralCard', () => {
     MockDate.reset();
   });
 
-  const referral = createReferral(
+  const referral = createReferralById(
     '2025-01-01',
     'add2f0f4-a1ea-4dea-a504-a54ab57c68',
   );
@@ -43,7 +43,7 @@ describe('VAOS Component: PendingReferralCard', () => {
       ),
     ).to.exist;
   });
-  // skipped for now unitl we can figure out how to test the click event
+  // TODO: figure out how to test the click event
   it.skip('should call handleClick when the link is clicked', () => {
     const link = screen.getByTestId('appointment-list-item');
     fireEvent.click(link);

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCard.unit.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { format } from 'date-fns';
 import ReferralTaskCard from './ReferralTaskCard';
-import { createReferral } from '../utils/referrals';
+import { createReferralById } from '../utils/referrals';
 import {
   createTestStore,
   renderWithStoreAndRouter,
@@ -29,7 +29,7 @@ describe('VAOS Component: ReferralTaskCard', () => {
   });
 
   const uuid = 'add2f0f4-a1ea-4dea-a504-a54ab57c68';
-  const referralData = createReferral('2024-09-06', uuid);
+  const referralData = createReferralById('2024-09-06', uuid);
   referralData.ReferralExpirationDate = '2025-03-04';
   const expectedDateFormated = format(
     new Date(referralData.ReferralExpirationDate),

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
@@ -22,14 +22,16 @@ export default function ReferralTaskCardWithReferral() {
   const params = new URLSearchParams(search);
   const id = params.get('id');
 
-  const { currentReferral, referralFetchStatus } = useGetReferralById(id);
+  const { referral, referralFetchStatus } = useGetReferralById(id);
 
   if (
-    id &&
-    !currentReferral &&
-    (referralFetchStatus === FETCH_STATUS.succeeded ||
-      referralFetchStatus === FETCH_STATUS.failed)
+    referralFetchStatus === FETCH_STATUS.loading ||
+    referralFetchStatus === FETCH_STATUS.notStarted
   ) {
+    return <va-loading-indicator set-focus message="Loading your data..." />;
+  }
+
+  if (id && referralFetchStatus === FETCH_STATUS.failed) {
     return (
       <va-alert
         data-testid="referral-error"
@@ -45,7 +47,7 @@ export default function ReferralTaskCardWithReferral() {
     );
   }
 
-  if (isExpired(currentReferral)) {
+  if (isExpired(referral)) {
     return (
       <va-alert-expandable
         status="warning"
@@ -68,5 +70,5 @@ export default function ReferralTaskCardWithReferral() {
     );
   }
 
-  return <ReferralTaskCard data={currentReferral} />;
+  return <ReferralTaskCard data={referral} />;
 }

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
@@ -25,8 +25,9 @@ export default function ReferralTaskCardWithReferral() {
   const { referral, referralFetchStatus } = useGetReferralById(id);
 
   if (
-    referralFetchStatus === FETCH_STATUS.loading ||
-    referralFetchStatus === FETCH_STATUS.notStarted
+    id &&
+    (referralFetchStatus === FETCH_STATUS.loading ||
+      referralFetchStatus === FETCH_STATUS.notStarted)
   ) {
     return <va-loading-indicator set-focus message="Loading your data..." />;
   }

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import MockDate from 'mockdate';
-
+import { waitFor } from '@testing-library/dom';
 import {
   renderWithStoreAndRouter,
   createTestStore,
@@ -92,17 +92,13 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
   });
 
   it('should display the error alert when fetch fails', async () => {
-    const store = createTestStore({
-      ...initialState,
-      referral: {
-        referralDetails: [],
-        referralFetchStatus: FETCH_STATUS.failed,
-      },
-    });
+    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
       store,
       path: '/?id=error',
     });
-    expect(await screen.getByTestId('referral-error')).to.exist;
+    await waitFor(() => {
+      expect(screen.getByTestId('referral-error')).to.exist;
+    });
   });
 });

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -8,7 +8,7 @@ import {
 } from '../../tests/mocks/setup';
 import ReferralTaskCardWithReferral from './ReferralTaskCardWithReferral';
 
-import { createReferral } from '../utils/referrals';
+import { createReferralById } from '../utils/referrals';
 import { FETCH_STATUS } from '../../utils/constants';
 
 const initialState = {
@@ -17,8 +17,8 @@ const initialState = {
   },
   referral: {
     facility: null,
-    referrals: [
-      createReferral('2024-11-29', 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
+    referralDetails: [
+      createReferralById('2024-11-29', 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
     ],
     referralFetchStatus: FETCH_STATUS.succeeded,
   },
@@ -91,8 +91,8 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
       ...initialState,
       referral: {
         ...initialState.referral,
-        referrals: [
-          createReferral(
+        referralDetails: [
+          createReferralById(
             '2024-11-29',
             '445e2d1b-7150-4631-97f2-f6f473bdef00',
             '111',
@@ -108,26 +108,17 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
     expect(await screen.getByTestId('expired-alert')).to.exist;
   });
 
-  it('should display the error alert when referral is not found', async () => {
-    const store = createTestStore(initialState);
-    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
-      store,
-      path: '/?id=thisisareferralthatwontbefound',
-    });
-    expect(await screen.getByTestId('referral-error')).to.exist;
-  });
-
   it('should display the error alert when fetch fails', async () => {
     const store = createTestStore({
       ...initialState,
       referral: {
-        referrals: [],
+        referralDetails: [],
         referralFetchStatus: FETCH_STATUS.failed,
       },
     });
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
       store,
-      path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801',
+      path: '/?id=error',
     });
     expect(await screen.getByTestId('referral-error')).to.exist;
   });

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -48,23 +48,6 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
     expect(await screen.findByTestId('referral-task-card')).to.exist;
   });
 
-  it('should not display the task card when feature toggle is off', async () => {
-    const modifiedState = {
-      ...initialState,
-      featureToggles: {
-        vaOnlineSchedulingCCDirectScheduling: false,
-      },
-    };
-    const store = createTestStore(modifiedState);
-    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
-      store,
-      path: '/?id=add2f0f4-a1ea-a504-a54ab57c6801',
-    });
-
-    const taskCard = screen.queryByTestId('referral-task-card');
-    expect(taskCard).to.be.null;
-  });
-
   it('should not display the task card when referral ID is not found', async () => {
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { getReferral } from '../redux/selectors';
 import { fetchReferralById } from '../redux/actions';
@@ -6,44 +6,28 @@ import { FETCH_STATUS } from '../../utils/constants';
 import { useIsInCCPilot } from './useIsInCCPilot';
 
 const useGetReferralById = id => {
-  const [referralNotFound, setReferralNotFound] = useState(false);
-  const [currentReferral, setCurrentReferral] = useState(null);
   const dispatch = useDispatch();
   const { isInCCPilot } = useIsInCCPilot();
-  const { referrals, referralFetchStatus } = useSelector(
-    state => getReferral(state),
+  const { referral, referralFetchStatus } = useSelector(
+    state => getReferral(state, id),
     shallowEqual,
-  );
-  useEffect(
-    () => {
-      if (isInCCPilot && (referrals.length && id)) {
-        const referralFromParam = referrals.find(ref => ref.UUID === id);
-        if (referralFromParam) {
-          setCurrentReferral(referralFromParam);
-        } else {
-          setReferralNotFound(true);
-        }
-      }
-    },
-    [id, referrals, referralFetchStatus, isInCCPilot],
   );
   useEffect(
     () => {
       if (
         id &&
         isInCCPilot &&
-        !referrals.length &&
+        !referral &&
         referralFetchStatus === FETCH_STATUS.notStarted
       ) {
         dispatch(fetchReferralById(id));
       }
     },
-    [dispatch, isInCCPilot, id, referralFetchStatus, referrals],
+    [dispatch, isInCCPilot, id, referralFetchStatus, referral],
   );
   return {
-    currentReferral,
+    referral,
     referralFetchStatus,
-    referralNotFound,
   };
 };
 

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import { getReferral } from '../redux/selectors';
 import { fetchReferralById } from '../redux/actions';
-import { FETCH_STATUS } from '../../utils/constants';
 import { useIsInCCPilot } from './useIsInCCPilot';
 
 const useGetReferralById = id => {
@@ -14,12 +13,7 @@ const useGetReferralById = id => {
   );
   useEffect(
     () => {
-      if (
-        id &&
-        isInCCPilot &&
-        !referral &&
-        referralFetchStatus === FETCH_STATUS.notStarted
-      ) {
+      if (id && isInCCPilot && !referral) {
         dispatch(fetchReferralById(id));
       }
     },

--- a/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useGetReferralById.jsx
@@ -17,7 +17,7 @@ const useGetReferralById = id => {
         dispatch(fetchReferralById(id));
       }
     },
-    [dispatch, isInCCPilot, id, referralFetchStatus, referral],
+    [dispatch, isInCCPilot, id, referral],
   );
   return {
     referral,

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -41,12 +41,13 @@ export default function ReferralAppointments() {
     return <Redirect from={basePath.url} to="/" />;
   }
 
-  if (referralFetchStatus === FETCH_STATUS.failed) {
+  if (!referral && referralFetchStatus === FETCH_STATUS.failed) {
     // Referral Layout shows the error component is apiFailure is true
     return <ReferralLayout apiFailure hasEyebrow heading="Referral Error" />;
   }
 
   if (
+    !referral ||
     referralFetchStatus === FETCH_STATUS.loading ||
     referralFetchStatus === FETCH_STATUS.notStarted
   ) {

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import {
   Switch,
   Route,
@@ -25,18 +25,7 @@ export default function ReferralAppointments() {
   const { search } = useLocation();
   const params = new URLSearchParams(search);
   const id = params.get('id');
-  const {
-    currentReferral,
-    referralNotFound,
-    referralFetchStatus,
-  } = useGetReferralById(id);
-  const [referral, setReferral] = useState(currentReferral);
-  useEffect(
-    () => {
-      setReferral(currentReferral);
-    },
-    [currentReferral],
-  );
+  const { referral, referralFetchStatus } = useGetReferralById(id);
   useEffect(
     () => {
       if (referralFetchStatus === FETCH_STATUS.succeeded) {
@@ -48,7 +37,7 @@ export default function ReferralAppointments() {
     [referralFetchStatus],
   );
 
-  if (referralNotFound || !isInCCPilot) {
+  if (!isInCCPilot) {
     return <Redirect from={basePath.url} to="/" />;
   }
 
@@ -57,7 +46,10 @@ export default function ReferralAppointments() {
     return <ReferralLayout apiFailure hasEyebrow heading="Referral Error" />;
   }
 
-  if (!referral && referralFetchStatus !== FETCH_STATUS.failed) {
+  if (
+    referralFetchStatus === FETCH_STATUS.loading ||
+    referralFetchStatus === FETCH_STATUS.notStarted
+  ) {
     // @TODO: Switch to using ReferralLayout
     return (
       <FormLayout pageTitle="Review Approved Referral">

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -198,12 +198,12 @@ export function fetchReferralById(id) {
       type: FETCH_REFERRAL,
     });
     try {
-      const referrals = await getPatientReferralById(id);
+      const referral = await getPatientReferralById(id);
       dispatch({
         type: FETCH_REFERRAL_SUCCEEDED,
-        data: [referrals],
+        data: referral,
       });
-      return referrals;
+      return referral;
     } catch (error) {
       dispatch({
         type: FETCH_REFERRAL_FAILED,

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -23,6 +23,7 @@ const initialState = {
   draftAppointmentInfo: {},
   currentPage: null,
   referrals: [],
+  referralDetails: [],
   selectedSlot: '',
   referralsFetchStatus: FETCH_STATUS.notStarted,
   referralFetchStatus: FETCH_STATUS.notStarted,
@@ -81,7 +82,6 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         referralsFetchStatus: FETCH_STATUS.succeeded,
-        referralFetchStatus: FETCH_STATUS.succeeded,
         referrals: action.data,
       };
     case FETCH_REFERRALS_FAILED:
@@ -98,7 +98,7 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         referralFetchStatus: FETCH_STATUS.succeeded,
-        referrals: [...state.referrals, ...action.data],
+        referralDetails: [...state.referralDetails, action.data],
       };
     case FETCH_REFERRAL_FAILED:
       return {

--- a/src/applications/vaos/referral-appointments/redux/selectors.js
+++ b/src/applications/vaos/referral-appointments/redux/selectors.js
@@ -26,9 +26,10 @@ export function getReferrals(state) {
   };
 }
 
-export function getReferral(state) {
+export function getReferral(state, id) {
+  const referral = state.referral.referralDetails.find(ref => ref.UUID === id);
   return {
-    referrals: state.referral.referrals,
+    referral,
     referralFetchStatus: state.referral.referralFetchStatus,
   };
 }

--- a/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/TestComponent.jsx
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/TestComponent.jsx
@@ -3,17 +3,14 @@ import React from 'react';
 import { useGetReferralById } from '../../../hooks/useGetReferralById';
 
 export default function TestComponent() {
-  const {
-    currentReferral,
-    referralFetchStatus,
-    referralNotFound,
-  } = useGetReferralById('add2f0f4-a1ea-4dea-a504-a54ab57c6800');
+  const { referral, referralFetchStatus } = useGetReferralById(
+    'add2f0f4-a1ea-4dea-a504-a54ab57c6800',
+  );
   return (
     <div>
       <p>Test component</p>
-      <p>{currentReferral?.UUID}</p>
+      <p>{referral?.UUID}</p>
       <p>{referralFetchStatus}</p>
-      <p>{`Referral not found: ${referralNotFound}`}</p>
     </div>
   );
 }

--- a/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useGetReferralById/useGetReferralById.unit.spec.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import * as getPatientReferralByIdModule from '../../../../services/referral';
 import { renderWithStoreAndRouter } from '../../../../tests/mocks/setup';
-import { createReferral } from '../../../utils/referrals';
+import { createReferralById } from '../../../utils/referrals';
 import { FETCH_STATUS } from '../../../../utils/constants';
 
 import TestComponent from './TestComponent';
@@ -21,14 +21,14 @@ describe('Community Care Referrals', () => {
     it('Loads test component with hook and fetches referral when state is empty', () => {
       sandbox
         .stub(getPatientReferralByIdModule, 'getPatientReferralById')
-        .resolves(createReferral(now, '111'));
+        .resolves(createReferralById(now, '111'));
       const initialState = {
         featureToggles: {
           vaOnlineSchedulingCCDirectScheduling: true,
         },
         referral: {
           facility: null,
-          referrals: [],
+          referralDetails: [],
           referralFetchStatus: FETCH_STATUS.notStarted,
         },
         user: {
@@ -48,15 +48,15 @@ describe('Community Care Referrals', () => {
     it('Returns the referral from store if exists without calling endpoint', () => {
       sandbox
         .stub(getPatientReferralByIdModule, 'getPatientReferralById')
-        .resolves(createReferral(now, '111'));
+        .resolves(createReferralById(now, '111'));
       const initialState = {
         featureToggles: {
           vaOnlineSchedulingCCDirectScheduling: true,
         },
         referral: {
           facility: null,
-          referrals: [
-            createReferral(now, 'add2f0f4-a1ea-4dea-a504-a54ab57c6800'),
+          referralDetails: [
+            createReferralById(now, 'add2f0f4-a1ea-4dea-a504-a54ab57c6800'),
           ],
           referralFetchStatus: FETCH_STATUS.notStarted,
         },
@@ -70,35 +70,6 @@ describe('Community Care Referrals', () => {
         initialState,
       });
       expect(screen.getByText('add2f0f4-a1ea-4dea-a504-a54ab57c6800')).to.exist;
-      sandbox.assert.notCalled(
-        getPatientReferralByIdModule.getPatientReferralById,
-      );
-    });
-    it('Returns the referral not found when referral not in store', () => {
-      sandbox
-        .stub(getPatientReferralByIdModule, 'getPatientReferralById')
-        .resolves(createReferral(now, '111'));
-      const initialState = {
-        featureToggles: {
-          vaOnlineSchedulingCCDirectScheduling: true,
-        },
-        referral: {
-          facility: null,
-          referrals: [
-            createReferral(now, 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
-          ],
-          referralFetchStatus: FETCH_STATUS.notStarted,
-        },
-        user: {
-          profile: {
-            facilities: [{ facilityId: '983' }],
-          },
-        },
-      };
-      const screen = renderWithStoreAndRouter(<TestComponent />, {
-        initialState,
-      });
-      expect(screen.getByText('Referral not found: true')).to.exist;
       sandbox.assert.notCalled(
         getPatientReferralByIdModule.getPatientReferralById,
       );

--- a/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.js
@@ -5,8 +5,8 @@ const referralUtil = require('../../utils/referrals');
 
 describe('VAOS referral generator', () => {
   const today = format(new Date(), 'yyyy-MM-dd');
-  describe('createReferral', () => {
-    const referral = referralUtil.createReferral(today, '1');
+  describe('createReferralById', () => {
+    const referral = referralUtil.createReferralById(today, '1');
     it('Create a referral based on specific date', () => {
       expect(referral.ReferralDate).to.equal(today);
     });
@@ -21,12 +21,6 @@ describe('VAOS referral generator', () => {
       expect(referrals[0].ReferralDate).to.equal('2024-10-30');
       expect(referrals[1].ReferralDate).to.equal('2024-10-31');
     });
-    it('Creates specified number of expired referrals', () => {
-      const referrals = referralUtil.createReferrals(3, '2024-10-30', 2);
-      expect(referrals[0].ReferralExpirationDate).to.equal('2024-05-06');
-      expect(referrals[1].ReferralExpirationDate).to.equal('2024-05-07');
-      expect(referrals[2].ReferralExpirationDate).to.equal('2025-05-01');
-    });
   });
   describe('getReferralSlotKey', () => {
     expect(referralUtil.getReferralSlotKey('111')).to.equal(
@@ -34,14 +28,14 @@ describe('VAOS referral generator', () => {
     );
   });
   describe('filterReferrals', () => {
-    const nonPhysicalTherapyReferral = referralUtil.createReferral(
+    const nonPhysicalTherapyReferral = referralUtil.createReferralById(
       today,
       'uid',
       '333',
       null,
       'non-physical-therapy',
     );
-    const physicalTherapyReferral = referralUtil.createReferral(
+    const physicalTherapyReferral = referralUtil.createReferralById(
       today,
       'uid-2',
       '111',
@@ -56,7 +50,7 @@ describe('VAOS referral generator', () => {
   });
   describe('getAddressString', () => {
     it('Formats the address string', () => {
-      const referral = referralUtil.createReferral(today, '111', '333');
+      const referral = referralUtil.createReferralById(today, '111', '333');
       expect(
         referralUtil.getAddressString(referral.ReferringFacilityInfo.Address),
       ).to.equal('222 Richmond Avenue, BATAVIA, NY, 14020');

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -110,11 +110,11 @@ const draftAppointments = {
     },
     provider: {
       id: '9mN718pH',
-      name: 'Dr. Moreen S. Rafa @ FHA South Melbourne Medical Complex',
+      name: 'Dr. Bones @ FHA South Melbourne Medical Complex',
       isActive: true,
       individualProviders: [
         {
-          name: 'Dr. Moreen S. Rafa',
+          name: 'Dr. Bones',
           npi: '91560381x',
         },
       ],
@@ -179,11 +179,11 @@ const draftAppointments = {
     },
     provider: {
       id: '9mN718pH',
-      name: 'Dr. Moreen S. Rafa @ FHA South Melbourne Medical Complex',
+      name: 'Dr. Bones @ FHA South Melbourne Medical Complex',
       isActive: true,
       individualProviders: [
         {
-          name: 'Dr. Moreen S. Rafa',
+          name: 'Dr. Bones',
           npi: '91560381x',
         },
       ],
@@ -248,11 +248,11 @@ const draftAppointments = {
     },
     provider: {
       id: '9mN718pH',
-      name: 'Dr. Moreen S. Rafa @ FHA South Melbourne Medical Complex',
+      name: 'Dr. Bones @ FHA South Melbourne Medical Complex',
       isActive: true,
       individualProviders: [
         {
-          name: 'Dr. Moreen S. Rafa',
+          name: 'Dr. Bones',
           npi: '91560381x',
         },
       ],
@@ -317,11 +317,11 @@ const draftAppointments = {
     },
     provider: {
       id: '9mN718pH',
-      name: 'Dr. Moreen S. Rafa @ FHA South Melbourne Medical Complex',
+      name: 'Dr. Bones @ FHA South Melbourne Medical Complex',
       isActive: true,
       individualProviders: [
         {
-          name: 'Dr. Moreen S. Rafa',
+          name: 'Dr. Bones',
           npi: '91560381x',
         },
       ],

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -4,6 +4,38 @@ const { addDays, addMonths, format, subMonths } = require('date-fns');
 
 const defaultUUIDBase = 'add2f0f4-a1ea-4dea-a504-a54ab57c68';
 const expiredUUIDBase = '445e2d1b-7150-4631-97f2-f6f473bdef';
+
+/**
+ * Creates a referral list object relative to a start date.
+ *
+ * @param {String} startDate The date in 'yyyy-MM-dd' format to base the referrals around
+ * @param {String} uuid The UUID for the referral
+ * @param {String} providerId The ID for the provider
+ * @param {String} expirationDate The date in 'yyyy-MM-dd' format to expire the referral
+ * @returns {Object} Referral object
+ */
+
+const createReferralListItem = (
+  startDate,
+  uuid,
+  providerId = '111',
+  expirationDate,
+  categoryOfCare = 'Physical Therapy',
+) => {
+  const [year, month, day] = startDate.split('-');
+  const relativeDate = new Date(year, month - 1, day);
+  const mydFormat = 'yyyy-MM-dd';
+  return {
+    UUID: uuid,
+    ReferralDate: startDate,
+    CategoryOfCare: categoryOfCare,
+    numberOfAppointments: 5,
+    ReferralExpirationDate:
+      expirationDate || format(addMonths(relativeDate, 6), mydFormat),
+    providerId,
+  };
+};
+
 /**
  * Creates a referral object relative to a start date.
  *
@@ -13,7 +45,7 @@ const expiredUUIDBase = '445e2d1b-7150-4631-97f2-f6f473bdef';
  * @param {String} expirationDate The date in 'yyyy-MM-dd' format to expire the referral
  * @returns {Object} Referral object
  */
-const createReferral = (
+const createReferralById = (
   startDate,
   uuid,
   providerId = '111',
@@ -92,7 +124,7 @@ const createReferrals = (
     const mydFormat = 'yyyy-MM-dd';
     const referralDate = format(startDate, mydFormat);
     referrals.push(
-      createReferral(
+      createReferralListItem(
         referralDate,
         `${uuidBase}${i.toString().padStart(2, '0')}`,
         providerIds[i % providerIds.length],
@@ -148,7 +180,8 @@ const getAddressString = addressObject => {
 };
 
 module.exports = {
-  createReferral,
+  createReferralById,
+  createReferralListItem,
   createReferrals,
   getReferralSlotKey,
   filterReferrals,

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -324,30 +324,41 @@ const responses = {
   },
 
   // EPS api
-  'GET /vaos/v2/epsApi/referralDetails': (req, res) => {
+  'GET /vaos/v2/epsApi/referrals': (req, res) => {
     return res.json({
       data: referralUtils.createReferrals(4, '2024-12-02'),
     });
   },
-  'GET /vaos/v2/epsApi/referralDetails/:referralId': (req, res) => {
-    let expiredReferrals = 0;
+  'GET /vaos/v2/epsApi/referrals/:referralId': (req, res) => {
     if (req.params.referralId === 'error') {
       return res.status(500).json({ error: true });
     }
 
     if (req.params.referralId?.startsWith(referralUtils.expiredUUIDBase)) {
-      expiredReferrals = 1;
+      const yesterday = moment()
+        .subtract(1, 'days')
+        .format('YYYY-MM-DD');
+      const expiredReferral = referralUtils.createReferralById(
+        '2024-12-02',
+        req.params.referralId,
+        '111',
+        yesterday,
+      );
+      return res.json({
+        data: expiredReferral,
+      });
     }
-    const referrals = referralUtils.createReferrals(
-      3,
+    const tomorrow = moment()
+      .add(1, 'days')
+      .format('YYYY-MM-DD');
+    const referral = referralUtils.createReferralById(
       '2024-12-02',
-      expiredReferrals,
-    );
-    const singleReferral = referrals.find(
-      referral => referral?.UUID === req.params.referralId,
+      req.params.referralId,
+      '111',
+      tomorrow,
     );
     return res.json({
-      data: singleReferral ?? {},
+      data: referral,
     });
   },
   'GET /vaos/v2/epsApi/providerDetails/:providerId': (req, res) => {

--- a/src/applications/vaos/services/referral/index.js
+++ b/src/applications/vaos/services/referral/index.js
@@ -1,7 +1,7 @@
 import { apiRequestWithUrl } from '../utils';
 
 export async function getPatientReferrals() {
-  const response = await apiRequestWithUrl(`/vaos/v2/epsApi/referralDetails`, {
+  const response = await apiRequestWithUrl(`/vaos/v2/epsApi/referrals`, {
     method: 'GET',
   });
 
@@ -10,7 +10,7 @@ export async function getPatientReferrals() {
 
 export async function getPatientReferralById(referralId) {
   const response = await apiRequestWithUrl(
-    `/vaos/v2/epsApi/referralDetails/${referralId}`,
+    `/vaos/v2/epsApi/referrals/${referralId}`,
     {
       method: 'GET',
     },


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Changes the get requests for referrals so that there is a separate one for referralDetails that is required for each referral.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#100746](https://github.com/department-of-veterans-affairs/va.gov-team/issues/100746)

## Testing done

- It used to call getReferralById only when it didn't already fetch it as part of the getReferrals call.
- Now it should call getReferrals/[id] whenever clicking on a referral in the list and on the appointments page where it shows the card.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

VAOS Appointments list and CC

## Acceptance criteria

- It should make the necessary calls to get referral details
- It should not call when it has already fetched a referral 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
