### PR TITLE
[SIMPLE-FORMS] fix: add logic to properly format the form upload page link

### DIFF
--- a/src/applications/static-pages/simple-forms/form-upload/App.js
+++ b/src/applications/static-pages/simple-forms/form-upload/App.js
@@ -23,7 +23,7 @@ export const App = ({ formNumber, hasOnlineTool }) => {
           <div className="vads-u-background-color--primary vads-u-padding--1">
             <a
               className="vads-c-action-link--white"
-              href={`/find-forms/upload/${formNumber}`}
+              href={`/find-forms/upload/${formNumber.toLowerCase()}`}
             >
               Go to the upload tool for this form
             </a>

--- a/src/platform/forms-system/src/js/review/submit-states/Default.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Default.jsx
@@ -14,15 +14,6 @@ export default function Default({
   const ariaDescribedBy = formConfig?.ariaDescribedBySubmit ?? null;
   const hideBackButton = formConfig?.useTopBackLink || false;
 
-  const renderProgressButton = () => (
-    <ProgressButton
-      ariaDescribedBy={ariaDescribedBy}
-      onButtonClick={onSubmit}
-      buttonText={buttonText}
-      buttonClass="usa-button-primary"
-    />
-  );
-
   return (
     <>
       <PreSubmitSection formConfig={formConfig} />
@@ -30,7 +21,12 @@ export default function Default({
         {hideBackButton ? (
           <>
             <Column classNames="vads-u-flex--1">
-              {renderProgressButton()}
+              <ProgressButton
+                ariaDescribedBy={ariaDescribedBy}
+                onButtonClick={onSubmit}
+                buttonText={buttonText}
+                buttonClass="usa-button-primary"
+              />
             </Column>
             <Column classNames="vads-u-flex--1" />
           </>
@@ -40,7 +36,12 @@ export default function Default({
               <Back onButtonClick={onBack} />
             </Column>
             <Column classNames="vads-u-flex--1">
-              {renderProgressButton()}
+              <ProgressButton
+                ariaDescribedBy={ariaDescribedBy}
+                onButtonClick={onSubmit}
+                buttonText={buttonText}
+                buttonClass="usa-button-primary"
+              />
             </Column>
           </>
         )}


### PR DESCRIPTION
## Summary

- This work adds logic to properly format the link on the find a form static page which allows the user to navigate to the associated form's upload flow.
- This work fixes a bug where form upload forms which have a letter in them aren't parsed properly, leading to a dead link which goes nowhere.
- I work for the Veteran Facing Forms team who owns this page.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#2027

## Testing done

- Unit and E2E tests pass

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any
