### PR TITLE
MHV-65855 SM to Profile: focus on signature 

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect, useDispatch, useSelector } from 'react-redux';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
@@ -32,6 +34,7 @@ const LegalNameDescription = () => (
 
 const PersonalInformationSection = ({ dob }) => {
   const dispatch = useDispatch();
+  const location = useLocation();
   const messagingSignatureEnabled = useSelector(
     state =>
       state.featureToggles[
@@ -46,6 +49,7 @@ const PersonalInformationSection = ({ dob }) => {
   const messagingSignature = useSelector(
     state => state.user?.profile?.mhvAccount?.messagingSignature,
   );
+  const messagingSignatureName = messagingSignature?.signatureName;
 
   useEffect(
     () => {
@@ -62,6 +66,20 @@ const PersonalInformationSection = ({ dob }) => {
       messagingSignature,
       messagingSignatureEnabled,
     ],
+  );
+
+  useEffect(
+    () => {
+      const fieldName = `#${FIELD_IDS[FIELD_NAMES.MESSAGING_SIGNATURE]}`;
+      if (messagingSignatureName !== null && location.hash === fieldName) {
+        const targetElement = document.querySelector(fieldName);
+        if (targetElement) {
+          targetElement.scrollIntoView({ behavior: 'smooth' });
+          focusElement(targetElement.querySelector('h2'));
+        }
+      }
+    },
+    [messagingSignatureName, location.hash],
   );
 
   const updatedCardFields = useMemo(


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

```
Feature flag: `mhv_secure_messaging_signature_settings`
```
**User Story**:  As a SM user, I want to be able to edit my signature settings from the start a new message page, so I can easily navigate to VA.gov profile to make necessary changes without having to go to MHC classic to make changes to my signature settings. 

**GIVEN**: User with signature settings is on the start a new message page
**WHEN**: User wants to change his signature settings
**THEN**: User can click a new link to take user to VA.gov profile where user is able to edit signature settings

Figma link:

https://www.figma.com/design/x9YoKDPekIPiqlDiZdmjci/Z---Signature%2Fpreferences?node-id=1409-28685&t=cjAwOfHCy58mdIs9-4

<img width=300 src="https://github.com/user-attachments/assets/8397c31d-7082-4c40-aa80-6bcc93323b13"/>


1. Add "Edit signature for all messages" link below the message field. This link will only appear to users who have an existing signature setting.
2. Link will navigate user to VA.gov profile-personal information.  Link will open in the same tab.
3. Focus state:  Once  a user clicks on the link and gets to profile, the user shouldn't have to scroll down and the focus state should be on the messaging signature box
4. Edit Preferences button is hidden when the flag is enabled, continue displaying when flag is disabled  (see screen shot below)

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-65855
- https://github.com/department-of-veterans-affairs/vets-website/pull/34814 related to the following ticket

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width=100 src="https://github.com/user-attachments/assets/133b14be-f1fa-407d-8cc1-48602db59717"/> |<img width=100 src="https://github.com/user-attachments/assets/44fb5fd5-fda0-4dc7-bdac-050f4230990e" />|
| Desktop |<img width=200 src="https://github.com/user-attachments/assets/0e8e104c-6076-46bc-85fb-956fcd38e7e2" />|<img width=200 src="https://github.com/user-attachments/assets/9cd72828-edf1-4c6f-9306-0396399390ed" />|

## What areas of the site does it impact?

My Health - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
