### PR TITLE
updates content on prod test page

### DIFF
--- a/src/applications/login/containers/ProdTestAccess.jsx
+++ b/src/applications/login/containers/ProdTestAccess.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { apiRequest } from 'platform/utilities/api';
 import { login } from 'platform/user/authentication/utilities';
 
-export default function MhvSignIn() {
+export default function ProdTestAccess() {
   const [email, setEmail] = useState('');
   const [isValidEmail, setIsValidEmail] = useState(false);
 
@@ -34,12 +34,10 @@ export default function MhvSignIn() {
   return (
     <section className="container row login vads-u-padding--3">
       <div className="columns small-12 vads-u-padding--0">
-        <h1 id="signin-signup-modal-title">
-          Access My HealtheVet test account
-        </h1>
+        <h1 id="signin-signup-modal-title">Access production test account</h1>
         <p>
-          My HealtheVet test accounts are available for VA and Oracle Health
-          staff only.
+          Production test accounts are available for VA and Oracle Health staff
+          only.
         </p>
       </div>
       <h2 className="vads-u-padding-top--4">
@@ -61,16 +59,17 @@ export default function MhvSignIn() {
       />
       <div className="vads-u-margin-y--2">
         <p>
-          <strong>Disclaimer:</strong> By providing your email address you are
-          agreeing to only use <br />
-          My HealtheVet for official VA testing, training, or development
-          purposes.
+          <strong>Disclaimer:</strong> By providing your email address you agree
+          to only use this
+          <br />
+          production test account for official VA testing, training, or
+          development purposes.
         </p>
       </div>
       <div className="vads-u-margin-y--2">
         <va-button
           onClick={handleButtonClick}
-          text="Access My HealtheVet"
+          text="Access test account"
           data-testid="accessMhvBtn"
           disabled={!isValidEmail}
         />

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -2,7 +2,7 @@ import environment from 'platform/utilities/environment';
 import SignInApp from './containers/SignInApp';
 import SignInWrapper from './components/SignInWrapper';
 import MockAuth from './containers/MockAuth';
-import MhvProdTestAccess from './containers/MhvProdTestAccess';
+import ProdTestAccess from './containers/ProdTestAccess';
 import MhvTemporaryAccess from './containers/MhvTemporaryAccess';
 
 const routes = {
@@ -17,8 +17,8 @@ const routes = {
             component: MockAuth,
           },
           {
-            path: 'access-myhealthevet-test-account',
-            component: MhvProdTestAccess,
+            path: 'access-production-test-account',
+            component: ProdTestAccess,
           },
           {
             path: 'mhv',
@@ -27,8 +27,8 @@ const routes = {
         ]
       : [
           {
-            path: 'access-myhealthevet-test-account',
-            component: MhvProdTestAccess,
+            path: 'access-production-test-account',
+            component: ProdTestAccess,
           },
           {
             path: 'mhv',

--- a/src/applications/login/tests/containers/ProdTestAccess.unit.spec.js
+++ b/src/applications/login/tests/containers/ProdTestAccess.unit.spec.js
@@ -2,25 +2,25 @@ import React from 'react';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import { fireEvent, render } from '@testing-library/react';
 import { expect } from 'chai';
-import MhvProdTestAccess from '../../containers/MhvProdTestAccess';
+import ProdTestAccess from '../../containers/ProdTestAccess';
 
-describe('MhvProdTestAccess Component', () => {
+describe('ProdTestAccess Component', () => {
   it('renders the heading and description', () => {
-    const screen = renderInReduxProvider(<MhvProdTestAccess />);
+    const screen = renderInReduxProvider(<ProdTestAccess />);
     expect(
       screen.getByRole('heading', {
-        name: /Access My HealtheVet test account/i,
+        name: /Access production test account/i,
       }),
     ).to.exist;
     expect(
       screen.getByText(
-        /My HealtheVet test accounts are available for VA and Oracle Health staff only\./i,
+        /production test accounts are available for VA and Oracle Health staff only\./i,
       ),
     ).to.exist;
   });
 
   it('renders email input and validates email with allowed domains', async () => {
-    const screen = render(<MhvProdTestAccess />);
+    const screen = render(<ProdTestAccess />);
     const emailInput = screen.getByTestId('mvhemailinput');
 
     emailInput.value = 'test@va.gov';
@@ -38,7 +38,7 @@ describe('MhvProdTestAccess Component', () => {
   });
 
   it('renders the login button and calls handleButtonClick', () => {
-    const screen = renderInReduxProvider(<MhvProdTestAccess />);
+    const screen = renderInReduxProvider(<ProdTestAccess />);
     const emailInput = screen.getByTestId('mvhemailinput');
     const loginButton = screen.getByTestId('accessMhvBtn');
 
@@ -50,7 +50,7 @@ describe('MhvProdTestAccess Component', () => {
   });
 
   it('disables the login button for invalid email', () => {
-    const screen = renderInReduxProvider(<MhvProdTestAccess />);
+    const screen = renderInReduxProvider(<ProdTestAccess />);
     const emailInput = screen.getByTestId('mvhemailinput');
     const loginButton = screen.getByTestId('accessMhvBtn');
 
@@ -60,7 +60,7 @@ describe('MhvProdTestAccess Component', () => {
   });
 
   it('renders the "Having trouble signing in?" section', () => {
-    const screen = renderInReduxProvider(<MhvProdTestAccess />);
+    const screen = renderInReduxProvider(<ProdTestAccess />);
     expect(
       screen.getByRole('heading', { name: /Having trouble signing in\?/i }),
     ).to.exist;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Uodate this production test account page's content to not include any mention of My HealtheVet

## Related issue(s)

[Slack thread](https://dsva.slack.com/archives/C068QM7CCKG/p1740151228695249)

## Testing done

- unit test pass
- build was successful

## Screenshots

![Screenshot 2025-02-21 at 8 19 40 AM](https://github.com/user-attachments/assets/879231ae-a576-470f-9f86-98a25a196cb3)


## What areas of the site does it impact?

https://www.va.gov/sign-in/access-myhealthevet-test-account

## Acceptance criteria

Update content on the access page to not mention MHV anywhere

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

