### PR TITLE
Fix non-VA evidence summary page edit labels

### DIFF
--- a/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
@@ -9,7 +9,6 @@ import { content } from '../content/evidenceSummary';
 import {
   authorizationLabel,
   authorizationError,
-  authorizationEdit,
 } from '../content/evidencePrivateRecordsAuthorization';
 import { content as limitContent } from '../content/evidencePrivateLimitation';
 import { content as vaContent } from '../content/evidenceVaRecords';
@@ -296,7 +295,7 @@ export const PrivateContent = ({
                   id="edit-private-authorization"
                   className="edit-item"
                   to={`/${EVIDENCE_PRIVATE_AUTHORIZATION}`}
-                  aria-label={authorizationEdit}
+                  aria-label={`edit ${title4142WithId}`}
                   data-link={testing ? EVIDENCE_PRIVATE_AUTHORIZATION : null}
                 >
                   {content.edit}
@@ -321,7 +320,7 @@ export const PrivateContent = ({
                   id="edit-limitation-y-n"
                   className="edit-item"
                   to={`/${EVIDENCE_LIMITATION_PATH1}`}
-                  aria-label={`${content.edit} ${limitContent.nameYn} `}
+                  aria-label={`${content.edit} ${limitContent.title} `}
                   data-link={testing ? EVIDENCE_LIMITATION_PATH1 : null}
                 >
                   {content.edit}
@@ -346,7 +345,7 @@ export const PrivateContent = ({
                   id="edit-limitation"
                   className="edit-item"
                   to={`/${EVIDENCE_LIMITATION_PATH2}`}
-                  aria-label={`${content.edit} ${limitContent.name}`}
+                  aria-label={`${content.edit} ${limitContent.textAreaTitle}`}
                   data-link={testing ? EVIDENCE_LIMITATION_PATH2 : null}
                 >
                   {content.edit}

--- a/src/applications/appeals/995/content/evidencePrivateLimitation.js
+++ b/src/applications/appeals/995/content/evidencePrivateLimitation.js
@@ -30,7 +30,6 @@ export const content = {
   update: 'Update page',
 
   // New form content
-  nameYn: 'do you want to limit information', // edit aria-label
   ynTitle: 'Do you want to limit consent for the information requested?',
   errorMessage: 'You must enter a limitation',
 

--- a/src/applications/appeals/995/content/evidencePrivateRecordsAuthorization.jsx
+++ b/src/applications/appeals/995/content/evidencePrivateRecordsAuthorization.jsx
@@ -33,9 +33,6 @@ export const authorizationHeader = <h3>{title4142}</h3>;
 export const authorizationError =
   'You must give us authorization for us to get your non-VA medical records';
 
-// for edit link aria-label
-export const authorizationEdit = 'edit authorization choice';
-
 export const authorizationInfo = (
   <>
     <p id="authorize-text">


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > On the evidence summary page, some non-VA edit links had `aria-label`s that did not include the page title. This PR updates the `aria-labels` to match the accessibility recommendations (see related ticket) 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/101973

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

<img width="940" alt="dev tools inspection of 3 edit links shown for authorize release of non-VA medical records to VA, do you want to limit the information we can request, and what do you want your information request to be limited to. Arrows associate the edit link with their aria label text which contain the page title prefixed by the word 'edit'" src="https://github.com/user-attachments/assets/65a62050-e37d-40f0-84fc-d0f4fb4005ef" />

## What areas of the site does it impact?

Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
