### PR TITLE
Add new feature toggle to form 0966 for the new confirmation page

### DIFF
--- a/src/applications/simple-forms/21-0966/config/features.js
+++ b/src/applications/simple-forms/21-0966/config/features.js
@@ -1,5 +1,0 @@
-import environment from 'platform/utilities/environment';
-
-export function useNewConfirmationPage() {
-  return environment.isLocalhost() || environment.isDev();
-}

--- a/src/applications/simple-forms/21-0966/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0966/containers/ConfirmationPage.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import FormFooter from 'platform/forms/components/FormFooter';
+import { Toggler } from 'platform/utilities/feature-toggles';
 
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import { DevOnlyTestVariations } from '../components/DevOnlyTestVariations';
@@ -26,7 +27,6 @@ import {
   survivingDependentBenefits,
   submissionApis,
 } from '../definitions/constants';
-import { useNewConfirmationPage } from '../config/features';
 
 const { COMPENSATION, PENSION } = veteranBenefits;
 const { SURVIVOR } = survivingDependentBenefits;
@@ -329,140 +329,142 @@ export const ConfirmationPage = props => {
   const [submitDate, setSubmitDate] = useState(submission.timestamp);
   const { statementOfTruthSignature } = formData;
 
-  if (useNewConfirmationPage()) {
-    return (
-      <ConfirmationView
-        submitDate={submitDate}
-        confirmationNumber={confirmationNumber}
-        formConfig={route?.formConfig}
-        pdfUrl={submissionResponse?.pdfUrl}
-      >
-        <ConfirmationView.SubmissionAlert
-          title={confirmationPageAlertHeadlineV2({
-            formData,
-            submissionApi,
-            submitDate,
-          })}
-          status={confirmationPageAlertStatus(formData)}
-          content={confirmationPageAlertParagraphV2({
-            formData,
-            submissionApi,
-            expirationDate: submissionResponse?.expirationDate,
-            confirmationNumber,
-          })}
-          actions={<></>}
-        />
-        {!confirmationPageFormBypassed(formData) && (
-          <>
-            <ConfirmationView.SavePdfDownload
-              pdfUrl={submissionResponse?.pdfUrl}
-            />
-            <ConfirmationView.ChapterSectionCollection />
-            <ConfirmationView.PrintThisPage />
-            {submissionApi === submissionApis.BENEFITS_INTAKE && (
-              <ConfirmationView.WhatsNextProcessList
-                item1Header="We’ll confirm that we’ve received your form"
-                item1Content="We will contact you when we have received your submission. This can take up to 30 days."
-                item2Header="Next, we’ll review your form"
-                item2Content={
-                  <p>
-                    After we review your form, we’ll confirm next steps. Then
-                    you’ll have 1 year to file your claim.
-                  </p>
-                }
-                item1Actions={<></>}
-              />
-            )}
-          </>
-        )}
-        <NextStepsV2 formData={formData} />
-        <ConfirmationView.HowToContact />
-        <ConfirmationView.GoBackLink />
-        <ConfirmationView.NeedHelp />
-        <DevOnlyTestVariations
-          formData={formData}
-          setFormData={setFormData}
-          submissionResponse={submissionResponse}
-          setSubmissionResponse={setSubmissionResponse}
-          submitDate={submitDate}
-          setSubmitDate={setSubmitDate}
-        />
-      </ConfirmationView>
-    );
-  }
-
-  // Re-enable and incorporate if needed for certain flows
-  // const activeSurvivorITF = submission.response?.survivorIntent;
   return (
-    <>
-      <div className="print-only">
-        <img
-          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-          alt="VA logo"
-          width="300"
-        />
-      </div>
-      <va-alert
-        close-btn-aria-label="Close notification"
-        status={confirmationPageAlertStatus(formData)}
-        visible
-        uswds
-      >
-        <h2 slot="headline">{confirmationPageAlertHeadline(formData)}</h2>
-        <p className="vads-u-margin-bottom--0">
-          {confirmationPageAlertParagraph(formData)}
-        </p>
-      </va-alert>
-      {!confirmationPageFormBypassed(formData) && (
-        <div className="inset">
-          <h3 className="vads-u-margin-top--1" slot="headline">
-            Your submission information
-          </h3>
-          <dl>
-            {statementOfTruthSignature && (
-              <>
+    <Toggler toggleName={Toggler.TOGGLE_NAMES.form210966ConfirmationPage}>
+      <Toggler.Enabled>
+        <ConfirmationView
+          submitDate={submitDate}
+          confirmationNumber={confirmationNumber}
+          formConfig={route?.formConfig}
+          pdfUrl={submissionResponse?.pdfUrl}
+        >
+          <ConfirmationView.SubmissionAlert
+            title={confirmationPageAlertHeadlineV2({
+              formData,
+              submissionApi,
+              submitDate,
+            })}
+            status={confirmationPageAlertStatus(formData)}
+            content={confirmationPageAlertParagraphV2({
+              formData,
+              submissionApi,
+              expirationDate: submissionResponse?.expirationDate,
+              confirmationNumber,
+            })}
+            actions={<></>}
+          />
+          {!confirmationPageFormBypassed(formData) && (
+            <>
+              <ConfirmationView.SavePdfDownload
+                pdfUrl={submissionResponse?.pdfUrl}
+              />
+              <ConfirmationView.ChapterSectionCollection />
+              <ConfirmationView.PrintThisPage />
+              {submissionApi === submissionApis.BENEFITS_INTAKE && (
+                <ConfirmationView.WhatsNextProcessList
+                  item1Header="We’ll confirm that we’ve received your form"
+                  item1Content="We will contact you when we have received your submission. This can take up to 30 days."
+                  item2Header="Next, we’ll review your form"
+                  item2Content={
+                    <p>
+                      After we review your form, we’ll confirm next steps. Then
+                      you’ll have 1 year to file your claim.
+                    </p>
+                  }
+                  item1Actions={<></>}
+                />
+              )}
+            </>
+          )}
+          <NextStepsV2 formData={formData} />
+          <ConfirmationView.HowToContact />
+          <ConfirmationView.GoBackLink />
+          <ConfirmationView.NeedHelp />
+          <DevOnlyTestVariations
+            formData={formData}
+            setFormData={setFormData}
+            submissionResponse={submissionResponse}
+            setSubmissionResponse={setSubmissionResponse}
+            submitDate={submitDate}
+            setSubmitDate={setSubmitDate}
+          />
+        </ConfirmationView>
+      </Toggler.Enabled>
+      <Toggler.Disabled>
+        <>
+          <div className="print-only">
+            <img
+              src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+              alt="VA logo"
+              width="300"
+            />
+          </div>
+          <va-alert
+            close-btn-aria-label="Close notification"
+            status={confirmationPageAlertStatus(formData)}
+            visible
+            uswds
+          >
+            <h2 slot="headline">{confirmationPageAlertHeadline(formData)}</h2>
+            <p className="vads-u-margin-bottom--0">
+              {confirmationPageAlertParagraph(formData)}
+            </p>
+          </va-alert>
+          {!confirmationPageFormBypassed(formData) && (
+            <div className="inset">
+              <h3 className="vads-u-margin-top--1" slot="headline">
+                Your submission information
+              </h3>
+              <dl>
+                {statementOfTruthSignature && (
+                  <>
+                    <dt>
+                      <h4>Who submitted this form</h4>
+                    </dt>
+                    <dd>{statementOfTruthSignature}</dd>
+                  </>
+                )}
+                {confirmationNumber && (
+                  <>
+                    <dt>
+                      <h4>Confirmation number</h4>
+                    </dt>
+                    <dd>{confirmationNumber}</dd>
+                  </>
+                )}
+                {isValid(submitDate) && (
+                  <>
+                    <dt>
+                      <h4>Date submitted</h4>
+                    </dt>
+                    <dd>{format(submitDate, 'MMMM d, yyyy')}</dd>
+                  </>
+                )}
                 <dt>
-                  <h4>Who submitted this form</h4>
+                  <h4>Confirmation for your records</h4>
                 </dt>
-                <dd>{statementOfTruthSignature}</dd>
-              </>
-            )}
-            {confirmationNumber && (
-              <>
-                <dt>
-                  <h4>Confirmation number</h4>
-                </dt>
-                <dd>{confirmationNumber}</dd>
-              </>
-            )}
-            {isValid(submitDate) && (
-              <>
-                <dt>
-                  <h4>Date submitted</h4>
-                </dt>
-                <dd>{format(submitDate, 'MMMM d, yyyy')}</dd>
-              </>
-            )}
-            <dt>
-              <h4>Confirmation for your records</h4>
-            </dt>
-            <dd>You can print this confirmation page for your records</dd>
-          </dl>
-          <va-button onClick={window.print} text="Print this page" />
-        </div>
-      )}
-      <AlreadySubmittedHeader formData={formData} />
-      <NextSteps formData={formData} />
-      <ActionLinksToCompleteClaims formData={formData} />
-      {!confirmationPageFormBypassed(formData) && (
-        <a className="vads-c-action-link--green vads-u-margin-y--2" href="/">
-          Go back to VA.gov
-        </a>
-      )}
-      <div>
-        <FormFooter formConfig={{ getHelp: GetFormHelp }} />
-      </div>
-    </>
+                <dd>You can print this confirmation page for your records</dd>
+              </dl>
+              <va-button onClick={window.print} text="Print this page" />
+            </div>
+          )}
+          <AlreadySubmittedHeader formData={formData} />
+          <NextSteps formData={formData} />
+          <ActionLinksToCompleteClaims formData={formData} />
+          {!confirmationPageFormBypassed(formData) && (
+            <a
+              className="vads-c-action-link--green vads-u-margin-y--2"
+              href="/"
+            >
+              Go back to VA.gov
+            </a>
+          )}
+          <div>
+            <FormFooter formConfig={{ getHelp: GetFormHelp }} />
+          </div>
+        </>
+      </Toggler.Disabled>
+    </Toggler>
   );
 };
 

