### PR TITLE
Capitalize PDF

### DIFF
--- a/src/applications/simple-forms/form-upload/config/constants.js
+++ b/src/applications/simple-forms/form-upload/config/constants.js
@@ -30,11 +30,11 @@ export const MUST_MATCH_ALERT = (variant, onCloseEvent, formData) => {
     >
       {variant === 'name-and-zip-code' ? (
         <h3 slot="headline">
-          Veteran’s name and postal code must match your pdf
+          Veteran’s name and postal code must match your PDF
         </h3>
       ) : (
         <h3 slot="headline">
-          Veteran’s identification information must match your pdf
+          Veteran’s identification information must match your PDF
         </h3>
       )}
       {isLoa3 ? (
@@ -46,12 +46,12 @@ export const MUST_MATCH_ALERT = (variant, onCloseEvent, formData) => {
       {variant === 'name-and-zip-code' ? (
         <p>
           If the Veteran’s name and postal code here don’t match your uploaded
-          pdf, it will cause processing delays.
+          PDF, it will cause processing delays.
         </p>
       ) : (
         <p>
           If the Veteran’s identification information you enter here doesn’t
-          match your uploaded pdf, it will cause processing delays.
+          match your uploaded PDF, it will cause processing delays.
         </p>
       )}
     </VaAlert>


### PR DESCRIPTION


## Summary
Fixing capitalization in an alert - pdf should be PDF

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1991

## Testing done

- _Describe what the old behavior was prior to the change_
PDF was lowercase


It is now uppercase

<img width="512" alt="image" src="https://github.com/user-attachments/assets/cd6794ca-3caf-4e91-883c-abecd04d0c6f" />


## What areas of the site does it impact?

Only form upload

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
