### PR TITLE
Remove static pages from Staged Continuous Deployment

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -220,10 +220,6 @@
       "slackGroup": "@benefits-app-builds"
     },
     {
-      "rootFolder": "static-pages",
-      "slackGroup": "@C059Q28DV99"
-    },
-    {
       "rootFolder": "terms-of-use",
       "continuousDeployment": false
     },

--- a/src/applications/static-pages/find-forms/components/InvalidFormAlert.jsx
+++ b/src/applications/static-pages/find-forms/components/InvalidFormAlert.jsx
@@ -11,7 +11,9 @@ const InvalidFormAlert = ({ downloadUrl, isRelatedForm }) => {
 
   return (
     <va-alert status="error">
-      {!isRelatedForm && <h3 slot="headline">This form link isn’t working</h3>}
+      {!isRelatedForm && (
+        <h3 slot="headline">This formmm link isn’t working</h3>
+      )}
       {isRelatedForm && <h4 slot="headline">This form link isn’t working</h4>}
       We’re sorry, but the form you’re trying to download appears to have an
       invalid link. Please{' '}

--- a/src/applications/static-pages/find-forms/components/InvalidFormAlert.jsx
+++ b/src/applications/static-pages/find-forms/components/InvalidFormAlert.jsx
@@ -11,9 +11,7 @@ const InvalidFormAlert = ({ downloadUrl, isRelatedForm }) => {
 
   return (
     <va-alert status="error">
-      {!isRelatedForm && (
-        <h3 slot="headline">This formmm link isn’t working</h3>
-      )}
+      {!isRelatedForm && <h3 slot="headline">This form link isn’t working</h3>}
       {isRelatedForm && <h4 slot="headline">This form link isn’t working</h4>}
       We’re sorry, but the form you’re trying to download appears to have an
       invalid link. Please{' '}


### PR DESCRIPTION
Temporarily remove static pages from SCD while investigation into why failures is happening takes place.
