### PR TITLE
updates login modal for CSP switch

### DIFF
--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -72,6 +72,20 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
                 />
               </>
             )}
+            {mhvButtonDeprecated && (
+              <div>
+                <h3 id="mhvH3" className="vads-u-margin-top--3">
+                  My HealtheVet sign-in option
+                  <span className="vads-u-display--block vads-u-font-size--md vads-u-font-family--sans">
+                    This option is no longer available
+                  </span>
+                </h3>
+                <va-link
+                  text="Learn how to access your benefits and set up your new account"
+                  href="/resources/what-to-do-if-you-havent-switched-to-logingov-or-idme-yet"
+                />
+              </div>
+            )}
             {dslogon && (
               <>
                 <h3
@@ -96,20 +110,6 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
                   actionLocation={actionLocation}
                 />
               </>
-            )}
-            {mhvButtonDeprecated && (
-              <div>
-                <h3 id="mhvH3" className="vads-u-margin-top--3">
-                  My HealtheVet sign-in option
-                  <span className="vads-u-display--block vads-u-font-size--md vads-u-font-family--sans">
-                    This option is no longer available
-                  </span>
-                </h3>
-                <va-link
-                  text="Learn how to access your benefits and set up your new account"
-                  href="/resources/what-to-do-if-you-havent-switched-to-logingov-or-idme-yet"
-                />
-              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
Updates Login modal/ sign-in page to switch the location of the mhv and ds logon info.
Ticker [here](https://github.com/orgs/department-of-veterans-affairs/projects/1621/views/1?pane=issue&itemId=100718278&issue=department-of-veterans-affairs%7Cva.gov-team%7C104581)
Screen shot:

![Screenshot 2025-03-06 at 11 20 37 AM](https://github.com/user-attachments/assets/f34dde92-3756-4d93-bbca-699d148c5d94)


- unit tests did not need to be updated