### PR TITLE
Update location of death pages

### DIFF
--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -201,29 +201,44 @@ const formConfig = {
           schema: locationOfDeathV2.schema,
         },
         nursingHomeUnpaid: {
-          title: 'Veteran death location information',
+          title: 'Veteran death location details',
+          reviewTitle: () => (
+            <span className="vads-u-font-size--h3">
+              Veteran death location details
+            </span>
+          ),
           path: 'veteran-information/location-of-death/nursing-home-unpaid',
           depends: form =>
             showLocationOfDeath() &&
             get('locationOfDeath.location', form) === 'nursingHomeUnpaid',
           ...generateDeathFacilitySchemas(
             'nursingHomeUnpaid',
-            'facility or nursing home that VA doesn’t pay for',
+            'nursing home or facility',
           ),
         },
         nursingHomePaid: {
-          title: 'Veteran death location information',
+          title: 'Veteran death location details',
+          reviewTitle: () => (
+            <span className="vads-u-font-size--h3">
+              Veteran death location details
+            </span>
+          ),
           path: 'veteran-information/location-of-death/nursing-home-paid',
           depends: form =>
             showLocationOfDeath() &&
             get('locationOfDeath.location', form) === 'nursingHomePaid',
           ...generateDeathFacilitySchemas(
             'nursingHomePaid',
-            'facility or nursing home that VA pays for',
+            'nursing home or facility',
           ),
         },
         vaMedicalCenter: {
-          title: 'Veteran death location information',
+          title: 'Veteran death location details',
+          reviewTitle: () => (
+            <span className="vads-u-font-size--h3">
+              Veteran death location details
+            </span>
+          ),
           path: 'veteran-information/location-of-death/va-medical-center',
           depends: form =>
             showLocationOfDeath() &&
@@ -234,7 +249,12 @@ const formConfig = {
           ),
         },
         stateVeteransHome: {
-          title: 'Veteran death location information',
+          title: 'Veteran death location details',
+          reviewTitle: () => (
+            <span className="vads-u-font-size--h3">
+              Veteran death location details
+            </span>
+          ),
           path: 'veteran-information/location-of-death/state-veterans-home',
           depends: form =>
             showLocationOfDeath() &&

--- a/src/applications/burials-ez/utils/helpers.jsx
+++ b/src/applications/burials-ez/utils/helpers.jsx
@@ -35,19 +35,19 @@ export const generateDeathFacilitySchemas = (
 ) => {
   return {
     uiSchema: {
-      'ui:title': generateTitle('Veteran death location information'),
-      'ui:description': `You selected that the deceased Veteran died in a ${facilityName}. We need more information about where the death occurred.`,
+      'ui:title': generateTitle('Veteran death location details'),
       [facilityKey]: {
         facilityName: textUI({
-          title: `Name of the ${facilityName}`,
+          title: `Name of ${facilityName}`,
           errorMessages: {
-            required: `Enter the Name of the ${facilityName}`,
+            required: `Enter the Name of ${facilityName}`,
           },
         }),
         facilityLocation: textUI({
-          title: `City and state of the ${facilityName}`,
+          title: `Location of ${facilityName}`,
+          hint: 'City and state',
           errorMessages: {
-            required: `Enter the city and state of the ${facilityName}`,
+            required: `Enter the city and state of ${facilityName}`,
           },
         }),
       },


### PR DESCRIPTION
Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes

## Summary
Update the 'Location of death' page on the Burial Benefits form (21P-530EZ) to a more accessible UI pattern.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80105

## Associated Pull Request(s)
- https://github.com/department-of-veterans-affairs/vets-api/pull/20576
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/971

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. In your local environment, set the `burial_location_of_death_update ` flipper to 'enabled' at http://localhost:3000/flipper/features/burial_location_of_death_update
4. Go to `http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/` in your browser

## How to verify
### Location of Death page
1. Sign in
2. Go to the `/location-of-death-v2` page
#### At Home
1. Select 'At home' and then 'Continue'
2. Verify that the 'Veteran death location details' page is NOT displayed
#### In a nursing home or facility that VA doesn't pay for
1. Select 'In a nursing home or facility that VA doesn't pay for' and then 'Continue'
2. Verify that the 'Veteran death location details' page is displayed with the correct field labels
#### In a nursing home or facility that VA pays for
1. Select 'In a nursing home or facility that VA pays for' and then 'Continue'
2. Verify that the 'Veteran death location details' page is displayed with the correct field labels
#### In a VA medical center
1. Select 'In a VA medical center' and then 'Continue'
2. Verify that the 'Veteran death location details' page is displayed with the correct field labels
#### In a state Veterans facility
1. Select 'In a state Veterans facility' and then 'Continue'
2. Verify that the 'Veteran death location details' page is displayed with the correct field labels
#### Other
1. Select 'Other' and then 'Continue'
2. Verify that 'Other' is a required field
3. Enter text into 'Other' field and then 'Continue'
4. Verify that the 'Veteran death location details' page is NOT displayed

### Review and submit
1. Sign in
2. Load data into the 'Save in progress' menu
3. Return to the `/review-and-submit` page
4. Expand the 'Deceased Veteran information' accordion
5. Verify that the 'Veteran death location' data is correct
6. Verify that the 'Veteran death location information' is correct
7. Verify that only the active 'Veteran death location information' is included in the submission


## What areas of the site does it impact?
Burial Benefits Application

## Screenshots
### Location of death page(s)
| Before       | After       |
| ----------- | ----------- |
|![Screenshot 2025-02-03 at 1 50 10 PM](https://github.com/user-attachments/assets/1657d30a-9317-421f-b328-4b6164205dc6)|![Screenshot 2025-02-06 at 12 55 21 PM](https://github.com/user-attachments/assets/0983c3dd-9d2a-432a-9039-d56864a1869b)



### Review and submit page
| Before      | After       |
| ----------- | ----------- |
|![Screenshot 2025-02-04 at 8 54 59 AM](https://github.com/user-attachments/assets/53a4b4e2-7750-4223-9f3a-0e9f86ba237f)|![Screenshot 2025-02-06 at 12 56 20 PM](https://github.com/user-attachments/assets/da838a85-3140-4993-9bd0-8b9d5ab21f53)


### Quality Assurance & Testing
- [ ] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
