### PR TITLE
Edm 395 lacp cypress

### DIFF
--- a/src/applications/gi/components/FilterControls.jsx
+++ b/src/applications/gi/components/FilterControls.jsx
@@ -17,7 +17,7 @@ function FilterControls({
           options={categoryCheckboxes}
           label="Category"
           label-header-level="3"
-          class="vads-u-margin-top--0"
+          class="category-checkbox-group vads-u-margin-top--0"
         >
           {categoryCheckboxes.map((option, index) => {
             return (
@@ -26,6 +26,7 @@ function FilterControls({
                 label={option.label}
                 name={option.name}
                 checked={option.checked}
+                class="category-checkbox"
               />
             );
           })}

--- a/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
+++ b/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
@@ -45,7 +45,7 @@ export default function LicenseCertificationFilterAccordion({
           className="usa-accordion-button vads-u-font-size--md vads-u-padding-right--3"
           // aria-isExpanded={isExpanded}
           // aria-controls={id}
-          data-testid="update-tuition-housing"
+          data-testid="update-lc-search"
         >
           <div className="vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between">
             <span className="vads-u-font-family--serif accordion-button-text">

--- a/src/applications/gi/components/LicenseCertificationSearchPage.jsx
+++ b/src/applications/gi/components/LicenseCertificationSearchPage.jsx
@@ -15,7 +15,7 @@ export default function LicenseCertificationSearchPage() {
           <h1 className="mobile-lg:vads-u-text-align--left vads-l-col--12 medium-screen:vads-l-col--7">
             Licenses, certifications, and prep courses
           </h1>
-          <p className=" vads-l-col--12 medium-screen:vads-l-col--7">
+          <p className="lc-description vads-l-col--12 medium-screen:vads-l-col--7">
             Use the search tool to find out which tests or related prep courses
             are reimbursable. If you don’t see a test or prep course listed, it
             may be a valid test that’s not yet approved. We encourage you to

--- a/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
@@ -246,9 +246,11 @@ export default function LicenseCertificationSearchResults() {
   }
 
   if (error) {
-    <div className="row">
-      <LicesnseCertificationServiceError />
-    </div>;
+    return (
+      <div className="row">
+        <LicesnseCertificationServiceError />
+      </div>
+    );
   }
 
   if (

--- a/src/applications/gi/tests/data/lc-details.json
+++ b/src/applications/gi/tests/data/lc-details.json
@@ -1,7 +1,7 @@
 {
   "lac": {
-    "enrichedId": "1@sec",
-    "lacNm": "Security+ Certification",
+    "enrichedId": "3871@4494f",
+    "lacNm": "General Electrician",
     "eduLacTypeNm": "Certification",
     "institution": {
       "name": "CompTIA",

--- a/src/applications/gi/tests/data/lc-details.json
+++ b/src/applications/gi/tests/data/lc-details.json
@@ -1,5 +1,5 @@
 {
-  "data": {
+  "lac": {
     "enrichedId": "1@sec",
     "lacNm": "Security+ Certification",
     "eduLacTypeNm": "Certification",
@@ -26,17 +26,11 @@
     "tests": [
       {
         "name": "CompTIA Security+ Certification Exam",
-        "fee": "370",
-        "beginDate": "01-JAN-20",
-        "endDate": "31-DEC-23",
-        "description": "CompTIA Security+ is a global certification that validates the baseline skills necessary to perform core security functions"
+        "fee": "370"
       },
       {
         "name": "CompTIA Security+ Retake Exam",
-        "fee": "225",
-        "beginDate": "01-JAN-20",
-        "endDate": "31-DEC-23",
-        "description": "Retake exam for failed attempts"
+        "fee": "225"
       }
     ]
   }

--- a/src/applications/gi/tests/data/lc-details.json
+++ b/src/applications/gi/tests/data/lc-details.json
@@ -1,0 +1,43 @@
+{
+  "data": {
+    "enrichedId": "1@sec",
+    "lacNm": "Security+ Certification",
+    "eduLacTypeNm": "Certification",
+    "institution": {
+      "name": "CompTIA",
+      "physicalAddress": {
+        "address1": "3500 Lacey Road",
+        "address2": "Suite 100",
+        "city": "Downers Grove",
+        "state": "IL",
+        "zip": "60515",
+        "country": "USA"
+      },
+      "mailingAddress": {
+        "address1": "3500 Lacey Road",
+        "address2": "Suite 100",
+        "city": "Downers Grove",
+        "state": "IL",
+        "zip": "60515",
+        "country": "USA"
+      },
+      "webAddress": "https://www.comptia.org"
+    },
+    "tests": [
+      {
+        "name": "CompTIA Security+ Certification Exam",
+        "fee": "370",
+        "beginDate": "01-JAN-20",
+        "endDate": "31-DEC-23",
+        "description": "CompTIA Security+ is a global certification that validates the baseline skills necessary to perform core security functions"
+      },
+      {
+        "name": "CompTIA Security+ Retake Exam",
+        "fee": "225",
+        "beginDate": "01-JAN-20",
+        "endDate": "31-DEC-23",
+        "description": "Retake exam for failed attempts"
+      }
+    ]
+  }
+}

--- a/src/applications/gi/tests/data/lc-details.json
+++ b/src/applications/gi/tests/data/lc-details.json
@@ -4,7 +4,7 @@
     "lacNm": "General Electrician",
     "eduLacTypeNm": "Certification",
     "institution": {
-      "name": "CompTIA",
+      "name": "Electric School",
       "physicalAddress": {
         "address1": "3500 Lacey Road",
         "address2": "Suite 100",
@@ -25,11 +25,11 @@
     },
     "tests": [
       {
-        "name": "CompTIA Security+ Certification Exam",
+        "name": "Comp Security+ Certification Exam",
         "fee": "370"
       },
       {
-        "name": "CompTIA Security+ Retake Exam",
+        "name": "Comp Security+ Retake Exam",
         "fee": "225"
       }
     ]

--- a/src/applications/gi/tests/data/lc-list.json
+++ b/src/applications/gi/tests/data/lc-list.json
@@ -1,58 +1,136 @@
 {
-  "data": {
-    "items": [
-      {
-        "enrichedId": "1@sec",
-        "lacNm": "Security+ Certification",
-        "eduLacTypeNm": "Certification",
-        "state": null,
-        "institution": {
-          "name": "CompTIA",
-          "physicalAddress": {
-            "address1": "3500 Lacey Road",
-            "address2": "Suite 100",
-            "city": "Downers Grove",
-            "state": "IL",
-            "zip": "60515",
-            "country": "USA"
-          }
-        }
-      },
-      {
-        "enrichedId": "2@sec",
-        "lacNm": "Security Guard Training",
-        "eduLacTypeNm": "License",
-        "state": "NY",
-        "institution": {
-          "name": "NY Department of State",
-          "physicalAddress": {
-            "address1": "123 State Street",
-            "city": "Albany",
-            "state": "NY",
-            "zip": "12207",
-            "country": "USA"
-          }
-        }
-      },
-      {
-        "enrichedId": "3@sec",
-        "lacNm": "CISSP Certification Prep Course",
-        "eduLacTypeNm": "Prep Course",
-        "state": null,
-        "institution": {
-          "name": "(ISC)²",
-          "physicalAddress": {
-            "address1": "311 Park Place Blvd",
-            "city": "Clearwater",
-            "state": "FL",
-            "zip": "33759",
-            "country": "USA"
-          }
-        }
-      }
-    ],
-    "totalItems": 15,
-    "currentPage": 1,
-    "perPage": 10
-  }
+  "lacs": [
+    {
+      "enrichedId": "14@418bc",
+      "lacNm": "Cybersecurity Professional Certificate Bootcamp",
+      "eduLacTypeNm": "Certification",
+      "state": "TN"
+    },
+    {
+      "enrichedId": "3859@058dc",
+      "lacNm": "FORTINET CERTIFIED NETWORK SECURITY ADMINISTRATOR",
+      "eduLacTypeNm": "Certification",
+      "state": "CA"
+    },
+    {
+      "enrichedId": "4366@b0f6b",
+      "lacNm": "NORTH DAKOTA REAL ESTATE PRE-LICENSE COURSE",
+      "eduLacTypeNm": "Prep Course",
+      "state": "ND"
+    },
+    {
+      "enrichedId": "3871@4494f",
+      "lacNm": "GENERAL ELECTRICIAN",
+      "eduLacTypeNm": "License",
+      "state": "CA"
+    },
+    {
+      "enrichedId": "3862@70364",
+      "lacNm": "SHRM CERTIFIED PROFESSIONAL",
+      "eduLacTypeNm": "Certification",
+      "state": "VA"
+    },
+    {
+      "enrichedId": "3693@d0ff8",
+      "lacNm": "MSSC PRODUCTION TECHNICIAN CERTIFICATION",
+      "eduLacTypeNm": "Certification",
+      "state": "VA"
+    },
+    {
+      "enrichedId": "3689@f69d3",
+      "lacNm": "CERTIFIED LOGISTICS ASSOCIATE",
+      "eduLacTypeNm": "License",
+      "state": "VA"
+    },
+    {
+      "enrichedId": "3610@5a833",
+      "lacNm": "CERTIFIED PUBLIC ACCOUNTANT",
+      "eduLacTypeNm": "License",
+      "state": "CA"
+    },
+    {
+      "enrichedId": "4379@97c9c",
+      "lacNm": "ADD-ON-LICENSE PATHWAY-ELEMENTARY EDUCATION",
+      "eduLacTypeNm": "Prep Course",
+      "state": "WI"
+    },
+    {
+      "enrichedId": "3864@3a4d4",
+      "lacNm": "TOGAF 9 CERTIFIED",
+      "eduLacTypeNm": "Certification",
+      "state": "CA"
+    },
+    {
+      "enrichedId": "159@8ad7c",
+      "lacNm": "Attorney",
+      "eduLacTypeNm": "License",
+      "state": "NM"
+    },
+    {
+      "enrichedId": "4327@fbc5e",
+      "lacNm": "Chartered Market Technician Certificate",
+      "eduLacTypeNm": "Certification",
+      "state": "NY"
+    },
+    {
+      "enrichedId": "4381@baeb0",
+      "lacNm": "COMPUTER SCIENCE CERTIFICATION PATHWAY-COMPUTER SC",
+      "eduLacTypeNm": "Prep Course",
+      "state": "WI"
+    },
+    {
+      "enrichedId": "98@1336b",
+      "lacNm": "Certified Manager of Animal Resources",
+      "eduLacTypeNm": "Certification",
+      "state": "TN"
+    },
+    {
+      "enrichedId": "4329@52e49",
+      "lacNm": "NURSING HOME ADMINISTRATOR",
+      "eduLacTypeNm": "License",
+      "state": "OH"
+    },
+    {
+      "enrichedId": "4334@7b107",
+      "lacNm": "Emergency Medical Technician - Basic",
+      "eduLacTypeNm": "License",
+      "state": "OH"
+    },
+    {
+      "enrichedId": "4344@cbeff",
+      "lacNm": "PROFESSIONAL ENGINEER",
+      "eduLacTypeNm": "License",
+      "state": "OH"
+    },
+    {
+      "enrichedId": "4353@e674a",
+      "lacNm": "COSMETOLOGIST EXAM AND LICENSE",
+      "eduLacTypeNm": "License",
+      "state": "OH"
+    },
+    {
+      "enrichedId": "4392@68b80",
+      "lacNm": "PREP-5 DAY HOME INSPECTION TEST PREP COURSE",
+      "eduLacTypeNm": "Prep Course",
+      "state": "WI"
+    },
+    {
+      "enrichedId": "4397@7a8bc",
+      "lacNm": "PREP-APICS LOGISTICS TRANS AND DIS CLTD TEST PREP",
+      "eduLacTypeNm": "Prep Course",
+      "state": "WI"
+    },
+    {
+      "enrichedId": "33@9f97e",
+      "lacNm": "Certified Safety Manager",
+      "eduLacTypeNm": "Certification",
+      "state": "NC"
+    },
+    {
+      "enrichedId": "38@93601",
+      "lacNm": "COVID 19 Infectious Disease Prevention Specialist",
+      "eduLacTypeNm": "Certification",
+      "state": "NC"
+    }
+  ]
 }

--- a/src/applications/gi/tests/data/lc-list.json
+++ b/src/applications/gi/tests/data/lc-list.json
@@ -1,0 +1,58 @@
+{
+  "data": {
+    "items": [
+      {
+        "enrichedId": "1@sec",
+        "lacNm": "Security+ Certification",
+        "eduLacTypeNm": "Certification",
+        "state": null,
+        "institution": {
+          "name": "CompTIA",
+          "physicalAddress": {
+            "address1": "3500 Lacey Road",
+            "address2": "Suite 100",
+            "city": "Downers Grove",
+            "state": "IL",
+            "zip": "60515",
+            "country": "USA"
+          }
+        }
+      },
+      {
+        "enrichedId": "2@sec",
+        "lacNm": "Security Guard Training",
+        "eduLacTypeNm": "License",
+        "state": "NY",
+        "institution": {
+          "name": "NY Department of State",
+          "physicalAddress": {
+            "address1": "123 State Street",
+            "city": "Albany",
+            "state": "NY",
+            "zip": "12207",
+            "country": "USA"
+          }
+        }
+      },
+      {
+        "enrichedId": "3@sec",
+        "lacNm": "CISSP Certification Prep Course",
+        "eduLacTypeNm": "Prep Course",
+        "state": null,
+        "institution": {
+          "name": "(ISC)²",
+          "physicalAddress": {
+            "address1": "311 Park Place Blvd",
+            "city": "Clearwater",
+            "state": "FL",
+            "zip": "33759",
+            "country": "USA"
+          }
+        }
+      }
+    ],
+    "totalItems": 15,
+    "currentPage": 1,
+    "perPage": 10
+  }
+}

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -122,13 +122,45 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.injectAxeThenAxeCheck();
     });
 
-    // TODO: updates results correctly when category checkboxes are changed
-    // TODO: updates results correctly when state dropdown is changed
-
-    // TODO: update test "displays search results with pagination"
     it('displays search results', () => {
       cy.get('h1').should('contain.text', 'Search results');
       cy.get('va-card').should('have.length', 10);
+    });
+
+    it('updates results correctly when category checkboxes and state dropdown are changed', () => {
+      // Change category checkboxes using VA checkbox components
+      cy.get('va-checkbox[name="all"]')
+        .shadow()
+        .find('input[type="checkbox"]')
+        .uncheck({ force: true });
+      cy.get('va-checkbox[name="license"]')
+        .shadow()
+        .find('input[type="checkbox"]')
+        .check({ force: true });
+      cy.get('va-checkbox[name="certification"]')
+        .shadow()
+        .find('input[type="checkbox"]')
+        .uncheck({ force: true });
+
+      cy.get('.state-dropdown select#State').select('CA', { force: true });
+
+      cy.get('.update-results-button-after').click();
+
+      cy.url().should('include', 'category=license');
+      cy.url().should('include', 'state=CA');
+
+      cy.get('va-card')
+        .should('exist')
+        .each($card => {
+          // Verify each result shows "License" as type
+          cy.wrap($card)
+            .find('h4.lc-card-subheader')
+            .should('contain.text', 'License');
+          // Verify state is California
+          cy.wrap($card)
+            .find('p.state')
+            .should('contain.text', 'California');
+        });
     });
 
     it('displays loading state while fetching results', () => {

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -21,6 +21,10 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
 
   describe('License & Certification Search Page', () => {
     beforeEach(() => {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs*', {
+        statusCode: 200,
+        body: lcListMockData,
+      }).as('lcSearch');
       cy.visit(
         '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses',
       );
@@ -32,7 +36,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.get('h1')
         .should('exist')
         .and('contain.text', 'Licenses, certifications, and prep courses');
-      cy.get('p')
+      cy.get('p.lc-description')
         .first()
         .should('contain.text', 'Use the search tool to find out which tests');
     });
@@ -46,24 +50,25 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       }).as('lcSearch');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results?name=security',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results',
       );
       cy.wait('@lcSearch');
       cy.wait('@featureToggles');
       cy.injectAxeThenAxeCheck();
     });
 
-    it('displays search results with pagination', () => {
+    // TODO: Add test for pagination
+
+    // it('displays search results with pagination', () => {
+    it('displays search results', () => {
       cy.get('h1').should('contain.text', 'Search results');
-      cy.get('#results-summary').should('contain', 'Showing 1-10');
       cy.get('va-card').should('have.length', 10);
 
-      // Test pagination
-      cy.get('va-pagination')
-        .shadow()
-        .find('[aria-label="Next page"]')
-        .click();
-      cy.get('#results-summary').should('not.contain', 'Showing 1-10');
+      // cy.get('va-pagination')
+      //   .shadow()
+      //   .find('[aria-label="Next page"]')
+      //   .click();
+      // cy.get('#results-summary').should('not.contain', 'Showing 1-10');
     });
 
     it('displays loading state while fetching results', () => {
@@ -74,7 +79,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       }).as('lcSearchDelayed');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses?name=security',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses',
       );
       cy.get('va-loading-indicator')
         .should('exist')
@@ -83,28 +88,30 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.get('va-loading-indicator').should('not.exist');
     });
 
-    it('handles filter updates correctly', () => {
-      cy.get('.filter-your-results')
-        .should('exist')
-        .within(() => {
-          cy.get('input[type="checkbox"]')
-            .first()
-            .check();
-          cy.contains('Update Search').click();
-        });
-      cy.wait('@lcSearch');
-    });
+    // TODO: Add test for filter updates
+
+    // it('handles filter updates correctly', () => {
+    //   cy.get('.filter-your-results')
+    //     .should('exist')
+    //     .within(() => {
+    //       cy.get('va-checkbox')
+    //         .second()
+    //         .click();
+    //       cy.contains('Update Search').click();
+    //     });
+    //   cy.wait('@lcSearch');
+    // });
   });
 
   describe('License & Certification Detail Page', () => {
     beforeEach(() => {
-      cy.intercept('GET', '**/v1/gi/lcpe/lacs*', {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs/3871@4494f', {
         statusCode: 200,
         body: lcDetailsMockData,
       }).as('lcDetails');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/1@sec*',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/3871@4494f/GENERAL%20ELECTRICIAN',
       );
       cy.wait('@lcDetails');
       cy.wait('@featureToggles');
@@ -117,26 +124,33 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
         .should('exist')
         .within(() => {
           cy.get('h2').should('exist');
-          cy.contains('Admin Info').should('be.visible');
-          cy.contains('Test Info').should('be.visible');
+          cy.get('h3')
+            .contains('Admin info')
+            .should('be.visible');
+          cy.get('h3')
+            .contains('Test info')
+            .should('be.visible');
         });
     });
 
     it('displays error state when details fetch fails', () => {
-      cy.intercept('GET', '**/v1/gi/lcpe/lacs', {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs/3871@4494f', {
         statusCode: 500,
         body: { error: 'Internal Server Error' },
       }).as('lcDetailsError');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/1@sec*',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/3871@4494f/GENERAL%20ELECTRICIAN',
       );
       cy.wait('@lcDetailsError');
 
-      cy.get('va-alert[data-e2e-id="alert-box"]')
+      cy.get('va-alert')
         .should('exist')
         .and('be.visible')
-        .and('contain.text', `We can't load the details right now`);
+        .and(
+          'contain.text',
+          `We can't load the licenses and certifications details`,
+        );
     });
   });
 });

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -33,6 +33,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
     });
 
     // TODO: displays error state when details fetch fails
+    // TODO: displays typeahead suggestions filttered by category when user types in search box
 
     it('renders the search page header and description correctly', () => {
       cy.get('h1')
@@ -41,6 +42,26 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.get('p.lc-description')
         .first()
         .should('contain.text', 'Use the search tool to find out which tests');
+    });
+
+    it('displays error state when fetching results fails', () => {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs*', {
+        statusCode: 500,
+        body: { error: 'Internal Server Error' },
+      }).as('lcError');
+
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses',
+      );
+      cy.wait('@lcError');
+
+      cy.get('va-alert')
+        .should('exist')
+        .and('be.visible')
+        .and(
+          'contain.text',
+          `We can't load the licenses and certifications details`,
+        );
     });
   });
 
@@ -63,10 +84,8 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
     // TODO: updates results correctly when state dropdown is changed
     // TODO: displays error state when details fetch fails
 
-    // it('displays search results with pagination', () => {
+    // TODO: update test "displays search results with pagination"
     it('displays search results', () => {
-      // TODO: update test "displays search results with pagination"
-
       cy.get('h1').should('contain.text', 'Search results');
       cy.get('va-card').should('have.length', 10);
     });
@@ -79,13 +98,33 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       }).as('lcSearchDelayed');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results',
       );
       cy.get('va-loading-indicator')
         .should('exist')
         .and('be.visible');
       cy.wait('@lcSearchDelayed');
       cy.get('va-loading-indicator').should('not.exist');
