### PR TITLE
MHV-66102: Blue button appointments fix

### DIFF
--- a/src/platform/pdf/templates/blue_button_report.js
+++ b/src/platform/pdf/templates/blue_button_report.js
@@ -185,6 +185,10 @@ const generateDateRangeParagraph = (section, doc, data) => {
 const getAvailableRecordSets = recordSets => {
   return recordSets.filter(recordSet => {
     if (!recordSet.selected) return false;
+    // appointments records are broken into two sub-lists: past and upcoming
+    if (recordSet.type === 'appointments') {
+      return !recordSet.records.every(type => !type?.results?.items?.length);
+    }
     if (Array.isArray(recordSet.records)) {
       return recordSet.records.length;
     }
@@ -198,6 +202,12 @@ const getAvailableRecordSets = recordSets => {
 const getUnavailableRecordSets = recordSets => {
   return recordSets.filter(recordSet => {
     if (!recordSet.selected) return false;
+    // appointments records are broken into two sub-lists: past and upcoming
+    if (recordSet.type === 'appointments') {
+      return recordSet.records.every(
+        type => type?.results?.items?.length === 0,
+      );
+    }
     if (Array.isArray(recordSet.records)) {
       return recordSet.records.length === 0;
     }

--- a/src/platform/pdf/test/templates/blue_button_report/blue_button_report.unit.spec.js
+++ b/src/platform/pdf/test/templates/blue_button_report/blue_button_report.unit.spec.js
@@ -122,8 +122,9 @@ describe('Blue Button report PDF template', () => {
       const data = cloneDeep(require('./fixtures/all_sections.json'));
 
       // Mark some sections as having no records.
-      data.recordSets[0].records = [];
-      data.recordSets[3].records = [];
+      data.recordSets[0].records = []; // lab and test results
+      data.recordSets[3].records = []; // allergies
+      data.recordSets[7].records = []; // appointments
 
       const { pdf } = await generateAndParsePdf(data);
 
@@ -153,7 +154,7 @@ describe('Blue Button report PDF template', () => {
       const listItemsText = listItems
         .filter(item => item.str)
         .map(item => item.str);
-      expect(listItemsText.length).to.equal(data.recordSets.length - 2);
+      expect(listItemsText.length).to.equal(data.recordSets.length - 3);
 
       // Get Records not in this Report section.
       const noRecordsItemIndex = content.items.findIndex(
@@ -180,7 +181,7 @@ describe('Blue Button report PDF template', () => {
       const unavailableListItemsText = unavailableListItems
         .filter(item => item.str)
         .map(item => item.str);
-      expect(unavailableListItemsText.length).to.equal(2);
+      expect(unavailableListItemsText.length).to.equal(3);
     });
   });
 
@@ -189,7 +190,7 @@ describe('Blue Button report PDF template', () => {
       const data = require('./fixtures/all_sections.json');
       const { pdf } = await generateAndParsePdf(data);
 
-      const pageNumber = 3;
+      const pageNumber = 2;
       const page = await pdf.getPage(pageNumber);
 
       const content = await page.getTextContent({ includeMarkedContent: true });

--- a/src/platform/pdf/test/templates/blue_button_report/fixtures/all_sections.json
+++ b/src/platform/pdf/test/templates/blue_button_report/fixtures/all_sections.json
@@ -1,1514 +1,7527 @@
 {
+  "fromDate": "Any",
+  "toDate": "any",
   "recordSets": [
-    {
-      "type": "lab and test results",
-      "title": "Lab and test results",
-      "subtitles": [
-        "If your results are outside the reference range, this doesn't automatically mean you have a health problem. Your provider will explain what your results mean for your health."
-      ],
-      "toc": {
-        "title": "Lab and test results…………………………………………",
-        "subtitle": "Review lab and test results in your VA medical records."
-      },
-      "selected": true,
-      "records": [
-        {
-          "title": "POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN: on January 21, 2021",
-          "details": {
-            "header": "Details about this test",
-            "items": [
+      {
+          "type": "lab and test results",
+          "title": "Lab and test results",
+          "subtitles": [
+              "Most lab and test results are available 36 hours after the lab confirms them. Pathology results may take 14 days or longer to confirm.",
+              "If you have questions about these results, send a secure message to your care team.",
+              "Note: If you have questions about more than 1 test ordered by the same care team, send 1 message with all of your questions.",
+              "Showing 13 records from newest to oldest"
+          ],
+          "selected": true,
+          "records": [
               {
-                "title": "Type of test",
-                "value": "chemistry_hematology",
-                "inline": true
-              },
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordered by",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordering location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Collecting location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Provider notes",
-                "value": [
-                  "Lisa's Test 1/20/2021 - Second lab\nAdded Potassium test"
-                ],
-                "inline": false
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "header": "POTASSIUM",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "3.5 mEq/L",
-                    "inline": true
+                  "title": "Complete blood count",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "December 12, 2024, 9:00 a.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Blood",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Beth M. Smith",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": [
+                                  "Pat Wilsons' blood panel is standard"
+                              ],
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Standard range",
-                    "value": "3.6-5.1",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "WBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "5.5 bil/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.2 - 10.6 bil/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "RBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "5 tril/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.5 - 5.5 tril/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "HGB",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "12.4 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "13.6 - 17.0 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "HCT",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "40.9 % (Low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "41 - 51 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "MCV",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "82 fL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "82 - 100 fL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "ACK",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "5 K/ccm",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.5 - 10.5 K/ccm",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "MCHC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "30 g/dL (Low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "32 - 36 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "RDW",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "15 % (High)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "12 - 14.2 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Complete blood count",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "November 15, 2024, 9:30 a.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Blood",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Beth M. Smith",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": [
+                                  "Pat Wilsons' blood panel is standard"
+                              ],
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Status",
-                    "value": "final",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "WBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "5.3 bil/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.2 - 10.6 bil/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "RBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "5.07 tril/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.5 - 5.5 tril/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "HGB",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "12.8 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "13.6 - 17.0 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "HCT",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "41 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "41 - 51 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "MCV",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "81 fL (Low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "82 - 100 fL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "ACK",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "5 K/ccm",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.5 - 10.5 K/ccm",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "MCHC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "31 g/dL (Low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "32 - 36 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "RDW",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "15 % (High)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "12 - 14.2 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Electrocardiogram (EKG)",
+                  "results": {
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "title": "Date",
+                                      "value": "November 2, 2024, 10:00 a.m.",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider",
+                                      "value": "DOE, JANE A",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Microbiology",
+                  "details": {
+                      "header": "Details about this test",
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "November 2, 2024, 9:30 a.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Blood",
+                              "inline": true
+                          },
+                          {
+                              "title": "Collection sample",
+                              "value": "Blood",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Gregory House, M.D.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date completed",
+                              "value": "November 2, 2024",
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Lab location",
-                    "value": "None noted",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": {
+                          "prefaceOptions": {
+                              "paragraphGap": 20
+                          },
+                          "value": "Your provider will review your results. If you need to do anything, your provider will contact you. If you have questions, send a message to the care team that ordered this test."
+                      },
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": [
+                                          "Accession [UID]: MI 16 3065 [1216003065] Received: Nov 2, 2024@09:30\nCollection sample: VENOUS BLOOD Collection date: Nov 2, 2024 9:30\nSite/Specimen: BLOOD VENOUS\nProvider: WILSON, PAT\n\n* BACTERIOLOGY FINAL REPORT => Nov 2, 2024 09:30 TECH CODE: 205931\nCULTURE RESULTS: ESCHERICHIA COLI - Quantity: 2+\nANTIBIOTIC SUSCEPTIBILITY TEST RESULTS:\nESCHERICHIA COLI\n:\nAMPICILLIN.................... S\nAMPICILLIN/SULBACTAM.......... S\nCEFAZOLIN..................... S\nTOBRMCN....................... S\nGENTMCN....................... S\nCEFTRIAXONE................... S\nCIPROFLOXACIN................. S\nAMOXICILLIN/CLAVULANATE....... S\nTRIMETH/SULF.................. S\nLEVOFLOXACIN.................. S\n\n=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--\nPerforming Laboratory:\nBacteriology Report Performed By:\nWashington DC VAMC\n-----------------------------------------------------------------------------\nResult Key:\nSUSC = Susceptibility Result S = Susceptible\nINTP = Interpretation I = Intermediate\nMIC = Minimum Inhibitory Concentration R = Resistant"
+                                      ],
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Metabolic Panel",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "September 18, 2024, 8:00 a.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Serum (substance)",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Beth M. Smith",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": "None noted",
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Interpretation",
-                    "value": "Low",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "BUN",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "21 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "7.8 - 21.4 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "CALCIUM",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "8.7 MG/DL (Low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "8.8 - 10.2 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "Result is low when compared to reference range"
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "CREATININE (SERUM)",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "1.1 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "0.7 - 1.5 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "POTASSIUM",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "4 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "3.5 - 5.1 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "CHLORIDE",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "102 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "98 - 107 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "SODIUM",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "161 mmol/l (Critical high)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "136 - 145 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "Result is citically high when compared to ref. range."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "CO2",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "26 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "21 - 32 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "GLUCOSE",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "49 MG/DL (Critical low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "70 - 110 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "Result is critically low when compared to ref. range."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "EGFR",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": ">60 mL/min",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": ">60 mL/min",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "The following conditions may alter the eGFR result: severe malnutrition or obesity, skeletal muscle disease and rapidly changing kidney function."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "ANION GAP",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "13 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "5 - 16 mmol/l",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
                   }
-                ]
               },
               {
-                "header": "SODIUM:SCNC:PT:SER/PLAS:QN:",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "138 mEq/L",
-                    "inline": true
+                  "title": "Cytology",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "August 27, 2024, 12:54 p.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "None noted",
+                              "inline": true
+                          },
+                          {
+                              "title": "Collection sample",
+                              "value": "None noted",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date completed",
+                              "value": "August 27, 2024",
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Standard range",
-                    "value": "136-145",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you. If you have questions, send a message to the care team that ordered this test."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Note: If you have questions about more than 1 test ordered by the same care team, send 1 message with all of your questions."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": [
+                                          "Date Spec taken: Dec 21, 2021 12:54 Pathologist: CHERYL JAMES\nDate Spec rec'd: Dec 21, 2021 12:55 Tech: CHERYL JAMES\nDate completed: Dec 21, 2021 Accession #: CY 14 999998\nSubmitted by: GREGORY HOUSE, M.D. Practitioner: SANDRA DENTON\n-------------------------------------------------------------------------------\nSpecimen:\nFLUID\nDESCRIPTION:\nThis is the National package - testing for MHV.\nMICROSCOPIC EXAM (Date Spec taken: Dec 21, 2021 12:54)\nNormal fluid - TEST ONLY\n=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--\nPerforming Laboratory:\nCytology Report Performed By:\nWASHINGTION DC VAMC"
+                                      ],
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "SARS-CoV-2 RNA QI NAA+probe~PCR",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "May 16, 2024, 1:46 p.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Site or sample tested Nasopharyngeal structure (body structure)",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Gregory House",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": [
+                                  "This assay is approved for the detection of nucleic acid from SARS-Cov-2 under a FDA Emergency Use Authorization and its performance is limited to qualified high and moderately complex laboratories designated by CLIA. Negative results do not preclude SARS-Cov-2 infection and should not be used as the sole basis for treatment or other patient management decisions. Negative results must be combined with clinical observations, patient history, and epidemiological information.  Negative SARS-CoV-2 Interpretation: The 2019 novel coronavirus (SARS-CoV-2) nucleic acids are not detected. Positive SARS-CoV-2 Interpretation: The 2019 novel coronavirus (SARS-CoV-2) target nucleic acids are detected. NOTE: These results must be accompanied with the following  Fact Sheets for: Healthcare Providers: https://www.fda.gov/media/136313/download Patients: https://www.fda.gov/media/136312/download"
+                              ],
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Status",
-                    "value": "final",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "COVID-19 CEPHEID",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "POSITIVE  (Critical high)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEGATIVE",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "Result is critical high when compared to ref. range."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Complete blood count",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "May 1, 2024, 8:45 a.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Blood",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Spencer Reid",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": [
+                                  "Pat Wilsons' blood panel is standard"
+                              ],
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Lab location",
-                    "value": "None noted",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "WBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "6.7 bil/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.2 - 10.6 bil/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "RBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "4.98 tril/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.5 - 5.5 tril/L",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "HGB",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "15 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "13.6 - 17.0 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "HCT",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "41.6 % (Low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "41 - 51 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "MCV",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "84 fL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "82 - 100 fL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "ACK",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "15 K/ccm (High)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.5 - 10.5 K/ccm",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "MCHC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "31 g/dL (Low)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "32 - 36 g/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "RDW",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "14 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "12 - 14.2 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Surgical Pathology",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "April 13, 2024, 12:54 p.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Left pointer finger",
+                              "inline": true
+                          },
+                          {
+                              "title": "Collection sample",
+                              "value": "Left pointer finger",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "DAYTON, OH VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date completed",
+                              "value": "April 13, 2024",
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Interpretation",
-                    "value": "Low",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you. If you have questions, send a message to the care team that ordered this test."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Note: If you have questions about more than 1 test ordered by the same care team, send 1 message with all of your questions."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": [
+                                          "Date Spec taken: Apr 13, 2024 12:54 Pathologist: CHERYL JAMES\nDate Spec rec'd: Apr 13, 2024 12:55 Tech: CHERYL JAMES\nDate completed: Apr 13, 2024 Accession #: CY 14 999998\nSubmitted by: GREGORY HOUSE, M.D. Practitioner: SANDRA DENTON\n-------------------------------------------------------------------------------\nSpecimen:\nFLUID\nDESCRIPTION:\nThis is the National package - testing for MHV.\nMICROSCOPIC EXAM (Date Spec taken: Apr 13, 2024 12:54)\nNormal fluid - TEST ONLY\n=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--\nPerforming Laboratory:\nCytology Report Performed By:\nWASHINGTION DC VAMC"
+                                      ],
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
                   }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Microbiology on August 3, 1995",
-          "details": {
-            "header": "Details about this test",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
               },
               {
-                "title": "Sample from",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordered by",
-                "value": "Beth M. Smith",
-                "inline": true
-              },
-              {
-                "title": "Ordering location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Collecting location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "August 3, 1995",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": false,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND",
-                    "monospace": true
+                  "title": "Electrocardiogram (EKG)",
+                  "results": {
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "title": "Date",
+                                      "value": "March 7, 2024, 10:00 a.m.",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider",
+                                      "value": "DOE, JANE A",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
                   }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Microbiology on August 3, 1995",
-          "details": {
-            "header": "Details about this test",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
               },
               {
-                "title": "Sample from",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordered by",
-                "value": "Beth M. Smith",
-                "inline": true
-              },
-              {
-                "title": "Ordering location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Collecting location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "August 3, 1995",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": false,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Electrocardiogram (EKG) on 2000-12-14T11:35:00Z",
-          "results": {
-            "sectionSeparators": true,
-            "items": [
-              {
-                "items": [
-                  {
-                    "title": "Date",
-                    "value": "2000-12-14T11:35:00Z",
-                    "inline": true
+                  "title": "Urinalysis (UA)",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "April 21, 2020, 12:37 p.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Urine",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Gregory House, M.D.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": "None noted",
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Location",
-                    "value": "school parking lot",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "URINE KETONES",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "NEG MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEG MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "APPEARANCE",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "CLEAR ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "None noted",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "COLOR",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "YELLOW ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "None noted",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "SPECIFIC GRAVITY",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "1.02 ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "1.003 - 1.035",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "UROBILINOGEN",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "0.2 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "0.1 - 1.9 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE BLOOD",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "NEG ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEG",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE BILIRUBIN",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "NEG ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEG",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE GLUCOSE",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "NEG MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEG MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE PROTEIN",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "Trace MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEG MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE pH",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "6.0 ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "4.6 - 8.0",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE WBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": ">180 WBC/HPF (High)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "<5 WBC/HPF",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "Result is high when compared to ref. range."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE RBC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "6 RBC/HPF (High)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "<3 RBC/HPF",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "Result is high when compared to ref. range."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "URINE NITRITE",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "POSITIVE ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEG",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "LEUKOESTERASE",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "LARGE ",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "NEG",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Hemoglobin A1C (HbA1C)",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "April 1, 2020, 9:31 a.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Whole blood",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Gregory House, M.D.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": [
+                                  "*** If Diabetic, recommended HgA1C should be <7% *** Hemoglobin A1c values reported after 1-1-95 are standardized in accordance with recommendations of the Diabetes Control and Complications Trial(DCCT). Based on these recommendations, a upward shift in reported results will be noted. A table depicting this shift is available in Chemistry on request."
+                              ],
+                              "inline": true
+                          }
+                      ]
                   },
-                  {
-                    "title": "Provider",
-                    "value": "Beth M. Smith",
-                    "inline": true
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "HEMOGLOBIN A1C",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "14 % (High)",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "3.4 - 6.1 %",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "Result is high when compared to ref. range."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
                   }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "RADIOLOGIC EXAMINATION, SPINE, LUMBOSACRAL; 2 OR 3 VIEWS on September 24, 2004",
-          "details": {
-            "header": "Details about this test",
-            "items": [
-              {
-                "title": "Reason for test",
-                "value": "None noted",
-                "inline": true
               },
               {
-                "title": "Clinical history",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordered by",
-                "value": "GARFUNKEL,FELIX",
-                "inline": true
-              },
-              {
-                "title": "Imaging location",
-                "value": "GARFUNKEL,FELIX, DAYT29 TEST LAB",
-                "inline": true
-              },
-              {
-                "title": "Imaging provider",
-                "value": "None noted",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "SPINE LUMBOSACRAL MIN 2 VIEWS\n   \nExm Date: SEP 24, 2004@11:25\nReq Phys: FELKLEY,KENNETH E              Pat Loc: PCT_O PATIL (F/U) (Req'g Loc)\n                                         Img Loc: RADIOLOGY\n                                         Service: Unknown\n\n \n\n(Case 1582 COMPLETE) SPINE LUMBOSACRAL MIN 2 VIEWS    (RAD  Detailed) CPT:72100\n     Proc Modifiers : BILATERAL EXAM\n\n    Clinical History:\n      having 3 weeks of back pains need to re-eval for arhritis or any \n      worsneing disc spaces etc. \n\n    Report Status: Verified                   Date Reported: SEP 27, 2004\n                                              Date Verified: SEP 28, 2004\n    Verifier E-Sig:/ES/Thong D. Nguyen, M.D.\n\n    Report:\n      Three views of the lumbosacral spine are compared with a previous \n      examination of 9/23/02.  \n       \n      There has been a partial collapse of L2 which is similar in\n      appearance and degree to the previous examination of September\n      2002.  There is also collapse of the body of T12 which apparently\n      is new since the previous exam and the collapse has been\n      estimated above 75 to 80% of the height of the vertebral body.  \n       \n      There is mild marginal spurring of the upper anterior aspect of\n      L4.  There are arteriosclerotic calcifications in the abdominal\n      aorta and branches.  \n       \n      The intervertebral disc spaces are preserved.  \n\n    Impression:\n      1.  Old compression fracture of L2 with anterior marginal\n      spurring and apparent ankylosis L1-L2.  \n       \n      2.  Collapse or compression fracture of the body of T12 which is\n      new since the previous examination in 2002 and involves loss of\n      height of that vertebral body by about 70%.  Arteriosclerotic\n      calcifications of the aorta.  \n\n    Primary Diagnostic Code: \n\nPrimary Interpreting Staff:\n  FELIX GARFUNKEL, Staff Physician\nVERIFIED BY:\n  THONG NGUYEN, Radiologist/Chief\n\n/GEG",
-                    "monospace": true
+                  "title": "Lipid Panel",
+                  "details": {
+                      "header": "Details about this test",
+                      "items": [
+                          {
+                              "title": "Date and time collected",
+                              "value": "February 26, 2020, 9:54 a.m.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Type of test",
+                              "value": "chemistry_hematology",
+                              "inline": true
+                          },
+                          {
+                              "title": "Site or sample tested",
+                              "value": "Plasma",
+                              "inline": true
+                          },
+                          {
+                              "title": "Ordered by",
+                              "value": "Gregory House, M.D.",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Lab comments",
+                              "value": "None noted",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Results",
+                      "preface": [
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "If your results are outside the reference range (the expected range for that test), your results may include a word like “high” or “low.” But this doesn’t automatically mean you have a health problem."
+                          },
+                          {
+                              "prefaceOptions": {
+                                  "paragraphGap": 20
+                              },
+                              "value": "Your provider will review your results. If you need to do anything, your provider will contact you."
+                          }
+                      ],
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "CHOLESTEROL",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "238 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "1 - 240 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "DESIRABLE VALUE: <200 BORDERLINE VALUE: 201-239 ELEVATED VALUE: >240"
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "TRYGLYCERIDES",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "45 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "35 - 160 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": [
+                                          "DESIRABLE VALUE: <150 BORDERLINE VALUE: 150-199 ELEVATED VALUE: 200-499 Patient should be fasting at time of specimen collection for valid interpretation of triglyceride level."
+                                      ],
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "HDL CHOLESTEROL",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "65 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "32 - 78 mg/dL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "LDL-CHOL CALC",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Reference range",
+                                      "value": "43 - 161 MG/DL",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Final",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Lab comments",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
                   }
-                ]
               }
-            ]
-          }
-        },
-        {
-          "title": "Microbiology on August 3, 1995",
-          "details": {
-            "header": "Details about this test",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Sample from",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordered by",
-                "value": "Beth M. Smith",
-                "inline": true
-              },
-              {
-                "title": "Ordering location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Collecting location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "August 3, 1995",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": false,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Microbiology on August 3, 1995",
-          "details": {
-            "header": "Details about this test",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Sample from",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordered by",
-                "value": "Beth M. Smith",
-                "inline": true
-              },
-              {
-                "title": "Ordering location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Collecting location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "August 3, 1995",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": false,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Accession [UID]: PARAS 95 263 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 29, 1995 07:00\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND \nMODERATE WBC'S SEEN \nMODERATE YEAST",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Microbiology on August 1, 1995",
-          "details": {
-            "header": "Details about this test",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Sample from",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Ordered by",
-                "value": "Beth M. Smith",
-                "inline": true
-              },
-              {
-                "title": "Ordering location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Collecting location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "August 1, 1995",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": false,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Accession [UID]: PARAS 95 262 []            Received: Aug 01, 1995@11:00\nCollection sample: STOOL               Collection date: Jul 28, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 01, 1995   TECH CODE: 420\nParasitology Remark(s):\nREJECTED=LEAKED",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "LR SURGICAL PATHOLOGY REPORT on August 10, 2000",
-          "details": {
-            "header": "Details about this test",
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "August 10, 2000",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Date Spec taken: Aug 09, 2000        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 09, 2000 16:14  Resident: \nDate  completed: Aug 10, 2000        Accession #: SP 00 1982\nSubmitted by: MARK MAZUR MD          Practitioner:MARK MAZUR DPM\n-------------------------------------------------------------------------------\nSpecimen: \nOLD HARDWARE LEFT FOOT X2\nBrief Clinical History:\nThis 71 y/o wm presents with painful hardware L 1st metatarsal head. The\npins were inserted 3 years ago for a bunion procedure. The Bunionprocedure\nis well healed and pt is now wanting the pin removed. Will probably need\nk-wire driver and power for this case.\nPreoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nPostoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nGross description:\nRECEIVED UNFIXED AND LABELED \"OLD HARDWARE LEFT FOOT X 2\" CONSISTS OF TWO\n1.7 CM AND 2.5 CM LONG 1 MM WIDE METALLIC PINS.\n|TAB||NOWRAP|\nDIAGNOSIS: HARDWARE (CLINICALLY FROM LEFT FOOT)",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "LR SURGICAL PATHOLOGY REPORT on September 27, 1999",
-          "details": {
-            "header": "Details about this test",
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "September 27, 1999",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Date Spec taken: Sep 24, 1999        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 24, 1999 13:46  Resident: \nDate  completed: Sep 27, 1999        Accession #: SP 99 2207\nSubmitted by: KHURSHID YOUSUF MD     Practitioner:KHURSHID YOUSUF\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYPS (A) CECAL\n       (B) PROXIMAL ASCENDING\n       (C) RECTAL\nBrief Clinical History:\nCOLON POLYPS PER FLEX SIG\nPreoperative Diagnosis:\nCOLON POLYPS\nOperative Findings:\n|TAB||NOWRAP|\n1. CECAL POLYPS X 2\n2. ASCENDING COLON POLYP\n3. RECTAL POLYP\nPostoperative Diagnosis:\nSAME\nGross description:\n|TAB||NOWRAP|\nSPECIMEN (A) LABELED CECAL POLYP X 2.  RECEIVED IN FORMALIN IS ONE PALE\nGREY TISSUE FRAGMENT MEASURING 0.4 CM IN DIAMETER.  EMBEDDED ENTIRELY IN\nONE BLOCK.\nSPECIMEN (B) LABELED PROXIMAL ASCENDING COLON.  RECEIVED IN FORMALIN ARE\nTWO PALE BROWN TISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED\nENTIRELY IN ONE BLOCK.\nSPECIMEN (C) LABELED RECTAL POLYP.  RECEIVED IN FORMALIN ARE THREE MINUTE\nTISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED ENTIRELY\nIN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Sep 24, 1999)\n|TAB||BLANK(3)|\n|TAB||NOWRAP|\nDIAGNOSIS:\nA) CECAL POLYP: HYPERPLASTIC POLYP.  (SEE NOTE)\nB &amp; C)\nPROXIMAL ASCENDING COLON AND RECTAL POLYPS: TUBULAR ADENOMAS. (SEE\nNOTE)\n\nNOTE: COAGULATION ARTEFACT AND POOR TISSUE PRESERVATION IS NOTED CAUSING\nDIFFICULTY IN EVALUATION OF LESION.\nDR. YOUSUF WAS NOTIFIED.",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "LR SURGICAL PATHOLOGY REPORT on August 11, 1999",
-          "details": {
-            "header": "Details about this test",
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "August 11, 1999",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Date Spec taken: Aug 09, 1999        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 10, 1999 13:27  Resident: \nDate  completed: Aug 11, 1999        Accession #: SP 99 1804\nSubmitted by: KATHLEEN MARIE WOLNER  Practitioner:KATHLEEN MARIE WOLNER MD\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYP @ 12CM\nBrief Clinical History:\n70 YEAR OLD MALE FOR SCREENING EXAM.  \nOperative Findings:\nSMOOTH BROAD BASED POLYP\nPostoperative Diagnosis:\nPROBABLE BENIGN POLYP\nGross description:\nRECEIVED IN FORMALIN AND LABELED \"POLYP\"  CONSISTS OF TWO 1 MM FRAGMENTS\nOF PINK TISSUE.  SUBMITTED IN TOTAL IN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Aug 09, 1999)\n|TAB||BLANK(3)|\nDIAGNOSIS:\nPOLYP AT 12 CM. TUBULAR ADENOMA.",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "LR SURGICAL PATHOLOGY REPORT on September 9, 1997",
-          "details": {
-            "header": "Details about this test",
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "September 9, 1997",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Date Spec taken: Sep 08, 1997        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 08, 1997 13:08  Resident: \nDate  completed: Sep 09, 1997        Accession #: SP 97 2091\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \n(A) BONE FROM RIGHT FOOT\n(B) BONE RIGHT FOOT",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "LR SURGICAL PATHOLOGY REPORT on May 14, 1997",
-          "details": {
-            "header": "Details about this test",
-            "items": [
-              {
-                "title": "Sample tested",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Lab location",
-                "value": "None noted",
-                "inline": true
-              },
-              {
-                "title": "Date completed",
-                "value": "May 14, 1997",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Results",
-            "sectionSeparators": true,
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "Date Spec taken: May 12, 1997        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: May 12, 1997 14:00  Resident: \nDate  completed: May 13, 1997        Accession #: SP 97 1099\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \nBONE FRAGMENTS, LEFT FOOT",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "type": "care summaries and notes",
-      "title": "Care summaries and notes",
-      "subtitles": [
-        "This report only includes care summaries and notes from 2013 and later.",
-        "For after-visit summaries, (summaries of your appointments with VA providers), go to your appointment records."
-      ],
-      "toc": {
-        "title": "Care summaries and notes………………………………",
-        "subtitle": "Review notes from your VA providers about your health and health care."
-      },
-      "selected": true,
-      "records": [
-        {
-          "title": "Progress note",
-          "details": {
-            "header": "Details",
-            "items": [
-              {
-                "title": "Location",
-                "value": "DAYTSHR TEST LAB",
-                "inline": true
-              },
-              {
-                "title": "Written by",
-                "value": "AHMED,MARUF",
-                "inline": true
-              },
-              {
-                "title": "Signed by",
-                "value": "AHMED,MARUF",
-                "inline": true
-              },
-              {
-                "title": "Date signed",
-                "value": "August 8, 2022",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Notes",
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "LOCAL TITLE: Adverse React/Allergy                              \nSTANDARD TITLE: ALLERGY &amp; IMMUNOLOGY ADVERSE EVENT NOTE         \nDATE OF NOTE: AUG 05, 2022@11:23:54  ENTRY DATE: AUG 05, 2022@11:23:54      \n      AUTHOR: AHMED,MARUF          EXP COSIGNER:                           \n     URGENCY:                            STATUS: COMPLETED                     \n\nThis patient has had the following reactions \nsigned-off on Aug 05, 2022@11:23:54.\n\nWHITE FISH\n\nAuthor's comments:\n\nMaruf's test data \n\n \n/es/ MARUF AHMED\nPHYSICIAN\nSigned: 08/08/2022 10:50",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Discharge summary",
-          "details": {
-            "header": "Details",
-            "items": [
-              {
-                "title": "Location",
-                "value": "DAYTON",
-                "inline": true
-              },
-              {
-                "title": "Discharge date",
-                "value": "August 9, 2022",
-                "inline": true
-              },
-              {
-                "title": "Discharged by",
-                "value": "AHMED,MARUF",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Summary",
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "LOCAL TITLE: Discharge Summary                                  \nSTANDARD TITLE: DISCHARGE SUMMARY                               \n   DICT DATE: AUG 09, 2022@13:42     ENTRY DATE: AUG 09, 2022@13:43:02      \n DICTATED BY: AHMED,MARUF             ATTENDING: AHMED,NAJEEB                 \n     URGENCY: routine                    STATUS: COMPLETED                     \n\n \n \nDATE OF ADMISSION:\nDATE OF DISCHARGE: Aug 9,2022\n \nPRINCIPLE DISCHARGE DIAGNOSIS: TEST DISGNOSIS, Maruf Ahmed.\nADDITIONAL DIAGNOSES:\n \nCONSULTANT(S):\nPROCEDURE(S):\n \nBRIEF ADMISSION HISTORY:\n71 year old MALE test\n \nBRIEF ADMISSION PHYSICAL EXAM:  test exam\n \nADMISSION LAB/EKG/X-RAY RESULTS:  test again\n \nHOSPITAL COURSE:\n  via2vdif transstition\n \nCONDITION ON DISCHARGE: test\n \nDISCHARGE INSTRUCTIONS:\n   Activity:    test1\n   Diet:        test2\n   Medications: test3\n   Special Instructions: test again\n   Follow-up Plans: test again again\n \n/es/ MARUF AHMED\nPHYSICIAN\nSigned: 08/09/2022 13:44\n \n/es/ MUAZZAM KHAN\nPhysician\nCosigned: 08/12/2022 12:17\nfor NAJEEB AHMED                                  \nAMOD",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Progress note",
-          "details": {
-            "header": "Details",
-            "items": [
-              {
-                "title": "Location",
-                "value": "DAYTSHR TEST LAB",
-                "inline": true
-              },
-              {
-                "title": "Written by",
-                "value": "AHMED,MARUF",
-                "inline": true
-              },
-              {
-                "title": "Signed by",
-                "value": "AHMED,MARUF",
-                "inline": true
-              },
-              {
-                "title": "Date signed",
-                "value": "August 14, 2022",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Notes",
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "LOCAL TITLE: Adverse React/Allergy                              \nSTANDARD TITLE: ALLERGY &amp; IMMUNOLOGY ADVERSE EVENT NOTE         \nDATE OF NOTE: AUG 05, 2022@11:23:54  ENTRY DATE: AUG 05, 2022@11:23:54      \n      AUTHOR: AHMED,MARUF          EXP COSIGNER:                           \n     URGENCY:                            STATUS: COMPLETED                     \n\nThis patient has had the following reactions \nsigned-off on Aug 05, 2022@11:23:54.\n\nWHITE FISH\n\nAuthor's comments:\n\nMaruf's test data \n\n \n/es/ MARUF AHMED\nPHYSICIAN\nSigned: 08/08/2022 10:50",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "title": "Discharge summary",
-          "details": {
-            "header": "Details",
-            "items": [
-              {
-                "title": "Location",
-                "value": "DAYTON",
-                "inline": true
-              },
-              {
-                "title": "Discharge date",
-                "value": "August 15, 2022",
-                "inline": true
-              },
-              {
-                "title": "Discharged by",
-                "value": "AHMED,MARUF",
-                "inline": true
-              }
-            ]
-          },
-          "results": {
-            "header": "Summary",
-            "items": [
-              {
-                "items": [
-                  {
-                    "value": "LOCAL TITLE: Discharge Summary                                  \nSTANDARD TITLE: DISCHARGE SUMMARY                               \n   DICT DATE: AUG 09, 2022@13:42     ENTRY DATE: AUG 09, 2022@13:43:02      \n DICTATED BY: AHMED,MARUF             ATTENDING: AHMED,NAJEEB                 \n     URGENCY: routine                    STATUS: COMPLETED                     \n\n \n \nDATE OF ADMISSION:\nDATE OF DISCHARGE: Aug 9,2022\n \nPRINCIPLE DISCHARGE DIAGNOSIS: TEST DISGNOSIS, Maruf Ahmed.\nADDITIONAL DIAGNOSES:\n \nCONSULTANT(S):\nPROCEDURE(S):\n \nBRIEF ADMISSION HISTORY:\n71 year old MALE test\n \nBRIEF ADMISSION PHYSICAL EXAM:  test exam\n \nADMISSION LAB/EKG/X-RAY RESULTS:  test again\n \nHOSPITAL COURSE:\n  via2vdif transstition\n \nCONDITION ON DISCHARGE: test\n \nDISCHARGE INSTRUCTIONS:\n   Activity:    test1\n   Diet:        test2\n   Medications: test3\n   Special Instructions: test again\n   Follow-up Plans: test again again\n \n/es/ MARUF AHMED\nPHYSICIAN\nSigned: 08/09/2022 13:44\n \n/es/ MUAZZAM KHAN\nPhysician\nCosigned: 08/12/2022 12:17\nfor NAJEEB AHMED                                  \nAMOD",
-                    "monospace": true
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "type": "vaccines",
-      "title": "Vaccines",
-      "subtitles": [
-        "This list includes vaccines you got at VA health facilities and from providers or pharmacies in our community care network. It may not include vaccines you got outside our network.",
-        "For complete records of your allergies and reactions to vaccines, review your allergy records in this report."
-      ],
-      "toc": {
-        "title": "Vaccines……………………………………………………………",
-        "subtitle": "Review a list of all vaccines (immunizations) in your VA medical records."
-      },
-      "selected": true,
-      "records": {
-        "results": {
-          "items": [
-            {
-              "header": "INFLUENZA, INJECTABLE, QUADRIVALENT",
-              "items": [
-                {
-                  "title": "Date received",
-                  "value": "March 5, 2023",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "test comment",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "INFLUENZA, INJECTABLE, QUADRIVALENT",
-              "items": [
-                {
-                  "title": "Date received",
-                  "value": "January 3, 2023",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "test comment",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "COVID-19 (MODERNA), MRNA, LNP-S, PF, 100 MCG/0.5ML DOSE OR 50 MCG/0.25ML DOSE",
-              "items": [
-                {
-                  "title": "Date received",
-                  "value": "August 8, 2022",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "test",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "INFLUENZA, INJECTABLE, QUADRIVALENT",
-              "items": [
-                {
-                  "title": "Date received",
-                  "value": "August 5, 2022",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "ADTP BURNETT",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "test comment",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "INFLUENZA, INJECTABLE, QUADRIVALENT",
-              "items": [
-                {
-                  "title": "Date received",
-                  "value": "August 5, 2022",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "test comment",
-                  "inline": false
-                }
-              ]
-            }
           ]
-        }
-      }
-    },
-    {
-      "type": "allergies",
-      "title": "Allergies",
-      "subtitles": [
-        "If you have allergies that are missing from this list, send a secure message to your care team."
-      ],
-      "toc": {
-        "title": "Allergies…………………………………………………………",
-        "subtitle": "Review a list of all allergies, reactions, and side effects in your VA medical records."
       },
-      "selected": true,
-      "records": {
-        "results": {
-          "items": [
-            {
-              "header": "RED MEAT",
-              "items": [
-                {
-                  "title": "Date entered",
-                  "value": "September 27, 2023",
-                  "inline": true
-                },
-                {
-                  "title": "Signs and symptoms",
-                  "value": "SWELLING",
-                  "inline": true
-                },
-                {
-                  "title": "Type of allergy",
-                  "value": "Food",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "SLC10.FO-BAYPINES.MED.VA.GOV",
-                  "inline": true
-                },
-                {
-                  "title": "Observed or historical",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "Maruf's test ",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "NUTS",
-              "items": [
-                {
-                  "title": "Date entered",
-                  "value": "August 4, 2023",
-                  "inline": true
-                },
-                {
-                  "title": "Signs and symptoms",
-                  "value": "RASH",
-                  "inline": true
-                },
-                {
-                  "title": "Type of allergy",
-                  "value": "Food",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "SLC10.FO-BAYPINES.MED.VA.GOV",
-                  "inline": true
-                },
-                {
-                  "title": "Observed or historical",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "Maruf's test ",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "PENICILLIN",
-              "items": [
-                {
-                  "title": "Date entered",
-                  "value": "July 27, 2022",
-                  "inline": true
-                },
-                {
-                  "title": "Signs and symptoms",
-                  "value": "SEDATED",
-                  "inline": true
-                },
-                {
-                  "title": "Type of allergy",
-                  "value": "Medication",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "SLC10.FO-BAYPINES.MED.VA.GOV",
-                  "inline": true
-                },
-                {
-                  "title": "Observed or historical",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "Maruf's test ",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "PENNSAID",
-              "items": [
-                {
-                  "title": "Date entered",
-                  "value": "March 27, 2022",
-                  "inline": true
-                },
-                {
-                  "title": "Signs and symptoms",
-                  "value": "RENAL IMPAIRMENT",
-                  "inline": true
-                },
-                {
-                  "title": "Type of allergy",
-                  "value": "Medication",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "SLC10.FO-BAYPINES.MED.VA.GOV",
-                  "inline": true
-                },
-                {
-                  "title": "Observed or historical",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "maruf's test ",
-                  "inline": false
-                }
-              ]
-            },
-            {
-              "header": "MEDIPLAST",
-              "items": [
-                {
-                  "title": "Date entered",
-                  "value": "December 27, 2020",
-                  "inline": true
-                },
-                {
-                  "title": "Signs and symptoms",
-                  "value": "DELIRIUM. RASH",
-                  "inline": true
-                },
-                {
-                  "title": "Type of allergy",
-                  "value": "Medication",
-                  "inline": true
-                },
-                {
-                  "title": "Location",
-                  "value": "SLC10.FO-BAYPINES.MED.VA.GOV",
-                  "inline": true
-                },
-                {
-                  "title": "Observed or historical",
-                  "value": "None noted",
-                  "inline": true
-                },
-                {
-                  "title": "Provider notes",
-                  "value": "Maruf's test ",
-                  "inline": false
-                }
-              ]
-            }
+      {
+          "type": "care summaries and notes",
+          "title": "Care summaries and notes",
+          "subtitles": [
+              "This report only includes care summaries and notes from 2013 and later.",
+              "For after-visit summaries, (summaries of your appointments with VA providers), go to your appointment records."
+          ],
+          "selected": true,
+          "records": [
+              {
+                  "title": "ANESTHESIOLOGY NOTE (E)",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "November 1, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "John J. Lydon",
+                              "inline": true
+                          },
+                          {
+                              "title": "Signed by",
+                              "value": "John Simon Ritchie",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "November 1, 2024",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: ANESTHESIOLOGY NOTE (E)\nSTANDARD TITLE: ANESTHESIOLOGY NOTE\nDATE OF NOTE: FEB 28, 2024@10:37 ENTRY DATE: FEB 28, 2024@10:37:46\nAUTHOR: JOHN J. LYDON EXP COSIGNER: JOHN SIMON RITCHIE\nURGENCY: STATUS: COMPLETED\n[X} MAC [ ] General anesthesia was administered for Colonoscopy\n/es/ JOHN J. LYDON\nANESTHESIOLOGIST\nSigned: 02/28/2024 10:38",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "GI/HEPATOLOGY TELEPHONE NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "June 29, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "Calvin Broadus",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "February 22, 2024",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: GI/HEPATOLOGY TELEPHONE NOTE\nSTANDARD TITLE: INTERNAL MEDICINE TELEPHONE ENCOUNTER NOTE\nDATE OF NOTE: FEB 22, 2024@14:10 ENTRY DATE: FEB 22, 2024@14:10:21\nAUTHOR: CALVIN BROADUS EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nPt was called and left a message to call the GI office with request to speak with Preprocedure tele provider of the day.\nThanks,\nCALVIN BROADUS\n/es/ CALVIN BROADUS\nPHYSICIAN ASSISTANT\nSigned: 02/22/2024 14:10",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "HT NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "May 20, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "Andre Young",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "January 30, 2024",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: HT NOTE\nSTANDARD TITLE: CARE COORDINATION HOME TELEHEALTH NOTE\nDATE OF NOTE: JAN 30, 2024@13:12 ENTRY DATE: JAN 30, 2024@13:12:12\nAUTHOR: ANDRE YOUNG EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nSUBJECT: Monthly Contact Note\nHOME TELEHEALTH MONTHLY CONTACT\n===============================\nVENDOR/DEVICE UTILIZED: Cognosante/Tablet\nDMP: DMP - VHA Diabetes 063023 / (64/364)\nENROLLMENT DATE: 11/6/23\nFIRST TRANSMISSION DATE: 11/7/23\nTRANSMISSION RATE:\nHT program requires meeting a score goal of at least 90-100% for monthly data transmissions which involves transmitting vital sign data most days of the week via HT device\n>Veteran's monthly data transmission scores:\nDec. 2023=81%\nJan. 2024=77% so far for the month\n30-DAY VITAL SIGN SUMMARY\nBG average 108 mg/dl\n***Veteran states the results of A1c from DOD provider done Jan. 17th was 8.3\nSpecimen: BLOOD. CH 0703 529\nSpecimen Collection Date: Jul 03, 2023@10:58\nTest name Result units Ref. range Site Code\nHgb A1C 8.2 H % 4.0 - 6.0 [688]\nEval: Values obtained from A1C measurements can vary. For typical A1C assays,\nEval: a reported value of 7.0 could actually be between 6.72 and 7.28 if\nEval: measured by a reference method. A reported value of 9.0 could actually be\nEval: between 8.73 and 9.27.\nEval: Ref: http://www.ngsp.org/CAPdata.asp\n***States DOD provider currently doing work up with additional labs to assess if he has type 2 DM. Has upcoming DOD provider appt. next Tuesday\n-------------------------\nSMART GOAL(S) AS ESTABLISHED UPON ENROLLMENT:\nDM GOAL: The Veteran will decrease his HgbA1c by at least 1-2% in 3-6 months, by taking DM medications as prescribed, making lifestyle changes with diet/exercise, transmitting vital sign data/answering daily educational health check questions via HT device/platform over the next 90 days Veteran will walk at least 10 minutes after each meal for a total of 30 minutes per day to help control post-prandial blood sugars x 30-60 days\nASSESSMENT OF VETERAN CONDITION/SMART GOAL PROGRESS:\nVeteran contacted at this time for monthly progress review. Veteran expresses concerns about increase in his A1c. States he and his wife consume the same prepared meals at home, but she has a better A1c. States he has had f/u DOD nutrition referral and has been provided handouts for carbohydrate counting. He states he will keep writer posted regarding lab results when he sees his DOD provider next Tuesday (Feb. 6th)\nDiscussed the benefits of being more active which can help the body use insulin better by increasing insulin sensitivity. Exercise can be broken up in increments of 10 min. 3x/day or 15 minutes 2x/day\n***States he tries to walk at least 30 min per day during his 30 minute lunch\nbreak\nDiscussed the importance of eating a consistent amount of food and taking insulin as directed which can greatly improve sugar levels. States he is currently taking 16 units of glargine insulin.\nVeteran reports 100% compliance with all medications.\nNo further needs at this time, veteran thanked writer for call.\nSMART GOALS\n-----------\n( )MET\n( )NOT MET\n(X)IN PROGRESS\n================================================================================\nCARE COORDINATOR PLAN:\n> Will continue to monitor transmitted data and contact veteran and/or provider as needed\n> Encouraged veteran to increase current transmission rate in accordance with HT program goal of 100%\n> Will continue to support veteran in his progress toward SMART goal(s)\n/es/ ANDRE YOUNG\nMSN, RN Home Telehealth Care Coordinator\nSigned: 01/30/2024 14:38",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "HT MONTHLY MONITOR NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "March 5, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "Andre Young",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "March 5, 2024",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: HT MONTHLY MONITOR NOTE\nSTANDARD TITLE: CARE COORDINATION HOME TELEHEALTH SUMMARIZATION\nDATE OF NOTE: JAN 30, 2024@09:38 ENTRY DATE: JAN 30, 2024@09:39\nAUTHOR: ANDRE YOUNG EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nThe Veteran is enrolled in the Home Telehealth (HT) program and continues to be monitored via HT technology. The data sent by the Veteran is reviewed and analyzed by the HT staff, who provide ongoing case management and Veteran health education while communicating and collaborating with the health care team as appropriate. This note covers a total of 30 minutes for the month monitored.\nMonth monitored: Jan. 2024\n/es/ ANDRE YOUNG\nMSN, RN Home Telehealth Care Coordinator\nSigned: 01/30/2024 09:40",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "HT MONTHLY MONITOR NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "February 28, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "Andre Young",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "February 28, 2024",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: HT MONTHLY MONITOR NOTE\nSTANDARD TITLE: CARE COORDINATION HOME TELEHEALTH SUMMARIZATION\nDATE OF NOTE: FEB 28, 2024@08:32 ENTRY DATE: FEB 28, 2024@08:32:50\nAUTHOR: ANDRE YOUNG EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nThe Veteran is enrolled in the Home Telehealth (HT) program and continues to be monitored via HT technology. The data sent by the Veteran is reviewed and analyzed by the HT staff, who provide ongoing case management and Veteran health education while communicating and collaborating with the health care team as appropriate. This note covers a total of 30 minutes for the month monitored.\nMonth monitored: February 2024\n/es/ ANDRE YOUNG\nMSN, RN Home Telehealth Care Coordinator\nSigned: 02/28/2024 08:35",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "PRIMARY CARE NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "January 8, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "Dana Owens",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "January 8, 2024",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: PRIMARY CARE NOTE\nSTANDARD TITLE: PRIMARY CARE NOTE\nDATE OF NOTE: JAN 08, 2024@09:45 ENTRY DATE: JAN 08, 2024@09:45:00\nAUTHOR: BETH M. SMITH EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nPRIMARY CARE NOTE\nFace-to-Face\nWILSON, PAT is a 21 year old veteran who presents for a\nface-to-face follow-up visit.\nCHIEF COMPLAINT/HISTORY OF PRESENT ILLNESS: Testing to see if after visit\nsummary viewable in JLV\nEXAM\nNO VITALS FOUND Sp02 ---\nGeneral:\nChest:\nCardiovascular:\nAbdomen:\nExtremeties:\nOther:\nASSESSMENT/PLAN\nWritten After Visit Summary instructions reviewed with patient. Patient\nprovided copy of updated medication list.\nRETURN TO CLINIC: Per RTC order, or sooner PRN\nTotal time spent in clinical care related to this visit: 5 minutes\nMEDICATION RECONCILIATION:\nMedication Reconciliation was not performed at this visit as patient\nand/or caregiver is not able to confirm medications he/she is taking. The\nimportance of managing medication information was explained to the\npatient.\nPAST MEDICAL HISTORY\nEnter Problems:\nNo active problems in computerized problem list as of 7/19/22@21:36\nSERVICE CONNECTED CONDITIONS\nLUNG CONDITION 60% S/C\nMEDICATIONS\nLocal:\nActive Outpatient Medications (excluding Supplies):\nNo Medications Found\nRemote: No Active Remote Medications for this patient\nALLERGIES\nLocal: Allergy Assessment Not Donee\nRemote:\nFACILITY ALLERGY/ADR\n-------- -----------\n363^ANCHORAGE VA MEDICALCENTER^463 TETANUS TOXOID\n648^PORTLAND VA MEDICAL CENTER^648 ADHESIVE TAPE\n648^PORTLAND VA MEDICAL CENTER^648 ALUMINUM HYDROXIDE/MAGNESIUM HYDROXIDE WILSON PAT CONFIDENTIAL Page 46 of 2094\n648^PORTLAND VA MEDICAL CENTER^648 EGGS\n648^PORTLAND VA MEDICAL CENTER^648 LISINOPRIL\n648^PORTLAND VA MEDICAL CENTER^648 PENICILLIN\n648^PORTLAND VA MEDICAL CENTER^648 PRAZOSIN\n648^PORTLAND VA MEDICAL CENTER^648 SULFA DRUGS\n648^PORTLAND VA MEDICAL CENTER^648 TETRACYCLINE\n668^MANN-GRANDSTAFF VAMC^668 CLINDAMYCIN\n687^JONATHAN M. WAINWRIGHT VAMC^687 PENICILLIN\nLABS:\nNo data available HEMOGLOBIN A1c, INTEGRA - NONE FOUND\nNo data available for: CHOLESTEROL\nTRIGLYCERIDES\nHDL CHOLESTEROL\nLDL, CALCULATED\nLOL, DIRECT No CBC Panel Found\n/es/ BETH M. SMITH, DNP, ARNP, FNP-BC\nNurse Practitioner - Women's Health Clinic\nSigned: 01/08/2024 21:42",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "DISCHARGE SUMMARY",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date admitted",
+                              "value": "January 8, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date discharged",
+                              "value": "January 8, 2024",
+                              "inline": true
+                          },
+                          {
+                              "title": "Discharged by",
+                              "value": "Dana Owens",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Summary",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: DISCHARGE SUMMARY\nSTANDARD TITLE: DISCHARGE SUMMARY\nDATE OF NOTE: JAN 08, 2024@10:12 ENTRY DATE: JAN 08, 2024@10:12:54\nAUTHOR: DANA OWENS EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nDISCHARGE SUMMARY:\nVITAL SIGNS MONITORING\nDate and Time:1/8/2024 @ 0949\nBlood pressure : 122/87mm HG\nPulse rate : 88per min\nRespiratory rate : 17per min\nTemperature : 97.7F\nO2 Saturation : 100percent\n**********************************************\nPost Anesthesia Sedation Score - Phase 1\nPhase 1 Discharge Criteria\nTOTAL SCORE=14\nOxygenation\n2 Points - SpO2 greater than or equal to 94% or baseline on room air\nPACU Respiratory Status\n2 Points - Normal breathing and deep cough on command\nCirculatory Status\n2 Points - BP/HR less than 20% or 20 mmHg of baseline\nLevel of Consciousness\n2 Points - Fully awake or easily awakened\nPain\n2 Points - Minimal or none - Pain Score 0-4 or at tolerable level or at baseline\nNausea/Vomiting\n2 Points - Minimal or none\nLevel of Activity\n2 Points - Able to move all extremities voluntarily or on command or moves all extremities with the exception of extremity treated with peripheral nerve block or patient baseline\nVA-PAS Phase 1 time documented\nTime: 0949\nNursing Note:Patient ready for discharge. Discharge instructions and procedure report given to patient. The patient verbalizes understanding of instructions.\nEKG: No acute EKG changes\nRESPIRATORY:\nO2 administered:none,\nGU:\nUrine Output:has not voided\nColor: Urine:n/a\nGI:\nNausea : No\nVomiting: No\nAbdomen:non-distended\nBowel Sounds:present\nINTAKE:\nPO: 0 ml\nIV: 500ml\nTOTAL: 500ml\nOUTPUT:\nUrine: 0ml\nTOTAL: 0ml\nPACU DISCHARGE CRITERIA\nDischarged by anesthesiologist.\nAlert and oriented or at baseline.\nMoves all extremities or at baseline.\nVital signs are stable or at baseline.\nNo excessive bleeding.\nAdequate pain control\n/es/ DANA OWENS\nRN STAFF\nSigned: 01/08/2024 10:23",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "DISCHARGE SUMMARY",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date admitted",
+                              "value": "November 30, 2023",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date discharged",
+                              "value": "November 30, 2023",
+                              "inline": true
+                          },
+                          {
+                              "title": "Discharged by",
+                              "value": "Christopher Wallace",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Summary",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: DISCHARGE SUMMARY\nSTANDARD TITLE: DISCHARGE SUMMARY\nDATE OF NOTE: NOV 30, 2023@10:12 ENTRY DATE: NOV 30, 2023@10:12:54\nAUTHOR: CHRISTOPHER WALLACE EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nDISCHARGE SUMMARY:\nVITAL SIGNS MONITORING\nDate and Time:11/30/2023 @ 0949\nBlood pressure : 122/87mm HG\nPulse rate : 88per min\nRespiratory rate : 17per min\nTemperature : 97.7F\nO2 Saturation : 100percent\n**********************************************\nPost Anesthesia Sedation Score - Phase 1\nPhase 1 Discharge Criteria\nTOTAL SCORE=14\nOxygenation\n2 Points - SpO2 greater than or equal to 94% or baseline on room air\nPACU Respiratory Status\n2 Points - Normal breathing and deep cough on command\nCirculatory Status\n2 Points - BP/HR less than 20% or 20 mmHg of baseline\nLevel of Consciousness\n2 Points - Fully awake or easily awakened\nPain\n2 Points - Minimal or none - Pain Score 0-4 or at tolerable level or at baseline\nNausea/Vomiting\n2 Points - Minimal or none\nLevel of Activity\n2 Points - Able to move all extremities voluntarily or on command or moves all extremities with the exception of extremity treated with peripheral nerve block or patient baseline\nVA-PAS Phase 1 time documented\nTime: 0949\nNursing Note:Patient ready for discharge. Discharge instructions and procedure report given to patient. The patient verbalizes understanding of instructions.\nEKG: No acute EKG changes\nRESPIRATORY:\nO2 administered:none,\nGU:\nUrine Output:has not voided\nColor: Urine:n/a\nGI:\nNausea : No\nVomiting: No\nAbdomen:non-distended\nBowel Sounds:present\nINTAKE:\nPO: 0 ml\nIV: 500ml\nTOTAL: 500ml\nOUTPUT:\nUrine: 0ml\nTOTAL: 0ml\nPACU DISCHARGE CRITERIA\nDischarged by anesthesiologist.\nAlert and oriented or at baseline.\nMoves all extremities or at baseline.\nVital signs are stable or at baseline.\nNo excessive bleeding.\nAdequate pain control\n/es/ CHRISTOPHER WALLACE\nRN STAFF\nSigned: 11/30/2023 10:23",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "HT MONTHLY MONITOR NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "July 19, 2023",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "Andre Young",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "December 28, 2023",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: HT MONTHLY MONITOR NOTE\nSTANDARD TITLE: CARE COORDINATION HOME TELEHEALTH SUMMARIZATION\nDATE OF NOTE: DEC 28, 2023@06:58 ENTRY DATE: DEC 28, 2023@06:58:38\nAUTHOR: ANDRE YOUNG EXP COSIGNER:\nURGENCY: STATUS: COMPLETED\nThe Veteran is enrolled in the Home Telehealth (HT) program and continues to be monitored via HT technology. The data sent by the Veteran is reviewed and analyzed by the HT staff, who provide ongoing case management and Veteran health education while communicating and collaborating with the health care team as appropriate. This note covers a total of 30 minutes for the month monitored.\nMonth monitored: December 2023\n/es/ ANDRE YOUNG\nMSN, RN Home Telehealth Care Coordinator\nSigned: 12/28/2023 06:59",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "ANESTHESIA PREINDUCTION NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "August 1, 2022",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "John J. Lydon",
+                              "inline": true
+                          },
+                          {
+                              "title": "Signed by",
+                              "value": "John Simon Ritchie",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "February 28, 2024",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: ANESTHESIA PREINDUCTION NOTE\nSTANDARD TITLE: ANESTHESIOLOGY NOTE\nDATE OF NOTE: FEB 28, 2024@10:36 ENTRY DATE: FEB 28, 2024@10:36:28\nAUTHOR: JOHN J. LYDON EXP COSIGNER: JOHN SIMON RITCHIE\nURGENCY: STATUS: COMPLETED\nANESTHESIA PREINDUCTION NOTE WITH PRIOR ANESTHESIA PREOP ASSESSMENT\nPatient identified by name and either date of birth or full social security.\n-------------------------------------------------\nScheduled procedure: Colon\n-------------------------------------------------\nDiagnosis:Screening\nPREOPERATIVE ASSESSMENT--------------------------\nASA status: III\n-------------------------------------------------\nAllergy:Patient has answered NKA\n-------------------------------------------------\nPatient's preoperative assessment reviewed-------\nThere are no significant changes, new conditions, or additions from the patient's anesthesia preoperative assessment\nNPO status----------------------------------------\nMet ASA guidelines (>2 hrs clear liquids, >6 hrs light meal, >8 hrs\nheavy\nmeal)\n--------------------------------------------------\nVital signs stable\nHR: 91 (02/28/2024 10:13)\nBP: 147/90 (02/28/2024 10:13)\nRR: 17 (02/28/2024 10:13)\nO2: 100% (02/28/2024 10:13)\nTemp: 97.3 F [36.3 C] (02/28/2024 10:13)\n--------------------------------------------------\nAirway Exam:\nMallampati Class: 2\nMouth opening: full\nNeck: full range of motion\nThyromental distance: >6cm\nDentition: normal\nCardiac System:\nCardiovascular exam normal\nRespiratory:\nClear to auscultation, normal respiratory rate and effort\nMental/Neuro exam:\nAlert, oriented, calm, cooperative\nAnesthetic technique-----------------------------\nMonitored anesthesia care\nMonitors/Equipment: Standard monitors-----------\nNon-invasive:\nInformed consent discussion of anesthesia plan\nThe anesthetic plan has been discussed with the patient and/or responsible representative. The patient/representative has been encouraged to ask questions and any concerns have been addressed. The risks, benefits, side effects, and alternative options of the plan were discussed. The patient/representative endorses understanding of the information disclosed.\nThe patient/representative voluntarily elects to move forward with the anesthetic plan.\nPlanned destination------------------------------\nPhase I PACU\n/es/ JOHN J. LYDON\nANESTHESIOLOGIST\nSigned: 02/28/2024 10:37",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "GI CONSULT NOTE",
+                  "details": {
+                      "header": "Details",
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "April 8, 2018",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VAMC",
+                              "inline": true
+                          },
+                          {
+                              "title": "Written by",
+                              "value": "Beth M. Smith",
+                              "inline": true
+                          },
+                          {
+                              "title": "Signed by",
+                              "value": " M.D. Gregory House",
+                              "inline": true
+                          },
+                          {
+                              "title": "Date signed",
+                              "value": "April 8, 2018",
+                              "inline": true
+                          }
+                      ]
+                  },
+                  "results": {
+                      "header": "Note",
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "value": "LOCAL TITLE: CONSULT GI (E)\nSTANDARD TITLE: GASTROENTEROLOGY CONSULT\nDATE OF NOTE: APR 8, 2018@10:40 ENTRY DATE: APR 8, 2018@10:40:07\nAUTHOR: BETH M. SMITH EXP COSIGNER: GREGORY HOUSE, M.D.\nURGENCY: STATUS: COMPLETED\n*** CONSULT GI (E) Has ADDENDA ***\nProcedure performed. See full note in procedure section of reports tab or in vista imaging.\n/es/ BETH M. SMITH\nATTENDING PHYSICIAN\nSigned: 04/08/2018 10:40\n04/08/2018 ADDENDUM STATUS: COMPLETED\nColonoscopy GAP Reminder:\nRecommendations are needed in the clinical reminder system following the patient's most recent colorectal cancer screening/surveillance test\n(Colonoscopy, Sigmoidoscopy or CT Colonography)\nColonoscopy reminder set 7 years from MAR 02, 2018.\n/es/ BETH M. SMITH",
+                                      "monospace": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              }
           ]
-        }
+      },
+      {
+          "type": "vaccines",
+          "title": "Vaccines",
+          "subtitles": [
+              "This list includes vaccines you got at VA health facilities and from providers or pharmacies in our community care network. It may not include vaccines you got outside our network.",
+              "For complete records of your allergies and reactions to vaccines, review your allergy records in this report."
+          ],
+          "selected": true,
+          "records": {
+              "results": {
+                  "items": [
+                      {
+                          "header": "INFLUENZA, HIGH-DOSE, QUADRIVALENT",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date received",
+                                  "value": "March 12, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "INFLUENZA, HIGH-DOSE, QUADRIVALENT, PF",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date received",
+                                  "value": "December 8, 2023",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "INFLUENZA, HIGH-DOSE, QUADRIVALENT",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date received",
+                                  "value": "September 17, 2022",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "TDAP",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date received",
+                                  "value": "October 14, 2021",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "ZOSTER RECOMBINANT",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date received",
+                                  "value": "October 14, 2021",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "INFLUENZA, HIGH-DOSE, QUADRIVALENT, PF",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date received",
+                                  "value": "September 17, 2020",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "type": "allergies",
+          "title": "Allergies and reactions",
+          "subtitles": [
+              "This list includes all allergies, reactions, and side effects in your VA medical records. If you have allergies or reactions that are missing from this list, tell your care team at your next appointment.",
+              "Showing 6 records from newest to oldest"
+          ],
+          "selected": true,
+          "records": {
+              "results": {
+                  "items": [
+                      {
+                          "header": "Bee Pollen",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date entered",
+                                  "value": "January 12, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Signs and symptoms",
+                                  "value": "SWELLING",
+                                  "isRich": false,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Type of allergy",
+                                  "value": "Medication",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Observed or historical",
+                                  "value": "Historical (you experienced this allergy or reaction in the past, before you started getting care at this VA location)",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Provider notes",
+                                  "value": "Patient reports having this allergy since childhood. They carry an epi-pen.",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "Nuts",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date entered",
+                                  "value": "January 12, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Signs and symptoms:",
+                                  "value": [
+                                      {
+                                          "value": [
+                                              "SWELLING",
+                                              "RESPIRATORY DISTRESS"
+                                          ],
+                                          "indent": 0,
+                                          "paragraphGap": 0
+                                      }
+                                  ],
+                                  "isRich": true,
+                                  "inline": false
+                              },
+                              {
+                                  "title": "Type of allergy",
+                                  "value": "Food",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Observed or historical",
+                                  "value": "Historical (you experienced this allergy or reaction in the past, before you started getting care at this VA location)",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Provider notes",
+                                  "value": "Patient reported severe reaction to tree nuts. Carries an epi-pen.",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "Sunflower Oil",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date entered",
+                                  "value": "January 12, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Signs and symptoms",
+                                  "value": "RESPIRATORY DISTRESS",
+                                  "isRich": false,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Type of allergy",
+                                  "value": "Medication",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Observed or historical",
+                                  "value": "Observed (you experienced this allergy or reaction while you were getting care at this VA location)",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Provider notes",
+                                  "value": "Patient reported.",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "Penicillin",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date entered",
+                                  "value": "April 29, 2022",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Signs and symptoms",
+                                  "value": "Anaphylaxis",
+                                  "isRich": false,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Type of allergy",
+                                  "value": "Drug allergy",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Observed or historical",
+                                  "value": "Observed (you experienced this allergy or reaction while you were getting care at this VA location)",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Provider notes",
+                                  "value": "Patient is to have no cillin or cef/ceph antibiotics",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "Skin Prep",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date entered",
+                                  "value": "June 15, 2018",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Signs and symptoms",
+                                  "value": "SWELLING",
+                                  "isRich": false,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Type of allergy",
+                                  "value": "Medication",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Observed or historical",
+                                  "value": "Observed (you experienced this allergy or reaction while you were getting care at this VA location)",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Provider notes",
+                                  "value": "Reaction on left arm while prepping for blood draw.",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "Aspirin",
+                          "headerType": "H2",
+                          "items": [
+                              {
+                                  "title": "Date entered",
+                                  "value": "November 1, 2001",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Signs and symptoms",
+                                  "value": "URTICARIA",
+                                  "isRich": false,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Type of allergy",
+                                  "value": "Medication",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Location",
+                                  "value": "Washington DC VAMC",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Observed or historical",
+                                  "value": "Observed (you experienced this allergy or reaction while you were getting care at this VA location)",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Provider notes",
+                                  "value": "Patient experienced a rash on their neck and chest. Benadryl was administered. Patient advised to avoid aspirin.",
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "title": "Health conditions",
+          "subtitles": [
+              "This list includes your current health conditions that VA providers are helping you manage. It may not include conditions non-VA providers are helping you manage."
+          ],
+          "selected": true,
+          "records": [
+              {
+                  "title": "Back pain (SCT53978)",
+                  "details": {
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "April 29, 2022",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider",
+                              "value": "Gregory House",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VA Medical Center",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider notes",
+                              "value": "None noted",
+                              "inline": true
+                          },
+                          {
+                              "title": "About the code in this condition name",
+                              "value": "Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.",
+                              "inline": false
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Sick sinus syndrome",
+                  "details": {
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "March 8, 2022",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider",
+                              "value": "Gregory Jacobs",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VA Medical Center",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider notes",
+                              "value": [
+                                  "Consistent Tachycardia-Brachycardia"
+                              ],
+                              "inline": true
+                          },
+                          {
+                              "title": "About the code in this condition name",
+                              "value": "Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.",
+                              "inline": false
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Asthma",
+                  "details": {
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "January 11, 2022",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider",
+                              "value": "Jackson O'Shea",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VA Medical Center",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider notes",
+                              "value": [
+                                  "Spirometry, PEF, below standard, chest CT shows airway thickening"
+                              ],
+                              "inline": true
+                          },
+                          {
+                              "title": "About the code in this condition name",
+                              "value": "Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.",
+                              "inline": false
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Hypertension (SCT48073)",
+                  "details": {
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "December 9, 2021",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider",
+                              "value": " M.D. Christina Yang",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VA Medical Center",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider notes",
+                              "value": [
+                                  "BP ranging from 150/90 to 170/110"
+                              ],
+                              "inline": true
+                          },
+                          {
+                              "title": "About the code in this condition name",
+                              "value": "Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.",
+                              "inline": false
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Anemia (ICD102894)",
+                  "details": {
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "September 17, 2020",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider",
+                              "value": " M.D. Tracy Marrow",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VA Medical Center",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider notes",
+                              "value": [
+                                  "Hemoglobin baseline <10"
+                              ],
+                              "inline": true
+                          },
+                          {
+                              "title": "About the code in this condition name",
+                              "value": "Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.",
+                              "inline": false
+                          }
+                      ]
+                  }
+              },
+              {
+                  "title": "Inflammation",
+                  "details": {
+                      "items": [
+                          {
+                              "title": "Date entered",
+                              "value": "June 5, 2018",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider",
+                              "value": " M.D. Tracy Marrow",
+                              "inline": true
+                          },
+                          {
+                              "title": "Location",
+                              "value": "Washington DC VA Medical Center",
+                              "inline": true
+                          },
+                          {
+                              "title": "Provider notes",
+                              "value": [
+                                  "Counseled patient on DASH diet"
+                              ],
+                              "inline": true
+                          },
+                          {
+                              "title": "About the code in this condition name",
+                              "value": "Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.",
+                              "inline": false
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      {
+          "type": "vitals",
+          "title": "Vitals",
+          "subtitles": [
+              "This list includes vitals and other basic health numbers your providers check at your appointments."
+          ],
+          "selected": true,
+          "records": [
+              {
+                  "results": {
+                      "header": "BLOOD PRESSURE",
+                      "headerType": "H3",
+                      "headerIndent": 30,
+                      "preface": "Showing 15 records, from newest to oldest",
+                      "prefaceIndent": 30,
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "November 20, 2024, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "August 8, 2024, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 5, 2024, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 25, 2023, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "October 11, 2023, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "September 9, 2023, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "July 24, 2023, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 19, 2023, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 2, 2023, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 9, 2022, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "October 3, 2022, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "July 9, 2022, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 18, 2022, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 17, 2022, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 20, 2022, 10:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "120/80",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "ADTP BURNETT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "results": {
+                      "header": "PULSE",
+                      "headerType": "H3",
+                      "headerIndent": 30,
+                      "preface": "Showing 10 records, from newest to oldest",
+                      "prefaceIndent": 30,
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "November 20, 2024, 1:27 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 4, 2021, 8:27 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "85 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 15, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "80 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 17, 2020, 11:48 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "83 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 10, 2020, 10:36 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "77 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 10, 2020, 8:20 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "84 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 3, 2020, 9:05 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "86 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 9, 2020, 2:15 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "89 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 5, 2020, 4:39 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "81 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 23, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "85 beats per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "results": {
+                      "header": "RESPIRATION",
+                      "headerType": "H3",
+                      "headerIndent": 30,
+                      "preface": "Showing 10 records, from newest to oldest",
+                      "prefaceIndent": 30,
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "November 20, 2024, 1:27 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "18 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 4, 2021, 8:27 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "17 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 15, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "19 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 17, 2020, 11:48 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "18 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 10, 2020, 10:36 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "18 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 10, 2020, 8:20 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "19 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 3, 2020, 9:05 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "17 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 9, 2020, 2:15 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "19 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 5, 2020, 4:39 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "17 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 23, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "18 breaths per minute",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "results": {
+                      "header": "PULSE OXIMETRY",
+                      "headerType": "H3",
+                      "headerIndent": 30,
+                      "preface": "Showing 10 records, from newest to oldest",
+                      "prefaceIndent": 30,
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "November 20, 2024, 1:27 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 4, 2021, 8:27 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 15, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 17, 2020, 11:48 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 10, 2020, 10:36 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 10, 2020, 8:20 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 3, 2020, 9:05 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 9, 2020, 2:15 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 5, 2020, 4:39 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 23, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99%",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "results": {
+                      "header": "TEMPERATURE",
+                      "headerType": "H3",
+                      "headerIndent": 30,
+                      "preface": "Showing 10 records, from newest to oldest",
+                      "prefaceIndent": 30,
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "November 20, 2024, 1:27 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "97.9 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 4, 2021, 8:27 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "98.2 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 15, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "98.6 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 17, 2020, 11:48 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "97.9 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 10, 2020, 10:36 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "99.1 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 10, 2020, 8:20 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "98.2 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 3, 2020, 9:05 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "98.8 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 9, 2020, 2:15 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "98.1 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 5, 2020, 4:39 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "98 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 23, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "98.2 °F",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "results": {
+                      "header": "WEIGHT",
+                      "headerType": "H3",
+                      "headerIndent": 30,
+                      "preface": "Showing 10 records, from newest to oldest",
+                      "prefaceIndent": 30,
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "November 20, 2024, 1:27 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "152 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 4, 2021, 8:27 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "153 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 15, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "157 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 17, 2020, 11:48 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "150 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 10, 2020, 10:36 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "155 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 10, 2020, 8:20 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "159 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 3, 2020, 9:05 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "158 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 9, 2020, 2:15 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "150 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 5, 2020, 4:39 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "153 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 23, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "158 pounds",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              },
+              {
+                  "results": {
+                      "header": "HEIGHT",
+                      "headerType": "H3",
+                      "headerIndent": 30,
+                      "preface": "Showing 40 records, from newest to oldest",
+                      "prefaceIndent": 30,
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "November 20, 2024, 1:27 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "August 3, 2024, 8:27 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "July 24, 2024, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 4, 2024, 11:48 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 18, 2024, 10:36 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 17, 2024, 8:20 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 30, 2024, 9:05 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 20, 2023, 2:15 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 3, 2023, 4:39 p.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "November 10, 2023, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "July 19, 2023, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 8, 2023, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 22, 2023, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 15, 2023, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 29, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "October 31, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "August 1, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 9, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 2, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 20, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "November 18, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "October 4, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "July 21, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "April 3, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 28, 2022, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "December 30, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "August 21, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "May 9, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 9, 2021, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "October 19, 2020, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "July 24, 2020, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "February 19, 2020, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 1, 2020, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "November 27, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 20, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "March 7, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "January 23, 2019, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "November 2, 2018, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "August 30, 2018, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "67.5 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "June 5, 2018, 9:00 a.m.",
+                              "items": [
+                                  {
+                                      "title": "Result",
+                                      "value": "68 inches",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "Washington DC VAMC",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider notes",
+                                      "value": "None noted",
+                                      "inline": true
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      {
+          "type": "medications",
+          "title": "Medications",
+          "subtitles": [
+              "This is a list of prescriptions and other medications in your VA medical records.",
+              "When you share your medications list with providers, make sure you also tell them about your allergies and reactions to medications. When you download medications records, we also include a list of allergies and reactions in your VA medical records.",
+              "Showing 20 medications, alphabetically by name"
+          ],
+          "selected": true,
+          "records": [
+              {
+                  "title": "AAAAA",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "March 5, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Active",
+                                  "inline": true
+                              },
+                              {
+                                  "value": "This is a current prescription. If you have refills left, you can request a refill now."
+                              },
+                              {
+                                  "title": "Note",
+                                  "value": "If you have no refills left, you'll need to request a renewal instead.",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "0",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "BBBBB",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "March 3, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Active",
+                                  "inline": true
+                              },
+                              {
+                                  "value": "This is a current prescription. If you have refills left, you can request a refill now."
+                              },
+                              {
+                                  "title": "Note",
+                                  "value": "If you have no refills left, you'll need to request a renewal instead.",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "1",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "CCCCC",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "March 1, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Active",
+                                  "inline": true
+                              },
+                              {
+                                  "value": "This is a current prescription. If you have refills left, you can request a refill now."
+                              },
+                              {
+                                  "title": "Note",
+                                  "value": "If you have no refills left, you'll need to request a renewal instead.",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "2",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "DDDDD",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 27, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Active",
+                                  "inline": true
+                              },
+                              {
+                                  "value": "This is a current prescription. If you have refills left, you can request a refill now."
+                              },
+                              {
+                                  "title": "Note",
+                                  "value": "If you have no refills left, you'll need to request a renewal instead.",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 2,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "3",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "EEEEE",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 25, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Active",
+                                  "inline": true
+                              },
+                              {
+                                  "value": "This is a current prescription. If you have refills left, you can request a refill now."
+                              },
+                              {
+                                  "title": "Note",
+                                  "value": "If you have no refills left, you'll need to request a renewal instead.",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "4",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "FFFFF",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 23, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Active",
+                                  "inline": true
+                              },
+                              {
+                                  "value": "This is a current prescription. If you have refills left, you can request a refill now."
+                              },
+                              {
+                                  "title": "Note",
+                                  "value": "If you have no refills left, you'll need to request a renewal instead.",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "5",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "GGGGG",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 21, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Active",
+                                  "inline": true
+                              },
+                              {
+                                  "value": "This is a current prescription. If you have refills left, you can request a refill now."
+                              },
+                              {
+                                  "title": "Note",
+                                  "value": "If you have no refills left, you'll need to request a renewal instead.",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 2,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "6",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "HHHHH",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 19, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "7",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "IIIII",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 17, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "8",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "JJJJJ",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 15, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 3,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "9",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "KKKKK",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 13, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "10",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "LLLLL",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 11, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "11",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "MMMMM",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 9, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 3,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "12",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "NNNNN",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 7, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "13",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "OOOOO",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 5, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "14",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "PPPPP",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 3, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 3,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "15",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "QQQQQ",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "February 1, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "16",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "RRRRR",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "January 30, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "17",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "SSSSS",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "January 28, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 3,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "18",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "title": "TTTTT",
+                  "details": [
+                      {
+                          "header": "About your prescription",
+                          "items": [
+                              {
+                                  "title": "Last filled on",
+                                  "value": "January 26, 2025",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Status",
+                                  "value": "Expired",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Refills left",
+                                  "value": 0,
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Request refills by this prescription expiration date",
+                                  "value": "January 2, 2099",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescription number",
+                                  "value": "19",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed on",
+                                  "value": "February 23, 2024",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Prescribed by",
+                                  "value": "ProviderFirst ProviderLast",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Facility",
+                                  "value": "The Facility",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Pharmacy phone number",
+                                  "value": "(555) 555-5555",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "About this medication or supply",
+                          "items": [
+                              {
+                                  "title": "Instructions",
+                                  "value": "No instructions available",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Reason for use",
+                                  "value": "None recorded",
+                                  "inline": true
+                              },
+                              {
+                                  "title": "Quantity",
+                                  "value": 1,
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "type": "appointments",
+          "title": "Appointments",
+          "subtitles": [
+              "Your VA appointments may be by telephone, video, or in person. Always bring your insurance information with you to your appointment."
+          ],
+          "selected": true,
+          "records": [
+              {
+                  "title": "Upcoming appointments",
+                  "results": {
+                      "preface": "Showing 0 appointments, sorted by date",
+                      "sectionSeparators": false,
+                      "items": []
+                  }
+              },
+              {
+                  "title": "Past appointments",
+                  "results": {
+                      "preface": "Showing 2 appointments, sorted by date",
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "header": "October 3, 2024, 8:00 a.m. MDT",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "title": "Appointment type",
+                                      "value": "Clinic",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Confirmed",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider",
+                                      "value": [
+                                          {
+                                              "value": "Cheyenne VA Medical Center"
+                                          },
+                                          {
+                                              "value": "2360 East Pershing Boulevard"
+                                          },
+                                          {
+                                              "value": "Cheyenne, WY 82001-5356"
+                                          }
+                                      ],
+                                      "isRich": true
+                                  },
+                                  {
+                                      "title": "Phone",
+                                      "value": "7561",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "What",
+                                      "value": "COVID VACCINE CLIN2",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Who",
+                                      "value": [
+                                          {
+                                              "value": "Cheyenne VA Medical Center"
+                                          },
+                                          {
+                                              "value": "2360 East Pershing Boulevard"
+                                          },
+                                          {
+                                              "value": "Cheyenne, WY 82001-5356"
+                                          }
+                                      ],
+                                      "isRich": true
+                                  },
+                                  {
+                                      "title": "Where to attend",
+                                      "value": [
+                                          "Cheyenne VA Medical Center",
+                                          "2360 East Pershing Boulevard",
+                                          "Cheyenne, WY 82001-5356"
+                                      ],
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Clinic",
+                                      "value": "621",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "AMB CARE",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Clinic phone",
+                                      "value": "7561",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Details you shared with your provider",
+                                      "isRich": true,
+                                      "paragraphGap": 2,
+                                      "lineGap": 4,
+                                      "value": [
+                                          {
+                                              "title": "Reason",
+                                              "value": "REGULAR",
+                                              "paragraphGap": 2
+                                          },
+                                          {
+                                              "title": "Other details",
+                                              "value": "COVID VACCINE CLIN2",
+                                              "paragraphGap": 2
+                                          }
+                                      ]
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "October 29, 2024, 11:00 a.m. MDT",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "title": "Appointment type",
+                                      "value": "Clinic",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Status",
+                                      "value": "Confirmed",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Provider",
+                                      "value": [
+                                          {
+                                              "value": "Cheyenne VA Medical Center"
+                                          },
+                                          {
+                                              "value": "2360 East Pershing Boulevard"
+                                          },
+                                          {
+                                              "value": "Cheyenne, WY 82001-5356"
+                                          }
+                                      ],
+                                      "isRich": true
+                                  },
+                                  {
+                                      "title": "Phone",
+                                      "value": "7580",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "What",
+                                      "value": "COVID VACCINE CLIN5",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Who",
+                                      "value": [
+                                          {
+                                              "value": "Cheyenne VA Medical Center"
+                                          },
+                                          {
+                                              "value": "2360 East Pershing Boulevard"
+                                          },
+                                          {
+                                              "value": "Cheyenne, WY 82001-5356"
+                                          }
+                                      ],
+                                      "isRich": true
+                                  },
+                                  {
+                                      "title": "Where to attend",
+                                      "value": [
+                                          "Cheyenne VA Medical Center",
+                                          "2360 East Pershing Boulevard",
+                                          "Cheyenne, WY 82001-5356"
+                                      ],
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Clinic",
+                                      "value": "985",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Location",
+                                      "value": "EMERGENCY ROOM",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Clinic phone",
+                                      "value": "7580",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Details you shared with your provider",
+                                      "isRich": true,
+                                      "paragraphGap": 2,
+                                      "lineGap": 4,
+                                      "value": [
+                                          {
+                                              "title": "Reason",
+                                              "value": "REGULAR",
+                                              "paragraphGap": 2
+                                          },
+                                          {
+                                              "title": "Other details",
+                                              "value": "COVID VACCINE CLIN5",
+                                              "paragraphGap": 2
+                                          }
+                                      ]
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      {
+          "type": "demographics",
+          "title": "Demographics",
+          "subtitles": [
+              "Each of your VA facilities may have different demographic information for you. If you need update your information, contact your facility."
+          ],
+          "selected": true,
+          "records": [
+              {
+                  "title": "VA facility: DAYTSHR",
+                  "titleMoveDownAmount": 0.5,
+                  "results": {
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "items": [
+                                  {
+                                      "title": "First name",
+                                      "value": "VETERAN",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Middle name",
+                                      "value": "ROBERT",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Last name",
+                                      "value": "CASEY",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Date of birth",
+                                      "value": "January 3, 1953",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Age",
+                                      "value": 71,
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Gender",
+                                      "value": "Male",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Ethnicity",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Religion",
+                                      "value": "UNIVERSAL LIFE CHURCH",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Place of birth",
+                                      "value": "ALDIE, VIRGINIA",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Marital status",
+                                      "value": "MARRIED",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "Permanent address and contact information",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "title": "Street address",
+                                      "value": "123 TEST STREET TEST",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "City",
+                                      "value": "FAIRFAX",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "State",
+                                      "value": "VIRGINIA",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Zip code",
+                                      "value": "20151",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "County",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Country",
+                                      "value": "USA",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Home phone number",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Work phone number",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Cell phone number",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Email address",
+                                      "value": "MARUF.AHMED@VA.GOV",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "Eligibility",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "title": "Service connected percentage",
+                                      "value": "90",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Means test status",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Primary eligibility code",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "Employment",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "title": "Occupation",
+                                      "value": "UNKNOWN",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Means test status",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Employer name",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "Primary next of kin",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "title": "Name",
+                                      "value": "GEORGE,TEST",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Street address",
+                                      "value": "123 TEST STREET TEST",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "City",
+                                      "value": "FAIRFAX",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "State",
+                                      "value": "VIRGINIA",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Zip code",
+                                      "value": "20151",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Home phone number",
+                                      "value": "571-123-4567",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Work phone number",
+                                      "value": "None recorded",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "Emergency contact",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "title": "Name",
+                                      "value": "GEORGE,TEST",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Street address",
+                                      "value": "123 TEST STREET TEST",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "City",
+                                      "value": "FAIRFAX",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "State",
+                                      "value": "VIRGINIA",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Zip code",
+                                      "value": "20151",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Home phone number",
+                                      "value": "571-123-4567",
+                                      "inline": true
+                                  },
+                                  {
+                                      "title": "Work phone number",
+                                      "value": "571-123-4567",
+                                      "inline": true
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "VA guardian",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "value": "No information reported"
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "Civil guardian",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "value": "No information reported"
+                                  }
+                              ]
+                          },
+                          {
+                              "header": "Active insurance",
+                              "headerType": "H4",
+                              "items": [
+                                  {
+                                      "value": "No information reported"
+                                  }
+                              ]
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      {
+          "type": "military service",
+          "title": "DOD military service information",
+          "titleParagraphGap": 0,
+          "titleMoveDownAmount": 0.5,
+          "selected": true,
+          "records": [
+              {
+                  "details": {
+                      "sectionSeparators": false,
+                      "items": [
+                          {
+                              "monospace": true,
+                              "lineGap": 0,
+                              "value": "NOTES:\n1) This report may not show your complete DoD Military Service\n        Information.\n   Data prior to establishment of DEERS and full service reporting\n        (c. 1980) \n   may not appear.\n2) It is normal for the begin/end dates in\n        DoD records, adjusted by the\n   Personnel Center after separation, to vary\n        slightly from the DD-214.\n3) No peacetime deployments will be displayed.\n        For Gulf War I, only one\n   period will be displayed even if you deployed\n        more than once.  No conflict\n   prior to Gulf War I will be displayed.  Kosovo,\n        Bosnia, and Southern Watch\n   data is incomplete and may not display.\n4) For Guard/Reserve, periods of active duty may not display.  No periods of\n        Active duty service less than 30 days will display.\n   \n   -- Regular Active Service\nService      Begin Date  End Date    Character of Service   Rank\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\nArmy         01/04/1990  02/15/1995  Honorable              SSG\n             \n-- Reserve/Guard Association Periods\nService      Begin Date  End Date    Character of Service   Rank\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\nArmy Reserve 02/16/1995  06/21/2016  Unknown                MSG              \n             \n-- Reserve/Guard Activation Periods\nService      Begin Date  End Date    Activated Under (Title 10, 32, etc.)\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \nArmy Reserve 08/19/1997  05/15/1998  Unknown (for use with Project Code A99 o\nArmy Reserve 10/01/2001  09/30/2002  Section 12302 of 10 U.S.C.              \nArmy Reserve 02/03/2003  01/17/2004  Section 12302 of 10 U.S.C.              \nArmy Reserve 11/30/2008  03/15/2010  Section 12302 of 10 U.S.C.              \nArmy Reserve 11/30/2008  01/03/2010  Section 12302 of 10 U.S.C.              \nArmy Reserve 01/04/2010  03/15/2010  Section 12301(h) of 10 U.S.C.           \nArmy Reserve 03/16/2010  12/04/2010  Section 12301(h) of 10 U.S.C.           \nArmy Reserve 03/16/2010  12/04/2010  Section 12301(d) of 10 U.S.C.           \nArmy Reserve 03/16/2010  12/04/2010  Section 12301(d) of 10 U.S.C.           \nArmy Reserve 12/05/2010  02/24/2012  Section 12301(h) of 10 U.S.C.           \n\n-- Deployment Periods\nService      Begin Date  End Date    Conflict               Location\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\nArmy Reserve 03/25/2003  12/04/2003  Post-9/11              Unknown     \nArmy Reserve 12/31/2008  01/06/2009  Post-9/11              Unknown     \nArmy Reserve 01/07/2009  04/15/2009  Post-9/11              Kuwait      \nArmy Reserve 04/16/2009  05/18/2009  Post-9/11              Iraq        \nArmy Reserve 05/19/2009  05/19/2009  Post-9/11              Kuwait      \nArmy Reserve 05/20/2009  07/20/2009  Post-9/11              Iraq        \nArmy Reserve 07/21/2009  11/17/2009  Post-9/11              Kuwait      \nArmy Reserve 11/18/2009  11/22/2009  Post-9/11              Unknown     \nArmy Reserve 11/23/2009  11/23/2009  Post-9/11              Unknown     \n\n-- DoD MOS/Occupation Codes \n-- Note: Both Service and DoD Generic codes may not be present in all records\nService      Begin Date  Enl/Off   Type       Svc Occ Code       DoD Occ Code\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\nArmy Reserve 02/16/1995  Enlisted  Primary    54B3OZZ            220500        \nArmy Reserve 02/16/1995  Enlisted  Duty       95B3OZZ            830        \nArmy Reserve 10/31/1999  Enlisted  Secondary  ZZZZZZZZ           null       \nArmy Reserve 11/30/1999  Enlisted  Primary    95B3OV5            830        \nArmy Reserve 10/31/2001  Enlisted  Duty       11B3O              010        \nArmy Reserve 01/31/2002  Enlisted  Duty       95B4O              830        \nArmy Reserve 04/30/2002  Enlisted  Primary    95B4O              830        \nArmy Reserve 05/31/2002  Enlisted  Duty       00D1O              920        \n\n...\n\n-- Retirement Type Code\nA       Mandatory\nB       Voluntary\nC       Fleet Reserve\nD       Temporary Disability Retirement List\nE       Permanent Disability Retirement List\nF       Title III\nG       Special Act\nH       Philippine Scouts\nZ       Unknown\n\nRetired Pay Termination Reason Code\nC       Pay condition terminated\nS       Pay terminated for the reason reported in the Stop Payment Reason Code\nW       Not terminated\n",
+                              "indent": 16
+                          }
+                      ]
+                  }
+              }
+          ]
+      },
+      {
+          "type": "account summary",
+          "title": "My HealtheVet account summary",
+          "titleParagraphGap": 0,
+          "titleMoveDownAmount": 0.5,
+          "selected": true,
+          "records": {
+              "details": {
+                  "items": [
+                      {
+                          "title": "Source",
+                          "value": "VA",
+                          "inline": true
+                      },
+                      {
+                          "title": "Authentication status",
+                          "value": "Authenticated",
+                          "inline": true
+                      },
+                      {
+                          "title": "Authentication date",
+                          "value": "November 5, 2024",
+                          "inline": true
+                      },
+                      {
+                          "title": "Authentication facility name",
+                          "value": "Unknown facility",
+                          "inline": true
+                      },
+                      {
+                          "title": "Authentication facility ID",
+                          "value": "Unknown ID",
+                          "inline": true
+                      }
+                  ]
+              },
+              "results": {
+                  "header": "VA treatment facilities",
+                  "headerType": "H3",
+                  "headerIndent": 30,
+                  "sectionSeparators": false,
+                  "items": [
+                      {
+                          "header": "IPO TEST 1",
+                          "headerType": "H4",
+                          "headerGap": 6,
+                          "items": [
+                              {
+                                  "title": "Type",
+                                  "value": "Treatment",
+                                  "inline": true
+                              }
+                          ]
+                      },
+                      {
+                          "header": "IPO TEST 2",
+                          "headerType": "H4",
+                          "headerGap": 6,
+                          "items": [
+                              {
+                                  "title": "Type",
+                                  "value": "Treatment",
+                                  "inline": true
+                              }
+                          ]
+                      }
+                  ]
+              }
+          }
       }
-    },
-    {
-      "title": "Health conditions",
-      "subtitles": [
-        "This list includes your current health conditions that VA providers are helping you manage. It may not include conditions non-VA providers are helping you manage."
-      ],
-      "toc": {
-        "title": "Health conditions……………………………………………",
-        "subtitle": "Review a list of all health conditions in your VA medical records."
-      },
-      "selected": true,
-      "records": [
-        {
-          "title": "Back pain (SCT 161891005)",
-          "details": {
-            "items": [
-              {
-                "title": "Date",
-                "value": "April 1, 2022",
-                "inline": true
-              },
-              {
-                "title": "Provider",
-                "value": "Dr. John",
-                "inline": true
-              },
-              {
-                "title": "Provider Notes",
-                "inline": false
-              },
-              {
-                "title": "Status of health condition",
-                "value": "inactive",
-                "inline": true
-              },
-              {
-                "title": "Location",
-                "value": "chiropractor's office",
-                "inline": true
-              },
-              {
-                "title": "SNOMED Clinical term",
-                "value": "Back pain (SCT 161891005)",
-                "inline": true
-              }
-            ]
-          }
-        },
-        {
-          "title": "Sick sinus syndrome (SCT 867530999)",
-          "details": {
-            "items": [
-              {
-                "title": "Date",
-                "value": "April 1, 2021",
-                "inline": true
-              },
-              {
-                "title": "Provider",
-                "value": "Dr. John",
-                "inline": true
-              },
-              {
-                "title": "Provider Notes",
-                "inline": false
-              },
-              {
-                "title": "Status of health condition",
-                "value": "inactive",
-                "inline": true
-              },
-              {
-                "title": "Location",
-                "value": "No one nose",
-                "inline": true
-              },
-              {
-                "title": "SNOMED Clinical term",
-                "value": "Sick sinus syndrome (SCT 867530999)",
-                "inline": true
-              }
-            ]
-          }
-        },
-        {
-          "title": "Asthma (SCT 525000600)",
-          "details": {
-            "items": [
-              {
-                "title": "Date",
-                "value": "April 1, 2019",
-                "inline": true
-              },
-              {
-                "title": "Provider",
-                "value": "Dr. John",
-                "inline": true
-              },
-              {
-                "title": "Provider Notes",
-                "inline": false
-              },
-              {
-                "title": "Status of health condition",
-                "value": "inactive",
-                "inline": true
-              },
-              {
-                "title": "Location",
-                "value": "Lung doctor's office",
-                "inline": true
-              },
-              {
-                "title": "SNOMED Clinical term",
-                "value": "Asthma (SCT 525000600)",
-                "inline": true
-              }
-            ]
-          }
-        },
-        {
-          "title": "Hypertension (SCT 500530505)",
-          "details": {
-            "items": [
-              {
-                "title": "Date",
-                "value": "April 1, 2018",
-                "inline": true
-              },
-              {
-                "title": "Provider",
-                "value": "Dr. John",
-                "inline": true
-              },
-              {
-                "title": "Provider Notes",
-                "inline": false
-              },
-              {
-                "title": "Status of health condition",
-                "value": "inactive",
-                "inline": true
-              },
-              {
-                "title": "Location",
-                "value": "Cardiologist's office",
-                "inline": true
-              },
-              {
-                "title": "SNOMED Clinical term",
-                "value": "Hypertension (SCT 500530505)",
-                "inline": true
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "type": "vitals",
-      "title": "Vitals",
-      "subtitles": [
-        "This list includes vitals and other basic health numbers your providers check at your appointments."
-      ],
-      "toc": {
-        "title": "Vitals…………………………………………………………………",
-        "subtitle": "Review a list of vitals and other basic health numbers your providers check at your appointments. This includes your blood pressure, breathing rate, heart rate, height, temperature, pain level, and weight."
-      },
-      "selected": true,
-      "records": [
-        {
-          "results": {
-            "header": "Heart rate",
-            "items": [
-              {
-                "header": "December 25, 2004, 8:50 p.m. PST",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "185 /min",
-                    "inline": true
-                  },
-                  {
-                    "title": "Location",
-                    "value": "None noted",
-                    "inline": true
-                  },
-                  {
-                    "title": "Provider notes",
-                    "value": "a bit fast",
-                    "inline": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "results": {
-            "header": "Blood pressure",
-            "items": [
-              {
-                "header": "September 24, 2004, 4:17 a.m. PDT",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "126/70",
-                    "inline": true
-                  },
-                  {
-                    "title": "Location",
-                    "value": "None noted",
-                    "inline": true
-                  },
-                  {
-                    "title": "Provider notes",
-                    "value": "None noted",
-                    "inline": true
-                  }
-                ]
-              },
-              {
-                "header": "September 24, 2004, 4:17 a.m. PDT",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "126/70",
-                    "inline": true
-                  },
-                  {
-                    "title": "Location",
-                    "value": "None noted",
-                    "inline": true
-                  },
-                  {
-                    "title": "Provider notes",
-                    "value": "None noted",
-                    "inline": true
-                  }
-                ]
-              },
-              {
-                "header": "September 24, 2004, 4:17 a.m. PDT",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "126/70",
-                    "inline": true
-                  },
-                  {
-                    "title": "Location",
-                    "value": "None noted",
-                    "inline": true
-                  },
-                  {
-                    "title": "Provider notes",
-                    "value": "None noted",
-                    "inline": true
-                  }
-                ]
-              },
-              {
-                "header": "September 24, 2004, 4:17 a.m. PDT",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "126/70",
-                    "inline": true
-                  },
-                  {
-                    "title": "Location",
-                    "value": "None noted",
-                    "inline": true
-                  },
-                  {
-                    "title": "Provider notes",
-                    "value": "None noted",
-                    "inline": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "results": {
-            "header": "Weight",
-            "items": [
-              {
-                "header": "August 9, 1999, 6:13 a.m. PDT",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "150.4 [lb_av]",
-                    "inline": true
-                  },
-                  {
-                    "title": "Location",
-                    "value": "PCT_O",
-                    "inline": true
-                  },
-                  {
-                    "title": "Provider notes",
-                    "value": "Here is a provider note",
-                    "inline": true
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "results": {
-            "header": "Pain",
-            "items": [
-              {
-                "header": "September 14, 2000, 6:00 a.m. PDT",
-                "items": [
-                  {
-                    "title": "Result",
-                    "value": "0 undefined",
-                    "inline": true
-                  },
-                  {
-                    "title": "Location",
-                    "value": "ZZZHEMATOLOGY II",
-                    "inline": true
-                  },
-                  {
-                    "title": "Provider notes",
-                    "value": "None noted",
-                    "inline": true
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      ]
-    }
   ],
-  "headerLeft": "null",
-  "headerRight": "Date of birth: Invalid date",
+  "headerLeft": "Maveteran, Veteran",
+  "headerRight": "Date of birth: April 6, 1974",
   "headerBanner": [
-    {
-      "text": "If you’re ever in crisis and need to talk with someone right away, call the Veterans Crisis line at "
-    },
-    {
-      "text": "988",
-      "weight": "bold"
-    },
-    {
-      "text": ". Then select 1."
-    }
+      {
+          "text": "If you’re ever in crisis and need to talk with someone right away, call the Veterans Crisis Line at "
+      },
+      {
+          "text": "988",
+          "weight": "bold"
+      },
+      {
+          "text": ". Then select 1."
+      }
   ],
-  "footerLeft": "Report generated by My HealtheVet on VA.gov on January 25, 2024",
+  "footerLeft": "Report generated by My HealtheVet on VA.gov on March 9, 2025",
   "footerRight": "Page %PAGE_NUMBER% of %TOTAL_PAGES%",
   "title": "Blue Button report",
   "subject": "VA Medical Record",
-  "name": "null",
-  "dob": "Invalid date",
-  "lastUpdated": "Last updated at 10:34 a.m. EST on January 25, 2024"
+  "name": "Maveteran, Veteran",
+  "dob": "April 6, 1974",
+  "lastUpdated": "Last updated at 6:15 p.m. on March 9, 2025"
 }


### PR DESCRIPTION
## Summary
- Appointments appropriately appear in the "Records not in this report" section and not in the "Records in this report" section when there is no appointments data
- The appointments section longer appears in the blue button report when there is no appointments data

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-66102
### Blue Button – Appointments domain displaying as having records incorrectly
<img width="996" alt="Screenshot 2025-03-09 at 6 39 02 PM" src="https://github.com/user-attachments/assets/2fd0135c-b3be-4ec1-8b7d-bd1d00f67c03" />

## Testing done
- unit tests have been fixed
- a unit test was added to test for the bug in the future

## Screenshots
<img width="818" alt="Screenshot 2025-03-09 at 6 09 26 PM" src="https://github.com/user-attachments/assets/8ab48244-0f77-4ac8-b6e4-95384677ee57" />

[VA-Blue-Button-report-Veteran-Maveteran-3-9-2025_061606pm.pdf](https://github.com/user-attachments/files/19153539/VA-Blue-Button-report-Veteran-Maveteran-3-9-2025_061606pm.pdf)


## What areas of the site does it impact?
MHV medical records Blue Button report

## Acceptance criteria
AC1 If no appointments are available, appointments should appear in the correct list, "Records not in this report"
AC2 UCD validation

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

