### PR TITLE
fixed styling for refill alert on details page

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -159,7 +159,10 @@ const VaPrescription = prescription => {
                       className="vads-u-margin-bottom--2"
                       uswds
                     >
-                      <h3 slot="headline">
+                      <h3
+                        slot="headline"
+                        className="vads-u-margin-top--0 vads-u-margin-bottom--1"
+                      >
                         Your refill request for this medication is taking longer
                         than expected
                       </h3>


### PR DESCRIPTION
Follow up for #34633 

Minor layout fix for the alert header:

<img width="747" alt="image" src="https://github.com/user-attachments/assets/49fa5ec3-820c-43a8-bc08-f93385021324" />