### PR TITLE
Ask VA 1519 - Fix in progress form clearing after submission

### DIFF
--- a/src/applications/ask-va/actions/index.js
+++ b/src/applications/ask-va/actions/index.js
@@ -1,3 +1,7 @@
+import { removeFormApi } from 'platform/forms/save-in-progress/api';
+import recordEvent from 'platform/monitoring/record-event';
+import { REMOVING_SAVED_FORM_SUCCESS } from 'platform/user/profile/actions';
+
 export const SET_CATEGORY_ID = 'SET_CATEGORY_ID';
 export const SET_TOPIC_ID = 'SET_TOPIC_ID';
 export const SET_SUBTOPIC_ID = 'SET_SUBTOPIC_ID';
@@ -6,6 +10,7 @@ export const OPEN_REVIEW_CHAPTER = 'OPEN_REVIEW_CHAPTER';
 export const CLOSE_REVIEW_CHAPTER = 'CLOSE_REVIEW_CHAPTER';
 export const SET_LOCATION_SEARCH = 'SET_LOCATION_SEARCH';
 export const SET_VA_HEALTH_FACILITY = 'SET_VA_HEALTH_FACILITY';
+export const REMOVE_ASK_VA_FORM = 'REMOVE_ASK_VA_FORM';
 
 export function setCategoryID(id) {
   return { type: SET_CATEGORY_ID, payload: id };
@@ -44,4 +49,20 @@ export function setLocationInput(searchInput) {
 
 export function setVAHealthFacility(name) {
   return { type: SET_VA_HEALTH_FACILITY, payload: name };
+}
+
+export function removeAskVaForm(formId) {
+  return dispatch => {
+    return removeFormApi(formId)
+      .then(() => {
+        recordEvent({ event: 'sip-form-delete-success' });
+        dispatch({ type: REMOVING_SAVED_FORM_SUCCESS, formId });
+      })
+      .catch(error => {
+        recordEvent({
+          event: 'sip-form-delete-failed',
+          error: error?.message,
+        });
+      });
+  };
 }

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -21,13 +21,17 @@ import React, { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
+import { StorageAdapter } from '../../_mock-form-ae-design-patterns/vadx/utils/StorageAdapter';
 import {
   closeReviewChapter,
   openReviewChapter,
+  removeAskVaForm,
   setUpdatedInReview,
 } from '../actions';
 import FileUpload from '../components/FileUpload';
 import ReviewCollapsibleChapter from '../components/ReviewCollapsibleChapter';
+import ReviewSectionContent from '../components/reviewPage/ReviewSectionContent';
+import SaveCancelButtons from '../components/reviewPage/SaveCancelButtons';
 import formConfig from '../config/form';
 import { DownloadLink } from '../config/helpers';
 import submitTransformer from '../config/submit-transformer';
@@ -39,15 +43,12 @@ import {
 } from '../constants';
 import { mockSubmitResponse } from '../utils/mockData';
 import {
+  chapterTitles,
   createPageListByChapterAskVa,
   getChapterFormConfigAskVa,
   getPageKeysForReview,
   pagesToMoveConfig,
-  chapterTitles,
 } from '../utils/reviewPageHelper';
-import ReviewSectionContent from '../components/reviewPage/ReviewSectionContent';
-import SaveCancelButtons from '../components/reviewPage/SaveCancelButtons';
-import { StorageAdapter } from '../../_mock-form-ae-design-patterns/vadx/utils/StorageAdapter';
 
 const { scroller } = Scroll;
 
@@ -147,6 +148,7 @@ const ReviewPage = props => {
   };
 
   const postFormData = async (url, data) => {
+    const id = formConfig.formId;
     setIsDisabled(true);
     const options = {
       method: 'POST',
@@ -165,6 +167,7 @@ const ReviewPage = props => {
           const inquiryNumber = 'A-20230622-306458';
           const contactPreference = props.formData.contactPreference || 'Email';
           askVAAttachmentStorage.clear();
+          dispatch(removeAskVaForm(id));
           props.router.push({
             pathname: '/confirmation',
             state: { contactPreference, inquiryNumber },
@@ -179,6 +182,7 @@ const ReviewPage = props => {
         const { inquiryNumber } = response;
         const contactPreference = props.formData.contactPreference || 'Email';
         askVAAttachmentStorage.clear();
+        dispatch(removeAskVaForm(id));
         props.router.push({
           pathname: '/confirmation',
           state: { contactPreference, inquiryNumber },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Create custom redux action to clear the Ask VA form from saved forms based on platform user actions
- The Ask VA team owns this

## Related issue(s)

- Link to ticket here: https://github.com/orgs/department-of-veterans-affairs/projects/1033/views/1?pane=issue&itemId=90743958&issue=department-of-veterans-affairs%7Cask-va%7C1519

## Testing done

- Manual testing of flow and seeing no in progress forms after successful submissions

## Screenshots

*no UI changes

![image](https://github.com/user-attachments/assets/db1cb13f-f652-4ba0-9c7e-47a65daf3fe6)

## What areas of the site does it impact?

- This only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
