### PR TITLE
[#1957] Adding required tags to Datadog initialization for chatbot logging.

### DIFF
--- a/src/applications/virtual-agent/utils/logging.js
+++ b/src/applications/virtual-agent/utils/logging.js
@@ -1,17 +1,19 @@
 import { datadogLogs } from '@datadog/browser-logs';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 // Conditional added to prevent initialization of Datadog as it was causing tests to hang indefinitely and prevented coverage report generation
 if (!process.env.NODE_ENV === 'test') {
   // Initialize Datadog logging
   datadogLogs.init({
-    clientToken: 'pubf64b43174e3eb74fa640b1ec28781c07', // Replace with your Datadog API key
+    clientToken: 'pubf64b43174e3eb74fa640b1ec28781c07',
+    service: 'virtual-agent-front-end',
+    team: 'virtual-agent-platform',
     site: 'ddog-gov.com',
-    forwardErrorsToLogs: true, // Automatically capture unhandled errors
-    sampleRate: 100, // Percentage of sessions to log (adjust as needed)
+    env: environment.vspEnvironment(),
+    sessionSampleRate: 100,
+    forwardConsoleLogs: ['error'],
+    telemetrySampleRate: 100,
   });
-
-  // Add a global context attribute to identify the source of the logs as the chatbot
-  datadogLogs.addLoggerGlobalContext('source', 'chatbot');
 }
 
 /**
@@ -25,7 +27,6 @@ export function logErrorToDatadog(
   context = {},
 ) {
   if (isDatadogLoggingEnabled) {
-    // Replace with your actual feature toggle name
     datadogLogs.logger.error(message, context);
   }
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- Adding additional tags to the Datadog initialization to fix logging from vets-website.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- We reviewed [relevant platform documentation](https://depo-platform-documentation.scrollhelp.site/developer-docs/monitor-tagging-standards#MonitorTaggingStandards) and found we were missing required tags.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- Chatbot Platform Team, we own the maintenance of this component.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- We have implemented our Datadog logging behind a feature toggle which we aim to remove once we see logs are populating inside the Datadog UI across environments, hopefully before the end of the month.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/1957)
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- Logs from generated by our chatbot from vets-website were not received/viewable inside Datadog UI.
- _Describe the steps required to verify your changes are working as expected_
- We found we were missing required tags (env tag for example) we have now added behind a feature toggle. Once logs are being captured correctly for Dev, we will move on to Staging, and to Prod.
- _Describe the tests completed and the results_
- Because we are unable to initialize and connect to Datadog locally, we aim to use our feature toggle to test that the initialization works in Dev and Staging. We have followed previous implementations inside vets-website and [relevant platform documentation](https://depo-platform-documentation.scrollhelp.site/developer-docs/monitor-tagging-standards#MonitorTaggingStandards). 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
This impacts the Datadog logging for the chatbot on vets-website.

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
**- [ ] Events are being sent to the appropriate logging solution - Trying to fix this with this PR.**
**- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - Trying to fix this with this PR.**

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
