### PR TITLE
[CDP] 103705 - One VA debt letter download button

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -65,7 +65,7 @@ const OverviewPage = () => {
     // let's tryy this for now
     const downloadAnchor = document.createElement('a');
     downloadAnchor.href = pdfDownloadUrl;
-    downloadAnchor.download = 'CombinedStatements.pdf';
+    downloadAnchor.download = 'CombinedStatement.pdf';
     document.body.appendChild(downloadAnchor);
     downloadAnchor.click();
     document.body.removeChild(downloadAnchor);
@@ -114,7 +114,7 @@ const OverviewPage = () => {
             {showOneVADebtLetterDownload ? (
               <VaButton
                 onClick={downloadPDF}
-                text="View Combined Statements"
+                text="View combined statement"
                 secondary
               />
             ) : null}

--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -118,7 +118,7 @@ const OverviewPage = () => {
                 secondary
               />
             ) : null}
-            <h2>What to do if you have qußestions about your debt and bills</h2>
+            <h2>What to do if you have questions about your debt and bills</h2>
             <h3>Questions about benefit debt</h3>
             <p>
               Call the Debt Management Center (DMC) at{' '}

--- a/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/OverviewPage.jsx
@@ -2,6 +2,12 @@ import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import environment from '~/platform/utilities/environment';
+import {
+  VaButton,
+  VaLoadingIndicator,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 import Balances from '../components/Balances';
 import ComboAlerts from '../components/ComboAlerts';
 import { ALERT_TYPES, setPageFocus } from '../utils/helpers';
@@ -37,6 +43,40 @@ const OverviewPage = () => {
   const bothZero =
     totalDebts === 0 && totalBills === 0 && !billError && !debtError;
 
+  // feature toggle stuff for One VA Debt Letter flag
+  const {
+    useToggleValue,
+    useToggleLoadingValue,
+    TOGGLE_NAMES,
+  } = useFeatureToggle();
+  // boolean value to represent if toggles are still loading or not
+  const togglesLoading = useToggleLoadingValue();
+  // value of specific toggle
+  const showOneVADebtLetterDownload = useToggleValue(
+    TOGGLE_NAMES.showOneVADebtLetter,
+  );
+
+  const downloadPDF = async () => {
+    // One VA Debt Letter Download url
+    const pdfDownloadUrl = `${
+      environment.API_URL
+    }/debts_api/v0/download_one_debt_letter_pdf`;
+
+    // let's tryy this for now
+    const downloadAnchor = document.createElement('a');
+    downloadAnchor.href = pdfDownloadUrl;
+    downloadAnchor.download = 'CombinedStatements.pdf';
+    document.body.appendChild(downloadAnchor);
+    downloadAnchor.click();
+    document.body.removeChild(downloadAnchor);
+    URL.revokeObjectURL(pdfDownloadUrl);
+  };
+
+  // give features a chance to fully load before we conditionally render
+  if (togglesLoading) {
+    return <VaLoadingIndicator message="Loading features..." />;
+  }
+
   return (
     <>
       <VaBreadcrumbs
@@ -71,7 +111,14 @@ const OverviewPage = () => {
           <>
             <h2>Debt and bill overview</h2>
             <Balances />
-            <h2>What to do if you have questions about your debt and bills</h2>
+            {showOneVADebtLetterDownload ? (
+              <VaButton
+                onClick={downloadPDF}
+                text="View Combined Statements"
+                secondary
+              />
+            ) : null}
+            <h2>What to do if you have qußestions about your debt and bills</h2>
             <h3>Questions about benefit debt</h3>
             <p>
               Call the Debt Management Center (DMC) at{' '}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary
Adding download button for One VA Debt Letter effort. This feature is controlled by the `show_one_va_debt_letter` feature flag. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#103705
- `vets-api` pr for endpoint
department-of-veterans-affairs/vets-api/pull/20921

## Testing done
Manual testing complete

## Screenshots
| Flag enabled | Flag disabled |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/5933ae8b-49a9-49a5-bec9-27478012debd) | ![image](https://github.com/user-attachments/assets/2874fcba-f1d3-40ea-b0a8-34704c2b803d) |

## What areas of the site does it impact?
combined-debt-portal

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
