### PR TITLE
VAGOV-TEAM-101162: Render custom step (with text input)

### DIFF
--- a/src/applications/simple-forms-form-engine/shared/config/components/textInput.js
+++ b/src/applications/simple-forms-form-engine/shared/config/components/textInput.js
@@ -1,0 +1,7 @@
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @returns {[SchemaOptions, UISchemaOptions]} */
+export default ({ hint, label }) => [
+  webComponentPatterns.textSchema,
+  webComponentPatterns.textUI({ title: label, hint }),
+];

--- a/src/applications/simple-forms-form-engine/shared/config/formConfig.js
+++ b/src/applications/simple-forms-form-engine/shared/config/formConfig.js
@@ -88,6 +88,43 @@ export const normalizedForm = {
       chapterTitle: 'Generated List & Loop',
       pageTitle: 'List & Loop',
     },
+    {
+      id: 172736,
+      type: 'digital_form_custom_step',
+      chapterTitle: 'My custom step',
+      pages: [
+        {
+          bodyText: 'My custom body text',
+          components: [
+            {
+              hint: 'This is optional hint text',
+              label: 'My custom text input',
+              required: true,
+              type: 'digital_form_text_input',
+            },
+          ],
+          pageTitle: 'My custom page',
+        },
+        {
+          bodyText: 'With additonal body text',
+          components: [
+            {
+              hint: null,
+              label: 'A text input with no hint text',
+              required: true,
+              type: 'digital_form_text_input',
+            },
+            {
+              hint: 'This text input is not required',
+              label: 'An optional text input',
+              required: false,
+              type: 'digital_form_text_input',
+            },
+          ],
+          pageTitle: 'An additional page',
+        },
+      ],
+    },
   ],
 };
 

--- a/src/applications/simple-forms-form-engine/shared/config/pages/customStepPage.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/customStepPage.js
@@ -4,7 +4,7 @@ import textInput from '../components/textInput';
 
 /** @returns {PageSchema} */
 export default ({ components, bodyText, pageTitle }) => {
-  const schema = { properties: {}, required: [] };
+  const schema = { properties: {}, required: [], type: 'object' };
   const uiSchema = {
     ...webComponentPatterns.titleUI(pageTitle, bodyText),
   };

--- a/src/applications/simple-forms-form-engine/shared/config/pages/customStepPage.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/customStepPage.js
@@ -1,5 +1,6 @@
 import { camelCase, kebabCase } from 'lodash';
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+import textInput from '../components/textInput';
 
 /** @returns {PageSchema} */
 export default ({ components, bodyText, pageTitle }) => {
@@ -12,8 +13,12 @@ export default ({ components, bodyText, pageTitle }) => {
     // This assumes every component on a page will have a unique label.
     const key = camelCase(component.label);
 
-    schema.properties[key] = {};
-    uiSchema[key] = {};
+    // This will eventually become a switch statement or its own function as
+    // more components get added.
+    const [componentSchema, componentUiSchema] = textInput(component);
+
+    schema.properties[key] = componentSchema;
+    uiSchema[key] = componentUiSchema;
 
     if (component.required) {
       schema.required.push(key);

--- a/src/applications/simple-forms-form-engine/shared/config/pages/customStepPage.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/customStepPage.js
@@ -1,0 +1,30 @@
+import { camelCase, kebabCase } from 'lodash';
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @returns {PageSchema} */
+export default ({ components, bodyText, pageTitle }) => {
+  const schema = { properties: {}, required: [] };
+  const uiSchema = {
+    ...webComponentPatterns.titleUI(pageTitle, bodyText),
+  };
+
+  components.forEach(component => {
+    // This assumes every component on a page will have a unique label.
+    const key = camelCase(component.label);
+
+    schema.properties[key] = {};
+    uiSchema[key] = {};
+
+    if (component.required) {
+      schema.required.push(key);
+    }
+  });
+
+  return {
+    // This assumes every page title within a form is unique.
+    path: kebabCase(pageTitle),
+    schema,
+    title: pageTitle,
+    uiSchema,
+  };
+};

--- a/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
@@ -112,3 +112,36 @@ export const namePage = options => ({
     required: ['name', 'address'],
   },
 });
+
+/** @returns {PageSchema} */
+export const summaryPage = options => ({
+  path: options.required ? 'employers-summary' : 'employers',
+  schema: {
+    type: 'object',
+    properties: {
+      'view:hasEmployers': webComponentPatterns.arrayBuilderYesNoSchema,
+    },
+    required: ['view:hasEmployers'],
+  },
+  title: options.required ? 'Review your employers' : 'Your employers',
+  uiSchema: {
+    'view:hasEmployers': webComponentPatterns.arrayBuilderYesNoUI(
+      options,
+      {
+        title:
+          'Were you employed by the VA, others or self-employed at any time during the last 12 months?',
+        labels: {
+          Y: 'Yes, I have employment to report',
+          N: 'No, I don’t have any employment to report',
+        },
+      },
+      {
+        title: 'Do you have another employer to report?',
+        labels: {
+          Y: 'Yes, I have another employment to report',
+          N: 'No, I don’t have another employment to report',
+        },
+      },
+    ),
+  },
+});

--- a/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
@@ -1,0 +1,26 @@
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @returns {PageSchema} */
+export const datePage = {
+  title: 'Dates you were employed',
+  path: 'employers/:index/dates',
+  uiSchema: {
+    ...webComponentPatterns.arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
+        formData?.name
+          ? `Dates you were employed at ${formData.name}`
+          : 'Dates you were employed',
+    ),
+    dateRange: webComponentPatterns.currentOrPastDateRangeUI(
+      'Start date of employment',
+      'End date of employment',
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      dateRange: webComponentPatterns.currentOrPastDateRangeSchema,
+    },
+    required: ['dateRange'],
+  },
+};

--- a/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
@@ -68,3 +68,29 @@ export const detailPage = {
     }),
   },
 };
+
+/** @returns {PageSchema} */
+export const namePage = options => ({
+  title: 'Name and address of employer or unit',
+  path: 'employers/:index/name-and-address',
+  uiSchema: {
+    ...webComponentPatterns.arrayBuilderItemFirstPageTitleUI({
+      title: 'Name and address of employer or unit',
+      nounSingular: options.nounSingular,
+    }),
+    name: webComponentPatterns.textUI('Name of employer'),
+    address: webComponentPatterns.addressNoMilitaryUI({
+      omit: ['street2', 'street3'],
+    }),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      name: webComponentPatterns.textSchema,
+      address: webComponentPatterns.addressNoMilitarySchema({
+        omit: ['street2', 'street3'],
+      }),
+    },
+    required: ['name', 'address'],
+  },
+});

