### PR TITLE
Add loading indicator to Proof of Status section

### DIFF
--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatusNew.jsx
@@ -28,6 +28,7 @@ const ProofOfVeteranStatusNew = ({
   const [errors, setErrors] = useState([]);
   const [data, setData] = useState(null);
   const [shouldFocusError, setShouldFocusError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const { first, middle, last, suffix } = userFullName;
 
   const userAgent =
@@ -107,6 +108,8 @@ const ProofOfVeteranStatusNew = ({
     let isMounted = true;
 
     const fetchVerificationStatus = async () => {
+      setIsLoading(true);
+
       try {
         const path = '/profile/vet_verification_status';
         const response = await apiRequest(path);
@@ -119,6 +122,10 @@ const ProofOfVeteranStatusNew = ({
             "We're sorry. There's a problem with our system. We can't show your Veteran status card right now. Try again later.",
           ]);
           captureError(error, { eventName: 'vet-status-fetch-verification' });
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
         }
       }
     };
@@ -273,150 +280,160 @@ const ProofOfVeteranStatusNew = ({
           This card identifies a Veteran of the U.S. Uniformed Services.
         </p>
 
-        {userHasRequiredCardData ? (
+        {isLoading ? (
+          <va-loading-indicator
+            setFocus
+            message="Checking your eligibility..."
+            data-testid="proof-of-status-loading-indicator"
+          />
+        ) : (
           <>
-            {!useLighthouseApi ? (
+            {userHasRequiredCardData ? (
               <>
-                {vetStatusEligibility.confirmed ? (
+                {!useLighthouseApi ? (
+                  <>
+                    {vetStatusEligibility.confirmed ? (
+                      <>
+                        {errors?.length > 0 ? (
+                          <div className="vet-status-pdf-download-error vads-u-padding-y--2">
+                            <va-alert status="error" uswds>
+                              {errors[0]}
+                            </va-alert>
+                          </div>
+                        ) : null}
+                        <div className="vads-l-grid-container--full">
+                          <div className="vads-l-row">
+                            <ProofOfVeteranStatusCard
+                              edipi={edipi}
+                              formattedFullName={formattedFullName}
+                              latestService={latestService}
+                              totalDisabilityRating={totalDisabilityRating}
+                            />
+                          </div>
+                        </div>
+                        <div className="vads-u-font-size--md">
+                          <va-link
+                            active
+                            filetype="PDF"
+                            // exception to eslint: the url is a dynamically generated blob url
+                            // eslint-disable-next-line no-script-url
+                            href="javascript:void(0)"
+                            text="Print your Proof of Veteran status (PDF)"
+                            onClick={createPdf}
+                          />
+                        </div>
+                        <div className="vads-u-margin-y--4">
+                          <MobileAppCallout
+                            headingText="Get proof of Veteran status on your mobile device"
+                            bodyText={
+                              <>
+                                You can use our mobile app to get proof of
+                                Veteran status. To get started, download the{' '}
+                                <strong> VA: Health and Benefits </strong>{' '}
+                                mobile app.
+                              </>
+                            }
+                          />
+                        </div>
+                      </>
+                    ) : null}
+                    {!vetStatusEligibility.confirmed &&
+                    vetStatusEligibility.message.length > 0 ? (
+                      <>{profileApiErrorMessage}</>
+                    ) : null}
+                  </>
+                ) : null}
+
+                {useLighthouseApi && hasConfirmationData ? (
+                  <>
+                    {data?.attributes?.veteranStatus === 'confirmed' ? (
+                      <>
+                        {errors?.length > 0 ? (
+                          <div className="vet-status-pdf-download-error vads-u-padding-y--2">
+                            <va-alert status="error" uswds>
+                              {errors[0]}
+                            </va-alert>
+                          </div>
+                        ) : null}
+                        <div className="vads-l-grid-container--full">
+                          <div className="vads-l-row">
+                            <ProofOfVeteranStatusCard
+                              edipi={edipi}
+                              formattedFullName={formattedFullName}
+                              latestService={latestService}
+                              totalDisabilityRating={totalDisabilityRating}
+                            />
+                          </div>
+                        </div>
+                        <div className="vads-u-font-size--md">
+                          <va-link
+                            active
+                            filetype="PDF"
+                            // exception to eslint: the url is a dynamically generated blob url
+                            // eslint-disable-next-line no-script-url
+                            href="javascript:void(0)"
+                            text="Print your Proof of Veteran status (PDF)"
+                            onClick={createPdf}
+                          />
+                        </div>
+                        <div className="vads-u-margin-y--4">
+                          <MobileAppCallout
+                            headingText="Get proof of Veteran status on your mobile device"
+                            bodyText={
+                              <>
+                                You can use our mobile app to get proof of
+                                Veteran status. To get started, download the{' '}
+                                <strong> VA: Health and Benefits </strong>{' '}
+                                mobile app.
+                              </>
+                            }
+                          />
+                        </div>
+                      </>
+                    ) : null}
+
+                    {isVetStatusEligibilityPopulated &&
+                    data?.attributes?.veteranStatus === 'not confirmed' &&
+                    data?.message?.length > 0 ? (
+                      <>{lighthouseApiErrorMessage}</>
+                    ) : null}
+                  </>
+                ) : null}
+
+                {useLighthouseApi && !hasConfirmationData ? (
+                  <>{systemErrrorAlert}</>
+                ) : null}
+              </>
+            ) : null}
+
+            {!userHasRequiredCardData ? (
+              <>
+                {!useLighthouseApi ? <>{systemErrrorAlert}</> : null}
+
+                {useLighthouseApi ? (
                   <>
                     {errors?.length > 0 ? (
-                      <div className="vet-status-pdf-download-error vads-u-padding-y--2">
-                        <va-alert status="error" uswds>
-                          {errors[0]}
-                        </va-alert>
-                      </div>
+                      <>
+                        <div className="vet-status-pdf-download-error vads-u-padding-y--2">
+                          <va-alert status="error" uswds>
+                            {errors[0]}
+                          </va-alert>
+                        </div>
+                      </>
                     ) : null}
-                    <div className="vads-l-grid-container--full">
-                      <div className="vads-l-row">
-                        <ProofOfVeteranStatusCard
-                          edipi={edipi}
-                          formattedFullName={formattedFullName}
-                          latestService={latestService}
-                          totalDisabilityRating={totalDisabilityRating}
-                        />
-                      </div>
-                    </div>
-                    <div className="vads-u-font-size--md">
-                      <va-link
-                        active
-                        filetype="PDF"
-                        // exception to eslint: the url is a dynamically generated blob url
-                        // eslint-disable-next-line no-script-url
-                        href="javascript:void(0)"
-                        text="Print your Proof of Veteran status (PDF)"
-                        onClick={createPdf}
-                      />
-                    </div>
-                    <div className="vads-u-margin-y--4">
-                      <MobileAppCallout
-                        headingText="Get proof of Veteran status on your mobile device"
-                        bodyText={
-                          <>
-                            You can use our mobile app to get proof of Veteran
-                            status. To get started, download the{' '}
-                            <strong> VA: Health and Benefits </strong> mobile
-                            app.
-                          </>
-                        }
-                      />
-                    </div>
-                  </>
-                ) : null}
-                {!vetStatusEligibility.confirmed &&
-                vetStatusEligibility.message.length > 0 ? (
-                  <>{profileApiErrorMessage}</>
-                ) : null}
-              </>
-            ) : null}
 
-            {useLighthouseApi && hasConfirmationData ? (
-              <>
-                {data?.attributes?.veteranStatus === 'confirmed' ? (
-                  <>
-                    {errors?.length > 0 ? (
-                      <div className="vet-status-pdf-download-error vads-u-padding-y--2">
-                        <va-alert status="error" uswds>
-                          {errors[0]}
-                        </va-alert>
-                      </div>
+                    {data?.attributes?.veteranStatus === 'confirmed' ? (
+                      <>{profileApiErrorMessage}</>
                     ) : null}
-                    <div className="vads-l-grid-container--full">
-                      <div className="vads-l-row">
-                        <ProofOfVeteranStatusCard
-                          edipi={edipi}
-                          formattedFullName={formattedFullName}
-                          latestService={latestService}
-                          totalDisabilityRating={totalDisabilityRating}
-                        />
-                      </div>
-                    </div>
-                    <div className="vads-u-font-size--md">
-                      <va-link
-                        active
-                        filetype="PDF"
-                        // exception to eslint: the url is a dynamically generated blob url
-                        // eslint-disable-next-line no-script-url
-                        href="javascript:void(0)"
-                        text="Print your Proof of Veteran status (PDF)"
-                        onClick={createPdf}
-                      />
-                    </div>
-                    <div className="vads-u-margin-y--4">
-                      <MobileAppCallout
-                        headingText="Get proof of Veteran status on your mobile device"
-                        bodyText={
-                          <>
-                            You can use our mobile app to get proof of Veteran
-                            status. To get started, download the{' '}
-                            <strong> VA: Health and Benefits </strong> mobile
-                            app.
-                          </>
-                        }
-                      />
-                    </div>
+                    {data?.attributes?.veteranStatus === 'not confirmed' ? (
+                      <>{lighthouseApiErrorMessage}</>
+                    ) : null}
                   </>
-                ) : null}
-
-                {isVetStatusEligibilityPopulated &&
-                data?.attributes?.veteranStatus === 'not confirmed' &&
-                data?.message?.length > 0 ? (
-                  <>{lighthouseApiErrorMessage}</>
-                ) : null}
-              </>
-            ) : null}
-
-            {useLighthouseApi && !hasConfirmationData ? (
-              <>{systemErrrorAlert}</>
-            ) : null}
-          </>
-        ) : null}
-
-        {!userHasRequiredCardData ? (
-          <>
-            {!useLighthouseApi ? <>{systemErrrorAlert}</> : null}
-
-            {useLighthouseApi ? (
-              <>
-                {errors?.length > 0 ? (
-                  <>
-                    <div className="vet-status-pdf-download-error vads-u-padding-y--2">
-                      <va-alert status="error" uswds>
-                        {errors[0]}
-                      </va-alert>
-                    </div>
-                  </>
-                ) : null}
-
-                {data?.attributes?.veteranStatus === 'confirmed' ? (
-                  <>{profileApiErrorMessage}</>
-                ) : null}
-                {data?.attributes?.veteranStatus === 'not confirmed' ? (
-                  <>{lighthouseApiErrorMessage}</>
                 ) : null}
               </>
             ) : null}
           </>
-        ) : null}
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR adds a loading indicator to the Proof of Status section on the military-information page. This loading indicator is tied to the API request to retrieve the veterans's verification status from Lighthouse. This API request occurs when the component loads.
- I work on the IIR Product team and we currently own this feature.
- The entire implementation of the confirmation statuses is behind a feature toggle. The success criteria targeted for the flipper is to make sure that we receive the same access rate or better for known test users when trying to view their Vet Status card. Additional testing will also be done with veterans on production to further solidify our test cases.

## Related issue(s)

- [1393](https://github.com/department-of-veterans-affairs/va-iir/issues/1393)

## Testing done

- Old behavior showed a system error alert until the API returned with data. At that point it would show the correct status (card or alert message). Now, instead of showing that system error alert, we will show a loading indicator until the API response is received. Lots of testing was done using `setTimeout` to make sure the loading indicator was working as expected.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |  ![Screen Shot 2025-02-06 at 15 34 03](https://github.com/user-attachments/assets/2db5345b-8f9a-448c-91fa-50f3d00da5a0) |
| Desktop | <img width="1346" alt="Screenshot 2025-02-06 at 3 31 07 PM" src="https://github.com/user-attachments/assets/73ecdb46-324c-457b-b39a-ad2322f8dbbc" />  | <img width="1346" alt="Screenshot 2025-02-06 at 3 33 21 PM" src="https://github.com/user-attachments/assets/70eb4182-70b8-4e57-8de2-9149a8e66870" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
