### PR TITLE
VAGOV-TEAM-102422: Update fetchDrupalDigitalForms to fetch from current environment

### DIFF
--- a/src/applications/simple-forms-form-engine/shared/actions/form-load/index.js
+++ b/src/applications/simple-forms-form-engine/shared/actions/form-load/index.js
@@ -4,13 +4,9 @@ export const FORM_LOADING_SUCCEEDED = 'FORM_RENDERER/FORM_LOADING_SUCCEEDED';
 export const FORM_LOADING_FAILED = 'FORM_RENDERER/FORM_LOADING_FAILED';
 
 import { fetchDrupalStaticDataFile } from 'platform/site-wide/drupal-static-data/connect/fetch';
-import ENVIRONMENTS from 'site/constants/environments';
-import ENVIRONMENT_CONFIGURATIONS from 'site/constants/environments-configs';
 import environment from 'platform/utilities/environment';
 import mockForms from '../../config/formConfig';
 import { createFormConfig } from '../../utils/formConfig';
-
-const PROD_ENV = ENVIRONMENT_CONFIGURATIONS[ENVIRONMENTS.VAGOVPROD];
 
 export const formLoadingInitiated = formId => {
   return {
@@ -34,7 +30,7 @@ export const formLoadingFailed = error => {
 };
 
 export const fetchDrupalDigitalForms = () =>
-  fetchDrupalStaticDataFile(DIGITAL_FORMS_FILENAME, PROD_ENV.BASE_URL);
+  fetchDrupalStaticDataFile(DIGITAL_FORMS_FILENAME, environment.BASE_URL);
 
 /**
  * Mocks a fetch of content-build forms data.

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/actions/form-load.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/actions/form-load.unit.spec.js
@@ -2,8 +2,7 @@ import { expect } from 'chai';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { DATA_FILES_PATH } from 'platform/site-wide/drupal-static-data/constants';
-import ENVIRONMENTS from 'site/constants/environments';
-import ENVIRONMENT_CONFIGURATIONS from 'site/constants/environments-configs';
+import environment from 'platform/utilities/environment';
 import {
   employmentQuestionnaire,
   normalizedForm,
@@ -19,7 +18,6 @@ import {
 
 const sinon = require('sinon');
 
-const PROD_ENV = ENVIRONMENT_CONFIGURATIONS[ENVIRONMENTS.VAGOVPROD];
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 const initialState = {
@@ -39,7 +37,9 @@ describe('form-load actions', () => {
         .expects('fetch')
         .once()
         .withArgs(
-          `${PROD_ENV.BASE_URL}/${DATA_FILES_PATH}/${DIGITAL_FORMS_FILENAME}`,
+          `${
+            environment.BASE_URL
+          }/${DATA_FILES_PATH}/${DIGITAL_FORMS_FILENAME}`,
         );
 
       await fetchDrupalDigitalForms();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Because of CORS issues, lower environments cannot successfully pull from the prod Drupal KISS file.
- Updates `fetchDrupalDigitalForms` to pull from the current environment instead.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#102422

## Testing done

- Updated unit test

## What areas of the site does it impact?

All forms created using the simple-forms-form-engine shared code.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
