### PR TITLE
MHV-65696 SM: OH alert content updates

### DIFF
--- a/src/applications/mhv-secure-messaging/components/MessageList/CernerFacilityAlert.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/CernerFacilityAlert.jsx
@@ -21,68 +21,72 @@ const CernerFacilityAlert = ({ cernerFacilities }) => {
     [cernerFacilities, ehrDataByVhaId],
   );
 
+  const isMultipleFacilities = cernerFacilitiesNames.length > 1;
+  const isOneFacility = cernerFacilitiesNames.length === 1;
+
+  if (!cernerFacilitiesNames?.length) {
+    return null;
+  }
+
+  const renderMultipleFacilities = () => (
+    <>
+      <p>
+        Some of your messages may be in a different portal. To view or manage
+        messages at these facilities, go to My VA Health
+      </p>
+      <ul>
+        {cernerFacilitiesNames.map((facilityName, i) => (
+          <li data-testid="cerner-facility" key={i}>
+            {facilityName}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+
+  const renderSingleFacility = () => (
+    <p data-testId="single-cerner-facility-text">
+      Some of your messages may be in a different portal. To send a secure
+      message to a provider at <strong>{cernerFacilitiesNames[0]}</strong>, go
+      to My VA Health.
+    </p>
+  );
+
   return (
     <>
-      {cernerFacilitiesNames?.length > 0 && (
-        <va-alert
-          className="vads-u-margin-bottom--2"
-          status="warning"
-          background-only
-          close-btn-aria-label="Close notification"
-          visible
-          data-testid="cerner-facilities-alert"
-        >
-          <h2 className="vads-u-font-size--md">
-            Make sure you’re in the right health portal
-          </h2>
-          <div>
-            {cernerFacilitiesNames?.length > 1 && (
-              <>
-                <p>
-                  To send a secure message to a provider at these facilities, go
-                  to My VA Health:
-                </p>
-                <ul>
-                  {cernerFacilitiesNames.map((facilityName, i) => (
-                    <li data-testid="cerner-facility" key={i}>
-                      {facilityName}
-                    </li>
-                  ))}
-                </ul>
-              </>
-            )}
-            {cernerFacilitiesNames?.length === 1 && (
-              <p data-testId="single-cerner-facility-text">
-                To send a secure message to a provider at{' '}
-                <strong>{cernerFacilitiesNames[0]}</strong>, go to My VA Health.
-              </p>
-            )}
+      <va-alert
+        className="vads-u-margin-bottom--2"
+        status="warning"
+        background-only
+        close-btn-aria-label="Close notification"
+        visible
+        data-testid="cerner-facilities-alert"
+      >
+        <h2 className="vads-u-font-size--md">
+          {`To send a secure message to a provider at ${
+            isMultipleFacilities ? 'these facilities' : 'this facility'
+          }, go to My VA Health`}
+        </h2>
+        <div>
+          {isMultipleFacilities && renderMultipleFacilities()}
+          {isOneFacility && renderSingleFacility()}
 
-            <a
-              className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
-              href={getCernerURL('/pages/messaging/inbox', true)}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Go to My VA Health (opens in new tab)
-            </a>
+          <a
+            className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
+            href={getCernerURL('/pages/messaging/inbox', true)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Go to My VA Health (opens in new tab)
+          </a>
 
-            <va-additional-info
-              trigger="Having trouble opening My VA Health?"
-              uswds
-            >
-              <div>Try these steps:</div>
-              <ul>
-                <li>Disable your browser’s pop-up blocker</li>
-                <li>
-                  Sign in to My VA Health with the same account you used to sign
-                  in to VA.gov
-                </li>
-              </ul>
-            </va-additional-info>
-          </div>
-        </va-alert>
-      )}
+          <p>
+            <strong>Note:</strong> Having trouble opening up My VA Health? Try
+            disabling your browser’s pop-up blocker or signing in to My VA
+            Health with the same account you used to sign in to VA.gov.
+          </p>
+        </div>
+      </va-alert>
     </>
   );
 };

--- a/src/applications/mhv-secure-messaging/components/MessageList/CernerFacilityAlert.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/CernerFacilityAlert.jsx
@@ -31,8 +31,8 @@ const CernerFacilityAlert = ({ cernerFacilities }) => {
   const renderMultipleFacilities = () => (
     <>
       <p>
-        Some of your messages may be in a different portal. To view or manage
-        messages at these facilities, go to My VA Health
+        Some of your secure messages may be in a different portal. To view or
+        manage secure messages at these facilities, go to My VA Health:
       </p>
       <ul>
         {cernerFacilitiesNames.map((facilityName, i) => (
@@ -46,9 +46,9 @@ const CernerFacilityAlert = ({ cernerFacilities }) => {
 
   const renderSingleFacility = () => (
     <p data-testId="single-cerner-facility-text">
-      Some of your messages may be in a different portal. To send a secure
-      message to a provider at <strong>{cernerFacilitiesNames[0]}</strong>, go
-      to My VA Health.
+      Some of your secure messages may be in a different portal. To send a
+      secure message to a provider at{' '}
+      <strong>{cernerFacilitiesNames[0]}</strong>, go to My VA Health.
     </p>
   );
 

--- a/src/applications/mhv-secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
@@ -63,6 +63,12 @@ describe('Cerner Facility Alert', () => {
     expect(screen.getByText('VA Spokane health care')).to.exist;
     expect(screen.getByText('VA Walla Walla health care')).to.exist;
     expect(screen.getByText('VA Southern Oregon health care')).to.exist;
+    expect(screen.queryByText('VA Puget Sound health care')).to.not.exist;
+    expect(
+      screen.queryByText(
+        'Some of your messages may be in a different portal. To view or manage messages at these facilities, go to My VA Health',
+      ),
+    ).to.exist;
   });
 
   it(`renders CernerFacilityAlert with 1 facility if cernerFacilities.length === 1`, async () => {
@@ -75,7 +81,8 @@ describe('Cerner Facility Alert', () => {
     expect(
       screen.getByTestId('single-cerner-facility-text').textContent,
     ).to.contain(
-      'To send a secure message to a provider at VA Spokane health care, go to My VA Health.',
+      'Some of your messages may be in a different portal. To send a secure message to a provider at VA Spokane health care, go to My VA Health.',
     );
+    expect(screen.queryByRole('ul')).to.not.exist;
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
@@ -65,8 +65,8 @@ describe('Cerner Facility Alert', () => {
     expect(screen.getByText('VA Southern Oregon health care')).to.exist;
     expect(screen.queryByText('VA Puget Sound health care')).to.not.exist;
     expect(
-      screen.queryByText(
-        'Some of your messages may be in a different portal. To view or manage messages at these facilities, go to My VA Health',
+      screen.getByText(
+        'Some of your secure messages may be in a different portal. To view or manage secure messages at these facilities, go to My VA Health:',
       ),
     ).to.exist;
   });
@@ -81,7 +81,7 @@ describe('Cerner Facility Alert', () => {
     expect(
       screen.getByTestId('single-cerner-facility-text').textContent,
     ).to.contain(
-      'Some of your messages may be in a different portal. To send a secure message to a provider at VA Spokane health care, go to My VA Health.',
+      'Some of your secure messages may be in a different portal. To send a secure message to a provider at VA Spokane health care, go to My VA Health.',
     );
     expect(screen.queryByRole('ul')).to.not.exist;
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/facilities-tests/secure-messaging-mixed-facilities-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/facilities-tests/secure-messaging-mixed-facilities-inbox.cypress.spec.js
@@ -24,9 +24,10 @@ describe('Secure Messaging Inbox Cerner', () => {
 
     cy.get(Locators.ALERTS.CERNER_ALERT).should('be.visible');
 
-    cy.contains('h2', 'Make sure you’re in the right health portal').should(
-      'be.visible',
-    );
+    cy.contains(
+      'h2',
+      'To send a secure message to a provider at these facilities, go to My VA Health',
+    ).should('be.visible');
 
     cy.get('[data-testid="cerner-facility"]').should(
       'have.length',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update content on the OH alert shown to users associated with an OH facility

From Katelyn:  There is a request to standardize the OH alert shown to users associated with an OH facility so it's the same across all tools.  The updated design is [here](https://www.figma.com/design/m992k2m1DSl9MXV9hDytsQ/MHV-Account-Security-%26-Sign-In?node-id=263-24267&p=f&t=5mNnUCyflJWfNfwt-0).  It should be a fairly small content update from our current alert.  Can you add a ticket for devs and get prioritized whenever we have time? 

Figma Link:  **  https://www.figma.com/design/m992k2m1DSl9MXV9hDytsQ/MHV-Account-Security-%26-Sign-In?node-id=263-24267&p=f&t=Tw7BTm9H4vBXRQrz-0 
https://dsva.slack.com/archives/C03ECSBGSKX/p1735938853743299


## Related issue(s)

- [MHV-65696](https://jira.devops.va.gov/browse/MHV-65696)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width=200 src="https://github.com/user-attachments/assets/d0d2442c-48ba-4aee-9d79-a35b140971f5"/><img width=200 src="https://github.com/user-attachments/assets/870ec389-8bfb-465f-b510-2e08fea97117"/>|<img width=200 src="https://github.com/user-attachments/assets/11b90486-9733-4da1-af09-6b16e6e422e1"/><img width=200 src="https://github.com/user-attachments/assets/07b3211d-2f7c-40f4-bbe5-5411e87c8095"/>|
| Desktop |<img width=200 src="https://github.com/user-attachments/assets/6a61953b-a780-4f76-8bcc-aa08dd2d2447"/><img width=200 src ="https://github.com/user-attachments/assets/ceae0371-5d89-40cd-bbea-abb3ed3909a9"/>|<img width=200 src="https://github.com/user-attachments/assets/0d32a8fb-8b84-4c03-9d46-e02c6a1b2907"/><img width=200 src="https://github.com/user-attachments/assets/ed08e2ab-9a0c-4893-848f-f2513b40b431"/>|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
