### PR TITLE
VACMS-11589 Combine Facilities PPMS flippers

### DIFF
--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -212,14 +212,14 @@ const SearchControls = props => {
   };
 
   const renderFacilityTypeDropdown = () => {
-    const { suppressPharmacies, suppressPPMS } = props;
+    const { suppressPPMS } = props;
     const { facilityType, isValid, facilityTypeChanged } = currentQuery;
     const locationOptions = suppressPPMS
       ? nonPPMSfacilityTypeOptions
       : facilityTypesOptions;
     const showError = !isValid && facilityTypeChanged && !facilityType;
 
-    if (suppressPharmacies) {
+    if (suppressPPMS) {
       delete locationOptions.pharmacy;
     }
 

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -24,7 +24,6 @@ import {
 } from '../actions';
 import {
   facilitiesPpmsSuppressAll,
-  facilitiesPpmsSuppressPharmacies,
   facilityLocatorPredictiveLocationSearch,
 } from '../utils/featureFlagSelectors';
 import NoResultsMessage from '../components/NoResultsMessage';
@@ -442,7 +441,6 @@ const FacilitiesMap = props => {
           onChange={props.updateSearchQuery}
           onSubmit={handleSearch}
           suppressPPMS={props.suppressPPMS}
-          suppressPharmacies={props.suppressPharmacies}
           clearSearchText={props.clearSearchText}
         />
         {(isEmergencyCareType || isCppEmergencyCareTypes) && (
@@ -689,7 +687,6 @@ const FacilitiesMap = props => {
 const mapStateToProps = state => ({
   currentQuery: state.searchQuery,
   suppressPPMS: facilitiesPpmsSuppressAll(state),
-  suppressPharmacies: facilitiesPpmsSuppressPharmacies(state),
   usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),
   results: state.searchResult.results,
   searchError: state.searchResult.error,

--- a/src/applications/facility-locator/types/index.js
+++ b/src/applications/facility-locator/types/index.js
@@ -220,7 +220,6 @@ export const FacilitiesMapTypes = {
   selectedResult: PropTypes.any,
   specialties: PropTypes.any,
   suppressPPMS: PropTypes.bool,
-  suppressPharmacies: PropTypes.bool,
   updateSearchQuery: PropTypes.func,
   usePredictiveGeolocation: PropTypes.bool,
 };
@@ -233,5 +232,4 @@ export const SearchControlsTypes = {
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
   suppressPPMS: PropTypes.bool,
-  suppressPharmacies: PropTypes.bool,
 };

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -4,9 +4,6 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 export const facilitiesPpmsSuppressAll = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressAll];
 
-export const facilitiesPpmsSuppressPharmacies = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressPharmacies];
-
 export const facilityLocatorPredictiveLocationSearch = state =>
   toggleValues(state)[
     FEATURE_FLAG_NAMES.facilityLocatorPredictiveLocationSearch

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -7,10 +7,6 @@
         "value": false
       },
       {
-        "name": "facilitiesPpmsSuppressPharmacies",
-        "value": false
-      },
-      {
         "name": "profile_show_profile_2.0",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "facilitiesPpmsSuppressPharmacies",
-        "value": true
-      },
-      {
         "name": "profile_show_profile_2.0",
         "value": true
       },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -69,7 +69,6 @@
   "ezrProdEnabled": "ezr_prod_enabled",
   "ezrUploadEnabled": "ezr_upload_enabled",
   "facilitiesPpmsSuppressAll": "facilities_ppms_suppress_all",
-  "facilitiesPpmsSuppressPharmacies": "facilities_ppms_suppress_pharmacies",
   "facilityLocatorPredictiveLocationSearch": "facility_locator_predictive_location_search",
   "fileUploadShortWorkflowEnabled": "file_upload_short_workflow_enabled",
   "financialStatusReportDebtsApiModule": "financial_status_report_debts_api_module",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
We need to retain the functionality to suppress PPMS data, but we can combine our similar PPMS flippers:

- `facilities_ppms_suppress_all`
- `facilities_ppms_suppress_pharmacies`

In any code where `facilities_ppms_suppress_all` is applicable, the Pharmacies suppression code will also apply.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11589

## Testing done / screenshots
With the suppress all flag on **true**, you can't select the pharmacy option from the `Facility type` dropdown anymore:

<img width="1062" alt="Screenshot 2025-02-07 at 2 34 14 PM" src="https://github.com/user-attachments/assets/2c870e2c-b476-482e-b821-c37357529b29" />
<img width="1072" alt="Screenshot 2025-02-07 at 2 34 20 PM" src="https://github.com/user-attachments/assets/52926bc7-dc7d-4aed-9d9a-32e1a86a639d" />