### PR TITLE
Refactored tests to account for new data fetching

### DIFF
--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
@@ -29,7 +29,13 @@ export default function ReferralTaskCardWithReferral() {
     (referralFetchStatus === FETCH_STATUS.loading ||
       referralFetchStatus === FETCH_STATUS.notStarted)
   ) {
-    return <va-loading-indicator set-focus message="Loading your data..." />;
+    return (
+      <va-loading-indicator
+        data-testid="loading-indicator"
+        set-focus
+        message="Loading your data..."
+      />
+    );
   }
 
   if (id && referralFetchStatus === FETCH_STATUS.failed) {

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -86,6 +86,38 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
     useGetReferralByIdStub.restore();
   });
 
+  it('should display the loading component when fetch status is loading', async () => {
+    const store = createTestStore();
+    const useGetReferralByIdStub = sinon
+      .stub(useGetReferralByIdModule, 'useGetReferralById')
+      .returns({
+        referral: undefined,
+        referralFetchStatus: FETCH_STATUS.loading,
+      });
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=1234',
+    });
+    expect(screen.getByTestId('loading-indicator')).to.exist;
+    useGetReferralByIdStub.restore();
+  });
+
+  it('should display the loading component when fetch status is notStarted', async () => {
+    const store = createTestStore();
+    const useGetReferralByIdStub = sinon
+      .stub(useGetReferralByIdModule, 'useGetReferralById')
+      .returns({
+        referral: undefined,
+        referralFetchStatus: FETCH_STATUS.notStarted,
+      });
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=1234',
+    });
+    expect(screen.getByTestId('loading-indicator')).to.exist;
+    useGetReferralByIdStub.restore();
+  });
+
   it('should display the error alert when fetch fails', async () => {
     const store = createTestStore();
     const useGetReferralByIdStub = sinon

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -35,7 +35,7 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
 
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
       store,
-      path: '/',
+      path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801',
     });
     expect(await screen.findByTestId('referral-task-card')).to.exist;
     useGetReferralByIdStub.restore();

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import MockDate from 'mockdate';
-import { waitFor } from '@testing-library/dom';
+import sinon from 'sinon';
 import {
   renderWithStoreAndRouter,
   createTestStore,
@@ -10,24 +10,7 @@ import ReferralTaskCardWithReferral from './ReferralTaskCardWithReferral';
 
 import { createReferralById } from '../utils/referrals';
 import { FETCH_STATUS } from '../../utils/constants';
-
-const initialState = {
-  featureToggles: {
-    vaOnlineSchedulingCCDirectScheduling: true,
-  },
-  referral: {
-    facility: null,
-    referralDetails: [
-      createReferralById('2024-11-29', 'add2f0f4-a1ea-4dea-a504-a54ab57c6801'),
-    ],
-    referralFetchStatus: FETCH_STATUS.succeeded,
-  },
-  user: {
-    profile: {
-      facilities: [{ facilityId: '983' }],
-    },
-  },
-};
+import * as useGetReferralByIdModule from '../hooks/useGetReferralById';
 
 describe('VAOS Component: ReferralTaskCardWithReferral', () => {
   beforeEach(() => {
@@ -38,67 +21,84 @@ describe('VAOS Component: ReferralTaskCardWithReferral', () => {
     MockDate.reset();
   });
 
-  it('should display the task card when an ID is found', async () => {
-    const store = createTestStore(initialState);
-    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
-      store,
-      path: '/?id=add2f0f4-a1ea-4dea-a504-a54ab57c6801',
-    });
+  it('should display the task card when the referral is fetched successfully', async () => {
+    const store = createTestStore();
+    const useGetReferralByIdStub = sinon
+      .stub(useGetReferralByIdModule, 'useGetReferralById')
+      .returns({
+        referral: createReferralById(
+          '2024-11-29',
+          'add2f0f4-a1ea-4dea-a504-a54ab57c6801',
+        ),
+        referralFetchStatus: FETCH_STATUS.succeeded,
+      });
 
-    expect(await screen.findByTestId('referral-task-card')).to.exist;
-  });
-
-  it('should not display the task card when referral ID is not found', async () => {
-    const store = createTestStore(initialState);
-    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
-      store,
-      path: '/?id=non-existent-id',
-    });
-
-    const taskCard = screen.queryByTestId('referral-task-card');
-    expect(taskCard).to.be.null;
-  });
-
-  it('should not display the task card when no ID is provided in the URL', async () => {
-    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
       store,
       path: '/',
     });
+    expect(await screen.findByTestId('referral-task-card')).to.exist;
+    useGetReferralByIdStub.restore();
+  });
+
+  it('should not display anything when url paramter is not populated', async () => {
+    const store = createTestStore();
+    const useGetReferralByIdStub = sinon
+      .stub(useGetReferralByIdModule, 'useGetReferralById')
+      .returns({
+        referral: undefined,
+        referralFetchStatus: FETCH_STATUS.notStarted,
+      });
+    const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
+      store,
+      path: '/?id=',
+    });
 
     const taskCard = screen.queryByTestId('referral-task-card');
+    const error = screen.queryByTestId('referral-error');
+    const loading = screen.queryByTestId('loading-indicator');
+    const expired = screen.queryByTestId('expired-alert');
     expect(taskCard).to.be.null;
+    expect(error).to.be.null;
+    expect(loading).to.be.null;
+    expect(expired).to.be.null;
+    useGetReferralByIdStub.restore();
   });
+
   it('should display the expired alert when referral is expired', async () => {
-    const store = createTestStore({
-      ...initialState,
-      referral: {
-        ...initialState.referral,
-        referralDetails: [
-          createReferralById(
-            '2024-11-29',
-            '445e2d1b-7150-4631-97f2-f6f473bdef00',
-            '111',
-            '2024-12-01',
-          ),
-        ],
-      },
-    });
+    const store = createTestStore();
+    const useGetReferralByIdStub = sinon
+      .stub(useGetReferralByIdModule, 'useGetReferralById')
+      .returns({
+        referral: createReferralById(
+          '2024-11-29',
+          '445e2d1b-7150-4631-97f2-f6f473bdef00',
+          '111',
+          '2024-12-01',
+        ),
+        referralFetchStatus: FETCH_STATUS.succeeded,
+      });
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
       store,
       path: '/?id=445e2d1b-7150-4631-97f2-f6f473bdef00',
     });
-    expect(await screen.getByTestId('expired-alert')).to.exist;
+    expect(screen.getByTestId('expired-alert')).to.exist;
+    useGetReferralByIdStub.restore();
   });
 
   it('should display the error alert when fetch fails', async () => {
-    const store = createTestStore(initialState);
+    const store = createTestStore();
+    const useGetReferralByIdStub = sinon
+      .stub(useGetReferralByIdModule, 'useGetReferralById')
+      .returns({
+        referral: undefined,
+        referralFetchStatus: FETCH_STATUS.failed,
+      });
     const screen = renderWithStoreAndRouter(<ReferralTaskCardWithReferral />, {
       store,
       path: '/?id=error',
     });
-    await waitFor(() => {
-      expect(screen.getByTestId('referral-error')).to.exist;
-    });
+    expect(screen.getByTestId('referral-error')).to.exist;
+    useGetReferralByIdStub.restore();
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Modifies unit tests to account for new referral fetching
- Uses sinon.stub to mock the hook

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#102636](https://github.com/department-of-veterans-affairs/va.gov-team/issues/102636)

## Testing done

- Run the unit tests

## Acceptance criteria

- [ ] Tests pass
- [ ] Test coverage is 100%

`yarn test:coverage-app vaos`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
