### PR TITLE
Implement h1 header on review page for minimal header enabled forms

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -16,6 +16,8 @@ import {
   getCurrentChapterDisplay,
 } from '../helpers';
 
+import { isMinimalHeaderApp } from '../patterns/minimal-header';
+
 import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 
 export default function FormNav(props) {
@@ -117,7 +119,7 @@ export default function FormNav(props) {
         window.location.pathname.endsWith('review-and-submit')
       ) {
         scrollTo('topScrollElement');
-        if (hideFormNavProgress) {
+        if (hideFormNavProgress || isMinimalHeaderApp()) {
           focusElement('h1');
         } else {
           // Focus on review & submit page h2 in stepper

--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -9,6 +9,7 @@ import DowntimeMessage from 'platform/monitoring/DowntimeNotification/components
 
 import ReviewChapters from './ReviewChapters';
 import SubmitController from './SubmitController';
+import { isMinimalHeaderApp } from '../patterns/minimal-header';
 
 class ReviewPage extends React.Component {
   renderDowntime = (downtime, children) => {
@@ -27,6 +28,9 @@ class ReviewPage extends React.Component {
     const downtimeDependencies = formConfig?.downtime?.dependencies || [];
     return (
       <div>
+        {isMinimalHeaderApp() && (
+          <h1 className="vads-u-font-size--h2">Review and submit</h1>
+        )}
         <ReviewChapters formConfig={formConfig} pageList={pageList} />
         <DowntimeNotification
           appTitle="application"

--- a/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
@@ -62,6 +62,40 @@ describe('Schemaform review: ReviewPage', () => {
     tree.unmount();
   });
 
+  it('should render h1 header if MINIMAL_HEADER_APPLICABLE is true', () => {
+    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
+
+    const treeWithMinimalHeader = shallow(
+      <ReviewPage
+        form={form}
+        openChapters={{}}
+        route={{ formConfig, pageList }}
+        setEditMode={f => f}
+        setPreSubmit={f => f}
+        location={location}
+      />,
+    );
+
+    expect(treeWithMinimalHeader.find('h1').exists()).to.be.true;
+    treeWithMinimalHeader.unmount();
+
+    sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
+
+    const treeWithoutMinimalHeader = shallow(
+      <ReviewPage
+        form={form}
+        openChapters={{}}
+        route={{ formConfig, pageList }}
+        setEditMode={f => f}
+        setPreSubmit={f => f}
+        location={location}
+      />,
+    );
+
+    expect(treeWithoutMinimalHeader.find('h1').exists()).to.be.false;
+    treeWithoutMinimalHeader.unmount();
+  });
+
   it('should appropriately render a downtime notification', () => {
     const tree = shallow(
       <ReviewPage

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -6,6 +6,7 @@ import { withRouter } from 'react-router';
 import { Element } from 'platform/utilities/scroll';
 import ReviewChapters from 'platform/forms-system/src/js/review/ReviewChapters';
 import SubmitController from 'platform/forms-system/src/js/review/SubmitController';
+import { isMinimalHeaderApp } from 'platform/forms-system/src/js/patterns/minimal-header';
 
 import DowntimeNotification, {
   externalServiceStatus,
@@ -61,6 +62,9 @@ class RoutedSavableReviewPage extends React.Component {
       <div>
         <Element name="topContentElement" />
         {CustomReviewTopContent && <CustomReviewTopContent />}
+        {isMinimalHeaderApp() && (
+          <h1 className="vads-u-font-size--h2">Review and submit</h1>
+        )}
         {!hideReviewChapters && (
           <ReviewChapters
             formConfig={formConfig}

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
@@ -77,6 +77,69 @@ describe('Schemaform save in progress: RoutedSavableReviewPage', () => {
     tree.unmount();
   });
 
+  it('should render h1 header if MINIMAL_HEADER_APPLICABLE is true', () => {
+    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
+
+    const formConfig = {
+      chapters: {
+        chapter1: {
+          pages: {
+            page1: {},
+          },
+        },
+        chapter2: {
+          pages: {
+            page2: {},
+          },
+        },
+      },
+    };
+
+    const form = {
+      submission: {
+        hasAttemptedSubmit: false,
+      },
+      data: {
+        privacyAgreementAccepted: false,
+      },
+    };
+
+    const user = {
+      profile: {
+        savedForms: [],
+      },
+      login: {
+        currentlyLoggedIn: true,
+      },
+    };
+
+    const treeWithMinimalHeader = shallow(
+      <RoutedSavableReviewPage
+        form={form}
+        user={user}
+        formConfig={formConfig}
+        setPrivacyAgreement={f => f}
+      />,
+    );
+
+    expect(treeWithMinimalHeader.find('h1').exists()).to.be.true;
+    treeWithMinimalHeader.unmount();
+
+    sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
+
+    const treeWithoutMinimalHeader = shallow(
+      <RoutedSavableReviewPage
+        form={form}
+        user={user}
+        formConfig={formConfig}
+        setPrivacyAgreement={f => f}
+      />,
+    );
+
+    expect(treeWithoutMinimalHeader.find('h1').exists()).to.be.false;
+    treeWithoutMinimalHeader.unmount();
+  });
+
   it('should auto save after change', () => {
     const formConfig = {
       chapters: {


### PR DESCRIPTION
## Summary

Forms using minimal header should now see an h1 render on the review page with the title "Review and submit". Focus has also been updated to focus on this h1 when in a minimal header form.

## Related issue(s)

department-of-veterans-affairs/va.gov-team-forms#2023

## Testing done

- Updated unit tests for both review pages

## Screenshots

![Screenshot 2025-03-12 at 11 22 49 AM](https://github.com/user-attachments/assets/c8163522-b087-4321-ae68-33a2be238ac6)
