### PR TITLE
MHV-66103: Account summaries treatment facilities properly filtered

### DIFF
--- a/src/applications/mhv-medical-records/reducers/blueButton.js
+++ b/src/applications/mhv-medical-records/reducers/blueButton.js
@@ -270,11 +270,13 @@ export const convertAccountSummary = data => {
   const { facilities = [], ipas } = data;
 
   // Map facilities
-  const mappedFacilities = facilities.map(facility => ({
-    facilityName: facility.facilityInfo?.name || 'Unknown facility',
-    stationNumber: facility.facilityInfo?.stationNumber || 'Unknown ID',
-    type: facility.facilityInfo?.treatment ? 'Treatment' : 'VAMC',
-  }));
+  const mappedFacilities = facilities
+    .filter(facility => facility.facilityInfo.treatment)
+    .map(facility => ({
+      facilityName: facility.facilityInfo?.name || 'Unknown facility',
+      stationNumber: facility.facilityInfo?.stationNumber || 'Unknown ID',
+      type: facility.facilityInfo?.treatment ? 'Treatment' : 'VAMC',
+    }));
 
   // Extract user profile details
   const ipa = ipas && ipas[0];

--- a/src/applications/mhv-medical-records/tests/reducers/blueButton.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/blueButton.unit.spec.js
@@ -283,6 +283,14 @@ describe('convertAccountSummary', () => {
             treatment: true,
           },
         },
+        {
+          facilityInfo: {
+            id: '124',
+            name: 'VA Medical Center 2',
+            stationNumber: 'TEST2',
+            treatment: false,
+          },
+        },
       ],
       ipas: [
         {
@@ -308,18 +316,13 @@ describe('convertAccountSummary', () => {
       '123',
     );
     expect(result.vaTreatmentFacilities).to.be.an('array');
-  });
 
-  it('should handle missing optional fields', () => {
-    const data = {
-      facilities: [],
-      ipas: [],
-    };
-
-    const result = convertAccountSummary(data);
-    expect(result).to.deep.equal({
-      authenticationSummary: {},
-      vaTreatmentFacilities: [],
+    // Ensure result.vaTreatmentFacilities only contains facilities where treatment is true
+    expect(result.vaTreatmentFacilities).to.have.lengthOf(1);
+    expect(result.vaTreatmentFacilities[0]).to.deep.equal({
+      facilityName: 'VA Medical Center',
+      stationNumber: 'TEST',
+      type: 'Treatment',
     });
   });
 });


### PR DESCRIPTION
## Summary
Patients' facilities in the account summary section of Blue Button report now only shows facilities that the patient has been treated at. This matches the behavior of the legacy BB report. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-66103
### Blue Button – MHV Account summary includes more fields than MHV Classic and should only display VA treatment facilities

## Testing done
Tests added to verify treatment facilities are being filtered properly. 

## Screenshots
<img width="837" alt="Screenshot 2025-02-25 at 10 35 24 AM" src="https://github.com/user-attachments/assets/94d11fbb-f599-4371-9477-e785c31bb610" />

## What areas of the site does it impact?
MHV medical records Blue Button report

## Acceptance criteria
Facilities in VA.gov Blue Button report match the list in legacy

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
