### PR TITLE
VA.GOV-TEAM-103949 form engine breadcrumbs

### DIFF
--- a/src/applications/simple-forms-form-engine/21-4140/app-entry.jsx
+++ b/src/applications/simple-forms-form-engine/21-4140/app-entry.jsx
@@ -5,4 +5,11 @@ startFormEngineApp({
   formId: '21-4140',
   rootUrl: manifest.rootUrl,
   trackingPrefix: '21-4140-eq-',
+  breadcrumbs: [
+    { href: '/', label: 'Home' },
+    {
+      href: '/employment-questionnaire-form-21-4140',
+      label: 'Employment Questionnaire',
+    },
+  ],
 });

--- a/src/applications/simple-forms-form-engine/shared/containers/FormRenderer.jsx
+++ b/src/applications/simple-forms-form-engine/shared/containers/FormRenderer.jsx
@@ -74,6 +74,9 @@ const FormRenderer = ({ formId, rootUrl, trackingPrefix, breadcrumbs }) => {
 };
 
 FormRenderer.propTypes = {
+  breadcrumbs: PropTypes.arrayOf(
+    PropTypes.shape({ label: PropTypes.string, href: PropTypes.string }),
+  ),
   formId: PropTypes.string,
   rootUrl: PropTypes.string,
   trackingPrefix: PropTypes.string,

--- a/src/applications/simple-forms-form-engine/shared/containers/FormRenderer.jsx
+++ b/src/applications/simple-forms-form-engine/shared/containers/FormRenderer.jsx
@@ -10,8 +10,9 @@ import {
   fetchAndBuildFormConfig,
 } from '../actions/form-load';
 import { getReducerFromFormConfig } from '../reducers/form-render';
+import { wrapWithBreadcrumb } from '../utils/breadcrumbs';
 
-const FormRenderer = ({ formId, rootUrl, trackingPrefix }) => {
+const FormRenderer = ({ formId, rootUrl, trackingPrefix, breadcrumbs }) => {
   const dispatch = useDispatch();
   const store = useStore();
   const [routes, setRoutes] = useState(null);
@@ -52,7 +53,7 @@ const FormRenderer = ({ formId, rootUrl, trackingPrefix }) => {
   }
 
   if (routes) {
-    return (
+    return wrapWithBreadcrumb(
       <Router
         history={history}
         createElement={(Element, elementProps) => (
@@ -60,7 +61,8 @@ const FormRenderer = ({ formId, rootUrl, trackingPrefix }) => {
         )}
       >
         {routes}
-      </Router>
+      </Router>,
+      breadcrumbs,
     );
   }
 

--- a/src/applications/simple-forms-form-engine/shared/utils/breadcrumbs.jsx
+++ b/src/applications/simple-forms-form-engine/shared/utils/breadcrumbs.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+// component: React.Component
+// breadcrumbs: {href: '/foo', label: 'Bar'}[]
+// https://design.va.gov/storybook/?path=/docs/uswds-va-breadcrumbs--docs
+export const wrapWithBreadcrumb = (component, breadcrumbs) => (
+  <>
+    <div className="row vads-u-padding-x--1p5">
+      {breadcrumbs && <VaBreadcrumbs uswds breadcrumbList={breadcrumbs} />}
+    </div>
+    {component}
+  </>
+);

--- a/src/applications/simple-forms-form-engine/shared/utils/startApp.js
+++ b/src/applications/simple-forms-form-engine/shared/utils/startApp.js
@@ -7,7 +7,7 @@ import reducer from '../reducers';
 import FormRenderer from '../containers/FormRenderer';
 import { removeTrailingSlash } from './string';
 
-export default ({ formId, rootUrl, trackingPrefix = null }) => {
+export default ({ formId, rootUrl, trackingPrefix = null, breadcrumbs }) => {
   const rootUrlNoTrailingSlash = removeTrailingSlash(rootUrl);
 
   startAppFromIndex({
@@ -18,6 +18,7 @@ export default ({ formId, rootUrl, trackingPrefix = null }) => {
         formId={formId}
         rootUrl={rootUrlNoTrailingSlash}
         trackingPrefix={trackingPrefix}
+        breadcrumbs={breadcrumbs}
       />
     ),
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Similar to [other apps in vets-website](https://github.com/search?q=repo%3Adepartment-of-veterans-affairs%2Fvets-website%20wrapWithBreadcrumb&type=code), the form engine creates a wrapper function for adding relevant breadcrumbs to forms built in this manner. Similar to the `breadcrumb_override` function in content-build's registry, this PR provides a mechanism for each simple form's `app-entry` to provide the breadcrumb hierarchy required.


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/103949

## Testing done

- verified breadcrumbs appeared on the expected pages with desired spacing

## Screenshots
Breadcrumbs visible around the form app:
![Screenshot 2025-03-03 at 2 16 32 PM](https://github.com/user-attachments/assets/d4c91554-5271-4492-839f-43cc7459bd0e)

Can be updated to any required depth:
![Screenshot 2025-03-03 at 2 27 38 PM](https://github.com/user-attachments/assets/7fdff5c5-8ce8-4e08-b1ca-446df44cce10)


## What areas of the site does it impact?

Forms rendered via the `simple-forms-form-engine` app.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
