### PR TITLE
Update 0966 submit transformer to always include veteranFullName and strip all view: fields

### DIFF
--- a/src/applications/simple-forms/21-0966/config/submit-transformer.js
+++ b/src/applications/simple-forms/21-0966/config/submit-transformer.js
@@ -1,12 +1,25 @@
+import { cloneDeep } from 'lodash';
 import sharedTransformForSubmit from '../../shared/config/submit-transformer';
 import {
   veteranBenefits,
   survivingDependentBenefits,
 } from '../definitions/constants';
+import { preparerIsVeteranAndHasPrefill } from './helpers';
 
 export default function transformForSubmit(formConfig, form) {
+  const formData = cloneDeep(form.data);
+
+  if (preparerIsVeteranAndHasPrefill({ formData })) {
+    formData.veteranFullName = formData['view:veteranPrefillStore'].fullName;
+  }
+
+  // remove all view: fields
+  Object.keys(formData)
+    .filter(key => key.startsWith('view:'))
+    .forEach(key => delete formData[key]);
+
   const transformedData = JSON.parse(
-    sharedTransformForSubmit(formConfig, form),
+    sharedTransformForSubmit(formConfig, { ...form, data: formData }),
   );
 
   return JSON.stringify({


### PR DESCRIPTION
## Summary
 This updates the 21-0966 submit transformer to always pass `veteranFullName` for veterans and to fully remove all `view:` fields. In the future, we should roll out this `view:` removal function to the shared submit transformer.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#2041