### PR TITLE
MHV-68094 Fixed a link

### DIFF
--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -236,7 +236,7 @@ ${record.results}`;
       {allowMarchUpdates ? (
         <va-link
           className="vads-u-margin-top--1"
-          href="www.va.gov/profile/notifications"
+          href="/profile/notifications"
           text="Go to notification settings"
         />
       ) : (


### PR DESCRIPTION
## Summary

- Fixed a bad link

## Related issue(s)

### [MHV-68094](https://jira.devops.va.gov/browse/MHV-68094) - Wrong link for image notifications ###

> Currently the link goes to:
> 
> https://staging.va.gov/my-health/medical-records/labs-and-tests/www.va.gov/profile/notifications 
> 
> It should go to a relative link: "/profile/notifications"

## Testing done

- Tiny content change -- tested locally

## Screenshots

<img width="369" alt="image" src="https://github.com/user-attachments/assets/058377b7-1f33-4a24-98bd-36d17048aa17" />


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
