### PR TITLE
VACMS-9473 Update function to properly clear the event start date

### DIFF
--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -58,7 +58,6 @@ export const Search = ({ onSearch }) => {
   const [endDateYearError, setEndDateYearError] = useState(false);
   const [fullDateError, setFullDateError] = useState(false);
   // End Local State =================================================
-
   const anyDateErrorsExist =
     startDateMonthError ||
     startDateDayError ||
@@ -133,6 +132,7 @@ export const Search = ({ onSearch }) => {
     setEndDateMonth('');
     setEndDateDay('');
     setEndDateYear('');
+    setStartDateFull(false);
     resetErrorState();
 
     setSelectedOption(filterByOption);

--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -24,6 +24,7 @@ export const Search = ({ onSearch }) => {
   };
 
   // Local State =================================================
+
   const [selectedOption, setSelectedOption] = useState(defaultSelectedOption);
   const [startDateMonth, setStartDateMonth] = useState(
     queryParams.get('startDateMonth') || '',

--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -105,6 +105,7 @@ export const Search = ({ onSearch }) => {
     return null;
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     setStartDateFull(getFullDate(startDateDay, startDateMonth, startDateYear));
     setEndDateFull(getFullDate(endDateDay, endDateMonth, endDateYear));

--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -24,7 +24,6 @@ export const Search = ({ onSearch }) => {
   };
 
   // Local State =================================================
-
   const [selectedOption, setSelectedOption] = useState(defaultSelectedOption);
   const [startDateMonth, setStartDateMonth] = useState(
     queryParams.get('startDateMonth') || '',
@@ -59,6 +58,7 @@ export const Search = ({ onSearch }) => {
   const [endDateYearError, setEndDateYearError] = useState(false);
   const [fullDateError, setFullDateError] = useState(false);
   // End Local State =================================================
+  
   const anyDateErrorsExist =
     startDateMonthError ||
     startDateDayError ||

--- a/src/applications/static-pages/events/components/Search/index.js
+++ b/src/applications/static-pages/events/components/Search/index.js
@@ -58,7 +58,7 @@ export const Search = ({ onSearch }) => {
   const [endDateYearError, setEndDateYearError] = useState(false);
   const [fullDateError, setFullDateError] = useState(false);
   // End Local State =================================================
-  
+
   const anyDateErrorsExist =
     startDateMonthError ||
     startDateDayError ||


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR adds the clearing of the start date when switching between filters for events.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9473

## Testing done
Testing URL: `/outreach-and-events/events/` and `/greater-los-angeles-health-care/events/`
Tested locally against the outreach events and vamc events filters. 
First select Specific Date in the filter dropdown then select a start date 
Then select Custom Date Range and verify the start date is no longer populated

## Screenshots
Screen recording of the code change locally
https://github.com/user-attachments/assets/46e1df16-a7ab-4952-9559-93ef4ce1468c


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria


