### PR TITLE
Add alerts and text for the 1095-b Download widget

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -55,17 +55,12 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
   };
 
   const getAvailableForms = () => {
-    return apiRequest('/form1095_bs/available_forms')
-      .then(response => {
-        if (response.errors || !response.availableForms.length) {
-          updateFormError({ error: true, type: errorTypes.NOT_FOUND });
-        }
-        return response.availableForms;
-      })
-      .catch(() => {
+    return apiRequest('/form1095_bs/available_forms').then(response => {
+      if (response.errors || !!response.availableForms.length) {
         updateFormError({ error: true, type: errorTypes.NOT_FOUND });
-        return null; // Return null in case of an error
-      });
+      }
+      return response.availableForms;
+    });
   };
 
   useEffect(
@@ -128,9 +123,13 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
   useEffect(
     () => {
       getAvailableForms().then(result => {
-        const mostRecentYearData = result[0];
-        if (mostRecentYearData?.lastUpdated && mostRecentYearData?.year) {
-          updateYear(mostRecentYearData.year);
+        if (result) {
+          const mostRecentYearData = result[0];
+          if (mostRecentYearData?.lastUpdated && mostRecentYearData?.year) {
+            updateYear(mostRecentYearData.year);
+          } else {
+            updateFormError({ error: true, type: errorTypes.NOT_FOUND });
+          }
         } else {
           updateFormError({ error: true, type: errorTypes.NOT_FOUND });
         }
@@ -207,7 +206,7 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
     if (!displayToggle) {
       return unavailableComponent();
     }
-    if (formError.error === errorTypes.NOT_FOUND) {
+    if (formError.type === errorTypes.NOT_FOUND) {
       return notFoundComponent();
     }
     if (isLOA1) {

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -56,7 +56,7 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
 
   const getAvailableForms = () => {
     return apiRequest('/form1095_bs/available_forms').then(response => {
-      if (response.errors || !!response.availableForms.length) {
+      if (response.errors || response.availableForms.length === 0) {
         updateFormError({ error: true, type: errorTypes.NOT_FOUND });
       }
       return response.availableForms;
@@ -127,11 +127,7 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
           const mostRecentYearData = result[0];
           if (mostRecentYearData?.lastUpdated && mostRecentYearData?.year) {
             updateYear(mostRecentYearData.year);
-          } else {
-            updateFormError({ error: true, type: errorTypes.NOT_FOUND });
           }
-        } else {
-          updateFormError({ error: true, type: errorTypes.NOT_FOUND });
         }
       });
     },

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -4,8 +4,8 @@ import { useSelector, connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { apiRequest } from 'platform/utilities/api';
 // Relative imports.
+import { focusElement } from 'platform/utilities/ui';
 import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import {
   VaAlertSignIn,
   VaButton,
@@ -22,23 +22,35 @@ import { isLOA1 as isLOA1Selector } from '~/platform/user/selectors';
 import {
   notFoundComponent,
   unavailableComponent,
-  phoneComponent,
-  LastUpdatedComponent,
+  downloadErrorComponent,
+  errorTypes,
 } from './utils';
 import '../../sass/download-1095b.scss';
 
 export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
-  const [lastUpdated, updateLastUpdated] = useState('');
   const [year, updateYear] = useState(0);
-  const [formError, updateFormError] = useState({ error: false, type: '' }); // types: "not found", "download error"
+  const [formError, updateFormError] = useState({ error: false, type: '' });
   const cspId = useSelector(signInServiceName);
   const [verifyAlertVariant, setverifyAlertVariant] = useState(null);
+
+  useEffect(
+    () => {
+      if (formError.type === errorTypes.DOWNLOAD_ERROR) {
+        focusElement('#downloadError');
+      }
+    },
+    [formError],
+  );
 
   const getFile = format => {
     return apiRequest(`/form1095_bs/download_${format}/${year}`)
       .then(response => response.blob())
       .then(blob => {
         return window.URL.createObjectURL(blob);
+      })
+      .catch(() => {
+        updateFormError({ error: true, type: errorTypes.DOWNLOAD_ERROR });
+        return false;
       });
   };
 
@@ -46,12 +58,12 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
     return apiRequest('/form1095_bs/available_forms')
       .then(response => {
         if (response.errors || !response.availableForms.length) {
-          updateFormError({ error: true, type: 'not found' });
+          updateFormError({ error: true, type: errorTypes.NOT_FOUND });
         }
         return response.availableForms;
       })
       .catch(() => {
-        updateFormError({ error: true, type: 'not found' });
+        updateFormError({ error: true, type: errorTypes.NOT_FOUND });
         return null; // Return null in case of an error
       });
   };
@@ -117,90 +129,67 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
     () => {
       getAvailableForms().then(result => {
         const mostRecentYearData = result[0];
-        if (
-          mostRecentYearData &&
-          mostRecentYearData?.lastUpdated &&
-          mostRecentYearData?.year
-        ) {
-          const date = new Date(mostRecentYearData.lastUpdated);
-          const options = { year: 'numeric', month: 'long', day: 'numeric' };
-          // expected output (varies according to local timezone and default locale): December 20, 2012
-          updateLastUpdated(date.toLocaleDateString(undefined, options));
+        if (mostRecentYearData?.lastUpdated && mostRecentYearData?.year) {
           updateYear(mostRecentYearData.year);
         } else {
-          updateFormError({ error: true, type: 'not found' });
+          updateFormError({ error: true, type: errorTypes.NOT_FOUND });
         }
       });
     },
     [loggedIn],
   );
 
-  const errorComponent = (
-    <>
-      <LastUpdatedComponent lastUpdated={lastUpdated} />
-      <va-alert
-        close-btn-aria-label="Close notification"
-        status="error"
-        visible
-      >
-        <h2 slot="headline">We couldn’t download your form</h2>
-        <div>
-          <p>
-            We’re sorry. Something went wrong when we tried to download your
-            form. Please try again. If your form still doesn’t download, call us
-            at {phoneComponent(CONTACTS.HELP_DESK)}. We’re here 24/7.
-          </p>
-        </div>
-      </va-alert>
-    </>
-  );
-
-  const getErrorComponent = () => {
-    if (formError.type === 'not found') {
-      return notFoundComponent();
-    }
-    return errorComponent;
-  };
-
   const downloadForm = (
-    <va-card>
-      <div>
-        <h4 className="vads-u-margin-bottom--0 vads-u-margin-top--0">
-          1095-B Proof of VA health coverage
-        </h4>
-        <span className="vads-u-font-size--h5">
-          <b>Tax year:</b> {year}
-        </span>
-      </div>
-      <div className="download-links vads-u-font-size--h5 vads-u-margin-y--1p5 vads-u-padding-top--3">
-        <div className="vads-u-padding-bottom--1">
-          <va-link
-            download
-            id="pdf-download-link"
-            label="Download PDF (best for printing)"
-            text="Download PDF (best for printing)"
-            onClick={e => {
-              e.preventDefault();
-              recordEvent({ event: '1095b-pdf-download' });
-              downloadFileToUser('pdf');
-            }}
-          />
+    <>
+      <va-card>
+        <div>
+          <h4 className="vads-u-margin-bottom--0 vads-u-margin-top--0">
+            1095-B Proof of VA health coverage
+          </h4>
+          <span>
+            <b>Tax year:</b> {year}
+          </span>
         </div>
-        <div className="vads-u-padding-top--1">
-          <va-link
-            download
-            id="txt-download-link"
-            label="Download Text file (best for screen readers, enlargers, and refreshable Braille displays)"
-            text="Download Text file (best for screen readers, enlargers, and refreshable Braille displays)"
-            onClick={e => {
-              e.preventDefault();
-              recordEvent({ event: '1095b-txt-download' });
-              downloadFileToUser('txt');
-            }}
-          />
+        <div className="download-links vads-u-margin-y--1p5 vads-u-padding-top--3">
+          {formError.type === errorTypes.DOWNLOAD_ERROR &&
+            downloadErrorComponent}
+          <div className="vads-u-padding-bottom--1">
+            <va-link
+              download
+              id="pdf-download-link"
+              label="Download PDF (best for printing)"
+              text="Download PDF (best for printing)"
+              onClick={e => {
+                e.preventDefault();
+                recordEvent({ event: '1095b-pdf-download' });
+                downloadFileToUser('pdf');
+              }}
+            />
+          </div>
+          <div className="vads-u-padding-top--1">
+            <va-link
+              download
+              id="txt-download-link"
+              label="Download Text file (best for screen readers, enlargers, and refreshable Braille displays)"
+              text="Download Text file (best for screen readers, enlargers, and refreshable Braille displays)"
+              onClick={e => {
+                e.preventDefault();
+                recordEvent({ event: '1095b-txt-download' });
+                downloadFileToUser('txt');
+              }}
+            />
+          </div>
         </div>
-      </div>
-    </va-card>
+      </va-card>
+      <p className="vads-u-margin-y--4">
+        If you’re having trouble viewing your IRS 1095-B tax form you may need
+        the latest version of Adobe Acrobat Reader. It’s free to download.{' '}
+        <va-link
+          href="https://get.adobe.com/reader"
+          text="Get Acrobat Reader for free from Adobe."
+        />
+      </p>
+    </>
   );
 
   const loggedOutComponent = (
@@ -214,12 +203,12 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
     </VaAlertSignIn>
   );
 
-  if (!displayToggle) {
-    return unavailableComponent();
-  }
   if (loggedIn) {
-    if (formError.error) {
-      return getErrorComponent();
+    if (!displayToggle) {
+      return unavailableComponent();
+    }
+    if (formError.error === errorTypes.NOT_FOUND) {
+      return notFoundComponent();
     }
     if (isLOA1) {
       return verifyAlertVariant;

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -55,12 +55,17 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
   };
 
   const getAvailableForms = () => {
-    return apiRequest('/form1095_bs/available_forms').then(response => {
-      if (response.errors || response.availableForms.length === 0) {
-        updateFormError({ error: true, type: errorTypes.NOT_FOUND });
-      }
-      return response.availableForms;
-    });
+    return apiRequest('/form1095_bs/available_forms')
+      .then(response => {
+        if (response.errors || response.availableForms.length === 0) {
+          updateFormError({ error: true, type: errorTypes.NOT_FOUND });
+        }
+        return response.availableForms;
+      })
+      .catch(() => {
+        updateFormError({ error: true, type: 'not found' });
+        return null; // Return null in case of an error
+      });
   };
 
   useEffect(

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -63,7 +63,7 @@ export const App = ({ displayToggle, isLOA1, loggedIn, toggleLoginModal }) => {
         return response.availableForms;
       })
       .catch(() => {
-        updateFormError({ error: true, type: 'not found' });
+        updateFormError({ error: true, type: errorTypes.NOT_FOUND });
         return null; // Return null in case of an error
       });
   };

--- a/src/applications/static-pages/download-1095b/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.unit.spec.js
@@ -22,7 +22,7 @@ describe('App component', () => {
       },
       profile: {
         loa: {
-          current: 1,
+          current: null,
         },
       },
     },

--- a/src/applications/static-pages/download-1095b/components/App/utils.js
+++ b/src/applications/static-pages/download-1095b/components/App/utils.js
@@ -1,31 +1,10 @@
 import React from 'react';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
-export const dateOptions = {
-  year: 'numeric',
-  month: 'numeric',
-  day: 'numeric',
-  hour: 'numeric',
-  minute: 'numeric',
-  hour12: true,
-};
-
-export const radioOptions = [
-  { label: 'Option 1: PDF document (best for printing)', value: 'pdf' },
-  {
-    label:
-      'Option 2: Text file (best for screen readers, screen enlargers, and refreshable Braille displays)',
-    value: 'txt',
-  },
-];
-
-// VA content time formatting - should be lowercase with periods
-export const formatTimeString = string => {
-  if (string.includes('AM')) {
-    return string.replace('AM', 'a.m.');
-  }
-  return string.replace('PM', 'p.m.');
-};
+export const errorTypes = Object.freeze({
+  NOT_FOUND: 'not found',
+  DOWNLOAD_ERROR: 'download error',
+});
 
 export const phoneComponent = number => {
   return (
@@ -52,21 +31,15 @@ export const LastUpdatedComponent = props => {
 export const notFoundComponent = () => {
   return (
     <va-alert close-btn-aria-label="Close notification" status="info" visible>
-      <h2 slot="headline">
+      <h4 id="track-your-status-on-mobile" slot="headline">
         You don’t have a 1095-B tax form available right now
-      </h2>
-      <div>
-        <p>
-          If you recently enrolled in VA health care, you may not have a 1095-B
-          form yet. We process 1095-B forms in early January each year, based on
-          your enrollment in VA health care during the past year.
-        </p>
-        <p>
-          If you think you should have a 1095-B form, call us at{' '}
-          {phoneComponent(CONTACTS['222_VETS'])}. We’re here Monday through
-          Friday, 8:00 a.m. to 8:00 p.m. ET.
-        </p>
-      </div>
+      </h4>
+      <p className="vads-u-margin-y--0">
+        You do not have a 1095-B tax form available. This could be because you
+        weren’t enrolled in VA healthcare in 2024. If you think you were
+        enrolled, call us at {phoneComponent(CONTACTS['222_VETS'])}. We’re here
+        Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+      </p>
     </va-alert>
   );
 };
@@ -87,3 +60,15 @@ export const unavailableComponent = () => {
     </va-alert>
   );
 };
+
+export const downloadErrorComponent = (
+  <div id="downloadError" className="vads-u-margin-bottom--2p5">
+    <va-alert close-btn-aria-label="Close notification" status="error" visible>
+      <p className="vads-u-margin-y--0">
+        We’re sorry. Something went wrong when we tried to download your form.
+        Please try again. If your form still doesn’t download, call us at{' '}
+        {phoneComponent(CONTACTS['222_VETS'])}. We’re here 24/7.
+      </p>
+    </va-alert>
+  </div>
+);

--- a/src/applications/static-pages/download-1095b/components/App/utils.js
+++ b/src/applications/static-pages/download-1095b/components/App/utils.js
@@ -31,7 +31,7 @@ export const LastUpdatedComponent = props => {
 export const notFoundComponent = () => {
   return (
     <va-alert close-btn-aria-label="Close notification" status="info" visible>
-      <h4 id="track-your-status-on-mobile" slot="headline">
+      <h4 slot="headline">
         You don’t have a 1095-B tax form available right now
       </h4>
       <p className="vads-u-margin-y--0">

--- a/src/applications/static-pages/download-1095b/mocks/server.js
+++ b/src/applications/static-pages/download-1095b/mocks/server.js
@@ -18,7 +18,7 @@ const responses = {
   },
   'GET /v0/form1095_bs/available_forms': (_req, res) => {
     return res.json({
-      availableForms: [{ year: 2020, lastUpdated: '2025-02-03T18:50:40.548Z' }],
+      availableForms: [{ year: 2024, lastUpdated: '2025-02-03T18:50:40.548Z' }],
     });
   },
   'GET /v0/user': (_req, res) => {

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -228,7 +228,7 @@ const defaultPostHook = pathname => {
   return () => {
     cy.findByText(/continue/i, {
       selector: 'button',
-      timeout: 10000,
+      timeout: 20000,
     })
       .should('be.visible')
       .click(FORCE_OPTION);


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds error alerts and focuses them for when the download throws an error
- Adds some text
- I work for VA IIR and we currently own this product.

## Related issue(s)

[VA IIR issue #1417](https://github.com/department-of-veterans-affairs/va-iir/issues/1417)

## Testing done

## Screenshots

When there are no available forms:
<img width="753" alt="Screenshot 2025-02-22 at 2 26 38 PM" src="https://github.com/user-attachments/assets/3e7b30eb-a023-445b-8c4b-9100b7ae6020" />

When the download link causes an error:
<img width="738" alt="Screenshot 2025-02-22 at 2 08 47 PM" src="https://github.com/user-attachments/assets/b525ad2d-359a-4216-88ab-e8bb630b2242" />


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

- When clicking the download link errors, an alert appears and is focused.
- When no forms are available, an alert appears instead of the download form.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
