### PR TITLE
Migrate Burials forms - Location of Death

### DIFF
--- a/src/applications/burials-ez/BurialsApp.jsx
+++ b/src/applications/burials-ez/BurialsApp.jsx
@@ -55,8 +55,16 @@ export default function BurialsApp({ location, children }) {
     return <NoFormPage />;
   }
 
+  // Temporary overwrite of version until flipper is removed.
+  const ldFormConfig = !burialLocationOfDeathUpdate
+    ? formConfig
+    : {
+        ...formConfig,
+        version: 3,
+      };
+
   return (
-    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+    <RoutedSavableApp formConfig={ldFormConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );

--- a/src/applications/burials-ez/migrations.js
+++ b/src/applications/burials-ez/migrations.js
@@ -23,4 +23,22 @@ export default [
 
     return { formData, metadata: newMetadata };
   },
+  // 2 > 3, use new location of death format
+  ({ formData = {}, metadata = {} }) => {
+    const { locationOfDeath } = formData;
+    if (
+      !locationOfDeath ||
+      locationOfDeath.location === 'other' ||
+      locationOfDeath.location === 'atHome'
+    ) {
+      return { formData, metadata };
+    }
+
+    const newFormData = formData;
+    const { location } = locationOfDeath;
+    newFormData[location] = locationOfDeath[location];
+    newFormData.locationOfDeath[location] = {};
+
+    return { formData: newFormData, metadata };
+  },
 ];

--- a/src/applications/burials-ez/tests/migrations.unit.spec.js
+++ b/src/applications/burials-ez/tests/migrations.unit.spec.js
@@ -71,4 +71,119 @@ describe('Burials migrations', () => {
     expect(metadata.returnUrl).to.equal('/original-url');
     expect(formData).to.be.an('object');
   });
+  context('v3 migration', () => {
+    it('should update nursingHomeUnpaid location', () => {
+      const { formData, metadata } = migrations[2]({
+        formData: {
+          locationOfDeath: {
+            location: 'nursingHomeUnpaid',
+            nursingHomeUnpaid: {
+              facilityName: 'Facility Name',
+              facilityLocation: 'Facility Location',
+            },
+          },
+        },
+        metadata: {
+          returnUrl: '/original-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal('/original-url');
+      expect(formData.locationOfDeath.location).to.equal('nursingHomeUnpaid');
+      expect(formData.nursingHomeUnpaid.facilityName).to.equal('Facility Name');
+      expect(formData.nursingHomeUnpaid.facilityLocation).to.equal(
+        'Facility Location',
+      );
+      expect(formData.locationOfDeath.nursingHomeUnpaid).to.be.empty;
+    });
+    it('should update nursingHomePaid location', () => {
+      const { formData, metadata } = migrations[2]({
+        formData: {
+          locationOfDeath: {
+            location: 'nursingHomePaid',
+            nursingHomePaid: {
+              facilityName: 'Facility Name',
+              facilityLocation: 'Facility Location',
+            },
+          },
+        },
+        metadata: {
+          returnUrl: '/original-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal('/original-url');
+      expect(formData.locationOfDeath.location).to.equal('nursingHomePaid');
+      expect(formData.nursingHomePaid.facilityName).to.equal('Facility Name');
+      expect(formData.nursingHomePaid.facilityLocation).to.equal(
+        'Facility Location',
+      );
+      expect(formData.locationOfDeath.nursingHomePaid).to.be.empty;
+    });
+    it('should update vaMedicalCenter location', () => {
+      const { formData, metadata } = migrations[2]({
+        formData: {
+          locationOfDeath: {
+            location: 'vaMedicalCenter',
+            vaMedicalCenter: {
+              facilityName: 'Facility Name',
+              facilityLocation: 'Facility Location',
+            },
+          },
+        },
+        metadata: {
+          returnUrl: '/original-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal('/original-url');
+      expect(formData.locationOfDeath.location).to.equal('vaMedicalCenter');
+      expect(formData.vaMedicalCenter.facilityName).to.equal('Facility Name');
+      expect(formData.vaMedicalCenter.facilityLocation).to.equal(
+        'Facility Location',
+      );
+      expect(formData.locationOfDeath.vaMedicalCenter).to.be.empty;
+    });
+    it('should update stateVeteransHome location', () => {
+      const { formData, metadata } = migrations[2]({
+        formData: {
+          locationOfDeath: {
+            location: 'stateVeteransHome',
+            stateVeteransHome: {
+              facilityName: 'Facility Name',
+              facilityLocation: 'Facility Location',
+            },
+          },
+        },
+        metadata: {
+          returnUrl: '/original-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal('/original-url');
+      expect(formData.locationOfDeath.location).to.equal('stateVeteransHome');
+      expect(formData.stateVeteransHome.facilityName).to.equal('Facility Name');
+      expect(formData.stateVeteransHome.facilityLocation).to.equal(
+        'Facility Location',
+      );
+      expect(formData.locationOfDeath.stateVeteransHome).to.be.empty;
+    });
+    it('should update stateVeteransHome location', () => {
+      const { formData, metadata } = migrations[2]({
+        formData: {
+          locationOfDeath: {
+            location: 'other',
+            other: 'Location',
+          },
+        },
+        metadata: {
+          returnUrl: '/original-url',
+        },
+      });
+
+      expect(metadata.returnUrl).to.equal('/original-url');
+      expect(formData.locationOfDeath.location).to.equal('other');
+      expect(formData.locationOfDeath.other).to.equal('Location');
+    });
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- With the https://github.com/department-of-veterans-affairs/va.gov-team/issues/80105 page in the Burial Benefits form (21P-530EZ), a migration is needed to ensure that returning applicants’ existing form data remains compatible with the new structure. This migration will transform the stored form data to align with the new page layout and field organization.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102512

## Testing done

- Fill out the Burials form until you're past the Location of Death page
- Save the form to continue later
- Enable burial_location_of_death_update flipper
- Refresh the Burials form page and continue saved form
- Go forward to review or back to the location of death page and confirm the location of death is displayed correctly in the new version

## What areas of the site does it impact?

Burials

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

