### PR TITLE
VACMS-20422 launch injected header on bva.va.gov

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -43,12 +43,12 @@
     {
       "hostname": "bva.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.bva.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "cem.va.gov",


### PR DESCRIPTION
Only updates cookie value from requiring cookie to see the injected header (`true`), to make the injected header visible for all visitors to bva.va.gov (cookieOnly: `false`). 

Stakeholder (Josh Tuscher) has approved this launch. 

No other changes or testing required.

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20422