### PR TITLE
MHV-65333 + MHV-66798: Rx updates to Print/PDF/TXT

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
@@ -109,13 +109,7 @@ const MedicationsList = props => {
       <div className="no-print rx-page-total-info vads-u-border-bottom--2px vads-u-border-color--gray-lighter" />
       <div className="print-only vads-u-margin--0 vads-u-width--full">
         {rxList?.length > 0 &&
-          rxList.map((rx, idx) => (
-            <PrescriptionPrintOnly
-              hideLineBreak={idx === rxList.length - 1}
-              key={idx}
-              rx={rx}
-            />
-          ))}
+          rxList.map((rx, idx) => <PrescriptionPrintOnly key={idx} rx={rx} />)}
       </div>
       <div
         className="vads-u-display--block vads-u-margin-top--3"

--- a/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/PrescriptionPrintOnly.jsx
@@ -13,7 +13,7 @@ import {
 import VaPharmacyText from '../shared/VaPharmacyText';
 
 const PrescriptionPrintOnly = props => {
-  const { rx, hideLineBreak, refillHistory, isDetailsRx } = props;
+  const { rx, refillHistory, isDetailsRx } = props;
   const pharmacyPhone = pharmacyPhoneNumber(rx);
   const latestTrackingStatus = rx?.trackingList?.[0];
 
@@ -83,14 +83,21 @@ const PrescriptionPrintOnly = props => {
           (rx.dispStatus === 'Active: Non-VA' ? rx.orderableItem : '')}
       </NameElement>
       {rx?.prescriptionSource !== 'NV' ? (
-        <>
-          <DetailsHeaderElement>About your prescription</DetailsHeaderElement>
+        <div className={isDetailsRx ? '' : 'vads-u-margin-left--2'}>
+          <DetailsHeaderElement>
+            {isDetailsRx
+              ? 'Most recent prescription'
+              : 'About your prescription'}
+          </DetailsHeaderElement>
           <div className="print-only-rx-details-container">
             <p>
               <strong>Last filled on:</strong>{' '}
               {rx?.sortedDispensedDate
                 ? dateFormat(rx.sortedDispensedDate, 'MMMM D, YYYY')
                 : 'Not filled yet'}
+            </p>
+            <p>
+              <strong>Prescription number:</strong> {rx.prescriptionNumber}
             </p>
             <p>
               <strong>Status:</strong>{' '}
@@ -135,17 +142,6 @@ const PrescriptionPrintOnly = props => {
               {dateFormat(rx.expirationDate, 'MMMM D, YYYY')}
             </p>
             <p>
-              <strong>Prescription number:</strong> {rx.prescriptionNumber}
-            </p>
-            <p>
-              <strong>Prescribed on:</strong>{' '}
-              {dateFormat(rx.orderedDate, 'MMMM D, YYYY')}
-            </p>
-            <p>
-              <strong>Prescribed by:</strong>{' '}
-              {(rx.providerFirstName && rx.providerLastName) || EMPTY_FIELD}
-            </p>
-            <p>
               <strong>Facility:</strong> {validateField(rx.facilityName)}
             </p>
             <p>
@@ -159,12 +155,7 @@ const PrescriptionPrintOnly = props => {
                 EMPTY_FIELD
               )}
             </p>
-          </div>
-          <DetailsHeaderElement>
-            About this medication or supply
-          </DetailsHeaderElement>
-          <div className="print-only-rx-details-container">
-            <p className="no-break">
+            <p>
               <strong>Instructions:</strong> {validateField(rx.sig)}
             </p>
             <p>
@@ -174,29 +165,55 @@ const PrescriptionPrintOnly = props => {
             <p>
               <strong>Quantity:</strong> {validateField(rx.quantity)}
             </p>
+            <p>
+              <strong>Prescribed on:</strong>{' '}
+              {dateFormat(rx.orderedDate, 'MMMM D, YYYY')}
+            </p>
+            <p>
+              <strong>Prescribed by:</strong>{' '}
+              {rx.providerLastName
+                ? `${rx.providerLastName}, ${rx.providerFirstName || ''}`
+                : 'None noted'}
+            </p>
+            {!isDetailsRx &&
+              rx.groupedMedications?.length > 0 && (
+                <p>
+                  <strong>
+                    Previous prescriptions associated with this medication:
+                  </strong>{' '}
+                  {rx.groupedMedications
+                    .map(previousRx => {
+                      return previousRx.prescriptionNumber;
+                    })
+                    .join(', ')}
+                </p>
+              )}
           </div>
           {refillHistory && (
-            <div className="print-only-refill-container">
-              <DetailsHeaderElement>Refill history</DetailsHeaderElement>
+            <div className="print-only-refill-container vads-u-margin-left--2">
+              <h4>Refill history</h4>
+              <p className="vads-u-margin-y--1p5">
+                {`Showing ${refillHistory.length} refill${
+                  refillHistory.length > 1 ? 's, from newest to oldest' : ''
+                }`}
+              </p>
               <div className="print-only-rx-details-container">
                 {refillHistory.map((entry, i) => {
                   const index = refillHistory.length - i - 1;
                   const { shape, color, backImprint, frontImprint } = entry;
                   return (
-                    <div key={index}>
-                      <h4>
-                        {`${index === 0 ? 'First fill' : `Refill ${index}`}`}
-                      </h4>
-                      <p>
-                        <strong>Filled by pharmacy on:</strong>{' '}
-                        {entry?.dispensedDate
-                          ? dateFormat(entry.dispensedDate)
-                          : EMPTY_FIELD}
-                      </p>
-                      <p>
-                        <strong>Shipped on:</strong>{' '}
-                        {dateFormat(latestTrackingStatus?.completeDateTime)}
-                      </p>
+                    <div key={index} className="vads-u-margin-bottom--2">
+                      <h5 className="vads-u-margin-top--1">
+                        {`${
+                          index === 0 ? 'Original fill' : `Refill`
+                        }: ${dateFormat(entry.dispensedDate)}`}
+                      </h5>
+                      {i === 0 && (
+                        <p>
+                          <strong>Shipped on:</strong>{' '}
+                          {dateFormat(latestTrackingStatus?.completeDateTime)}
+                        </p>
+                      )}
                       <p className="vads-u-margin--0">
                         <strong>Medication description: </strong>
                       </p>
@@ -244,18 +261,68 @@ const PrescriptionPrintOnly = props => {
                           if you need help identifying this medication.
                         </>
                       )}
-                      <div className="line-break" />
                     </div>
                   );
                 })}
               </div>
             </div>
           )}
-        </>
+          {isDetailsRx &&
+            rx.groupedMedications?.length > 0 && (
+              <>
+                <h3>Previous prescriptions</h3>
+                <div className="vads-u-margin-left--2">
+                  <p className="vads-u-margin-y--1p5">
+                    {`Showing ${rx.groupedMedications.length} prescription${
+                      rx.groupedMedications.length > 1
+                        ? 's, from newest to oldest'
+                        : ''
+                    }`}
+                  </p>
+                  <div className="print-only-rx-details-container">
+                    {rx.groupedMedications.map(entry => {
+                      return (
+                        <div
+                          key={entry.prescriptionNumber}
+                          className="vads-u-margin-bottom--2"
+                        >
+                          <h4>
+                            {`Prescription number: ${entry.prescriptionNumber}`}
+                          </h4>
+                          <p>
+                            <strong>Last filled:</strong>{' '}
+                            {entry.sortedDispensedDate
+                              ? dateFormat(
+                                  entry.sortedDispensedDate,
+                                  'MMMM D, YYYY',
+                                )
+                              : 'Not filled yet'}
+                          </p>
+                          <p>
+                            <strong>Quantity:</strong>{' '}
+                            {validateField(entry.quantity)}
+                          </p>
+                          <p>
+                            <strong>Prescribed on:</strong>{' '}
+                            {dateFormat(entry.orderedDate, 'MMMM D, YYYY')}
+                          </p>
+                          <p>
+                            <strong>Prescribed by:</strong>{' '}
+                            {(entry.providerFirstName &&
+                              entry.providerLastName) ||
+                              EMPTY_FIELD}
+                          </p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </>
+            )}
+        </div>
       ) : (
         activeNonVaContent(rx)
       )}
-      {!hideLineBreak && <div className="line-break vads-u-margin-top--2" />}
     </div>
   );
 };
@@ -264,7 +331,6 @@ export default PrescriptionPrintOnly;
 
 PrescriptionPrintOnly.propTypes = {
   rx: PropTypes.object.isRequired,
-  hideLineBreak: PropTypes.bool,
   isDetailsRx: PropTypes.bool,
   refillHistory: PropTypes.array,
 };

--- a/src/applications/mhv-medications/components/shared/AllergiesPrintOnly.jsx
+++ b/src/applications/mhv-medications/components/shared/AllergiesPrintOnly.jsx
@@ -11,26 +11,18 @@ const AllergiesPrintOnly = props => {
         {allergies?.length > 0 ? (
           <>
             <div>
-              <div>
+              <div className="vads-u-margin-bottom--1">
                 This list includes all allergies, reactions, and side effects in
                 your VA medical records. This includes medication side effects
                 (also called adverse drug reactions). If you have allergies or
                 reactions that are missing from this list, tell your care team
                 at your next appointment.
               </div>
-              <br />
               Showing {allergies.length} records from newest to oldest
             </div>
             <div>
-              {allergies?.map((allergy, index) => (
-                <div
-                  key={allergy.id}
-                  className={
-                    allergies.length - 1 !== index
-                      ? 'vads-u-border-bottom--1px'
-                      : ''
-                  }
-                >
+              {allergies?.map(allergy => (
+                <div key={allergy.id}>
                   <div className="print-only-rx-details-container">
                     <h3>{allergy.name}</h3>
                     <div className="print-only-rx-details-container">
@@ -83,7 +75,7 @@ const AllergiesPrintOnly = props => {
   };
 
   return (
-    <div className="print-only print-only-rx-container">
+    <div className="print-only print-only-rx-container vads-u-border-top--1px vads-u-border-color--black">
       <h2>Allergies</h2>
       {content()}
     </div>

--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -160,11 +160,7 @@ const PrescriptionDetails = () => {
               preface: [
                 {
                   value:
-                    'We couldn’t access your allergy records when you downloaded this list. We’re sorry. There was a problem with our system. Try again later.',
-                },
-                {
-                  value:
-                    'If it still doesn’t work, call us at 877-327-0022 (TTY: 711). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
+                    'We couldn’t access your allergy records when you downloaded this list. We’re sorry. There was a problem with our system. Try again later. If it still doesn’t work, call us at 877-327-0022 (TTY: 711). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
                 },
               ],
             }),
@@ -428,7 +424,6 @@ const PrescriptionDetails = () => {
             }
           >
             <PrescriptionPrintOnly
-              hideLineBreak
               rx={prescription}
               refillHistory={!nonVaPrescription ? refillHistory : []}
               isDetailsRx

--- a/src/applications/mhv-medications/containers/PrintOnlyPage.jsx
+++ b/src/applications/mhv-medications/containers/PrintOnlyPage.jsx
@@ -32,11 +32,8 @@ const PrintOnlyPage = props => {
         <div>
           <p>
             We’re sorry. There’s a problem with our system. We can’t print your
-            records right now. Try again later.
-          </p>
-          <p>
-            If it still doesn’t work, call us at{' '}
-            <va-telephone not-clickable contact="8773270022" /> (
+            records right now. Try again later. If it still doesn’t work, call
+            us at <va-telephone not-clickable contact="8773270022" /> (
             <va-telephone not-clickable contact={CONTACTS[711]} tty />
             ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
           </p>

--- a/src/applications/mhv-medications/sass/medications.scss
+++ b/src/applications/mhv-medications/sass/medications.scss
@@ -182,10 +182,6 @@
     margin: 0.9375rem 0 !important;
     padding: 0;
   }
-  .line-break {
-    margin: 0.625rem 0;
-    border-bottom: 1px solid rgb(0, 0, 0);
-  }
   .no-print,
   .no-print * {
     visibility: hidden;
@@ -220,8 +216,7 @@
       word-wrap: break-word;
     }
     .print-only-rx-details-container {
-      margin: 0 auto 0.625rem auto;
-      width: 95%;
+      margin-bottom: 0.625rem;
     }
     h4 {
       margin: 0.625rem 0 0.3125rem 0;

--- a/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
@@ -11,11 +11,7 @@ describe('Prescription print only container', () => {
       ...(!params.va && { prescriptionSource: 'NV' }),
     };
     return renderWithStoreAndRouter(
-      <PrescriptionPrintOnly
-        hideLineBreak={false}
-        rx={rx}
-        isDetailsRx={params.isDetailsRx}
-      />,
+      <PrescriptionPrintOnly rx={rx} isDetailsRx={params.isDetailsRx} />,
       {
         initialState: {},
         reducers: {},
@@ -34,7 +30,7 @@ describe('Prescription print only container', () => {
   });
   it('should render VA rx details', () => {
     const screen = setup();
-    expect(screen.findByText('About your prescription')).to.exist;
+    expect(screen.findByText('Most recent prescription')).to.exist;
     expect(screen.findByText('Last filled on:')).to.exist;
     expect(screen.findByText('Status:')).to.exist;
     expect(screen.findByText('Refills left:')).to.exist;

--- a/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/PrescriptionDetails/PrescriptionPrintOnly.unit.spec.jsx
@@ -60,7 +60,7 @@ describe('Prescription print only container', () => {
   it('should render h2 tag', () => {
     const screen = setup({ isDetailsRx: true, va: true });
     const nameElement = screen.getByText('ONDANSETRON 8 MG TAB');
-    const detailsHeaderElement = screen.getByText('About your prescription');
+    const detailsHeaderElement = screen.getByText('Most recent prescription');
     expect(nameElement.tagName).to.equal('H2');
     expect(detailsHeaderElement.tagName).to.equal('H3');
   });

--- a/src/applications/mhv-medications/tests/containers/PrintOnlyPage.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/PrintOnlyPage.unit.spec.jsx
@@ -50,12 +50,7 @@ describe('Medications detail page with PrintOnlyPage component wrapper', () => {
       >
         {rx && (
           <>
-            <PrescriptionPrintOnly
-              hideLineBreak
-              rx={rx}
-              refillHistory={[]}
-              isDetailsRx
-            />
+            <PrescriptionPrintOnly rx={rx} refillHistory={[]} isDetailsRx />
           </>
         )}
       </PrintOnlyPage>,

--- a/src/applications/mhv-medications/tests/util/pdfConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/pdfConfigs.unit.spec.jsx
@@ -43,9 +43,9 @@ describe('Allergies List Config', () => {
 });
 
 describe('VA prescription Config', () => {
-  it('should create "About your prescription" section', () => {
+  it('should create "Most recent prescription" section', () => {
     const pdfGen = buildVAPrescriptionPDFList(prescriptionDetails);
-    expect(pdfGen[0].header).to.equal('About your prescription');
+    expect(pdfGen[0].header).to.equal('Most recent prescription');
   });
 
   it('should create "About this medication or supply" section', () => {

--- a/src/applications/mhv-medications/tests/util/pdfConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/pdfConfigs.unit.spec.jsx
@@ -10,10 +10,7 @@ import prescriptions from '../fixtures/prescriptions.json';
 import allergies from '../fixtures/allergies.json';
 import prescriptionDetails from '../fixtures/prescriptionDetails.json';
 import nonVAPrescription from '../fixtures/nonVaPrescription.json';
-import {
-  pdfDefaultStatusDefinition,
-  DOWNLOAD_FORMAT,
-} from '../../util/constants';
+import { DOWNLOAD_FORMAT, EMPTY_FIELD } from '../../util/constants';
 import { convertHtmlForDownload } from '../../util/helpers';
 
 describe('Prescriptions List Config', () => {
@@ -29,9 +26,7 @@ describe('Prescriptions List Config', () => {
       },
     ];
     const pdfList = buildPrescriptionsPDFList(blankPrescriptions);
-    expect(pdfList[0].sections[0].items[2].value).to.equal(
-      pdfDefaultStatusDefinition,
-    );
+    expect(pdfList[0].sections[0].items[2].value).to.equal(EMPTY_FIELD);
   });
 });
 
@@ -48,9 +43,9 @@ describe('VA prescription Config', () => {
     expect(pdfGen[0].header).to.equal('Most recent prescription');
   });
 
-  it('should create "About this medication or supply" section', () => {
+  it('should create "Refill history" section', () => {
     const pdfGen = buildVAPrescriptionPDFList(prescriptionDetails);
-    expect(pdfGen[1].header).to.equal('About this medication or supply');
+    expect(pdfGen[1].header).to.equal('Refill history');
   });
 
   it('should handle single name provider', () => {
@@ -58,7 +53,7 @@ describe('VA prescription Config', () => {
       providerLastName: 'test',
     };
     const pdfList = buildVAPrescriptionPDFList(blankPrescription);
-    expect(pdfList[0].sections[0].items[7].value).to.equal('test, ');
+    expect(pdfList[0].sections[0].items[12].value).to.equal('test, ');
   });
 });
 

--- a/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
@@ -73,15 +73,10 @@ describe('VA prescription Config', () => {
   it('should create "Most recent prescription" section', () => {
     const txt = buildVAPrescriptionTXT(prescriptionDetails.data.attributes);
     expect(txt).to.include('Most recent prescription');
+    expect(txt).to.include('Quantity: 30');
     expect(txt).to.include(
       prescriptionDetails.data.attributes.prescriptionName,
     );
-  });
-
-  it('should create "About this medication or supply" section', () => {
-    const txt = buildVAPrescriptionTXT(prescriptionDetails.data.attributes);
-    expect(txt).to.include('About this medication or supply');
-    expect(txt).to.include('Quantity: 30');
   });
 
   it('should show refill information', () => {

--- a/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/util/txtConfigs.unit.spec.jsx
@@ -70,9 +70,9 @@ describe('Allergies List Config', () => {
 });
 
 describe('VA prescription Config', () => {
-  it('should create "About your prescription" section', () => {
+  it('should create "Most recent prescription" section', () => {
     const txt = buildVAPrescriptionTXT(prescriptionDetails.data.attributes);
-    expect(txt).to.include('About your prescription');
+    expect(txt).to.include('Most recent prescription');
     expect(txt).to.include(
       prescriptionDetails.data.attributes.prescriptionName,
     );

--- a/src/applications/mhv-medications/util/constants.js
+++ b/src/applications/mhv-medications/util/constants.js
@@ -93,15 +93,8 @@ export const imageRootUri = 'https://www.myhealth.va.gov/static/MILDrugImages/';
 export const pdfStatusDefinitions = {
   active: [
     {
-      value: `This is a current prescription. If you have refills left, you can request a refill now.`,
-    },
-    {
-      continued: true,
-      value: `Note: `,
-      weight: 'bold',
-    },
-    {
-      value: `If you have no refills left, you’ll need to request a renewal instead.`,
+      value:
+        'This is a current prescription. If you have refills left, you can request a refill now. If you have no refills left, you’ll need to request a renewal instead.',
     },
   ],
   activeParked: [

--- a/src/applications/mhv-medications/util/txtConfigs.js
+++ b/src/applications/mhv-medications/util/txtConfigs.js
@@ -10,6 +10,7 @@ import {
   pdfStatusDefinitions,
   pdfDefaultStatusDefinition,
   nonVAMedicationTypes,
+  EMPTY_FIELD,
 } from './constants';
 
 /**
@@ -77,7 +78,11 @@ export const buildPrescriptionsTXT = prescriptions => {
     result += `
 ${rx.prescriptionName}
 
+About your prescription
+
 Last filled on: ${dateFormat(rx.sortedDispensedDate, 'MMMM D, YYYY')}
+
+Prescription number: ${rx.prescriptionNumber}
 
 Status: ${validateField(rx.dispStatus)}
 ${(pdfStatusDefinitions[rx.refillStatus] || pdfDefaultStatusDefinition).reduce(
@@ -92,12 +97,6 @@ Request refills by this prescription expiration date: ${dateFormat(
       'MMMM D, YYYY',
     )}
 
-Prescription number: ${rx.prescriptionNumber}
-
-Prescribed on: ${dateFormat(rx.orderedDate, 'MMMM D, YYYY')}
-
-Prescribed by: ${(rx.providerFirstName && rx.providerLastName) || 'None noted'}
-
 Facility: ${validateField(rx.facilityName)}
 
 Pharmacy phone number: ${validateField(rx.phoneNumber)}
@@ -108,10 +107,21 @@ Reason for use: ${validateField(rx.indicationForUse)}
 
 Quantity: ${validateField(rx.quantity)}
 
+Prescribed on: ${dateFormat(rx.orderedDate, 'MMMM D, YYYY')}
 
----------------------------------------------------------------------------------
+Prescribed by: ${(rx.providerFirstName && rx.providerLastName) || 'None noted'}
 
-    `;
+${
+      rx.groupedMedications?.length > 0
+        ? `Previous prescriptions associated with this medication: ${rx.groupedMedications
+            .map(previousRx => {
+              return previousRx.prescriptionNumber;
+            })
+            .join(', ')}
+  
+`
+        : ``
+    }`;
   });
 
   return result;
@@ -130,6 +140,8 @@ export const buildAllergiesTXT = allergies => {
   }
 
   let result = `
+---------------------------------------------------------------------------------
+
 Allergies
 
 This list includes all allergies, reactions, and side effects in your VA medical records. This includes medication side effects (also called adverse drug reactions). If you have allergies or reactions that are missing from this list, tell your care team at your next appointment.
@@ -153,9 +165,6 @@ Location: ${validateField(item.location)}
 Observed or historical: ${validateField(item.observedOrReported)}
 
 Provider notes: ${validateField(item.notes)}
-
-
----------------------------------------------------------------------------------
 
     `;
   });
@@ -181,7 +190,7 @@ ${prescription?.prescriptionName ||
       : '')}
 
 
-About your prescription
+Most recent prescription
 
 
 Last filled on: ${
@@ -189,6 +198,8 @@ Last filled on: ${
       ? dateFormat(prescription.sortedDispensedDate, 'MMMM D, YYYY')
       : 'Not filled yet'
   }
+
+Prescription number: ${prescription.prescriptionNumber}
 
 Status: ${validateField(prescription.dispStatus)}
 ${(
@@ -206,21 +217,9 @@ Request refills by this prescription expiration date: ${dateFormat(
     'MMMM D, YYYY',
   )}
 
-Prescription number: ${prescription.prescriptionNumber}
-
-Prescribed on: ${dateFormat(prescription.orderedDate, 'MMMM D, YYYY')}
-
-Prescribed by: ${(prescription.providerFirstName &&
-    prescription.providerLastName) ||
-    'None noted'}
-
 Facility: ${validateField(prescription.facilityName)}
 
 Pharmacy phone number: ${validateField(prescription.phoneNumber)}
-
-
-About this medication or supply
-
 
 Instructions: ${validateField(prescription.sig)}
 
@@ -228,8 +227,18 @@ Reason for use: ${validateField(prescription.indicationForUse)}
 
 Quantity: ${validateField(prescription.quantity)}
 
+Prescribed on: ${dateFormat(prescription.orderedDate, 'MMMM D, YYYY')}
+
+Prescribed by: ${(prescription.providerFirstName &&
+    prescription.providerLastName) ||
+    'None noted'}
+
 
 Refill history
+
+Showing ${refillHistory.length} refill${
+    refillHistory.length > 1 ? 's, from newest to oldest' : ''
+  }
 
   `;
 
@@ -250,20 +259,51 @@ Note: If the medication you’re taking doesn’t match this description, call $
 ${backImprint ? `* Back marking: ${backImprint}` : ''}`
       : createNoDescriptionText(phone);
     result += `
-${index === 0 ? 'First fill' : `Refill ${index}`}
-
-Filled by pharmacy on: ${
-      entry?.dispensedDate ? dateFormat(entry.dispensedDate) : 'None noted'
-    }
-
+${index === 0 ? 'Original fill' : `Refill`}: ${dateFormat(entry.dispensedDate)}
+${
+      i === 0
+        ? `
 Shipped on: ${dateFormat(prescription?.trackingList?.[0]?.completeDateTime)}
-
+`
+        : ``
+    }
 Description: ${description}
-
----------------------------------------------------------------------------------
 
     `;
   });
+
+  if (prescription?.groupedMedications?.length > 0) {
+    result += `
+Previous prescriptions
+
+Showing ${prescription.groupedMedications.length} prescription${
+      prescription.groupedMedications.length > 1
+        ? 's, from newest to oldest'
+        : ''
+    }
+    `;
+
+    prescription.groupedMedications.forEach(previousPrescription => {
+      result += `
+
+Prescription number: ${previousPrescription.prescriptionNumber}
+
+Last filled: ${
+        previousPrescription.sortedDispensedDate
+          ? dateFormat(previousPrescription.sortedDispensedDate, 'MMMM D, YYYY')
+          : 'Not filled yet'
+      }
+
+Quantity: ${validateField(previousPrescription.quantity)}
+
+Prescribed on: ${dateFormat(previousPrescription.orderedDate, 'MMMM D, YYYY')}
+
+Prescribed by: ${(previousPrescription.providerFirstName &&
+        previousPrescription.providerLastName) ||
+        EMPTY_FIELD}
+      `;
+    });
+  }
 
   return result;
 };

--- a/src/platform/pdf/templates/medications.js
+++ b/src/platform/pdf/templates/medications.js
@@ -171,7 +171,7 @@ const generateResultsMedicationListContent = async (
       }
     }
 
-    doc.moveDown(0.5);
+    doc.moveDown(0.75);
   }
 
   // horizontal line
@@ -183,7 +183,7 @@ const generateResultsMedicationListContent = async (
 };
 
 const generateResultsContent = async (doc, parent, data) => {
-  for (const resultItem of data.results) {
+  for (const [i, resultItem] of data.results.entries()) {
     const results = doc.struct('Sect', {
       title: resultItem.header || 'Results',
     });
@@ -227,6 +227,18 @@ const generateResultsContent = async (doc, parent, data) => {
         results,
         hasHorizontalRule,
         listItem.sectionSeperatorOptions,
+      );
+    }
+
+    // horizontal line at the end of results (typically before allergies)
+    if (i < data.results.length - 1) {
+      addHorizontalRule(
+        doc,
+        ...Object.values({
+          spaceFromEdge: 16,
+          linesAbove: 1,
+          linesBelow: 1,
+        }),
       );
     }
 

--- a/src/platform/pdf/templates/medications.js
+++ b/src/platform/pdf/templates/medications.js
@@ -44,6 +44,10 @@ const config = {
       font: 'Bitter-Bold',
       size: 12.75,
     },
+    H5: {
+      font: 'Bitter-Bold',
+      size: 12,
+    },
   },
   subHeading: {
     boldFont: 'SourceSansPro-Bold',
@@ -102,10 +106,16 @@ const generateResultsMedicationListContent = async (
   // medication header
   if (medication.header) {
     results.add(
-      await createHeading(doc, 'H3', config, medication.header, {
-        paragraphGap: 10,
-        x: 16,
-      }),
+      await createHeading(
+        doc,
+        medication.headerSize || 'H3',
+        config,
+        medication.header,
+        {
+          paragraphGap: 10,
+          x: medication.indent || 16,
+        },
+      ),
     );
   }
 
@@ -120,7 +130,7 @@ const generateResultsMedicationListContent = async (
           section.header,
           {
             paragraphGap: 10,
-            x: 16,
+            x: section.indent || 16,
           },
         ),
       );
@@ -134,7 +144,7 @@ const generateResultsMedicationListContent = async (
         structs = await createImageDetailItem(
           doc,
           config,
-          resultItem.noIndentation ? 16 : 32,
+          resultItem.indent || 16,
           resultItem,
         );
         // rich text item
@@ -142,7 +152,7 @@ const generateResultsMedicationListContent = async (
         structs = await createRichTextDetailItem(
           doc,
           config,
-          resultItem.noIndentation ? 16 : 32,
+          resultItem.indent || 16,
           resultItem,
         );
         // regular item
@@ -150,7 +160,7 @@ const generateResultsMedicationListContent = async (
         structs = await createDetailItem(
           doc,
           config,
-          resultItem.noIndentation ? 16 : 32,
+          resultItem.indent || 16,
           resultItem,
         );
       }
@@ -220,7 +230,7 @@ const generateResultsContent = async (doc, parent, data) => {
 
     // results --> items
     for (const listItem of resultItem.list) {
-      const hasHorizontalRule = listItem.sectionSeparators !== false;
+      const hasHorizontalRule = !!listItem.sectionSeparators;
       await generateResultsMedicationListContent(
         listItem,
         doc,
@@ -236,7 +246,7 @@ const generateResultsContent = async (doc, parent, data) => {
         doc,
         ...Object.values({
           spaceFromEdge: 16,
-          linesAbove: 1,
+          linesAbove: 0.5,
           linesBelow: 1,
         }),
       );

--- a/src/platform/pdf/test/templates/medications/fixtures/medications_list.json
+++ b/src/platform/pdf/test/templates/medications/fixtures/medications_list.json
@@ -42,6 +42,7 @@
       "list": [
         {
           "header": "ABACAVIR SO4 600MG/LAMIVUDINE 300MG TAB",
+          "sectionSeparators": true,
           "sections": [
             {
               "header": "About your prescription",
@@ -133,6 +134,7 @@
         },
         {
           "header": "ACEBUTOLOL HCL 400MG CAP",
+          "sectionSeparators": true,
           "sections": [
             {
               "header": "About your prescription",
@@ -216,6 +218,7 @@
         },
         {
           "header": "ACETIC ACID 0.25% IRRG SOLN",
+          "sectionSeparators": true,
           "sections": [
             {
               "header": "About your prescription",

--- a/src/platform/pdf/test/templates/medications/medications.unit.spec.js
+++ b/src/platform/pdf/test/templates/medications/medications.unit.spec.js
@@ -94,13 +94,13 @@ describe('Medications PDF template', () => {
       const content = await page.getTextContent({ includeMarkedContent: true });
 
       // This is the acetic acid medication header
-      expect(content.items[91].tag).to.eq('H3');
-      expect(content.items[93].str).to.eq('ACETIC ACID 0.25% IRRG SOLN');
+      expect(content.items[89].tag).to.eq('H3');
+      expect(content.items[91].str).to.eq('ACETIC ACID 0.25% IRRG SOLN');
 
       // The two items before it should be the start and end of the Artifact tag.
-      expect(content.items[89].type).to.eq('beginMarkedContent');
-      expect(content.items[89].tag).to.eq('Artifact');
-      expect(content.items[90].type).to.eq('endMarkedContent');
+      expect(content.items[87].type).to.eq('beginMarkedContent');
+      expect(content.items[87].tag).to.eq('Artifact');
+      expect(content.items[88].type).to.eq('endMarkedContent');
     });
 
     it('Outputs document sections in the correct order', async () => {


### PR DESCRIPTION
## Summary

1. Updated `medications` PDF template
2. Updated Print view, PDF and TXT generation for Rx List and Details pages

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-65333
https://jira.devops.va.gov/browse/MHV-66798

## Examples:

[VA-medications-details-null-2-5-2025 (5).pdf](https://github.com/user-attachments/files/18667423/VA-medications-details-null-2-5-2025.5.pdf)
[VA-medications-details-null-2-5-2025 (7).txt](https://github.com/user-attachments/files/18667424/VA-medications-details-null-2-5-2025.7.txt)

## Figma file:
https://www.figma.com/design/brTf5ZBdG6gn3hop0yvrjU/Medications-Phase-1?node-id=13352-108515&t=UWwA1fcJWay8c27t-0

## Testing done

- Unit testing
- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Change: Reorder fields for “About your prescription”
matches order on Medications Details mockup
AC2: Remove: “Note:...” after Status
AC3: Add: “Previous prescriptions associated with this medication” field
remove section when there are no previous prescriptions
AC4: Remove: “About this medication or supply” header
remove divider after header
AC5: Change: header from “About your prescription” to “Most recent prescription”
AC6: Remove: Dividers between refills
AC7: Add: “Previous prescription” as H3
AC8: Add: “Prescription number:...” as H4
include last filled, quantity, prescribed on, and prescribed by fields
AC9: Remove: Dividers between allergies
AC10: Change: Content change from “Older prescriptions” to “Previous prescriptions”

AC1: Header from “About your prescription” to “Most recent prescription”
“Most recent prescription” h3 and following fields in the section should be not be indented
AC2: Change: “Refill history” is an h4
Fields below this header should be indented and left aligned with the “Refill: Month DD, YYYY” fields
AC3: Change: “Shipped on” field is only included in the most recent entry of the refill history, applying to refills, partial fills, and original fill. This applies for the UI and pdf/txt files
AC4: Note: We should be using the content "Original fill" instead of "First fill"
AC5: Change: “Showing # refills from newest to oldest” with total number of refills
Change content to “Showing 1 refill” when there is only one
AC6: Change: All “Refill: Month DD, YYYY” headers are h5 and contain the filled on date
AC7: Note: The order of the refill history should be from newest to oldest last filled date across the UI and pdf/txt files
AC8: Change: “Showing # prescriptions from newest to oldest” with total number of prescriptions
Change content to “Showing 1 prescription” when there is only one
AC9: Change: “Allergy name” is an h3
Should not be indented
AC10: Change: “Non-VA Medication name + strength + form” h2 and following fields in the section should not be indented
AC11: Change: “Allergy name” is an h3
Fields below this header should not be indented
AC12: Change: Remove line break between “Try again later” and “If it still ...” so there are no breaks between sentences

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
