### PR TITLE
[art/103340] - poa status update, remove br tag

### DIFF
--- a/src/applications/accredited-representative-portal/components/POARequestCard.jsx
+++ b/src/applications/accredited-representative-portal/components/POARequestCard.jsx
@@ -21,7 +21,7 @@ const POARequestCard = ({ poaRequest }) => {
       <va-card class="poa-request__card">
         <span
           data-testid={`poa-request-card-${poaRequest.id}-status`}
-          className={`usa-label poa-request__card-field poa-request__card-field--status status status--${poaStatus}`}
+          className="usa-label poa-request__card-field poa-request__card-field--status status status--processing"
         >
           {formatStatus(poaStatus)}
         </span>

--- a/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
@@ -152,9 +152,6 @@ const POARequestDetailsPage = () => {
 
   const poaRequestSubmission =
     poaRequest?.powerOfAttorneyFormSubmission?.status;
-  const statusCheck =
-    poaRequestSubmission === BANNER_TYPES.PROCESSING ? 'processing' : poaStatus;
-
   return (
     <section className="poa-request-details">
       <h1
@@ -167,7 +164,7 @@ const POARequestDetailsPage = () => {
         {claimantLastName}, {claimantFirstName}
         {poaStatus !== 'expired' && (
           <span
-            className={`usa-label vads-u-font-family--sans poa-request-details__status status status--${statusCheck.toLowerCase()} ${poaRequestSubmission ===
+            className={`usa-label vads-u-font-family--sans poa-request-details__status status status--processing ${poaRequestSubmission ===
               BANNER_TYPES.FAILED && 'vads-u-display--none'}`}
           >
             {poaRequestSubmission === BANNER_TYPES.PROCESSING

--- a/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
@@ -93,12 +93,11 @@ const POARequestSearchPage = () => {
         You can accept or decline power of attorney (POA) requests in the
         Accredited Representative Portal. Requests will expire and be removed
         from the portal after 60 days.
-        <br />
-        <br />
+      </p>
+      <p className="poa-request__copy">
         <strong>Note:</strong> requests need to be submitted using the digital
         VA Form 21-22 on VA.gov.
       </p>
-      <br />
       <Link to="/get-help-from-accredited-representative/appoint-rep/introduction">
         VA Form 21-22 (on VA.gov)
       </Link>

--- a/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
@@ -98,9 +98,9 @@ const POARequestSearchPage = () => {
         <strong>Note:</strong> requests need to be submitted using the digital
         VA Form 21-22 on VA.gov.
       </p>
-      <Link to="/get-help-from-accredited-representative/appoint-rep/introduction">
+      <a href="https://www.va.gov/get-help-from-accredited-representative/appoint-rep/introduction/">
         VA Form 21-22 (on VA.gov)
-      </Link>
+      </a>
       <div className="poa-requests-page-table-container">
         <div role="tablist" className="poa-request__tabs">
           <StatusTabLink

--- a/src/applications/accredited-representative-portal/sass/POARequestCard.scss
+++ b/src/applications/accredited-representative-portal/sass/POARequestCard.scss
@@ -7,7 +7,7 @@
     margin: 0 0 24px;
   }
   &__copy {
-    margin: 0;
+    margin: 0 0 16px 0;
   }
   &__tabs {
     margin: 60px 0 24px;


### PR DESCRIPTION
Removing status tag color, removing `<br>` tag and using margins instead, see [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103340).