### PR TITLE
Update location of death page(s)

### DIFF
--- a/src/applications/burials-ez/BurialsApp.jsx
+++ b/src/applications/burials-ez/BurialsApp.jsx
@@ -12,6 +12,7 @@ export default function BurialsApp({ location, children }) {
     loading: isLoadingFeatures,
     burialFormEnabled,
     burialDocumentUploadUpdate,
+    burialLocationOfDeathUpdate,
     burialModuleEnabled,
   } = useSelector(state => state?.featureToggles);
 
@@ -26,12 +27,20 @@ export default function BurialsApp({ location, children }) {
     () => {
       if (!isLoadingFeatures) {
         window.sessionStorage.setItem(
+          'showLocationOfDeath',
+          !!burialLocationOfDeathUpdate,
+        );
+        window.sessionStorage.setItem(
           'showUploadDocuments',
           !!burialDocumentUploadUpdate,
         );
       }
     },
-    [isLoadingFeatures, burialDocumentUploadUpdate],
+    [
+      isLoadingFeatures,
+      burialLocationOfDeathUpdate,
+      burialDocumentUploadUpdate,
+    ],
   );
 
   if (isLoadingFeatures) {

--- a/src/applications/burials-ez/config/chapters/02-veteran-information/locationOfDeathV2.js
+++ b/src/applications/burials-ez/config/chapters/02-veteran-information/locationOfDeathV2.js
@@ -1,0 +1,52 @@
+import fullSchemaBurials from 'vets-json-schema/dist/21P-530EZ-schema.json';
+import get from '@department-of-veterans-affairs/platform-forms-system/get';
+import {
+  radioUI,
+  textUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { generateTitle } from '../../../utils/helpers';
+import { locationOfDeathLabels } from '../../../utils/labels';
+
+const { locationOfDeath } = fullSchemaBurials.properties;
+
+export default {
+  uiSchema: {
+    'ui:title': generateTitle('Veteran death location'),
+    locationOfDeath: {
+      location: radioUI({
+        title: `Where did the Veteran’s death occur?`,
+        labels: locationOfDeathLabels,
+        errorMessages: {
+          required: `Select where the Veteran’s death happened`,
+        },
+        labelHeaderLevel: '',
+      }),
+      other: {
+        ...textUI({
+          title: 'Place where the Veteran’s death happened',
+          errorMessages: {
+            required: 'Enter where the Veteran’s death happened',
+          },
+          required: form => get('locationOfDeath.location', form) === 'other',
+        }),
+        'ui:options': {
+          hideIf: form => get('locationOfDeath.location', form) !== 'other',
+          classNames: 'vads-u-margin-top--2',
+        },
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['locationOfDeath'],
+    properties: {
+      locationOfDeath: {
+        ...locationOfDeath,
+        properties: {
+          location: locationOfDeath.properties.location,
+          other: locationOfDeath.properties.other,
+        },
+      },
+    },
+  },
+};

--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -201,7 +201,7 @@ const formConfig = {
           schema: locationOfDeathV2.schema,
         },
         nursingHomeUnpaid: {
-          title: 'Veteran death facility information',
+          title: 'Veteran death location information',
           path: 'veteran-information/location-of-death/nursing-home-unpaid',
           depends: form =>
             showLocationOfDeath() &&
@@ -212,7 +212,7 @@ const formConfig = {
           ),
         },
         nursingHomePaid: {
-          title: 'Veteran death facility information',
+          title: 'Veteran death location information',
           path: 'veteran-information/location-of-death/nursing-home-paid',
           depends: form =>
             showLocationOfDeath() &&
@@ -223,7 +223,7 @@ const formConfig = {
           ),
         },
         vaMedicalCenter: {
-          title: 'Veteran death facility information',
+          title: 'Veteran death location information',
           path: 'veteran-information/location-of-death/va-medical-center',
           depends: form =>
             showLocationOfDeath() &&
@@ -234,7 +234,7 @@ const formConfig = {
           ),
         },
         stateVeteransHome: {
-          title: 'Veteran death facility information',
+          title: 'Veteran death location information',
           path: 'veteran-information/location-of-death/state-veterans-home',
           depends: form =>
             showLocationOfDeath() &&

--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -19,6 +19,7 @@ import contactInformation from './chapters/01-claimant-information/contactInform
 import veteranInformation from './chapters/02-veteran-information/veteranInformation';
 import burialInformation from './chapters/02-veteran-information/burialInformation';
 import locationOfDeath from './chapters/02-veteran-information/locationOfDeath';
+import locationOfDeathV2 from './chapters/02-veteran-information/locationOfDeathV2';
 
 import separationDocuments from './chapters/03-military-history/separationDocuments';
 import uploadDD214 from './chapters/03-military-history/uploadDD214';
@@ -45,7 +46,11 @@ import deathCertificateV2 from './chapters/05-additional-information/deathCertif
 import transportationReceipts from './chapters/05-additional-information/transportationReceipts';
 import additionalEvidence from './chapters/05-additional-information/additionalEvidence';
 
-import { showUploadDocuments } from '../utils/helpers';
+import {
+  showUploadDocuments,
+  showLocationOfDeath,
+  generateDeathFacilitySchemas,
+} from '../utils/helpers';
 import { submit } from './submit';
 import manifest from '../manifest.json';
 import migrations from '../migrations';
@@ -181,8 +186,63 @@ const formConfig = {
             <span className="vads-u-font-size--h3">Veteran death location</span>
           ),
           path: 'veteran-information/location-of-death',
+          depends: () => !showLocationOfDeath(),
           uiSchema: locationOfDeath.uiSchema,
           schema: locationOfDeath.schema,
+        },
+        locationOfDeathV2: {
+          title: 'Veteran death location',
+          reviewTitle: () => (
+            <span className="vads-u-font-size--h3">Veteran death location</span>
+          ),
+          path: 'veteran-information/location-of-death-v2',
+          depends: () => showLocationOfDeath(),
+          uiSchema: locationOfDeathV2.uiSchema,
+          schema: locationOfDeathV2.schema,
+        },
+        nursingHomeUnpaid: {
+          title: 'Veteran death facility information',
+          path: 'veteran-information/location-of-death/nursing-home-unpaid',
+          depends: form =>
+            showLocationOfDeath() &&
+            get('locationOfDeath.location', form) === 'nursingHomeUnpaid',
+          ...generateDeathFacilitySchemas(
+            'nursingHomeUnpaid',
+            'facility or nursing home that VA doesn’t pay for',
+          ),
+        },
+        nursingHomePaid: {
+          title: 'Veteran death facility information',
+          path: 'veteran-information/location-of-death/nursing-home-paid',
+          depends: form =>
+            showLocationOfDeath() &&
+            get('locationOfDeath.location', form) === 'nursingHomePaid',
+          ...generateDeathFacilitySchemas(
+            'nursingHomePaid',
+            'facility or nursing home that VA pays for',
+          ),
+        },
+        vaMedicalCenter: {
+          title: 'Veteran death facility information',
+          path: 'veteran-information/location-of-death/va-medical-center',
+          depends: form =>
+            showLocationOfDeath() &&
+            get('locationOfDeath.location', form) === 'vaMedicalCenter',
+          ...generateDeathFacilitySchemas(
+            'vaMedicalCenter',
+            'VA medical center',
+          ),
+        },
+        stateVeteransHome: {
+          title: 'Veteran death facility information',
+          path: 'veteran-information/location-of-death/state-veterans-home',
+          depends: form =>
+            showLocationOfDeath() &&
+            get('locationOfDeath.location', form) === 'stateVeteransHome',
+          ...generateDeathFacilitySchemas(
+            'stateVeteransHome',
+            'state Veterans facility',
+          ),
         },
       },
     },

--- a/src/applications/burials-ez/utils/helpers.jsx
+++ b/src/applications/burials-ez/utils/helpers.jsx
@@ -4,8 +4,10 @@ import set from 'platform/utilities/data/set';
 import get from 'platform/utilities/data/get';
 
 import {
-  fullNameUI,
   checkboxGroupSchema,
+  fullNameUI,
+  textUI,
+  textSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import { validateBenefitsIntakeName } from './validation';
@@ -19,6 +21,51 @@ export const generateHelpText = (
   className = 'vads-u-color--gray vads-u-font-size--md',
 ) => {
   return <span className={className}>{text}</span>;
+};
+
+/**
+ * Function to generate UI Schema and Schema for death facility information
+ * @param {string} facilityKey - Key for death facility in the schema
+ * @param {string} facilityName - Name for the facility in UI
+ * @returns {Object} - Object containing uiSchema and schema
+ */
+export const generateDeathFacilitySchemas = (
+  facilityKey,
+  facilityName = 'Default Facility Name',
+) => {
+  return {
+    uiSchema: {
+      'ui:title': generateTitle('Veteran death location information'),
+      'ui:description': `You selected that the deceased Veteran died in a ${facilityName}. We need more information about where the death occurred.`,
+      [facilityKey]: {
+        facilityName: textUI({
+          title: `Name of the ${facilityName}`,
+          errorMessages: {
+            required: `Enter the Name of the ${facilityName}`,
+          },
+        }),
+        facilityLocation: textUI({
+          title: `City and state of the ${facilityName}`,
+          errorMessages: {
+            required: `Enter the city and state of the ${facilityName}`,
+          },
+        }),
+      },
+    },
+    schema: {
+      type: 'object',
+      properties: {
+        [facilityKey]: {
+          type: 'object',
+          required: ['facilityName', 'facilityLocation'],
+          properties: {
+            facilityName: textSchema,
+            facilityLocation: textSchema,
+          },
+        },
+      },
+    },
+  };
 };
 
 export const checkboxGroupSchemaWithReviewLabels = keys => {
@@ -52,6 +99,9 @@ export const isProductionEnv = () => {
     !window.Mocha
   );
 };
+
+export const showLocationOfDeath = () =>
+  window.sessionStorage.getItem('showLocationOfDeath') === 'true';
 
 export const showUploadDocuments = () =>
   window.sessionStorage.getItem('showUploadDocuments') === 'true';


### PR DESCRIPTION
Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes

## Summary
Update the 'Location of death' page on the Burial Benefits form (21P-530EZ) to a more accessible UI pattern.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80105

## Associated Pull Request(s)
- https://github.com/department-of-veterans-affairs/vets-api/pull/20576
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/971

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. In your local environment, set the `burial_location_of_death_update ` flipper to 'enabled' at http://localhost:3000/flipper/features/burial_location_of_death_update
4. Go to `http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/` in your browser

## How to verify
### Location of Death page
1. Sign in
2. Go to the `/location-of-death-v2` page
#### At Home
1. Select 'At home' and then 'Continue'
2. Verify that the 'Veteran death location information' page is NOT displayed
#### In a nursing home or facility that VA doesn't pay for
1. Select 'In a nursing home or facility that VA doesn't pay for' and then 'Continue'
2. Verify that the 'Veteran death location information' page is displayed with the correct field labels
#### In a nursing home or facility that VA pays for
1. Select 'In a nursing home or facility that VA pays for' and then 'Continue'
2. Verify that the 'Veteran death location information' page is displayed with the correct field labels
#### In a VA medical center
1. Select 'In a VA medical center' and then 'Continue'
2. Verify that the 'Veteran death location information' page is displayed with the correct field labels
#### In a state Veterans facility
1. Select 'In a state Veterans facility' and then 'Continue'
2. Verify that the 'Veteran death location information' page is displayed with the correct field labels
#### Other
1. Select 'Other' and then 'Continue'
2. Verify that 'Other' is a required field
3. Enter text into 'Other' field and then 'Continue'
4. Verify that the 'Veteran death location information' page is NOT displayed

### Review and submit
1. Sign in
2. Load data into the 'Save in progress' menu
3. Return to the `/review-and-submit` page
4. Expand the 'Deceased Veteran information' accordion
5. Verify that the 'Veteran death location' data is correct
6. Verify that the 'Veteran death location information' is correct
7. Verify that only the active 'Veteran death location information' is included in the submission


## What areas of the site does it impact?
Burial Benefits Application

## Screenshots
### Location of death page(s)
| Before      | After       | After       |
| ----------- | ----------- | ----------- |
|![Screenshot 2025-02-03 at 8 20 39 AM](https://github.com/user-attachments/assets/afe6c570-7f48-4dcb-9024-6ca1c055a369)|![Screenshot 2025-02-03 at 1 48 42 PM](https://github.com/user-attachments/assets/e169b5e5-6018-459c-96f1-224f149d2db7)|![Screenshot 2025-02-03 at 1 50 10 PM](https://github.com/user-attachments/assets/1657d30a-9317-421f-b328-4b6164205dc6)|

### Review and submit page
| Before      | After       |
| ----------- | ----------- |
|![Screenshot 2025-02-03 at 3 36 47 PM](https://github.com/user-attachments/assets/5c87f879-3aa7-40a7-919d-c8caf3b1ce41)|![Screenshot 2025-02-04 at 8 54 59 AM](https://github.com/user-attachments/assets/53a4b4e2-7750-4223-9f3a-0e9f86ba237f)|


### Quality Assurance & Testing
- [ ] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
