### PR TITLE
[SIMPLE-FORMS] feat: update 4138 confirmation page to use new page design

### DIFF
--- a/src/applications/simple-forms/21-4138/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-4138/containers/ConfirmationPage.jsx
@@ -1,43 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
-import { TITLE, SUBTITLE } from '../config/constants';
+import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 
-const content = {
-  headlineText: "You've submitted your statement to support your claim",
-  nextStepsText: (
-    <>
-      <p>
-        We’ll review your statement. If we have any questions or need additional
-        information from you, we’ll contact you.
-      </p>
-    </>
-  ),
-};
-const childContent = <div />;
-
-export const ConfirmationPage = () => {
+export const ConfirmationPage = props => {
   const form = useSelector(state => state.form || {});
   const { submission } = form;
   const submitDate = submission.timestamp;
   const confirmationNumber = submission.response?.confirmationNumber;
-  const submitterFullName = form.data.fullName;
 
   return (
-    <>
-      <FormTitle title={TITLE} subTitle={SUBTITLE} />
-      <ConfirmationPageView
-        formType="submission"
-        submitterHeader="Who submitted this form"
-        submitterName={submitterFullName}
-        submitDate={submitDate}
-        confirmationNumber={confirmationNumber}
-        content={content}
-        childContent={childContent}
-      />
-    </>
+    <ConfirmationView
+      formConfig={props.route?.formConfig}
+      submitDate={submitDate}
+      confirmationNumber={confirmationNumber}
+      pdfUrl={submission.response?.pdfUrl}
+      devOnly={{
+        showButtons: true,
+      }}
+    />
   );
 };
 
@@ -48,6 +29,7 @@ ConfirmationPage.propTypes = {
         first: PropTypes.string.isRequired,
         middle: PropTypes.string,
         last: PropTypes.string.isRequired,
+        suffix: PropTypes.string,
       },
     }),
     formId: PropTypes.string,
@@ -61,6 +43,9 @@ ConfirmationPage.propTypes = {
     }),
   }),
   name: PropTypes.string,
+  route: PropTypes.shape({
+    formConfig: PropTypes.object,
+  }),
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
## Summary

- This work updates form 21-4138 to use the updated confirmation page design.
- I'm a member of the Veteran Facing Forms team who owns this page.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1975

## Testing done

- Unit and E2E tests pass.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |


## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any
