### PR TITLE
[#102998] Travel Pay, UTC-less claim datetime

### DIFF
--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -15,6 +15,7 @@ export default function ClaimDetailsContent(props) {
 
   const [appointmentDate, appointmentTime] = formatDateTime(
     appointmentDateTime,
+    true,
   );
   const [createDate, createTime] = formatDateTime(createdOn);
   const [updateDate, updateTime] = formatDateTime(modifiedOn);

--- a/src/applications/travel-pay/components/TravelClaimCard.jsx
+++ b/src/applications/travel-pay/components/TravelClaimCard.jsx
@@ -24,6 +24,7 @@ export default function TravelClaimCard(props) {
   } else {
     const [appointmentDate, appointmentTime] = formatDateTime(
       appointmentDateTime,
+      true,
     );
     appointmentDateTitle = `${appointmentDate} at ${appointmentTime} appointment`;
   }

--- a/src/applications/travel-pay/tests/util/dates.spec.js
+++ b/src/applications/travel-pay/tests/util/dates.spec.js
@@ -229,3 +229,19 @@ describe('getDaysLeft', () => {
     expect(actual).to.eq(0);
   });
 });
+
+describe('formatDateTime', () => {
+  it('should format datetime', () => {
+    expect(formatDateTime('2024-06-25T14:00:00Z')).to.deep.equal([
+      'Tuesday, June 25, 2024',
+      '7:00 AM',
+    ]);
+  });
+
+  it('should format datetime without UTC indicator', () => {
+    expect(formatDateTime('2024-06-25T14:00:00Z', true)).to.deep.equal([
+      'Tuesday, June 25, 2024',
+      '2:00 PM',
+    ]);
+  });
+});

--- a/src/applications/travel-pay/util/dates.js
+++ b/src/applications/travel-pay/util/dates.js
@@ -14,8 +14,11 @@ import {
 
 import { utcToZonedTime } from 'date-fns-tz';
 
-export function formatDateTime(datetimeString) {
-  const dateTime = new Date(datetimeString);
+export function formatDateTime(datetimeString, stripUTCIndicator = false) {
+  const str = stripUTCIndicator
+    ? (datetimeString ?? '').split('Z')[0]
+    : datetimeString;
+  const dateTime = new Date(str);
   const formattedDate = format(dateTime, 'eeee, MMMM d, yyyy');
   const formattedTime = format(dateTime, 'h:mm a');
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Adding the option to strip the UTC indicator from datetime strings to support cases where Travel Pay should assume a claim datetime being communicated as local timezone.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/102998

## Testing done

Prior to the change, datetimes for claims were being formatted to respect the `Z` UTC indicator, transforming them from the implicit local timezone we now wish to respect.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="1391" alt="Screenshot 2025-02-12 at 7 11 45 AM" src="https://github.com/user-attachments/assets/4d6a41f4-2afa-4330-833e-b0b7df835cc9" /> <img width="1391" alt="Screenshot 2025-02-12 at 7 11 13 AM" src="https://github.com/user-attachments/assets/7fa33a55-6acd-4711-b563-d836a27bebd7" /> | <img width="1391" alt="Screenshot 2025-02-12 at 7 10 05 AM" src="https://github.com/user-attachments/assets/66d2ad52-4ba6-476c-b308-efef0c1b7fa8" /> <img width="1393" alt="Screenshot 2025-02-12 at 7 10 26 AM" src="https://github.com/user-attachments/assets/6315e9d2-409d-41b3-ae8b-9aece1c2c679" /> |
| Desktop | <img width="1393" alt="Screenshot 2025-02-12 at 7 11 34 AM" src="https://github.com/user-attachments/assets/5b0b1b7a-51cb-4b1f-a0e4-26822309dc50" /> <img width="1393" alt="Screenshot 2025-02-12 at 7 11 06 AM" src="https://github.com/user-attachments/assets/21861c8c-85c4-49ad-8cac-7728615561cf" /> | <img width="1651" alt="Screenshot 2025-02-12 at 7 24 08 AM" src="https://github.com/user-attachments/assets/b988487f-6aee-40a6-b917-1947beac3a8c" /> <img width="1655" alt="Screenshot 2025-02-12 at 7 25 33 AM" src="https://github.com/user-attachments/assets/34e3308d-1793-453a-bc74-77bee98b2334" /> |

## What areas of the site does it impact?

Travel Pay only

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user