### PR TITLE
[WIP] adding status to api errors

### DIFF
--- a/src/applications/accredited-representative-portal/tests/unit/utilities/api.unit.spec.js
+++ b/src/applications/accredited-representative-portal/tests/unit/utilities/api.unit.spec.js
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import api from '../../../utilities/api';
+
+describe('API Utilities', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  describe('createPOARequestDecision', () => {
+    it('should expose HTTP status codes from failed requests', async () => {
+      // Mock fetch to return a 403
+      fetchStub.resolves(
+        new Response(JSON.stringify({ errors: ['Not authorized'] }), {
+          status: 403,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+
+      try {
+        await api.createPOARequestDecision('123', { type: 'acceptance' });
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.have.property('status', 403);
+      }
+    });
+
+    it('should handle network errors', async () => {
+      // Mock fetch to simulate network failure
+      fetchStub.rejects(new Error('Network error'));
+
+      try {
+        await api.createPOARequestDecision('123', { type: 'acceptance' });
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.have.property('message', 'Network error');
+      }
+    });
+
+    it('should make requests with correct parameters', async () => {
+      // Mock successful request
+      fetchStub.resolves(
+        new Response(JSON.stringify({ status: 'success' }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+
+      await api.createPOARequestDecision('123', { type: 'acceptance' });
+
+      expect(
+        fetchStub.calledWith(
+          sinon.match(url =>
+            url.includes('/power_of_attorney_requests/123/decision'),
+          ),
+          sinon.match({
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              decision: { type: 'acceptance' },
+            }),
+          }),
+        ),
+      ).to.be.true;
+    });
+  });
+});

--- a/src/applications/accredited-representative-portal/utilities/api.js
+++ b/src/applications/accredited-representative-portal/utilities/api.js
@@ -27,6 +27,7 @@ const wrapApiRequest = fn => {
 
     const options = {
       apiVersion: API_VERSION,
+      includeStatus: true,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -166,7 +166,11 @@ export function apiRequest(
         }
       }
 
-      return data.then(Promise.reject.bind(Promise));
+      return data.then(_result => {
+        const err = new Error();
+        err.status = response.status;
+        return Promise.reject(err);
+      });
     })
     .then(success)
     .catch(error);


### PR DESCRIPTION
The `apiRequest` shared component doesn't expose HTTP response status codes to callers. This small change adds the status code to the rejected Promise