### PR TITLE
Adds no available slots logic to OH provider select page

### DIFF
--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 
 export default function ProviderCard({ provider }) {
-  const { lastSeen, providerName } = provider;
+  const { lastSeen, providerName, hasAvailability } = provider;
   return (
     <div>
       <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0 vads-u-margin-top--2">
@@ -12,7 +12,17 @@ export default function ProviderCard({ provider }) {
       <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
         Your last appointment was on {format(new Date(lastSeen), 'M/d/yyyy')}
       </p>
-      <va-link active href="#" text="Choose your preferred date and time" />
+
+      {!hasAvailability && (
+        <va-additional-info trigger="Why you can't schedule online with this provider">
+          This provider has no appointments available for online scheduling.
+        </va-additional-info>
+      )}
+
+      {hasAvailability && (
+        <va-link active href="#" text="Choose your preferred date and time" />
+      )}
+
       <hr
         aria-hidden="true"
         className="vads-u-margin-bottom--2 vads-u-margin-top--2"

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 
 export default function ProviderCard({ provider }) {
+  const { lastSeen, providerName } = provider;
   return (
     <div>
       <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0 vads-u-margin-top--2">
-        {provider.providerName}
+        {providerName}
       </h2>
       <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
-        Your last appointment was on{' '}
-        {format(new Date(provider.lastSeen), 'M/d/yyyy')}
+        Your last appointment was on {format(new Date(lastSeen), 'M/d/yyyy')}
       </p>
       <va-link active href="#" text="Choose your preferred date and time" />
       <hr

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ProviderCard.jsx
@@ -14,13 +14,21 @@ export default function ProviderCard({ provider }) {
       </p>
 
       {!hasAvailability && (
-        <va-additional-info trigger="Why you can't schedule online with this provider">
+        <va-additional-info
+          data-testid="no-appointments-available"
+          trigger="Why you can't schedule online with this provider"
+        >
           This provider has no appointments available for online scheduling.
         </va-additional-info>
       )}
 
       {hasAvailability && (
-        <va-link active href="#" text="Choose your preferred date and time" />
+        <va-link
+          active
+          data-testid="choose-date-time"
+          href="#"
+          text="Choose your preferred date and time"
+        />
       )}
 
       <hr

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
+import { waitFor } from '@testing-library/dom';
 import SelectProviderPage from './index';
 import {
   createTestStore,
@@ -38,6 +39,7 @@ const defaultState = {
         clinicName: 'Zanesville Primary Care',
         vistaId: '534',
         lastSeen: '2024-11-26T00:32:34.216Z',
+        hasAvailability: true,
       },
       {
         resourceType: 'PatientProviderRelationship',
@@ -48,6 +50,7 @@ const defaultState = {
         clinicName: 'Zanesville Primary Care',
         vistaId: '534',
         lastSeen: '2024-10-15T00:32:34.216Z',
+        hasAvailability: true,
       },
     ],
   },
@@ -56,6 +59,48 @@ const defaultState = {
 describe('VAOS Page: ProviderSelectPage', () => {
   beforeEach(() => {
     mockFetch();
+  });
+
+  describe('when a provider has no availability', () => {
+    const store = createTestStore({
+      ...defaultState,
+      newAppointment: {
+        ...defaultState.newAppointment,
+        patientProviderRelationships: [
+          {
+            resourceType: 'PatientProviderRelationship',
+            providerName: 'Doe, John D, MD',
+            providerId: 'Practitioner/123456',
+            serviceType: 'Routine Follow-up',
+            locationName: 'Marion VA Clinic',
+            clinicName: 'Zanesville Primary Care',
+            vistaId: '534',
+            lastSeen: '2024-11-26T00:32:34.216Z',
+            hasAvailability: false,
+          },
+        ],
+      },
+    });
+
+    it('should not display the schedule link', async () => {
+      const screen = renderWithStoreAndRouter(<SelectProviderPage />, {
+        store,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('choose-date-time')).to.not.exist;
+      });
+    });
+
+    it('should display additional info', async () => {
+      const screen = renderWithStoreAndRouter(<SelectProviderPage />, {
+        store,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('no-appointments-available')).to.exist;
+      });
+    });
   });
 
   describe('when there is a single provider', () => {
@@ -74,6 +119,7 @@ describe('VAOS Page: ProviderSelectPage', () => {
               clinicName: 'Zanesville Primary Care',
               vistaId: '534',
               lastSeen: '2024-11-26T00:32:34.216Z',
+              hasAvailability: true,
             },
           ],
         },

--- a/src/applications/vaos/services/patient/transformers.js
+++ b/src/applications/vaos/services/patient/transformers.js
@@ -23,6 +23,6 @@ export function transformPatientRelationships(patientRelationships) {
     clinicName: relationship.attributes.attributes.clinic.name,
     vistaId: relationship.attributes.attributes.clinic.vistaSite,
     lastSeen: relationship.attributes.attributes.lastSeen,
-    hasAvailability: relationship.attributes.hasAvailability,
+    hasAvailability: relationship.attributes.attributes.hasAvailability,
   }));
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds conditionally displayed text when a provider has the `hasAvailability` attribute returned as `false`
- Hides the _hoose your preferred date and time_ link when a provider has the `hasAvailability` attribute returned as `false`
- Adds appropriate unit tests

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/100735

## Testing done

Set VAOS feature flags to:

```js
  { name: 'vaOnlineSchedulingOhDirectSchedule', value: true },
  { name: 'vaOnlineSchedulingOhRequest', value: true },
```

This must be tested locally, to do so:

1. Check out this branch and start the dev server and mock server
2. Go to the VAOS app at [localhost](http://localhost:3001/my-health/appointments/)
3. Click _Start scheduling_
4. Select _Nutrition and food_
5. Select _VA medical center or clinic_
6. Select _White City VA Medical Center_

When the feature flags are on, the first provider listed **should not have** a _Choose your preferred date and time_ link and **should have** a _Why you can't schedule..._ additional info text blurb:

![CleanShot 2025-02-13 at 19 03 36@2x](https://github.com/user-attachments/assets/1e41a988-863b-4e06-847f-a316cccd2f33)

You may test further by adjusting toggling the `hasAvailability` attribute in the [patient provider mocks file](https://github.com/department-of-veterans-affairs/vets-website/blob/596e080c719aeb1a7874f01b4cf05b79053f4189/src/applications/vaos/services/mocks/v2/patient_provider_relationships.json#L47).

When the feature flags are off, following the same steps as above should result in the display of _How to schedule_ page:

<img width="677" alt="CleanShot 2025-02-13 at 19 07 45@2x" src="https://github.com/user-attachments/assets/f6715b39-345e-4ae3-805f-ebb6ad739c8c" />


## What areas of the site does it impact?
VAOS OH direct schedule flow

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
