### PR TITLE
VACMS-20422 add bva.va.gov to injected header whitelist

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -41,6 +41,16 @@
       "cookieOnly": false
     },
     {
+      "hostname": "bva.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
+      "hostname": "www.bva.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": true
+    },
+    {
       "hostname": "cem.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": false


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)


### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary
Adding bva.va.gov and www.bva.va.gov to the injected header whitelist.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20422
