### PR TITLE
MHV-66726 Data-Dog-Tagging-Update-Settings

### DIFF
--- a/src/applications/mhv-medical-records/containers/SettingsPage.jsx
+++ b/src/applications/mhv-medical-records/containers/SettingsPage.jsx
@@ -153,7 +153,9 @@ const SettingsPage = () => {
           text={isSharing ? 'Opt out' : 'Opt in'}
           onClick={() => {
             setShowSharingModal(true);
-            sendDataDogAction(isSharing ? 'Opt out' : 'Opt in');
+            sendDataDogAction(
+              isSharing ? 'Opt out - Settings page' : 'Opt in - Settings page',
+            );
             // If you want to focus an element, you can call it here or handle it elsewhere
           }}
         />
@@ -172,7 +174,9 @@ const SettingsPage = () => {
         modalTitle={title}
         onCloseEvent={() => {
           handleCloseModal();
-          sendDataDogAction(`Close opt ${isSharing ? 'out' : 'in'} modal`);
+          sendDataDogAction(
+            `Close opt ${isSharing ? 'Opt out - Modal' : 'Opt in - Modal'}`,
+          );
         }}
         onPrimaryButtonClick={() => {
           handleUpdateSharing(isSharing);

--- a/src/applications/mhv-medical-records/containers/SettingsPage.jsx
+++ b/src/applications/mhv-medical-records/containers/SettingsPage.jsx
@@ -167,8 +167,10 @@ const SettingsPage = () => {
     const title = `Opt ${
       isSharing ? 'out of' : 'back in to'
     } sharing your electronic health information?`;
-    const primaryButtonText = isSharing ? 'Opt out' : 'Opt in';
-    const secondaryButtonText = isSharing ? "Don't opt out" : "Don't opt in";
+    const primaryButtonText = isSharing ? 'Opt out - Modal' : 'Opt in - Modal';
+    const secondaryButtonText = isSharing
+      ? "Don't Opt out - Modal"
+      : "Don't Opt in - Modal";
     return (
       <VaModal
         modalTitle={title}

--- a/src/applications/mhv-medical-records/containers/SettingsPage.jsx
+++ b/src/applications/mhv-medical-records/containers/SettingsPage.jsx
@@ -168,17 +168,13 @@ const SettingsPage = () => {
       isSharing ? 'out of' : 'back in to'
     } sharing your electronic health information?`;
     const primaryButtonText = isSharing ? 'Opt out - Modal' : 'Opt in - Modal';
-    const secondaryButtonText = isSharing
-      ? "Don't Opt out - Modal"
-      : "Don't Opt in - Modal";
+    const secondaryButtonText = isSharing ? "Don't opt out" : "Don't opt in";
     return (
       <VaModal
         modalTitle={title}
         onCloseEvent={() => {
           handleCloseModal();
-          sendDataDogAction(
-            `Close ${isSharing ? 'Opt out - Modal' : 'Opt in - Modal'}`,
-          );
+          sendDataDogAction(`Close opt ${isSharing ? 'out' : 'in'} modal`);
         }}
         onPrimaryButtonClick={() => {
           handleUpdateSharing(isSharing);

--- a/src/applications/mhv-medical-records/containers/SettingsPage.jsx
+++ b/src/applications/mhv-medical-records/containers/SettingsPage.jsx
@@ -175,7 +175,7 @@ const SettingsPage = () => {
         onCloseEvent={() => {
           handleCloseModal();
           sendDataDogAction(
-            `Close opt ${isSharing ? 'Opt out - Modal' : 'Opt in - Modal'}`,
+            `Close ${isSharing ? 'Opt out - Modal' : 'Opt in - Modal'}`,
           );
         }}
         onPrimaryButtonClick={() => {


### PR DESCRIPTION
## Summary
Data Dog tagging updates in settings now include "Opt in - Settings page" , "Opt out - Settings page", "Opt in - Modal", and "Opt out - Modal" strings.

Settings Page:

"Opt in - Settings page"
"Opt out - Settings page"
Modal:

"Opt in - Modal"
"Opt out - Modal"

## Related issue(s)
[MHV-66726](https://jira.devops.va.gov/browse/MHV-66726) - Data dog Tagging update - Settings

Update tagging in settings:

Opt in/ Opt out buttons on settings page:
"Opt in - Settings page"

"Opt out - Settings page"


Opt in/Opt out buttons on modal:

"Opt in - Modal"

"Opt out - Modal"

Story: As an MR developer, I want to tag interactions in Medical Records so the research team can monitor usage to ensure the best user experience for Veterans.

Acceptance Criteria:
AC1: Tagging complete/merged
AC2: Ping Anne (please) when merged

Test Coverage
No Tests were found testing the requirement.

## Acceptance criteria
AC1: Tagging complete/merged
AC2: Ping Anne (please) when merged

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


