### PR TITLE
Add feature flag for FE API source of truth changes

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -120,6 +120,9 @@ export const selectFeatureUseVaDate = state =>
 export const selectFeaturePastApptDateRange = state =>
   toggleValues(state).vaOnlineSchedulingPastApptDateRange;
 
+export const selectFeatureFeSourceOfTruth = state =>
+  toggleValues(state).vaOnlineSchedulingFeSourceOfTruth;
+
 export const selectFeatureTravelPayViewClaimDetails = state =>
   toggleValues(state).travelPayViewClaimDetails;
 

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -27,6 +27,7 @@ module.exports = [
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
   { name: 'vaOnlineSchedulingUseVaDate', value: false },
   { name: 'vaOnlineSchedulingPastApptDateRange', value: false },
+  { name: 'vaOnlineSchedulingFeSourceOfTruth', value: false },
   { name: 'selectFeaturePocTypeOfCare', value: true },
   { name: 'edu_section_103', value: true },
   { name: 'gibctEybBottomSheet', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -284,6 +284,7 @@
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
   "vaOnlineSchedulingUseVaDate": "vaos_online_scheduling_use_va_date",
   "vaOnlineSchedulingPastApptDateRange": "va_online_scheduling_past_appt_date_range",
+  "vaOnlineSchedulingFeSourceOfTruth": "va_online_scheduling_FE_source_of_truth",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",
   "veteranOnboardingContactInfoFlow": "veteran_onboarding_contact_info_flow",
   "veteranOnboardingShowWelcomeMessageToNewUsers": "veteran_onboarding_show_welcome_message_to_new_users",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -284,7 +284,7 @@
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
   "vaOnlineSchedulingUseVaDate": "vaos_online_scheduling_use_va_date",
   "vaOnlineSchedulingPastApptDateRange": "va_online_scheduling_past_appt_date_range",
-  "vaOnlineSchedulingFeSourceOfTruth": "va_online_scheduling_FE_source_of_truth",
+  "vaOnlineSchedulingFeSourceOfTruth": "va_online_scheduling_fe_source_of_truth",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",
   "veteranOnboardingContactInfoFlow": "veteran_onboarding_contact_info_flow",
   "veteranOnboardingShowWelcomeMessageToNewUsers": "veteran_onboarding_show_welcome_message_to_new_users",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adding a feature toggle for changes made in the FE based on API source of truth changes.
- Appointments Tool Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103404

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments Tool

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
