### PR TITLE
Redirect Reno RO site to modernized page

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1591,5 +1591,17 @@
     "src": "/ROMANCHESTER",
     "dest": "/manchester-va-regional-benefit-office/",
     "catchAll": true
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/reno",
+    "dest": "/reno-va-regional-benefit-office/",
+    "catchAll": true
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/RORENO",
+    "dest": "/reno-va-regional-benefit-office/",
+    "catchAll": true
   }
 ]


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding a redirect in Proxy-rewrite for Reno Regional Office TeamSite, to send traffic to the newly published modernized page. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20840
https://github.com/department-of-veterans-affairs/va.gov-team/issues/104774
