### PR TITLE
VACMS-20625: Add span for search icon button

### DIFF
--- a/src/platform/site-wide/header/components/Search/SearchDropdownComponent.js
+++ b/src/platform/site-wide/header/components/Search/SearchDropdownComponent.js
@@ -805,7 +805,11 @@ class SearchDropdownComponent extends React.Component {
                   d="M15.5 14H14.71L14.43 13.73C15.41 12.59 16 11.11 16 9.5C16 5.91 13.09 3 9.5 3C5.91 3 3 5.91 3 9.5C3 13.09 5.91 16 9.5 16C11.11 16 12.59 15.41 13.73 14.43L14 14.71V15.5L19 20.49L20.49 19L15.5 14ZM9.5 14C7.01 14 5 11.99 5 9.5C5 7.01 7.01 5 9.5 5C11.99 5 14 7.01 14 9.5C14 11.99 11.99 14 9.5 14Z"
                 />
               </svg>
-              {buttonText && <span className="button-text">{buttonText}</span>}
+              {buttonText ? (
+                <span className="button-text">{buttonText}</span>
+              ) : (
+                <span className="usa-sr-only">Search</span>
+              )}
             </button>
           )}
         {validOpen &&

--- a/src/platform/site-wide/user-nav/components/SearchDropdownComponent.js
+++ b/src/platform/site-wide/user-nav/components/SearchDropdownComponent.js
@@ -806,7 +806,11 @@ class SearchDropdownComponent extends React.Component {
                   d="M15.5 14H14.71L14.43 13.73C15.41 12.59 16 11.11 16 9.5C16 5.91 13.09 3 9.5 3C5.91 3 3 5.91 3 9.5C3 13.09 5.91 16 9.5 16C11.11 16 12.59 15.41 13.73 14.43L14 14.71V15.5L19 20.49L20.49 19L15.5 14ZM9.5 14C7.01 14 5 11.99 5 9.5C5 7.01 7.01 5 9.5 5C11.99 5 14 7.01 14 9.5C14 11.99 11.99 14 9.5 14Z"
                 />
               </svg>
-              {buttonText && <span className="button-text">{buttonText}</span>}
+              {buttonText ? (
+                <span className="button-text">{buttonText}</span>
+              ) : (
+                <span className="usa-sr-only">Search</span>
+              )}
             </button>
           )}
         {validOpen &&


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR adds a sr-only span for the search icon button on the homepage which handles a critical a11y issue with no label on buttons.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20625

## Testing done
Tested locally to check HTML markup and screen reader.

## Screenshots
![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/user-attachments/assets/7a0148a3-5a9d-483f-b493-c1b362af6136)

## What areas of the site does it impact?
Homepage Icon button for search

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