--- a/src/applications/simple-forms/21-0966/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
-import sinon from 'sinon';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { expect } from 'chai';
+import { Toggler } from 'platform/utilities/feature-toggles';
 import formConfig from '../../config/form';
-import * as features from '../../config/features';
 import ConfirmationPage, {
   getNextStepsActionsPlaceholders,
 } from '../../containers/ConfirmationPage';
@@ -98,7 +97,11 @@ const responseExistingBenefitsIntake = {
   submissionApi: 'benefitsIntake',
 };
 
-function makeStore(response, data) {
+function makeStore(
+  response,
+  data,
+  confirmationPageFeatureToggleEnabled = false,
+) {
   return {
     form: {
       formId: formConfig.formId,
@@ -107,6 +110,10 @@ function makeStore(response, data) {
         timestamp: Date.now(),
       },
       data,
+    },
+    featureToggles: {
+      [Toggler.TOGGLE_NAMES
+        .form210966ConfirmationPage]: confirmationPageFeatureToggleEnabled,
     },
   };
 }
@@ -118,43 +125,37 @@ const STORE_SURVIVOR_EXISTING = makeStore(responseExisting, survivorData);
 const STORE_VETERAN_FIRST_TIME_BENEFITS_CLAIMS = makeStore(
   responseNewBenefitsClaims,
   veteranData,
+  true,
 );
 const STORE_VETERAN_FIRST_TIME_BENEFITS_INTAKE = makeStore(
   responseNewBenefitsIntake,
   veteranData,
+  true,
 );
 const STORE_SURVIVOR_FIRST_TIME_BENEFITS_CLAIMS = makeStore(
   responseNewBenefitsClaims,
   survivorData,
+  true,
 );
 const STORE_SURVIVOR_FIRST_TIME_BENEFITS_INTAKE = makeStore(
   responseNewBenefitsIntake,
   survivorData,
+  true,
 );
 const STORE_VETERAN_EXISTING_BENEFITS_CLAIMS = makeStore(
   responseExistingBenefitsClaims,
   veteranData,
+  true,
 );
 const STORE_SURVIVOR_EXISTING_BENEFITS_INTAKE = makeStore(
   responseExistingBenefitsIntake,
   survivorData,
+  true,
 );
-
-let useNewConfirmationPageStub;
 
 describe('Confirmation page V2', () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
-
-  before(() => {
-    useNewConfirmationPageStub = sinon
-      .stub(features, 'useNewConfirmationPage')
-      .returns(true);
-  });
-
-  after(() => {
-    useNewConfirmationPageStub.restore();
-  });
 
   it('it should show status success and the correct name of person for a veteran submitting for the first time (benefits claims)', () => {
     const { container, getByText } = render(
@@ -352,16 +353,6 @@ describe('Confirmation page V2', () => {
 describe('Confirmation page V1', () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
-
-  before(() => {
-    useNewConfirmationPageStub = sinon
-      .stub(features, 'useNewConfirmationPage')
-      .returns(false);
-  });
-
-  after(() => {
-    useNewConfirmationPageStub.restore();
-  });
 
   it('it should show status success and the correct name of person for a veteran submitting for the first time', () => {
     const { container, getByText } = render(

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -80,6 +80,7 @@
   "form2010207": "form2010207",
   "form210845": "form210845",
   "form210966": "form210966",
+  "form210966ConfirmationPage": "form210966ConfirmationPage",
   "form210972": "form210972",
   "form2110210": "form2110210",
   "form214138": "form214138",


### PR DESCRIPTION
## Summary

This adds the new 21-0966 confirmation page feature toggle and uses it in place of the existing dev/localhost checker function. Tests have been updated to check for this feature toggle.

## Related issue(s)

department-of-veterans-affairs/va.gov-team-forms#2031

## Testing done

Updated unit tests for the confirmation page to account for the feature toggle

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed