### PR TITLE
1957 hard code version

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -487,6 +487,19 @@ module.exports = async (env = {}) => {
         ),
         'process.env.USE_LOCAL_DIRECTLINE':
           process.env.USE_LOCAL_DIRECTLINE || false,
+        'process.env.DATADOG_APP_NAME': JSON.stringify(
+          process.env.DATADOG_APP_NAME || '',
+        ),
+        'process.env.DATADOG_API_KEY': JSON.stringify(
+          process.env.DATADOG_API_KEY || '',
+        ),
+        'process.env.HOST_NAME': JSON.stringify(process.env.HOST_NAME || ''),
+        'process.env.LOG_LEVEL': JSON.stringify(
+          process.env.LOG_LEVEL || 'info',
+        ),
+        'process.env.DATADOG_TAGS': JSON.stringify(
+          process.env.DATADOG_TAGS || '',
+        ),
       }),
 
       new webpack.ProvidePlugin({

--- a/src/applications/virtual-agent/components/WebChat.jsx
+++ b/src/applications/virtual-agent/components/WebChat.jsx
@@ -96,7 +96,7 @@ const WebChat = ({
     TOGGLE_NAMES.virtualAgentEnableDatadogLogging,
   );
 
-  logger.info('Winston logger: Ding! Test message');
+  logger.info('Winston logger: Ding! Testing, 1, 2, 3!');
 
   validateParameters({
     csrfToken,

--- a/src/applications/virtual-agent/tests/utils/logger/loggerHelpers.unit.spec.js
+++ b/src/applications/virtual-agent/tests/utils/logger/loggerHelpers.unit.spec.js
@@ -1,10 +1,8 @@
 import winston from 'winston';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import fs from 'fs';
 import {
   buildDefaultLoggerOptions,
-  getVersionNumber,
   createLogger,
   setLoggerOutput,
   getDatadogTags,
@@ -68,19 +66,6 @@ describe('loggerHelpers', () => {
       expect(loggerOptionsActual.level).to.equal('debug');
       expect(loggerOptionsActual.exitOnError).to.be.false;
       expect(loggerOptionsActual).to.have.property('format');
-    });
-  });
-  describe('getVersionNumber', () => {
-    it('should get the version number', () => {
-      const readFileSyncStub = sinon.stub(fs, 'readFileSync');
-      readFileSyncStub.returns('{"version":"1.0.1"}');
-
-      const versionNumber = getVersionNumber();
-
-      const mockVersionNumber = '1.0.1';
-
-      expect(versionNumber).to.deep.equal(mockVersionNumber);
-      readFileSyncStub.restore();
     });
   });
   describe('getDatadogTags', () => {

--- a/src/applications/virtual-agent/utils/logger/loggerHelpers.js
+++ b/src/applications/virtual-agent/utils/logger/loggerHelpers.js
@@ -1,5 +1,4 @@
 const winston = require('winston');
-const fs = require('fs');
 const path = require('path');
 
 const ENV_FILE = path.join(
@@ -28,21 +27,10 @@ function isLocalHost() {
   return host === 'localhost';
 }
 
-function getVersionNumber() {
-  /**
-   * This function reads the version number from the package.json file
-   * and returns it as a string.
-   */
-
-  const packageJson = fs.readFileSync('package.json');
-  const { version } = JSON.parse(packageJson);
-  return version;
-}
-
 function getDatadogTags() {
   return process.env.DATADOG_TAGS
-    ? `version:${getVersionNumber()},${process.env.DATADOG_TAGS}`
-    : `version:${getVersionNumber()}`;
+    ? `version:1.0.1,${process.env.DATADOG_TAGS}`
+    : `version:1.0.1`;
 }
 
 function buildDefaultLoggerOptions() {
@@ -104,7 +92,6 @@ function setLoggerOutput(logger) {
 
 module.exports = {
   buildDefaultLoggerOptions,
-  getVersionNumber,
   createLogger,
   setLoggerOutput,
   getDatadogTags,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- We have been struggling to replace Sentry with Datadog logging for our chatbot in vets-website. Our previous implementation used a function, fs.readFIleSync('package.json'), which was causing an error when running our bot locally. We have instead hardcoded the version number, which used to be read from our package.json, and would like to deploy this change to determine if this was the only issue blocking our Datadog implementation.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- We have tried many implementations so far, but this implementation is the only one that has been able send logs visible from the Datadog UI. We verified it is working locally and would like to test in Dev/Staging.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- Chatbot Platform Team and we own this component.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/1957
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- Prior to this change we were unable to log anything to Datadog from vets-website. When attempting this locally we found we needed a work around for the previous function we used to read the version number from our package.json. This workaround is contained in this PR.
- _Describe the steps required to verify your changes are working as expected_
- Followed all platform documentation, fully unit tested our solution, along with running vets-api together with vets-website locally with our changes. We also were able to find out test message inside the Datadog UI.
- _Describe the tests completed and the results_
- We tested locally as well as previously wrote several unit tests covering this implementation. We were able to find out test message inside the Datadog UI.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
- This impacts logging for our chatbot from vets-website.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution - **(This is what we aim to fix with this PR)**
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) - **(This is what we aim to fix with this PR)**

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
