### PR TITLE
fixing error boundary page

### DIFF
--- a/src/applications/accredited-representative-portal/components/ErrorHeader.jsx
+++ b/src/applications/accredited-representative-portal/components/ErrorHeader.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import GovBanner from './Header/GovBanner';
+
+const ErrorHeader = () => {
+  return (
+    <header
+      data-testid="arp-error-header"
+      className="header vads-u-background-color--white"
+    >
+      <GovBanner />
+      <nav className="nav">
+        <div className="nav__container nav__container-primary vads-u-display--flex">
+          <Link
+            data-testid="nav-home-link"
+            aria-label="VA Accredited Representative Portal"
+            className="nav__link vads-u-display--flex"
+            to="/"
+          >
+            <img
+              data-testid="mobile-logo"
+              className="nav__logo mobile"
+              src="/img/va.svg"
+              alt="Veteran Affairs"
+            />
+            <span className="nav__logo-text mobile">
+              Accredited Representative Portal
+            </span>
+            <img
+              data-testid="desktop-logo"
+              className="nav__logo nav__logo--desktop desktop"
+              src="/img/arp-header-logo-dark.svg"
+              alt="VA Accredited Representative Portal, U.S. Department of Veterans Affairs"
+            />
+          </Link>
+        </div>
+      </nav>
+    </header>
+  );
+};
+
+export default ErrorHeader;

--- a/src/applications/accredited-representative-portal/containers/ErrorPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/ErrorPage.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Header from '../components/Header';
+import ErrorHeader from '../components/ErrorHeader';
 import Footer from '../components/Footer';
 
 const ErrorPage = ({ children }) => {
   return (
     <div className="container">
-      <Header />
+      <ErrorHeader />
       <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
         <div className="vads-l-row">
           <div className="vads-l-col--12 vads-u-padding-y--5">{children}</div>

--- a/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/components/ErrorBoundary.unit.spec.jsx
@@ -1,25 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import sinon from 'sinon';
-
-// Mock the Header component
-import * as Header from '../../../components/Header';
+import { BrowserRouter } from 'react-router-dom';
 import ErrorBoundary from '../../../components/ErrorBoundary';
 
 describe('ErrorBoundary', () => {
-  let sandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    sandbox.stub(Header, 'default').returns(<div data-testid="mock-header" />);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  const getErrorBoundary = () => render(<ErrorBoundary />);
+  const getErrorBoundary = () =>
+    render(
+      <BrowserRouter>
+        <ErrorBoundary />
+      </BrowserRouter>,
+    );
 
   it('renders error message', () => {
     const { getByTestId } = getErrorBoundary();


### PR DESCRIPTION
The Error Boundary page is throwing an error because you are not supposed to use loaders inside an error boundary and we are via including the `UserNav` component.  To fix this, we are not including the `UserNav` component in the `ErrorPage`. `UserNav` is what leads to the loader in order to display profile or sign-in UI.  Below are images showing before and after the fix:

### Before:
![error-page-with-loader](https://github.com/user-attachments/assets/ac143cc8-d461-454f-9379-395a6b290275)

### After:
![error-no-sign-in-fix](https://github.com/user-attachments/assets/d65678df-1905-49a9-8cfd-12905fa85151)
