### PR TITLE
Record additional appointment null state attributes

### DIFF
--- a/src/applications/vaos/components/layouts/CCLayout.jsx
+++ b/src/applications/vaos/components/layouts/CCLayout.jsx
@@ -48,10 +48,17 @@ export default function CCLayout({ data: appointment }) {
     heading = 'Canceled community care appointment';
   else heading = 'Community care appointment';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.PROVIDER]: !providerName,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.PROVIDER]: !providerName,
+    },
+  );
 
   return (
     <>

--- a/src/applications/vaos/components/layouts/CCLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/CCLayout.unit.spec.js
@@ -15,6 +15,8 @@ describe('VAOS Component: CCLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'COMMUNITY_CARE_APPOINTMENT',
+        modality: 'communityCare',
         communityCareProvider: {
           telecom: [{ system: 'phone', value: '123-456-7890' }],
           providers: [
@@ -35,9 +37,15 @@ describe('VAOS Component: CCLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: false,
           isUpcomingAppointment: true,
+          isCerner: false,
           apiData: {},
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'COMMUNITY_CARE_APPOINTMENT',
+        modality: 'communityCare',
+        isCerner: false,
       };
 
       // Act
@@ -70,18 +78,21 @@ describe('VAOS Component: CCLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-any',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-type-of-care',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-provider',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-provider',
+        ...nullAttributes,
       });
     });
   });