+    });
+
+    it('displays error state when fetching results fails', () => {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs*', {
+        statusCode: 500,
+        body: { error: 'Internal Server Error' },
+      }).as('lcError');
+
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results',
+      );
+      cy.wait('@lcError');
+
+      cy.get('va-alert')
+        .should('exist')
+        .and('be.visible')
+        .and(
+          'contain.text',
+          `We can't load the licenses and certifications details`,
+        );
     });
   });
 
@@ -121,6 +160,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
 
     // TODO: does not display tests in a table if there is one test.
     // TODO: displays tests in a table if there are multiple tests.
+
     it('displays error state when details fetch fails', () => {
       cy.intercept('GET', '**/v1/gi/lcpe/lacs/3871@4494f', {
         statusCode: 500,

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -1,0 +1,142 @@
+import data from '../data/calculator-constants.json';
+import lcListMockData from '../data/lc-list.json';
+import lcDetailsMockData from '../data/lc-details.json';
+
+describe('GI Bill Comparison Tool - License & Certification Pages', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'v1/gi/calculator_constants', {
+      statusCode: 200,
+      body: data,
+    });
+    cy.intercept('GET', '/data/cms/vamc-ehr.json', {
+      statusCode: 200,
+    });
+    cy.intercept('GET', '/v0/feature_toggles?*', {
+      data: {
+        type: 'feature_toggles',
+        features: [{ name: 'gi_comparison_tool_lce_toggle_flag', value: true }],
+      },
+    }).as('featureToggles');
+  });
+
+  describe('License & Certification Search Page', () => {
+    beforeEach(() => {
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses',
+      );
+      cy.wait('@featureToggles');
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('renders the search page header and description correctly', () => {
+      cy.get('h1')
+        .should('exist')
+        .and('contain.text', 'Licenses, certifications, and prep courses');
+      cy.get('p')
+        .first()
+        .should('contain.text', 'Use the search tool to find out which tests');
+    });
+  });
+
+  describe('License & Certification Search Results Page', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '**/v1/gi/lcpe/search*', {
+        statusCode: 200,
+        body: lcListMockData,
+      }).as('lcSearch');
+
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses?name=security',
+      );
+      cy.wait('@lcSearch');
+      cy.wait('@featureToggles');
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('displays search results with pagination', () => {
+      cy.get('h1').should('contain.text', 'Search results');
+      cy.get('#results-summary').should('contain', 'Showing 1-10');
+      cy.get('va-card').should('have.length', 10);
+
+      // Test pagination
+      cy.get('va-pagination')
+        .shadow()
+        .find('[aria-label="Next page"]')
+        .click();
+      cy.get('#results-summary').should('not.contain', 'Showing 1-10');
+    });
+
+    it('displays loading state while fetching results', () => {
+      cy.intercept('GET', '**/v1/gi/lcpe/search*', {
+        delayMs: 2000,
+        statusCode: 200,
+        body: lcListMockData,
+      }).as('lcSearchDelayed');
+
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses?name=security',
+      );
+      cy.get('va-loading-indicator')
+        .should('exist')
+        .and('be.visible');
+      cy.wait('@lcSearchDelayed');
+      cy.get('va-loading-indicator').should('not.exist');
+    });
+
+    it('handles filter updates correctly', () => {
+      cy.get('.filter-your-results')
+        .should('exist')
+        .within(() => {
+          cy.get('input[type="checkbox"]')
+            .first()
+            .check();
+          cy.contains('Update Search').click();
+        });
+      cy.wait('@lcSearch');
+    });
+  });
+
+  describe('License & Certification Detail Page', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '**/v1/gi/lcpe/search/detail/*', {
+        statusCode: 200,
+        body: lcDetailsMockData,
+      }).as('lcDetails');
+
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/123',
+      );
+      cy.wait('@lcDetails');
+      cy.wait('@featureToggles');
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('displays license/certification details correctly', () => {
+      cy.get('h1').should('exist');
+      cy.get('.lc-result-details')
+        .should('exist')
+        .within(() => {
+          cy.get('h2').should('exist');
+          cy.contains('Admin Info').should('be.visible');
+          cy.contains('Test Info').should('be.visible');
+        });
+    });
+
+    it('displays error state when details fetch fails', () => {
+      cy.intercept('GET', '**/v1/gi/lcpe/search/detail/*', {
+        statusCode: 500,
+        body: { error: 'Internal Server Error' },
+      }).as('lcDetailsError');
+
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/123',
+      );
+      cy.wait('@lcDetailsError');
+
+      cy.get('va-alert[data-e2e-id="alert-box"]')
+        .should('exist')
+        .and('be.visible')
+        .and('contain.text', `We can't load the details right now`);
+    });
+  });
+});

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -156,7 +156,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
           cy.get('h3')
             .contains('Admin info')
             .should('be.visible');
-          cy.get('.name-wrapper').should('contain.text', 'Comptia');
+          cy.get('.name-wrapper').should('contain.text', 'Electric School');
           cy.contains(
             'Certification tests are available to be taken nationally',
           ).should('be.visible');
@@ -183,7 +183,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
           lacNm: 'General Electrician',
           eduLacTypeNm: 'Certification',
           institution: {
-            name: 'CompTIA',
+            name: 'Electric School',
             physicalAddress: {
               address1: '3500 Lacey Road',
               city: 'Downers Grove',
@@ -199,7 +199,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
           },
           tests: [
             {
-              name: 'CompTIA General Electrician Exam',
+              name: 'General Electrician Exam',
               fee: '370',
             },
           ],
@@ -221,14 +221,11 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
         .within(() => {
           cy.get('h4').should(
             'contain.text',
-            'Test name: CompTIA General Electrician Exam',
+            'Test name: General Electrician Exam',
           );
           cy.get('.fee').should('contain.text', 'Fee: $370.00');
         });
     });
-
-    // TODO: does not display tests in a table if there is one test.
-    // TODO: displays tests in a table if there are multiple tests.
 
     it('displays error state when details fetch fails', () => {
       cy.intercept('GET', '**/v1/gi/lcpe/lacs/3871@4494f', {

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -32,6 +32,8 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.injectAxeThenAxeCheck();
     });
 
+    // TODO: displays error state when details fetch fails
+
     it('renders the search page header and description correctly', () => {
       cy.get('h1')
         .should('exist')
@@ -57,18 +59,16 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.injectAxeThenAxeCheck();
     });
 
-    // TODO: Add test for pagination
+    // TODO: updates results correctly when category checkboxes are changed
+    // TODO: updates results correctly when state dropdown is changed
+    // TODO: displays error state when details fetch fails
 
     // it('displays search results with pagination', () => {
     it('displays search results', () => {
+      // TODO: update test "displays search results with pagination"
+
       cy.get('h1').should('contain.text', 'Search results');
       cy.get('va-card').should('have.length', 10);
-
-      // cy.get('va-pagination')
-      //   .shadow()
-      //   .find('[aria-label="Next page"]')
-      //   .click();
-      // cy.get('#results-summary').should('not.contain', 'Showing 1-10');
     });
 
     it('displays loading state while fetching results', () => {
@@ -87,20 +87,6 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.wait('@lcSearchDelayed');
       cy.get('va-loading-indicator').should('not.exist');
     });
-
-    // TODO: Add test for filter updates
-
-    // it('handles filter updates correctly', () => {
-    //   cy.get('.filter-your-results')
-    //     .should('exist')
-    //     .within(() => {
-    //       cy.get('va-checkbox')
-    //         .second()
-    //         .click();
-    //       cy.contains('Update Search').click();
-    //     });
-    //   cy.wait('@lcSearch');
-    // });
   });
 
   describe('License & Certification Detail Page', () => {
@@ -133,6 +119,8 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
         });
     });
 
