### PR TITLE
added mhv sandbox enviornment to proxy rewrite whitelist

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -205,10 +205,20 @@
       "pathnameBeginning": "/",
       "cookieOnly": false
     },
+     {
+      "hostname": "myhealth.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": false
+    },
+        {
+      "hostname": "www.sandbox-patientportal.myhealth.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
     {
       "hostname": "sandbox-patientportal.myhealth.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": false
+      "cookieOnly": true
     }
   ]
 }

--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -204,6 +204,11 @@
       "hostname": "www.m.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": false
+    },
+    {
+      "hostname": "sandbox-patientportal.myhealth.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": false
     }
   ]
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Users are getting stuck in a loop when trying to access the Patient Portal **sandbox** environment due to **missing allowlist entries**.  
- If a user has **already accepted the Terms of Use (ToU)**, they are redirected to the sandbox but see **no user data** (404 error on `keep_alive`).  
- If a user has **not accepted ToU yet**, they experience **422 errors** during provisioning, leading to an **authentication failure (error 110, missing RequestID)**.  
- After a failed attempt, users eventually gain access but encounter a **500 error on sandbox** and need to restart authentication.  

### **Steps I Took to Troubleshoot:**  
1. **Reviewed SAML assertions** to compare `NameID` settings in sandbox vs. staging.  
2. **Analyzed network requests**, verifying the sequence of API calls made after login.  
3. **Examined logs for session validation**, checking why users were getting redirected to the ToU page multiple times.  
4. **Investigated `user-provisioning` and `accept_and_provision` failures**, which returned `422` errors.  
5. **Checked allowlist configurations**, confirming that **sandbox was missing** from the approved environments.  
6. **Tested login behavior across different user states** (ToU accepted vs. not accepted).  

### **Fix:**  
Added **sandbox** to the allowlist should resolve these issues by ensuring users are provisioned correctly and redirected without failures.


## Related issue(s)



## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
