### PR TITLE
[104138] Only allow Veteran users to submit digital POA requests

### DIFF
--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -25,6 +25,12 @@ export default function prefillTransformer(formData) {
     newFormData.primaryPhone = formData?.contactInformation?.primaryPhone;
     newFormData['Branch of Service'] =
       formData?.militaryInformation?.serviceBranch;
+
+    // only Veteran users are digital submit eligible at this time
+    newFormData.userIsDigitalSubmitEligible =
+      formData?.identityValidation?.hasIcn &&
+      formData?.identityValidation?.hasParticipantId;
+
     // reset the applicant information in case of claimant type change
     newFormData.applicantName = undefined;
     newFormData.applicantDOB = undefined;
@@ -54,7 +60,10 @@ export default function prefillTransformer(formData) {
       street: formData?.contactInformation?.address?.street,
     };
 
-    // reset the applicant information in case of claimant type change
+    // only Veteran users are digital submit eligible at this time
+    newFormData.userIsDigitalSubmitEligible = undefined;
+
+    // reset the Veteran information in case of claimant type change
     newFormData.veteranFullName = undefined;
     newFormData.veteranDateOfBirth = undefined;
     newFormData.veteranSocialSecurityNumber = undefined;
@@ -69,10 +78,6 @@ export default function prefillTransformer(formData) {
     newFormData.primaryPhone = undefined;
     newFormData['Branch of Service'] = undefined;
   }
-
-  newFormData.userIsDigitalSubmitEligible =
-    formData?.identityValidation?.hasIcn &&
-    formData?.identityValidation?.hasParticipantId;
 
   return newFormData;
 }

--- a/src/applications/representative-appoint/config/prefillTransformer.js
+++ b/src/applications/representative-appoint/config/prefillTransformer.js
@@ -62,6 +62,7 @@ export default function prefillTransformer(formData) {
 
     // only Veteran users are digital submit eligible at this time
     newFormData.userIsDigitalSubmitEligible = undefined;
+    newFormData.representativeSubmissionMethod = undefined;
 
     // reset the Veteran information in case of claimant type change
     newFormData.veteranFullName = undefined;

--- a/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
+++ b/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
@@ -28,6 +28,44 @@ describe('prefillTransformer', () => {
       expect(result['Branch of Service']).to.eql('Army');
     });
 
+    context('when the user does not have an ICN', () => {
+      it('sets userIsDigitalSubmitEligible to false', () => {
+        const data = {
+          ...prefill,
+          identityValidation: { hasIcn: false, hasParticipantId: true },
+          'view:applicantIsVeteran': 'Yes',
+        };
+
+        const result = prefillTransformer(data);
+
+        expect(result.userIsDigitalSubmitEligible).to.be.false;
+      });
+    });
+
+    context('when the user does not have a participant id', () => {
+      it('sets userIsDigitalSubmitEligible to false', () => {
+        const data = {
+          ...prefill,
+          identityValidation: { hasIcn: true, hasParticipantId: false },
+          'view:applicantIsVeteran': 'Yes',
+        };
+
+        const result = prefillTransformer(data);
+
+        expect(result.userIsDigitalSubmitEligible).to.be.false;
+      });
+    });
+
+    context('when the user has an ICN and a participant id', () => {
+      it('sets userIsDigitalSubmitEligible to true', () => {
+        const data = { ...prefill, 'view:applicantIsVeteran': 'Yes' };
+
+        const result = prefillTransformer(data);
+
+        expect(result.userIsDigitalSubmitEligible).to.be.true;
+      });
+    });
+
     it('should reset the applicant attributes', () => {
       const data = {
         ...prefill,
@@ -119,41 +157,17 @@ describe('prefillTransformer', () => {
       expect(result['Branch of Service']).to.be.undefined;
       expect(result.veteranSocialSecurityNumber).to.be.undefined;
     });
-  });
 
-  context('when the user does not have an ICN', () => {
-    it('sets userIsDigitalSubmitEligible to false', () => {
+    it('should set userIsDigitalSubmitEligible to undefined', () => {
       const data = {
         ...prefill,
-        identityValidation: { hasIcn: false, hasParticipantId: true },
+        'view:applicantIsVeteran': 'No',
+        userIsDigitalSubmitEligible: true,
       };
 
       const result = prefillTransformer(data);
 
-      expect(result.userIsDigitalSubmitEligible).to.be.false;
-    });
-  });
-
-  context('when the user does not have a participant id', () => {
-    it('sets userIsDigitalSubmitEligible to false', () => {
-      const data = {
-        ...prefill,
-        identityValidation: { hasIcn: true, hasParticipantId: false },
-      };
-
-      const result = prefillTransformer(data);
-
-      expect(result.userIsDigitalSubmitEligible).to.be.false;
-    });
-  });
-
-  context('when the user has an ICN and a participant id', () => {
-    it('sets userIsDigitalSubmitEligible to true', () => {
-      const data = { ...prefill };
-
-      const result = prefillTransformer(data);
-
-      expect(result.userIsDigitalSubmitEligible).to.be.true;
+      expect(result.userIsDigitalSubmitEligible).to.be.undefined;
     });
   });
 });

--- a/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
+++ b/src/applications/representative-appoint/tests/config/prefillTransformer.unit.spec.js
@@ -169,5 +169,17 @@ describe('prefillTransformer', () => {
 
       expect(result.userIsDigitalSubmitEligible).to.be.undefined;
     });
+
+    it('should set representativeSubmissionMethod to undefined', () => {
+      const data = {
+        ...prefill,
+        'view:applicantIsVeteran': 'No',
+        representativeSubmissionMethod: 'digital',
+      };
+
+      const result = prefillTransformer(data);
+
+      expect(result.representativeSubmissionMethod).to.be.undefined;
+    });
   });
 });

