### PR TITLE
Login modal content bug fix

### DIFF
--- a/src/platform/user/authentication/components/LoginInfo.jsx
+++ b/src/platform/user/authentication/components/LoginInfo.jsx
@@ -21,7 +21,7 @@ export default () => {
     <div className="row">
       <div className="columns print-full-width sign-in-wrapper">
         <div className="help-info">
-          <h2 className="vads-u-margin-top--0">Having trouble signing in?</h2>
+          <h2 className="vads-u-margin-top--0">Help and support</h2>
 
           <div>
             <div>

--- a/src/platform/user/tests/authentication/components/LoginInfo.unit.spec.js
+++ b/src/platform/user/tests/authentication/components/LoginInfo.unit.spec.js
@@ -4,16 +4,8 @@ import { renderInReduxProvider } from 'platform/testing/unit/react-testing-libra
 import LoginInfo from 'platform/user/authentication/components/LoginInfo';
 
 describe('LoginInfo', () => {
-  it('renders 5 links', () => {
-    const { container } = renderInReduxProvider(<LoginInfo />, {
-      initialState: {
-        featureToggles: {
-          // eslint-disable-next-line camelcase
-          mhv_credential_button_disabled: true,
-        },
-      },
-    });
-
+  it('renders 6 links', () => {
+    const { container } = renderInReduxProvider(<LoginInfo />);
     const links = container.querySelectorAll('a');
     expect(links.length).to.eq(6);
   });


### PR DESCRIPTION
- Updates ```<LoginInfo />``` component to reflect the proper content on the [USiP](va.gov/sign-in) and [Login modal](https://www.va.gov/?next=loginModal).
- Updates ```<h2>``` content from "Have trouble signing in?" to "Help and support" to match this [Figma design](https://www.figma.com/design/skWgD0gHYGlKSoLdH097OX/Sign-in-changes-for-CSP-deprecation?node-id=0-1&p=f&t=diU40Jo1hurYl0mG-0). (See screenshot)
- Removes unneeded feature toggle check from unit test
<img width="659" alt="Screenshot 2025-02-11 at 10 40 19 AM" src="https://github.com/user-attachments/assets/51eed11e-a93a-4e74-84b3-51bda1ea0118" />
