### PR TITLE
[10-10CG] Add logging for facility search

### DIFF
--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -58,6 +58,12 @@ export const fetchFacilities = async ({
     headers: { 'Content-Type': 'application/json' },
   });
 
+  Sentry.withScope(scope => {
+    scope.setLevel(Sentry.Severity.Log);
+    scope.setExtra('facilityId(s)', formatFacilityIds(facilityIds));
+    Sentry.captureMessage('FetchFacilities facilityIds');
+  });
+
   return fetchRequest
     .then(response => {
       if (!response?.data?.length) {

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import * as Sentry from '@sentry/browser';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { VaSearchInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
@@ -123,6 +124,14 @@ const FacilitySearch = props => {
         if (loadedParent) {
           return loadedParent;
         }
+
+        // Log facility parent.id so we can troubleshoot if we are always sending the expected value
+        Sentry.withScope(scope => {
+          scope.setLevel(Sentry.Severity.Log);
+          scope.setExtra('facility', facility);
+          scope.setExtra('facility.parent.id', facility?.parent?.id);
+          Sentry.captureMessage('FetchFacilities parentId');
+        });
 
         const parentFacilityResponse = await fetchFacilities({
           facilityIds: [facility.parent.id],

--- a/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
@@ -65,6 +65,10 @@ describe('CG fetchFacilities action', () => {
 
       await waitFor(() => {
         expect(apiRequestStub.callCount).to.equal(1);
+        expect(sentrySpy.called).to.be.true;
+        expect(sentrySpy.firstCall.args[0]).to.equal(
+          'FetchFacilities facilityIds',
+        );
       });
     });
 
@@ -155,6 +159,9 @@ describe('CG fetchFacilities action', () => {
 
       expect(sentrySpy.called).to.be.true;
       expect(sentrySpy.firstCall.args[0]).to.equal(
+        'FetchFacilities facilityIds',
+      );
+      expect(sentrySpy.secondCall.args[0]).to.equal(
         'Error fetching Lighthouse VA facilities',
       );
 
@@ -178,9 +185,12 @@ describe('CG fetchFacilities action', () => {
 
       expect(sentrySpy.called).to.be.true;
       expect(sentrySpy.firstCall.args[0]).to.equal(
-        'Error fetching Lighthouse VA facilities',
+        'FetchFacilities facilityIds',
       );
       expect(sentrySpy.secondCall.args[0]).to.equal(
+        'Error fetching Lighthouse VA facilities',
+      );
+      expect(sentrySpy.thirdCall.args[0]).to.equal(
         'Error in fetchFacilities. Clearing csrfToken in localStorage.',
       );
       expect(localStorage.getItem('csrfToken')).to.eql('');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added some Sentry logs to validate what facility id is being selected and searched for on the 10-10CG. This id is not pii and is not tied to any submission data in these logs. We are running into some unexpected facilities being submitted and want to get more data around the values being selected.
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/104160

## Testing done

- Updated unit specs
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

No UI changes

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
