### PR TITLE
Form Upload - handle case in form numbers like 21P-0518

### DIFF
--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -26,9 +26,15 @@ const formMappings = {
 export const getFormNumber = (pathname = null) => {
   const path = pathname || window?.location?.pathname;
   const regex = /upload\/([^/]+)/;
-  const match = path.match(regex)?.[1].toUpperCase();
-  if (formMappings[match]) {
-    return match;
+  const match = path.match(regex)?.[1];
+  if (match) {
+    const normalizedMatch = Object.keys(formMappings).find(
+      key => key.toLowerCase() === match.toLowerCase(),
+    );
+
+    if (normalizedMatch) {
+      return normalizedMatch;
+    }
   }
 
   return '';

--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -27,17 +27,9 @@ export const getFormNumber = (pathname = null) => {
   const path = pathname || window?.location?.pathname;
   const regex = /upload\/([^/]+)/;
   const match = path.match(regex)?.[1];
-  if (match) {
-    const normalizedMatch = Object.keys(formMappings).find(
-      key => key.toLowerCase() === match.toLowerCase(),
-    );
-
-    if (normalizedMatch) {
-      return normalizedMatch;
-    }
-  }
-
-  return '';
+  return (
+    Object.keys(formMappings).find(key => key.toLowerCase() === match) || ''
+  );
 };
 
 export const getFormContent = (pathname = null) => {

--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -26,7 +26,7 @@ const formMappings = {
 export const getFormNumber = (pathname = null) => {
   const path = pathname || window?.location?.pathname;
   const regex = /upload\/([^/]+)/;
-  const match = path.match(regex)?.[1];
+  const match = path.match(regex)?.[1].toUpperCase();
   if (formMappings[match]) {
     return match;
   }

--- a/src/applications/simple-forms/form-upload/routes.jsx
+++ b/src/applications/simple-forms/form-upload/routes.jsx
@@ -8,12 +8,13 @@ const formUploadForms = ['21-0779', '21-509', '21P-0518-1', '21P-0516-1'];
 const config = formConfig();
 
 const routes = formUploadForms.map(formId => {
+  const lowerCaseFormId = formId.toLowerCase();
   return {
-    path: `/${formId.toLowerCase()}`,
+    path: `/${lowerCaseFormId}`,
     component: App,
     indexRoute: {
       onEnter: (nextState, replace) =>
-        replace(`/${formId.toLowerCase()}/introduction`),
+        replace(`/${lowerCaseFormId}/introduction`),
     },
     childRoutes: createRoutesWithSaveInProgress(config),
   };

--- a/src/applications/simple-forms/form-upload/routes.jsx
+++ b/src/applications/simple-forms/form-upload/routes.jsx
@@ -9,10 +9,11 @@ const config = formConfig();
 
 const routes = formUploadForms.map(formId => {
   return {
-    path: `/${formId}`,
+    path: `/${formId.toLowerCase()}`,
     component: App,
     indexRoute: {
-      onEnter: (nextState, replace) => replace(`/${formId}/introduction`),
+      onEnter: (nextState, replace) =>
+        replace(`/${formId.toLowerCase()}/introduction`),
     },
     childRoutes: createRoutesWithSaveInProgress(config),
   };

--- a/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
+++ b/src/applications/simple-forms/form-upload/tests/unit/helpers/index.unit.spec.js
@@ -26,6 +26,13 @@ describe('Helpers', () => {
       expect(getFormNumber()).to.eq('21-0779');
     });
 
+    it('retains upper-case characters from formMappings', () => {
+      global.window.location = {
+        pathname: '/find-forms/upload/21p-0518-1/upload',
+      };
+      expect(getFormNumber()).to.eq('21P-0518-1');
+    });
+
     it('returns empty string when formNumber does not match', () => {
       global.window.location = {
         pathname: 'find-forms/upload/fake-form/upload',


### PR DESCRIPTION
## Summary
This PR changes how we handle alphabetical characters in form numbers. We want letters to be lowercase in URLs but upper case in all other displays (breadcrumbs, H1, etc).

Before:
<img width="937" alt="Screenshot 2025-02-04 at 9 50 36 AM" src="https://github.com/user-attachments/assets/a9517361-6f48-4e65-9fdc-3b260827a431" />

After:
<img width="935" alt="Screenshot 2025-02-04 at 9 49 40 AM" src="https://github.com/user-attachments/assets/0ded2eee-8eb3-458b-9a37-8f10d5f046ee" />


## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=96307466&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C1994
