### PR TITLE
VACMS-20420 Income Limits updates

### DIFF
--- a/src/applications/discharge-wizard/components/VABenefitsAccordion.jsx
+++ b/src/applications/discharge-wizard/components/VABenefitsAccordion.jsx
@@ -20,8 +20,8 @@ const VABenefitsAccordion = ({ isResultsPage = false }) => {
 
   let learnMoreLinks = (
     <ul>
-      {links.map(link => (
-        <li key={link}>
+      {links.map((link, index) => (
+        <li key={`${link}-${index}`}>
           <va-link href={link.href} text={link.text} />
         </li>
       ))}
@@ -38,8 +38,8 @@ const VABenefitsAccordion = ({ isResultsPage = false }) => {
   if (isResultsPage) {
     learnMoreLinks = (
       <ul>
-        {links.map(link => (
-          <li key={link}>
+        {links.map((link, index) => (
+          <li key={`${link}-${index}`}>
             <a href={link.href} rel="noopener noreferrer" target="_blank">
               {link.text} (opens in a new tab)
             </a>

--- a/src/applications/discharge-wizard/constants/display-conditions.js
+++ b/src/applications/discharge-wizard/constants/display-conditions.js
@@ -4,7 +4,7 @@ import { RESPONSES } from './question-data-map';
 
 const get15YearsPast = () => `${new Date().getFullYear() - 15}`;
 const currentYear = new Date().getFullYear();
-const yearResponses = range(currentYear - 1900).map(i => {
+const yearResponses = range(currentYear - 1899).map(i => {
   const year = currentYear - i;
   return year.toString();
 });

--- a/src/applications/income-limits/components/Breadcrumbs.jsx
+++ b/src/applications/income-limits/components/Breadcrumbs.jsx
@@ -6,7 +6,6 @@ const Breadcrumbs = () => {
     <VaBreadcrumbs
       class="income-limits-breadcrumbs vads-u-margin-left--1"
       label="Breadcrumbs"
-      uswds
       breadcrumbList={[
         {
           href: '/',

--- a/src/applications/income-limits/components/IncomeLimitsApp.jsx
+++ b/src/applications/income-limits/components/IncomeLimitsApp.jsx
@@ -48,7 +48,7 @@ const IncomeLimitsApp = ({
 
   const alertBanner = (message = null) => {
     return (
-      <va-alert data-testid="il-service-error" status="error" uswds>
+      <va-alert data-testid="il-service-error" status="error">
         <h2 className="vads-u-margin-bottom--2" slot="headline">
           {message ? `We've run into a problem` : GENERAL_ERROR_HEADING}
         </h2>

--- a/src/applications/income-limits/containers/DependentsPage.jsx
+++ b/src/applications/income-limits/containers/DependentsPage.jsx
@@ -119,10 +119,10 @@ const DependentsPage = ({
           name="numberOfDependents"
           onBlur={onBlurInput}
           onInput={onDependentsInput}
-          uswds
+          required
           value={dependents || ''}
         />
-        <va-additional-info trigger="Who qualifies as a dependent" uswds>
+        <va-additional-info trigger="Who qualifies as a dependent">
           <div>
             <p className="vads-u-margin-top--0">
               Here&#8217;s who we consider dependents for health care
@@ -142,7 +142,6 @@ const DependentsPage = ({
           onPrimaryClick={onContinueClick}
           onSecondaryClick={onBackClick}
           continue
-          uswds
         />
       </form>
     </>

--- a/src/applications/income-limits/containers/ResultsPage.jsx
+++ b/src/applications/income-limits/containers/ResultsPage.jsx
@@ -131,17 +131,14 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
         <h1>Your income limits for {year || currentYear}</h1>
         {pastMode && pastFlowCopy}
         {!pastMode && currentFlowCopy}
-        <a
+        <va-link
+          external
           href="/resources/va-health-care-income-limits"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn more about income limits and deductions (opens in a new tab)
-        </a>
+          text="Learn more about income limits and deductions"
+        />
         <h2>Select your {previousYear} household income range</h2>
-        <va-accordion bordered data-testid="il-results" open-single uswds>
+        <va-accordion bordered data-testid="il-results" open-single>
           <va-accordion-item
-            uswds
             bordered
             level="3"
             data-testid="il-results-1"
@@ -163,7 +160,6 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
             {!pastMode && applyUrl}
           </va-accordion-item>
           <va-accordion-item
-            uswds
             bordered
             level="3"
             data-testid="il-results-2"
@@ -181,7 +177,6 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
           </va-accordion-item>
           {isStandard && (
             <va-accordion-item
-              uswds
               bordered
               level="3"
               data-testid="il-results-3"
@@ -200,7 +195,6 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
             </va-accordion-item>
           )}
           <va-accordion-item
-            uswds
             bordered
             level="3"
             data-testid="il-results-4"
@@ -217,7 +211,6 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
             {!pastMode && applyUrl}
           </va-accordion-item>
           <va-accordion-item
-            uswds
             bordered
             level="3"
             data-testid="il-results-5"
@@ -226,34 +219,27 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
             {pastMode ? pastFlowDisclaimer : currentFlowDisclaimer}
             {!pastMode && (
               <>
-                <a
+                <va-link
+                  external
                   href="/health-care/eligibility/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Find out if you may be eligible for VA health care (opens in a
-                  new tab)
-                </a>
+                  text="Find out if you may be eligible for VA health care"
+                />
                 <p>
                   We can connect you with mental health care&#8212;no matter
                   your discharge status, service history, or eligibility for VA
                   health care.
                 </p>
-                <a
+                <va-link
+                  external
                   href="/health-care/health-needs-conditions/mental-health/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Find out how to get mental health care (opens in a new tab)
-                </a>
+                  text="Find out how to get mental health care"
+                />
                 <p>You can also explore non-VA health insurance options.</p>
-                <a
+                <va-link
+                  external
                   href="https://www.healthcare.gov/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Explore health insurance options on the HealthCare.gov website
-                </a>
+                  text="Explore health insurance options on the HealthCare.gov website"
+                />
               </>
             )}
           </va-accordion-item>
@@ -273,58 +259,46 @@ const Results = ({ dependents, pastMode, results, router, year, zipCode }) => {
         <h2>More helpful information</h2>
         <ul className="il-results-more-info">
           <li>
-            <a
+            <va-link
+              external
               href="/health-care/eligibility/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Eligibility for VA health care (opens in a new tab)
-            </a>
+              text="Eligibility for VA health care"
+            />
           </li>
           <li>
-            <a
+            <va-link
+              external
               href="/health-care/copay-rates/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Current VA health care copay rates (opens in a new tab)
-            </a>
+              text="Current VA health care copay rates"
+            />
           </li>
           <li>
-            <a
+            <va-link
+              external
               href="/health-care/update-health-information/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Update your VA health benefits information (opens in a new tab)
-            </a>
+              text="Update your VA health benefits information"
+            />
           </li>
           <li>
-            <a
+            <va-link
+              external
               href="/health-care/get-reimbursed-for-travel-pay/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              VA travel pay reimbursement (opens in a new tab)
-            </a>
+              text="VA travel pay reimbursement"
+            />
           </li>
           <li>
-            <a
+            <va-link
+              external
               href="/health-care/health-needs-conditions/mental-health/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              VA mental health services (opens in a new tab)
-            </a>
+              text="VA mental health services"
+            />
           </li>
           <li>
-            <a
+            <va-link
+              external
               href="/health-care/about-va-health-benefits/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              About VA health benefits (opens in a new tab)
-            </a>
+              text="About VA health benefits"
+            />
           </li>
         </ul>
         <h2>What to do if you have more questions</h2>

--- a/src/applications/income-limits/containers/ReviewPage.jsx
+++ b/src/applications/income-limits/containers/ReviewPage.jsx
@@ -75,7 +75,8 @@ const ReviewPage = ({
         const messageText = {
           DEPENDENTS:
             'Your information couldn’t go through. Enter a number of dependents between 0 and 100.',
-          YEAR: 'Your information couldn’t go through. Select a year again.',
+          YEAR:
+            'Your information couldn’t go through. Enter a valid four digit year again.',
           ZIP:
             'Your information couldn’t go through. Enter a valid 5 digit zip code.',
         };
@@ -169,7 +170,6 @@ const ReviewPage = ({
           onPrimaryClick={onContinueClick}
           onSecondaryClick={onBackClick}
           continue
-          uswds
         />
       )}
       {submitting && (

--- a/src/applications/income-limits/containers/YearPage.jsx
+++ b/src/applications/income-limits/containers/YearPage.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   VaButtonPair,
-  VaSelect,
+  VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 import { ROUTES } from '../constants';
 import { updateEditMode, updateYear } from '../actions';
@@ -37,10 +37,13 @@ const YearPage = ({
     [pastMode, router],
   );
 
+  const yearIsValid = year =>
+    year && +year >= 2001 && +year <= new Date().getFullYear();
+
   const onContinueClick = () => {
     setSubmitted(true);
 
-    if (!yearInput) {
+    if (!yearIsValid(yearInput)) {
       setError(true);
     } else if (editMode) {
       setError(false);
@@ -56,40 +59,20 @@ const YearPage = ({
   };
 
   const onYearInput = event => {
-    updateYearField(event.target.value);
-  };
+    const year = event?.target?.value;
 
-  const makeYearArray = () => {
-    const years = [];
-    let currentYear = new Date().getFullYear();
-    const earliestYear = 2001;
-
-    while (currentYear >= earliestYear) {
-      years.push(currentYear);
-
-      currentYear -= 1;
+    if (error && year?.length === 4 && yearIsValid(year)) {
+      setError(false);
     }
 
-    const options = years.map(year => (
-      <option key={year} value={year}>
-        {year}
-      </option>
-    ));
-
-    options.unshift(
-      <option key="Select a year" value="">
-        Select a year
-      </option>,
-    );
-
-    return options;
+    updateYearField(event.target.value);
   };
 
   return (
     <>
       <h1>Income limits from past years going back to 2001</h1>
       <p>
-        Select the year you&#8217;d like to check income limits for. Then answer
+        Enter the year you&#8217;d like to check income limits for. Then answer
         2 questions to find out how your income may have affected your VA health
         care eligibility and costs for that year.
       </p>
@@ -98,26 +81,24 @@ const YearPage = ({
         income and deductions to check income limits. Limits vary by where you
         live and change each year.
       </p>
-      <VaSelect
-        autocomplete="false"
+      <VaTextInput
         data-testid="il-year"
-        error={(submitted && error && 'Select a year.') || null}
+        error={submitted && error ? 'Enter a valid four digit year.' : null}
         id="year"
+        inputmode="numeric"
         label="Year"
-        name="year"
+        maxlength={4}
+        onInput={onYearInput}
+        required
+        type="number"
         value={yearInput}
-        onVaSelect={onYearInput}
-        uswds
-      >
-        {makeYearArray()}
-      </VaSelect>
+      />
       <VaButtonPair
         class="vads-u-margin-top--1"
         data-testid="il-buttonPair"
         onPrimaryClick={onContinueClick}
         onSecondaryClick={onBackClick}
         continue
-        uswds
       />
     </>
   );

--- a/src/applications/income-limits/containers/ZipCodePage.jsx
+++ b/src/applications/income-limits/containers/ZipCodePage.jsx
@@ -149,7 +149,7 @@ const ZipCodePage = ({
           name="zipCode"
           onBlur={onBlurInput}
           onInput={onZipInput}
-          uswds
+          required
           value={zipCode || ''}
         />
         {!submitting && (
@@ -159,7 +159,6 @@ const ZipCodePage = ({
             onPrimaryClick={onContinueClick}
             onSecondaryClick={onBackClick}
             continue
-            uswds
           />
         )}
         {submitting && (

--- a/src/applications/income-limits/tests/cypress/editing-form.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/editing-form.cypress.spec.js
@@ -11,7 +11,7 @@ describe('editing form', () => {
 
     // Year
     h.verifyElement(h.YEARINPUT);
-    h.selectFromDropdown(h.YEARINPUT, h.YEAR);
+    h.typeInInput(h.YEARINPUT, h.YEAR);
     h.clickContinue();
 
     // Zip code
@@ -33,7 +33,8 @@ describe('editing form', () => {
 
     // Year
     h.verifyElement(h.YEARINPUT);
-    h.selectFromDropdown(h.YEARINPUT, h.NEWYEAR);
+    h.clearInput(h.YEARINPUT);
+    h.typeInInput(h.YEARINPUT, h.NEWYEAR);
     h.clickContinue();
 
     // Review

--- a/src/applications/income-limits/tests/cypress/form-validation.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/form-validation.cypress.spec.js
@@ -41,7 +41,7 @@ describe('form validation', () => {
       h.verifyElement(h.YEARINPUT);
       h.clickContinue();
 
-      h.checkFormAlertText(h.YEARINPUT, 'ErrorSelect a year.');
+      h.checkFormAlertText(h.YEARINPUT, 'ErrorEnter a valid four digit year.');
     });
   });
 

--- a/src/applications/income-limits/tests/cypress/non-standard-flow.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/non-standard-flow.cypress.spec.js
@@ -18,7 +18,7 @@ describe('non-standard flow', () => {
 
     // Year
     h.verifyElement(h.YEARINPUT);
-    h.selectFromDropdown(h.YEARINPUT, h.YEAR);
+    h.typeInInput(h.YEARINPUT, h.YEAR);
     h.clickContinue();
 
     // Zip code

--- a/src/applications/income-limits/tests/cypress/past-flow.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/past-flow.cypress.spec.js
@@ -11,7 +11,7 @@ describe('past year flow', () => {
 
     // Year
     h.verifyElement(h.YEARINPUT);
-    h.selectFromDropdown(h.YEARINPUT, h.YEAR);
+    h.typeInInput(h.YEARINPUT, h.YEAR);
     h.clickContinue();
 
     // Zip code
@@ -48,7 +48,7 @@ describe('past year flow', () => {
 
     // Year
     h.verifyElement(h.YEARINPUT);
-    h.selectFromDropdown(h.YEARINPUT, h.YEAR);
+    h.typeInInput(h.YEARINPUT, h.YEAR);
     h.clickBack();
 
     // Home

--- a/src/applications/income-limits/tests/cypress/results-errors.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/results-errors.cypress.spec.js
@@ -87,7 +87,7 @@ describe('retrieving results - errors', () => {
       h.verifyLoadingIndicatorShown();
 
       h.checkServiceAlertText(
-        `We've run into a problemYour information couldn’t go through. Select a year again.`,
+        `We've run into a problemYour information couldn’t go through. Enter a valid four digit year again.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });

--- a/src/applications/income-limits/tests/helpers.js
+++ b/src/applications/income-limits/tests/helpers.js
@@ -84,14 +84,6 @@ export const clearInput = selector =>
     .focus()
     .clear();
 
-export const selectFromDropdown = (selector, value) =>
-  cy
-    .findByTestId(selector)
-    .shadow()
-    .get('select')
-    .first()
-    .select(value, { force: true });
-
 export const checkInputText = (selector, expectedValue) =>
   cy.findByTestId(selector).should('have.value', expectedValue);
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updates to Income Limits:

- Change the year dropdown (past mode) into a text input with a range of 2001 to the current year
- Add `required` to all inputs
- Change all external links to the `external` variant of `va-link`. We know that the `(opens in a new tab)` is duplicative but DST already has a bug to fix this later

This also includes an update to Discharge Upgrade Wizard. On production, if you enter the year 1900 in the discharge year field (obviously an unlikely edge case), there is no error state and the form doesn't submit. I fixed this issue and also addressed some warnings in the console.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20420

## Testing done & screenshots
Tested at `/health-care/income-limits` and `/discharge-upgrade-instructions`

### Year input update (past mode)

| Before | After |
| --- | --- |
| <img width="883" alt="Screenshot 2025-02-18 at 10 02 39 AM" src="https://github.com/user-attachments/assets/e2af13bb-8b51-4ec4-8c85-e3424f65cf8c" /> | <img width="882" alt="Screenshot 2025-02-18 at 10 02 35 AM" src="https://github.com/user-attachments/assets/a3dfb100-787d-4b19-8c0b-984631301dec" /> |
| <img width="883" alt="Screenshot 2025-02-18 at 10 03 30 AM" src="https://github.com/user-attachments/assets/6b004bdc-96df-4261-9423-e37c24a86b46" /> | <img width="883" alt="Screenshot 2025-02-18 at 9 50 06 AM" src="https://github.com/user-attachments/assets/60e6eb1a-d40c-4c28-8fd8-68f7e30269b0" /> |
| <img width="883" alt="Screenshot 2025-02-18 at 10 03 30 AM" src="https://github.com/user-attachments/assets/6b004bdc-96df-4261-9423-e37c24a86b46" /> | <img width="883" alt="Screenshot 2025-02-18 at 9 50 14 AM" src="https://github.com/user-attachments/assets/69e8e4e6-08c2-4753-a969-1ecee888b736" /> |

### Required inputs
| Before | After |
| --- | --- |
| <img width="884" alt="Screenshot 2025-02-18 at 10 04 22 AM" src="https://github.com/user-attachments/assets/0341297f-4689-40ba-b036-ec2a24aa3d2c" /> | <img width="882" alt="Screenshot 2025-02-18 at 10 05 20 AM" src="https://github.com/user-attachments/assets/a6b277a1-bb76-42c7-9480-975f95e5a739" /> |
| <img width="882" alt="Screenshot 2025-02-18 at 10 04 33 AM" src="https://github.com/user-attachments/assets/32973d3c-db4e-4c93-914f-d60c265df578" /> | <img width="881" alt="Screenshot 2025-02-18 at 9 54 18 AM" src="https://github.com/user-attachments/assets/5c55605a-b907-44a5-91b0-549fc0082db8" /> |

### Link updates (results page)

| Before | After |
| --- | --- |
| <img width="516" alt="Screenshot 2025-02-18 at 10 06 34 AM" src="https://github.com/user-attachments/assets/46c43a1c-5e8f-4171-9cef-b0e41055a659" /> | <img width="487" alt="Screenshot 2025-02-18 at 9 54 57 AM" src="https://github.com/user-attachments/assets/e89f657a-5d55-419d-aef5-61517c4bdd38" /> |
| <img width="549" alt="Screenshot 2025-02-18 at 10 08 14 AM" src="https://github.com/user-attachments/assets/d70b75c9-0986-44f5-939b-36061bda01c3" /> | <img width="556" alt="Screenshot 2025-02-18 at 10 08 38 AM" src="https://github.com/user-attachments/assets/8af66f0a-1d0a-4704-81cf-af443e3fb3d7" /> |
| <img width="495" alt="Screenshot 2025-02-18 at 10 06 40 AM" src="https://github.com/user-attachments/assets/b823f0f6-9ae0-43ed-b67d-f37b8945a585" /> | <img width="500" alt="Screenshot 2025-02-18 at 9 55 01 AM" src="https://github.com/user-attachments/assets/078701cf-a3ea-4200-a594-f1944a5f631a" /> |

#### Previous DOM structure
<img width="420" alt="Screenshot 2025-02-18 at 10 06 48 AM" src="https://github.com/user-attachments/assets/1741df13-0366-421a-9b07-a6f9175c08af" />

#### New DOM structure

**Note**: We know that the `(opens in a new tab)` is duplicative but DST already has a bug to fix this.

<img width="432" alt="Screenshot 2025-02-18 at 10 11 19 AM" src="https://github.com/user-attachments/assets/00bc1926-b3e6-4f17-a2b5-bb4d91bb97e7" />


## Acceptance criteria

- [x] The Year field (in the previous year user flow) is now a text field that the user may enter a four digit number in.
- [x] The error message that displays when a user clicks the Continue button without entering a four digit year is now: `Enter a valid four digit year`
- [x] All questions/fields now have (*Required) displays above the field (per the screenshot in this ticket)
  - [x] Year field in the previous year user flow
  - [x] Zip code field in both previous year and current year user flows
  - [x] Number of dependents field in both previous year and current year user flows
- [x] The link on the results page (displayed in the accordion '$93,501 or more' and possibly elsewhere?) has been appended with the text: (opens in a new tab) e.g. Explore health insurance options on the HealthCare.gov website (opens in a new tab)