### PR TITLE
Fixed bug when RxBreadcrumbs is not showinng up if there is a trailing slash in url

### DIFF
--- a/src/applications/mhv-medications/util/helpers.js
+++ b/src/applications/mhv-medications/util/helpers.js
@@ -301,7 +301,7 @@ export const createBreadcrumbs = (
       },
     ]);
   }
-  if (pathname === subdirectories.REFILL) {
+  if (pathname.includes(subdirectories.REFILL)) {
     return defaultBreadcrumbs.concat([
       ...(!removeLandingPage
         ? [{ href: MEDICATIONS_ABOUT, label: 'About medications' }]


### PR DESCRIPTION
https://jira.devops.va.gov/browse/MHV-68388

Context:

https://dsva.slack.com/archives/C059Q28DV99/p1741799670820059

<img width="1917" alt="image" src="https://github.com/user-attachments/assets/f65bdad2-1626-4a02-81e5-e5700e67ab05" />