--- a/src/applications/representative-appoint/tests/pages/representative/representativeSubmissionMethod.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/pages/representative/representativeSubmissionMethod.unit.spec.jsx
@@ -167,7 +167,7 @@ describe('<RepresentativeSubmissionMethod>', () => {
             type: 'organization',
             attributes: { canAcceptDigitalPoaRequests: true },
           },
-          userIsDigitalSubmitEligible: true,
+          'view:applicantIsVeteran': 'Yes',
           identityValidation: { hasIcn: true, hasParticipantId: true },
         };
 
@@ -187,7 +187,7 @@ describe('<RepresentativeSubmissionMethod>', () => {
               type: 'organization',
               attributes: { canAcceptDigitalPoaRequests: false },
             },
-            userIsDigitalSubmitEligible: true,
+            'view:applicantIsVeteran': 'Yes',
             identityValidation: { hasIcn: true, hasParticipantId: true },
           };
 
@@ -206,7 +206,7 @@ describe('<RepresentativeSubmissionMethod>', () => {
             type: 'organization',
             attributes: { canAcceptDigitalPoaRequests: true },
           },
-          userIsDigitalSubmitEligible: false,
+          'view:applicantIsVeteran': 'Yes',
           identityValidation: { hasIcn: false, hasParticipantId: false },
         };
 
@@ -224,7 +224,7 @@ describe('<RepresentativeSubmissionMethod>', () => {
             type: 'organization',
             attributes: { canAcceptDigitalPoaRequests: true },
           },
-          userIsDigitalSubmitEligible: true,
+          'view:applicantIsVeteran': 'Yes',
           identityValidation: { hasIcn: true, hasParticipantId: true },
         };
 

--- a/src/applications/representative-appoint/tests/utilities/userIsDigitalSubmitEligible.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/utilities/userIsDigitalSubmitEligible.unit.spec.jsx
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+
+import { userIsDigitalSubmitEligible } from '../../utilities/helpers';
+
+describe('userIsDigitalSubmitEligible', () => {
+  context('the user is not a Veteran', () => {
+    it('returns false', () => {
+      const formData = {
+        'view:applicantIsVeteran': 'No',
+        'view:v2IsEnabled': true,
+        identityValidation: {
+          hasIcn: true,
+          hasParticipantId: true,
+        },
+      };
+
+      const result = userIsDigitalSubmitEligible(formData);
+      expect(result).to.be.false;
+    });
+  });
+
+  context('the user is does not have an ICN', () => {
+    it('returns false', () => {
+      const formData = {
+        'view:applicantIsVeteran': 'Yes',
+        'view:v2IsEnabled': true,
+        identityValidation: {
+          hasIcn: false,
+          hasParticipantId: true,
+        },
+      };
+
+      const result = userIsDigitalSubmitEligible(formData);
+      expect(result).to.be.false;
+    });
+  });
+
+  context('the user is does not have a participant id', () => {
+    it('returns false', () => {
+      const formData = {
+        'view:applicantIsVeteran': 'Yes',
+        'view:v2IsEnabled': true,
+        identityValidation: {
+          hasIcn: true,
+          hasParticipantId: false,
+        },
+      };
+
+      const result = userIsDigitalSubmitEligible(formData);
+      expect(result).to.be.false;
+    });
+  });
+
+  context('v2 is not enabled', () => {
+    it('returns false', () => {
+      const formData = {
+        'view:applicantIsVeteran': 'Yes',
+        'view:v2IsEnabled': false,
+        identityValidation: {
+          hasIcn: true,
+          hasParticipantId: true,
+        },
+      };
+
+      const result = userIsDigitalSubmitEligible(formData);
+      expect(result).to.be.false;
+    });
+  });
+
+  context('all criteria are met', () => {
+    it('returns true', () => {
+      const formData = {
+        'view:applicantIsVeteran': 'Yes',
+        'view:v2IsEnabled': true,
+        identityValidation: {
+          hasIcn: true,
+          hasParticipantId: true,
+        },
+      };
+
+      const result = userIsDigitalSubmitEligible(formData);
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/src/applications/representative-appoint/utilities/helpers.js
+++ b/src/applications/representative-appoint/utilities/helpers.js
@@ -271,6 +271,7 @@ export const addressExists = address =>
 
 export const userIsDigitalSubmitEligible = formData => {
   return (
+    preparerIsVeteran({ formData }) && // only Veteran users are eligible at this time
     formData?.identityValidation?.hasIcn &&
     formData?.identityValidation?.hasParticipantId &&
     formData?.['view:v2IsEnabled']


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds front end logic to prevent non-Veteran users from digitally submitting the 21-22 form

## Related issue(s)

- [104138](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104138)

## Testing done

- went through several scenarios of the flow picking and switching claimant type to confirm

## Screenshots
### Before
#### Selecting non-Veteran at the start
https://github.com/user-attachments/assets/1267c28b-6c49-4dbf-8aa6-448f5fa0b075

#### Switching from Veteran to non-Veteran

https://github.com/user-attachments/assets/dcdd99b8-7962-4b08-a7d6-9a62629f61d5

### After
#### Selecting non-Veteran at the start
https://github.com/user-attachments/assets/d216153e-693d-4b32-8641-e83d533fb08e

#### Switching from Veteran to non-Veteran
https://github.com/user-attachments/assets/fb68e709-1831-4434-baec-bcc5daa5b238

## What areas of the site does it impact?

Appoint a Rep Form 21-22 V2

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user