### PR TITLE
[DBEX] Add external property to link to open in new tab

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/traumaticEventsList.jsx
+++ b/src/applications/disability-benefits/all-claims/content/traumaticEventsList.jsx
@@ -38,6 +38,7 @@ export const maxEventsAlert = () => {
         <li>
           You may also print this form, fill it out, and mail it to us.{' '}
           <va-link
+            external
             href="https://www.va.gov/find-forms/about-form-21-0781/"
             text="Get VA Form 21-0781"
           />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - In the ["Event List" section](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=10498-213739&t=rmNCUWpAqkTdoofn-4) of the new, digitized Form 0781 flow:
    - update the link in the content of the max events alert modal to open in a new tab
- _(If bug, how to reproduce)_
  - n/a
- _(What is the solution, why is this the solution)_
  - Create a new flow and pages to align the digital form with the [VA Form 21-0781](https://www.vba.va.gov/pubs/forms/VBA-21-0781-ARE.pdf) paper version 
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - `sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101754

## Testing done

- _Describe what the old behavior was prior to the change_
  - content change; no new functionality or components added/removed
- _Describe the steps required to verify your changes are working as expected_
   1. in the development environment, ensure that the [`sync_modern_0781_flow`](https://dev-api.va.gov/flipper/features#:~:text=disability_compensation_sync_modern_0781_flow) toggle is enabled 
  2. start a new claim
  3. claim at least 1 new condition
  4. click through to and select "Yes, I want to complete VA Form 21-0781 online" on the ["0781 choice page"](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=13076-114549&t=PVu7Q8pLMkh5DU6W-4)
  6. click through to the ["Event list"](https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=10498-213739&t=rmNCUWpAqkTdoofn-4) page
  7. after adding 20 events, on the Event list page, an alert should render with the updated link type
- _Describe the tests completed and the results_
  - corresponding unit tests pass
  - manual/visual verification 

## Screenshots

| Before | After |
| ----- | ----------- |
| ![Screenshot 2025-02-18 at 12 33 48 PM](https://github.com/user-attachments/assets/a5e93fb2-7e2c-4868-9ac0-7d27cecf5bde) | ![Screenshot 2025-02-18 at 12 32 59 PM](https://github.com/user-attachments/assets/470b457b-562c-4671-a6c7-e651ce025845) |

## What areas of the site does it impact?

- Only impacts 526 EZ (within a new "Additional Forms" chapter)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing] has been performed – 0 issues found during axe DevTools scan

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user