### PR TITLE
10-7959a Accessibility 

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
@@ -105,6 +105,7 @@ export const applicantAddressSchema = {
     },
     applicantNewAddress: {
       ...radioUI({
+        type: 'radio',
         updateUiSchema: formData => {
           const labels = {
             yes: 'Yes',

--- a/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
@@ -60,6 +60,7 @@ export const claimWorkSchema = {
   uiSchema: {
     ...titleUI('Claim relationship to work'),
     claimIsWorkRelated: yesNoUI({
+      type: 'radio',
       title: 'Is this a claim for a work-related injury or condition?',
       updateUiSchema: formData => {
         return {
@@ -89,6 +90,7 @@ export const claimAutoSchema = {
   uiSchema: {
     ...titleUI('Claim relationship to a car accident'),
     claimIsAutoRelated: yesNoUI({
+      type: 'radio',
       title:
         'Is this a claim for an injury or condition caused by car accident?',
       updateUiSchema: formData => {

--- a/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
@@ -72,6 +72,7 @@ export const insuranceStatusSchema = {
     }),
     hasOhi: {
       ...yesNoUI({
+        type: 'radio',
         updateUiSchema: formData => {
           return {
             'ui:title': `${
@@ -133,6 +134,7 @@ const insuranceProviderPage = {
     ),
     type: {
       ...radioUI({
+        type: 'radio',
         title:
           'What type of insurance does the beneficiary have through this provider?',
         labels: radioLabels,

--- a/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
@@ -22,6 +22,7 @@ export const certifierRoleSchema = {
   uiSchema: {
     ...titleUI('Your information'),
     certifierRole: radioUI({
+      type: 'radio',
       title: 'Which of these best describes you?',
       required: () => true,
       labels: {
@@ -97,6 +98,7 @@ export const certifierRelationshipSchema = {
   uiSchema: {
     ...titleUI('Your relationship to the beneficiary'),
     certifierRelationship: radioUI({
+      type: 'radio',
       title: 'Which of these best describes you?',
       required: () => true,
       labels: {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR added types to some radio buttons/checkboxes. I ran aXe and did not see any of the issues mentioned in the ticket, but I sent ahead and updated anyway to make things explicit. I did not see any aXe warnings when I finished either. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/102852

## Testing done
unit
e2e

## Screenshots
This did not change any views

## What areas of the site does it impact?
this form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
