### PR TITLE
Form Upload make URL lower case for all pages

### DIFF
--- a/src/applications/simple-forms/form-upload/config/form.js
+++ b/src/applications/simple-forms/form-upload/config/form.js
@@ -38,7 +38,7 @@ const formConfig = (pathname = null) => {
 
   return {
     rootUrl: manifest.rootUrl,
-    urlPrefix: `/${formNumber}/`,
+    urlPrefix: `/${formNumber.toLowerCase()}/`,
     submitUrl: `${environment.API_URL}/simple_forms_api/v1/submit_scanned_form`,
     dev: { collapsibleNavLinks: true, showNavLinks: !window.Cypress },
     trackingPrefix,


### PR DESCRIPTION
## Summary
This PR fixes a little whoopsie-doodle where [I made the URL lower-case in the intro page here](https://github.com/department-of-veterans-affairs/vets-website/pull/34486) but didn't make that change apply to every subsequent page. This PR will make all the pages of form upload be lower case.
