### PR TITLE
[10-10CG] Pass Method name for logging in ensureCSRFToken

### DIFF
--- a/src/applications/caregivers/actions/ensureValidCSRFToken.js
+++ b/src/applications/caregivers/actions/ensureValidCSRFToken.js
@@ -3,8 +3,8 @@ import { apiRequest } from 'platform/utilities/api';
 import recordEvent from 'platform/monitoring/record-event';
 import environment from 'platform/utilities/environment';
 
-const fetchNewCSRFToken = async () => {
-  const message = 'No csrfToken when making fetchFacilities.';
+const fetchNewCSRFToken = async methodName => {
+  const message = `No csrfToken when making ${methodName} call.`;
   const url = '/v0/maintenance_windows';
   recordEvent({
     event: 'caregivers-10-10cg-fetch-csrf-token-empty',
@@ -35,10 +35,10 @@ const fetchNewCSRFToken = async () => {
     });
 };
 
-export const ensureValidCSRFToken = async () => {
+export const ensureValidCSRFToken = async methodName => {
   const csrfToken = localStorage.getItem('csrfToken');
   if (!csrfToken) {
-    await fetchNewCSRFToken();
+    await fetchNewCSRFToken(methodName);
   } else {
     recordEvent({
       event: 'caregivers-10-10cg-fetch-csrf-token-present',

--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -36,7 +36,7 @@ export const fetchFacilities = async ({
   facilityIds = [],
   type = 'health',
 }) => {
-  await ensureValidCSRFToken();
+  await ensureValidCSRFToken('fetchFacilities');
 
   const url = `${
     environment.API_URL

--- a/src/applications/caregivers/components/ApplicationDownloadLink.jsx
+++ b/src/applications/caregivers/components/ApplicationDownloadLink.jsx
@@ -51,7 +51,7 @@ const ApplicationDownloadLink = () => {
     event.preventDefault();
     isLoading(true);
 
-    await ensureValidCSRFToken();
+    await ensureValidCSRFToken('fetchPdf');
 
     // get pdf file to download
     apiRequest(apiURL, {

--- a/src/applications/caregivers/tests/unit/actions/ensureValidCSRFToken.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/actions/ensureValidCSRFToken.unit.spec.js
@@ -33,7 +33,7 @@ describe('CG ensureValidCSRFToken action', () => {
     });
 
     it('calls recordEvent token-present successfully', async () => {
-      await ensureValidCSRFToken();
+      await ensureValidCSRFToken('myMethod');
 
       await waitFor(() => {
         expect(
@@ -53,7 +53,7 @@ describe('CG ensureValidCSRFToken action', () => {
     it('successfully makes extra HEAD request to refresh csrfToken', async () => {
       apiRequestStub.onFirstCall().resolves({ meta: {} });
 
-      await ensureValidCSRFToken();
+      await ensureValidCSRFToken('myMethod');
 
       await waitFor(() => {
         expect(
@@ -72,10 +72,10 @@ describe('CG ensureValidCSRFToken action', () => {
         expect(apiRequestStub.callCount).to.equal(1);
         expect(sentrySpy.callCount).to.equal(2);
         expect(sentrySpy.firstCall.args[0]).to.equal(
-          'No csrfToken when making fetchFacilities. Calling /v0/maintenance_windows to generate new one.',
+          'No csrfToken when making myMethod call. Calling /v0/maintenance_windows to generate new one.',
         );
         expect(sentrySpy.secondCall.args[0]).to.equal(
-          'No csrfToken when making fetchFacilities. /v0/maintenance_windows successfully called to generate token.',
+          'No csrfToken when making myMethod call. /v0/maintenance_windows successfully called to generate token.',
         );
       });
     });
@@ -83,16 +83,16 @@ describe('CG ensureValidCSRFToken action', () => {
     it('returns error making extra HEAD request to refresh csrfToken', async () => {
       apiRequestStub.onFirstCall().rejects(errorResponse);
 
-      await ensureValidCSRFToken();
+      await ensureValidCSRFToken('myMethod');
 
       await waitFor(() => {
         expect(apiRequestStub.callCount).to.equal(1);
         expect(sentrySpy.callCount).to.equal(2);
         expect(sentrySpy.firstCall.args[0]).to.equal(
-          'No csrfToken when making fetchFacilities. Calling /v0/maintenance_windows to generate new one.',
+          'No csrfToken when making myMethod call. Calling /v0/maintenance_windows to generate new one.',
         );
         expect(sentrySpy.secondCall.args[0]).to.equal(
-          'No csrfToken when making fetchFacilities. /v0/maintenance_windows failed when called to generate token.',
+          'No csrfToken when making myMethod call. /v0/maintenance_windows failed when called to generate token.',
         );
       });
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Passing a string into the `ensureValidCSRFToken` that is used for logs to help is pinpoint when this is happening.
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95115

## Testing done

- Updated specs
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

No UI changes

## What areas of the site does it impact?

10-10CG 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
