### PR TITLE
VACMS-20009 Remove 2025 alert for Income Limits

### DIFF
--- a/src/applications/income-limits/containers/HomePage.jsx
+++ b/src/applications/income-limits/containers/HomePage.jsx
@@ -52,19 +52,6 @@ const HomePage = ({
         Answer 2 questions to find out how your income may affect your VA health
         care eligibility and costs.
       </p>
-      <va-alert
-        class="vads-u-margin-top--1 vads-u-margin-bottom--3"
-        close-btn-aria-label="Close notification"
-        status="info"
-        visible
-      >
-        <h2 slot="headline">
-          We’ve updated this tool to check 2025 income limits
-        </h2>
-        <p className="vads-u-margin-y--0">
-          You can check your income limits for 2025 now.
-        </p>
-      </va-alert>
       <h2>What to know before you start:</h2>
       <ul className="vads-u-margin-left--1">
         <li>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removes the informational alert that tells Veterans that we have 2025 data available now.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20009

## Screenshots
 | Before | After |
 | ------ | ----- |
 | <img width="754" alt="Screenshot 2025-02-28 at 11 26 59 AM" src="https://github.com/user-attachments/assets/398723b8-c7ef-494e-b364-3fb1f37175d9" /> | <img width="736" alt="Screenshot 2025-02-28 at 11 27 04 AM" src="https://github.com/user-attachments/assets/44fa461e-d092-4aa3-88d8-eb93a6cbd49b" /> |

## What areas of the site does it impact?

Income Limits only.

## Acceptance criteria

- [x] Income limits warning alert re: 2025 data is no longer visible