### PR TITLE
Use VaDateField for preferred date selection and use tomorrow as default date

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.js
@@ -28,6 +28,7 @@ import { createMockClinic } from '../../../tests/mocks/data';
 const initialState = {
   featureToggles: {
     vaOnlineSchedulingDirect: true,
+    vaOnlineSchedulingUseVaDate: true,
   },
   user: {
     profile: {

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.js
@@ -28,7 +28,6 @@ import { createMockClinic } from '../../../tests/mocks/data';
 const initialState = {
   featureToggles: {
     vaOnlineSchedulingDirect: true,
-    vaOnlineSchedulingUseVaDate: true,
   },
   user: {
     profile: {

--- a/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.jsx
+++ b/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.jsx
@@ -6,6 +6,7 @@ import {
   format,
   isAfter,
   isBefore,
+  isValid,
   parse,
   startOfDay,
 } from 'date-fns';
@@ -47,6 +48,9 @@ const uiSchema = {
     'ui:validations': [
       (errors, preferredDate) => {
         const date = parse(preferredDate, 'yyyy-MM-dd', new Date());
+        if (!isValid(date)) {
+          errors.addError('Please enter a valid date ');
+        }
         const today = startOfDay(new Date());
         if (isBefore(date, today)) {
           errors.addError('Please enter a future date ');

--- a/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.jsx
+++ b/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.jsx
@@ -1,0 +1,113 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
+import { VaDateField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
+import { useHistory } from 'react-router-dom';
+import {
+  addDays,
+  format,
+  isAfter,
+  isBefore,
+  parse,
+  startOfDay,
+} from 'date-fns';
+import FormButtons from '../../components/FormButtons';
+import { getFormData, selectPageChangeInProgress } from '../redux/selectors';
+import { scrollAndFocus } from '../../utils/scrollAndFocus';
+import useFormState from '../../hooks/useFormState';
+
+import {
+  openFormPage,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+} from '../redux/actions';
+import { getPageTitle } from '../newAppointmentFlow';
+
+const initialSchema = {
+  type: 'object',
+  required: ['preferredDate'],
+  properties: {
+    preferredDate: {
+      type: 'string',
+      format: 'date',
+    },
+  },
+};
+
+const uiSchema = {
+  preferredDate: {
+    'ui:title':
+      "Tell us the earliest day you're available and we'll try to find the date closest to your request.",
+    'ui:widget': 'date',
+    'ui:webComponentField': VaDateField,
+    'ui:description':
+      'Choose a date within the next 13 months for this appointment.',
+    'ui:validations': [
+      (errors, preferredDate) => {
+        const date = parse(preferredDate, 'yyyy-MM-dd', new Date());
+        const today = startOfDay(new Date());
+        if (isBefore(date, today)) {
+          errors.addError('Please enter a future date ');
+        }
+        if (isAfter(date, addDays(today, 395))) {
+          errors.addError(
+            'Please enter a date less than 395 days in the future ',
+          );
+        }
+      },
+    ],
+  },
+};
+
+const pageKey = 'preferredDate';
+
+export default function PreferredDatePageVaDate() {
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
+  const pageChangeInProgress = useSelector(selectPageChangeInProgress);
+  const dispatch = useDispatch();
+  const currentData = useSelector(getFormData);
+  const { data, schema, setData } = useFormState({
+    initialSchema,
+    uiSchema,
+    initialData: {
+      ...currentData,
+      preferredDate:
+        currentData.preferredDate ||
+        format(addDays(new Date(), 1), 'yyyy-MM-dd'),
+    },
+  });
+
+  const history = useHistory();
+  useEffect(() => {
+    document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
+    dispatch(openFormPage(pageKey, uiSchema, initialSchema));
+  }, []);
+
+  return (
+    <div>
+      <h1 className="vaos__dynamic-font-size--h2">{pageTitle}</h1>
+      {!!schema && (
+        <SchemaForm
+          name="Type of appointment"
+          title="Type of appointment"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() =>
+            dispatch(routeToNextAppointmentPage(history, pageKey, data))
+          }
+          onChange={newData => setData(newData)}
+          data={data}
+        >
+          <FormButtons
+            onBack={() =>
+              dispatch(routeToPreviousAppointmentPage(history, pageKey, data))
+            }
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
+    </div>
+  );
+}

--- a/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.unit.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { addDays, format } from 'date-fns';
+import { addDays, addYears, format, isAfter, set } from 'date-fns';
 
 import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
@@ -128,7 +128,35 @@ describe('VAOS Page: PreferredDatePageVaDate', () => {
     expect(screen.history.push.called).to.be.false;
   });
 
-  it('should submit with valid data', async () => {
+  it('it should not submit with invalid date', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<PreferredDatePageVaDate />, {
+      store,
+    });
+
+    let date = new Date();
+    if (isAfter(date, set(date, { month: 1, date: 27 }))) {
+      date = addYears(date, 1);
+    }
+
+    await screen.findByText(/Continue/);
+    const vaDate = screen.container.querySelector('va-date');
+    vaDate.__events.dateChange({
+      target: {
+        // the next February 31th is not a valid date
+        value: `${format(date, 'yyyy')}-02-31`,
+      },
+    });
+    fireEvent.click(screen.getByText(/Continue/));
+    // Assertion currently disabled due to
+    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/82624
+    // expect(await screen.findByRole('alert')).to.contain.text(
+    //   'Please enter a valid date ',
+    // );
+    expect(screen.history.push.called).to.be.false;
+  });
+
+  it('should submit with valid date', async () => {
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<PreferredDatePageVaDate />, {
       store,

--- a/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.unit.spec.js
@@ -79,6 +79,11 @@ describe('VAOS Page: PreferredDatePageVaDate', () => {
     // );
     // expect(screen.history.push.called).to.be.false;
     expect(screen.history.push.called).to.be.true;
+
+    // Do not record preferred-date-modified event
+    expect(window.dataLayer).not.to.deep.include({
+      event: 'vaos-preferred-date-modified',
+    });
   });
 
   it('it should not submit with past date', async () => {
@@ -138,5 +143,9 @@ describe('VAOS Page: PreferredDatePageVaDate', () => {
 
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() => expect(screen.history.push.called).to.be.true);
+    // Record preferred-date-modified event
+    expect(window.dataLayer).to.deep.include({
+      event: 'vaos-preferred-date-modified',
+    });
   });
 });

--- a/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.unit.spec.js
+++ b/src/applications/vaos/new-appointment/components/PreferredDatePageVaDate.unit.spec.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { expect } from 'chai';
+import { addDays, format } from 'date-fns';
+
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
+import { fireEvent, waitFor } from '@testing-library/dom';
+import {
+  createTestStore,
+  renderWithStoreAndRouter,
+} from '../../tests/mocks/setup';
+import PreferredDatePageVaDate from './PreferredDatePageVaDate';
+
+const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingDirect: true,
+    vaOnlineSchedulingCommunityCare: true,
+  },
+  user: {
+    profile: {
+      facilities: [
+        { facilityId: '983', isCerner: false },
+        { facilityId: '984', isCerner: false },
+      ],
+    },
+  },
+};
+
+describe('VAOS Page: PreferredDatePageVaDate', () => {
+  beforeEach(() => mockFetch());
+
+  it('should display form fields', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<PreferredDatePageVaDate />, {
+      store,
+    });
+
+    const dateSelector = screen.container.querySelector('va-date');
+    await waitFor(() => {
+      // Verify date widget is rendered.
+      expect(dateSelector).to.exist;
+      expect(dateSelector).to.have.attribute(
+        'label',
+        "Tell us the earliest day you're available and we'll try to find the date closest to your request.",
+      );
+    });
+
+    expect(screen.baseElement).to.contain.text(
+      'When are you available for this appointment?',
+    );
+
+    expect(screen.baseElement).to.contain.text(
+      'Choose a date within the next 13 months for this appointment.',
+    );
+  });
+
+  it('should submit form with default date', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<PreferredDatePageVaDate />, {
+      store,
+    });
+
+    const dateSelector = screen.container.querySelector('va-date');
+    await waitFor(() => {
+      // Verify date widget is rendered.
+      expect(dateSelector).to.exist;
+      expect(dateSelector.value).to.equal(
+        // Note that although the format of the date saved in the state is 'yyyy-MM-dd', the date
+        // represented by the value attribute rendered by va-date uses the 'yyyy-M-d' format.
+        format(addDays(new Date(), 1), 'yyyy-M-d'),
+      );
+    });
+
+    fireEvent.click(await screen.findByText(/Continue/));
+
+    // Assertion currently disabled due to
+    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/82624
+    // expect(await screen.findByRole('alert')).to.contain.text(
+    //   'You must provide a response',
+    // );
+    // expect(screen.history.push.called).to.be.false;
+    expect(screen.history.push.called).to.be.true;
+  });
+
+  it('it should not submit with past date', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<PreferredDatePageVaDate />, {
+      store,
+    });
+
+    await screen.findByText(/Continue/);
+
+    const vaDate = screen.container.querySelector('va-date');
+    vaDate.__events.dateChange({
+      target: { value: format(new Date(2016, 2, 2), 'yyyy-MM-dd') },
+    });
+
+    fireEvent.click(screen.getByText(/Continue/));
+    // Assertion currently disabled due to
+    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/82624
+    // expect(await screen.findByRole('alert')).to.contain.text(
+    //   'Please enter a future date ',
+    // );
+    expect(screen.history.push.called).to.be.false;
+  });
+
+  it('it should not submit beyond 395 days into the future', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<PreferredDatePageVaDate />, {
+      store,
+    });
+
+    await screen.findByText(/Continue/);
+    const vaDate = screen.container.querySelector('va-date');
+    vaDate.__events.dateChange({
+      target: { value: format(addDays(new Date(), 396), 'yyyy-MM-dd') },
+    });
+    fireEvent.click(screen.getByText(/Continue/));
+    // Assertion currently disabled due to
+    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/82624
+    // expect(await screen.findByRole('alert')).to.contain.text(
+    //   'Please enter a date less than 395 days in the future ',
+    // );
+    expect(screen.history.push.called).to.be.false;
+  });
+
+  it('should submit with valid data', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<PreferredDatePageVaDate />, {
+      store,
+    });
+
+    await screen.findByText(/Continue/);
+
+    const vaDate = screen.container.querySelector('va-date');
+    vaDate.__events.dateChange({
+      target: { value: format(addDays(new Date(), 395), 'yyyy-MM-dd') },
+    });
+
+    fireEvent.click(screen.getByText(/Continue/));
+    await waitFor(() => expect(screen.history.push.called).to.be.true);
+  });
+});

--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -7,9 +7,11 @@ import {
   useLocation,
   Redirect,
 } from 'react-router-dom';
-// import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import { selectIsCernerOnlyPatient } from 'platform/user/cerner-dsot/selectors';
-import { selectFeatureBreadcrumbUrlUpdate } from '../redux/selectors';
+import {
+  selectFeatureBreadcrumbUrlUpdate,
+  selectFeatureUseVaDate,
+} from '../redux/selectors';
 import { selectIsNewAppointmentStarted } from './redux/selectors';
 import newAppointmentReducer from './redux/reducer';
 import FormLayout from './components/FormLayout';
@@ -20,6 +22,7 @@ import TypeOfSleepCarePage from './components/TypeOfSleepCarePage';
 import TypeOfEyeCarePage from './components/TypeOfEyeCarePage';
 import TypeOfAudiologyCarePage from './components/TypeOfAudiologyCarePage';
 import PreferredDatePage from './components/PreferredDatePage';
+import PreferredDatePageVaDate from './components/PreferredDatePageVaDate';
 import DateTimeRequestPage from './components/DateTimeRequestPage';
 import VARequest from './components/DateTimeRequestPage/VA';
 import CCRequest from './components/DateTimeRequestPage/CommunityCare';
@@ -45,6 +48,7 @@ export function NewAppointment() {
   const featureBreadcrumbUrlUpdate = useSelector(state =>
     selectFeatureBreadcrumbUrlUpdate(state),
   );
+  const featureUseVaDate = useSelector(state => selectFeatureUseVaDate(state));
   const match = useRouteMatch();
   const location = useLocation();
   const [crumb, setCrumb] = useState('Schedule an appointment');
@@ -105,7 +109,13 @@ export function NewAppointment() {
             />
           </Route>
           <Route path={`${match.url}/preferred-date`}>
-            <PreferredDatePage changeCrumb={newTitle => setCrumb(newTitle)} />
+            {featureUseVaDate ? (
+              <PreferredDatePageVaDate
+                changeCrumb={newTitle => setCrumb(newTitle)}
+              />
+            ) : (
+              <PreferredDatePage changeCrumb={newTitle => setCrumb(newTitle)} />
+            )}
           </Route>
           <Route path={`${match.url}/date-time`}>
             <DateTimeSelectPage changeCrumb={newTitle => setCrumb(newTitle)} />

--- a/src/applications/vaos/tests/e2e/page-objects/PreferredDatePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PreferredDatePageObject.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import { addDays, addMonths, format, startOfMonth } from 'date-fns';
 import PageObject from './PageObject';
 
 export class PreferredDatePageObject extends PageObject {
@@ -10,18 +10,9 @@ export class PreferredDatePageObject extends PageObject {
   }
 
   typeDate({ date } = {}) {
-    let preferredDate;
-    if (date) {
-      preferredDate = moment(date);
-    } else {
-      preferredDate = moment()
-        .add(1, 'month')
-        .startOf('month')
-        .add(4, 'days');
-    }
-    cy.findByLabelText('Month').select(preferredDate.format('MMMM'));
-    cy.findByLabelText('Day').select(preferredDate.format('D'));
-    cy.findByLabelText('Year').type(preferredDate.format('YYYY'));
+    const preferredDate =
+      date || addDays(startOfMonth(addMonths(new Date(), 1)), 4);
+    cy.fillVaDate('root_preferredDate', format(preferredDate, 'yyyy-MM-dd'));
 
     return this;
   }

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/calendar-dead-ends.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/calendar-dead-ends.cypress.spec.js
@@ -95,7 +95,7 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
           .clickNextButton();
 
         PreferredDatePageObject.assertUrl()
-          .typeDate({ date: moment() })
+          .typeDate({ date: new Date() })
           .clickNextButton();
 
         DateTimeSelectPageObject.assertUrl()
@@ -145,7 +145,7 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
           .clickNextButton();
 
         PreferredDatePageObject.assertUrl()
-          .typeDate({ date: moment() })
+          .typeDate({ date: new Date() })
           .clickNextButton();
 
         DateTimeSelectPageObject.assertUrl()
@@ -193,7 +193,7 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
           .clickNextButton();
 
         PreferredDatePageObject.assertUrl()
-          .typeDate({ date: moment() })
+          .typeDate({ date: new Date() })
           .clickNextButton();
 
         DateTimeSelectPageObject.assertUrl()
@@ -268,7 +268,7 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
           .clickNextButton();
 
         PreferredDatePageObject.assertUrl()
-          .typeDate({ date: moment() })
+          .typeDate({ date: new Date() })
           .clickNextButton();
 
         DateTimeSelectPageObject.assertUrl()
@@ -318,7 +318,7 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
           .clickNextButton();
 
         PreferredDatePageObject.assertUrl()
-          .typeDate({ date: moment() })
+          .typeDate({ date: new Date() })
           .clickNextButton();
 
         DateTimeSelectPageObject.assertUrl()
@@ -366,7 +366,7 @@ describe('VAOS direct schedule flow - calendar dead ends', () => {
           .clickNextButton();
 
         PreferredDatePageObject.assertUrl()
-          .typeDate({ date: moment() })
+          .typeDate({ date: new Date() })
           .clickNextButton();
 
         DateTimeSelectPageObject.assertUrl()

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -21,7 +21,7 @@ import TypeOfCarePage from '../../new-appointment/components/TypeOfCarePage';
 import moment from '../../lib/moment-tz';
 import ClinicChoicePage from '../../new-appointment/components/ClinicChoicePage';
 import VaccineClinicChoicePage from '../../covid-19-vaccine/components/ClinicChoicePage';
-import PreferredDatePage from '../../new-appointment/components/PreferredDatePage';
+import PreferredDatePageVaDate from '../../new-appointment/components/PreferredDatePageVaDate';
 
 import TypeOfEyeCarePage from '../../new-appointment/components/TypeOfEyeCarePage';
 import TypeOfFacilityPage from '../../new-appointment/components/TypeOfFacilityPage';
@@ -353,22 +353,17 @@ export async function setVaccineClinic(store, label) {
  */
 export async function setPreferredDate(store, preferredDate) {
   const screen = renderWithStoreAndRouter(
-    <Route component={PreferredDatePage} />,
+    <Route component={PreferredDatePageVaDate} />,
     {
       store,
     },
   );
 
-  await screen.findByText(/earliest day/);
-  fireEvent.change(screen.getByLabelText('Month'), {
-    target: { value: preferredDate.month() + 1 },
+  const vaDate = screen.container.querySelector('va-date');
+  vaDate.__events.dateChange({
+    target: { value: preferredDate.format('YYYY-MM-DD') },
   });
-  fireEvent.change(screen.getByLabelText('Day'), {
-    target: { value: preferredDate.date() },
-  });
-  fireEvent.change(screen.getByLabelText('Year'), {
-    target: { value: preferredDate.year() },
-  });
+
   fireEvent.click(screen.getByText(/Continue/));
   await waitFor(() => expect(screen.history.push.called).to.be.true);
   await cleanup();

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -25,7 +25,7 @@ module.exports = [
   { name: 'vaOnlineSchedulingOhDirectSchedule', value: false },
   { name: 'vaOnlineSchedulingOhRequest', value: false },
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
-  { name: 'vaOnlineSchedulingUseVaDate', value: false },
+  { name: 'vaOnlineSchedulingUseVaDate', value: true },
   { name: 'vaOnlineSchedulingPastApptDateRange', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruth', value: false },
   { name: 'selectFeaturePocTypeOfCare', value: true },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR updates the preferred date page in the appointments direct scheduling flow
  - Updated form to use the recommended `VaDateField` component
  - Set a default date to tomorrow
  - Added metrics to track how many users modify the date from the default date (tomorrow)
- Appointments tool team
- The feature is toggled by the `vaos_online_scheduling_use_va_date` feature flag

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99423

## Testing done

- Tested locally, see screenshots
- Added new unit tests and updated existing unit tests and e2e tests for the new component and behaviors.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
|    <img width="510" alt="image" src="https://github.com/user-attachments/assets/b0a7d43b-221f-409a-add1-844596bcb4e4" />   |   <img width="686" alt="image" src="https://github.com/user-attachments/assets/33c61bb2-0df2-45a0-9203-21501671d5ef" />   |

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
