### PR TITLE
updates return url for unauthenticated verify page

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -4,6 +4,7 @@ import 'url-search-params-polyfill';
 import environment from 'platform/utilities/environment';
 import { createOAuthRequest } from 'platform/utilities/oauth/utilities';
 import { setLoginAttempted } from 'platform/utilities/sso/loginAttempted';
+import { hasSession } from 'platform/user/profile/utilities';
 import { externalApplicationsConfig } from './usip-config';
 import {
   AUTH_EVENTS,
@@ -195,6 +196,9 @@ export const createAndStoreReturnUrl = () => {
     }
     // If we are not on the USiP, we should always return the user back to their current location
     returnUrl = window.location.toString();
+  }
+  if (window.location.pathname === '/verify/' && !hasSession()) {
+    returnUrl = '/';
   }
 
   sessionStorage.setItem(

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -426,6 +426,16 @@ describe('Authentication Utilities', () => {
 
         setup({});
       });
+
+      it('should return "/" when pathname is "/verify/" and hasSession() is false', () => {
+        setup({ path: '/verify/' });
+        sinon.stub(authUtilities, 'hasSession').returns(false);
+
+        expect(authUtilities.createAndStoreReturnUrl()).to.equal('/');
+        expect(sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL)).to.equal('/');
+
+        authUtilities.hasSession.restore();
+      });
     });
 
     it('should return the `authReturnUrl` if it is already presented', () => {


### PR DESCRIPTION
Updates ```src/platform/user/authentication/utilities.js``` to redirect a user to the home page after verifying their identity if they started the verification process from this [verified page](va.gov/verify) as an unauthenticated user
- adds ```if``` statement to update ```returnUrl``` to ```/``` (home page)
- checks if user is unauthenticated with ```hasSession()``` utility
- checks if the window locations pathname is equal to ```'/verify/'```