### PR TITLE
[101792] Appoint a Rep submission type selection routing fixes

### DIFF
--- a/src/applications/representative-appoint/pages/representative/representativeSubmissionMethod.js
+++ b/src/applications/representative-appoint/pages/representative/representativeSubmissionMethod.js
@@ -1,4 +1,5 @@
 import RepresentativeSubmissionMethod from '../../components/RepresentativeSubmissionMethod';
+import { entityAcceptsDigitalPoaRequests } from '../../utilities/helpers';
 
 export const uiSchema = {
   representativeSubmissionMethod: {
@@ -22,15 +23,16 @@ export const schema = {
 };
 
 export const pageDepends = formData => {
-  const { v2IsEnabled } = formData;
-  // temporarily hardcoding these values
+  const { userIsDigitalSubmitEligible, v2IsEnabled } = formData;
+  const entity = formData['view:selectedRepresentative'];
 
-  const userCanSubmitDigitally = true;
-  const representativeAcceptsDigitalSubmission = true;
+  const representativeAcceptsDigitalSubmission = entityAcceptsDigitalPoaRequests(
+    entity,
+  );
 
   return (
     v2IsEnabled &&
-    userCanSubmitDigitally &&
+    userIsDigitalSubmitEligible &&
     representativeAcceptsDigitalSubmission
   );
 };

--- a/src/applications/representative-appoint/tests/pages/representative/representativeSubmissionMethod.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/pages/representative/representativeSubmissionMethod.unit.spec.jsx
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import { RepresentativeSubmissionMethod } from '../../../components/RepresentativeSubmissionMethod';
+import { representativeSubmissionMethod } from '../../../pages';
 import * as reviewPageHook from '../../../hooks/useReviewPage';
 
 describe('<RepresentativeSubmissionMethod>', () => {
@@ -154,6 +155,79 @@ describe('<RepresentativeSubmissionMethod>', () => {
       ).to.be.true;
 
       useReviewPageStub.restore();
+    });
+  });
+
+  context('pageDepends', () => {
+    context('when v2 is not enabled', () => {
+      it('returns false', () => {
+        const formData = {
+          v2IsEnabled: false,
+          'view:selectedRepresentative': {
+            type: 'organization',
+            attributes: { canAcceptDigitalPoaRequests: true },
+          },
+          userIsDigitalSubmitEligible: true,
+        };
+
+        const result = representativeSubmissionMethod.pageDepends(formData);
+
+        expect(result).to.be.false;
+      });
+    });
+
+    context(
+      'when the selected representative does not accept digital submission',
+      () => {
+        it('returns false', () => {
+          const formData = {
+            v2IsEnabled: true,
+            'view:selectedRepresentative': {
+              type: 'organization',
+              attributes: { canAcceptDigitalPoaRequests: false },
+            },
+            userIsDigitalSubmitEligible: true,
+          };
+
+          const result = representativeSubmissionMethod.pageDepends(formData);
+
+          expect(result).to.be.false;
+        });
+      },
+    );
+
+    context('when the user is not eligible for digital submission', () => {
+      it('returns false', () => {
+        const formData = {
+          v2IsEnabled: true,
+          'view:selectedRepresentative': {
+            type: 'organization',
+            attributes: { canAcceptDigitalPoaRequests: true },
+          },
+          userIsDigitalSubmitEligible: false,
+        };
+
+        const result = representativeSubmissionMethod.pageDepends(formData);
+
+        expect(result).to.be.false;
+      });
+    });
+
+    context('when all digital submission criteria met', () => {
+      it('returns true', () => {
+        const formData = {
+          v2IsEnabled: true,
+          'view:selectedRepresentative': {
+            type: 'organization',
+            attributes: { canAcceptDigitalPoaRequests: true },
+          },
+          userIsDigitalSubmitEligible: true,
+        };
+
+        const result = representativeSubmissionMethod.pageDepends(formData);
+
+        expect(result).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr updates the submission type selection pages 'pageDepends` method to check for v2 enablement, user eligibility, and representative eligibility in routing logic.
- Routing to submission type selection is not hard coded anymore

## Related issue(s)

- [101792](https://github.com/department-of-veterans-affairs/va.gov-team/issues/101792)

## Testing done

- Logged into local with test user and confirmed routing paths with various rep selections
- Verified unauthed user paths

## What areas of the site does it impact?

Appoint a Rep Form 21-22 and 21-22a - currently hidden by feature flag

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user