### PR TITLE
Updating api wrapper to bypass platform code that hides response status

### DIFF
--- a/src/applications/accredited-representative-portal/tests/unit/utilities/api.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/utilities/api.unit.spec.jsx
@@ -1,0 +1,203 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import api from '../../../utilities/api';
+
+describe('API utilities', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  describe('getPOARequests', () => {
+    it('builds correct URL with query params', async () => {
+      const successResponse = new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      fetchStub.resolves(successResponse);
+
+      await api.getPOARequests({ status: 'pending', sort: 'created_at_desc' });
+
+      expect(fetchStub.called).to.be.true;
+      const url = fetchStub.firstCall.args[0];
+      expect(url).to.include(
+        '/power_of_attorney_requests?status=pending&sort=created_at_desc',
+      );
+    });
+  });
+
+  describe('getPOARequest', () => {
+    it('builds correct URL with ID', async () => {
+      const successResponse = new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      fetchStub.resolves(successResponse);
+
+      await api.getPOARequest('123');
+
+      expect(fetchStub.called).to.be.true;
+      const url = fetchStub.firstCall.args[0];
+      expect(url).to.include('/power_of_attorney_requests/123');
+    });
+
+    it('preserves 401 unauthorized responses', async () => {
+      const errorResponse = new Response(
+        JSON.stringify({
+          errors: ['Access token JWT is malformed'],
+          status: 'UNAUTHORIZED',
+        }),
+        {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+      fetchStub.resolves(errorResponse);
+
+      try {
+        await api.getPOARequest('123');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Response);
+        expect(error.status).to.equal(401);
+        const errorData = await error.json();
+        expect(errorData.errors).to.deep.equal([
+          'Access token JWT is malformed',
+        ]);
+        expect(errorData.status).to.equal('UNAUTHORIZED');
+      }
+    });
+
+    it('preserves 403 forbidden responses', async () => {
+      const errorResponse = new Response(
+        JSON.stringify({
+          errors: ['User is not authorized to access this resource'],
+          status: 'FORBIDDEN',
+        }),
+        {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+      fetchStub.resolves(errorResponse);
+
+      try {
+        await api.getPOARequest('123');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Response);
+        expect(error.status).to.equal(403);
+        const errorData = await error.json();
+        expect(errorData.errors).to.deep.equal([
+          'User is not authorized to access this resource',
+        ]);
+        expect(errorData.status).to.equal('FORBIDDEN');
+      }
+    });
+
+    it('preserves 404 not found responses', async () => {
+      const errorResponse = new Response(
+        JSON.stringify({
+          errors: ['Power of attorney request not found'],
+          status: 'NOT_FOUND',
+        }),
+        {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+      fetchStub.resolves(errorResponse);
+
+      try {
+        await api.getPOARequest('123');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Response);
+        expect(error.status).to.equal(404);
+        const errorData = await error.json();
+        expect(errorData.errors).to.deep.equal([
+          'Power of attorney request not found',
+        ]);
+        expect(errorData.status).to.equal('NOT_FOUND');
+      }
+    });
+
+    it('preserves 500 server error responses', async () => {
+      const errorResponse = new Response(
+        JSON.stringify({
+          errors: ['An internal server error occurred'],
+          status: 'SERVER_ERROR',
+        }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+      fetchStub.resolves(errorResponse);
+
+      try {
+        await api.getPOARequest('123');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Response);
+        expect(error.status).to.equal(500);
+        const errorData = await error.json();
+        expect(errorData.errors).to.deep.equal([
+          'An internal server error occurred',
+        ]);
+        expect(errorData.status).to.equal('SERVER_ERROR');
+      }
+    });
+
+    it('handles network errors', async () => {
+      const networkError = new TypeError('Failed to fetch');
+      fetchStub.rejects(networkError);
+
+      try {
+        await api.getPOARequest('123');
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(TypeError);
+        expect(error.message).to.equal('Failed to fetch');
+      }
+    });
+  });
+
+  describe('getUser', () => {
+    it('calls correct user endpoint', async () => {
+      const successResponse = new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      fetchStub.resolves(successResponse);
+
+      await api.getUser();
+
+      expect(fetchStub.called).to.be.true;
+      const url = fetchStub.firstCall.args[0];
+      expect(url).to.include('/user');
+    });
+  });
+
+  describe('createPOARequestDecision', () => {
+    it('sends POST with correct decision payload', async () => {
+      const successResponse = new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      fetchStub.resolves(successResponse);
+
+      const decision = { type: 'acceptance' };
+      await api.createPOARequestDecision('123', decision);
+
+      expect(fetchStub.called).to.be.true;
+      const url = fetchStub.firstCall.args[0];
+      const options = fetchStub.firstCall.args[1];
+
+      expect(url).to.include('/power_of_attorney_requests/123/decision');
+      expect(options.method).to.equal('POST');
+      expect(JSON.parse(options.body)).to.deep.equal({ decision });
+    });
+  });
+});

--- a/src/applications/accredited-representative-portal/utilities/api.js
+++ b/src/applications/accredited-representative-portal/utilities/api.js
@@ -49,7 +49,7 @@ const wrapApiRequest = fn => {
         localStorage.setItem('csrfToken', csrfToken);
       }
 
-      // For successful responses, parse and return data
+      // For successful responses,return data
       if (response.ok || response.status === 304) {
         return response;
       }

--- a/src/applications/accredited-representative-portal/utilities/api.js
+++ b/src/applications/accredited-representative-portal/utilities/api.js
@@ -1,40 +1,75 @@
-import { apiRequest } from 'platform/utilities/api';
-
-/**
- * `window.appName` is used for the value of the `Source-App-Name` header in the
- * platform `apiRequest` function. We set that property here so that it is
- * guaranteed to be set before it is attempted to be used.
- */
+import * as Sentry from '@sentry/browser';
+import merge from 'lodash/merge';
+import { fetchAndUpdateSessionExpiration } from 'platform/utilities/api';
+import environment from 'platform/utilities/environment';
+import localStorage from 'platform/utilities/storage/localStorage';
 import manifest from '../manifest.json';
 
+// Set app name for request headers
 window.appName = manifest.entryName;
 
 const API_VERSION = 'accredited_representative_portal/v0';
 
+const isJson = response => {
+  const contentType = response.headers.get('Content-Type');
+  return contentType && contentType.includes('application/json');
+};
+
 /**
- * This abstraction was introduced to let us pass fetch options to API methods
- * so that we could forward an abort signal from route loaders. This abstraction
- * only accomodates inner functions that don't have default parameters.
- *
- * Not every API method needs to be defined using this abstraction. Furthermore,
- * it is okay to refactor this abstraction, or even just unwind it altogether,
- * if that seems justified.
+ * Enhanced API wrapper that preserves Response objects for error handling
+ * while maintaining existing platform functionality where beneficial
  */
 const wrapApiRequest = fn => {
-  return (...args) => {
+  return async (...args) => {
+    // Set up request options similarly to platform apiRequest
     const optionsFromCaller = args[fn.length] || {};
     const [resource, optionsFromFn = {}] = fn(...args.slice(0, fn.length));
 
-    const options = {
-      apiVersion: API_VERSION,
+    const csrfTokenStored = localStorage.getItem('csrfToken');
+
+    const defaultSettings = {
+      method: 'GET',
+      credentials: 'include',
       headers: {
+        'X-Key-Inflection': 'camel',
+        'Source-App-Name': window.appName,
+        'X-CSRF-Token': csrfTokenStored,
         'Content-Type': 'application/json',
       },
-      ...optionsFromFn,
-      ...optionsFromCaller,
     };
 
-    return apiRequest(resource, options);
+    const settings = merge(defaultSettings, optionsFromFn, optionsFromCaller);
+
+    // Build URL like platform apiRequest
+    const baseUrl = `${environment.API_URL}/${API_VERSION}`;
+    const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
+
+    try {
+      // Reuse session management from platform
+      const response = await fetchAndUpdateSessionExpiration(url, settings);
+
+      // Handle CSRF token updates
+      const csrfToken = response.headers.get('X-CSRF-Token');
+      if (csrfToken && csrfToken !== csrfTokenStored) {
+        localStorage.setItem('csrfToken', csrfToken);
+      }
+
+      // For successful responses, parse and return data
+      if (response.ok || response.status === 304) {
+        return isJson(response) ? await response.json() : response;
+      }
+
+      // For errors, preserve the Response object
+      throw response;
+    } catch (err) {
+      // Log network-like errors to Sentry
+      Sentry.withScope(scope => {
+        scope.setExtra('error', err);
+        scope.setFingerprint(['{{default}}', scope._tags?.source]);
+        Sentry.captureMessage(`vets_client_error: ${err.message}`);
+      });
+      throw err;
+    }
   };
 };
 

--- a/src/applications/accredited-representative-portal/utilities/api.js
+++ b/src/applications/accredited-representative-portal/utilities/api.js
@@ -58,11 +58,13 @@ const wrapApiRequest = fn => {
       throw response;
     } catch (err) {
       // Log network-like errors to Sentry
-      Sentry.withScope(scope => {
-        scope.setExtra('error', err);
-        scope.setFingerprint(['{{default}}', scope._tags?.source]);
-        Sentry.captureMessage(`vets_client_error: ${err.message}`);
-      });
+      if (!(err instanceof Response)) {
+        Sentry.withScope(scope => {
+          scope.setExtra('error', err);
+          scope.setFingerprint(['{{default}}', scope._tags?.source]);
+          Sentry.captureMessage(`vets_client_error: ${err.message}`);
+        });
+      }
       throw err;
     }
   };

--- a/src/applications/accredited-representative-portal/utilities/api.js
+++ b/src/applications/accredited-representative-portal/utilities/api.js
@@ -10,11 +10,6 @@ window.appName = manifest.entryName;
 
 const API_VERSION = 'accredited_representative_portal/v0';
 
-const isJson = response => {
-  const contentType = response.headers.get('Content-Type');
-  return contentType && contentType.includes('application/json');
-};
-
 /**
  * Enhanced API wrapper that preserves Response objects for error handling
  * while maintaining existing platform functionality where beneficial
@@ -56,7 +51,7 @@ const wrapApiRequest = fn => {
 
       // For successful responses, parse and return data
       if (response.ok || response.status === 304) {
-        return isJson(response) ? await response.json() : response;
+        return response;
       }
 
       // For errors, preserve the Response object


### PR DESCRIPTION
The apiRequest shared component doesn't expose HTTP response status codes to callers. This change adds more robust code to our api wrapper that preserves response objects