### PR TITLE
Add redux store.form.activeContext

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -6,6 +6,7 @@ import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from 'platform/forms-system/src/js/
 import { timeFromNow } from '../../../utilities/date';
 import { transformForSubmit } from './helpers';
 
+export const SET_ACTIVE_CONTEXT = 'SET_ACTIVE_CONTEXT';
 export const SET_EDIT_MODE = 'SET_EDIT_MODE';
 export const SET_DATA = 'SET_DATA';
 export const SET_VIEWED_PAGES = 'SET_VIEWED_PAGES';
@@ -31,6 +32,21 @@ export function openReviewChapter(openedChapter) {
   };
 }
 
+/**
+ * Sets context based on the current route such as pageKey, chapterKey, array index, etc.
+ *
+ * @param {ActiveContext} activeContext
+ */
+export function setActiveContext(activeContext) {
+  return {
+    type: SET_ACTIVE_CONTEXT,
+    activeContext,
+  };
+}
+
+/**
+ * Primary action for setting data in redux. Also recalculates schemas and uiSchemas.
+ */
 export function setData(data) {
   return {
     type: SET_DATA,

--- a/src/platform/forms-system/src/js/state/index.js
+++ b/src/platform/forms-system/src/js/state/index.js
@@ -1,5 +1,6 @@
-import { createInitialState } from '../state/helpers';
-import reducers from '../state/reducers';
+import { createInitialState } from './helpers';
+import reducers from './reducers';
+import { applyFormMiddleware } from './middleware';
 
 export default function createSchemaFormReducer(
   formConfig,
@@ -7,10 +8,11 @@ export default function createSchemaFormReducer(
   formReducers = reducers,
 ) {
   return (state = initialState, action) => {
-    const reducer = formReducers[action.type];
+    const formAction = applyFormMiddleware(state, action);
+    const reducer = formReducers[formAction.type];
 
     if (reducer) {
-      return reducer(state, action);
+      return reducer(state, formAction);
     }
 
     return state;

--- a/src/platform/forms-system/src/js/state/middleware.js
+++ b/src/platform/forms-system/src/js/state/middleware.js
@@ -1,0 +1,36 @@
+import { setActiveContext } from '../actions';
+import { activeContextFromFormPages } from '../helpers';
+
+/**
+ * Redux middleware for `store.form.activeContext`
+ *
+ * When UPDATE_ROUTE action is dispatched from a navigation change,
+ * this would normally be ignored by `store.form` reducer. So we
+ * can leverage this event and transform it into a SET_ACTIVE_CONTEXT
+ * action for `store.form.activeContext`
+ */
+export const applyActiveContextMiddleware = (formState, action) => {
+  let nextAction = action;
+
+  if (action.type === 'UPDATE_ROUTE') {
+    const formPages = formState?.pages;
+    const newRoute = action.location?.path;
+    const activeContext = activeContextFromFormPages(formPages, newRoute);
+    nextAction = setActiveContext(activeContext);
+  }
+
+  return nextAction;
+};
+
+/**
+ * Redux middleware for `store.form`
+ *
+ * Usually middleware is handled in `platform/startup/store.js`, however to keep
+ * `platform/startup` package and `platform/forms-system` package separate, we are
+ * handling `store.form` middleware here, since all the respective logic is in forms-system
+ *
+ * No dispatches should be made in this middleware.
+ */
+export const applyFormMiddleware = (formState, action) => {
+  return applyActiveContextMiddleware(formState, action);
+};

--- a/src/platform/forms-system/src/js/state/middleware.js
+++ b/src/platform/forms-system/src/js/state/middleware.js
@@ -8,14 +8,16 @@ import { activeContextFromFormPages } from '../helpers';
  * this would normally be ignored by `store.form` reducer. So we
  * can leverage this event and transform it into a SET_ACTIVE_CONTEXT
  * action for `store.form.activeContext`
+ *
+ * @param {Object} formState store.form state
+ * @param {Object} action any action dispatched from redux
  */
 export const applyActiveContextMiddleware = (formState, action) => {
   let nextAction = action;
 
-  if (action.type === 'UPDATE_ROUTE') {
-    const formPages = formState?.pages;
-    const newRoute = action.location?.path;
-    const activeContext = activeContextFromFormPages(formPages, newRoute);
+  if (action.type === 'UPDATE_ROUTE' && formState?.pages) {
+    const newPath = action.location?.path;
+    const activeContext = activeContextFromFormPages(formState.pages, newPath);
     nextAction = setActiveContext(activeContext);
   }
 
@@ -30,6 +32,9 @@ export const applyActiveContextMiddleware = (formState, action) => {
  * handling `store.form` middleware here, since all the respective logic is in forms-system
  *
  * No dispatches should be made in this middleware.
+ *
+ * @param {Object} formState store.form state
+ * @param {Object} action any action dispatched from redux
  */
 export const applyFormMiddleware = (formState, action) => {
   return applyActiveContextMiddleware(formState, action);

--- a/src/platform/forms-system/src/js/state/reducers.js
+++ b/src/platform/forms-system/src/js/state/reducers.js
@@ -10,6 +10,7 @@ import {
   SET_SUBMITTED,
   SET_VIEWED_PAGES,
   SET_FORM_ERRORS,
+  SET_ACTIVE_CONTEXT,
 } from '../actions';
 
 import { recalculateSchemaAndData } from './helpers';
@@ -36,6 +37,9 @@ export default {
     action.pageKeys.forEach(pageKey => viewedPages.add(pageKey));
 
     return set('reviewPageView.viewedPages', viewedPages, newState);
+  },
+  [SET_ACTIVE_CONTEXT]: (state, action) => {
+    return set('activeContext', action.activeContext, state);
   },
   [SET_DATA]: (state, action) => {
     const newState = set('data', action.data, state);

--- a/src/platform/forms-system/src/js/state/selectors.js
+++ b/src/platform/forms-system/src/js/state/selectors.js
@@ -1,3 +1,4 @@
+export const getActiveContext = state => state.form?.activeContext;
 export const getFormData = state => state.form.data;
 export const getFormPages = state => state.form.pages;
 export const getSubmission = state => state.form.submission;

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -472,3 +472,12 @@
  * @property {boolean} [allowPartialAddress] Allows addresses with missing fields
  * @property {boolean} [replaceEscapedCharacters] Replaces escaped characters
  */
+
+/**
+ * @typedef {Object} ActiveContext
+ * @property {string} arrayPath
+ * @property {string} chapterKey
+ * @property {number} index
+ * @property {string} pageKey
+ * @property {string} pathname
+ */

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -479,5 +479,5 @@
  * @property {string} chapterKey
  * @property {number} index
  * @property {string} pageKey
- * @property {string} pathname
+ * @property {string} pagePath
  */

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -17,6 +17,8 @@ import {
   uploadFile,
   setFormErrors,
   SET_FORM_ERRORS,
+  setActiveContext,
+  SET_ACTIVE_CONTEXT,
 } from '../../src/js/actions';
 
 describe('Schemaform actions:', () => {
@@ -972,6 +974,21 @@ describe('Schemaform actions:', () => {
       const action = setFormErrors(data);
       expect(action.data).to.equal(data);
       expect(action.type).to.equal(SET_FORM_ERRORS);
+    });
+  });
+
+  describe('setActiveContext', () => {
+    it('should return activeContext', () => {
+      const activeContext = {
+        pageKey: 'pageKey',
+        chapterKey: 'chapterKey',
+        pagePath: 'pagePath',
+        arrayPath: undefined,
+        index: undefined,
+      };
+      const action = setActiveContext(activeContext);
+      expect(action.activeContext).to.equal(activeContext);
+      expect(action.type).to.equal(SET_ACTIVE_CONTEXT);
     });
   });
 });

--- a/src/platform/forms-system/test/js/state/middleware.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/middleware.unit.spec.js
@@ -75,7 +75,7 @@ describe('applyActiveContextMiddleware', () => {
         pageKey: undefined,
         arrayPath: undefined,
         index: undefined,
-        pagePath: undefined,
+        pagePath: '',
       },
     });
   });

--- a/src/platform/forms-system/test/js/state/middleware.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/middleware.unit.spec.js
@@ -1,0 +1,99 @@
+import { applyActiveContextMiddleware } from 'platform/forms-system/src/js/state/middleware';
+import { expect } from 'chai';
+
+const mockPages = {
+  veteranInformation: {
+    chapterKey: 'veteranInformation',
+    editMode: false,
+    pageKey: 'veteranInformation',
+    path: 'veteran-information',
+    schema: {},
+    uiSchema: {},
+  },
+  eventsList: {
+    chapterKey: 'mentalHealth',
+    CustomPage: {},
+    editMode: false,
+    pageKey: 'eventsList',
+    path: 'mental-health/events-summary',
+    schema: {},
+    uiSchema: {},
+  },
+  eventsDetails: {
+    arrayPath: 'events',
+    chapterKey: 'mentalHealth',
+    editMode: [],
+    pageKey: 'eventsDetails',
+    path: 'mental-health/:index/events-details',
+    schema: {},
+    showPagePerItem: true,
+    uiSchema: {},
+  },
+};
+
+describe('applyActiveContextMiddleware', () => {
+  it('should set activeContext when UPDATE_ROUTE is dispatched with a location', () => {
+    const formState = {
+      pages: mockPages,
+    };
+
+    const action = {
+      type: 'UPDATE_ROUTE',
+      location: {
+        path: '/mental-health/events-summary',
+      },
+    };
+
+    const nextAction = applyActiveContextMiddleware(formState, action);
+    expect(nextAction).to.deep.equal({
+      type: 'SET_ACTIVE_CONTEXT',
+      activeContext: {
+        chapterKey: 'mentalHealth',
+        pageKey: 'eventsList',
+        arrayPath: undefined,
+        index: undefined,
+        pagePath: 'mental-health/events-summary',
+      },
+    });
+  });
+
+  it('should set activeContext when UPDATE_ROUTE is dispatched with no location', () => {
+    const formState = {
+      pages: mockPages,
+    };
+
+    const action = {
+      type: 'UPDATE_ROUTE',
+      location: {},
+    };
+
+    const nextAction = applyActiveContextMiddleware(formState, action);
+    expect(nextAction).to.deep.equal({
+      type: 'SET_ACTIVE_CONTEXT',
+      activeContext: {
+        chapterKey: undefined,
+        pageKey: undefined,
+        arrayPath: undefined,
+        index: undefined,
+        pagePath: undefined,
+      },
+    });
+  });
+
+  it('should NOT set activeContext for redux events other than UPDATE_ROUTE', () => {
+    const formState = {
+      pages: mockPages,
+    };
+
+    const action = {
+      type: 'SET_DATA',
+      data: {
+        someData: 'someValue',
+      },
+    };
+
+    const nextAction = applyActiveContextMiddleware(formState, action);
+    // no change should be made to the action
+    expect(nextAction).to.equal(action);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `store.form.activeContext` which updates on route change
- This is preparation work for recalculatation of schemas and uiSchemas to work consistently, including on first load.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#2026

## Testing done

- Browser, unit, cypress

## Screenshots

![image](https://github.com/user-attachments/assets/943a0e9d-5a0a-4245-a174-672f873ab752)
![image](https://github.com/user-attachments/assets/ba79224c-1900-4579-9587-0d6130bfb7d9)
![image](https://github.com/user-attachments/assets/17e45430-cab4-4c29-a4ca-d07fef7ab1d6)

## What areas of the site does it impact?

Should be no change - just adding new redux state

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
