### PR TITLE
MHV-66617- e2e validation for  unallowed rerouting

### DIFF
--- a/src/applications/mhv-medications/tests/e2e/fixtures/unallowed-user.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/unallowed-user.json
@@ -1,0 +1,143 @@
+{
+    "data": {
+        "id": "",
+        "type": "user",
+        "attributes": {
+            "services": [
+                "facilities",
+                "hca",
+                "edu-benefits",
+                "form-save-in-progress",
+                "form-prefill",
+                "user-profile"
+            ],
+            "account": {
+                "accountUuid": "62842c5e-3638-4ce4-9762-754d562b7044"
+            },
+            "profile": {
+                "email": "mhv.non.verified@id.me",
+                "firstName": null,
+                "middleName": null,
+                "lastName": null,
+                "preferredName": null,
+                "birthDate": null,
+                "gender": null,
+                "zip": null,
+                "lastSignedIn": "2025-02-14T15:16:04.630Z",
+                "loa": {
+                    "current": 1,
+                    "highest": 3
+                },
+                "multifactor": false,
+                "verified": false,
+                "signIn": {
+                    "serviceName": "idme",
+                    "clientId": "vaweb",
+                    "authBroker": "sis"
+                },
+                "authnContext": "http://idmanagement.gov/ns/assurance/loa/1/vets",
+                "claims": {
+                    "appeals": false,
+                    "coe": false,
+                    "communicationPreferences": false,
+                    "connectedApps": true,
+                    "medicalCopays": false,
+                    "militaryHistory": false,
+                    "paymentHistory": false,
+                    "personalInformation": false,
+                    "ratingInfo": false,
+                    "form526RequiredIdentifierPresence": {
+                        "participantId": false,
+                        "birlsId": false,
+                        "ssn": false,
+                        "birthDate": false,
+                        "edipi": false
+                    }
+                },
+                "icn": null,
+                "birlsId": null,
+                "edipi": null,
+                "secId": null,
+                "logingovUuid": null,
+                "idmeUuid": "55d9d6779d954391885cb22c15f437a9",
+                "idTheftFlag": null,
+                "initialSignIn": "2025-02-12T21:25:40.823Z"
+            },
+            "vaProfile": null,
+            "veteranStatus": null,
+            "inProgressForms": [],
+            "prefillsAvailable": [
+                "21-686C",
+                "40-10007",
+                "0873",
+                "21-22",
+                "21-22A",
+                "26-4555",
+                "26-1880",
+                "20-0995",
+                "20-0996",
+                "10182",
+                "686C-674",
+                "686C-674-V2",
+                "DISPUTE-DEBT",
+                "22-1990",
+                "22-1990N",
+                "22-1990E",
+                "22-1990EMEB",
+                "22-1995",
+                "22-5490",
+                "22-5490E",
+                "22-5495",
+                "22-0993",
+                "22-0994",
+                "FEEDBACK-TOOL",
+                "22-10203",
+                "22-1990S",
+                "22-1990EZ",
+                "21-526EZ",
+                "FORM-MOCK-AE-DESIGN-PATTERNS",
+                "21-0779-UPLOAD",
+                "21-509-UPLOAD",
+                "21P-0516-1-UPLOAD",
+                "21P-0518-1-UPLOAD",
+                "5655",
+                "1010ez",
+                "10-10EZR",
+                "21-0966",
+                "10-7959C",
+                "MDOT",
+                "21P-530EZ",
+                "21P-527EZ",
+                "28-8832",
+                "28-1900"
+            ],
+            "vet360ContactInformation": {},
+            "session": {
+                "authBroker": "sis",
+                "ssoe": false,
+                "transactionid": null
+            },
+            "onboarding": {
+                "show": null
+            }
+        }
+    },
+    "meta": {
+        "errors": [
+            {
+                "externalService": "MVI",
+                "startTime": "2025-02-14T15:16:26Z",
+                "endTime": null,
+                "description": "401, 401, Not authorized, Not authorized",
+                "status": 401
+            },
+            {
+                "externalService": "VAProfile",
+                "startTime": "2025-02-14T15:16:26Z",
+                "endTime": null,
+                "description": "RuntimeError, User does not have a valid edipi, User does not have a valid edipi",
+                "status": 503
+            }
+        ]
+    }
+}

--- a/src/applications/mhv-medications/tests/e2e/med_site/MedicationsSite.js
+++ b/src/applications/mhv-medications/tests/e2e/med_site/MedicationsSite.js
@@ -179,6 +179,18 @@ class MedicationsSite {
   mockVamcEhr = () => {
     cy.intercept('GET', '/data/cms/vamc-ehr.json', mockVamcEhr).as('vamcEhr');
   };
+
+  unallowedUserLogin = user => {
+    cy.login(user);
+    this.mockFeatureToggles();
+    this.mockVamcEhr();
+    cy.intercept('GET', '/v0/user', user).as('mockUser');
+    cy.intercept(
+      'GET',
+      '/my_health/v1/prescriptions?page=1&per_page=20&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date',
+      emptyPrescriptionsList,
+    ).as('emptyPrescriptionsList');
+  };
 }
 
 export default MedicationsSite;

--- a/src/applications/mhv-medications/tests/e2e/medications-unallowed-user-rerouting.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-unallowed-user-rerouting.cypress.spec.js
@@ -1,0 +1,19 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import allergies from './fixtures/allergies.json';
+import prescriptions from './fixtures/listOfPrescriptions.json';
+import unAuthUser from './fixtures/unallowed-user.json';
+import { Paths } from './utils/constants';
+
+describe('Medications Landing Page', () => {
+  it('visits Medications landing Page', () => {
+    const site = new MedicationsSite();
+    site.unallowedUserLogin(unAuthUser);
+    cy.intercept('GET', Paths.MED_LIST, prescriptions).as('medicationsList');
+    cy.intercept('GET', '/my_health/v1/medical_records/allergies', allergies);
+    cy.visit('/my-health/medications');
+    cy.location('pathname').should('contain', '/my-health/');
+    cy.location('pathname').should('not.contain', '/my-health/medications');
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});


### PR DESCRIPTION
Summary
- Automation test added to validate unallowed user rerouting to my-health instead of navigate to medications list page



## Are you removing, renaming or moving a folder in this PR?
- [x ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [X ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario


## Related issue(s)
DevTicket - https://jira.devops.va.gov/browse/MHV-65762
SubTask -  https://jira.devops.va.gov/browse/MHV-66617

## Testing done

Local testing passing 150x.

## What areas of the site does it impact?

This test is for VA.gov medications.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

