### PR TITLE
[SIMPLE-FORMS] fix: update logic to use the useTopBackLink attribute

### DIFF
--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -287,8 +287,8 @@ const formConfig = {
       checkboxLabel:
         'I confirm that the information above is correct and true to the best of my knowledge and belief.',
     },
-    hideBackButton: true,
   },
+  useTopBackLink: true,
   footerContent,
   getHelp,
 };

--- a/src/platform/forms-system/src/js/review/submit-states/Default.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Default.jsx
@@ -12,7 +12,7 @@ export default function Default({
   onSubmit,
 }) {
   const ariaDescribedBy = formConfig?.ariaDescribedBySubmit ?? null;
-  const hideBackButton = formConfig?.preSubmitInfo?.hideBackButton || false;
+  const hideBackButton = formConfig?.useTopBackLink || false;
 
   const progressButton = (
     <ProgressButton


### PR DESCRIPTION
## Summary

- This work updates the hide back button logic to use the useTopBackLink attribute instead of the hideBackButton attribute.
- I work for the Veteran Facing Forms team which owns this component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1418

## Testing done

- Unit and E2E tests pass

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any
