### PR TITLE
MHV-65626: Previous prescription section changes

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/GroupedMedications.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/GroupedMedications.jsx
@@ -80,10 +80,10 @@ const GroupedMedications = props => {
                 </dd>
                 <dd>Quantity: {rx.quantity}</dd>
                 <dd>
-                  Prescribed on: {dateFormat(rx.orderedDate, 'MMMM D, YYYY')}
+                  Prescribed on {dateFormat(rx.orderedDate, 'MMMM D, YYYY')}
                 </dd>
                 <dd>
-                  Prescribed by:{' '}
+                  Prescribed by{' '}
                   {(rx.providerFirstName && rx.providerLastName) || EMPTY_FIELD}
                 </dd>
               </dl>


### PR DESCRIPTION
## Summary

- Minor UI updates to Rx Details Previous Prescriptions section

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-65626

## Testing done

- Manual testing

## Screenshots

![image](https://github.com/user-attachments/assets/1d4a6302-e528-487a-aecf-bffe2ccd3427)
![image](https://github.com/user-attachments/assets/21ccd67d-85e7-41de-8da9-4f77c1624d26)


## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Remove: “Previous Prescriptions” section when there are none associated with this medication
AC2: Change: When there is only 1 previous prescription, the subtext should say “Showing 1 prescription”
AC3: Prescribed on and Prescribed by fields should not contain a colon. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

