### PR TITLE
Utilize in-progress form for Cypress tests in Health Care Application

### DIFF
--- a/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.household.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.household.json
@@ -1,0 +1,47 @@
+{
+  "statusCode": 200,
+  "body": {
+    "formData": {
+      "veteranFullName": { "first": "Julio", "middle": "E", "last": "Hunter" },
+      "gender": "M",
+      "veteranDateOfBirth": "1951-11-18",
+      "veteranSocialSecurityNumber": "796378321",
+      "homePhone": "6575107441",
+      "email": "vets.gov.user+71@gmail.com",
+      "lastServiceBranch": "air force",
+      "lastEntryDate": "1977-06-03",
+      "lastDischargeDate": "1998-06-30",
+      "dischargeType": "honorable",
+      "veteranAddress": {
+        "street": "123 aspen st",
+        "street2": "Apt 4",
+        "street3": "Room 6",
+        "city": "Hadley",
+        "country": "USA",
+        "state": "MA",
+        "postalCode": "01070"
+      },
+      "view:doesMailingMatchHomeAddress": true,
+      "hasTeraResponse": false,
+      "vaCompensationType": "none",
+      "vaPensionType": "No",
+      "dependents": []
+    },
+    "metadata": {
+      "version": 0,
+      "returnUrl": "/household-information/financial-information-use",
+      "savedAt": 1739200257608,
+      "submission": {
+          "status": false,
+          "errorMessage": false,
+          "id": false,
+          "timestamp": false,
+          "hasAttemptedSubmit": false
+      },
+      "createdAt": 1739200226,
+      "expiresAt": 1744384257,
+      "lastUpdated": 1739200257,
+      "inProgressFormId": 12345
+    }
+  }
+}

--- a/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.insurance.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.insurance.json
@@ -1,0 +1,46 @@
+{
+  "statusCode": 200,
+  "body": {
+    "formData": {
+      "veteranFullName": { "first": "Julio", "middle": "E", "last": "Hunter" },
+      "gender": "M",
+      "veteranDateOfBirth": "1951-11-18",
+      "veteranSocialSecurityNumber": "796378321",
+      "homePhone": "6575107441",
+      "email": "vets.gov.user+71@gmail.com",
+      "lastServiceBranch": "air force",
+      "lastEntryDate": "1977-06-03",
+      "lastDischargeDate": "1998-06-30",
+      "dischargeType": "honorable",
+      "veteranAddress": {
+        "street": "123 aspen st",
+        "street2": "Apt 4",
+        "street3": "Room 6",
+        "city": "Hadley",
+        "country": "USA",
+        "state": "MA",
+        "postalCode": "01070"
+      },
+      "view:doesMailingMatchHomeAddress": true,
+      "hasTeraResponse": false,
+      "vaCompensationType": "highDisability",
+      "discloseFinancialInformation": false
+    },
+    "metadata": {
+      "version": 0,
+      "returnUrl": "/insurance-information/health-insurance",
+      "savedAt": 1739200257608,
+      "submission": {
+          "status": false,
+          "errorMessage": false,
+          "id": false,
+          "timestamp": false,
+          "hasAttemptedSubmit": false
+      },
+      "createdAt": 1739200226,
+      "expiresAt": 1744384257,
+      "lastUpdated": 1739200257,
+      "inProgressFormId": 12345
+    }
+  }
+}

--- a/src/applications/hca/tests/e2e/fixtures/mocks/user.inProgressForm.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/user.inProgressForm.json
@@ -1,0 +1,132 @@
+{
+  "data": {
+    "id": "",
+    "type": "users_scaffolds",
+    "attributes": {
+      "profile": {
+        "sign_in": {
+          "service_name": "idme"
+        },
+        "email": "vets.gov.user+71@gmail.com",
+        "loa": {
+          "current": 3
+        },
+        "first_name": "Julio",
+        "middle_name": "E",
+        "last_name": "Hunter",
+        "gender": "M",
+        "birth_date": "1951-11-18",
+        "verified": true
+      },
+      "veteran_status": {
+        "status": "OK",
+        "is_veteran": true
+      },
+      "inProgressForms": [
+        {
+          "form": "1010ez",
+          "metadata": {
+            "version": 0,
+            "returnUrl": "/",
+            "savedAt": 1739200257608,
+            "submission": {
+              "status": false,
+              "errorMessage": false,
+              "id": false,
+              "timestamp": false,
+              "hasAttemptedSubmit": false
+            },
+            "createdAt": 1739200226,
+            "expiresAt": 1744384257,
+            "lastUpdated": 1739200257,
+            "inProgressFormId": 12345
+          },
+          "lastUpdated": 1739200257
+        }
+      ],
+      "prefillsAvailable": ["1010ez"],
+      "services": [
+        "facilities",
+        "hca",
+        "edu-benefits",
+        "evss-claims",
+        "user-profile",
+        "rx",
+        "messaging"
+      ],
+      "va_profile": {
+        "status": "OK",
+        "birth_date": "19511118",
+        "family_name": "Hunter",
+        "gender": "M",
+        "given_names": ["Julio", "E"]
+      },
+      "vet360ContactInformation": {
+        "email": null,
+        "residentialAddress": null,
+        "mailingAddress": {
+          "addressLine1": "123 elm st",
+          "addressLine2": null,
+          "addressLine3": null,
+          "addressPou": "CORRESPONDENCE",
+          "addressType": "DOMESTIC",
+          "city": "Northampton",
+          "countryName": "United States",
+          "countryCodeIso2": "US",
+          "countryCodeIso3": "USA",
+          "countryCodeFips": null,
+          "countyCode": "36005",
+          "countyName": "Bronx County",
+          "createdAt": "2020-12-10T20:02:29.000+00:00",
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2021-01-20T02:29:58.000+00:00",
+          "geocodeDate": "2021-01-20T02:31:05.000+00:00",
+          "geocodePrecision": 31,
+          "id": 208622,
+          "internationalPostalCode": null,
+          "latitude": 40.8293,
+          "longitude": -73.9284,
+          "province": null,
+          "sourceDate": "2021-01-20T02:29:58.000+00:00",
+          "sourceSystemUser": null,
+          "stateCode": "MA",
+          "transactionId": "0edf4400-9de7-442c-ae65-abf192702cef",
+          "updatedAt": "2021-01-20T02:31:06.000+00:00",
+          "validationKey": null,
+          "vet360Id": "1273500",
+          "zipCode": "01060",
+          "zipCodeSuffix": "2100"
+        },
+        "mobilePhone": null,
+        "homePhone": null,
+        "workPhone": {
+          "areaCode": "270",
+          "countryCode": "1",
+          "createdAt": "2018-04-20T17:22:56.000+00:00",
+          "extension": null,
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2012-10-25T09:03:30.000+00:00",
+          "id": 2270938,
+          "isInternational": false,
+          "isTextable": false,
+          "isTextPermitted": false,
+          "isTty": false,
+          "isVoicemailable": false,
+          "phoneNumber": "2323232",
+          "phoneType": "WORK",
+          "sourceDate": "2012-10-25T09:03:30.000+00:00",
+          "sourceSystemUser": null,
+          "transactionId": "DATA SEEDING",
+          "updatedAt": "2018-04-20T17:22:56.000+00:00",
+          "vet360Id": "1273500"
+        },
+        "temporaryPhone": null,
+        "faxNumber": null,
+        "textPermission": null
+      }
+    }
+  },
+  "meta": {
+    "errors": null
+  }
+}

--- a/src/applications/hca/tests/e2e/hca-household.dependents.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.dependents.cypress.spec.js
@@ -9,7 +9,7 @@ import {
   fillVeteranIncome,
   goToNextPage,
   setupForAuth,
-  startSaveInProgressUser,
+  startAsInProgressUser,
 } from './utils';
 
 const { data: testData } = maxTestData;
@@ -17,7 +17,7 @@ const { data: testData } = maxTestData;
 describe('HCA-Household: Dependent disclosure', () => {
   beforeEach(() => {
     setupForAuth({ user: mockUser, prefill: mockPrefill });
-    startSaveInProgressUser();
+    startAsInProgressUser();
   });
 
   it('works with dependent who is of college age, lived with Veteran and did not earn income', () => {

--- a/src/applications/hca/tests/e2e/hca-household.dependents.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.dependents.cypress.spec.js
@@ -1,145 +1,23 @@
 import maxTestData from './fixtures/data/maximal-test.json';
+import mockPrefill from './fixtures/mocks/prefill.inProgress.household.json';
+import mockUser from './fixtures/mocks/user.inProgressForm.json';
 import {
   advanceFromHouseholdToSubmit,
-  advanceToHousehold,
   fillDeductibleExpenses,
   fillDependentBasicInformation,
   fillDependentIncome,
-  fillSpousalBasicInformation,
-  fillSpousalIncome,
   fillVeteranIncome,
   goToNextPage,
   setupForAuth,
+  startSaveInProgressUser,
 } from './utils';
 
 const { data: testData } = maxTestData;
 
-describe('HCA-Household: Non-disclosure', () => {
-  beforeEach(() => {
-    setupForAuth();
-    advanceToHousehold();
-  });
-
-  it('works without sharing household information', () => {
-    goToNextPage('/household-information/share-financial-information');
-    cy.selectRadio('root_discloseFinancialInformation', 'N');
-
-    goToNextPage('/household-information/share-financial-information-confirm');
-    goToNextPage('/household-information/marital-status');
-    cy.get('[name="root_maritalStatus"]').select(testData.maritalStatus);
-
-    advanceFromHouseholdToSubmit(testData, { disclosureAssertionValue: false });
-    cy.injectAxeThenAxeCheck();
-  });
-
-  it('works without spouse or dependent information', () => {
-    goToNextPage('/household-information/share-financial-information');
-    cy.selectRadio('root_discloseFinancialInformation', 'Y');
-
-    goToNextPage('/household-information/financial-information-needed');
-    goToNextPage('/household-information/marital-status');
-    cy.get('[name="root_maritalStatus"]').select('Never Married');
-
-    goToNextPage('/household-information/dependents');
-    cy.selectRadio('root_view:reportDependents', 'N');
-
-    goToNextPage('/household-information/veteran-annual-income');
-    fillVeteranIncome(testData);
-
-    goToNextPage('/household-information/deductible-expenses');
-    fillDeductibleExpenses(testData);
-
-    advanceFromHouseholdToSubmit(testData);
-    cy.injectAxeThenAxeCheck();
-  });
-});
-
-describe('HCA-Household: Spousal disclosure', () => {
-  beforeEach(() => {
-    setupForAuth();
-    advanceToHousehold();
-  });
-
-  it('works with spouse who lived with Veteran', () => {
-    goToNextPage('/household-information/share-financial-information');
-    cy.selectRadio('root_discloseFinancialInformation', 'Y');
-
-    goToNextPage('/household-information/financial-information-needed');
-    goToNextPage('/household-information/marital-status');
-    cy.get('[name="root_maritalStatus"]').select(testData.maritalStatus);
-
-    goToNextPage('/household-information/spouse-personal-information');
-    fillSpousalBasicInformation(testData);
-
-    goToNextPage('/household-information/spouse-additional-information');
-    cy.selectRadio('root_cohabitedLastYear', 'Y');
-    cy.selectRadio('root_sameAddress', 'Y');
-
-    goToNextPage('/household-information/dependents');
-    cy.selectRadio('root_view:reportDependents', 'N');
-
-    goToNextPage('/household-information/veteran-annual-income');
-    fillVeteranIncome(testData);
-
-    goToNextPage('/household-information/spouse-annual-income');
-    fillSpousalIncome(testData);
-
-    goToNextPage('/household-information/deductible-expenses');
-    fillDeductibleExpenses(testData);
-
-    advanceFromHouseholdToSubmit(testData);
-    cy.injectAxeThenAxeCheck();
-  });
-
-  it('works with spouse who did not live with Veteran', () => {
-    goToNextPage('/household-information/share-financial-information');
-    cy.selectRadio('root_discloseFinancialInformation', 'Y');
-
-    goToNextPage('/household-information/financial-information-needed');
-    goToNextPage('/household-information/marital-status');
-    cy.get('[name="root_maritalStatus"]').select(testData.maritalStatus);
-
-    goToNextPage('/household-information/spouse-personal-information');
-    fillSpousalBasicInformation(testData);
-
-    goToNextPage('/household-information/spouse-additional-information');
-    cy.selectRadio('root_cohabitedLastYear', 'N');
-    cy.selectRadio('root_sameAddress', 'N');
-
-    goToNextPage('/household-information/spouse-financial-support');
-    cy.selectRadio('root_provideSupportLastYear', 'N');
-
-    goToNextPage('/household-information/spouse-contact-information');
-    cy.fillAddress(
-      'root_spouseAddress',
-      testData['view:spouseContactInformation'].spouseAddress,
-    );
-    cy.fill(
-      '[name="root_spousePhone"]',
-      testData['view:spouseContactInformation'].spousePhone,
-    );
-
-    goToNextPage('/household-information/dependents');
-    cy.selectRadio('root_view:reportDependents', 'N');
-
-    goToNextPage('/household-information/veteran-annual-income');
-    fillVeteranIncome(testData);
-
-    goToNextPage('/household-information/spouse-annual-income');
-    fillSpousalIncome(testData);
-
-    goToNextPage('/household-information/deductible-expenses');
-    fillDeductibleExpenses(testData);
-
-    advanceFromHouseholdToSubmit(testData);
-    cy.injectAxeThenAxeCheck();
-  });
-});
-
 describe('HCA-Household: Dependent disclosure', () => {
   beforeEach(() => {
-    setupForAuth();
-    advanceToHousehold();
+    setupForAuth({ user: mockUser, prefill: mockPrefill });
+    startSaveInProgressUser();
   });
 
   it('works with dependent who is of college age, lived with Veteran and did not earn income', () => {
@@ -440,68 +318,6 @@ describe('HCA-Household: Dependent disclosure', () => {
 
     goToNextPage('/household-information/veteran-annual-income');
     fillVeteranIncome(testData);
-
-    goToNextPage('/household-information/deductible-expenses');
-    fillDeductibleExpenses(testData);
-
-    advanceFromHouseholdToSubmit(testData);
-    cy.injectAxeThenAxeCheck();
-  });
-});
-
-describe('HCA-Household: Full disclosure', () => {
-  beforeEach(() => {
-    setupForAuth();
-    advanceToHousehold();
-  });
-
-  it('works with full spousal and dependent information', () => {
-    goToNextPage('/household-information/share-financial-information');
-    cy.selectRadio('root_discloseFinancialInformation', 'Y');
-
-    goToNextPage('/household-information/financial-information-needed');
-    goToNextPage('/household-information/marital-status');
-    cy.get('[name="root_maritalStatus"]').select('Married');
-
-    goToNextPage('/household-information/spouse-personal-information');
-    fillSpousalBasicInformation(testData);
-
-    goToNextPage('/household-information/spouse-additional-information');
-    cy.selectRadio('root_cohabitedLastYear', 'Y');
-    cy.selectRadio('root_sameAddress', 'Y');
-
-    goToNextPage('/household-information/dependents');
-    cy.selectRadio('root_view:reportDependents', 'Y');
-
-    goToNextPage('/household-information/dependent-information');
-    fillDependentBasicInformation(testData.dependents[0]);
-
-    goToNextPage();
-    cy.selectRadio('root_disabledBefore18', 'N');
-    cy.selectRadio('root_cohabitedLastYear', 'N');
-    cy.selectRadio('root_view:dependentIncome', 'Y');
-
-    goToNextPage();
-    cy.selectRadio('root_receivedSupportLastYear', 'Y');
-
-    goToNextPage();
-    fillDependentIncome(testData.dependents[0]);
-
-    goToNextPage();
-    cy.selectRadio('root_attendedSchoolLastYear', 'Y');
-    cy.fill(
-      '[name="root_dependentEducationExpenses"]',
-      testData.dependents[0].dependentEducationExpenses,
-    );
-
-    goToNextPage('/household-information/dependents');
-    cy.selectRadio('root_view:reportDependents', 'N');
-
-    goToNextPage('/household-information/veteran-annual-income');
-    fillVeteranIncome(testData);
-
-    goToNextPage('/household-information/spouse-annual-income');
-    fillSpousalIncome(testData);
 
     goToNextPage('/household-information/deductible-expenses');
     fillDeductibleExpenses(testData);

--- a/src/applications/hca/tests/e2e/hca-household.fullDisclosure.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.fullDisclosure.cypress.spec.js
@@ -1,0 +1,79 @@
+import maxTestData from './fixtures/data/maximal-test.json';
+import mockPrefill from './fixtures/mocks/prefill.inProgress.household.json';
+import mockUser from './fixtures/mocks/user.inProgressForm.json';
+import {
+  advanceFromHouseholdToSubmit,
+  fillDeductibleExpenses,
+  fillDependentBasicInformation,
+  fillDependentIncome,
+  fillSpousalBasicInformation,
+  fillSpousalIncome,
+  fillVeteranIncome,
+  goToNextPage,
+  setupForAuth,
+  startSaveInProgressUser,
+} from './utils';
+
+const { data: testData } = maxTestData;
+
+describe('HCA-Household: Full disclosure', () => {
+  beforeEach(() => {
+    setupForAuth({ user: mockUser, prefill: mockPrefill });
+    startSaveInProgressUser();
+  });
+
+  it('works with full spousal and dependent information', () => {
+    goToNextPage('/household-information/share-financial-information');
+    cy.selectRadio('root_discloseFinancialInformation', 'Y');
+
+    goToNextPage('/household-information/financial-information-needed');
+    goToNextPage('/household-information/marital-status');
+    cy.get('[name="root_maritalStatus"]').select('Married');
+
+    goToNextPage('/household-information/spouse-personal-information');
+    fillSpousalBasicInformation(testData);
+
+    goToNextPage('/household-information/spouse-additional-information');
+    cy.selectRadio('root_cohabitedLastYear', 'Y');
+    cy.selectRadio('root_sameAddress', 'Y');
+
+    goToNextPage('/household-information/dependents');
+    cy.selectRadio('root_view:reportDependents', 'Y');
+
+    goToNextPage('/household-information/dependent-information');
+    fillDependentBasicInformation(testData.dependents[0]);
+
+    goToNextPage();
+    cy.selectRadio('root_disabledBefore18', 'N');
+    cy.selectRadio('root_cohabitedLastYear', 'N');
+    cy.selectRadio('root_view:dependentIncome', 'Y');
+
+    goToNextPage();
+    cy.selectRadio('root_receivedSupportLastYear', 'Y');
+
+    goToNextPage();
+    fillDependentIncome(testData.dependents[0]);
+
+    goToNextPage();
+    cy.selectRadio('root_attendedSchoolLastYear', 'Y');
+    cy.fill(
+      '[name="root_dependentEducationExpenses"]',
+      testData.dependents[0].dependentEducationExpenses,
+    );
+
+    goToNextPage('/household-information/dependents');
+    cy.selectRadio('root_view:reportDependents', 'N');
+
+    goToNextPage('/household-information/veteran-annual-income');
+    fillVeteranIncome(testData);
+
+    goToNextPage('/household-information/spouse-annual-income');
+    fillSpousalIncome(testData);
+
+    goToNextPage('/household-information/deductible-expenses');
+    fillDeductibleExpenses(testData);
+
+    advanceFromHouseholdToSubmit(testData);
+    cy.injectAxeThenAxeCheck();
+  });
+});

--- a/src/applications/hca/tests/e2e/hca-household.fullDisclosure.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.fullDisclosure.cypress.spec.js
@@ -11,7 +11,7 @@ import {
   fillVeteranIncome,
   goToNextPage,
   setupForAuth,
-  startSaveInProgressUser,
+  startAsInProgressUser,
 } from './utils';
 
 const { data: testData } = maxTestData;
@@ -19,7 +19,7 @@ const { data: testData } = maxTestData;
 describe('HCA-Household: Full disclosure', () => {
   beforeEach(() => {
     setupForAuth({ user: mockUser, prefill: mockPrefill });
-    startSaveInProgressUser();
+    startAsInProgressUser();
   });
 
   it('works with full spousal and dependent information', () => {

--- a/src/applications/hca/tests/e2e/hca-household.nonDisclosure.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.nonDisclosure.cypress.spec.js
@@ -7,7 +7,7 @@ import {
   fillVeteranIncome,
   goToNextPage,
   setupForAuth,
-  startSaveInProgressUser,
+  startAsInProgressUser,
 } from './utils';
 
 const { data: testData } = maxTestData;
@@ -15,7 +15,7 @@ const { data: testData } = maxTestData;
 describe('HCA-Household: Non-disclosure', () => {
   beforeEach(() => {
     setupForAuth({ user: mockUser, prefill: mockPrefill });
-    startSaveInProgressUser();
+    startAsInProgressUser();
   });
 
   it('works without sharing household information', () => {

--- a/src/applications/hca/tests/e2e/hca-household.nonDisclosure.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.nonDisclosure.cypress.spec.js
@@ -1,0 +1,53 @@
+import maxTestData from './fixtures/data/maximal-test.json';
+import mockPrefill from './fixtures/mocks/prefill.inProgress.household.json';
+import mockUser from './fixtures/mocks/user.inProgressForm.json';
+import {
+  advanceFromHouseholdToSubmit,
+  fillDeductibleExpenses,
+  fillVeteranIncome,
+  goToNextPage,
+  setupForAuth,
+  startSaveInProgressUser,
+} from './utils';
+
+const { data: testData } = maxTestData;
+
+describe('HCA-Household: Non-disclosure', () => {
+  beforeEach(() => {
+    setupForAuth({ user: mockUser, prefill: mockPrefill });
+    startSaveInProgressUser();
+  });
+
+  it('works without sharing household information', () => {
+    goToNextPage('/household-information/share-financial-information');
+    cy.selectRadio('root_discloseFinancialInformation', 'N');
+
+    goToNextPage('/household-information/share-financial-information-confirm');
+    goToNextPage('/household-information/marital-status');
+    cy.get('[name="root_maritalStatus"]').select(testData.maritalStatus);
+
+    advanceFromHouseholdToSubmit(testData, { disclosureAssertionValue: false });
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('works without spouse or dependent information', () => {
+    goToNextPage('/household-information/share-financial-information');
+    cy.selectRadio('root_discloseFinancialInformation', 'Y');
+
+    goToNextPage('/household-information/financial-information-needed');
+    goToNextPage('/household-information/marital-status');
+    cy.get('[name="root_maritalStatus"]').select('Never Married');
+
+    goToNextPage('/household-information/dependents');
+    cy.selectRadio('root_view:reportDependents', 'N');
+
+    goToNextPage('/household-information/veteran-annual-income');
+    fillVeteranIncome(testData);
+
+    goToNextPage('/household-information/deductible-expenses');
+    fillDeductibleExpenses(testData);
+
+    advanceFromHouseholdToSubmit(testData);
+    cy.injectAxeThenAxeCheck();
+  });
+});

--- a/src/applications/hca/tests/e2e/hca-household.spouse.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.spouse.cypress.spec.js
@@ -9,7 +9,7 @@ import {
   fillVeteranIncome,
   goToNextPage,
   setupForAuth,
-  startSaveInProgressUser,
+  startAsInProgressUser,
 } from './utils';
 
 const { data: testData } = maxTestData;
@@ -17,7 +17,7 @@ const { data: testData } = maxTestData;
 describe('HCA-Household: Spousal disclosure', () => {
   beforeEach(() => {
     setupForAuth({ user: mockUser, prefill: mockPrefill });
-    startSaveInProgressUser();
+    startAsInProgressUser();
   });
 
   it('works with spouse who lived with Veteran', () => {

--- a/src/applications/hca/tests/e2e/hca-household.spouse.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-household.spouse.cypress.spec.js
@@ -1,0 +1,97 @@
+import maxTestData from './fixtures/data/maximal-test.json';
+import mockPrefill from './fixtures/mocks/prefill.inProgress.household.json';
+import mockUser from './fixtures/mocks/user.inProgressForm.json';
+import {
+  advanceFromHouseholdToSubmit,
+  fillDeductibleExpenses,
+  fillSpousalBasicInformation,
+  fillSpousalIncome,
+  fillVeteranIncome,
+  goToNextPage,
+  setupForAuth,
+  startSaveInProgressUser,
+} from './utils';
+
+const { data: testData } = maxTestData;
+
+describe('HCA-Household: Spousal disclosure', () => {
+  beforeEach(() => {
+    setupForAuth({ user: mockUser, prefill: mockPrefill });
+    startSaveInProgressUser();
+  });
+
+  it('works with spouse who lived with Veteran', () => {
+    goToNextPage('/household-information/share-financial-information');
+    cy.selectRadio('root_discloseFinancialInformation', 'Y');
+
+    goToNextPage('/household-information/financial-information-needed');
+    goToNextPage('/household-information/marital-status');
+    cy.get('[name="root_maritalStatus"]').select(testData.maritalStatus);
+
+    goToNextPage('/household-information/spouse-personal-information');
+    fillSpousalBasicInformation(testData);
+
+    goToNextPage('/household-information/spouse-additional-information');
+    cy.selectRadio('root_cohabitedLastYear', 'Y');
+    cy.selectRadio('root_sameAddress', 'Y');
+
+    goToNextPage('/household-information/dependents');
+    cy.selectRadio('root_view:reportDependents', 'N');
+
+    goToNextPage('/household-information/veteran-annual-income');
+    fillVeteranIncome(testData);
+
+    goToNextPage('/household-information/spouse-annual-income');
+    fillSpousalIncome(testData);
+
+    goToNextPage('/household-information/deductible-expenses');
+    fillDeductibleExpenses(testData);
+
+    advanceFromHouseholdToSubmit(testData);
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('works with spouse who did not live with Veteran', () => {
+    goToNextPage('/household-information/share-financial-information');
+    cy.selectRadio('root_discloseFinancialInformation', 'Y');
+
+    goToNextPage('/household-information/financial-information-needed');
+    goToNextPage('/household-information/marital-status');
+    cy.get('[name="root_maritalStatus"]').select(testData.maritalStatus);
+
+    goToNextPage('/household-information/spouse-personal-information');
+    fillSpousalBasicInformation(testData);
+
+    goToNextPage('/household-information/spouse-additional-information');
+    cy.selectRadio('root_cohabitedLastYear', 'N');
+    cy.selectRadio('root_sameAddress', 'N');
+
+    goToNextPage('/household-information/spouse-financial-support');
+    cy.selectRadio('root_provideSupportLastYear', 'N');
+
+    goToNextPage('/household-information/spouse-contact-information');
+    cy.fillAddress(
+      'root_spouseAddress',
+      testData['view:spouseContactInformation'].spouseAddress,
+    );
+    cy.fill(
+      '[name="root_spousePhone"]',
+      testData['view:spouseContactInformation'].spousePhone,
+    );
+
+    goToNextPage('/household-information/dependents');
+    cy.selectRadio('root_view:reportDependents', 'N');
+
+    goToNextPage('/household-information/veteran-annual-income');
+    fillVeteranIncome(testData);
+
+    goToNextPage('/household-information/spouse-annual-income');
+    fillSpousalIncome(testData);
+
+    goToNextPage('/household-information/deductible-expenses');
+    fillDeductibleExpenses(testData);
+
+    advanceFromHouseholdToSubmit(testData);
+    cy.injectAxeThenAxeCheck();
+  });
+});

--- a/src/applications/hca/tests/e2e/hca-insurance-v2.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-insurance-v2.cypress.spec.js
@@ -6,7 +6,7 @@ import {
   fillInsuranceInformation,
   goToNextPage,
   setupForAuth,
-  startSaveInProgressUser,
+  startAsInProgressUser,
 } from './utils';
 
 const { data: testData } = maxTestData;
@@ -18,7 +18,7 @@ describe('HCA-Health-Insurance-Information', () => {
       user: mockUser,
       prefill: mockPrefill,
     });
-    startSaveInProgressUser();
+    startAsInProgressUser();
   });
 
   it('should successfully advance to facility selection when user does not have health insurance coverage', () => {

--- a/src/applications/hca/tests/e2e/hca-insurance-v2.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-insurance-v2.cypress.spec.js
@@ -1,18 +1,24 @@
 import maxTestData from './fixtures/data/maximal-test.json';
 import mockFeatures from './fixtures/mocks/feature-toggles.insurance.json';
+import mockPrefill from './fixtures/mocks/prefill.inProgress.insurance.json';
+import mockUser from './fixtures/mocks/user.inProgressForm.json';
 import {
-  advanceToHealthInsurance,
   fillInsuranceInformation,
   goToNextPage,
   setupForAuth,
+  startSaveInProgressUser,
 } from './utils';
 
 const { data: testData } = maxTestData;
 
 describe('HCA-Health-Insurance-Information', () => {
   beforeEach(() => {
-    setupForAuth({ features: mockFeatures });
-    advanceToHealthInsurance(testData);
+    setupForAuth({
+      features: mockFeatures,
+      user: mockUser,
+      prefill: mockPrefill,
+    });
+    startSaveInProgressUser();
   });
 
   it('should successfully advance to facility selection when user does not have health insurance coverage', () => {

--- a/src/applications/hca/tests/e2e/utils/helpers.js
+++ b/src/applications/hca/tests/e2e/utils/helpers.js
@@ -29,6 +29,13 @@ export const startAsGuestUser = () => {
   cy.location('pathname').should('include', '/id-form');
 };
 
+export const startSaveInProgressUser = () => {
+  cy.get('[data-testid="continue-your-application"]')
+    .first()
+    .click();
+  cy.wait('@mockPrefill');
+};
+
 // Keyboard-only pattern helpers
 export const fillAddressWithKeyboard = (fieldName, value) => {
   cy.typeInIfDataExists(`[name="root_${fieldName}_street"]`, value.street);

--- a/src/applications/hca/tests/e2e/utils/helpers.js
+++ b/src/applications/hca/tests/e2e/utils/helpers.js
@@ -29,7 +29,7 @@ export const startAsGuestUser = () => {
   cy.location('pathname').should('include', '/id-form');
 };
 
-export const startSaveInProgressUser = () => {
+export const startAsInProgressUser = () => {
   cy.get('[data-testid="continue-your-application"]')
     .first()
     .click();

--- a/src/applications/hca/tests/e2e/utils/navigation.js
+++ b/src/applications/hca/tests/e2e/utils/navigation.js
@@ -26,69 +26,6 @@ export const advanceToVaBenefits = (testData, props = {}) => {
   cy.selectRadio('root_vaCompensationType', compensation);
 };
 
-export const advanceToTERA = (testData, props = {}) => {
-  const {
-    birthdate = testData.veteranDateOfBirth,
-    entryDate = testData.lastEntryDate,
-    dischargeDate = testData.lastDischargeDate,
-  } = props;
-
-  startAsGuestUser();
-  fillIdentityForm({ ...testData, veteranDateOfBirth: birthdate });
-
-  goToNextPage('/veteran-information/birth-information');
-  goToNextPage('/veteran-information/maiden-name-information');
-  goToNextPage('/veteran-information/birth-sex');
-  cy.selectRadio('root_gender', 'M');
-
-  goToNextPage('/veteran-information/demographic-information');
-  goToNextPage('/veteran-information/veteran-address');
-  cy.fillAddress('root_veteranAddress', testData.veteranAddress);
-  cy.selectRadio('root_view:doesMailingMatchHomeAddress', 'Y');
-
-  goToNextPage('/veteran-information/contact-information');
-  goToNextPage('/va-benefits/basic-information');
-  cy.selectRadio('root_vaCompensationType', 'none');
-
-  goToNextPage('/va-benefits/pension-information');
-  cy.selectRadio('root_vaPensionType', 'No');
-
-  goToNextPage('/military-service/service-information');
-  cy.get('[name="root_lastServiceBranch"]').select(testData.lastServiceBranch);
-  cy.fillDate('root_lastEntryDate', entryDate);
-  cy.fillDate('root_lastDischargeDate', dischargeDate);
-  cy.get('[name="root_dischargeType"]').select(testData.dischargeType);
-
-  goToNextPage('/military-service/additional-information');
-  goToNextPage('/military-service/toxic-exposure');
-  cy.selectRadio('root_hasTeraResponse', 'Y');
-};
-
-export const advanceToHousehold = () => {
-  startAsAuthUser();
-
-  goToNextPage('/veteran-information/birth-information');
-  goToNextPage('/veteran-information/maiden-name-information');
-  goToNextPage('/veteran-information/birth-sex');
-  goToNextPage('/veteran-information/demographic-information');
-  goToNextPage('/veteran-information/veteran-address');
-  cy.selectRadio('root_view:doesMailingMatchHomeAddress', 'Y');
-
-  goToNextPage('/veteran-information/contact-information');
-  goToNextPage('/va-benefits/basic-information');
-  cy.selectRadio('root_vaCompensationType', 'none');
-
-  goToNextPage('/va-benefits/pension-information');
-  cy.selectRadio('root_vaPensionType', 'No');
-
-  goToNextPage('/military-service/service-information');
-  goToNextPage('/military-service/additional-information');
-  goToNextPage('/military-service/toxic-exposure');
-  cy.selectRadio('root_hasTeraResponse', 'N');
-
-  goToNextPage('/household-information/financial-information-use');
-};
-
 export const advanceFromHouseholdToSubmit = (testData, props = {}) => {
   const { disclosureAssertionValue = true } = props;
 

--- a/src/applications/hca/tests/e2e/utils/navigation.js
+++ b/src/applications/hca/tests/e2e/utils/navigation.js
@@ -2,7 +2,6 @@ import { fillIdentityForm, fillVaFacility } from './fillers';
 import {
   acceptPrivacyAgreement,
   goToNextPage,
-  startAsAuthUser,
   startAsGuestUser,
 } from './helpers';
 
@@ -57,34 +56,6 @@ export const advanceFromHouseholdToSubmit = (testData, props = {}) => {
       .should(`be.${disclosureAssertionValue}`);
   });
   cy.location('pathname').should('include', '/confirmation');
-};
-
-export const advanceToHealthInsurance = testData => {
-  startAsAuthUser();
-
-  goToNextPage('/veteran-information/birth-information');
-  goToNextPage('/veteran-information/maiden-name-information');
-  goToNextPage('/veteran-information/birth-sex');
-  cy.selectRadio('root_gender', 'M');
-
-  goToNextPage('/veteran-information/demographic-information');
-  goToNextPage('/veteran-information/veteran-address');
-  cy.fillAddress('root_veteranAddress', testData.veteranAddress);
-  cy.selectRadio('root_view:doesMailingMatchHomeAddress', 'Y');
-
-  goToNextPage('/veteran-information/contact-information');
-  goToNextPage('/va-benefits/basic-information');
-  cy.selectRadio('root_vaCompensationType', 'highDisability');
-
-  goToNextPage('/va-benefits/confirm-service-pay');
-  goToNextPage('/military-service/toxic-exposure');
-  cy.selectRadio('root_hasTeraResponse', 'N');
-
-  goToNextPage('/insurance-information/medicaid');
-  cy.selectRadio('root_isMedicaidEligible', 'N');
-
-  goToNextPage('/insurance-information/your-health-insurance');
-  goToNextPage('/insurance-information/health-insurance');
 };
 
 export const advanceToAuthShortForm = () => {

--- a/src/applications/hca/tests/e2e/utils/setup.js
+++ b/src/applications/hca/tests/e2e/utils/setup.js
@@ -43,6 +43,7 @@ export const setupForAuth = (props = {}) => {
     disabilityRating = 0,
     enrollmentStatus = mockEnrollmentStatus,
     features = mockFeatures,
+    prefill = mockPrefill,
     user = mockUser,
   } = props;
 
@@ -58,7 +59,7 @@ export const setupForAuth = (props = {}) => {
   };
 
   setupBasicTest({ enrollmentStatus, features });
-  cy.intercept('GET', APIs.saveInProgress, mockPrefill).as('mockPrefill');
+  cy.intercept('GET', APIs.saveInProgress, prefill).as('mockPrefill');
   cy.intercept('PUT', APIs.saveInProgress, mockSaveInProgress);
   cy.intercept(APIs.disabilityRating, mockRating).as('mockDisabilityRating');
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In an effort to make the Cypress test suite run more efficiently and be more performant, this PR does two things:

1. It splits specs that have a considerable amount of individual tests into smaller sets of tests
2. It utilizes in-progress forms to start at the specific section being tested to cut down on total runtime

## Related issue(s)

department-of-veterans-affairs/va.gov-team#100726

## Acceptance criteria

- Tests are as performant as can be
- No unnecessary navigation/form filling is utilized in the specs

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution