### PR TITLE
Update shared simple forms transformer to remove all view: fields

### DIFF
--- a/src/applications/simple-forms/shared/config/submit-transformer.js
+++ b/src/applications/simple-forms/shared/config/submit-transformer.js
@@ -1,4 +1,5 @@
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
+import { cloneDeep } from 'lodash';
 
 /**
  * Example:
@@ -14,11 +15,22 @@ import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/fo
  * @param [options]
  */
 export default function transformForSubmit(formConfig, form, options) {
+  const formData = cloneDeep(form.data);
+
+  // remove all view: fields
+  Object.keys(formData)
+    .filter(key => key.startsWith('view:'))
+    .forEach(key => delete formData[key]);
+
   const transformedData = JSON.parse(
-    formsSystemTransformForSubmit(formConfig, form, {
-      ...options,
-      replaceEscapedCharacters: true,
-    }),
+    formsSystemTransformForSubmit(
+      formConfig,
+      { ...form, data: formData },
+      {
+        ...options,
+        replaceEscapedCharacters: true,
+      },
+    ),
   );
 
   return JSON.stringify({ ...transformedData, formNumber: formConfig.formId });


### PR DESCRIPTION
**DO NOT MERGE**

## Summary

This updates the shared simple-forms submit transformer to remove all `view:` prefixed fields. The forms in simple-forms have been audited and there should be no issue in doing this as the original, expected outcome was that all `view:` fields would be nuked anyway.
