### PR TITLE
Ask VA 1636 - Missing inquiry and topic ids

### DIFF
--- a/src/applications/ask-va/components/Footer.jsx
+++ b/src/applications/ask-va/components/Footer.jsx
@@ -1,4 +1,5 @@
 import { VaBackToTop } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import NeedHelpFooter from './NeedHelpFooter';
@@ -43,6 +44,12 @@ const Footer = ({ currentLocation, categoryID, topicID }) => {
       </div>
     </div>
   );
+};
+
+Footer.propTypes = {
+  categoryID: PropTypes.string,
+  currentLocation: PropTypes.object,
+  topicID: PropTypes.string,
 };
 
 function mapStateToProps(state) {

--- a/src/applications/ask-va/config/submit-transformer.js
+++ b/src/applications/ask-va/config/submit-transformer.js
@@ -24,10 +24,9 @@ const getFiles = files => {
   });
 };
 
-export default function submitTransformer(formData, uploadFiles, askVAStore) {
+export default function submitTransformer(formData, uploadFiles) {
   return {
     ...formData,
-    ...askVAStore,
     files: getFiles(uploadFiles),
     SchoolObj: {
       InstitutionName: getSchoolInfo(formData.school)?.name,

--- a/src/applications/ask-va/containers/CategorySelectPage.jsx
+++ b/src/applications/ask-va/containers/CategorySelectPage.jsx
@@ -38,9 +38,10 @@ const CategorySelectPage = props => {
     if (selected.attributes.requiresAuthentication && !isLoggedIn) {
       setShowModal(true);
     } else {
-      dispatch(setCategoryID(selected.id));
+      dispatch(setCategoryID(selected.id)); // askVA store categoryID
       onChange({
         ...formData,
+        categoryId: selected.id,
         selectCategory: selectedValue,
         allowAttachments: selected.attributes.allowAttachments,
       });

--- a/src/applications/ask-va/containers/SubTopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/SubTopicSelectPage.jsx
@@ -34,8 +34,12 @@ const SubTopicSelectPage = props => {
     const selected = apiData.find(
       subtopic => subtopic.attributes.name === selectedValue,
     );
-    onChange({ ...formData, selectSubtopic: selectedValue });
-    dispatch(setSubtopicID(selected.id));
+    dispatch(setSubtopicID(selected.id)); // askVA store subtopicID
+    onChange({
+      ...formData,
+      selectSubtopic: selectedValue,
+      subtopicId: selected.id,
+    });
   };
 
   const getApiData = url => {
@@ -131,7 +135,7 @@ function mapStateToProps(state) {
   return {
     loggedIn: isLoggedIn(state),
     formData: state.form.data,
-    topicID: state.askVA.topicID,
+    topicID: state.form.data.topicId,
   };
 }
 

--- a/src/applications/ask-va/containers/TopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/TopicSelectPage.jsx
@@ -58,8 +58,12 @@ const TopicSelectPage = props => {
     if (selected.attributes.requiresAuthentication && !loggedIn) {
       setShowModal(true);
     } else {
-      dispatch(setTopicID(selected.id));
-      onChange({ ...formData, selectTopic: selectedValue });
+      dispatch(setTopicID(selected.id)); // askVA store topicID
+      onChange({
+        ...formData,
+        selectTopic: selectedValue,
+        topicId: selected.id,
+      });
     }
   };
 
@@ -155,7 +159,7 @@ function mapStateToProps(state) {
   return {
     loggedIn: isLoggedIn(state),
     formData: state.form.data,
-    categoryID: state.askVA.categoryID,
+    categoryID: state.form.data.categoryId,
   };
 }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Context - fix error when resuming question - askVA redux store held category, topic, subtopic ids and were not stored in form data when saved to platform store
- Removed askVA store from transformer - no longer needed
- categoryId, topicId, and subtopicId now stored in form data and saved when leaving/resuming question
- Drive by fix for props linting on footer 

## Related issue(s)

- Link to ticket here: https://github.com/orgs/department-of-veterans-affairs/projects/1033/views/11?pane=issue&itemId=98763363&issue=department-of-veterans-affairs%7Cask-va%7C1636

## Testing done

- Manual testing of starting and resuming question when signed in
- Manual testing of question flow when unauth

## Screenshots

- no UI changes

## What areas of the site does it impact?

- This only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
