### PR TITLE
Profile | Update country codes

### DIFF
--- a/src/applications/ask-va/config/countries.json
+++ b/src/applications/ask-va/config/countries.json
@@ -161,6 +161,12 @@
       "countryCodeFIPS": "BL"
     },
     {
+      "countryName": "Bonaire, Sint Eustatius and Saba",
+      "countryCodeISO2": "BQ",
+      "countryCodeISO3": "BES",
+      "countryCodeFIPS": "NL"
+    },
+    {
       "countryName": "Bosnia and Herzegovina",
       "countryCodeISO2": "BA",
       "countryCodeISO3": "BIH",
@@ -337,6 +343,12 @@
       "countryCodeISO2": "CU",
       "countryCodeISO3": "CUB",
       "countryCodeFIPS": "CU"
+    },
+    {
+      "countryName": "Curaçao",
+      "countryCodeISO2": "CW",
+      "countryCodeISO3": "CUW",
+      "countryCodeFIPS": "UC"
     },
     {
       "countryName": "Cyprus",
@@ -923,12 +935,6 @@
       "countryCodeFIPS": "NL"
     },
     {
-      "countryName": "Netherlands Antilles",
-      "countryCodeISO2": "AN",
-      "countryCodeISO3": "ANT",
-      "countryCodeFIPS": "NT"
-    },
-    {
       "countryName": "New Caledonia",
       "countryCodeISO2": "NC",
       "countryCodeISO3": "NCL",
@@ -1468,7 +1474,7 @@
     },
     {
       "countryName": "Saint Maarten",
-      "countryCodeISO2": "NN",
+      "countryCodeISO2": "SX",
       "countryCodeISO3": "SXM",
       "countryCodeFIPS": "SX"
     },
@@ -1479,4 +1485,3 @@
       "countryCodeFIPS": "TB"
     }
   ]
-  

--- a/src/platform/user/profile/vap-svc/constants/countries.json
+++ b/src/platform/user/profile/vap-svc/constants/countries.json
@@ -161,6 +161,12 @@
     "countryCodeFIPS": "BL"
   },
   {
+    "countryName": "Bonaire, Sint Eustatius and Saba",
+    "countryCodeISO2": "BQ",
+    "countryCodeISO3": "BES",
+    "countryCodeFIPS": "NL"
+  },
+  {
     "countryName": "Bosnia and Herzegovina",
     "countryCodeISO2": "BA",
     "countryCodeISO3": "BIH",
@@ -337,6 +343,12 @@
     "countryCodeISO2": "CU",
     "countryCodeISO3": "CUB",
     "countryCodeFIPS": "CU"
+  },
+  {
+    "countryName": "Curaçao",
+    "countryCodeISO2": "CW",
+    "countryCodeISO3": "CUW",
+    "countryCodeFIPS": "UC"
   },
   {
     "countryName": "Cyprus",
@@ -923,12 +935,6 @@
     "countryCodeFIPS": "NL"
   },
   {
-    "countryName": "Netherlands Antilles",
-    "countryCodeISO2": "AN",
-    "countryCodeISO3": "ANT",
-    "countryCodeFIPS": "NT"
-  },
-  {
     "countryName": "New Caledonia",
     "countryCodeISO2": "NC",
     "countryCodeISO3": "NCL",
@@ -1468,7 +1474,7 @@
   },
   {
     "countryName": "Saint Maarten",
-    "countryCodeISO2": "NN",
+    "countryCodeISO2": "SX",
     "countryCodeISO3": "SXM",
     "countryCodeFIPS": "SX"
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > A Veteran living in Aruba submitted our form, but the ISO 3166 country code was submitted as "AN" and not the expected "AW" thus causing Lighthouse to reject the submission. After some investigation, we discovered that the [countries.json file](https://github.com/department-of-veterans-affairs/vets-website/blob/12cbb2c9f30197b8c13dae72d376fe49ee7fd54c/src/platform/user/profile/vap-svc/constants/countries.json#L925-L930) that profile is using is out of date. As it stands today, AN is not a valid ISO 3166-1 alpha-2 country code anymore. This code was for Netherlands Antilles, which was dissolved in 2010. Correct codes to use instead:
  >
  > - Aruba = `AW` (separated in 1986)
  > - Curaçao = `CW`
  > - Sint Maarten = `SX`
  > - Bonaire/Sint Eustatius/Saba = `BQ`
  >
  >
  > Ultimately, I would hope that the [Lighthouse Benefits Reference Data (BRD) countries API](https://developer.va.gov/explore/api/benefits-reference-data/docs?version=current) is used instead of a static JSON file.

- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/104336

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

- VA Profile
- Ask VA pages

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
