### PR TITLE
[ART/104998] - authorization fix

### DIFF
--- a/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestDetailsPage.jsx
@@ -107,9 +107,9 @@ const AccessToSome = () => {
 };
 const checkAuthorizations = x => {
   if (x) {
-    return <Authorized />;
+    return <NoAccess />;
   }
-  return <NoAccess />;
+  return <Authorized />;
 };
 const checkLimitations = (limitations, limit) => {
   const checkLimitation = limitations.includes(limit);
@@ -357,19 +357,21 @@ const POARequestDetailsPage = () => {
               <li>
                 <p>Change of address</p>
                 <p>
-                  {checkAuthorizations(
-                    poaRequest?.powerOfAttorneyForm.authorizations
-                      .addressChange,
+                  {poaRequest?.powerOfAttorneyForm.authorizations
+                    .addressChange ? (
+                    <Authorized />
+                  ) : (
+                    <NoAccess />
                   )}
                 </p>
               </li>
               <li>
                 <p>Protected medical records</p>
                 <p>
-                  {recordDisclosureLimitations.length === 0 && <NoAccess />}
+                  {recordDisclosureLimitations.length === 0 && <Authorized />}
                   {recordDisclosureLimitations.length < 4 &&
                     recordDisclosureLimitations.length > 0 && <AccessToSome />}
-                  {recordDisclosureLimitations.length === 4 && <Authorized />}
+                  {recordDisclosureLimitations.length === 4 && <NoAccess />}
                 </p>
               </li>
               <li>


### PR DESCRIPTION
P0 blocker, see [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104998) 

If items shows up in the `recordDisclosureLimitations` array, that means we do not have authorization to view record. Here are a few different combinations:

**Access to everything except address:**
<img width="1477" alt="Screenshot 2025-03-12 at 9 24 31 AM" src="https://github.com/user-attachments/assets/3cbf0fa9-94b5-454a-85bc-1155f2360db3" />

**No access to address and drug abuse records, "Access to some" medical records**
<img width="1477" alt="Screenshot 2025-03-12 at 9 24 54 AM" src="https://github.com/user-attachments/assets/587858a6-2946-44e7-bce7-3d574bcd455e" />

**Access to address, alcohol abuse records, "Access to some" medical records**
<img width="1475" alt="Screenshot 2025-03-12 at 9 25 59 AM" src="https://github.com/user-attachments/assets/a0cd8ad7-30fd-40e0-acd8-e018f3a82935" />



