### PR TITLE
Update feature toggle name mapping

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -115,7 +115,7 @@ export const selectFeatureRemovePodiatry = state =>
   toggleValues(state).vaOnlineSchedulingRemovePodiatry;
 
 export const selectFeatureUseVaDate = state =>
-  toggleValues(state).vaOnlineSchedulingUseVaDate;
+  toggleValues(state).vaosOnlineSchedulingUseVADate;
 
 export const selectFeaturePastApptDateRange = state =>
   toggleValues(state).vaOnlineSchedulingPastApptDateRange;

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -25,7 +25,7 @@ module.exports = [
   { name: 'vaOnlineSchedulingOhDirectSchedule', value: false },
   { name: 'vaOnlineSchedulingOhRequest', value: false },
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
-  { name: 'vaOnlineSchedulingUseVaDate', value: true },
+  { name: 'vaosOnlineSchedulingUseVADate', value: true },
   { name: 'vaOnlineSchedulingPastApptDateRange', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruth', value: false },
   { name: 'selectFeaturePocTypeOfCare', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -286,7 +286,7 @@
   "vaOnlineSchedulingVAOSServiceVAAppointments": "va_online_scheduling_vaos_service_va_appointments",
   "vaOnlineSchedulingVaosV2Next": "va_online_scheduling_vaos_v2_next",
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
-  "vaOnlineSchedulingUseVaDate": "vaos_online_scheduling_use_va_date",
+  "vaosOnlineSchedulingUseVADate": "vaos_online_scheduling_use_va_date",
   "vaOnlineSchedulingPastApptDateRange": "va_online_scheduling_past_appt_date_range",
   "vaOnlineSchedulingFeSourceOfTruth": "va_online_scheduling_fe_source_of_truth",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updating the feature name mapping due to match staging flipper data
- Appointments tool team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/99423

## Testing done

- verified with staging flipper feature payload:
<img width="456" alt="image" src="https://github.com/user-attachments/assets/8c00680d-b995-4f5e-af3c-555c77d5d17d" />


## Screenshots

N/A

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