--- a/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
@@ -24,3 +24,47 @@ export const datePage = {
     required: ['dateRange'],
   },
 };
+
+/** @type {PageSchema} */
+export const detailPage = {
+  path: 'employers/:index/detail',
+  schema: {
+    properties: {
+      typeOfWork: webComponentPatterns.textSchema,
+      hoursPerWeek: webComponentPatterns.numberSchema,
+      lostTime: webComponentPatterns.numberSchema,
+      highestIncome: webComponentPatterns.textSchema,
+    },
+    required: ['typeOfWork', 'hoursPerWeek', 'lostTime', 'highestIncome'],
+    type: 'object',
+  },
+  title: 'Employment detail for employer',
+  uiSchema: {
+    ...webComponentPatterns.arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
+        formData?.name
+          ? `Employment detail for ${formData.name}`
+          : 'Employment detail',
+    ),
+    typeOfWork: webComponentPatterns.textUI({
+      hint: 'If self-employed enter "Self"',
+      title: 'Type of work',
+    }),
+    hoursPerWeek: webComponentPatterns.numberUI({
+      title: 'Hours per week',
+      min: 0,
+      max: 168,
+    }),
+    lostTime: webComponentPatterns.numberUI({
+      hint: 'Total hours',
+      title: 'Lost time from illness',
+      min: 0,
+      max: 8760,
+    }),
+    highestIncome: webComponentPatterns.textUI({
+      currency: true,
+      hint: 'Total $ amount',
+      title: 'Highest gross income per month',
+    }),
+  },
+};

--- a/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/employmentHistory.js
@@ -1,6 +1,6 @@
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
 
-/** @returns {PageSchema} */
+/** @type {PageSchema} */
 export const datePage = {
   title: 'Dates you were employed',
   path: 'employers/:index/dates',
@@ -68,6 +68,24 @@ export const detailPage = {
     }),
   },
 };
