### PR TITLE
10-10EZ | Route guard identity verification page

### DIFF
--- a/src/applications/hca/containers/IdentityPage.jsx
+++ b/src/applications/hca/containers/IdentityPage.jsx
@@ -12,7 +12,10 @@ import {
   resetEnrollmentStatus as resetEnrollmentStatusAction,
 } from '../utils/actions';
 import { HCA_ENROLLMENT_STATUSES } from '../utils/constants';
-import { selectEnrollmentStatus } from '../utils/selectors';
+import {
+  selectEnrollmentStatus,
+  selectFeatureToggles,
+} from '../utils/selectors';
 import useAfterRenderEffect from '../hooks/useAfterRenderEffect';
 import IdentityVerificationForm from '../components/IdentityPage/VerificationForm';
 import VerificationPageDescription from '../components/IdentityPage/VerificationPageDescription';
@@ -26,6 +29,7 @@ const IdentityPage = props => {
     fetchAttempted,
     isUserInMPI,
   } = useSelector(selectEnrollmentStatus);
+  const { isPerformanceAlertEnabled } = useSelector(selectFeatureToggles);
   const { data: formData } = useSelector(state => state.form);
   const loggedIn = useSelector(isLoggedIn);
   const [localData, setLocalData] = useState({});
@@ -93,7 +97,7 @@ const IdentityPage = props => {
    */
   useEffect(
     () => {
-      if (loggedIn) {
+      if (loggedIn || isPerformanceAlertEnabled) {
         router.push('/');
       } else {
         const { resetEnrollmentStatus } = props;
@@ -102,7 +106,7 @@ const IdentityPage = props => {
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [loggedIn],
+    [loggedIn, isPerformanceAlertEnabled],
   );
 
   // trigger prefill and navigation if enrollment status criteria is met


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR is a temporary implementation based on scheduled downtime to the downstream services on Feb 23, 2025. During the downtime, the system will not be able to accept applications. This only affects guest users, as there is a rety queue in place for authenticated users that will allow the application to submit after the downtime period has passed. This PR will be reverted on Feb 24, 2025, once this downtime window has expired.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#103531

## Testing done

- Toggle `hca_performance_alert_enabled` feature toggle
- Navigate to `/health-care/apply-for-health-care-form-10-10ez/id-form`
- If the toggle is off, the page should render with the identity verificafion form
- If the toggle is on, you should be redirected to the Introduction page

## Acceptance criteria

- Unauthenticated users cannot access the form when the toggle is active

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution