### PR TITLE
better error page

### DIFF
--- a/src/applications/accredited-representative-portal/components/ErrorBoundary.jsx
+++ b/src/applications/accredited-representative-portal/components/ErrorBoundary.jsx
@@ -1,20 +1,19 @@
 import React from 'react';
-// import { useRouteError } from 'react-router-dom';
+import ErrorPage from '../containers/ErrorPage';
 
 const ErrorBoundary = () => {
-  // const error = useRouteError();
-  // console.log(error);
-
   return (
-    <va-alert data-testid="error-message" status="error" visible>
-      <h2 slot="headline">We’re sorry. Something went wrong.</h2>
-      <div>
-        <p className="vads-u-margin-y--0">
-          Please refresh this page or check back later. You can also check the
-          system status on the VA.gov homepage.
-        </p>
-      </div>
-    </va-alert>
+    <ErrorPage>
+      <va-alert data-testid="error-message" status="error" visible>
+        <h2 slot="headline">We’re sorry. Something went wrong.</h2>
+        <div>
+          <p className="vads-u-margin-y--0">
+            Please refresh this page or check back later. You can also check the
+            system status on the VA.gov homepage.
+          </p>
+        </div>
+      </va-alert>
+    </ErrorPage>
   );
 };
 

--- a/src/applications/accredited-representative-portal/containers/ErrorPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/ErrorPage.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+const ErrorPage = ({ children }) => {
+  return (
+    <div className="container">
+      <Header />
+      <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
+        <div className="vads-l-row">
+          <div className="vads-l-col--12 vads-u-padding-y--5">{children}</div>
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
@@ -5,9 +5,6 @@ import sinon from 'sinon';
 
 // Mock the Header component
 import * as Header from '../../../components/Header';
-
-sinon.stub(Header, 'default').returns(<div data-testid="mock-header" />);
-
 import ErrorBoundary from '../../../components/ErrorBoundary';
 
 describe('ErrorBoundary', () => {
@@ -15,6 +12,7 @@ describe('ErrorBoundary', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    sinon.stub(Header, 'default').returns(<div data-testid="mock-header" />);
   });
 
   afterEach(() => {

--- a/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
@@ -1,10 +1,26 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
+import sinon from 'sinon';
+
+// Mock the Header component
+import * as Header from '../../../components/Header';
+
+sinon.stub(Header, 'default').returns(<div data-testid="mock-header" />);
 
 import ErrorBoundary from '../../../components/ErrorBoundary';
 
 describe('ErrorBoundary', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   const getErrorBoundary = () => render(<ErrorBoundary />);
 
   it('renders error message', () => {

--- a/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
@@ -12,7 +12,7 @@ describe('ErrorBoundary', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    sinon.stub(Header, 'default').returns(<div data-testid="mock-header" />);
+    sandbox.stub(Header, 'default').returns(<div data-testid="mock-header" />);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Adding header/footer and container styling to outermost error boundary.

We will continue this work to handle specific errors but this shores up the outermost error boundary.

New page:
![image](https://github.com/user-attachments/assets/dd02287f-aab3-456c-8cae-da4f95a201ba)
