### PR TITLE
[DBEX] Properly extract date without month or year values

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.js
@@ -672,11 +672,6 @@ describe('transformTreatmentFacilities', () => {
 });
 
 describe('extractDateParts', () => {
-  it('should return empty strings if the date string is invalid or missing', () => {
-    const result = extractDateParts('invalid-date');
-    expect(result).to.deep.equal({ treatmentMonth: '', treatmentYear: '' });
-  });
-
   it('should correctly extract the month and year from a valid date string', () => {
     const result = extractDateParts('2022-05-15');
     expect(result).to.deep.equal({
@@ -685,8 +680,23 @@ describe('extractDateParts', () => {
     });
   });
 
+  it('should return an empty treatmentMonth if the month is missing or non-numeric', () => {
+    const result = extractDateParts('2022-XX-XX');
+    expect(result).to.deep.equal({ treatmentMonth: '', treatmentYear: '2022' });
+  });
+
+  it('should return empty strings if both the year and month are missing or non-numeric', () => {
+    const result = extractDateParts('XXXX-XX-XX');
+    expect(result).to.deep.equal({ treatmentMonth: '', treatmentYear: '' });
+  });
+
   it('should return empty strings if the date string is undefined', () => {
     const result = extractDateParts(undefined);
+    expect(result).to.deep.equal({ treatmentMonth: '', treatmentYear: '' });
+  });
+
+  it('should return empty strings if the date string is invalid or missing', () => {
+    const result = extractDateParts('invalid-date');
     expect(result).to.deep.equal({ treatmentMonth: '', treatmentYear: '' });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -417,10 +417,10 @@ export const addForm0781 = formData => {
  * @returns {object} object containing `treatmentMonth` (MM) and `treatmentYear` (YYYY)
  */
 export function extractDateParts(dateString) {
-  const match = dateString?.match(/^(\d{4})-(\d{2})/);
+  const match = dateString?.match(/^(\d{4}|\D+)-(\d{2}|\D+)/);
   return {
-    treatmentMonth: match ? match[2] : '',
-    treatmentYear: match ? match[1] : '',
+    treatmentMonth: match && /^\d{2}$/.test(match[2]) ? match[2] : '',
+    treatmentYear: match && /^\d{4}$/.test(match[1]) ? match[1] : '',
   };
 }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - corrects string matching and logic that did not properly extract date parts where optional month values were 'XX'
  - includes additional tests to verify expected functionality
- _(If bug, how to reproduce)_
  - start a claim, add a new condition, and opt-in to completing form 0781 online
  - add a VA treatment facility and include a year, but not month, of treatment
  - submit the claim and inspect the 'submit_all_claim' payload
  - prior to this update, a provided 'treatmentYear' would not appear in a 'treatmentProvidersDetails' if a month was not also selected in the earlier step 
- _(What is the solution, why is this the solution)_
  - Because the month field is not a required element for VA treatment facility details, and its omission is replaced with an 'XX' value, the date extraction function had to be modified to accommodate non-integer characters
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - `sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/35022
- [#103478](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103478)

## Testing done

- _Describe what the old behavior was prior to the change_
  - VA treatment facilities that were designated as locations where treatment related to an 0781 condition had been received were missing corresponding treatment dates after data transformation
- _Describe the steps required to verify your changes are working as expected_
  - inspect 'treatmentProvidersDetails' within the 'form0781' node to confirm the correct values for 'treatmentMonth' and 'treatmentYear'
  - `yarn test:unit src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.js`
  - `yarn test:unit src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js`
  - `yarn cy:run --spec src/applications/disability-benefits/all-claims/tests/modern-0781.cypress.spec.js`
- _Describe the tests completed and the results_
  - create additional tests to confirm expected results of executing `extractDateParts` function

## Screenshots

N/A

## What areas of the site does it impact?

- 526 EZ claim data submission, specifically related to form 0781, 4142, and VA medical providers

## Acceptance criteria

### Quality Assurance & Testing

- [x] I ~fixed~|~updated~|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing] has been performed – 0 issues found during axe DevTools scan

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
