### PR TITLE
Remove axe check from startup script

### DIFF
--- a/src/platform/startup/index.js
+++ b/src/platform/startup/index.js
@@ -8,7 +8,6 @@ import { Router, useRouterHistory, browserHistory } from 'react-router';
 import { createHistory } from 'history';
 import { updateRoute } from 'platform/site-wide/user-nav/actions';
 import startReactApp from './react';
-import runAxeCheck from './axe-check';
 import setUpCommonFunctionality from './setup';
 
 /**
@@ -48,11 +47,6 @@ export default function startApp({
     analyticsEvents,
     preloadScheduledDowntimes,
   });
-
-  // If the build is not production, run an axe check in the browser
-  if (process.env.NODE_ENV !== 'production') {
-    runAxeCheck();
-  }
 
   let history = browserHistory;
   if (url) {

--- a/src/platform/startup/tests/startup.unit.spec.js
+++ b/src/platform/startup/tests/startup.unit.spec.js
@@ -5,7 +5,6 @@ import * as reactRouter from 'react-router';
 import * as history from 'history';
 import * as navActions from 'platform/site-wide/user-nav/actions';
 import * as reactApp from '../react';
-import * as axeCheck from '../axe-check';
 import * as commonFunctionality from '../setup';
 import startApp from '../index';
 
@@ -13,7 +12,6 @@ describe('startApp', () => {
   let sandbox;
   let storeStub;
   let setUpCommonFunctionalityStub;
-  let runAxeCheckStub;
   let startReactAppStub;
   let updateRouteStub;
   let useRouterHistoryStub;
@@ -28,7 +26,6 @@ describe('startApp', () => {
     setUpCommonFunctionalityStub = sandbox
       .stub(commonFunctionality, 'default')
       .returns(storeStub);
-    runAxeCheckStub = sandbox.stub(axeCheck, 'default');
     startReactAppStub = sandbox.stub(reactApp, 'default');
     updateRouteStub = sandbox.stub(navActions, 'updateRoute');
     createHistoryStub = sandbox.stub(history, 'createHistory').returns({
@@ -47,13 +44,6 @@ describe('startApp', () => {
   it('should create a store with setUpCommonFunctionality', () => {
     startApp({ entryName: 'testApp' });
     expect(setUpCommonFunctionalityStub.called).to.be.true;
-  });
-
-  it('should run axe check in non-production environment', () => {
-    process.env.NODE_ENV = 'development';
-    startApp({ entryName: 'testApp' });
-    expect(runAxeCheckStub.called).to.be.true;
-    process.env.NODE_ENV = 'test';
   });
 
   it('should set up history with URL', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

All apps using the `startApp` function (which is most vets-website apps) in `src/platform/startup/index.js` currently run an axe check in the browser if the build is not production. (This change was made as part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/2909) 

However, the axe package is included in the production build, adding ~600kB. This constitutes a significant percentage of the bundle. For instance, it is 596kB out of 2157kB for the search app, or 28%. (See screenshots below) This PR removes this functionality from the startup script. Developers may still add it manually and/or use the axe checks that are included in all e2e tests.

## Testing done

- Updated unit test, confirmed that e2e tests continue to pass, confirmed that Axe is no longer present in app bundles.

## Screenshots

![image](https://github.com/user-attachments/assets/27ce7e0d-2a2e-4249-a3e7-0b5e1d3184ac)
![image](https://github.com/user-attachments/assets/05951739-4439-4a4d-ac75-0e2be642e013)
