### PR TITLE
Burial 99564: Remove module flipper logic

### DIFF
--- a/src/applications/burials-ez/BurialsApp.jsx
+++ b/src/applications/burials-ez/BurialsApp.jsx
@@ -15,14 +15,8 @@ export default function BurialsApp({ location, children }) {
     burialFormEnabled,
     burialDocumentUploadUpdate,
     burialLocationOfDeathUpdate,
-    burialModuleEnabled,
   } = useSelector(state => state?.featureToggles);
   const dispatch = useDispatch();
-
-  // Conditional to use new Burial module path in vets-api if enabled
-  formConfig.submitUrl = burialModuleEnabled
-    ? '/burials/v0/claims'
-    : '/v0/burial_claims';
 
   useBrowserMonitoring();
 

--- a/src/applications/burials-ez/config/submit.js
+++ b/src/applications/burials-ez/config/submit.js
@@ -57,7 +57,7 @@ export function submit(form, formConfig) {
   };
 
   return apiRequest(
-    `${environment.API_URL}${formConfig.submitUrl ?? '/v0/burial_claims'}`,
+    `${environment.API_URL}/burials/v0/claims`,
     apiRequestOptions,
   )
     .then(onSuccess)

--- a/src/applications/burials-ez/tests/e2e/burials.cypress.spec.js
+++ b/src/applications/burials-ez/tests/e2e/burials.cypress.spec.js
@@ -23,7 +23,7 @@ import pagePaths from './pagePaths';
 const TEST_URL =
   '/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/introduction';
 const IN_PROGRESS_URL = '/v0/in_progress_forms/21P-530EZ';
-const BURIALS_CLAIMS_URL = '/v0/burial_claims';
+const BURIALS_CLAIMS_URL = '/burials/v0/claims';
 const CLAIM_ATTACHMENTS_URL = '/v0/claim_attachments';
 const SUBMISSION_DATE = new Date().toISOString();
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -17,7 +17,6 @@
   "burialConfirmationPage": "burial_confirmation_page",
   "burialFormEnabled": "burial_form_enabled",
   "burialDocumentUploadUpdate": "burial_document_upload_update",
-  "burialModuleEnabled": "burial_module_enabled",
   "burialBrowserMonitoringEnabled": "burial_browser_monitoring_enabled",
   "caregiverBrowserMonitoringEnabled": "caregiver_browser_monitoring_enabled",
   "caregiverUseFacilitiesApi": "caregiver_use_facilities_API",


### PR DESCRIPTION
Remove module level logic since we've fully cutover

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _Remove burialModuleEnabled logic_

## Related issue(s)

- _https://github.com/department-of-veterans-affairs/va.gov-team/issues/99564_

## Screenshots

<img width="694" alt="Screenshot 2025-03-04 at 12 48 15 PM" src="https://github.com/user-attachments/assets/79e87dea-feb2-493e-9b3a-94c619fb778c" />
