### PR TITLE
[VACMS-20429] Adjust Mapbox location search to debounce

### DIFF
--- a/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
+++ b/src/applications/facility-locator/components/search-form/location/AddressAutosuggest.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import vaDebounce from 'platform/utilities/data/debounce';
 import recordEvent from 'platform/monitoring/record-event';
 import PropTypes from 'prop-types';
@@ -62,34 +62,41 @@ function AddressAutosuggest({
    * @returns {void}
    * updateSearch is not called directly but debounced below
    */
-  const updateSearch = term => {
-    const trimmedTerm = term?.trimStart();
-    if (trimmedTerm === searchString) {
-      return; // already have the values
-    }
-    if (trimmedTerm.length >= MIN_SEARCH_CHARS) {
-      // fetch results and set options
-      setIsGeocoding(true);
-      searchAddresses(trimmedTerm)
-        .then(features => {
-          if (!features) {
-            setOptions([]);
-          } else {
-            setOptions([
-              ...features.map(feature => ({
-                ...feature,
-                toDisplay: feature.place_name || trimmedTerm,
-              })),
-            ]);
-          }
-          setIsGeocoding(false);
-        })
-        .catch(() => {
-          onChange({ error: true });
-          setIsGeocoding(false);
-        });
-    }
-  };
+  const updateSearch = useCallback(
+    term => {
+      const trimmedTerm = term?.trimStart();
+      if (trimmedTerm === searchString) {
+        return; // already have the values
+      }
+      if (trimmedTerm.length >= MIN_SEARCH_CHARS) {
+        // fetch results and set options
+        setIsGeocoding(true);
+        searchAddresses(trimmedTerm)
+          .then(features => {
+            if (!features) {
+              setOptions([]);
+            } else {
+              setOptions([
+                ...features.map(feature => ({
+                  ...feature,
+                  toDisplay: feature.place_name || trimmedTerm,
+                })),
+              ]);
+            }
+            setIsGeocoding(false);
+          })
+          .catch(() => {
+            onChange({ error: true });
+            setIsGeocoding(false);
+          });
+      }
+    },
+    [searchString, onChange],
+  );
+
+  const debouncedUpdateSearch = useMemo(() => vaDebounce(500, updateSearch), [
+    updateSearch,
+  ]);
 
   const handleGeolocationButtonClick = e => {
     e.preventDefault();
@@ -98,8 +105,6 @@ function AddressAutosuggest({
     });
     geolocateUser();
   };
-
-  const debouncedUpdateSearch = vaDebounce(500, updateSearch);
 
   const onBlur = () => {
     const value = inputValue?.trimStart() || '';


### PR DESCRIPTION
## Summary

- The find locations form will now include a 500ms debounce to avoid excessive Mapbox queries
- This debounce was already in place, however because it was inside a component being re-rendered, it would reset the debouncing timer. Resulting in ever letter typed in a search resulting in API requests.
- This solution utilizes `useCallback` with `useMemo` to extract the debouncing timer from the component and maintain the timer across re-renders of the component.
- Sitewide team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20429

## Testing done

- When searching for a facility with find locations http://localhost:3001/find-locations/ every letter typed after the first 3 will result in API queries regardless of how fast they are entered.
- Open devoloper tools network tab and enter data into the find locations `Zip code or city, state` field and watch the delay.
- Without a 500ms break in typing, API requests will not be made

## What areas of the site does it impact?

Find Locations https://www.va.gov/find-locations

## Acceptance criteria
- [x] Mapbox queries are suppressed to avoid unnecessary queries

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

