### PR TITLE
Remove unused appointments feature toggles - 5

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -88,9 +88,6 @@ export const selectFeatureStaticLandingPage = state =>
 export const selectFeatureBookingExclusion = state =>
   toggleValues(state).vaOnlineSchedulingBookingExclusion;
 
-export const selectFeatureDatadogRum = state =>
-  toggleValues(state).vaOnlineSchedulingDatadogRum;
-
 export const selectFeatureCCDirectScheduling = state =>
   toggleValues(state).vaOnlineSchedulingCCDirectScheduling;
 

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -18,7 +18,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: true },
   { name: 'vaOnlineSchedulingBookingExclusion', value: false },
   { name: 'vaOnlineSchedulingStaticLandingPage', value: true },
-  { name: 'vaOnlineSchedulingDatadogRum', value: true },
   { name: 'vaOnlineSchedulingCCDirectScheduling', value: false },
   { name: 'vaOnlineSchedulingRecentLocationsFilter', value: true },
   { name: 'vaOnlineSchedulingOhDirectSchedule', value: false },

--- a/src/applications/vaos/utils/useDatadogRum.js
+++ b/src/applications/vaos/utils/useDatadogRum.js
@@ -2,8 +2,6 @@ import { useEffect } from 'react';
 import { datadogRum } from '@datadog/browser-rum';
 
 import environment from 'platform/utilities/environment';
-import { useSelector } from 'react-redux';
-import { selectFeatureDatadogRum } from '../redux/selectors';
 
 const initializeDatadogRum = () => {
   if (
@@ -32,20 +30,9 @@ const initializeDatadogRum = () => {
 };
 
 const useDatadogRum = () => {
-  const featureDatadogRum = useSelector(state =>
-    selectFeatureDatadogRum(state),
-  );
-
-  useEffect(
-    () => {
-      if (featureDatadogRum) {
-        initializeDatadogRum();
-      } else {
-        delete window.DD_RUM;
-      }
-    },
-    [featureDatadogRum],
-  );
+  useEffect(() => {
+    initializeDatadogRum();
+  }, []);
 };
 
 export { useDatadogRum };

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -272,7 +272,6 @@
   "vaOnlineSchedulingClinicFilter": "va_online_scheduling_clinic_filter",
   "vaOnlineSchedulingCommunityCare": "va_online_scheduling_community_care",
   "vaOnlineSchedulingConvertUtcToLocal": "va_online_scheduling_convert_utc_to_local",
-  "vaOnlineSchedulingDatadogRum": "va_online_scheduling_datadog_RUM",
   "vaOnlineSchedulingDirect": "va_online_scheduling_direct",
   "vaOnlineSchedulingGA4Migration": "va_online_scheduling_GA4_migration",
   "vaOnlineSchedulingOhDirectSchedule": "va_online_scheduling_OH_direct_schedule",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removing some of the obsolete feature toggles for features that have been fully released.
- Appointments tools team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103882

## Testing done

- Ensured existing test suites pass

## Screenshots

N/A

## What areas of the site does it impact?

Appointments tools

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] ~~Documentation has been updated ([link to documentation](#) \*if necessary)~~ Will update documentation after PRs are merged and feature toggles fully deleted from Flipper 
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
