### PR TITLE
SC | Fix radio selection in keyboard e2e test

### DIFF
--- a/src/applications/appeals/995/tests/995-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-keyboard-only.cypress.spec.js
@@ -77,7 +77,7 @@ describe('Supplemental Claim keyboard only navigation', () => {
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(100); // wait for focus on header
       cy.tabToElement('[value="home"]');
-      cy.realPress('Space');
+      cy.chooseRadion('home'); // make sure we're choosing home (either is fine)
       cy.tabToContinueForm();
 
       // *** Issues for review (sorted by random decision date) - only selecting
@@ -138,7 +138,7 @@ describe('Supplemental Claim keyboard only navigation', () => {
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(100);
       cy.tabToElement('[name="root_view:hasVaEvidence"]'); // Yes radio
-      cy.realPress('Space');
+      cy.chooseRadio('Y'); // make sure we're choosing yes
       cy.tabToSubmitForm();
 
       // *** VA evidence location
@@ -186,7 +186,7 @@ describe('Supplemental Claim keyboard only navigation', () => {
         chapters.evidence.pages.evidencePrivateRecordsRequest.path,
       );
       cy.tabToElement('[name="private"]'); // Yes radio
-      cy.realPress('Space');
+      cy.chooseRadio('y'); // make sure we're choosing yes
       cy.tabToSubmitForm();
 
       // *** Private evidence authorization
@@ -272,7 +272,7 @@ describe('Supplemental Claim keyboard only navigation', () => {
         chapters.evidence.pages.evidenceWillUpload.path,
       );
       cy.tabToElement('[name="root_view:hasOtherEvidence"]'); // No radio
-      cy.realPress('ArrowDown');
+      cy.chooseRadio('N'); // make sure we're choosing no
       cy.tabToSubmitForm();
 
       // *** Evidence summary

--- a/src/applications/appeals/995/tests/995-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-keyboard-only.cypress.spec.js
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import formConfig from '../config/form';
 import mockPrefill from './fixtures/mocks/prefill.json';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
@@ -7,27 +5,24 @@ import mockSubmit from './fixtures/mocks/application-submit.json';
 
 import { CONTESTABLE_ISSUES_API, ITF_API } from '../constants/apis';
 import { fetchItf } from './995.cypress.helpers';
+import mockData from './fixtures/data/keyboard-test.json';
 
 import { CONTACT_INFO_PATH } from '../../shared/constants';
 import { fixDecisionDates } from '../../shared/tests/cypress.helpers';
 import cypressSetup from '../../shared/tests/cypress.setup';
 
 describe('Supplemental Claim keyboard only navigation', () => {
-  before(() => {
+  it('navigates through a maximal form', () => {
     cypressSetup();
 
-    cy.fixture(path.join(__dirname, 'fixtures/data/keyboard-test.json')).as(
-      'testData',
-    );
+    cy.wrap(mockData.data).as('testData');
 
     cy.intercept('GET', '/v0/in_progress_forms/20-0995', mockPrefill);
     cy.intercept('PUT', '/v0/in_progress_forms/20-0995', mockInProgress);
     cy.intercept('POST', formConfig.submitUrl, mockSubmit);
     cy.intercept('GET', ITF_API, fetchItf());
-  });
 
-  it('navigates through a maximal form', () => {
-    cy.get('@testData').then(({ data }) => {
+    cy.get('@testData').then(data => {
       const { chapters } = formConfig;
 
       cy.intercept('GET', `${CONTESTABLE_ISSUES_API}/compensation`, {
@@ -77,7 +72,7 @@ describe('Supplemental Claim keyboard only navigation', () => {
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(100); // wait for focus on header
       cy.tabToElement('[value="home"]');
-      cy.chooseRadion('home'); // make sure we're choosing home (either is fine)
+      cy.chooseRadio('home'); // make sure we're choosing home (either is fine)
       cy.tabToContinueForm();
 
       // *** Issues for review (sorted by random decision date) - only selecting


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Attempt to fix flaky Supplemental Claim keyboard-only end-to-end test. While running locally, I notice that the evidence non-VA evidence & upload yes/no radio questions weren't always selecting the expected choice. 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Use `cy.chooseRadio` command to ensure correct radio choice is made
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/101940

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Locally running SC keyboard-only e2e test
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
