### PR TITLE
[DBEX] Revise report type selection validation

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -413,6 +413,7 @@ export const TRAUMATIC_EVENT_TYPES = Object.freeze({
 export const OFFICIAL_REPORT_TYPES_SUBTITLES = Object.freeze({
   military: 'Military incident reports',
   other: 'Other reporting options',
+  none: 'No reports to include',
 });
 
 export const MILITARY_REPORT_TYPES = Object.freeze({
@@ -425,8 +426,11 @@ export const MILITARY_REPORT_TYPES = Object.freeze({
 
 export const OTHER_REPORT_TYPES = Object.freeze({
   police: 'Police report',
-  unsure: 'A police report was filed but I’m not sure which type it was',
-  none: 'No official report was filed',
+  unsure: 'An official report was filed, but I’m not sure which type it was.',
+});
+
+export const NO_REPORT_TYPE = Object.freeze({
+  none: 'I don’t have offiical reports to include.',
 });
 
 export const LISTED_BEHAVIOR_TYPES_WITH_SECTION = Object.freeze({

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -430,7 +430,7 @@ export const OTHER_REPORT_TYPES = Object.freeze({
 });
 
 export const NO_REPORT_TYPE = Object.freeze({
-  none: 'I don’t have offiical reports to include.',
+  none: 'I don’t have official reports to include.',
 });
 
 export const LISTED_BEHAVIOR_TYPES_WITH_SECTION = Object.freeze({

--- a/src/applications/disability-benefits/all-claims/content/officialReport.jsx
+++ b/src/applications/disability-benefits/all-claims/content/officialReport.jsx
@@ -30,7 +30,7 @@ export const officialReportsDescription = (type = 'default') => {
         that traumatic events often go unreported. You can skip this question if
         you don’t feel comfortable answering.
       </p>
-      {type === 'mst' && <p>${reportTypesQuestion}</p>}
+      {type === 'mst' && <p>{reportTypesQuestion}</p>}
     </>
   );
 };

--- a/src/applications/disability-benefits/all-claims/pages/form0781/officialReport.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/officialReport.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   checkboxGroupUI,
   checkboxGroupSchema,
@@ -8,12 +7,12 @@ import {
   officialReportPageTitle,
   officialReportsDescription,
   reportTypesQuestion,
-  reportTypesHint,
-  otherReportTypesQuestion,
+  militaryReportsHint,
+  noReportHint,
+  otherReportsHint,
+  otherReportTypesTitle,
   otherReportTypesExamples,
   validateReportSelections,
-  // reportTypeValidationError,
-  // showConflictingAlert,
 } from '../../content/officialReport';
 import {
   titleWithTag,
@@ -25,6 +24,7 @@ import {
   OFFICIAL_REPORT_TYPES_SUBTITLES,
   MILITARY_REPORT_TYPES,
   OTHER_REPORT_TYPES,
+  NO_REPORT_TYPE,
 } from '../../constants';
 
 const pageTitleWithTag = titleWithTag(
@@ -39,24 +39,21 @@ export const officialReport = {
       editTitle: 'official report details',
     }),
     'ui:description': officialReportsDescription(),
-    // 'view:conflictingResponseAlert': {
-    //   'ui:description': reportTypeValidationError,
-    //   'ui:options': {
-    //     hideIf: (formData, index, fullData) => {
-    //       const data = fullData.events?.[index];
-    //       return showConflictingAlert(data) === false;
-    //     },
-    //   },
-    // },
     otherReports: checkboxGroupUI({
       title: reportTypesQuestion,
-      hint: reportTypesHint,
       labels: OTHER_REPORT_TYPES,
       required: false,
     }),
     unlistedReport: textUI({
-      title: otherReportTypesQuestion,
+      title: otherReportTypesTitle,
       description: otherReportTypesExamples,
+    }),
+    noReport: checkboxGroupUI({
+      title: OFFICIAL_REPORT_TYPES_SUBTITLES.none,
+      hint: noReportHint,
+      labelHeaderLevel: '4',
+      labels: NO_REPORT_TYPE,
+      required: false,
     }),
     'view:mentalHealthSupportAlert': {
       'ui:description': mentalHealthSupportAlert,
@@ -66,14 +63,11 @@ export const officialReport = {
   schema: {
     type: 'object',
     properties: {
-      // 'view:conflictingResponseAlert': {
-      //   type: 'object',
-      //   properties: {},
-      // },
       otherReports: checkboxGroupSchema(Object.keys(OTHER_REPORT_TYPES)),
       unlistedReport: {
         type: 'string',
       },
+      noReport: checkboxGroupSchema(Object.keys(NO_REPORT_TYPE)),
       'view:mentalHealthSupportAlert': {
         type: 'object',
         properties: {},
@@ -89,31 +83,30 @@ export const officialReportMst = {
       editTitle: 'official report details',
     }),
     'ui:description': officialReportsDescription('mst'),
-    // 'view:conflictingResponseAlert': {
-    //   'ui:description': reportTypeValidationError,
-    //   'ui:options': {
-    //     hideIf: (formData, index, fullData) => {
-    //       const data = fullData.events?.[index];
-    //       return showConflictingAlert(data) === false;
-    //     },
-    //   },
-    // },
     militaryReports: checkboxGroupUI({
-      title: reportTypesQuestion,
-      hint: reportTypesHint,
-      description: <h4>{OFFICIAL_REPORT_TYPES_SUBTITLES.military}</h4>,
+      title: OFFICIAL_REPORT_TYPES_SUBTITLES.military,
+      hint: militaryReportsHint,
+      labelHeaderLevel: '4',
       labels: MILITARY_REPORT_TYPES,
       required: false,
     }),
     otherReports: checkboxGroupUI({
       title: OFFICIAL_REPORT_TYPES_SUBTITLES.other,
+      hint: otherReportsHint,
       labelHeaderLevel: '4',
       labels: OTHER_REPORT_TYPES,
       required: false,
     }),
     unlistedReport: textUI({
-      title: otherReportTypesQuestion,
+      title: otherReportTypesTitle,
       description: otherReportTypesExamples,
+    }),
+    noReport: checkboxGroupUI({
+      title: OFFICIAL_REPORT_TYPES_SUBTITLES.none,
+      hint: noReportHint,
+      labelHeaderLevel: '4',
+      labels: NO_REPORT_TYPE,
+      required: false,
     }),
     'view:mentalHealthSupportAlert': {
       'ui:description': mentalHealthSupportAlert,
@@ -123,15 +116,12 @@ export const officialReportMst = {
   schema: {
     type: 'object',
     properties: {
-      // 'view:conflictingResponseAlert': {
-      //   type: 'object',
-      //   properties: {},
-      // },
       militaryReports: checkboxGroupSchema(Object.keys(MILITARY_REPORT_TYPES)),
       otherReports: checkboxGroupSchema(Object.keys(OTHER_REPORT_TYPES)),
       unlistedReport: {
         type: 'string',
       },
+      noReport: checkboxGroupSchema(Object.keys(NO_REPORT_TYPE)),
       'view:mentalHealthSupportAlert': {
         type: 'object',
         properties: {},

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/officialReport.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/officialReport.unit.spec.js
@@ -19,9 +19,17 @@ import {
 import {
   officialReportPageTitle,
   reportTypesQuestion,
-  otherReportTypesQuestion,
+  otherReportTypesTitle,
+  selectedReportTypes,
+  showConflictingAlert,
+  validateReportSelections,
 } from '../../../content/officialReport';
-import { MILITARY_REPORT_TYPES, OTHER_REPORT_TYPES } from '../../../constants';
+import {
+  OFFICIAL_REPORT_TYPES_SUBTITLES,
+  MILITARY_REPORT_TYPES,
+  OTHER_REPORT_TYPES,
+  NO_REPORT_TYPE,
+} from '../../../constants';
 
 describe('Official report without MST event type', () => {
   const { schema, uiSchema } = officialReport;
@@ -34,19 +42,22 @@ describe('Official report without MST event type', () => {
     expect(schema).to.be.a('object');
   });
 
-  it('should render only other report type checkboxes', () => {
+  it('should render only other and no report type checkboxes', () => {
     const { container, getByText } = render(
       <DefinitionTester schema={schema} uiSchema={uiSchema} data={{}} />,
     );
 
     getByText(officialReportPageTitle);
 
-    expect($$('va-checkbox-group', container).length).to.equal(1);
+    expect($$('va-checkbox-group', container).length).to.equal(2);
     expect($('va-checkbox-group', container).getAttribute('label')).to.equal(
       reportTypesQuestion,
     );
 
     Object.values(OTHER_REPORT_TYPES).forEach(option => {
+      expect($$(`va-checkbox[label="${option}"]`, container)).to.exist;
+    });
+    Object.values(NO_REPORT_TYPE).forEach(option => {
       expect($$(`va-checkbox[label="${option}"]`, container)).to.exist;
     });
     Object.values(MILITARY_REPORT_TYPES).forEach(option => {
@@ -65,7 +76,7 @@ describe('Official report without MST event type', () => {
     expect(textInputs.length).to.eq(1);
 
     const otherReportTextInput = Array.from(textInputs).find(
-      input => input.getAttribute('label') === otherReportTypesQuestion,
+      input => input.getAttribute('label') === otherReportTypesTitle,
     );
     expect(otherReportTextInput).to.not.be.null;
     expect(otherReportTextInput.getAttribute('required')).to.eq('false');
@@ -134,22 +145,25 @@ describe('Official Report with MST event type', () => {
     expect(schema).to.be.a('object');
   });
 
-  it('should render military and other report type checkboxes', () => {
+  it('should render military, other and no report type checkboxes', () => {
     const { container, getByText } = render(
       <DefinitionTester schema={schema} uiSchema={uiSchema} data={{}} />,
     );
 
     getByText(officialReportPageTitle);
 
-    expect($$('va-checkbox-group', container).length).to.equal(2);
+    expect($$('va-checkbox-group', container).length).to.equal(3);
     expect($('va-checkbox-group', container).getAttribute('label')).to.equal(
-      reportTypesQuestion,
+      OFFICIAL_REPORT_TYPES_SUBTITLES.military,
     );
 
     Object.values(MILITARY_REPORT_TYPES).forEach(option => {
       expect($$(`va-checkbox[label="${option}"]`, container)).to.exist;
     });
     Object.values(OTHER_REPORT_TYPES).forEach(option => {
+      expect($$(`va-checkbox[label="${option}"]`, container)).to.exist;
+    });
+    Object.values(NO_REPORT_TYPE).forEach(option => {
       expect($$(`va-checkbox[label="${option}"]`, container)).to.exist;
     });
   });
@@ -165,7 +179,7 @@ describe('Official Report with MST event type', () => {
     expect(textInputs.length).to.eq(1);
 
     const otherReportTextInput = Array.from(textInputs).find(
-      input => input.getAttribute('label') === otherReportTypesQuestion,
+      input => input.getAttribute('label') === otherReportTypesTitle,
     );
     expect(otherReportTextInput).to.not.be.null;
     expect(otherReportTextInput.getAttribute('required')).to.eq('false');
@@ -220,5 +234,102 @@ describe('Official Report with MST event type', () => {
 
     userEvent.click(getByText('Submit'));
     expect(onSubmit.called).to.be.true;
+  });
+});
+
+describe('Report Selection Validation', () => {
+  describe('selectedReportTypes', () => {
+    it('should correctly identify selected report types', () => {
+      const formData = {
+        militaryReports: { restricted: true, unrestricted: false },
+        otherReports: { police: true, unsure: false },
+        unlistedReport: 'Some unlisted report',
+      };
+
+      const result = selectedReportTypes(formData);
+      expect(result).to.deep.equal({
+        militaryReports: true,
+        otherReports: true,
+        unlistedReport: true,
+      });
+    });
+
+    it('should return false for all when no reports are selected', () => {
+      const formData = {
+        militaryReports: {},
+        otherReports: { none: true },
+        unlistedReport: '',
+      };
+
+      const result = selectedReportTypes(formData);
+      expect(result).to.deep.equal({
+        militaryReports: false,
+        otherReports: false,
+        unlistedReport: false,
+      });
+    });
+  });
+
+  describe('showConflictingAlert', () => {
+    it('should return true when "no report filed" is selected along with other reports', () => {
+      const formData = {
+        noReport: { none: true },
+        militaryReports: { restricted: true },
+      };
+      expect(showConflictingAlert(formData)).to.be.true;
+    });
+
+    it('should return false when only "no report filed" is selected', () => {
+      const formData = {
+        noReport: { none: true },
+        militaryReports: {},
+        otherReports: {},
+        unlistedReport: '',
+      };
+      expect(showConflictingAlert(formData)).to.be.false;
+    });
+
+    it('should return false when "no report filed" is not selected and reports are selected', () => {
+      const formData = {
+        noReport: { none: false },
+        militaryReports: { restricted: true },
+        otherReports: { none: true },
+      };
+      expect(showConflictingAlert(formData)).to.be.false;
+    });
+  });
+
+  describe('validateReportSelections', () => {
+    let errors;
+
+    beforeEach(() => {
+      errors = {
+        noReport: { addError: sinon.spy() },
+      };
+    });
+
+    it('should add an error if conflicting selections exist', () => {
+      const formData = {
+        noReport: { none: true },
+        militaryReports: { restricted: true },
+      };
+
+      validateReportSelections(errors, formData);
+
+      expect(errors.noReport.addError.calledOnce).to.be.true;
+    });
+
+    it('should not add an error if no conflict exists', () => {
+      const formData = {
+        noReport: { none: true },
+        militaryReports: {},
+        otherReports: { unsure: false },
+        unlistedReport: '',
+      };
+
+      validateReportSelections(errors, formData);
+
+      expect(errors.noReport.addError.called).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - In the "Event List" section of the new, digitized Form 0781 flow:
    - on the "Official report" page:
      - add hint text
      - revise checkbox labels
      - relocate “no reports” option to own subgroup
      - implement new conflicting selection error messaging
- _(If bug, how to reproduce)_
  - n/a
- _(What is the solution, why is this the solution)_
  - content changes improve information provided to user
  - prevent the submission of contradictory responses
  - direct focus to selection causing error
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - `sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/34939
- [#103969](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103969)
- [#103970](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103970)

## Testing done

- _Describe what the old behavior was prior to the change_
  - conflicting selections error messaging was confusing
- _Describe the steps required to verify your changes are working as expected_
   1. in the development environment, ensure that the [`sync_modern_0781_flow`](https://dev-api.va.gov/flipper/features#:~:text=disability_compensation_sync_modern_0781_flow) toggle is enabled 
  2. start a new claim
  3. claim at least 1 new condition
  4. click through to and select "Yes, I want to complete VA Form 21-0781 online" on the "0781 choice" page
  5. select any options other than "MST" on the "Types of Traumatic Events" page
  6. continue to the "Event list" page
  8. select "Add an event" to route to the "Event details" page
  9. the "Official report" page should display 1 report type checkbox group with 2 options, a text input field, and a "no report" checkbox in its own group
  11. no other combination other than selecting "I don't have official reports to include" and any other option or input text and clicking "Continue" should trigger a validation error, preventing one from being able to proceed; resolving the error should hide the visual error indicator
  12. return to the "Types of Traumatic Events" page and select the "MST" option
  13. return to an "Official report" page, where the "no report" checkbox, a text input field, and 2 report type groups (1 with 3 options and the other with 2 options) should appear, in addition to a longer paragraph in the description corresponding to MST-type events, and the same error validation functionality as previously summarized
- Describe the tests completed and the results
  - comprehensive unit tests updated and added
  - manual verification

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| **with MST**  | <img width="277" alt="Screenshot 2025-03-10 at 5 09 22 PM" src="https://github.com/user-attachments/assets/c861d24c-6cc9-46ea-aedc-1a80f9153fd2" /> | <img width="277" alt="Screenshot 2025-03-10 at 5 14 57 PM" src="https://github.com/user-attachments/assets/23e19cb6-2871-4b2a-bda9-5dcb28c5dfee" /> |
| **without MST** | <img width="277" alt="Screenshot 2025-03-10 at 5 10 14 PM" src="https://github.com/user-attachments/assets/4c21ee18-8e8a-4b57-9686-7da032a6a1c5" /> | <img width="277" alt="Screenshot 2025-03-10 at 5 13 59 PM" src="https://github.com/user-attachments/assets/e93dacd9-4e35-46a1-82cf-1214ae25c471" /> |

## What areas of the site does it impact?

- Only impacts 526 EZ (within a new "Mental health statement" chapter)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I ~fixed~|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
