### PR TITLE
MHV-67112 Remove content on Image details page for March 17 milestone

### DIFF
--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -213,7 +213,7 @@ ${record.results}`;
       <va-link
         className="vads-u-margin-top--1"
         href="www.va.gov/profile/notifications"
-        text="Go back to the previous version of My HealtheVet"
+        text="Go to notification settings"
       />
     </>
   );

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -53,13 +53,12 @@ const RadiologyDetails = props => {
       ],
   );
 
-  // const allowMarchUpdates = useSelector(
-  //   state =>
-  //     state.featureToggles[
-  //       FEATURE_FLAG_NAMES.mhvMedicalRecordsUpdateLandingPage
-  //     ],
-  // );
-  const allowMarchUpdates = true;
+  const allowMarchUpdates = useSelector(
+    state =>
+      state.featureToggles[
+        FEATURE_FLAG_NAMES.mhvMedicalRecordsUpdateLandingPage
+      ],
+  );
 
   const dispatch = useDispatch();
   const elementRef = useRef(null);

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -12,8 +12,6 @@ import {
   usePrintTitle,
 } from '@department-of-veterans-affairs/mhv/exports';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
-import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
@@ -200,22 +198,21 @@ ${record.results}`;
     <>
       {notificationStatus ? (
         <p>
-          <strong>Note: </strong> If you don’t want to get email notifications
-          for images anymore, you can change your notification settings on the
-          previous version of My HealtheVet.
+          <strong>Note: </strong> If you do not want us to notifiy you about
+          images, change your settings in your profile.
         </p>
       ) : (
         <>
           <h3>Get email notifications for images</h3>
           <p>
             If you want us to email you when your images are ready, change your
-            notification settings on the previous version of My HealtheVet.
+            notification settings in your profile.
           </p>
         </>
       )}
       <va-link
         className="vads-u-margin-top--1"
-        href={mhvUrl(isAuthenticatedWithSSOe(fullState), 'profiles')}
+        href="www.va.gov/profile/notifications"
         text="Go back to the previous version of My HealtheVet"
       />
     </>

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -316,7 +316,17 @@ ${record.results}`;
 
   const imageAlertError = imageRequest => (
     <>
-      <p>To review and download your images, you’ll need to request them.</p>
+      {notificationStatus ? (
+        <p>
+          After you request images, it may take serveral hours for us to load
+          them here. We’ll send you an email when your images are ready.
+        </p>
+      ) : (
+        <p>
+          After you request images, it may take serveral hours for us to load
+          them here.
+        </p>
+      )}
       {imageAlert(ERROR_REQUEST_AGAIN)}
       <va-button
         class="vads-u-margin-top--2"

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -12,6 +12,8 @@ import {
   usePrintTitle,
 } from '@department-of-veterans-affairs/mhv/exports';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
+import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
@@ -50,6 +52,14 @@ const RadiologyDetails = props => {
         FEATURE_FLAG_NAMES.mhvMedicalRecordsAllowTxtDownloads
       ],
   );
+
+  // const allowMarchUpdates = useSelector(
+  //   state =>
+  //     state.featureToggles[
+  //       FEATURE_FLAG_NAMES.mhvMedicalRecordsUpdateLandingPage
+  //     ],
+  // );
+  const allowMarchUpdates = true;
 
   const dispatch = useDispatch();
   const elementRef = useRef(null);
@@ -197,24 +207,46 @@ ${record.results}`;
   const notificationContent = () => (
     <>
       {notificationStatus ? (
-        <p>
-          <strong>Note: </strong> If you do not want us to notifiy you about
-          images, change your settings in your profile.
-        </p>
+        <>
+          {allowMarchUpdates ? (
+            <p>
+              <strong>Note: </strong> If you do not want us to notifiy you about
+              images, change your settings in your profile.
+            </p>
+          ) : (
+            <p>
+              <strong>Note: </strong>
+              If you don’t want to get email notifications for images anymore,
+              you can change your notification settings on the previous version
+              of My HealtheVet.
+            </p>
+          )}
+        </>
       ) : (
         <>
           <h3>Get email notifications for images</h3>
           <p>
             If you want us to email you when your images are ready, change your
-            notification settings in your profile.
+            notification settings
+            {allowMarchUpdates
+              ? ` in your profile.`
+              : ` on the previous version of My HealtheVet.`}
           </p>
         </>
       )}
-      <va-link
-        className="vads-u-margin-top--1"
-        href="www.va.gov/profile/notifications"
-        text="Go to notification settings"
-      />
+      {allowMarchUpdates ? (
+        <va-link
+          className="vads-u-margin-top--1"
+          href="www.va.gov/profile/notifications"
+          text="Go to notification settings"
+        />
+      ) : (
+        <va-link
+          className="vads-u-margin-top--1"
+          href={mhvUrl(isAuthenticatedWithSSOe(fullState), 'profiles')}
+          text="Go back to the previous version of My HealtheVet"
+        />
+      )}
     </>
   );
 
@@ -316,17 +348,7 @@ ${record.results}`;
 
   const imageAlertError = imageRequest => (
     <>
-      {notificationStatus ? (
-        <p>
-          After you request images, it may take serveral hours for us to load
-          them here. We’ll send you an email when your images are ready.
-        </p>
-      ) : (
-        <p>
-          After you request images, it may take serveral hours for us to load
-          them here.
-        </p>
-      )}
+      <p>To review and download your images, you’ll need to request them.</p>
       {imageAlert(ERROR_REQUEST_AGAIN)}
       <va-button
         class="vads-u-margin-top--2"


### PR DESCRIPTION
## Summary

- Updated content regarding the Image Page. 
  - Changed the link for "go to notification settings"
  - Updated the message in the notification section
- This is not a bug.
- Mostly just updated JSX and used already existing methods. 
 
- MHV Medical Records.

## Related issue(s)
### [MHV-67112](https://jira.devops.va.gov/browse/MHV-67112) Remove content on Image details page for March 17 milestone ###
![Screenshot 2025-02-27 at 2 30 40 PM](https://github.com/user-attachments/assets/a3a11efa-8737-49a1-8a22-af93d4e2c5bb)

## Screenshot
![Screenshot 2025-02-27 at 4 26 39 PM](https://github.com/user-attachments/assets/92ca1900-e2d8-4779-9498-9e5c2f6d975b)
![Screenshot 2025-02-27 at 4 27 31 PM](https://github.com/user-attachments/assets/f43a48ec-49d3-4cc5-b69a-c492058c8de5)

## Testing done

-  Tests are passing.

## What areas of the site does it impact?
MHV Medical Records
