### PR TITLE
Remove broken Form Upload breadcrumb

### DIFF
--- a/src/applications/simple-forms/form-upload/pages/helpers.jsx
+++ b/src/applications/simple-forms/form-upload/pages/helpers.jsx
@@ -9,10 +9,11 @@ export const CustomTopContent = () => {
   const breadcrumbs = [
     { href: '/', label: 'VA.gov home' },
     { href: '/find-forms', label: 'Find a VA form' },
-    {
-      href: `/find-forms/upload`,
-      label: `Upload VA forms`,
-    },
+    // TODO: Restore this breadcrumb when the static content at /find-forms/upload plays nicely with the Form Upload tool
+    // {
+    //   href: `/find-forms/upload`,
+    //   label: `Upload VA forms`,
+    // },
     {
       href: `/find-forms/upload/${formNumber}/introduction`,
       label: `Upload form ${formNumber}`,

--- a/src/applications/simple-forms/form-upload/tests/unit/pages/helpers.unit.spec.jsx
+++ b/src/applications/simple-forms/form-upload/tests/unit/pages/helpers.unit.spec.jsx
@@ -77,9 +77,14 @@ describe('CustomTopContent', () => {
 
     const breadcrumbs = $('va-breadcrumbs', container);
     expect(breadcrumbs).to.exist;
+    // TODO: Swap this commented bit back in when the static page works.
+    // expect(breadcrumbs).to.have.attr(
+    //   'breadcrumb-list',
+    //   '[{"href":"/","label":"VA.gov home"},{"href":"/find-forms","label":"Find a VA form"},{"href":"/find-forms/upload","label":"Upload VA forms"},{"href":"/find-forms/upload/21-0779/introduction","label":"Upload form 21-0779"}]',
+    // );
     expect(breadcrumbs).to.have.attr(
       'breadcrumb-list',
-      '[{"href":"/","label":"VA.gov home"},{"href":"/find-forms","label":"Find a VA form"},{"href":"/find-forms/upload","label":"Upload VA forms"},{"href":"/find-forms/upload/21-0779/introduction","label":"Upload form 21-0779"}]',
+      '[{"href":"/","label":"VA.gov home"},{"href":"/find-forms","label":"Find a VA form"},{"href":"/find-forms/upload/21-0779/introduction","label":"Upload form 21-0779"}]',
     );
   });
 });


### PR DESCRIPTION
## Summary
This PR temporarily removes a breadcrumb from the Form Upload tool because the static page that it links to is not quite working yet. [We are currently working on a more durable resolution here](https://github.com/orgs/department-of-veterans-affairs/projects/1443/views/3?sliceBy%5Bvalue%5D=Thrillberg&pane=issue&itemId=99735619&issue=department-of-veterans-affairs%7CVA.gov-team-forms%7C2035).

Before:
<img width="568" alt="Screenshot 2025-02-27 at 12 57 44 PM" src="https://github.com/user-attachments/assets/873f1e3e-35b0-4ab3-83f1-b5264e270f84" />

After:
<img width="432" alt="Screenshot 2025-02-27 at 12 58 35 PM" src="https://github.com/user-attachments/assets/c3bbce65-e0ba-459f-8c33-dbc11522f4a0" />
