### PR TITLE
MHV-65362 Should-Fix-CCD-Link-Text-Corrections-GH-99399

### DIFF
--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -363,7 +363,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
               download
               href="#"
               onClick={handleDownloadCCD}
-              text="Download .xml file"
+              text="Download Continuity of Care Document (XML)"
               data-testid="generateCcdButton"
             />
           )}
@@ -398,7 +398,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
                 generateSEIPdf();
                 sendDataDogAction('Self entered health information PDF link ');
               }}
-              text="Download PDF"
+              text="Download self-entered health information report (PDF)"
               data-testid="downloadSelfEnteredButton"
             />
           )}


### PR DESCRIPTION
## Summary
Updated the download page in medical records by replacing **"Download PDF or XML"** with **"Download Continuity of Care Document (XML)"** and **"Download Self-Entered Health Information Report (PDF)."**

## Related issue(s)
[MHV-65362](https://jira.devops.va.gov/browse/MHV-65362) - Should Fix: CCD link text corrections (GH 99399)

Description
The link text to download the CCD reads "download .xml file" but this may not be clear to screen readers users what file it's referring to. Similarly, the link text for self-entered health information just reads "download PDF"

Link, screenshot or steps to recreate
Recommended action
I think the best option is "Download Continuity of Care Document as a .xml file" if you think the .xml part is important to keep the .xml part. Similarly, "download self-entered health information as a PDF"

User Story:  As a MR user, I want to    so that I can

GIVEN:

WHEN:

THEN:

DEV:

Feature Flag Y/N ? N

Collab Cycle Y/N ? N

Platform Approval T/N ? N

UCD:

DataDog Analytics Y/N ?

Analytics Tagging Changes needed (Datadog or other)?  Y/N ? Y


Testing:

Manual Testing Y/N ?  Y-Maruf

Automated Testing Y/N ? N

Accessibility Testing Y/N ? Y-Bobby

UCD Validation Y/N ? Y

Acceptance Criteria:

AC1 Content change, "Download Continuity of Care
Document (XML)" is complete

AC2 Close the associated Github ticket

AC3 UCD validation

AC4 Check datadog tags to be sure they have not changed

 
Links to UCD:

Figma Link: [Download your medical records reports](https://www.figma.com/design/SGP1z2LejUWqDZyT61po5J/Medical-Records---Phase-1?node-id=14676-65422&t=FM8uuaByHPuqa8Ui-4)

Other Design Notes:

## Testing done
Tested affected page using new string structure. 

 ## Screenshots
 
![Screenshot 2025-02-10 at 9 52 10 AM (3)](https://github.com/user-attachments/assets/9e6c2a62-5ec9-4f0a-a044-68211ab2b64b)



## What areas of the site does it impact?
Download page section of medical records

## Acceptance criteria
'Download Continuity of Care Document (XML)' and Download self-entered health information report (PDF)' are the new
string format. 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


