### PR TITLE
Allow h1 headers to display the focus indicator

### DIFF
--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -13,10 +13,6 @@
   text-transform: uppercase;
 }
 
-h1:focus {
-  outline: none !important;
-}
-
 .title-text-eyebrow {
   display: block;
   text-transform: uppercase;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR updates the css file to allow the displaying of the focus indicator for h1 headers.
- Appointments tool team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103524

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    <img width="762" alt="image" src="https://github.com/user-attachments/assets/f237ead1-40d6-4ea9-8f3a-57d49ea789c4" />   |   <img width="760" alt="image" src="https://github.com/user-attachments/assets/d71930da-016f-4433-a721-7bda79475fde" />   |

## What areas of the site does it impact?

Appointments tools

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
