### PR TITLE
Remove additional_properties: false from fullNameNoSuffix schema

### DIFF
--- a/src/platform/forms-system/src/js/web-component-patterns/fullNamePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/fullNamePattern.js
@@ -217,14 +217,31 @@ const firstNameLastNameSchema = firstNameLastNameDef;
 /**
  * @returns `commonDefinitions.fullNameNoSuffix`
  */
-const fullNameNoSuffixSchema = commonDefinitions.fullNameNoSuffix;
+const fullNameNoSuffixSchema = {
+  type: 'object',
+  required: ['first', 'last'],
+  properties: {
+    first: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 30,
+    },
+    middle: {
+      type: 'string',
+      maxLength: 30,
+    },
+    last: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 30,
+    },
+  },
+};
 
 /**
  * @returns `commonDefinitions.fullNameNoSuffix` minus `middle`
  */
-const firstNameLastNameNoSuffixDef = cloneDeep(
-  commonDefinitions.fullNameNoSuffix,
-);
+const firstNameLastNameNoSuffixDef = cloneDeep(fullNameNoSuffixSchema);
 delete firstNameLastNameNoSuffixDef.properties.middle;
 const firstNameLastNameNoSuffixSchema = firstNameLastNameNoSuffixDef;
 


### PR DESCRIPTION
## Summary
This pull request fixes a bug where prefill data would load in a suffix for the `fullName` object and cause a hidden schema validation error. This was happening because the `fullNameNoSuffix` schema pulled from the vets-json-schema repo had `additional_properties` set to `false`. This was also impacting the `firstNameLastNameNoSuffix` schema because it used the same schema but with middle name removed.

This was impacting two forms: 4555 and form upload.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#2024