### PR TITLE
update happy-dom and test

### DIFF
--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -115,18 +115,20 @@ describe('focusElement', () => {
     );
     const input = screen.getByLabelText('Name');
 
-    // happy-dom bug sets this to -1 by default
-    input.tabIndex = 0;
+    expect(input.tabIndex).to.eq(0);
+    expect(input.getAttribute('tabIndex')).to.be.null;
 
     focusElement(input);
 
     await waitFor(() => {
       expect(document.activeElement).to.eq(input);
       expect(input.tabIndex).to.eq(0);
+      expect(input.getAttribute('tabindex')).to.be.null;
     });
     fireEvent.blur(input);
     await waitFor(() => {
       expect(input.tabIndex).to.eq(0);
+      expect(input.getAttribute('tabindex')).to.be.null;
     });
   });
   it('should focus on va-alert element', async () => {
@@ -171,15 +173,15 @@ describe('focusElement', () => {
     const container = screen.getByTestId('container');
     const button = screen.getByTestId('button');
 
-    // happy-dom bug sets tabIndex to -1 by default
-    button.tabIndex = 0;
     expect(button.tabIndex).to.eq(0);
+    expect(button.getAttribute('tabindex')).to.be.null;
 
     focusElement('button', {}, container);
 
     await waitFor(() => {
       expect(document.activeElement).to.eq(button);
       expect(button.tabIndex).to.eq(0);
+      expect(button.getAttribute('tabindex')).to.be.null;
     });
   });
 });

--- a/src/platform/testing/package.json
+++ b/src/platform/testing/package.json
@@ -31,7 +31,7 @@
     "cypress-real-events": "^1.12.0",
     "cypress-wait-until": "^1.7.2",
     "express-history-api-fallback": "^2.2.1",
-    "happy-dom": "^16.6.0",
+    "happy-dom": "^17.0.0",
     "morgan": "^1.10.0",
     "node-resemble-js": "^0.2.0",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11579,10 +11579,10 @@ handlebars@^4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-happy-dom@^16.6.0:
-  version "16.6.0"
-  resolved "https://registry.npmjs.org/happy-dom/-/happy-dom-16.6.0.tgz#e35e8568deb4f394cd5488c29f2519676661c1af"
-  integrity sha512-Zz5S9sog8a3p8XYZbO+eI1QMOAvCNnIoyrH8A8MLX+X2mJrzADTy+kdETmc4q+uD9AGAvQYGn96qBAn2RAciKw==
+happy-dom@^17.0.0:
+  version "17.0.3"
+  resolved "https://registry.npmjs.org/happy-dom/-/happy-dom-17.0.3.tgz#09785d87bdfe537e482960211ee5b47d5ac7d154"
+  integrity sha512-1vWCwpeguN02wQF8kGeaj69FDX19bXKQXmyUKcE+O0WLY0uhS0RPTLCJR8Omy8hrjMHwV3dUJ24JUrK07aOA9Q==
   dependencies:
     webidl-conversions "^7.0.0"
     whatwg-mimetype "^3.0.0"


### PR DESCRIPTION
This PR bumps `happy-dom` to its latest version which fixes a bug that was preventing a platform test from working the same way it did under Node 14. 