### PR TITLE
MHV-66902 Allergies-Download-Pdf-Content-Needs-To-Be-Updated-To-Match-With-Print-View-And-TXT-File

### DIFF
--- a/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
@@ -110,7 +110,7 @@ const AllergyDetails = props => {
 
   const generateAllergyPdf = async () => {
     setDownloadStarted(true);
-    const title = `Allergies and reactions: ${allergyData.name}`;
+    const title = allergyData.name;
     const subject = 'VA Medical Record';
     const scaffold = generatePdfScaffold(user, title, subject);
     const pdfData = { ...scaffold, details: generateAllergyItem(allergyData) };

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -153,10 +153,10 @@ ${vaccines.map(entry => generateVaccineListItemTxt(entry)).join('')}`;
     <div id="vaccines">
       <PrintHeader />
       <h1 className="vads-u-margin--0">Vaccines</h1>
-      <p>Review vaccines (immunizations) in your VA medical records.</p>
-      <p className="vads-u-margin-bottom--4">
-        For a list of your allergies and reactions (including any reactions to
-        vaccines), go to your allergy records.{' '}
+      <p>
+        This list includes all vaccines (immunizations) in your VA medical
+        records. For a list of your allergies and reactions (including any
+        reactions to vaccines), download your allergy records.
       </p>
       <div className="vads-u-margin-bottom--4">
         <Link


### PR DESCRIPTION
## Summary
Removed Prefix (Allergies and reactions) from AllergyDetails page.

## Related issue(s)
[MHV-66902](https://jira.devops.va.gov/browse/MHV-66902) - Allergies: Download pdf content needs to be updated to match with Print view and txt file

Navigate to Allergies details page after selecting a Allergy record , then select Download PDF the dropdown 

Notice that pdf contain domain prefix.

## Testing done
Checked whether the prefix was removed.

## Screenshots
![Screenshot 2025-02-03 at 10 46 20 AM (3)](https://github.com/user-attachments/assets/dfc4f0fa-08cc-41c8-a594-9c161ec6c522)
![Screenshot 2025-02-03 at 10 56 41 AM (3)](https://github.com/user-attachments/assets/939fdcf1-b1e4-4e96-b01b-3b2c463cd2d0)


## What areas of the site does it impact?
Allergies details section in medical records. 

## Acceptance criteria
Prefix not there.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