--- a/src/applications/vaos/components/layouts/CCRequestLayout.jsx
+++ b/src/applications/vaos/components/layouts/CCRequestLayout.jsx
@@ -46,10 +46,17 @@ export default function CCRequestLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled request for community care appointment';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.PROVIDER]: !providerName,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.PROVIDER]: !providerName,
+    },
+  );
 
   return (
     <PageLayout isDetailPage showNeedHelp>

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
@@ -55,13 +55,20 @@ export default function ClaimExamLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled claim exam';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
-    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
-    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
-    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+      [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+      [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+      [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
+    },
+  );
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.js
@@ -146,6 +146,8 @@ describe('VAOS Component: ClaimExamLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'claimExamAppointment',
         videoData: {},
         vaos: {
           isCommunityCare: false,
@@ -153,9 +155,15 @@ describe('VAOS Component: ClaimExamLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: false,
           isUpcomingAppointment: true,
+          isCerner: false,
           apiData: {},
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'claimExamAppointment',
+        isCerner: false,
       };
 
       // Act
@@ -184,36 +192,42 @@ describe('VAOS Component: ClaimExamLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-any',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-type-of-care',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-clinic-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-id',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-id',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-details',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-details',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-phone',
+        ...nullAttributes,
       });
     });
 

--- a/src/applications/vaos/components/layouts/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.jsx
@@ -56,14 +56,21 @@ export default function InPersonLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled in-person appointment';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
-    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
-    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
-    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
-    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
+      [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+      [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+      [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+      [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
+    },
+  );
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.js
@@ -132,6 +132,8 @@ describe('VAOS Component: InPersonLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'vaInPerson',
         videoData: {},
         vaos: {
           isCommunityCare: false,
@@ -139,9 +141,15 @@ describe('VAOS Component: InPersonLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: false,
           isUpcomingAppointment: true,
+          isCerner: false,
           apiData: {},
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'vaInPerson',
+        isCerner: false,
       };
 
       // Act
@@ -187,42 +195,49 @@ describe('VAOS Component: InPersonLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-any',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-type-of-care',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-provider',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-provider',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-clinic-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-id',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-id',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-details',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-details',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-phone',
+        ...nullAttributes,
       });
     });
 

--- a/src/applications/vaos/components/layouts/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.jsx
@@ -49,13 +49,20 @@ export default function PhoneLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled phone appointment';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
-    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
-    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
-    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.PROVIDER]: !practitionerName,
+      [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+      [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+      [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
+    },
+  );
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.js
@@ -37,6 +37,8 @@ describe('VAOS Component: PhoneLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'phone',
         videoData: {},
         practitioners: [
           {
@@ -57,9 +59,15 @@ describe('VAOS Component: PhoneLayout', () => {
           isUpcomingAppointment: true,
           isPhoneAppointment: true,
           isCancellable: true,
+          isCerner: false,
           apiData: {},
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'phone',
+        isCerner: false,
       };
 
       // Act
@@ -107,36 +115,42 @@ describe('VAOS Component: PhoneLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-any',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-type-of-care',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-provider',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-provider',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-clinic-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-details',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-details',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-phone',
+        ...nullAttributes,
       });
     });
 

--- a/src/applications/vaos/components/layouts/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.jsx
@@ -46,12 +46,19 @@ export default function VARequestLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled request for appointment';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
-    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
-    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+      [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+      [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
+    },
+  );
 
   return (
     <PageLayout isDetailPage showNeedHelp>

--- a/src/applications/vaos/components/layouts/VideoLayout.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.jsx
@@ -62,13 +62,20 @@ export default function VideoLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
-    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
-    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
-    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
+      [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+      [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+      [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
+    },
+  );
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layouts/VideoLayout.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayout.unit.spec.js
@@ -41,6 +41,8 @@ describe('VAOS Component: VideoLayout', () => {
       // Arrange
       const store = createTestStore(nullInitialState);
       const appointment = {
+        type: 'VA',
+        modality: 'vaVideoCareAtHome',
         location: {},
         videoData: {
           isVideo: true,
@@ -61,9 +63,15 @@ describe('VAOS Component: VideoLayout', () => {
           isPendingAppointment: false,
           isUpcomingAppointment: true,
           isVideo: true,
+          isCerner: false,
           apiData: {},
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'vaVideoCareAtHome',
+        isCerner: false,
       };
 
       // Act
@@ -104,36 +112,42 @@ describe('VAOS Component: VideoLayout', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-any',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-type-of-care',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-provider',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-provider',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-clinic-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-details',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-details',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-phone',
+        ...nullAttributes,
       });
     });
 

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
@@ -54,13 +54,20 @@ export default function VideoLayoutAtlas({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment at an ATLAS location';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
-    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
-    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
-    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
+      [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+      [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+      [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
+    },
+  );
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.js
@@ -44,6 +44,8 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
 
       const store = createTestStore(state);
       const appointment = {
+        type: 'VA',
+        modality: 'vaVideoCareAtAnAtlasLocation',
         videoData: {
           atlasConfirmationCode: '1234',
           atlasLocation: {
@@ -69,9 +71,15 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
           isPendingAppointment: false,
           isUpcomingAppointment: true,
           isVideo: true,
+          isCerner: false,
           apiData: {},
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'vaVideoCareAtAnAtlasLocation',
+        isCerner: false,
       };
 
       // Act
@@ -116,36 +124,42 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-any',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-type-of-care',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-provider',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-provider',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-clinic-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-details',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-details',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-phone',
+        ...nullAttributes,
       });
     });
 

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
@@ -51,14 +51,21 @@ export default function VideoLayoutVA({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment at VA location';
 
-  recordAppointmentDetailsNullStates({
-    [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
-    [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
-    [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
-    [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
-    [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
-    [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
-  });
+  recordAppointmentDetailsNullStates(
+    {
+      type: appointment.type,
+      modality: appointment.modality,
+      isCerner: appointment.vaos.isCerner,
+    },
+    {
+      [NULL_STATE_FIELD.TYPE_OF_CARE]: !typeOfCareName,
+      [NULL_STATE_FIELD.PROVIDER]: !videoProviderName,
+      [NULL_STATE_FIELD.CLINIC_PHONE]: !clinicPhone,
+      [NULL_STATE_FIELD.FACILITY_ID]: !facilityId,
+      [NULL_STATE_FIELD.FACILITY_DETAILS]: !facility,
+      [NULL_STATE_FIELD.FACILITY_PHONE]: !facilityPhone,
+    },
+  );
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.js
@@ -149,6 +149,8 @@ describe('VAOS Component: VideoLayoutVA', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'vaVideoCareAtAVaLocation',
         videoData: {
           isVideo: true,
           facilityId: '983',
@@ -164,9 +166,15 @@ describe('VAOS Component: VideoLayoutVA', () => {
           isPendingAppointment: false,
           isUpcomingAppointment: true,
           isVideo: true,
+          isCerner: false,
           apiData: {},
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'vaVideoCareAtAVaLocation',
+        isCerner: false,
       };
 
       // Act
@@ -204,42 +212,49 @@ describe('VAOS Component: VideoLayoutVA', () => {
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-any',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-type-of-care',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-type-of-care',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-provider',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-provider',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-clinic-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-clinic-phone',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-id',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-id',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-details',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-details',
+        ...nullAttributes,
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-expected-facility-phone',
       });
       expect(window.dataLayer).to.deep.include({
         event: 'vaos-null-states-missing-facility-phone',
+        ...nullAttributes,
       });
     });
 

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -109,6 +109,7 @@ function getAtlasLocation(appt) {
 
 export function transformVAOSAppointment(appt) {
   const appointmentType = getAppointmentType(appt);
+  const isCerner = appt?.id?.startsWith('CERN');
   const isCC = appt.kind === 'cc';
   const isVideo = appt.kind === 'telehealth' && !!appt.telehealth?.vvsKind;
   const isAtlas = !!appt.telehealth?.atlas;
@@ -218,6 +219,8 @@ export function transformVAOSAppointment(appt) {
   return {
     resourceType: 'Appointment',
     id: appt.id,
+    type: appt.type,
+    modality: appt.modality,
     status: appt.status,
     cancelationReason: appt.cancelationReason?.coding?.[0].code || null,
     avsPath: isPast ? appt.avsPath : null,
@@ -284,6 +287,7 @@ export function transformVAOSAppointment(appt) {
       isExpressCare: false,
       isPhoneAppointment: appt.kind === 'phone',
       isCOVIDVaccine: appt.serviceType === COVID_VACCINE_ID,
+      isCerner,
       apiData: appt,
       timeZone: appointmentTZ,
       facilityData,

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -59,6 +59,8 @@ export const NULL_STATE_FIELD = {
  * Records events for appointment details null states
  *
  * @export
+ * @param {Object} attributes  This is the dictionary containing the attributes
+ *   of the appointment to be recorded as part of the missing event.
  * @param {Object} nullStates This is the dictionary containing the null state
  *   details to be logged. The keys are the keys of NULL_STATE_TYPE and the
  *   values are booleans indicating whether that field is missing in the
@@ -66,7 +68,7 @@ export const NULL_STATE_FIELD = {
  *   information type is not applicable for the appointment type (e.g. Provider
  *   for Claim Exam) do not include an entry for the field in the dictionary.
  */
-export function recordAppointmentDetailsNullStates(nullStates) {
+export function recordAppointmentDetailsNullStates(attributes, nullStates) {
   const nullStateEventPrefix = `${GA_PREFIX}-null-states`;
   let anyNullState = false;
 
@@ -81,7 +83,10 @@ export function recordAppointmentDetailsNullStates(nullStates) {
       recordEvent({ event: `${nullStateEventPrefix}-expected-${key}` });
       // Record the missing event if needed and updated anyNullState
       if (nullStates[key]) {
-        recordEvent({ event: `${nullStateEventPrefix}-missing-${key}` });
+        recordEvent({
+          event: `${nullStateEventPrefix}-missing-${key}`,
+          ...attributes,
+        });
         anyNullState = true;
       }
     }
@@ -89,6 +94,9 @@ export function recordAppointmentDetailsNullStates(nullStates) {
 
   //  Increment if any null states were present
   if (anyNullState) {
-    recordEvent({ event: `${nullStateEventPrefix}-missing-any` });
+    recordEvent({
+      event: `${nullStateEventPrefix}-missing-any`,
+      ...attributes,
+    });
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We're adding some additional appointment attributes in cases where there are null states present to help us figure out where they are originating from
- Appointments tool team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103077

## Testing done

- Tested locally and added unit tests.

## Screenshots

N/A

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
