### PR TITLE
VACMS-20820: Resolve loading spinner for find forms

### DIFF
--- a/src/applications/static-pages/find-forms/actions/index.js
+++ b/src/applications/static-pages/find-forms/actions/index.js
@@ -2,6 +2,7 @@ import {
   FETCH_FORMS,
   FETCH_FORMS_FAILURE,
   FETCH_FORMS_SUCCESS,
+  FETCH_FORMS_SUCCESS_NO_RESULTS,
   UPDATE_HOW_TO_SORT,
   UPDATE_PAGINATION,
   UPDATE_RESULTS,
@@ -21,6 +22,11 @@ export const fetchFormsSuccess = (results, hasOnlyRetiredForms) => ({
   results,
   hasOnlyRetiredForms,
   type: FETCH_FORMS_SUCCESS,
+});
+
+export const fetchFormsSuccessNoResults = results => ({
+  results,
+  type: FETCH_FORMS_SUCCESS_NO_RESULTS,
 });
 
 export const updateResults = results => ({

--- a/src/applications/static-pages/find-forms/actions/index.js
+++ b/src/applications/static-pages/find-forms/actions/index.js
@@ -24,8 +24,7 @@ export const fetchFormsSuccess = (results, hasOnlyRetiredForms) => ({
   type: FETCH_FORMS_SUCCESS,
 });
 
-export const fetchFormsSuccessNoResults = results => ({
-  results,
+export const fetchFormsSuccessNoResults = () => ({
   type: FETCH_FORMS_SUCCESS_NO_RESULTS,
 });
 

--- a/src/applications/static-pages/find-forms/api/index.js
+++ b/src/applications/static-pages/find-forms/api/index.js
@@ -1,7 +1,11 @@
 import appendQuery from 'append-query';
 import { apiRequest } from 'platform/utilities/api';
 import { sentryLogger } from '../helpers/sentryLogger';
-import { fetchFormsFailure, fetchFormsSuccess } from '../actions';
+import {
+  fetchFormsFailure,
+  fetchFormsSuccess,
+  fetchFormsSuccessNoResults,
+} from '../actions';
 
 // Form URLs can be entered incorrectly, or the forms themselves can be deleted
 // by forms managers. This guards against sending users to 404 pages
@@ -67,9 +71,14 @@ export const fetchFormsApi = async (query, dispatch) => {
   try {
     const response = await apiRequest(FORMS_URL);
     const forms = response?.data;
+    // const forms = [];
 
     if (forms?.length) {
       dispatch(fetchFormsSuccess(forms, allFormsRetired(forms)));
+    }
+
+    if (forms?.length === 0) {
+      dispatch(fetchFormsSuccessNoResults([]));
     }
 
     return forms;

--- a/src/applications/static-pages/find-forms/api/index.js
+++ b/src/applications/static-pages/find-forms/api/index.js
@@ -71,14 +71,13 @@ export const fetchFormsApi = async (query, dispatch) => {
   try {
     const response = await apiRequest(FORMS_URL);
     const forms = response?.data;
-    // const forms = [];
 
     if (forms?.length) {
       dispatch(fetchFormsSuccess(forms, allFormsRetired(forms)));
     }
 
     if (forms?.length === 0) {
-      dispatch(fetchFormsSuccessNoResults([]));
+      dispatch(fetchFormsSuccessNoResults());
     }
 
     return forms;

--- a/src/applications/static-pages/find-forms/constants/index.js
+++ b/src/applications/static-pages/find-forms/constants/index.js
@@ -1,6 +1,8 @@
 export const FETCH_FORMS = 'findVAForms/FETCH_FORMS';
 export const FETCH_FORMS_FAILURE = 'findVAForms/FETCH_FORMS_FAILURE';
 export const FETCH_FORMS_SUCCESS = 'findVAForms/FETCH_FORMS_SUCCESS';
+export const FETCH_FORMS_SUCCESS_NO_RESULTS =
+  'findVAFORMS/FETCH_FORMS_SUCCESS_NO_RESULTS';
 export const UPDATE_PAGINATION = 'findVAForms/UPDATE_PAGINATION';
 export const FAF_OPTION_CLOSEST_MATCH = 'Closest match';
 export const FAF_SORT_OPTIONS = [

--- a/src/applications/static-pages/find-forms/reducers/index.js
+++ b/src/applications/static-pages/find-forms/reducers/index.js
@@ -4,6 +4,7 @@ import {
   FETCH_FORMS,
   FETCH_FORMS_FAILURE,
   FETCH_FORMS_SUCCESS,
+  FETCH_FORMS_SUCCESS_NO_RESULTS,
   INITIAL_SORT_STATE,
   FAF_OPTION_CLOSEST_MATCH,
   UPDATE_HOW_TO_SORT,
@@ -33,7 +34,6 @@ export default (state = initialState, action) => {
     }
     case FETCH_FORMS_SUCCESS: {
       const clonedResults = cloneDeep(action.results);
-
       return {
         ...state,
         fetching: false,
@@ -45,6 +45,13 @@ export default (state = initialState, action) => {
             : clonedResults.sort((a, b) =>
                 sortTheResults(state.sortByPropertyName, a, b),
               ),
+      };
+    }
+    case FETCH_FORMS_SUCCESS_NO_RESULTS: {
+      return {
+        ...state,
+        fetching: false,
+        results: [],
       };
     }
     case UPDATE_HOW_TO_SORT: {
@@ -68,7 +75,6 @@ export default (state = initialState, action) => {
         ...state,
         page: action.page,
         startIndex: action.startIndex,
-        fetching: false,
       };
     }
     default: {

--- a/src/applications/static-pages/find-forms/reducers/index.js
+++ b/src/applications/static-pages/find-forms/reducers/index.js
@@ -64,7 +64,12 @@ export default (state = initialState, action) => {
       };
     }
     case UPDATE_PAGINATION: {
-      return { ...state, page: action.page, startIndex: action.startIndex };
+      return {
+        ...state,
+        page: action.page,
+        startIndex: action.startIndex,
+        fetching: false,
+      };
     }
     default: {
       return { ...state };

--- a/src/applications/static-pages/find-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/static-pages/find-forms/tests/actions/index.unit.spec.js
@@ -4,6 +4,7 @@ import {
   fetchFormsAction,
   fetchFormsFailure,
   fetchFormsSuccess,
+  fetchFormsSuccessNoResults,
   updatePaginationAction,
   updateResults,
   updateSortByPropertyName,
@@ -13,6 +14,7 @@ import {
   FETCH_FORMS,
   FETCH_FORMS_FAILURE,
   FETCH_FORMS_SUCCESS,
+  FETCH_FORMS_SUCCESS_NO_RESULTS,
   INITIAL_SORT_STATE,
   UPDATE_HOW_TO_SORT,
   UPDATE_PAGINATION,
@@ -53,6 +55,16 @@ describe('Find VA Forms actions', () => {
         hasOnlyRetiredForms,
         results,
         type: FETCH_FORMS_SUCCESS,
+      });
+    });
+  });
+
+  describe('fetchFormsSuccessNoResults', () => {
+    it('should return an action in the shape we expect', () => {
+      const action = fetchFormsSuccessNoResults();
+
+      expect(action).to.be.deep.equal({
+        type: FETCH_FORMS_SUCCESS_NO_RESULTS,
       });
     });
   });

--- a/src/applications/static-pages/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
+++ b/src/applications/static-pages/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
@@ -96,7 +96,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
     });
 
     describe('FETCH_FORMS_SUCCESS_NO_RESULTS', () => {
-      it('returns the correct state when Closest Match is used', () => {
+      it('returns the correct state when no results are returned', () => {
         const results = [];
 
         expect(

--- a/src/applications/static-pages/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
+++ b/src/applications/static-pages/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
@@ -4,6 +4,7 @@ import {
   FETCH_FORMS,
   FETCH_FORMS_FAILURE,
   FETCH_FORMS_SUCCESS,
+  FETCH_FORMS_SUCCESS_NO_RESULTS,
   UPDATE_HOW_TO_SORT,
   UPDATE_PAGINATION,
   UPDATE_RESULTS,
@@ -91,6 +92,28 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
         ...initialState,
         closestMatchSearchResults: results,
         results,
+      });
+    });
+
+    describe('FETCH_FORMS_SUCCESS_NO_RESULTS', () => {
+      it('returns the correct state when Closest Match is used', () => {
+        const results = [];
+
+        expect(
+          findVAFormsReducer(
+            {
+              ...initialState,
+              fetching: true,
+            },
+            {
+              type: FETCH_FORMS_SUCCESS_NO_RESULTS,
+              results,
+            },
+          ),
+        ).to.be.deep.equal({
+          ...initialState,
+          results,
+        });
       });
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR adds a change to the find forms reducers to allow the find forms search to resolve without any returned results.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20820

## Testing done
Tested locally for the search term dd214 and made sure the loading spinner was no longer visible.
`/find-forms/?q=dd214`

## Screenshots
![Find_A_VA_Form___Veterans_Affairs](https://github.com/user-attachments/assets/61476b0c-757d-4ef3-a400-64ee75209583)



## What areas of the site does it impact?
Find forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed


