### PR TITLE
[SIMPLE-FORMS] feat: form upload update component to use storybook version of file form upload

### DIFF
--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -8,7 +8,7 @@ import { getFormNumber, mask, formattedPhoneNumber } from '../helpers';
 import EditLink from './EditLink';
 
 const CustomReviewTopContent = () => {
-  const { form } = useSelector(state => state || {});
+  const { data: formData } = useSelector(state => state?.form || {});
   const {
     uploadedFile,
     idNumber,
@@ -16,7 +16,7 @@ const CustomReviewTopContent = () => {
     fullName,
     phoneNumber,
     email,
-  } = form?.data;
+  } = formData;
 
   const renderPersonalInfo = () => (
     <div>

--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -56,7 +56,7 @@ const CustomReviewTopContent = () => {
   const filePayload = {
     name: uploadedFile?.name,
     size: uploadedFile?.size,
-    type: uploadedFile?.type,
+    type: '',
   };
 
   return (

--- a/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
+++ b/src/applications/simple-forms/form-upload/components/CustomReviewTopContent.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import {
-  VaCard,
-  VaIcon,
   VaTelephone,
+  VaFileInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import {
-  getFileSize,
-  getFormNumber,
-  mask,
-  formattedPhoneNumber,
-} from '../helpers';
+import { getFormNumber, mask, formattedPhoneNumber } from '../helpers';
 import EditLink from './EditLink';
 
 const CustomReviewTopContent = () => {
@@ -23,35 +17,6 @@ const CustomReviewTopContent = () => {
     phoneNumber,
     email,
   } = form?.data;
-
-  const renderFileInfo = file => (
-    <div className="vads-l-col--12 medium-screen:vads-l-col--12 small-desktop-screen:vads-l-col--8">
-      <VaCard>
-        <div className="vads-u-display--flex vads-u-flex-direction--row">
-          <span className="vads-u-color--primary">
-            <VaIcon
-              size={6}
-              icon="file_present"
-              className="vads-u-margin-right--1"
-              srtext="icon representing a file"
-              aria-hidden="true"
-            />
-          </span>
-          <div className="vads-u-display--flex vads-u-flex-direction--column">
-            <span
-              className="vads-u-font-weight--bold"
-              style={{ wordBreak: 'break-all' }}
-            >
-              {file.name}
-            </span>
-            <span className="vads-u-color--gray-darker">
-              {getFileSize(file.size)}
-            </span>
-          </div>
-        </div>
-      </VaCard>
-    </div>
-  );
 
   const renderPersonalInfo = () => (
     <div>
@@ -88,6 +53,11 @@ const CustomReviewTopContent = () => {
   );
 
   const formNumber = getFormNumber().toLowerCase();
+  const filePayload = {
+    name: uploadedFile?.name,
+    size: uploadedFile?.size,
+    type: uploadedFile?.type,
+  };
 
   return (
     <>
@@ -118,7 +88,7 @@ const CustomReviewTopContent = () => {
         <h3>Uploaded file</h3>
         <EditLink href={`/${formNumber}/upload`} label="Edit Uploaded file" />
       </div>
-      {uploadedFile && renderFileInfo(uploadedFile)}
+      {uploadedFile && <VaFileInput value={filePayload} readOnly uswds />}
     </>
   );
 };

--- a/src/applications/simple-forms/form-upload/tests/unit/components/CustomReviewTopContent.unit.spec.jsx
+++ b/src/applications/simple-forms/form-upload/tests/unit/components/CustomReviewTopContent.unit.spec.jsx
@@ -33,7 +33,7 @@ const mockStore = withPhoneNumber => ({
         metadata: {},
       },
       data: {
-        uploadedFile: { name: 'test-file.png', size: 800 },
+        uploadedFile: { name: 'test-file.png', size: 800, type: 'image/png' },
         idNumber: { ssn: '234232345' },
         address: { postalCode: '55555' },
         fullName: { first: 'John', last: 'Veteran' },
@@ -66,28 +66,20 @@ describe('CustomReviewTopContent', () => {
   });
 
   describe('renderFileInfo', () => {
-    it('renders the correct card', () => {
+    it('renders the correct component', () => {
       const { container } = subject();
 
-      const card = $('va-card', container);
-      expect(card).to.exist;
+      const component = $('va-file-input', container);
+      expect(component).to.exist;
     });
 
-    it('renders the correct icon', () => {
+    it('renders the file input component', () => {
       const { container } = subject();
+      const fileInput = $('va-file-input', container);
 
-      const card = $('va-card', container);
-      const icon = $('va-icon', card);
-
-      expect(icon).to.exist;
-      expect(icon).to.have.attr('icon', 'file_present');
-    });
-
-    it('renders the correct file data', () => {
-      const { getByText } = subject();
-
-      expect(getByText('test-file.png')).to.exist;
-      expect(getByText('800 B')).to.exist;
+      expect(fileInput).to.exist;
+      expect(fileInput).to.have.attr('read-only', 'true');
+      expect(fileInput).to.have.attr('uswds', 'true');
     });
   });
 

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
@@ -5,6 +5,48 @@ import PropTypes from 'prop-types';
 import vaFileInputFieldMapping from './vaFileInputFieldMapping';
 import { getFileSize, uploadScannedForm } from './vaFileInputFieldHelpers';
 
+const useFileValidator = options => {
+  const validateFileSize = file => {
+    const { maxFileSize } = options;
+    if (file && maxFileSize && file.size > maxFileSize) {
+      const fileSizeString = getFileSize(maxFileSize);
+      return `File size cannot be greater than ${fileSizeString}`;
+    }
+    return null;
+  };
+
+  return { validateFileSize };
+};
+
+const useFileUpload = (fileUploadUrl, formNumber, dispatch) => {
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadFile = (file, onSuccess) => {
+    setIsUploading(true);
+
+    const onFileUploaded = uploadedFile => {
+      setIsUploading(false);
+      if (onSuccess) onSuccess(uploadedFile);
+    };
+
+    const onFileUploading = () => {
+      setIsUploading(true);
+    };
+
+    dispatch(
+      uploadScannedForm(
+        fileUploadUrl,
+        formNumber,
+        file,
+        onFileUploaded,
+        onFileUploading,
+      ),
+    );
+  };
+
+  return { isUploading, uploadFile };
+};
+
 /**
  * Usage uiSchema:
  * ```
@@ -35,64 +77,66 @@ import { getFileSize, uploadScannedForm } from './vaFileInputFieldHelpers';
  * ```
  * @param {WebComponentFieldProps} props */
 const VaFileInputField = props => {
+  const { uiOptions = {}, childrenProps } = props;
+  const { formNumber } = uiOptions;
   const mappedProps = vaFileInputFieldMapping(props);
-  const dispatch = useDispatch();
-  const { formNumber } = props?.uiOptions;
   const { fileUploadUrl } = mappedProps;
+  const dispatch = useDispatch();
   const [error, setError] = useState(mappedProps.error);
-  const [isUploading, setIsUploading] = useState(false);
+  const fileValidator = useFileValidator(uiOptions);
+  const { isUploading, uploadFile } = useFileUpload(
+    fileUploadUrl,
+    formNumber,
+    dispatch,
+  );
 
-  const onFileUploaded = async uploadedFile => {
-    if (uploadedFile.file) {
-      const {
-        confirmationCode,
-        isEncrypted,
-        name,
-        size,
-        warnings,
-        errorMessage,
-      } = uploadedFile;
-      setError(errorMessage);
-      setIsUploading(false);
-      props.childrenProps.onChange({
-        confirmationCode,
-        isEncrypted,
-        name,
-        size,
-        warnings,
-      });
-    }
+  const assignFileUploadToStore = uploadedFile => {
+    if (!uploadedFile) return;
+
+    const {
+      confirmationCode,
+      isEncrypted,
+      name,
+      size,
+      file,
+      warnings,
+      errorMessage,
+    } = uploadedFile;
+
+    childrenProps.onChange({
+      confirmationCode,
+      isEncrypted,
+      name,
+      size,
+      type: file.type,
+      warnings,
+      errorMessage,
+    });
   };
 
-  const onFileUploading = () => {
-    setIsUploading(true);
-    props.childrenProps.onChange({ name: 'uploading' });
+  const handleFileProcessing = uploadedFile => {
+    if (!uploadedFile || !uploadedFile.file) return;
+
+    setError(uploadedFile.errorMessage);
+    assignFileUploadToStore(uploadedFile);
   };
 
   const handleVaChange = e => {
     const fileFromEvent = e.detail.files[0];
     if (!fileFromEvent) {
       setError(mappedProps.error);
-      props.childrenProps.onChange({});
+      childrenProps.onChange({});
       return;
     }
 
-    const { maxFileSize } = props.uiOptions;
-    if (fileFromEvent.size > maxFileSize) {
-      const fileSizeString = getFileSize(maxFileSize);
-      setError(`File size cannot be greater than ${fileSizeString}`);
+    const sizeError = fileValidator.validateFileSize(fileFromEvent);
+    if (sizeError) {
+      setError(sizeError);
       return;
     }
 
-    dispatch(
-      uploadScannedForm(
-        fileUploadUrl,
-        formNumber,
-        fileFromEvent,
-        onFileUploaded,
-        onFileUploading,
-      ),
-    );
+    childrenProps.onChange({ name: 'uploading' });
+    uploadFile(fileFromEvent, handleFileProcessing);
   };
 
   return (
@@ -102,19 +146,26 @@ const VaFileInputField = props => {
       uploadedFile={mappedProps.uploadedFile}
       onVaChange={handleVaChange}
     >
-      {isUploading ? (
+      {isUploading && (
         <div>
           <em>Uploading...</em>
         </div>
-      ) : null}
+      )}
     </VaFileInput>
   );
 };
 
 VaFileInputField.propTypes = {
   childrenProps: PropTypes.object.isRequired,
-  uiOptions: PropTypes.object.isRequired,
+  uiOptions: PropTypes.shape({
+    maxFileSize: PropTypes.number,
+    formNumber: PropTypes.string,
+  }),
   onVaChange: PropTypes.func,
+};
+
+VaFileInputField.defaultProps = {
+  uiOptions: {},
 };
 
 export default VaFileInputField;

--- a/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldMapping.jsx
@@ -14,6 +14,7 @@ const vaFileInputFieldMapping = props => {
     accept: uiOptions?.accept || '.pdf,.jpeg,.png', // A comma-separated list of unique file type specifiers.
     buttonText: uiOptions?.buttonText,
     fileUploadUrl: uiOptions?.fileUploadUrl,
+    readOnly: uiOptions?.readOnly,
     headerSize: commonFieldProps.labelHeaderLevel,
     messageAriaDescribedby:
       commonFieldProps.messageAriaDescribedby || textDescription || undefined,

--- a/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/fileInputPattern.jsx
@@ -129,6 +129,9 @@ export const fileInputSchema = {
     size: {
       type: 'integer',
     },
+    fileType: {
+      type: 'string',
+    },
     warnings: {
       type: 'array',
       items: {


### PR DESCRIPTION
## Summary

- This work updates the form upload review page to the use the new read-only version of the file upload component, including all changes which were necessary to allow this change.
- I'm on the Veteran Facing Forms team who owns this page and component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#2032

## Testing done

- Unit and E2E tests pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any
