### PR TITLE
[VACMS-20429] Prevent redundant location search

### DIFF
--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -42,6 +42,7 @@ const SearchForm = props => {
 
   const [selectedServiceType, setSelectedServiceType] = useState(null);
   const locationInputFieldRef = useRef(null);
+  const lastQueryRef = useRef(null);
 
   const onlySpaces = str => /^\s+$/.test(str);
 
@@ -82,6 +83,19 @@ const SearchForm = props => {
 
   const handleSubmit = e => {
     e.preventDefault();
+
+    const isSameQuery =
+      lastQueryRef.current &&
+      currentQuery.facilityType === lastQueryRef.current.facilityType &&
+      currentQuery.serviceType === lastQueryRef.current.serviceType &&
+      currentQuery.searchString === lastQueryRef.current.searchString &&
+      currentQuery.zoomLevel === lastQueryRef.current.zoomLevel;
+
+    if (isSameQuery) {
+      return;
+    }
+
+    lastQueryRef.current = currentQuery;
 
     const {
       facilityType,
@@ -191,7 +205,7 @@ const SearchForm = props => {
           'usa-input-error': showError,
         })}
       >
-        {/* 
+        {/*
         after the flipper useProgressiveDisclosure is removed,
         this id can be changed back to #location-input-field
         and the media query in it may be removed

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -339,6 +339,13 @@ describe('Facility VA search', () => {
     // Click the search button multiple times
     cy.get('#facility-search').click({ waitForAnimations: true });
     cy.get('#facility-search').click({ waitForAnimations: true });
+    // Reset facility dropdown values to ensure redux state is not changing in a way that
+    // triggers multiple API requests
+    cy.get('#facility-type-dropdown')
+      .shadow()
+      .find('select')
+      .select('VA health');
+    cy.get('#service-type-dropdown').select('Primary care');
     cy.get('#facility-search').click({ waitForAnimations: true });
     cy.get('#facility-search').click({ waitForAnimations: true });
 

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -318,4 +318,43 @@ describe('Facility VA search', () => {
     cy.injectAxe();
     cy.axeCheck();
   });
+
+  it('does not trigger repeat API requests when submit is clicked multiple times', () => {
+    cy.intercept('GET', '/geocoding/**/*', mockGeocodingData);
+
+    cy.visit('/find-locations');
+
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.verifyOptions();
+
+    cy.get('#street-city-state-zip').type('Austin, TX');
+    cy.get('#facility-type-dropdown')
+      .shadow()
+      .find('select')
+      .select('VA health');
+    cy.get('#service-type-dropdown').select('Primary care');
+
+    // Click the search button multiple times
+    cy.get('#facility-search').click({ waitForAnimations: true });
+    cy.get('#facility-search').click({ waitForAnimations: true });
+    cy.get('#facility-search').click({ waitForAnimations: true });
+    cy.get('#facility-search').click({ waitForAnimations: true });
+
+    // Only 2 requests should be made, Initial page load and 1st user submitted search
+    cy.wait('@searchFacilitiesVA');
+    cy.get('@searchFacilitiesVA.all').should('have.length', 2);
+
+    cy.get('#search-results-subheader').contains(
+      'Results for "VA health", "Primary care" near "Austin, Texas"',
+    );
+    cy.get('.facility-result a').should('exist');
+    cy.get('.i-pin-card-map').contains('1');
+    cy.get('.i-pin-card-map').contains('2');
+    cy.get('.i-pin-card-map').contains('3');
+    cy.get('.i-pin-card-map').contains('4');
+
+    cy.get('#other-tools').should('exist');
+  });
 });


### PR DESCRIPTION
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adjust Facility Locator Search form to avoid repeating API requests if a user repeatedly hits submit
- Go to Locations Search https://www.va.gov/find-locations and open your network tab, setup a facility search and click submit a handful of times to see the API requests for each click
- The search function will now hold a ref to the last query submitted and will take no further action if the current query is identical
- Sitewide Team supported

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20429

## Testing done

- Previously, each submit click results in API request
- Go to Locations Search http://localhost:3001/find-locations and open your network tab, setup a facility search and click submit a handful of times to see the API requests for the initial search only. If fields are changed and search is clicked again, another API requests occurs


## What areas of the site does it impact?

Facility Search

## Acceptance criteria
- [x] A subsequent search on the facility locator using the same input data will not result in an additional call to the MapBox API

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)