### PR TITLE
VACMS-18911 Address missed ACs for VAMC services autosuggest

### DIFF
--- a/src/applications/facility-locator/components/NoResultsMessage.jsx
+++ b/src/applications/facility-locator/components/NoResultsMessage.jsx
@@ -11,8 +11,8 @@ const NoResultsMessage = ({ isMobileListView, resultRef }) => {
         data-testid="no-results-mobile-list-view"
         className="vads-u-margin-top--2 mobile-lg:vads-u-margin-top--0 vads-u-margin-bottom--4 vads-u-margin-x--1 mobile-lg:vads-u-margin-x--0"
       >
-        Search for something else or in a different area. Try entering a
-        different location, facility type, or service type.
+        Try searching for something else. Or try searching in a different area.
+        You can enter a different location, facility type, or service type.
       </p>
     );
   }
@@ -26,7 +26,7 @@ const NoResultsMessage = ({ isMobileListView, resultRef }) => {
       tabIndex={0}
     >
       <p className="vads-u-margin-top--0">
-        Try searching for something else or in a different area.
+        Try searching for something else. Or try searching in a different area.
       </p>
       <p>
         <strong>Suggestions:</strong>

--- a/src/applications/facility-locator/components/SearchResultMessage.jsx
+++ b/src/applications/facility-locator/components/SearchResultMessage.jsx
@@ -29,8 +29,8 @@ const SearchResultMessage = ({
 
   return (
     <p className="search-result-title">
-      Please enter a location (street, city, state, or postal code) and facility
-      type, then click search above to find facilities.
+      Enter a location (street, city, state, or zip code) and facility type,
+      then search to find facilities.
     </p>
   );
 };

--- a/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
+++ b/src/applications/facility-locator/components/search-form/autosuggest/index.jsx
@@ -17,6 +17,7 @@ function Autosuggest({
   onInputValueChange,
   // input props
   onClearClick,
+  hintText = null,
   inputContainerClassName = 'input-container', // allows to work with fixed width from facility-locator
   inputError,
   inputId = 'autosuggest-input',
@@ -90,6 +91,7 @@ function Autosuggest({
       >
         <label className={`${inputId}-label`} {...getLabelProps()}>
           {label}
+          {hintText && <span className="usa-hint">{hintText}</span>}
         </label>
         {labelSibling}
       </div>

--- a/src/applications/facility-locator/components/search-form/facility-type/index.jsx
+++ b/src/applications/facility-locator/components/search-form/facility-type/index.jsx
@@ -52,10 +52,10 @@ const FacilityType = ({
         className={
           showError ? `vads-u-padding-left--1p5 vads-u-padding-top--1p5` : null
         }
-        label="Facility Type"
+        label="Facility type"
         value={facilityType || ''}
         onVaSelect={e => handleFacilityTypeChange(e)}
-        error={showError ? 'Please choose a facility type.' : null}
+        error={showError ? 'Select a facility type' : null}
       >
         {options}
       </VaSelect>

--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -11,7 +11,6 @@ import {
   geolocateUser,
   getProviderSpecialties,
 } from '../../actions';
-import { facilityLocatorAutosuggestVAMCServices } from '../../utils/featureFlagSelectors';
 import { LocationType } from '../../constants';
 import { setFocus } from '../../utils/helpers';
 import { SearchFormTypes } from '../../types';
@@ -256,7 +255,7 @@ export const SearchForm = props => {
         uswds
         modalTitle={
           currentQuery.geocodeError === 1
-            ? 'We need to use your location'
+            ? `Your device's location sharing is off.`
             : "We couldn't locate you"
         }
         onCloseEvent={() => props.clearGeocodeError()}
@@ -265,7 +264,7 @@ export const SearchForm = props => {
       >
         <p>
           {currentQuery.geocodeError === 1
-            ? 'Please enable location sharing in your browser to use this feature.'
+            ? 'To use your location when searching for a VA facility, go to the settings on your device and update sharing permissions.'
             : 'Sorry, something went wrong when trying to find your location. Please make sure location sharing is enabled and try again.'}
         </p>
       </VaModal>
@@ -308,10 +307,6 @@ export const SearchForm = props => {
   );
 };
 
-const mapStateToProps = state => ({
-  vamcAutoSuggestEnabled: facilityLocatorAutosuggestVAMCServices(state),
-});
-
 const mapDispatchToProps = {
   clearGeocodeError,
   clearSearchText,
@@ -322,6 +317,6 @@ const mapDispatchToProps = {
 SearchForm.propTypes = SearchFormTypes;
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps,
 )(SearchForm);

--- a/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/CCServiceTypeAhead.jsx
@@ -220,9 +220,7 @@ class CCServiceTypeAhead extends Component {
               <span className="usa-input-error-message" role="alert">
                 <span id="error-message">
                   <span className="sr-only">Error</span>
-                  {this.props.useProgressiveDisclosure
-                    ? 'Start typing and select an available service'
-                    : 'Please search for an available service'}
+                  Start typing and select a service type
                 </span>
               </span>
             )}

--- a/src/applications/facility-locator/components/search-form/service-type/VAMCServiceAutosuggest.jsx
+++ b/src/applications/facility-locator/components/search-form/service-type/VAMCServiceAutosuggest.jsx
@@ -152,6 +152,7 @@ const VAMCServiceAutosuggest = ({
         spellCheck: 'false',
       }}
       handleOnSelect={handleDropdownSelection}
+      hintText="Begin typing to search for a service, like vision or dental"
       initialSelectedItem={options?.[0]}
       inputId="vamc-services"
       inputRef={inputRef}

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -38,6 +38,7 @@ import {
   facilitiesUseAddressTypeahead,
   facilitiesPpmsSuppressAll,
   facilityLocatorMobileMapUpdate,
+  facilityLocatorAutosuggestVAMCServices,
   facilitiesUseFlProgressiveDisclosure,
   facilityLocatorPredictiveLocationSearch,
 } from '../utils/featureFlagSelectors';
@@ -60,7 +61,11 @@ const mapboxGlContainer = 'mapbox-gl-container';
 const zoomMessageDivID = 'screenreader-zoom-message';
 
 const FacilitiesMap = props => {
-  const { mobileMapPinSelected, mobileMapUpdateEnabled } = props;
+  const {
+    mobileMapPinSelected,
+    mobileMapUpdateEnabled,
+    vamcAutoSuggestEnabled,
+  } = props;
   const [map, setMap] = useState(null);
   const [verticalSize, setVerticalSize] = useState(0);
   const [horizontalSize, setHorizontalSize] = useState(0);
@@ -469,6 +474,7 @@ const FacilitiesMap = props => {
               selectMobileMapPin={props.selectMobileMapPin}
               suppressPPMS={props.suppressPPMS}
               useProgressiveDisclosure={useProgressiveDisclosure}
+              vamcAutoSuggestEnabled={vamcAutoSuggestEnabled}
             />
             <EmergencyCareAlert
               shouldShow={isEmergencyCareType || isCcpEmergencyCareTypes}
@@ -882,6 +888,7 @@ const mapStateToProps = state => ({
   suppressPPMS: facilitiesPpmsSuppressAll(state),
   usePredictiveGeolocation: facilityLocatorPredictiveLocationSearch(state),
   useProgressiveDisclosure: facilitiesUseFlProgressiveDisclosure(state),
+  vamcAutoSuggestEnabled: facilityLocatorAutosuggestVAMCServices(state),
 });
 
 const mapDispatchToProps = {

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -18,6 +18,11 @@ $text-color: rgba(27, 27, 27, 1);
     margin: 0;
   }
 
+  .usa-hint {
+    display: block;
+    color: var(--vads-color-gray-medium);
+  }
+
   .p1 {
     padding: 0.5em 0;
   }

--- a/src/applications/facility-locator/tests/components/search-form/index.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-form/index.unit.spec.jsx
@@ -49,14 +49,16 @@ describe('SearchForm', () => {
     const wrapper = shallow(<SearchForm currentQuery={query} />);
     const modal = wrapper.find('ForwardRef(VaModal)');
     expect(modal.prop('visible')).to.be.true;
-    expect(modal.prop('modalTitle')).to.equal('We need to use your location');
+    expect(modal.prop('modalTitle')).to.equal(
+      `Your device's location sharing is off.`,
+    );
     expect(
       modal
         .dive()
         .find('p')
         .text(),
     ).to.equal(
-      'Please enable location sharing in your browser to use this feature.',
+      'To use your location when searching for a VA facility, go to the settings on your device and update sharing permissions.',
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/e2e/errorMessages.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/errorMessages.cypress.spec.js
@@ -29,16 +29,13 @@ for (const featureSet of featureSets) {
     );
 
     let addrErrorMessage = 'Please fill in a city, state, or postal code.';
-    let serviceErrorMessage = 'Please search for an available service';
 
     if (isAddressTypeaheadEnabled || isProgDiscEnabled) {
       addrErrorMessage =
         'Enter a zip code or a city and state in the search box';
     }
 
-    if (isProgDiscEnabled) {
-      serviceErrorMessage = 'Start typing and select an available service';
-    }
+    const serviceErrorMessage = 'ErrorStart typing and select a service type';
 
     beforeEach(() => {
       cy.intercept('GET', '/v0/maintenance_windows', []);
@@ -81,7 +78,7 @@ for (const featureSet of featureSets) {
       cy.get(h.FACILITY_TYPE_DROPDOWN)
         .shadow()
         .find('.usa-error-message')
-        .contains('Please choose a facility type.');
+        .contains('Select a facility type');
       cy.get(h.FACILITY_TYPE_DROPDOWN)
         .shadow()
         .find('select')

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -147,65 +147,6 @@ describe('Facility VA search', () => {
     cy.get('#other-tools').should('exist');
   });
 
-  it.skip('should render breadcrumbs ', () => {
-    cy.visit('/find-locations');
-
-    cy.get('#street-city-state-zip').type('Austin, TX');
-    cy.get('#facility-type-dropdown')
-      .shadow()
-      .find('select')
-      .select('VA health');
-    cy.get('#facility-search')
-      .click({ waitForAnimations: true })
-      .then(() => {
-        cy.injectAxe();
-        cy.axeCheck();
-
-        cy.get('.facility-result va-link').should('exist');
-        cy.intercept(
-          'GET',
-          '/facilities_api/v2/va/vha_674BY',
-          mockFacilitiesSearchResultsV1,
-        ).as('fetchFacility');
-
-        cy.findByText(/austin va clinic/i, { selector: 'va-link' })
-          .first()
-          .click({ waitForAnimations: true })
-          .then(() => {
-            cy.axeCheck();
-
-            cy.get('.all-details', { timeout: 10000 }).should('exist');
-
-            cy.get('a[aria-current="page"').should('exist');
-
-            cy.get(
-              '.va-nav-breadcrumbs-list li:nth-of-type(3) a[aria-current="page"]',
-            ).should('exist');
-
-            cy.get(
-              '.va-nav-breadcrumbs-list li:nth-of-type(3) a[aria-current="page"]',
-            ).contains('Facility Details');
-
-            cy.get('.va-nav-breadcrumbs-list li:nth-of-type(2) a').click({
-              waitForAnimations: true,
-            });
-
-            // Mobile View
-            cy.viewport(375, 667);
-
-            cy.get('.va-nav-breadcrumbs-list').should('exist');
-
-            cy.get('.va-nav-breadcrumbs-list li:not(:nth-last-child(2))')
-              .should('have.css', 'display')
-              .and('match', /none/);
-
-            cy.get('.va-nav-breadcrumbs-list li:nth-last-child(2)').contains(
-              'Home',
-            );
-          });
-      });
-  });
-
   it('shows search result header even when no results are found', () => {
     cy.visit('/find-locations');
     cy.intercept('GET', '/facilities_api/v2/ccp/provider?**', {

--- a/src/applications/facility-locator/tests/e2e/facilitySearchProgDisc.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearchProgDisc.cypress.spec.js
@@ -118,53 +118,6 @@ describe('Facility VA search', () => {
     cy.get('#other-tools').should('exist');
   });
 
-  it.skip('should render breadcrumbs ', () => {
-    cy.visit('/find-locations');
-    typeInCityStateInput('Austin, TX');
-    selectFacilityTypeInDropdown(FACILITY_TYPES.HEALTH);
-    submitSearchForm().then(() => {
-      cy.injectAxe();
-      cy.axeCheck();
-
-      cy.get('.facility-result va-link').should('exist');
-      cy.findByText(/Washington VA Medical Center/i, { selector: 'va-link' })
-        .first()
-        .click({ waitForAnimations: true })
-        .then(() => {
-          cy.axeCheck();
-
-          cy.get('.all-details', { timeout: 10000 }).should('exist');
-
-          cy.get('a[aria-current="page"').should('exist');
-
-          cy.get(
-            '.va-nav-breadcrumbs-list li:nth-of-type(3) a[aria-current="page"]',
-          ).should('exist');
-
-          cy.get(
-            '.va-nav-breadcrumbs-list li:nth-of-type(3) a[aria-current="page"]',
-          ).contains('Facility Details');
-
-          cy.get('.va-nav-breadcrumbs-list li:nth-of-type(2) a').click({
-            waitForAnimations: true,
-          });
-
-          // Mobile View
-          cy.viewport(375, 667);
-
-          cy.get('.va-nav-breadcrumbs-list').should('exist');
-
-          cy.get('.va-nav-breadcrumbs-list li:not(:nth-last-child(2))')
-            .should('have.css', 'display')
-            .and('match', /none/);
-
-          cy.get('.va-nav-breadcrumbs-list li:nth-last-child(2)').contains(
-            'Home',
-          );
-        });
-    });
-  });
-
   it('shows search result header even when no results are found', () => {
     cy.visit('/find-locations');
     // override so no provider data

--- a/src/applications/facility-locator/tests/e2e/helpers/index.js
+++ b/src/applications/facility-locator/tests/e2e/helpers/index.js
@@ -28,10 +28,10 @@ export const MOBILE_MAP_PIN_SELECT_HELP_TEXT =
   'Select a number to show information about that location.';
 
 export const MOBILE_MAP_NO_RESULTS_TEXT =
-  'Try searching for something else or in a different area.';
+  'Try searching for something else. Or try searching in a different area.';
 
 export const MOBILE_LIST_SEARCH_TEXT =
-  'Please enter a location (street, city, state, or postal code) and facility type, then click search above to find facilities.';
+  'Enter a location (street, city, state, or zip code) and facility type, then search to find facilities.';
 
 export const MOBILE_TAB_BUTTON = 'button[class*="segment"]';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

While reviewing a previous PR for VAMC services autosuggest, Dave Pickett noticed some differences between the Figma comps and the working build. Some of them were autosuggest-specific missed ACs, and others were things that were just out of sync with the Figma. This PR addresses those issues.

Comments for context:
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18911#issuecomment-2711139012
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18911#issuecomment-2711151569
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18911#issuecomment-2711161516

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18911

## Screenshots

- [x] The "T" in "Facility Type" label should be lowercase

<img width="325" alt="Screenshot 2025-03-10 at 4 21 04 PM" src="https://github.com/user-attachments/assets/4930551a-938b-4faf-b804-db97e931ee8c" />

- [x] The [error message when no Facility type is selected](https://www.figma.com/design/GvNVeG9GAXZaBpny7vNxZP/Facility-Locator?node-id=172-20935&t=8Eius0shul8sfyoA-4) should read "Select a facility type"

<img width="322" alt="Screenshot 2025-03-10 at 4 21 10 PM" src="https://github.com/user-attachments/assets/a08d9049-cbcd-46a5-85c4-0bfc867ec9af" />

- [x] Service type field should have hint text "Begin typing to search for a service, like vision or dental"

<img width="322" alt="Screenshot 2025-03-10 at 4 21 18 PM" src="https://github.com/user-attachments/assets/b15a3c84-ed87-4a18-817b-9b5cf49ea8cf" />

- [x] Text below the search box should read "Enter a location (street, city, state, or zip code) and facility type, then search to find facilities."

<img width="364" alt="Screenshot 2025-03-10 at 4 21 23 PM" src="https://github.com/user-attachments/assets/8bfb379e-52e1-4dec-a036-517c82b1d84b" />

- [x] When there are no results found on mobile, the List view and Map view should have [different text for suggestions](https://www.figma.com/design/GvNVeG9GAXZaBpny7vNxZP/Facility-Locator?node-id=752-14458&t=8Eius0shul8sfyoA-4)

<img width="323" alt="Screenshot 2025-03-10 at 4 21 44 PM" src="https://github.com/user-attachments/assets/4698d6c0-1733-4d0b-a4de-6b1e4790c732" />
<img width="323" alt="Screenshot 2025-03-10 at 4 21 58 PM" src="https://github.com/user-attachments/assets/240aecf3-9b08-4b24-92a8-4f0006214933" />

- [x] If a user clicks "Use my location" but doesn't have location sharing enables, the error message shown should match the text [in Figma](https://www.figma.com/design/GvNVeG9GAXZaBpny7vNxZP/Facility-Locator?node-id=172-21049&t=8Eius0shul8sfyoA-4) 

<img width="320" alt="Screenshot 2025-03-10 at 4 22 15 PM" src="https://github.com/user-attachments/assets/4d6bbfef-c706-45b5-bc59-9b5090842c71" />

- [x] If a user selects "Community providers" and attempts to search without selecting a service type, the error message should [match Figma](https://www.figma.com/design/GvNVeG9GAXZaBpny7vNxZP/Facility-Locator?node-id=178-32761&t=8Eius0shul8sfyoA-4)

<img width="324" alt="Screenshot 2025-03-10 at 4 24 12 PM" src="https://github.com/user-attachments/assets/c7944602-01be-4c92-9ec8-f3e516511a88" />