### PR TITLE
Add Datadog RUM action for displaying unregistered alert box

### DIFF
--- a/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { datadogRum } from '@datadog/browser-rum';
 
 const AlertUnregistered = ({ headline, recordEvent, testId }) => {
   useEffect(
@@ -13,6 +14,7 @@ const AlertUnregistered = ({ headline, recordEvent, testId }) => {
         'alert-box-headline': headline,
         'alert-box-status': 'warning',
       });
+      datadogRum.addAction('Showed Alert Box: Unregistered');
     },
     [headline, recordEvent],
   );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- added a datadog dog rum action for unregistered users

## Related issue(s)

- slack thread: https://dsva.slack.com/archives/C0581MN69TJ/p1741789871475809

## Testing done
No Functionality change, existing suites passing are the standard

## Screenshots
No UI changes

## What areas of the site does it impact?

MHV

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
