### PR TITLE
Eliminate dependency cycle for PDF download link in Caregivers application

### DIFF
--- a/src/applications/caregivers/components/ApplicationDownloadLink.jsx
+++ b/src/applications/caregivers/components/ApplicationDownloadLink.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import * as Sentry from '@sentry/browser';
-
 import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from 'platform/utilities/ui';
 import environment from 'platform/utilities/environment';
@@ -9,14 +9,13 @@ import recordEvent from 'platform/monitoring/record-event';
 import { DOWNLOAD_ERRORS_BY_CODE } from '../utils/constants';
 import submitTransformer from '../config/submit-transformer';
 import { ensureValidCSRFToken } from '../actions/ensureValidCSRFToken';
-import formConfig from '../config/form';
 import content from '../locales/en/content.json';
 
 const apiURL = `${
   environment.API_URL
 }/v0/caregivers_assistance_claims/download_pdf`;
 
-const ApplicationDownloadLink = () => {
+const ApplicationDownloadLink = ({ formConfig }) => {
   const [loading, isLoading] = useState(false);
   const [errors, setErrors] = useState([]);
 
@@ -100,7 +99,7 @@ const ApplicationDownloadLink = () => {
   if (errors?.length > 0) {
     return (
       <div className="caregiver-download-error">
-        <va-alert status="error" uswds>
+        <va-alert status="error">
           <h4 slot="headline">{content['alert-heading--generic']}</h4>
           {errorMessage()}
         </va-alert>
@@ -117,6 +116,10 @@ const ApplicationDownloadLink = () => {
       download
     />
   );
+};
+
+ApplicationDownloadLink.propTypes = {
+  formConfig: PropTypes.object,
 };
 
 export default ApplicationDownloadLink;

--- a/src/applications/caregivers/components/ConfirmationPage/ConfirmationScreenView.jsx
+++ b/src/applications/caregivers/components/ConfirmationPage/ConfirmationScreenView.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-cycle */
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
@@ -9,7 +8,10 @@ import { normalizeFullName } from '../../utils/helpers';
 import content from '../../locales/en/content.json';
 import Abbr from '../Abbreviation';
 
-const ConfirmationScreenView = ({ name, timestamp }) => {
+const ConfirmationScreenView = props => {
+  const { name, route, timestamp } = props;
+  const { formConfig } = route;
+
   useEffect(() => {
     focusElement('.caregiver-success-message');
     scrollToTop();
@@ -55,7 +57,7 @@ const ConfirmationScreenView = ({ name, timestamp }) => {
         </div>
 
         <div className="caregiver-application--download">
-          <ApplicationDownloadLink />
+          <ApplicationDownloadLink formConfig={formConfig} />
         </div>
       </va-summary-box>
     </>
@@ -64,6 +66,7 @@ const ConfirmationScreenView = ({ name, timestamp }) => {
 
 ConfirmationScreenView.propTypes = {
   name: PropTypes.object,
+  route: PropTypes.object,
   timestamp: PropTypes.number,
 };
 

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-cycle */
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import environment from 'platform/utilities/environment';
 import FormFooter from 'platform/forms/components/FormFooter';

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -1,11 +1,11 @@
-/* eslint-disable import/no-cycle */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import ConfirmationScreenView from '../components/ConfirmationPage/ConfirmationScreenView';
 import ConfirmationPrintView from '../components/ConfirmationPage/ConfirmationPrintView';
 import ConfirmationFAQ from '../components/ConfirmationPage/ConfirmationFAQ';
 
-const ConfirmationPage = () => {
+const ConfirmationPage = ({ route }) => {
   const { submission, data } = useSelector(state => state.form);
   const { response, timestamp } = submission;
   const name = data.veteranFullName;
@@ -15,6 +15,7 @@ const ConfirmationPage = () => {
       <section className="caregiver-confirmation--screen no-print">
         <ConfirmationScreenView
           name={name}
+          route={route}
           timestamp={response ? timestamp : null}
         />
       </section>
@@ -36,6 +37,10 @@ const ConfirmationPage = () => {
       </a>
     </div>
   );
+};
+
+ConfirmationPage.propTypes = {
+  route: PropTypes.object,
 };
 
 export default ConfirmationPage;

--- a/src/applications/caregivers/tests/unit/components/ApplicationDownloadLink.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/ApplicationDownloadLink.unit.spec.js
@@ -4,33 +4,37 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as Sentry from '@sentry/browser';
-
 import {
   mockApiRequest,
   setFetchJSONResponse,
 } from 'platform/testing/unit/helpers';
 import * as recordEventModule from 'platform/monitoring/record-event';
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
-
 import ApplicationDownloadLink from '../../../components/ApplicationDownloadLink';
 import content from '../../../locales/en/content.json';
 
 describe('CG <ApplicationDownloadLink>', () => {
-  const mockStore = {
-    getState: () => ({
-      form: {
-        data: { veteranFullName: { first: 'John', last: 'Smith' } },
-      },
-    }),
-    subscribe: () => {},
-    dispatch: () => {},
-  };
-  const subject = () =>
-    render(
+  const subject = () => {
+    const mockStore = {
+      getState: () => ({
+        form: {
+          data: { veteranFullName: { first: 'John', last: 'Smith' } },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+    const { container } = render(
       <Provider store={mockStore}>
-        <ApplicationDownloadLink />
+        <ApplicationDownloadLink formConfig={{}} />
       </Provider>,
     );
+    const selectors = () => ({
+      vaAlert: container.querySelector('va-alert'),
+      vaLink: container.querySelector('va-link'),
+      vaLoadingIndicator: container.querySelector('va-loading-indicator'),
+    });
+    return { selectors };
+  };
 
   beforeEach(() => {
     localStorage.setItem('csrfToken', 'my-token');
@@ -42,27 +46,23 @@ describe('CG <ApplicationDownloadLink>', () => {
 
   context('default behavior', () => {
     it('should render a download file button', () => {
-      const { container } = subject();
-      const link = $('va-link', container);
-      expect(link).to.exist;
-      expect(link).to.have.attr('text', content['button-download']);
+      const { selectors } = subject();
+      const { vaAlert, vaLink, vaLoadingIndicator } = selectors();
+      expect(vaLink).to.exist;
+      expect(vaAlert).to.not.exist;
+      expect(vaLoadingIndicator).to.not.exist;
+      expect(vaLink).to.have.attr('text', content['button-download']);
     });
   });
 
   context('when clicking the download file button', () => {
-    const triggerError = ({ container, status }) => {
-      const link = $('va-link', container);
-      expect(link).to.exist;
-      expect(container.querySelector('va-loading-indicator')).to.not.exist;
-
+    const triggerError = ({ link, status }) => {
       mockApiRequest({}, false);
-
       setFetchJSONResponse(
         global.fetch.onCall(0),
         // eslint-disable-next-line prefer-promise-reject-errors
         Promise.reject({ errors: [{ status }] }),
       );
-
       fireEvent.click(link);
     };
     let recordEventStub;
@@ -75,28 +75,24 @@ describe('CG <ApplicationDownloadLink>', () => {
       recordEventStub.restore();
     });
 
-    it('should record success event when button is clicked', async () => {
-      const { container } = subject();
-      const loadingIndicator = container.querySelector('va-loading-indicator');
-
-      const link = $('va-link', container);
-      expect(link).to.exist;
-      expect(loadingIndicator).to.not.exist;
-
-      mockApiRequest({
-        blob: () => new Blob(['my blob'], { type: 'application/pdf' }),
-      });
+    it('should record `success` event when button is clicked', async () => {
+      const { selectors } = subject();
+      const { vaLink: downloadBtn } = selectors();
 
       const createObjectStub = sinon
         .stub(URL, 'createObjectURL')
         .returns('my_stubbed_url.com');
       const revokeObjectStub = sinon.stub(URL, 'revokeObjectURL');
 
-      fireEvent.click(link);
+      mockApiRequest({
+        blob: () => new Blob(['my blob'], { type: 'application/pdf' }),
+      });
+      fireEvent.click(downloadBtn);
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.exist;
-        expect($('va-link', container)).to.not.exist;
+        const { vaLink, vaLoadingIndicator } = selectors();
+        expect(vaLoadingIndicator).to.exist;
+        expect(vaLink).to.not.exist;
       });
 
       await waitFor(() => {
@@ -108,86 +104,77 @@ describe('CG <ApplicationDownloadLink>', () => {
       });
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.not.exist;
-        expect($('va-link', container)).to.exist;
+        const { vaLink, vaLoadingIndicator } = selectors();
+        expect(vaLoadingIndicator).to.not.exist;
+        expect(vaLink).to.exist;
       });
 
       createObjectStub.restore();
       revokeObjectStub.restore();
     });
 
-    it('should record error event when the request fails', async () => {
-      const spy = sinon.spy(Sentry, 'withScope');
-      const { container } = subject();
-      triggerError({ container, status: '503' });
+    it('should record `error` event when the request fails', async () => {
+      const sentrySpy = sinon.spy(Sentry, 'withScope');
+      const { selectors } = subject();
+      const { vaLink: link } = selectors();
+      triggerError({ link, status: '503' });
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.exist;
+        const { vaLoadingIndicator } = selectors();
+        expect(vaLoadingIndicator).to.exist;
       });
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.not.exist;
+        const { vaLink, vaLoadingIndicator } = selectors();
+        const event = 'caregivers-10-10cg-pdf--failure';
+
+        expect(recordEventStub.calledWith({ event })).to.be.true;
+        expect(sentrySpy.called).to.be.true;
+
+        expect(vaLoadingIndicator).to.not.exist;
+        expect(vaLink).to.not.exist;
       });
 
-      await waitFor(() => {
-        expect(
-          recordEventStub.calledWith({
-            event: 'caregivers-10-10cg-pdf--failure',
-          }),
-        ).to.be.true;
-      });
-
-      await waitFor(() => {
-        expect(spy.called).to.be.true;
-        spy.restore();
-      });
-
-      await waitFor(() => {
-        expect($('va-link', container)).to.not.exist;
-      });
+      sentrySpy.restore();
     });
 
     it('should display `downtime` error message when error has status of `5xx`', async () => {
-      const { getByText, container } = subject();
-      triggerError({ container, status: '503' });
+      const { selectors } = subject();
+      const { vaLink: link } = selectors();
+      triggerError({ link, status: '503' });
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.exist;
+        const { vaLoadingIndicator } = selectors();
+        expect(vaLoadingIndicator).to.exist;
       });
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.not.exist;
-      });
-
-      await waitFor(() => {
-        expect(getByText(content['alert-heading--generic'])).to.exist;
-        expect(getByText(content['alert-download-message--500'])).to.exist;
-      });
-
-      await waitFor(() => {
-        expect($('va-link', container)).to.not.exist;
+        const { vaAlert, vaLink, vaLoadingIndicator } = selectors();
+        const error = content['alert-download-message--500'];
+        expect(vaLoadingIndicator).to.not.exist;
+        expect(vaLink).to.not.exist;
+        expect(vaAlert).to.exist;
+        expect(vaAlert).to.contain.text(error);
       });
     });
 
     it('should display `generic` error message when error has status of anything other than `5xx`', async () => {
-      const { getByText, container } = subject();
-      triggerError({ container, status: '403' });
+      const { selectors } = subject();
+      const { vaLink: link } = selectors();
+      triggerError({ link, status: '403' });
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.exist;
+        const { vaLoadingIndicator } = selectors();
+        expect(vaLoadingIndicator).to.exist;
       });
 
       await waitFor(() => {
-        expect(container.querySelector('va-loading-indicator')).to.not.exist;
-      });
-
-      await waitFor(() => {
-        expect(getByText(content['alert-heading--generic'])).to.exist;
-        expect(getByText(content['alert-download-message--generic'])).to.exist;
-      });
-
-      await waitFor(() => {
-        expect($('va-link', container)).to.not.exist;
+        const { vaAlert, vaLink, vaLoadingIndicator } = selectors();
+        const error = content['alert-download-message--generic'];
+        expect(vaLoadingIndicator).to.not.exist;
+        expect(vaLink).to.not.exist;
+        expect(vaAlert).to.exist;
+        expect(vaAlert).to.contain.text(error);
       });
     });
   });

--- a/src/applications/caregivers/tests/unit/components/ApplicationDownloadLink.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/ApplicationDownloadLink.unit.spec.js
@@ -77,8 +77,7 @@ describe('CG <ApplicationDownloadLink>', () => {
 
     it('should record `success` event when button is clicked', async () => {
       const { selectors } = subject();
-      const { vaLink: downloadBtn } = selectors();
-
+      const { vaLink: link } = selectors();
       const createObjectStub = sinon
         .stub(URL, 'createObjectURL')
         .returns('my_stubbed_url.com');
@@ -87,7 +86,7 @@ describe('CG <ApplicationDownloadLink>', () => {
       mockApiRequest({
         blob: () => new Blob(['my blob'], { type: 'application/pdf' }),
       });
-      fireEvent.click(downloadBtn);
+      fireEvent.click(link);
 
       await waitFor(() => {
         const { vaLink, vaLoadingIndicator } = selectors();
@@ -96,15 +95,10 @@ describe('CG <ApplicationDownloadLink>', () => {
       });
 
       await waitFor(() => {
-        expect(
-          recordEventStub.calledWith({
-            event: 'caregivers-10-10cg-pdf-download--success',
-          }),
-        ).to.be.true;
-      });
-
-      await waitFor(() => {
         const { vaLink, vaLoadingIndicator } = selectors();
+        const event = 'caregivers-10-10cg-pdf-download--success';
+
+        expect(recordEventStub.calledWith({ event })).to.be.true;
         expect(vaLoadingIndicator).to.not.exist;
         expect(vaLink).to.exist;
       });
@@ -151,8 +145,10 @@ describe('CG <ApplicationDownloadLink>', () => {
       await waitFor(() => {
         const { vaAlert, vaLink, vaLoadingIndicator } = selectors();
         const error = content['alert-download-message--500'];
+
         expect(vaLoadingIndicator).to.not.exist;
         expect(vaLink).to.not.exist;
+
         expect(vaAlert).to.exist;
         expect(vaAlert).to.contain.text(error);
       });
@@ -171,8 +167,10 @@ describe('CG <ApplicationDownloadLink>', () => {
       await waitFor(() => {
         const { vaAlert, vaLink, vaLoadingIndicator } = selectors();
         const error = content['alert-download-message--generic'];
+
         expect(vaLoadingIndicator).to.not.exist;
         expect(vaLink).to.not.exist;
+
         expect(vaAlert).to.exist;
         expect(vaAlert).to.contain.text(error);
       });

--- a/src/applications/caregivers/tests/unit/components/ConfirmationPage/ConfirmationPrintView.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/ConfirmationPage/ConfirmationPrintView.unit.spec.js
@@ -6,39 +6,41 @@ import ConfirmationPrintView from '../../../../components/ConfirmationPage/Confi
 import content from '../../../../locales/en/content.json';
 
 describe('CG <ConfirmationPrintView>', () => {
-  const getData = ({ timestamp = undefined }) => ({
-    props: {
+  const subject = ({ timestamp = undefined } = {}) => {
+    const props = {
       name: { first: 'John', middle: 'Marjorie', last: 'Smith', suffix: 'Sr.' },
       timestamp,
-    },
-  });
-  const subject = ({ props }) => render(<ConfirmationPrintView {...props} />);
+    };
+    const { container } = render(<ConfirmationPrintView {...props} />);
+    const selectors = () => ({
+      title: container.querySelector('h1'),
+      logo: container.querySelector('.vagov-logo'),
+      veteranName: container.querySelector(
+        '[data-testid="cg-veteranfullname"]',
+      ),
+      submissionDate: container.querySelector('[data-testid="cg-timestamp"]'),
+    });
+    return { selectors };
+  };
 
   it('should render with default props', () => {
-    const { props } = getData({});
-    const { container } = subject({ props });
-    const selectors = {
-      image: container.querySelector('.vagov-logo'),
-      title: container.querySelector('h1'),
-      name: container.querySelector('[data-testid="cg-veteranfullname"]'),
-    };
-    expect(selectors.image).to.exist;
-    expect(selectors.title).to.contain.text(content['app-title']);
-    expect(selectors.name).to.contain.text('John Marjorie Smith Sr.');
+    const { selectors } = subject();
+    const { logo, title, veteranName } = selectors();
+    expect(logo).to.exist;
+    expect(title).to.contain.text(content['app-title']);
+    expect(veteranName).to.contain.text('John Marjorie Smith Sr.');
   });
 
   it('should not render timestamp in `application information` section when not provided', () => {
-    const { props } = getData({});
-    const { container } = subject({ props });
-    const selector = container.querySelector('[data-testid="cg-timestamp"]');
-    expect(selector).to.not.exist;
+    const { selectors } = subject();
+    const { submissionDate } = selectors();
+    expect(submissionDate).to.not.exist;
   });
 
   it('should render timestamp in `application information` section when provided', () => {
-    const { props } = getData({ timestamp: 1666887649663 });
-    const { container } = subject({ props });
-    const selector = container.querySelector('[data-testid="cg-timestamp"]');
-    expect(selector).to.exist;
-    expect(selector).to.contain.text('Oct. 27, 2022');
+    const { selectors } = subject({ timestamp: 1666887649663 });
+    const { submissionDate } = selectors();
+    expect(submissionDate).to.exist;
+    expect(submissionDate).to.contain.text('Oct. 27, 2022');
   });
 });

--- a/src/applications/caregivers/tests/unit/components/ConfirmationPage/ConfirmationScreenView.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/ConfirmationPage/ConfirmationScreenView.unit.spec.js
@@ -3,17 +3,17 @@ import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
 import ConfirmationScreenView from '../../../../components/ConfirmationPage/ConfirmationScreenView';
 import content from '../../../../locales/en/content.json';
 
 describe('CG <ConfirmationScreenView>', () => {
-  const getData = ({ timestamp = undefined }) => ({
-    props: {
+  const subject = ({ timestamp = undefined } = {}) => {
+    const props = {
       name: { first: 'John', middle: 'Marjorie', last: 'Smith', suffix: 'Sr.' },
+      route: { formConfig: {} },
       timestamp,
-    },
-    mockStore: {
+    };
+    const mockStore = {
       getState: () => ({
         form: {
           submission: {
@@ -25,69 +25,56 @@ describe('CG <ConfirmationScreenView>', () => {
       }),
       subscribe: () => {},
       dispatch: () => {},
-    },
-  });
-  const subject = ({ mockStore, props }) =>
-    render(
+    };
+    const { container } = render(
       <Provider store={mockStore}>
         <ConfirmationScreenView {...props} />
       </Provider>,
     );
-
-  it('should render with default props', () => {
-    const { mockStore, props } = getData({});
-    const { container, getByText, getByTitle } = subject({ mockStore, props });
-
-    const selectors = {
+    const selectors = () => ({
       veteranName: container.querySelector(
         '[data-testid="cg-veteran-fullname"]',
       ),
-      download: container.querySelector('.caregiver-application--download'),
-      printDescription: getByText(
-        /You can print this confirmation page for your records. You can also download your completed application as a/,
+      submissionDate: container.querySelector(
+        '[data-testid="cg-submission-date"]',
       ),
-      abbreviation: getByTitle('Portable Document Format'),
-    };
-    expect(selectors.veteranName).to.contain.text('John Marjorie Smith Sr.');
-    expect(selectors.download).to.not.be.empty;
-    expect(selectors.printDescription).to.exist;
-    expect(selectors.abbreviation).to.exist;
-    expect(selectors.abbreviation).to.have.text('PDF');
+      printBtn: container.querySelector('[data-testid="cg-print-button"]'),
+    });
+    return { selectors };
+  };
+
+  it('should render the appropriate Veteran name', () => {
+    const { selectors } = subject();
+    const { veteranName } = selectors();
+    expect(veteranName).to.contain.text('John Marjorie Smith Sr.');
   });
 
   it('should not render timestamp in `application information` section when not provided', () => {
-    const { mockStore, props } = getData({});
-    const { container } = subject({ mockStore, props });
-    const selector = container.querySelector(
-      '[data-testid="cg-submission-date"]',
-    );
-    expect(selector).to.not.exist;
+    const { selectors } = subject();
+    const { submissionDate } = selectors();
+    expect(submissionDate).to.not.exist;
   });
 
   it('should render timestamp in `application information` section when provided', () => {
-    const { mockStore, props } = getData({ timestamp: 1666887649663 });
-    const { container } = subject({ mockStore, props });
-    const selector = container.querySelector(
-      '[data-testid="cg-submission-date"]',
-    );
-    expect(selector).to.exist;
-    expect(selector).to.contain.text('Oct. 27, 2022');
+    const { selectors } = subject({ timestamp: 1666887649663 });
+    const { submissionDate } = selectors();
+    expect(submissionDate).to.exist;
+    expect(submissionDate).to.contain.text('Oct. 27, 2022');
   });
 
   it('should render application print button', () => {
-    const { mockStore, props } = getData({});
-    const { container } = subject({ mockStore, props });
-    const selector = container.querySelector('[data-testid="cg-print-button"]');
-    expect(selector).to.exist;
-    expect(selector).to.have.attr('text', content['button-print']);
+    const { selectors } = subject();
+    const { printBtn } = selectors();
+    expect(printBtn).to.exist;
+    expect(printBtn).to.have.attr('text', content['button-print']);
   });
 
   it('should fire `window.print` function when the print button is clicked', () => {
     const printSpy = sinon.spy(window, 'print');
-    const { mockStore, props } = getData({});
-    const { container } = subject({ mockStore, props });
-    const selector = container.querySelector('[data-testid="cg-print-button"]');
-    fireEvent.click(selector);
+    const { selectors } = subject();
+    const { printBtn } = selectors();
+
+    fireEvent.click(printBtn);
     expect(printSpy.called).to.be.true;
   });
 });

--- a/src/applications/caregivers/tests/unit/containers/ConfirmationPage.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/containers/ConfirmationPage.unit.spec.js
@@ -6,11 +6,11 @@ import { expect } from 'chai';
 import ConfirmationPage from '../../../containers/ConfirmationPage';
 
 describe('CG <ConfirmationPage>', () => {
-  const getData = ({ submission = {} }) => ({
-    mockStore: {
+  const subject = () => {
+    const mockStore = {
       getState: () => ({
         form: {
-          submission,
+          submission: {},
           data: {
             veteranFullName: {
               first: 'John',
@@ -23,52 +23,23 @@ describe('CG <ConfirmationPage>', () => {
       }),
       subscribe: () => {},
       dispatch: () => {},
-    },
-  });
-  const subject = ({ mockStore }) =>
-    render(
+    };
+    const { container } = render(
       <Provider store={mockStore}>
-        <ConfirmationPage />
+        <ConfirmationPage route={{ formConfig: {} }} />
       </Provider>,
     );
-
-  it('should render with Veterans name when submission response is omitted', () => {
-    const { mockStore } = getData({});
-    const { container } = subject({ mockStore });
-    const selectors = {
+    const selectors = () => ({
       wrapper: container.querySelector('.caregiver-confirmation'),
-      name: container.querySelector('[data-testid="cg-veteranfullname"]'),
-      timestamp: container.querySelector('[data-testid="cg-timestamp"]'),
-    };
-    expect(selectors.wrapper).to.not.be.empty;
-    expect(selectors.name).to.contain.text('John Marjorie Smith Sr.');
-    expect(selectors.timestamp).to.not.exist;
-  });
-
-  it('should render with Veterans name and submission timestamp when submission response is present', () => {
-    const submission = {
-      response: {
-        id: '60740',
-        type: 'saved_claim_caregivers_assistance_claims',
-      },
-      timestamp: 1666887649663,
-    };
-    const { mockStore } = getData({ submission });
-    const { container } = subject({ mockStore });
-    const selectors = {
-      wrapper: container.querySelector('.caregiver-confirmation'),
-      name: container.querySelector('[data-testid="cg-veteranfullname"]'),
-      timestamp: container.querySelector('[data-testid="cg-timestamp"]'),
-    };
-    expect(selectors.wrapper).to.not.be.empty;
-    expect(selectors.name).to.contain.text('John Marjorie Smith Sr.');
-    expect(selectors.timestamp).to.contain.text('Oct. 27, 2022');
-  });
+      printContainers: container.querySelectorAll('.no-print'),
+    });
+    return { selectors };
+  };
 
   it('should contain sections that will not be displayed in print view', () => {
-    const { mockStore } = getData({});
-    const { container } = subject({ mockStore });
-    const selector = container.querySelectorAll('.no-print');
-    expect(selector).to.have.length;
+    const { selectors } = subject();
+    const { wrapper, printContainers } = selectors();
+    expect(wrapper).to.not.be.empty;
+    expect(printContainers).to.have.length;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In order to properly format the data passed to the application download link on the confirmation page, the overall form config file is needed in the ApplicationDownloadLink component. Currently this file is directly imported into the component, which creates a dependency cycle, as the formConfig contains an import for the Confirmation page. This creates a dependency cycle, which tosses a linting warning.

This PR eliminates the dependency cycle by utilizing the `formConfig` object that is passed in via the `route` prop on the Confirmation page.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#103059

## Acceptance criteria

- No dependency cycle exists in the application

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
