### PR TITLE
Global | Fix required sign in alert

### DIFF
--- a/src/applications/appeals/10182/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/IntroductionPage.unit.spec.jsx
@@ -74,7 +74,7 @@ describe('IntroductionPage', () => {
     expect($('h1', container).textContent).to.eq('Request a Board Appeal');
     expect($('va-process-list', container)).to.exist;
     expect($('va-omb-info', container)).to.exist;
-    expect($('va-alert-sign-in[variant="signInOptional"]', container)).to.exist;
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
   });
 
   it('should render start action links', () => {

--- a/src/applications/appeals/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -110,7 +110,7 @@ describe('IntroductionPage', () => {
     );
     expect($('va-process-list', container)).to.exist;
     expect($('va-omb-info', container)).to.exist;
-    expect($('va-alert-sign-in[variant="signInOptional"]', container)).to.exist;
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
   });
 
   it('should render start action links', () => {

--- a/src/applications/appeals/shared/tests/components/ShowAlertOrSip.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ShowAlertOrSip.unit.spec.jsx
@@ -168,7 +168,7 @@ describe('<NeedsMissingInfoAlert>', () => {
         <ShowAlertOrSip {...props} />
       </Provider>,
     );
-    expect($('va-alert-sign-in[variant="signInOptional"]', container)).to.exist;
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
     expect($('va-button', container).text).to.eq(
       'Sign in to start your application',
     );

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -229,7 +229,11 @@ class SaveInProgressIntro extends React.Component {
         </>
       ) : (
         <va-alert-sign-in
-          variant="signInOptional"
+          variant={
+            this.props.hideUnauthedStartLink
+              ? 'signInRequired'
+              : 'signInOptional'
+          }
           time-limit={retentionPeriod}
           heading-level={this.props.headingLevel}
           no-sign-in-link=""

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -209,6 +209,8 @@ describe('Schemaform <SaveInProgressIntro>', () => {
 
     const link = tree.find('.va-button-link');
     expect(link.prop('text')).to.contain('Sign in to your account.');
+    expect(tree.find('va-alert-sign-in[variant="signInOptional"]').exists()).to
+      .be.true;
     expect(link.prop('aria-label')).to.eq('test aria-label');
     expect(link.prop('aria-describedby')).to.eq('test-id');
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.false;
@@ -258,6 +260,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     expect($('a', container).textContent).to.contain(
       'Start your application without signing in',
     );
+    expect($('va-alert-sign-in[variant="signInOptional"]', container)).to.exist;
   });
 
   it('should render message if signed in with no saved form', () => {
@@ -368,6 +371,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
 
     expect(signInAlertRetentionPeriod).to.eql('1 year');
     expect(signInAlertRetentionPeriod).to.not.eql('60 days');
+    expect($('va-alert-sign-in[variant="signInOptional"]', container)).to.exist;
   });
 
   it('should render loading indicator while profile is loading', () => {
@@ -610,6 +614,8 @@ describe('Schemaform <SaveInProgressIntro>', () => {
 
     expect(tree.find('.schemaform-start-button').exists()).to.be.false;
     expect(tree.text()).to.not.include('lose any information you already');
+    expect(tree.find('va-alert-sign-in[variant="signInOptional"]').exists()).to
+      .be.true;
 
     tree.unmount();
   });
@@ -646,6 +652,8 @@ describe('Schemaform <SaveInProgressIntro>', () => {
 
     expect(tree.find('.schemaform-start-button').exists()).to.be.false;
     expect(tree.text()).to.not.include('lose any information you already');
+    expect(tree.find('va-alert-sign-in[variant="signInRequired"]').exists()).to
+      .be.true;
 
     tree.unmount();
   });
@@ -679,9 +687,10 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         formConfig={formConfig}
       />,
     );
-    expect(container.querySelector('va-button').outerHTML).to.contain(
+    expect($('va-button', container).outerHTML).to.contain(
       'Custom message displayed to non-signed-in users',
     );
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
   });
 
   it('should not render an inProgress message', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > A [PR to update the sign-in alerts](https://github.com/department-of-veterans-affairs/vets-website/pull/34500) was merged in on 2/18, but we noticed in our required forms that the sign in alert variant was shown for a optional sign-in context (see note at bottom of "before" screenshot). 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/102154

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| SC required sign-in | <img width="698" alt="va-alert-sign-in optional sign in variant" src="https://github.com/user-attachments/assets/9f62d0ef-30fb-41d5-a346-6558315ff018" /> | <img width="707" alt="a-alert-sign-in required sign in variant" src="https://github.com/user-attachments/assets/a245fd1e-ab94-4150-98cc-ca9592f5f5b5" /> |

## What areas of the site does it impact?

All applications that are sign-in required

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
