### PR TITLE
Change to start travel claim url and appointment fetch url paramter

### DIFF
--- a/src/applications/vaos/components/AppointmentTasksSection.jsx
+++ b/src/applications/vaos/components/AppointmentTasksSection.jsx
@@ -23,7 +23,7 @@ export default function AppointmentTasksSection({ appointment }) {
       <va-link-action
         data-testid="file-claim-link"
         className="vads-u-margin-top--1"
-        href={`/appointments/claims/?date=${appointment.start}`}
+        href={`/my-health/travel-pay/file-new-claim/${appointment.id}`}
         text="File a travel reimbursement claim"
       />
     </Section>

--- a/src/applications/vaos/components/AppointmentTasksSection.unit.spec.js
+++ b/src/applications/vaos/components/AppointmentTasksSection.unit.spec.js
@@ -13,12 +13,13 @@ describe('VAOS Component: AppointmentTasks', () => {
     MockDate.reset();
   });
 
-  const startTime = '2021-09-01T10:00:00Z';
+  const appointmentId = '1234567890';
   const inPersonVideoKinds = [VIDEO_TYPES.clinic, VIDEO_TYPES.storeForward];
   inPersonVideoKinds.forEach(kind => {
     it(`should display Appointment tasks section with file claim link for ${kind} video appointment`, async () => {
       const appointment = {
-        start: startTime,
+        id: appointmentId,
+        start: '2021-09-01T10:00:00Z',
         vaos: {
           apiData: {
             travelPayClaim: {
@@ -45,13 +46,14 @@ describe('VAOS Component: AppointmentTasks', () => {
       expect(screen.getByText(/Appointment tasks/i)).to.exist;
       expect(screen.getByTestId('file-claim-link')).to.have.attribute(
         'href',
-        `/appointments/claims/?date=${startTime}`,
+        `/my-health/travel-pay/file-new-claim/${appointmentId}`,
       );
     });
   });
   it('should display Appointment tasks section with file claim link', async () => {
     const appointment = {
-      start: startTime,
+      id: appointmentId,
+      start: '2021-09-01T10:00:00Z',
       vaos: {
         apiData: {
           travelPayClaim: {
@@ -75,11 +77,12 @@ describe('VAOS Component: AppointmentTasks', () => {
     expect(screen.getByText(/Appointment tasks/i)).to.exist;
     expect(screen.getByTestId('file-claim-link')).to.have.attribute(
       'href',
-      `/appointments/claims/?date=${startTime}`,
+      `/my-health/travel-pay/file-new-claim/${appointmentId}`,
     );
   });
   it('should not display Appointment tasks section if not a past appointment', async () => {
     const appointment = {
+      id: appointmentId,
       start: '2021-09-01T10:00:00Z',
       vaos: {
         apiData: {
@@ -105,6 +108,7 @@ describe('VAOS Component: AppointmentTasks', () => {
   });
   it('should not display Appointment tasks section if appointment is cc', async () => {
     const appointment = {
+      id: appointmentId,
       start: '2021-09-01T10:00:00Z',
       vaos: {
         apiData: {
@@ -130,6 +134,7 @@ describe('VAOS Component: AppointmentTasks', () => {
   });
   it('should not display Appointment tasks section if appointment is video', async () => {
     const appointment = {
+      id: appointmentId,
       start: '2021-09-01T10:00:00Z',
       vaos: {
         apiData: {
@@ -155,6 +160,7 @@ describe('VAOS Component: AppointmentTasks', () => {
   });
   it('should not display Appointment tasks section if appointment is phone', async () => {
     const appointment = {
+      id: appointmentId,
       start: '2021-09-01T10:00:00Z',
       vaos: {
         apiData: {
@@ -180,6 +186,7 @@ describe('VAOS Component: AppointmentTasks', () => {
   });
   it('should not display file claim link if no claim data', async () => {
     const appointment = {
+      id: appointmentId,
       start: '2021-09-01T10:00:00Z',
       vaos: {
         apiData: {},

--- a/src/applications/vaos/components/TravelReimbursementSection.jsx
+++ b/src/applications/vaos/components/TravelReimbursementSection.jsx
@@ -21,14 +21,13 @@ export default function TravelReimbursementSection({ appointment }) {
     (claimData.metadata.message === TRAVEL_CLAIM_MESSAGES.success &&
       !claimData.claim)
   ) {
-    // TODO: change the link for submitting a travel claim once it's available
     return (
       <Section heading={heading}>
         <p className="vads-u-margin-y--0p5">
           <va-link
             data-testid="file-claim-link"
             className="vads-u-margin-y--0p5"
-            href={`/appointments/claims/?date=${appointment.start}`}
+            href={`/appointments/claims/?date=${appointment.id}`}
             text="File a travel reimbursement claim"
           />
         </p>

--- a/src/applications/vaos/components/TravelReimbursementSection.jsx
+++ b/src/applications/vaos/components/TravelReimbursementSection.jsx
@@ -27,7 +27,7 @@ export default function TravelReimbursementSection({ appointment }) {
           <va-link
             data-testid="file-claim-link"
             className="vads-u-margin-y--0p5"
-            href={`/appointments/claims/?date=${appointment.id}`}
+            href={`/my-health/travel-pay/file-new-claim/${appointment.id}`}
             text="File a travel reimbursement claim"
           />
         </p>

--- a/src/applications/vaos/components/TravelReimbursementSection.unit.spec.js
+++ b/src/applications/vaos/components/TravelReimbursementSection.unit.spec.js
@@ -47,6 +47,7 @@ describe('VAOS Component: TravelReimbursement', () => {
   });
   it('should display travel reimbursement section with file claim link', async () => {
     const appointment = {
+      id: '1234567890',
       start: startTime,
       vaos: {
         apiData: {
@@ -66,6 +67,10 @@ describe('VAOS Component: TravelReimbursement', () => {
     );
 
     expect(screen.getByTestId('file-claim-link')).to.exist;
+    expect(screen.getByTestId('file-claim-link')).to.have.attribute(
+      'href',
+      `/my-health/travel-pay/file-new-claim/${appointment.id}`,
+    );
   });
   it('should display travel reimbursement section with link to view claim status', async () => {
     const appointment = {

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1354,22 +1354,6 @@
           "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
           "atlas": null,
           "vvsKind": "CLINIC_BASED"
-        },
-        "travelPayClaim": {
-          "metadata": {
-            "status": 200,
-            "message": "Data retrieved successfully.",
-            "success": true
-          },
-          "claim": {
-            "id": "987654323",
-            "claimNumber": "internalclaimnumber",
-            "claimStatus": "InProgress",
-            "appointmentDateTime": "2024-01-01T16:45:34.465Z",
-            "facilityName": "Cheyenne VA Medical Center",
-            "createdOn": "2024-03-22T21:22:34.465Z",
-            "modifiedOn": "2024-01-01T16:44:34.465"
-          }
         }
       }
     },
@@ -1504,13 +1488,6 @@
               "SpecialtyCare"
             ]
           }
-        },
-        "travelPayClaim": {
-          "metadata": {
-            "status": 200,
-            "message": "No claims found.",
-            "success": true
-          }
         }
       }
     },
@@ -1604,22 +1581,6 @@
               "SpecialtyCare"
             ]
           }
-        },
-        "travelPayClaim": {
-          "metadata": {
-            "status": 200,
-            "message": "Data retrieved successfully.",
-            "success": true
-          },
-          "claim": {
-            "id": "987654324",
-            "claimNumber": "internalclaimnumber",
-            "claimStatus": "InProgress",
-            "appointmentDateTime": "2024-01-01T16:45:34.465Z",
-            "facilityName": "Cheyenne VA Medical Center",
-            "createdOn": "2024-03-22T21:22:34.465Z",
-            "modifiedOn": "2024-01-01T16:44:34.465"
-          }
         }
       }
     },
@@ -1712,13 +1673,6 @@
               "PrimaryCare",
               "SpecialtyCare"
             ]
-          }
-        },
-        "travelPayClaim": {
-          "metadata": {
-            "status": 200,
-            "message": "Data retrieved successfully.",
-            "success": true
           }
         }
       }
@@ -3388,6 +3342,407 @@
               "code": "NORMAL"
             },
             "visn": "10"
+          }
+        }
+      }
+    },
+    {
+      "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce-1",
+      "type": "appointments",
+      "attributes": {
+        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce-1",
+        "identifier": [
+          {
+            "system": "urn:va.gov:masv2:cerner:appointment",
+            "value": "Appointment/52499027"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
+                "code": "381456583"
+              }
+            ]
+          }
+        ],
+        "description": "PC Established Patient",
+        "reasonCode": {
+          "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling"
+        },
+        "patientComments": "test appointment scheduling",
+        "reasonForAppointment": "Medication concern",
+        "patientIcn": "1012845331V153043",
+        "locationId": "757",
+        "practitioners": [
+          {
+            "name": {
+              "family": "Bones",
+              "given": [
+                "Dr."
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-10T13:30:00Z",
+        "end": "2024-12-10T14:00:00Z",
+        "minutesDuration": 30,
+        "comment": "\nContact preference: Secure message",
+        "cancellable": false,
+        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          }
+        },
+        "requestedPeriods": null,
+        "localStartTime": "2024-12-10T09:30:00.000-04:00",
+        "location": {
+          "id": "757",
+          "type": "appointments",
+          "attributes": {
+            "id": "757",
+            "facilitiesApiId": "vha_757",
+            "vistaSite": "757",
+            "vastParent": "757",
+            "type": "va_health_facility",
+            "name": "Chalmers P. Wylie Veterans CERNER Clinic",
+            "classification": "Health Care Center (HCC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.98048,
+            "long": -82.9123,
+            "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+            "phone": {
+              "main": "614-257-5200",
+              "fax": "614-257-5460",
+              "pharmacy": "614-257-5230",
+              "afterHours": "614-257-5512",
+              "patientAdvocate": "614-257-5290",
+              "mentalHealthClinic": "614-257-5631",
+              "enrollmentCoordinator": "614-257-5628"
+            },
+            "hoursOfOperation": [
+              {
+                "daysOfWeek": "sun",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              },
+              {
+                "daysOfWeek": "mon",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "tue",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "wed",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "thu",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "fri",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "sat",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              }
+            ],
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
+              "city": "Columbus",
+              "state": "OH",
+              "postalCode": "43219-1834"
+            },
+            "mobile": false,
+            "healthService": [
+              "Allergy",
+              "Audiology",
+              "Cardiology",
+              "CaregiverSupport",
+              "Covid19Vaccine",
+              "Dental",
+              "Dermatology",
+              "Diabetic",
+              "Endocrinology",
+              "Gastroenterology",
+              "Geriatrics",
+              "Gynecology",
+              "Hematology",
+              "Homeless",
+              "Hospice",
+              "Laboratory",
+              "Lgbtq",
+              "MinorityCare",
+              "Nephrology",
+              "Neurology",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Otolaryngology",
+              "PainManagement",
+              "PatientAdvocates",
+              "Pharmacy",
+              "PhysicalMedicine",
+              "PlasticSurgery",
+              "Podiatry",
+              "PrimaryCare",
+              "Prosthetics",
+              "Ptsd",
+              "PulmonaryMedicine",
+              "Radiology",
+              "Rheumatology",
+              "Smoking",
+              "SocialWork",
+              "SpinalInjury",
+              "SuicidePrevention",
+              "Surgery",
+              "TransitionCounseling",
+              "UrgentCare",
+              "Urology",
+              "VascularSurgery",
+              "Vision",
+              "WeightManagement",
+              "WomensHealth",
+              "Wound"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            },
+            "visn": "10"
+          }
+        },
+        "travelPayClaim": {
+          "metadata": {
+            "status": 200,
+            "message": "Data retrieved successfully.",
+            "success": true
+          }
+        }
+      }
+    },
+    {
+      "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce-2",
+      "type": "appointments",
+      "attributes": {
+        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce-2",
+        "identifier": [
+          {
+            "system": "urn:va.gov:masv2:cerner:appointment",
+            "value": "Appointment/52499027"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
+                "code": "381456583"
+              }
+            ]
+          }
+        ],
+        "description": "PC Established Patient",
+        "reasonCode": {
+          "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling"
+        },
+        "patientComments": "test appointment scheduling",
+        "reasonForAppointment": "Medication concern",
+        "patientIcn": "1012845331V153043",
+        "locationId": "757",
+        "practitioners": [
+          {
+            "name": {
+              "family": "Bones",
+              "given": [
+                "Dr."
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-09T13:30:00Z",
+        "end": "2024-12-09T14:00:00Z",
+        "minutesDuration": 30,
+        "comment": "\nContact preference: Secure message",
+        "cancellable": false,
+        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          }
+        },
+        "requestedPeriods": null,
+        "localStartTime": "2024-12-09T09:30:00.000-04:00",
+        "location": {
+          "id": "757",
+          "type": "appointments",
+          "attributes": {
+            "id": "757",
+            "facilitiesApiId": "vha_757",
+            "vistaSite": "757",
+            "vastParent": "757",
+            "type": "va_health_facility",
+            "name": "Chalmers P. Wylie Veterans CERNER Clinic",
+            "classification": "Health Care Center (HCC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.98048,
+            "long": -82.9123,
+            "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+            "phone": {
+              "main": "614-257-5200",
+              "fax": "614-257-5460",
+              "pharmacy": "614-257-5230",
+              "afterHours": "614-257-5512",
+              "patientAdvocate": "614-257-5290",
+              "mentalHealthClinic": "614-257-5631",
+              "enrollmentCoordinator": "614-257-5628"
+            },
+            "hoursOfOperation": [
+              {
+                "daysOfWeek": "sun",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              },
+              {
+                "daysOfWeek": "mon",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "tue",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "wed",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "thu",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "fri",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "sat",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              }
+            ],
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
+              "city": "Columbus",
+              "state": "OH",
+              "postalCode": "43219-1834"
+            },
+            "mobile": false,
+            "healthService": [
+              "Allergy",
+              "Audiology",
+              "Cardiology",
+              "CaregiverSupport",
+              "Covid19Vaccine",
+              "Dental",
+              "Dermatology",
+              "Diabetic",
+              "Endocrinology",
+              "Gastroenterology",
+              "Geriatrics",
+              "Gynecology",
+              "Hematology",
+              "Homeless",
+              "Hospice",
+              "Laboratory",
+              "Lgbtq",
+              "MinorityCare",
+              "Nephrology",
+              "Neurology",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Otolaryngology",
+              "PainManagement",
+              "PatientAdvocates",
+              "Pharmacy",
+              "PhysicalMedicine",
+              "PlasticSurgery",
+              "Podiatry",
+              "PrimaryCare",
+              "Prosthetics",
+              "Ptsd",
+              "PulmonaryMedicine",
+              "Radiology",
+              "Rheumatology",
+              "Smoking",
+              "SocialWork",
+              "SpinalInjury",
+              "SuicidePrevention",
+              "Surgery",
+              "TransitionCounseling",
+              "UrgentCare",
+              "Urology",
+              "VascularSurgery",
+              "Vision",
+              "WeightManagement",
+              "WomensHealth",
+              "Wound"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            },
+            "visn": "10"
+          }
+        },
+        "travelPayClaim": {
+          "metadata": {
+            "status": 200,
+            "message": "Data retrieved successfully.",
+            "success": true
+          },
+          "claim": {
+            "id": "987654323",
+            "claimNumber": "internalclaimnumber",
+            "claimStatus": "InProgress",
+            "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+            "facilityName": "Cheyenne VA Medical Center",
+            "createdOn": "2024-03-22T21:22:34.465Z",
+            "modifiedOn": "2024-01-01T16:44:34.465"
           }
         }
       }

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -48,7 +48,7 @@ export function getAppointments({
     includeParams.push('avs');
   }
   if (fetchClaimStatus) {
-    includeParams.push('claims');
+    includeParams.push('travel_pay_claims');
   }
   if (includeEPS) {
     includeParams.push('eps');
@@ -72,7 +72,7 @@ export function getAppointment(id, avs = false, fetchClaimStatus = false) {
     includeParams.push('avs');
   }
   if (fetchClaimStatus) {
-    includeParams.push('claims');
+    includeParams.push('travel_pay_claims');
   }
   return apiRequestWithUrl(
     `/vaos/v2/appointments/${id}?_include=${includeParams

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -70,7 +70,7 @@ export function mockVAOSAppointmentsFetch({
   const baseUrl = `${
     environment.API_URL
   }/vaos/v2/appointments?_include=facilities,clinics${avs ? ',avs' : ''}${
-    fetchClaimStatus ? ',claims' : ''
+    fetchClaimStatus ? ',travel_pay_claims' : ''
   }&start=${start}&end=${end}&${statuses
     .map(status => `statuses[]=${status}`)
     .join('&')}`;
@@ -313,7 +313,7 @@ export function mockAppointmentApi({
   const baseUrl = `${environment.API_URL}/vaos/v2/appointments/${
     data.id
   }?_include=facilities,clinics${avs ? ',avs' : ''}${
-    fetchClaimStatus ? ',claims' : ''
+    fetchClaimStatus ? ',travel_pay_claims' : ''
   }`;
 
   if (responseCode === 200) {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- modifies the link to file a claim on the past appointment details view
- modifies the url parameter value so that it is `travel_pay_claims`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#102587](https://github.com/department-of-veterans-affairs/va.gov-team/issues/102587)
- _Link to previous change of the code/bug (if applicable)_
[department-of-veterans-affairs/vets-website#97545](https://github.com/department-of-veterans-affairs/va.gov-team/issues/97545)

## Testing done

- Navigate to the past appointments
- See that the network calls for appointments has the `_include` param has the string `travel_pay_claim`
- Choose the in-person appointment for December 10th
- It should have the correct links for both the top and bottom of the details card

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
