### PR TITLE
MHV-65358 Should Fix: BB flow checkboxes content (GH 99400)

### DIFF
--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadRecordType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadRecordType.jsx
@@ -232,7 +232,7 @@ const DownloadRecordType = () => {
           <div className="vads-u-margin-top--3" />
           <VaCheckbox
             label="Past VA appointments"
-            checkbox-description="From last 2 years only"
+            checkbox-description="Includes appointments from the last 2 years only."
             checked={pastAppCheck}
             onVaChange={e => {
               setPastAppCheck(e.detail.checked);


### PR DESCRIPTION
## Summary

- Updated content in DownloadRecordType.jsx. 
  - Removed "From last 2 years only".
  - Added "Includes appointments from the last 2 years only.". 
- This is not a bug.
- Updated the JSX and already existing functions. 
 
- MHV Medical Records.

## Related issue(s)
### [MHV-65358](https://jira.devops.va.gov/browse/MHV-65358) Should Fix: BB flow checkboxes content (GH 99400) ###
![Screenshot 2025-02-05 at 3 52 38 PM](https://github.com/user-attachments/assets/4fa133f4-6062-4066-a272-063a6455d992)


## Screenshot
![Screenshot 2025-02-05 at 3 53 54 PM](https://github.com/user-attachments/assets/ba79a633-a144-41cc-9082-1141b7ffff8c)


## Testing done

-  Tests are passing.

## What areas of the site does it impact?
MHV Medical Records