+
+/** @returns {PageSchema} */
+export const introPage = options => ({
+  path: 'employers',
+  title: 'Employers',
+  uiSchema: {
+    ...webComponentPatterns.titleUI(
+      `Treatment records`,
+      `In the next few questions, we’ll ask you about the treatment records you’re requesting. You must add at least one treatment request. You may add up to ${
+        options.maxItems
+      }.`,
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {},
+  },
+});
 
 /** @returns {PageSchema} */
 export const namePage = options => ({

--- a/src/applications/simple-forms-form-engine/shared/config/pages/identificationInformation.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/identificationInformation.js
@@ -1,0 +1,27 @@
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @returns {PageSchema} */
+export default ({ includeServiceNumber, pageTitle }) => {
+  const schema = {
+    properties: {
+      veteranId: webComponentPatterns.ssnOrVaFileNumberSchema,
+    },
+    type: 'object',
+  };
+  const uiSchema = {
+    ...webComponentPatterns.titleUI(pageTitle),
+    veteranId: webComponentPatterns.ssnOrVaFileNumberUI(),
+  };
+
+  if (includeServiceNumber) {
+    schema.properties.serviceNumber = webComponentPatterns.serviceNumberSchema;
+    uiSchema.serviceNumber = webComponentPatterns.serviceNumberUI();
+  }
+
+  return {
+    path: 'identification-information',
+    title: pageTitle,
+    schema,
+    uiSchema,
+  };
+};

--- a/src/applications/simple-forms-form-engine/shared/config/pages/index.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/index.js
@@ -1,3 +1,4 @@
+export * as employmentHistory from './employmentHistory';
 export {
   default as identificationInformation,
 } from './identificationInformation';

--- a/src/applications/simple-forms-form-engine/shared/config/pages/index.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/index.js
@@ -1,3 +1,4 @@
+export { default as customStepPage } from './customStepPage';
 export * as employmentHistory from './employmentHistory';
 export {
   default as identificationInformation,

--- a/src/applications/simple-forms-form-engine/shared/config/pages/index.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/index.js
@@ -1,0 +1,4 @@
+export {
+  default as identificationInformation,
+} from './identificationInformation';
+export { default as nameAndDateOfBirth } from './nameAndDateOfBirth';

--- a/src/applications/simple-forms-form-engine/shared/config/pages/nameAndDateOfBirth.js
+++ b/src/applications/simple-forms-form-engine/shared/config/pages/nameAndDateOfBirth.js
@@ -1,0 +1,27 @@
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @returns {PageSchema} */
+export default ({ includeDateOfBirth, pageTitle }) => {
+  const schema = {
+    properties: {
+      fullName: webComponentPatterns.fullNameSchema,
+    },
+    type: 'object',
+  };
+  const uiSchema = {
+    ...webComponentPatterns.titleUI(pageTitle),
+    fullName: webComponentPatterns.fullNameUI(),
+  };
+
+  if (includeDateOfBirth) {
+    schema.properties.dateOfBirth = webComponentPatterns.dateOfBirthSchema;
+    uiSchema.dateOfBirth = webComponentPatterns.dateOfBirthUI();
+  }
+
+  return {
+    path: 'name-and-date-of-birth',
+    title: pageTitle,
+    schema,
+    uiSchema,
+  };
+};

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/components/textInput.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/components/textInput.unit.spec.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import textInput from 'applications/simple-forms-form-engine/shared/config/components/textInput';
+import * as textPatterns from 'platform/forms-system/src/js/web-component-patterns/textPatterns';
+import sinon from 'sinon';
+
+describe('textInput', () => {
+  const component = {
+    hint: 'This is optional hint text',
+    label: 'My custom text input',
+    required: true,
+    type: 'digital_form_text_input',
+  };
+
+  it('is a tuple', () => {
+    const schemas = textInput(component);
+    expect(schemas.length).to.eq(2);
+  });
+
+  describe('schema', () => {
+    const [schema] = textInput(component);
+    it('contains the correct type', () => {
+      expect(schema.type).to.eq('string');
+    });
+  });
+
+  describe('uiSchema', () => {
+    beforeEach(() => {
+      sinon.spy(textPatterns, 'textUI');
+    });
+
+    afterEach(() => {
+      textPatterns.textUI.restore();
+    });
+
+    it('calls textUI with the correct args', () => {
+      textInput(component);
+
+      expect(
+        textPatterns.textUI.calledWithMatch({
+          title: component.label,
+          hint: component.hint,
+        }),
+      ).to.eq(true);
+    });
+  });
+});

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/customStepPage.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/customStepPage.unit.spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as titlePattern from 'platform/forms-system/src/js/web-component-patterns/titlePattern';
+import * as textInput from 'applications/simple-forms-form-engine/shared/config/components/textInput';
 import customStepPage from 'applications/simple-forms-form-engine/shared/config/pages/customStepPage';
 
 describe('customStepPage', () => {
@@ -70,6 +71,20 @@ describe('customStepPage', () => {
   });
 
   context('when component is a text input', () => {
-    it('calls the correct function');
+    let spy;
+
+    beforeEach(() => {
+      spy = sinon.spy(textInput, 'default');
+    });
+
+    afterEach(() => {
+      spy.restore();
+    });
+
+    it('calls the correct function', () => {
+      customStepPage(normalizedPage);
+
+      expect(spy.calledWithMatch(normalizedPage.components[0])).to.eq(true);
+    });
   });
 });

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/customStepPage.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/customStepPage.unit.spec.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as titlePattern from 'platform/forms-system/src/js/web-component-patterns/titlePattern';
+import customStepPage from 'applications/simple-forms-form-engine/shared/config/pages/customStepPage';
+
+describe('customStepPage', () => {
+  const normalizedPage = {
+    bodyText: 'My custom body text',
+    components: [
+      {
+        hint: 'This is optional hint text',
+        label: 'My custom text input',
+        required: true,
+        type: 'digital_form_text_input',
+      },
+      {
+        hint: 'This text input is not required',
+        label: 'An optional text input',
+        required: false,
+        type: 'digital_form_text_input',
+      },
+    ],
+    pageTitle: 'My custom page',
+  };
+
+  beforeEach(() => {
+    sinon.spy(titlePattern, 'titleUI');
+  });
+
+  afterEach(() => {
+    titlePattern.titleUI.restore();
+  });
+
+  it('includes the correct attributes', () => {
+    const pageSchema = customStepPage(normalizedPage);
+
+    expect(pageSchema.title).to.eq(normalizedPage.pageTitle);
+    expect(pageSchema.path).to.eq('my-custom-page');
+  });
+
+  it('calls titleUI with the correct args', () => {
+    customStepPage(normalizedPage);
+
+    expect(
+      titlePattern.titleUI.calledWith(
+        normalizedPage.pageTitle,
+        normalizedPage.bodyText,
+      ),
+    ).to.eq(true);
+  });
+
+  it('creates a schema and uiSchema key for every component', () => {
+    const pageSchema = customStepPage(normalizedPage);
+    const schemaKeys = Object.keys(pageSchema.schema.properties);
+    const uiSchemaKeys = Object.keys(pageSchema.uiSchema);
+
+    expect(schemaKeys.length).to.eq(normalizedPage.components.length);
+
+    [schemaKeys, uiSchemaKeys].forEach(keys => {
+      expect(keys).to.include('myCustomTextInput', 'anOptionalTextInput');
+    });
+  });
+
+  it('requires all required components', () => {
+    const pageSchema = customStepPage(normalizedPage);
+    const { required } = pageSchema.schema;
+
+    expect(required.length).to.eq(1);
+    expect(required[0]).to.eq('myCustomTextInput');
+  });
+
+  context('when component is a text input', () => {
+    it('calls the correct function');
+  });
+});

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
@@ -7,6 +7,7 @@ import {
   detailPage,
   introPage,
   namePage,
+  summaryPage,
 } from 'applications/simple-forms-form-engine/shared/config/pages/employmentHistory';
 
 describe('datePage', () => {
@@ -98,5 +99,21 @@ describe('namePage', () => {
         nounSingular: options.nounSingular,
       }),
     ).to.eq(true);
+  });
+});
+
+describe('summaryPage', () => {
+  it('includes the proper attributes', () => {
+    const options = {
+      required: true,
+    };
+
+    const employerSummary = summaryPage(options);
+
+    expect(employerSummary.schema.properties['view:hasEmployers']).to.eq(
+      webComponentPatterns.arrayBuilderYesNoSchema,
+    );
+    expect(employerSummary.uiSchema['view:hasEmployers']).to.not.eq(undefined);
+    expect(employerSummary.path).to.eq('employers-summary');
   });
 });

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
@@ -5,6 +5,7 @@ import * as arrayBuilderPatterns from 'platform/forms-system/src/js/web-componen
 import {
   datePage,
   detailPage,
+  introPage,
   namePage,
 } from 'applications/simple-forms-form-engine/shared/config/pages/employmentHistory';
 
@@ -39,6 +40,22 @@ describe('detailPage', () => {
     expect(detailPage.uiSchema.hoursPerWeek).to.not.eq(undefined);
     expect(detailPage.uiSchema.lostTime).to.not.eq(undefined);
     expect(detailPage.uiSchema.highestIncome).to.not.eq(undefined);
+  });
+});
+
+describe('introPage', () => {
+  const options = {
+    maxItems: 42,
+  };
+
+  it('includes an introPage', () => {
+    const pageSchema = introPage(options);
+
+    expect(pageSchema.title).to.eq('Employers');
+    expect(pageSchema.path).to.eq('employers');
+    // introPages have no schemas
+    expect(Object.keys(pageSchema.schema.properties).length).to.eq(0);
+    expect(pageSchema.uiSchema).to.not.eq(undefined);
   });
 });
 

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
-import { datePage } from 'applications/simple-forms-form-engine/shared/config/pages/employmentHistory';
+import {
+  datePage,
+  detailPage,
+} from 'applications/simple-forms-form-engine/shared/config/pages/employmentHistory';
 
 describe('datePage', () => {
   it('includes the proper attributes', () => {
@@ -10,5 +13,28 @@ describe('datePage', () => {
       webComponentPatterns.currentOrPastDateRangeSchema,
     );
     expect(datePage.uiSchema.dateRange).to.not.eq(undefined);
+  });
+});
+
+describe('detailPage', () => {
+  it('includes the proper attributes', () => {
+    expect(detailPage.title).to.eq('Employment detail for employer');
+    expect(detailPage.path).to.eq('employers/:index/detail');
+    expect(detailPage.schema.properties.typeOfWork).to.eq(
+      webComponentPatterns.textSchema,
+    );
+    expect(detailPage.schema.properties.hoursPerWeek).to.eq(
+      webComponentPatterns.numberSchema,
+    );
+    expect(detailPage.schema.properties.lostTime).to.eq(
+      webComponentPatterns.numberSchema,
+    );
+    expect(detailPage.schema.properties.highestIncome).to.eq(
+      webComponentPatterns.textSchema,
+    );
+    expect(detailPage.uiSchema.typeOfWork).to.not.eq(undefined);
+    expect(detailPage.uiSchema.hoursPerWeek).to.not.eq(undefined);
+    expect(detailPage.uiSchema.lostTime).to.not.eq(undefined);
+    expect(detailPage.uiSchema.highestIncome).to.not.eq(undefined);
   });
 });

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+import * as arrayBuilderPatterns from 'platform/forms-system/src/js/web-component-patterns/arrayBuilderPatterns';
 import {
   datePage,
   detailPage,
+  namePage,
 } from 'applications/simple-forms-form-engine/shared/config/pages/employmentHistory';
 
 describe('datePage', () => {
@@ -36,5 +39,47 @@ describe('detailPage', () => {
     expect(detailPage.uiSchema.hoursPerWeek).to.not.eq(undefined);
     expect(detailPage.uiSchema.lostTime).to.not.eq(undefined);
     expect(detailPage.uiSchema.highestIncome).to.not.eq(undefined);
+  });
+});
+
+describe('namePage', () => {
+  const options = {
+    nounSingular: 'test employer',
+  };
+
+  let spy;
+
+  beforeEach(() => {
+    spy = sinon.spy(arrayBuilderPatterns, 'arrayBuilderItemFirstPageTitleUI');
+  });
+
+  afterEach(() => {
+    spy.restore();
+  });
+
+  it('includes the proper attributes', () => {
+    const employerNamePage = namePage(options);
+
+    expect(employerNamePage.title).to.eq(
+      'Name and address of employer or unit',
+    );
+    expect(employerNamePage.path).to.eq('employers/:index/name-and-address');
+    expect(employerNamePage.schema.properties.address).to.not.eq(undefined);
+    expect(employerNamePage.schema.properties.name).to.eq(
+      webComponentPatterns.textSchema,
+    );
+    expect(employerNamePage.uiSchema.address).to.not.eq(undefined);
+    expect(employerNamePage.uiSchema.name).to.not.eq(undefined);
+  });
+
+  it('calls arrayBuilderItemFirstPageTitleUI with the correct option', () => {
+    namePage(options);
+
+    expect(
+      spy.calledWithMatch({
+        title: 'Name and address of employer or unit',
+        nounSingular: options.nounSingular,
+      }),
+    ).to.eq(true);
   });
 });

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/employmentHistory.unit.spec.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+import { datePage } from 'applications/simple-forms-form-engine/shared/config/pages/employmentHistory';
+
+describe('datePage', () => {
+  it('includes the proper attributes', () => {
+    expect(datePage.title).to.eq('Dates you were employed');
+    expect(datePage.path).to.eq('employers/:index/dates');
+    expect(datePage.schema.properties.dateRange).to.eq(
+      webComponentPatterns.currentOrPastDateRangeSchema,
+    );
+    expect(datePage.uiSchema.dateRange).to.not.eq(undefined);
+  });
+});

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/identificationInformation.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/identificationInformation.unit.spec.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+import identificationInformation from 'applications/simple-forms-form-engine/shared/config/pages/identificationInformation';
+
+describe('identificationInformation', () => {
+  const normalizedPage = {
+    pageTitle: 'Test Title for Identification Information Page',
+    includeServiceNumber: false,
+  };
+  const pageSchema = identificationInformation(normalizedPage);
+
+  it('includes an identification information page', () => {
+    expect(pageSchema.title).to.eq(normalizedPage.pageTitle);
+    expect(pageSchema.path).to.eq('identification-information');
+  });
+
+  context('when includeServiceNumber is true', () => {
+    const normalizedServiceNumber = {
+      ...normalizedPage,
+      includeServiceNumber: true,
+    };
+    const serviceNumberIncluded = identificationInformation(
+      normalizedServiceNumber,
+    );
+
+    it('includes serviceNumber', () => {
+      expect(serviceNumberIncluded.schema.properties.serviceNumber).to.eq(
+        webComponentPatterns.serviceNumberSchema,
+      );
+      expect(serviceNumberIncluded.uiSchema.serviceNumber).to.not.eq(undefined);
+    });
+  });
+
+  context('when includeServiceNumber is false', () => {
+    it('does not include serviceNumber', () => {
+      expect(pageSchema.schema.properties.serviceNumber).to.eq(undefined);
+      expect(pageSchema.uiSchema.serviceNumber).to.eq(undefined);
+    });
+  });
+});

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/nameAndDateOfBirth.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/config/pages/nameAndDateOfBirth.unit.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
+import nameAndDateOfBirth from 'applications/simple-forms-form-engine/shared/config/pages/nameAndDateOfBirth';
+
+describe('nameAndDateOfBirth', () => {
+  const normalizedPage = {
+    pageTitle: 'Test Title for Name and Date of Birth',
+    includeDateOfBirth: true,
+  };
+
+  const formattedPage = nameAndDateOfBirth(normalizedPage);
+
+  it('includes the correct attributes', () => {
+    expect(formattedPage.title).to.eq(normalizedPage.pageTitle);
+    expect(formattedPage.path).to.eq('name-and-date-of-birth');
+  });
+
+  it('contains fullName', () => {
+    expect(formattedPage.schema.properties.fullName).to.eq(
+      webComponentPatterns.fullNameSchema,
+    );
+    expect(formattedPage.uiSchema.fullName).to.not.eq(undefined);
+  });
+
+  context('when includeDateOfBirth is true', () => {
+    it('contains dateOfBirth', () => {
+      expect(formattedPage.schema.properties.dateOfBirth).to.eq(
+        webComponentPatterns.dateOfBirthSchema,
+      );
+      expect(formattedPage.uiSchema.dateOfBirth).to.not.eq(undefined);
+    });
+  });
+
+  context('when includeDateOfBirth is false', () => {
+    const noDob = { ...normalizedPage, includeDateOfBirth: false };
+    const formattedNameOnly = nameAndDateOfBirth(noDob);
+
+    it('does not contain dateOfBirth', () => {
+      expect(formattedNameOnly.schema.properties.dateOfBirth).to.eq(undefined);
+      expect(formattedNameOnly.uiSchema.dateOfBirth).to.eq(undefined);
+    });
+  });
+});

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -175,6 +175,11 @@ describe('listLoopPages', () => {
   });
 
   context('when the variation is employment history', () => {
+    const { employerDatePage, employerDetailPage } = listLoopPages(
+      optional,
+      arrayBuilderStub,
+    );
+
     it('includes a name page', () => {
       const { employerNamePage } = listLoopPages(optional, arrayBuilderStub);
 
@@ -191,32 +196,11 @@ describe('listLoopPages', () => {
     });
 
     it('includes a date page', () => {
-      const { employerDatePage } = listLoopPages(optional, arrayBuilderStub);
-
       expect(employerDatePage.title).to.eq('Dates you were employed');
     });
 
     it('includes a details page', () => {
-      const { employerDetailPage } = listLoopPages(optional, arrayBuilderStub);
-
       expect(employerDetailPage.title).to.eq('Employment detail for employer');
-      expect(employerDetailPage.path).to.eq('employers/:index/detail');
-      expect(employerDetailPage.schema.properties.typeOfWork).to.eq(
-        webComponentPatterns.textSchema,
-      );
-      expect(employerDetailPage.schema.properties.hoursPerWeek).to.eq(
-        webComponentPatterns.numberSchema,
-      );
-      expect(employerDetailPage.schema.properties.lostTime).to.eq(
-        webComponentPatterns.numberSchema,
-      );
-      expect(employerDetailPage.schema.properties.highestIncome).to.eq(
-        webComponentPatterns.textSchema,
-      );
-      expect(employerDetailPage.uiSchema.typeOfWork).to.not.eq(undefined);
-      expect(employerDetailPage.uiSchema.hoursPerWeek).to.not.eq(undefined);
-      expect(employerDetailPage.uiSchema.lostTime).to.not.eq(undefined);
-      expect(employerDetailPage.uiSchema.highestIncome).to.not.eq(undefined);
     });
   });
 

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -214,10 +214,6 @@ describe('listLoopPages', () => {
         const { employer: introPage, employerSummary } = pages;
 
         expect(introPage.title).to.eq('Employers');
-        expect(introPage.path).to.eq('employers');
-        // introPages have no schemas
-        expect(Object.keys(introPage.schema.properties).length).to.eq(0);
-        expect(introPage.uiSchema).to.not.eq(undefined);
 
         expect(employerSummary.title).to.eq('Review your employers');
         expect(employerSummary.path).to.eq('employers-summary');

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -194,11 +194,6 @@ describe('listLoopPages', () => {
       const { employerDatePage } = listLoopPages(optional, arrayBuilderStub);
 
       expect(employerDatePage.title).to.eq('Dates you were employed');
-      expect(employerDatePage.path).to.eq('employers/:index/dates');
-      expect(employerDatePage.schema.properties.dateRange).to.eq(
-        webComponentPatterns.currentOrPastDateRangeSchema,
-      );
-      expect(employerDatePage.uiSchema.dateRange).to.not.eq(undefined);
     });
 
     it('includes a details page', () => {

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -175,24 +175,16 @@ describe('listLoopPages', () => {
   });
 
   context('when the variation is employment history', () => {
-    const { employerDatePage, employerDetailPage } = listLoopPages(
-      optional,
-      arrayBuilderStub,
-    );
+    const {
+      employerDatePage,
+      employerDetailPage,
+      employerNamePage,
+    } = listLoopPages(optional, arrayBuilderStub);
 
     it('includes a name page', () => {
-      const { employerNamePage } = listLoopPages(optional, arrayBuilderStub);
-
       expect(employerNamePage.title).to.eq(
         'Name and address of employer or unit',
       );
-      expect(employerNamePage.path).to.eq('employers/:index/name-and-address');
-      expect(employerNamePage.schema.properties.address).to.not.eq(undefined);
-      expect(employerNamePage.schema.properties.name).to.eq(
-        webComponentPatterns.textSchema,
-      );
-      expect(employerNamePage.uiSchema.address).to.not.eq(undefined);
-      expect(employerNamePage.uiSchema.name).to.not.eq(undefined);
     });
 
     it('includes a date page', () => {

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -276,64 +276,17 @@ describe('listLoopPages', () => {
 });
 
 describe('personalInfoPages', () => {
-  const optionalFieldsIncluded = {
-    id: 54321,
-    type: 'digital_form_your_personal_info',
-    chapterTitle: 'Your personal information',
-    pages: [
-      {
-        pageTitle: 'Name',
-        includeDateOfBirth: true,
-      },
-      {
-        pageTitle: 'Identification information',
-        includeServiceNumber: true,
-      },
-    ],
-  };
   const yourPersonalInfo = findChapterByType('digital_form_your_personal_info');
   const [nameAndDob, identificationInfo] = yourPersonalInfo.pages;
   const { identificationInformation, nameAndDateOfBirth } = personalInfoPages(
     yourPersonalInfo,
   );
-  const {
-    identificationInformation: serviceNumberIncluded,
-  } = personalInfoPages(optionalFieldsIncluded);
 
   it('includes a nameAndDateOfBirth page', () => {
     expect(nameAndDateOfBirth.title).to.eq(nameAndDob.pageTitle);
   });
 
-  describe('identificationInformation', () => {
-    it('includes an identification information page', () => {
-      expect(identificationInformation.title).to.eq(
-        identificationInfo.pageTitle,
-      );
-      expect(identificationInformation.path).to.eq(
-        'identification-information',
-      );
-    });
-
-    context('when includeServiceNumber is true', () => {
-      it('includes serviceNumber', () => {
-        expect(serviceNumberIncluded.schema.properties.serviceNumber).to.eq(
-          webComponentPatterns.serviceNumberSchema,
-        );
-        expect(serviceNumberIncluded.uiSchema.serviceNumber).to.not.eq(
-          undefined,
-        );
-      });
-    });
-
-    context('when includeServiceNumber is false', () => {
-      it('does not include serviceNumber', () => {
-        expect(identificationInformation.schema.properties.serviceNumber).to.eq(
-          undefined,
-        );
-        expect(identificationInformation.uiSchema.serviceNumber).to.eq(
-          undefined,
-        );
-      });
-    });
+  it('includes an identificationInformation page', () => {
+    expect(identificationInformation.title).to.eq(identificationInfo.pageTitle);
   });
 });

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -168,10 +168,7 @@ describe('listLoopPages', () => {
   it('includes a summary page', () => {
     const { employerSummary } = listLoopPages(optional, arrayBuilderStub);
 
-    expect(employerSummary.schema.properties['view:hasEmployers']).to.eq(
-      webComponentPatterns.arrayBuilderYesNoSchema,
-    );
-    expect(employerSummary.uiSchema['view:hasEmployers']).to.not.eq(undefined);
+    expect(employerSummary.path).to.eq('employers');
   });
 
   context('when the variation is employment history', () => {

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -298,39 +298,10 @@ describe('personalInfoPages', () => {
   );
   const {
     identificationInformation: serviceNumberIncluded,
-    nameAndDateOfBirth: dobIncluded,
   } = personalInfoPages(optionalFieldsIncluded);
 
-  describe('nameAndDateOfBirth', () => {
-    it('includes the correct attributes', () => {
-      expect(nameAndDateOfBirth.title).to.eq(nameAndDob.pageTitle);
-      expect(nameAndDateOfBirth.path).to.eq('name-and-date-of-birth');
-    });
-
-    it('contains fullName', () => {
-      expect(nameAndDateOfBirth.schema.properties.fullName).to.eq(
-        webComponentPatterns.fullNameSchema,
-      );
-      expect(nameAndDateOfBirth.uiSchema.fullName).to.not.eq(undefined);
-    });
-
-    context('when includeDateOfBirth is true', () => {
-      it('contains dateOfBirth', () => {
-        expect(dobIncluded.schema.properties.dateOfBirth).to.eq(
-          webComponentPatterns.dateOfBirthSchema,
-        );
-        expect(dobIncluded.uiSchema.dateOfBirth).to.not.eq(undefined);
-      });
-    });
-
-    context('when includeDateOfBirth is false', () => {
-      it('does not contain dateOfBirth', () => {
-        expect(nameAndDateOfBirth.schema.properties.dateOfBirth).to.eq(
-          undefined,
-        );
-        expect(nameAndDateOfBirth.uiSchema.dateOfBirth).to.eq(undefined);
-      });
-    });
+  it('includes a nameAndDateOfBirth page', () => {
+    expect(nameAndDateOfBirth.title).to.eq(nameAndDob.pageTitle);
   });
 
   describe('identificationInformation', () => {

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/digitalFormPatterns.unit.spec.js
@@ -2,11 +2,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
 import * as addressPatterns from 'platform/forms-system/src/js/web-component-patterns/addressPattern';
+import { camelCase } from 'lodash';
 import * as digitalFormPatterns from '../../../utils/digitalFormPatterns';
 import { normalizedForm } from '../../../config/formConfig';
 
 const {
   addressPages,
+  customStepPages,
   listLoopPages,
   personalInfoPages,
   phoneAndEmailPages,
@@ -68,6 +70,17 @@ describe('addressPages', () => {
       expect(noMilitarySpy.calledOnce).to.eq(true);
       expect(schemas[chapter.id].uiSchema.address).to.not.eq(undefined);
     });
+  });
+});
+
+describe('customStepPages', () => {
+  it('returns the correct number of pages', () => {
+    const chapter = findChapterByType('digital_form_custom_step');
+    const schemas = customStepPages(chapter);
+    const camelTitle = camelCase(chapter.pages[0].pageTitle);
+
+    expect(Object.keys(schemas).length).to.eq(chapter.pages.length);
+    expect(schemas[camelTitle].title).to.eq(chapter.pages[0].pageTitle);
   });
 });
 

--- a/src/applications/simple-forms-form-engine/shared/tests/unit/utils/formConfig.unit.spec.js
+++ b/src/applications/simple-forms-form-engine/shared/tests/unit/utils/formConfig.unit.spec.js
@@ -20,6 +20,7 @@ const [
   address,
   phoneAndEmail,
   listLoop,
+  customStep,
 ] = normalizedForm.chapters;
 
 describe('createFormConfig', () => {
@@ -127,6 +128,18 @@ describe('formatPages', () => {
       formatPages(address);
 
       expect(spy.calledWith(address)).to.eq(true);
+    });
+  });
+
+  context('when digital_form_custom_step', () => {
+    beforeEach(() => {
+      spy = sinon.spy(digitalFormPatterns, 'customStepPages');
+    });
+
+    it('calls customStepPages', () => {
+      formatPages(customStep);
+
+      expect(spy.calledWith(customStep)).to.eq(true);
     });
   });
 

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -1,6 +1,7 @@
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import { formatReviewDate } from 'platform/forms-system/exportsFile';
+import { camelCase } from 'lodash';
 import {
   employmentHistory,
   identificationInformation,
@@ -12,8 +13,7 @@ const defaultSchema = {
   type: 'object',
 };
 
-// This chapter contains only one page. This is often referred to as a single
-// response step.
+// This chapter contains only one page.
 /** @returns {FormConfigPages} */
 const singlePageChapter = ({ id, pageTitle, schema, uiSchema }) => ({
   [id]: {
@@ -46,7 +46,15 @@ export const addressPages = ({ additionalFields, id, pageTitle }) => {
 };
 
 /** @returns {FormConfigPages} */
-export const customStepPages = _chapter => {};
+export const customStepPages = chapter => {
+  const pages = {};
+  chapter.pages.forEach(page => {
+    // This assumes every pageTitle within a chapter is unique.
+    pages[camelCase(page.pageTitle)] = { title: page.pageTitle };
+  });
+
+  return pages;
+};
 
 /** @returns {FormConfigPages} */
 export const phoneAndEmailPages = ({ additionalFields, id, pageTitle }) => {

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -46,6 +46,9 @@ export const addressPages = ({ additionalFields, id, pageTitle }) => {
 };
 
 /** @returns {FormConfigPages} */
+export const customStepPages = _chapter => {};
+
+/** @returns {FormConfigPages} */
 export const phoneAndEmailPages = ({ additionalFields, id, pageTitle }) => {
   const schema = {
     ...defaultSchema,

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -1,6 +1,7 @@
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import { formatReviewDate } from 'platform/forms-system/exportsFile';
+import nameAndDateOfBirth from '../config/pages/nameAndDateOfBirth';
 
 /** @type {SchemaOptions} */
 const defaultSchema = {
@@ -260,32 +261,6 @@ export const personalInfoPages = chapter => {
   const [nameAndDob, identificationInfo] = chapter.pages;
 
   /** @returns {PageSchema} */
-  const nameAndDobPage = ({ includeDateOfBirth, pageTitle }) => {
-    const schema = {
-      ...defaultSchema,
-      properties: {
-        fullName: webComponentPatterns.fullNameSchema,
-      },
-    };
-    const uiSchema = {
-      ...webComponentPatterns.titleUI(pageTitle),
-      fullName: webComponentPatterns.fullNameUI(),
-    };
-
-    if (includeDateOfBirth) {
-      schema.properties.dateOfBirth = webComponentPatterns.dateOfBirthSchema;
-      uiSchema.dateOfBirth = webComponentPatterns.dateOfBirthUI();
-    }
-
-    return {
-      path: 'name-and-date-of-birth',
-      title: pageTitle,
-      schema,
-      uiSchema,
-    };
-  };
-
-  /** @returns {PageSchema} */
   const identificationInfoPage = ({ includeServiceNumber, pageTitle }) => {
     const schema = {
       ...defaultSchema,
@@ -313,7 +288,7 @@ export const personalInfoPages = chapter => {
   };
 
   return {
-    nameAndDateOfBirth: nameAndDobPage(nameAndDob),
+    nameAndDateOfBirth: nameAndDateOfBirth(nameAndDob),
     identificationInformation: identificationInfoPage(identificationInfo),
   };
 };

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -3,11 +3,11 @@ import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-b
 import { formatReviewDate } from 'platform/forms-system/exportsFile';
 import { camelCase } from 'lodash';
 import {
+  customStepPage,
   employmentHistory,
   identificationInformation,
   nameAndDateOfBirth,
 } from '../config/pages';
-import customStepPage from '../config/pages/customStepPage';
 
 /** @type {SchemaOptions} */
 const defaultSchema = {

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -1,7 +1,7 @@
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import { formatReviewDate } from 'platform/forms-system/exportsFile';
-import nameAndDateOfBirth from '../config/pages/nameAndDateOfBirth';
+import { identificationInformation, nameAndDateOfBirth } from '../config/pages';
 
 /** @type {SchemaOptions} */
 const defaultSchema = {
@@ -260,35 +260,8 @@ export const listLoopPages = (
 export const personalInfoPages = chapter => {
   const [nameAndDob, identificationInfo] = chapter.pages;
 
-  /** @returns {PageSchema} */
-  const identificationInfoPage = ({ includeServiceNumber, pageTitle }) => {
-    const schema = {
-      ...defaultSchema,
-      properties: {
-        veteranId: webComponentPatterns.ssnOrVaFileNumberSchema,
-      },
-    };
-    const uiSchema = {
-      ...webComponentPatterns.titleUI(pageTitle),
-      veteranId: webComponentPatterns.ssnOrVaFileNumberUI(),
-    };
-
-    if (includeServiceNumber) {
-      schema.properties.serviceNumber =
-        webComponentPatterns.serviceNumberSchema;
-      uiSchema.serviceNumber = webComponentPatterns.serviceNumberUI();
-    }
-
-    return {
-      path: 'identification-information',
-      title: pageTitle,
-      schema,
-      uiSchema,
-    };
-  };
-
   return {
     nameAndDateOfBirth: nameAndDateOfBirth(nameAndDob),
-    identificationInformation: identificationInfoPage(identificationInfo),
+    identificationInformation: identificationInformation(identificationInfo),
   };
 };

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -1,7 +1,11 @@
 import * as webComponentPatterns from 'platform/forms-system/src/js/web-component-patterns';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import { formatReviewDate } from 'platform/forms-system/exportsFile';
-import { identificationInformation, nameAndDateOfBirth } from '../config/pages';
+import {
+  employmentHistory,
+  identificationInformation,
+  nameAndDateOfBirth,
+} from '../config/pages';
 
 /** @type {SchemaOptions} */
 const defaultSchema = {
@@ -89,30 +93,7 @@ export const listLoopPages = (
     },
   };
 
-  /** @returns {PageSchema} */
-  const datePage = {
-    title: 'Dates you were employed',
-    path: 'employers/:index/dates',
-    uiSchema: {
-      ...webComponentPatterns.arrayBuilderItemSubsequentPageTitleUI(
-        ({ formData }) =>
-          formData?.name
-            ? `Dates you were employed at ${formData.name}`
-            : 'Dates you were employed',
-      ),
-      dateRange: webComponentPatterns.currentOrPastDateRangeUI(
-        'Start date of employment',
-        'End date of employment',
-      ),
-    },
-    schema: {
-      type: 'object',
-      properties: {
-        dateRange: webComponentPatterns.currentOrPastDateRangeSchema,
-      },
-      required: ['dateRange'],
-    },
-  };
+  const { datePage } = employmentHistory;
 
   /** @returns {PageSchema} */
   const namePage = {

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -93,40 +93,13 @@ export const listLoopPages = (
     },
   };
 
-  const { datePage, detailPage, introPage, namePage } = employmentHistory;
-
-  /** @type {PageSchema} */
-  const summaryPage = {
-    path: optional ? 'employers' : 'employers-summary',
-    schema: {
-      type: 'object',
-      properties: {
-        'view:hasEmployers': webComponentPatterns.arrayBuilderYesNoSchema,
-      },
-      required: ['view:hasEmployers'],
-    },
-    title: optional ? 'Your employers' : 'Review your employers',
-    uiSchema: {
-      'view:hasEmployers': webComponentPatterns.arrayBuilderYesNoUI(
-        options,
-        {
-          title:
-            'Were you employed by the VA, others or self-employed at any time during the last 12 months?',
-          labels: {
-            Y: 'Yes, I have employment to report',
-            N: 'No, I don’t have any employment to report',
-          },
-        },
-        {
-          title: 'Do you have another employer to report?',
-          labels: {
-            Y: 'Yes, I have another employment to report',
-            N: 'No, I don’t have another employment to report',
-          },
-        },
-      ),
-    },
-  };
+  const {
+    datePage,
+    detailPage,
+    introPage,
+    namePage,
+    summaryPage,
+  } = employmentHistory;
 
   /** @returns {FormConfigPages} */
   const pageBuilderCallback = pageBuilder => {
@@ -139,7 +112,7 @@ export const listLoopPages = (
 
     return {
       ...pages,
-      employerSummary: pageBuilder.summaryPage(summaryPage),
+      employerSummary: pageBuilder.summaryPage(summaryPage(options)),
       employerNamePage: pageBuilder.itemPage(namePage(options)),
       employerDatePage: pageBuilder.itemPage(datePage),
       employerDetailPage: pageBuilder.itemPage(detailPage),

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -93,7 +93,7 @@ export const listLoopPages = (
     },
   };
 
-  const { datePage } = employmentHistory;
+  const { datePage, detailPage } = employmentHistory;
 
   /** @returns {PageSchema} */
   const namePage = {
@@ -118,50 +118,6 @@ export const listLoopPages = (
         }),
       },
       required: ['name', 'address'],
-    },
-  };
-
-  /** @type {PageSchema} */
-  const detailPage = {
-    path: 'employers/:index/detail',
-    schema: {
-      properties: {
-        typeOfWork: webComponentPatterns.textSchema,
-        hoursPerWeek: webComponentPatterns.numberSchema,
-        lostTime: webComponentPatterns.numberSchema,
-        highestIncome: webComponentPatterns.textSchema,
-      },
-      required: ['typeOfWork', 'hoursPerWeek', 'lostTime', 'highestIncome'],
-      type: 'object',
-    },
-    title: 'Employment detail for employer',
-    uiSchema: {
-      ...webComponentPatterns.arrayBuilderItemSubsequentPageTitleUI(
-        ({ formData }) =>
-          formData?.name
-            ? `Employment detail for ${formData.name}`
-            : 'Employment detail',
-      ),
-      typeOfWork: webComponentPatterns.textUI({
-        hint: 'If self-employed enter "Self"',
-        title: 'Type of work',
-      }),
-      hoursPerWeek: webComponentPatterns.numberUI({
-        title: 'Hours per week',
-        min: 0,
-        max: 168,
-      }),
-      lostTime: webComponentPatterns.numberUI({
-        hint: 'Total hours',
-        title: 'Lost time from illness',
-        min: 0,
-        max: 8760,
-      }),
-      highestIncome: webComponentPatterns.textUI({
-        currency: true,
-        hint: 'Total $ amount',
-        title: 'Highest gross income per month',
-      }),
     },
   };
 

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -93,25 +93,7 @@ export const listLoopPages = (
     },
   };
 
-  const { datePage, detailPage, namePage } = employmentHistory;
-
-  /** @type {PageSchema} */
-  const introPage = {
-    path: 'employers',
-    title: 'Employers',
-    uiSchema: {
-      ...webComponentPatterns.titleUI(
-        `Treatment records`,
-        `In the next few questions, we’ll ask you about the treatment records you’re requesting. You must add at least one treatment request. You may add up to ${
-          options.maxItems
-        }.`,
-      ),
-    },
-    schema: {
-      type: 'object',
-      properties: {},
-    },
-  };
+  const { datePage, detailPage, introPage, namePage } = employmentHistory;
 
   /** @type {PageSchema} */
   const summaryPage = {
@@ -152,7 +134,7 @@ export const listLoopPages = (
     const pages = {};
 
     if (!optional) {
-      pages.employer = pageBuilder.introPage(introPage);
+      pages.employer = pageBuilder.introPage(introPage(options));
     }
 
     return {

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -7,6 +7,7 @@ import {
   identificationInformation,
   nameAndDateOfBirth,
 } from '../config/pages';
+import customStepPage from '../config/pages/customStepPage';
 
 /** @type {SchemaOptions} */
 const defaultSchema = {
@@ -50,7 +51,7 @@ export const customStepPages = chapter => {
   const pages = {};
   chapter.pages.forEach(page => {
     // This assumes every pageTitle within a chapter is unique.
-    pages[camelCase(page.pageTitle)] = { title: page.pageTitle };
+    pages[camelCase(page.pageTitle)] = customStepPage(page);
   });
 
   return pages;

--- a/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/digitalFormPatterns.js
@@ -93,33 +93,7 @@ export const listLoopPages = (
     },
   };
 
-  const { datePage, detailPage } = employmentHistory;
-
-  /** @returns {PageSchema} */
-  const namePage = {
-    title: 'Name and address of employer or unit',
-    path: 'employers/:index/name-and-address',
-    uiSchema: {
-      ...webComponentPatterns.arrayBuilderItemFirstPageTitleUI({
-        title: 'Name and address of employer or unit',
-        nounSingular: options.nounSingular,
-      }),
-      name: webComponentPatterns.textUI('Name of employer'),
-      address: webComponentPatterns.addressNoMilitaryUI({
-        omit: ['street2', 'street3'],
-      }),
-    },
-    schema: {
-      type: 'object',
-      properties: {
-        name: webComponentPatterns.textSchema,
-        address: webComponentPatterns.addressNoMilitarySchema({
-          omit: ['street2', 'street3'],
-        }),
-      },
-      required: ['name', 'address'],
-    },
-  };
+  const { datePage, detailPage, namePage } = employmentHistory;
 
   /** @type {PageSchema} */
   const introPage = {
@@ -184,7 +158,7 @@ export const listLoopPages = (
     return {
       ...pages,
       employerSummary: pageBuilder.summaryPage(summaryPage),
-      employerNamePage: pageBuilder.itemPage(namePage),
+      employerNamePage: pageBuilder.itemPage(namePage(options)),
       employerDatePage: pageBuilder.itemPage(datePage),
       employerDetailPage: pageBuilder.itemPage(detailPage),
     };

--- a/src/applications/simple-forms-form-engine/shared/utils/formConfig.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/formConfig.js
@@ -3,6 +3,7 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import {
   addressPages,
+  customStepPages,
   listLoopPages,
   personalInfoPages,
   phoneAndEmailPages,
@@ -19,6 +20,8 @@ export const formatPages = chapter => {
   switch (chapter.type) {
     case 'digital_form_address':
       return addressPages(chapter);
+    case 'digital_form_custom_step':
+      return customStepPages(chapter);
     case 'digital_form_list_loop':
       return listLoopPages(chapter);
     case 'digital_form_phone_and_email':


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Renders custom Steps using the normalized output from https://github.com/department-of-veterans-affairs/content-build/pull/2454
- Renders text input components using the text patterns from the Forms System Web Component Patterns.
- Refactors PageSchemas into their own `config/pages` directory.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#101162

## Testing done

- New unit tests for `formConfig`, `customStepPages`, `customStepPage`, and `textInput`.
- Manually tested rendering of custom step pages to ensure configs were correct.

## Screenshots

A custom step being rendered off of normalized data:
<img width="537" alt="Screenshot 2025-02-25 at 11 47 30 AM" src="https://github.com/user-attachments/assets/ccb5d859-0499-4c1d-9f5b-9d2ce81c4ff4" />

## What areas of the site does it impact?

- All forms created using the `simple-forms-form-engine` shared code.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

In order to get aesthetically pleasing URLs, (`my-form-name-XX-XXXX/my-custom-step-page`) I had to make a lot of assumptions about the uniqueness of page titles. What do we do if a Form Builder user creates Custom Step pages with non-unique page titles? Ultimately, that is a Product question. Right now, the behavior will be unpredictable and undesirable.
