### PR TITLE
MHV-65361 Should-Fix-BB-Flow-Content-GH99398

### DIFF
--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -300,8 +300,8 @@ const DownloadReportPage = ({ runningUnitTest }) => {
         href="/my-health/medical-records/download/date-range"
         label="Select records and download report"
         text="Select records and download report"
-        data-dd-action-name="Select records and download report"
-        onClick={() => sendDataDogAction('Select records and download report')}
+        data-dd-action-name="Select records and download"
+        onClick={() => sendDataDogAction('Select records and download')}
         data-testid="go-to-download-all"
       />
       <h2>Other reports you can download</h2>

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -298,10 +298,10 @@ const DownloadReportPage = ({ runningUnitTest }) => {
       </p>
       <va-link-action
         href="/my-health/medical-records/download/date-range"
-        label="Select records and download"
-        text="Select records and download"
-        data-dd-action-name="Select records and download"
-        onClick={() => sendDataDogAction('Select records and download')}
+        label="Select records and download report"
+        text="Select records and download report"
+        data-dd-action-name="Select records and download report"
+        onClick={() => sendDataDogAction('Select records and download report')}
         data-testid="go-to-download-all"
       />
       <h2>Other reports you can download</h2>


### PR DESCRIPTION
## Summary
Updated the download page in medical records by changing 'Select records and download' to 'Select records and download report.'

## Related issue(s)
[MHV-65361](https://jira.devops.va.gov/browse/MHV-65361) - Should Fix: BB flow content (GH 99398)

Description
The link text under "download your VA blue button report" reads "select reports and download". As it is currently structured, the verb "download" has no clear subject or object attached

Link, screenshot or steps to recreate
Recommended action
If the link is used to download reports, then just saying "Select and download reports" works. Otherwise, it will need to specify what the user is downloading in the format "Select reports and download X"

 

User Story:  As a MR user, I want to be able to understand the content, so that I know what exactly I am downloading.     

 

 ** 

 
DEV:

Feature Flag Y/N ? N

Collab Cycle Y/N ? N

Platform Approval T/N ? N

 

UCD:

DataDog Analytics Y/N ?

Analytics Tagging Changes needed (Datadog or other)?  Y/N ? Y


Testing:

Manual Testing Y/N ? Y- Maruf

Automated Testing Y/N ? N

Accessibility Testing Y/N ? N

UCD Validation Y/N ? Y

Acceptance Criteria:

AC1 Content change is complete- “Select records and download report”

AC2 Close the associated Github ticket

AC3 UCD Validation

AC4 Review datadog tags to be sure they have not changed

Links to UCD:

Figma Link:

Other Design Notes:

## Testing done
Tested affected page by the relabeling 

 ## Screenshots
 
![Screenshot 2025-02-07 at 10 37 40 AM (3)](https://github.com/user-attachments/assets/0b721b41-a7d7-4006-b163-d63c97758460)


## What areas of the site does it impact?
Download page section of medical records

## Acceptance criteria
Replaced 'Select records and download' with 'Select records and download report'

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


