### PR TITLE
Form Upload - scroll and focus on error on upload page

### DIFF
--- a/src/applications/simple-forms/form-upload/pages/helpers.jsx
+++ b/src/applications/simple-forms/form-upload/pages/helpers.jsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormNavButtons, SchemaForm } from 'platform/forms-system/exportsFile';
+import { scrollAndFocus } from 'platform/utilities/ui';
 import { getAlert, getFormNumber, onClickContinue } from '../helpers';
 
 export const CustomTopContent = () => {
@@ -31,6 +32,15 @@ export const CustomTopContent = () => {
 /** @type {CustomPageType} */
 export const CustomAlertPage = props => {
   const [continueClicked, setContinueClicked] = useState(false);
+  useEffect(
+    () => {
+      const focusSelector = document.querySelector("va-alert[status='error']");
+      if (!window.Cypress) {
+        scrollAndFocus(focusSelector);
+      }
+    },
+    [continueClicked],
+  );
 
   return (
     <div className="form-panel">

--- a/src/applications/simple-forms/form-upload/pages/helpers.jsx
+++ b/src/applications/simple-forms/form-upload/pages/helpers.jsx
@@ -35,7 +35,7 @@ export const CustomAlertPage = props => {
   useEffect(
     () => {
       const focusSelector = document.querySelector("va-alert[status='error']");
-      if (!window.Cypress) {
+      if (focusSelector && continueClicked && !window.Cypress) {
         scrollAndFocus(focusSelector);
       }
     },


### PR DESCRIPTION
## Summary
This PR scrolls and focuses on the error alert when a user tries to Continue while their upload is still in progress. This will help for general visibility and for screen readers.

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/5?filterQuery=assignee%3A%40me+-status%3AIcebox%2CEpic%2CRefinement&pane=issue&itemId=96688713&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C2010
