### PR TITLE
[AVS] Fix back to appointment link

### DIFF
--- a/src/applications/avs/components/BreadCrumb.jsx
+++ b/src/applications/avs/components/BreadCrumb.jsx
@@ -8,7 +8,7 @@ const goBack = e => {
 
 const isPastAppointmentLink = url => {
   const { pathname } = new URL(url);
-  return pathname.match(/^\/my-health\/appointments\/past\/[0-9]+$/);
+  return pathname.match(/^\/my-health\/appointments\/past\/[^/]+$/);
 };
 
 const BreadCrumb = () => {

--- a/src/applications/avs/tests/components/BreadCrumb.unit.spec.jsx
+++ b/src/applications/avs/tests/components/BreadCrumb.unit.spec.jsx
@@ -6,7 +6,8 @@ import BreadCrumb from '../../components/BreadCrumb';
 
 describe('Avs: BreadCrumb', () => {
   it('correctly renders with past appointment referrer available', async () => {
-    const referrer = 'http://example.com/my-health/appointments/past/1234';
+    const referrer =
+      'http://example.com/my-health/appointments/past/f7e45e478ae348c03689b8c836d686d520d7e21b92c592161b210b369b180019';
     const originalReferrer = document.referrer;
     Object.defineProperty(document, 'referrer', {
       value: referrer,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

Fixes back to appointment link on After visit summaries. (The appointment id format in the URL was changed)

## Testing done

- Updated unit tests