+    // TODO: does not display tests in a table if there is one test.
+    // TODO: displays tests in a table if there are multiple tests.
     it('displays error state when details fetch fails', () => {
       cy.intercept('GET', '**/v1/gi/lcpe/lacs/3871@4494f', {
         statusCode: 500,

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -32,9 +32,6 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.injectAxeThenAxeCheck();
     });
 
-    // TODO: displays error state when details fetch fails
-    // TODO: displays typeahead suggestions filttered by category when user types in search box
-
     it('renders the search page header and description correctly', () => {
       cy.get('h1')
         .should('exist')
@@ -42,6 +39,51 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.get('p.lc-description')
         .first()
         .should('contain.text', 'Use the search tool to find out which tests');
+    });
+
+    it('displays typeahead suggestions when user types in search box', () => {
+      cy.get('#keyword-search input').type('electric');
+
+      cy.get('.suggestions-list').should('be.visible');
+
+      cy.get('.suggestions-list .suggestion')
+        .first()
+        .find('.keyword-suggestion-container')
+        .within(() => {
+          cy.contains('electric');
+          cy.contains('results').should('be.visible');
+        });
+
+      cy.get('.suggestions-list .suggestion')
+        .should('have.length.at.least', 2)
+        .each(($suggestion, index) => {
+          if (index > 0) {
+            cy.wrap($suggestion)
+              .invoke('text')
+              .should('match', /electric/i);
+          }
+        });
+
+      cy.get('#clear-input').click();
+      cy.get('.suggestions-list').should('not.exist');
+    });
+
+    it('redirects to results page with search parameters when form is submitted', () => {
+      cy.get('#keyword-search input').type('electric');
+
+      cy.get('select.dropdown-filter').select('License');
+
+      cy.get('va-button')
+        .contains('Submit')
+        .click();
+
+      cy.url().should('include', '/results');
+      cy.url().should('include', 'name=electric');
+      cy.url().should('include', 'category=license');
+
+      cy.get('h1').should('contain.text', 'Search results');
+
+      cy.get('va-card').should('exist');
     });
 
     it('displays error state when fetching results fails', () => {
@@ -82,7 +124,6 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
 
     // TODO: updates results correctly when category checkboxes are changed
     // TODO: updates results correctly when state dropdown is changed
-    // TODO: displays error state when details fetch fails
 
     // TODO: update test "displays search results with pagination"
     it('displays search results', () => {
@@ -176,7 +217,6 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
     });
 
     it('renders test details correctly when there is only one test', () => {
-      // Intercept with single test data
       const singleTestData = {
         lac: {
           enrichedId: '1@sec',

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -128,7 +128,6 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
     });
 
     it('updates results correctly when category checkboxes and state dropdown are changed', () => {
-      // Change category checkboxes using VA checkbox components
       cy.get('va-checkbox[name="all"]')
         .shadow()
         .find('input[type="checkbox"]')
@@ -152,11 +151,10 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
       cy.get('va-card')
         .should('exist')
         .each($card => {
-          // Verify each result shows "License" as type
           cy.wrap($card)
             .find('h4.lc-card-subheader')
             .should('contain.text', 'License');
-          // Verify state is California
+
           cy.wrap($card)
             .find('p.state')
             .should('contain.text', 'California');

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -144,17 +144,86 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
     });
 
     it('displays license/certification details correctly', () => {
-      cy.get('h1').should('exist');
+      cy.get('h1')
+        .should('exist')
+        .and('contain.text', 'General Electrician');
       cy.get('.lc-result-details')
         .should('exist')
         .within(() => {
-          cy.get('h2').should('exist');
+          cy.get('h2')
+            .should('exist')
+            .and('contain.text', 'Certification');
           cy.get('h3')
             .contains('Admin info')
             .should('be.visible');
+          cy.get('.name-wrapper').should('contain.text', 'Comptia');
+          cy.contains(
+            'Certification tests are available to be taken nationally',
+          ).should('be.visible');
+          cy.get('va-link')
+            .shadow()
+            .find('a')
+            .should(
+              'have.attr',
+              'href',
+              'https://www.va.gov/find-forms/about-form-22-0803/',
+            )
+            .and('contain.text', 'Get VA Form22-0803 to download');
           cy.get('h3')
             .contains('Test info')
             .should('be.visible');
+        });
+    });
+
+    it('renders test details correctly when there is only one test', () => {
+      // Intercept with single test data
+      const singleTestData = {
+        lac: {
+          enrichedId: '1@sec',
+          lacNm: 'General Electrician',
+          eduLacTypeNm: 'Certification',
+          institution: {
+            name: 'CompTIA',
+            physicalAddress: {
+              address1: '3500 Lacey Road',
+              city: 'Downers Grove',
+              state: 'IL',
+              zip: '60515',
+            },
+            mailingAddress: {
+              address1: '3500 Lacey Road',
+              city: 'Downers Grove',
+              state: 'IL',
+              zip: '60515',
+            },
+          },
+          tests: [
+            {
+              name: 'CompTIA General Electrician Exam',
+              fee: '370',
+            },
+          ],
+        },
+      };
+
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs/3871@4494f', {
+        statusCode: 200,
+        body: singleTestData,
+      }).as('lcDetailsSingle');
+
+      cy.visit(
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/3871@4494f/GENERAL%20ELECTRICIAN',
+      );
+      cy.wait('@lcDetailsSingle');
+
+      cy.get('.single-test-wrapper')
+        .should('exist')
+        .within(() => {
+          cy.get('h4').should(
+            'contain.text',
+            'Test name: CompTIA General Electrician Exam',
+          );
+          cy.get('.fee').should('contain.text', 'Fee: $370.00');
         });
     });
 

--- a/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
+++ b/src/applications/gi/tests/e2e/gi-license-certification.cypress.spec.js
@@ -40,13 +40,13 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
 
   describe('License & Certification Search Results Page', () => {
     beforeEach(() => {
-      cy.intercept('GET', '**/v1/gi/lcpe/search*', {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs*', {
         statusCode: 200,
         body: lcListMockData,
       }).as('lcSearch');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses?name=security',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results?name=security',
       );
       cy.wait('@lcSearch');
       cy.wait('@featureToggles');
@@ -67,7 +67,7 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
     });
 
     it('displays loading state while fetching results', () => {
-      cy.intercept('GET', '**/v1/gi/lcpe/search*', {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs*', {
         delayMs: 2000,
         statusCode: 200,
         body: lcListMockData,
@@ -98,13 +98,13 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
 
   describe('License & Certification Detail Page', () => {
     beforeEach(() => {
-      cy.intercept('GET', '**/v1/gi/lcpe/search/detail/*', {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs*', {
         statusCode: 200,
         body: lcDetailsMockData,
       }).as('lcDetails');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/123',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/1@sec*',
       );
       cy.wait('@lcDetails');
       cy.wait('@featureToggles');
@@ -123,13 +123,13 @@ describe('GI Bill Comparison Tool - License & Certification Pages', () => {
     });
 
     it('displays error state when details fetch fails', () => {
-      cy.intercept('GET', '**/v1/gi/lcpe/search/detail/*', {
+      cy.intercept('GET', '**/v1/gi/lcpe/lacs', {
         statusCode: 500,
         body: { error: 'Internal Server Error' },
       }).as('lcDetailsError');
 
       cy.visit(
-        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/123',
+        '/education/gi-bill-comparison-tool/licenses-certifications-and-prep-courses/results/1@sec*',
       );
       cy.wait('@lcDetailsError');
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Cypress testing for Licenses and Certifications 
- I work for Education Data Migration (EDM)

## Related issue(s)

- EDM-395: add cypress testing for Licenses and Certifications

## Testing done

- No cypress testing was implemented previously
    - With this PR there is now e2e coverage for all the 3 License and Certification pages 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
