### PR TITLE
Fix linting error in the Health Care Application

### DIFF
--- a/src/applications/hca/hooks/useDefaultFormData.jsx
+++ b/src/applications/hca/hooks/useDefaultFormData.jsx
@@ -22,10 +22,7 @@ export const useDefaultFormData = () => {
   const dispatch = useDispatch();
 
   const { veteranFullName } = formData;
-  const {
-    isInsuranceV2Enabled,
-    isRegOnlyEnabled,
-  } = featureToggles;
+  const { isInsuranceV2Enabled, isRegOnlyEnabled } = featureToggles;
 
   const setFormData = dataToSet => dispatch(setData(dataToSet));
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR corrects a linting error in the Health Care Application. This error was spawned due to two PRs that touched the same file getting merged in succession when no merge conflicts arose. 

## Related issue(s)

department-of-veterans-affairs/va.gov-team#101579

## Acceptance criteria

- Application is free of linting errors

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution