### PR TITLE
Enable web vitals reporting in production with sampling

### DIFF
--- a/src/platform/monitoring/tests/web-vitals.unit.spec.js
+++ b/src/platform/monitoring/tests/web-vitals.unit.spec.js
@@ -2,17 +2,19 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as recordEventModule from 'platform/monitoring/record-event';
-import { recordWebVitalsEvent } from '../web-vitals';
+import { recordWebVitalsEvent, trackWebVitals } from '../web-vitals';
+
+const sandbox = sinon.createSandbox();
 
 describe('recordWebVitalsEvent', () => {
   let recordEventStub;
 
   beforeEach(() => {
-    recordEventStub = sinon.stub(recordEventModule, 'default');
+    recordEventStub = sandbox.stub(recordEventModule, 'default');
   });
 
   afterEach(() => {
-    recordEventStub.restore();
+    sandbox.restore();
   });
 
   it('should record a web vitals event with correct properties for CLS', () => {
@@ -69,5 +71,21 @@ describe('recordWebVitalsEvent', () => {
       app_name: 'testApp',
     });
     delete window.appName;
+  });
+});
+
+describe('trackWebVitals', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return true 1% of the time when sampling events', () => {
+    sandbox.stub(Math, 'random').returns(0.005);
+    expect(trackWebVitals({ sampleEvents: true })).to.be.true;
+  });
+
+  it('should return false 99% of the time when sampling events', () => {
+    sandbox.stub(Math, 'random').returns(0.02);
+    expect(trackWebVitals({ sampleEvents: true })).to.be.false;
   });
 });

--- a/src/platform/monitoring/web-vitals.js
+++ b/src/platform/monitoring/web-vitals.js
@@ -20,11 +20,15 @@ const recordWebVitalsEvent = event => {
   recordEvent(webVitalsEvent);
 };
 
-const trackWebVitals =
-  // Exclude production for now.
-  !environment.isProduction() &&
+const trackWebVitals = () => {
+  // Sample ~1% of events from production.
+  if (environment.isProduction()) {
+    return Math.random() < 0.01;
+  }
+
   // Exclude cypress containers and localhost from tracking web vitals.
-  environment.BASE_URL.indexOf('localhost') < 0;
+  return environment.BASE_URL.indexOf('localhost') < 0;
+};
 
 if (trackWebVitals) {
   onCLS(recordWebVitalsEvent);

--- a/src/platform/monitoring/web-vitals.js
+++ b/src/platform/monitoring/web-vitals.js
@@ -20,9 +20,9 @@ const recordWebVitalsEvent = event => {
   recordEvent(webVitalsEvent);
 };
 
-const trackWebVitals = () => {
-  // Sample ~1% of events from production.
-  if (environment.isProduction()) {
+const trackWebVitals = ({ sampleEvents = false }) => {
+  if (sampleEvents) {
+    // Sample ~1% of events.
     return Math.random() < 0.01;
   }
 
@@ -30,11 +30,11 @@ const trackWebVitals = () => {
   return environment.BASE_URL.indexOf('localhost') < 0;
 };
 
-if (trackWebVitals) {
+if (trackWebVitals({ sampleEvents: environment.isProduction() })) {
   onCLS(recordWebVitalsEvent);
   onINP(recordWebVitalsEvent);
   onLCP(recordWebVitalsEvent);
   onTTFB(recordWebVitalsEvent);
 }
 
-export { recordWebVitalsEvent };
+export { recordWebVitalsEvent, trackWebVitals };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This is a follow-on from #33277 - the functionality has been validated in staging by the analytics team (@jestutt @johnny-jesensky-adhoc) and they have requested that it be enabled in production with sampling to 1% of events. (Sampling was uable to be applied in GTM)

## Testing done

local testing + added unit tests 

