### PR TITLE
Fix fullData not updating for array builder edit

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
@@ -46,6 +46,7 @@ export default function ArrayBuilderItemPage({
       index: props.pagePerItemIndex
         ? parseInt(props.pagePerItemIndex, 10)
         : null,
+      arrayPath,
     });
 
     if (!props.onReviewPage && !isEdit && !isAdd) {

--- a/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
@@ -320,3 +320,23 @@ export const defaultItemPageScrollAndFocusTarget = () => {
     focusByOrder([`form ${headerLevel}`, 'va-segmented-progress-bar']);
   }
 };
+
+export const replaceItemInFormData = ({
+  formData,
+  newItem,
+  arrayPath,
+  index,
+}) => {
+  let newFormData = formData;
+
+  if (formData?.[arrayPath]?.[index]) {
+    newFormData = {
+      ...formData,
+      [arrayPath]: formData[arrayPath].map((item, i) => {
+        return i === index ? newItem : item;
+      }),
+    };
+  }
+
+  return newFormData;
+};

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderHelpers.unit.spec.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderHelpers.unit.spec.js
@@ -330,3 +330,83 @@ describe('getUpdatedItemFromPath', () => {
     expect(updatedItem.index).to.eq(2);
   });
 });
+
+describe('replaceItemInFormData', () => {
+  it('should replace an item in the array and create new formData', () => {
+    const formData = {
+      otherField: 'test',
+      otherObject: { test: 'test' },
+      employers: [
+        { name: 'Test', type: 'pdf' },
+        { name: 'Test 2', type: 'jpg' },
+      ],
+    };
+
+    const newItem = { name: 'Test 3', type: 'png' };
+
+    const newFormData = helpers.replaceItemInFormData({
+      formData,
+      newItem,
+      arrayPath: 'employers',
+      index: 1,
+    });
+
+    expect(formData.employers[1].name).to.equal('Test 2');
+    expect(newFormData.employers[1].name).to.equal('Test 3');
+  });
+
+  it('should fail gracefully if wrong index', () => {
+    const formData = {
+      otherField: 'test',
+      otherObject: { test: 'test' },
+      employers: [
+        { name: 'Test', type: 'pdf' },
+        { name: 'Test 2', type: 'jpg' },
+      ],
+    };
+
+    const newItem = { name: 'Test 3', type: 'png' };
+
+    const newFormData = helpers.replaceItemInFormData({
+      formData,
+      newItem,
+      arrayPath: 'employers',
+      index: 2,
+    });
+
+    expect(formData.employers[1].name).to.equal('Test 2');
+    expect(newFormData.employers[1].name).to.equal('Test 2');
+  });
+
+  it('should fail gracefully if no form data', () => {
+    const formData = {};
+    const newItem = { name: 'Test 3', type: 'png' };
+
+    const newFormData = helpers.replaceItemInFormData({
+      formData,
+      newItem,
+      arrayPath: 'employers',
+      index: 1,
+    });
+
+    expect(formData).to.deep.equal({});
+    expect(newFormData).to.deep.equal({});
+  });
+
+  it('should fail gracefully if no array data', () => {
+    const formData = {
+      employers: undefined,
+    };
+    const newItem = { name: 'Test 3', type: 'png' };
+
+    const newFormData = helpers.replaceItemInFormData({
+      formData,
+      newItem,
+      arrayPath: 'employers',
+      index: 0,
+    });
+
+    expect(formData.employers).to.equal(undefined);
+    expect(newFormData.employers).to.equal(undefined);
+  });
+});

--- a/src/platform/forms-system/src/js/patterns/array-builder/useEditOrAddForm.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/useEditOrAddForm.jsx
@@ -73,7 +73,12 @@ export function useEditOrAddForm({
         // We run updateSchemasAndData before setting data in case
         // there are updateSchema, replaceSchema, updateUiSchema,
         // or other dynamic properties
-        let newFullData = fullData;
+
+        // array builder will always have an arrayPath, but
+        // in case other components use this hook, we need to
+        // set full data to the updated data since we're dealing
+        // with local data.
+        let newFullData = updatedData;
 
         if (arrayPath) {
           newFullData = replaceItemInFormData({

--- a/src/platform/forms-system/src/js/patterns/array-builder/useEditOrAddForm.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/useEditOrAddForm.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { updateSchemasAndData } from 'platform/forms-system/src/js/state/helpers';
+import { replaceItemInFormData } from './helpers';
 
 /**
  * Custom hook for handling form state for edit or add form pages.
@@ -33,6 +34,7 @@ export function useEditOrAddForm({
   onChange,
   onSubmit,
   index,
+  arrayPath,
 }) {
   // These states are only used in edit mode
   const [localData, setLocalData] = useState(null);
@@ -71,6 +73,17 @@ export function useEditOrAddForm({
         // We run updateSchemasAndData before setting data in case
         // there are updateSchema, replaceSchema, updateUiSchema,
         // or other dynamic properties
+        let newFullData = fullData;
+
+        if (arrayPath) {
+          newFullData = replaceItemInFormData({
+            fullData,
+            updatedData,
+            arrayPath,
+            index,
+          });
+        }
+
         const {
           data: newData,
           schema: newSchema,
@@ -80,7 +93,7 @@ export function useEditOrAddForm({
           localUiSchema,
           updatedData,
           false,
-          fullData,
+          newFullData,
           index,
         );
         setLocalData(newData);
@@ -93,7 +106,16 @@ export function useEditOrAddForm({
         });
       }
     },
-    [isEdit, localSchema, localUiSchema, onChange, data, fullData, index],
+    [
+      isEdit,
+      localSchema,
+      localUiSchema,
+      onChange,
+      data,
+      fullData,
+      index,
+      arrayPath,
+    ],
   );
 
   const handleOnSubmit = useCallback(


### PR DESCRIPTION
## Summary

- Fix fullData not updating for array builder edit

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#2065
department-of-veterans-affairs/va.gov-team-forms#2026

## Testing done

- unit, browser, regression

## What areas of the site does it impact?

array builder consumers using `fullData` for their conditions, during edit

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
