### PR TITLE
Lacp review cleanup 2

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -199,67 +199,62 @@ export function filterLcResults(
 export function fetchLicenseCertificationResults(signal) {
   const url = `${api.url}/lcpe/lacs`;
 
-  return dispatch => {
+  return async dispatch => {
     dispatch({ type: FETCH_LC_RESULTS_STARTED });
 
-    return fetch(url, {
-      ...api.settings,
-      signal, // Add the signal to the fetch options
-    })
-      .then(res => {
-        if (res.ok) {
-          return res.json();
-        }
-        throw new Error(res.statusText);
-      })
-      .then(results => {
-        const { lacs } = results;
-        dispatch({
-          type: FETCH_LC_RESULTS_SUCCEEDED,
-          payload: lacs,
-        });
-      })
-      .catch(err => {
-        // Only dispatch error if it's not an abort error
-        if (err.name !== 'AbortError') {
-          dispatch({
-            type: FETCH_LC_RESULTS_FAILED,
-            payload: err.message,
-          });
-        }
+    try {
+      const res = await fetch(url, {
+        ...api.settings,
+        signal,
       });
+
+      if (!res.ok) {
+        throw new Error(res.statusText);
+      }
+
+      const { lacs } = await res.json();
+      dispatch({
+        type: FETCH_LC_RESULTS_SUCCEEDED,
+        payload: lacs,
+      });
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        dispatch({
+          type: FETCH_LC_RESULTS_FAILED,
+          payload: err.message,
+        });
+      }
+    }
   };
 }
 
 export function fetchLcResult(id, signal) {
-  return dispatch => {
+  return async dispatch => {
     const url = `${api.url}/lcpe/lacs/${id}`;
     dispatch({ type: FETCH_LC_RESULT_STARTED });
 
-    return fetch(url, {
-      ...api.settings,
-      signal,
-    })
-      .then(res => {
-        if (res.ok) {
-          return res.json();
-        }
-        throw new Error(res.statusText);
-      })
-      .then(result => {
-        dispatch({
-          type: FETCH_LC_RESULT_SUCCEEDED,
-          payload: result.lac,
-        });
-      })
-      .catch(err => {
-        if (err.name !== 'AbortError') {
-          dispatch({
-            type: FETCH_LC_RESULT_FAILED,
-            payload: err.message,
-          });
-        }
+    try {
+      const res = await fetch(url, {
+        ...api.settings,
+        signal,
       });
+
+      if (!res.ok) {
+        throw new Error(res.statusText);
+      }
+      const { lac } = await res.json();
+      dispatch({
+        type: FETCH_LC_RESULT_SUCCEEDED,
+        payload: lac,
+      });
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        dispatch({
+          type: FETCH_LC_RESULT_FAILED,
+          payload: err.message,
+        });
+      }
+    }
   };
 }
 

--- a/src/applications/gi/components/LicenseCertificationSearchPage.jsx
+++ b/src/applications/gi/components/LicenseCertificationSearchPage.jsx
@@ -4,7 +4,7 @@ import LicenseCertificationFaq from './LicenseCertificationFaq';
 
 export default function LicenseCertificationSearchPage() {
   useEffect(() => {
-    window.scrollTo(0, 0); // create function for reuse
+    window.scrollTo(0, 0);
   }, []);
 
   return (

--- a/src/applications/gi/components/LicenseCertificationTestInfo.jsx
+++ b/src/applications/gi/components/LicenseCertificationTestInfo.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useEffect, useState } from 'react';
+import React, { useLayoutEffect, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
@@ -9,6 +9,7 @@ import {
 
 function LcTestInfo({ tests }) {
   const [currentPage, setCurrentPage] = useState(1);
+  const testInfoWrapperRef = useRef(null);
 
   useLayoutEffect(
     // eslint-disable-next-line consistent-return
@@ -76,6 +77,11 @@ function LcTestInfo({ tests }) {
 
   const handlePageChange = page => {
     setCurrentPage(page);
+    setTimeout(() => {
+      if (testInfoWrapperRef.current) {
+        testInfoWrapperRef.current.focus();
+      }
+    });
   };
 
   return (
@@ -86,8 +92,14 @@ function LcTestInfo({ tests }) {
           : 'vads-u-padding-bottom--9'
       }
     >
-      <h3>Test info</h3>
-      <p className="vads-u-color--gray-dark vads-u-margin--0 vads-u-padding-top--1">
+      <h3 className="vads-u-margin-bottom--2">Test info</h3>
+      <p
+        ref={testInfoWrapperRef}
+        tabIndex={-1}
+        aria-live="polite"
+        aria-atomic="true"
+        className="vads-u-color--gray-dark vads-u-margin--0"
+      >
         Showing{' '}
         <>
           {`${formatResultCount(tests, currentPage, itemsPerPage)} of ${

--- a/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
+import { useSignalFetch } from '../utils/useSignalFetch';
 
 import {
   capitalizeFirstLetter,
@@ -11,7 +12,7 @@ import {
   updateQueryParam,
 } from '../utils/helpers';
 
-import { filterLcResults, fetchLicenseCertificationResults } from '../actions';
+import { filterLcResults } from '../actions';
 
 import LicenseCertificationKeywordSearch from '../components/LicenseCertificationKeywordSearch';
 import Dropdown from '../components/Dropdown';
@@ -40,18 +41,7 @@ export default function LicenseCertificationSearchForm() {
     ...filteredResults,
   ];
 
-  useEffect(() => {
-    if (!hasFetchedOnce) {
-      const controller = new AbortController();
-
-      dispatch(fetchLicenseCertificationResults(controller.signal));
-
-      return () => {
-        controller.abort();
-      };
-    }
-    return null;
-  }, []);
+  useSignalFetch(hasFetchedOnce);
 
   useEffect(
     () => {

--- a/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
@@ -59,7 +59,6 @@ export default function LicenseCertificationSearchForm() {
     if (nameParam) {
       setName(nameParam);
     }
-    // We intentionally only want this to run once on mount to set initial values
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
@@ -47,10 +47,10 @@ export default function LicenseCertificationSearchForm() {
     () => {
       return dispatch(filterLcResults(name, dropdown.current.optionValue));
     },
-    [name],
+    [name, dropdown.current.optionValue],
   );
 
-  // If available, use url query params to assign initial dropdown values
+  // If available, use url query params to assign initial values ONLY on mount
   useEffect(() => {
     if (categoryParams) {
       setDropdown(updateCategoryDropdown(categoryParams[0]));
@@ -59,8 +59,8 @@ export default function LicenseCertificationSearchForm() {
     if (nameParam) {
       setName(nameParam);
     }
-
-    return null;
+    // We intentionally only want this to run once on mount to set initial values
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSearch = (category, nameInput) => {

--- a/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
@@ -5,8 +5,9 @@ import { useSelector, useDispatch } from 'react-redux';
 import ADDRESS_DATA from 'platform/forms/address/data';
 
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { useSignalFetch } from '../utils/useSignalFetch';
 
-import { filterLcResults, fetchLicenseCertificationResults } from '../actions';
+import { filterLcResults } from '../actions';
 import {
   handleLcResultsSearch,
   isSmallScreen,
@@ -73,18 +74,7 @@ export default function LicenseCertificationSearchResults() {
     currentPage * itemsPerPage,
   );
 
-  useEffect(() => {
-    if (!hasFetchedOnce) {
-      const controller = new AbortController();
-
-      dispatch(fetchLicenseCertificationResults(controller.signal));
-
-      return () => {
-        controller.abort();
-      };
-    }
-    return null;
-  }, []);
+  useSignalFetch(hasFetchedOnce);
 
   useEffect(
     () => {

--- a/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
@@ -14,6 +14,7 @@ import {
   showMultipleNames,
   createCheckboxes,
   updateStateDropdown,
+  handleZoom,
 } from '../utils/helpers';
 import { lacpCategoryList } from '../constants';
 
@@ -143,6 +144,20 @@ export default function LicenseCertificationSearchResults() {
     },
     [pageParam],
   );
+
+  useEffect(() => {
+    window.addEventListener('resize', handleZoom);
+    window.addEventListener('load', handleZoom);
+    window.addEventListener('zoom', handleZoom);
+    window.visualViewport?.addEventListener('resize', handleZoom);
+
+    return () => {
+      window.removeEventListener('resize', handleZoom);
+      window.removeEventListener('load', handleZoom);
+      window.removeEventListener('zoom', handleZoom);
+      window.visualViewport?.removeEventListener('resize', handleZoom);
+    };
+  }, []);
 
   const handleSearch = (categoryNames, name, state) => {
     const newParams = {

--- a/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
@@ -135,6 +135,7 @@ export default function LicenseCertificationSearchResults() {
     [pageParam],
   );
 
+  // handle UI for changes for high zoom levels
   useEffect(() => {
     window.addEventListener('resize', handleZoom);
     window.addEventListener('load', handleZoom);

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -425,7 +425,7 @@
     flex-direction: column;
   }
 
-  @media screen and (-webkit-min-device-pixel-ratio: 3) {
+  &.high-zoom {
     width: 100%;
   }
 }
@@ -433,13 +433,13 @@
 .lc-result-cards-wrapper {
   list-style: none;
 
-  @media screen and (-webkit-min-device-pixel-ratio: 3) {
+  &.high-zoom {
     width: 100%;
   }
 }
 
 .zoom-wrapper {
-  @media screen and (-webkit-min-device-pixel-ratio: 3) {
+  &.high-zoom {
     width: 100%;
   }
 }

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -1104,3 +1104,25 @@ export const toTitleCase = str => {
 
   return titled.join(' ');
 };
+
+export const handleZoom = () => {
+  const zoomLevel = Math.round(
+    (window.devicePixelRatio /
+      ((window.devicePixelRatio / window.outerWidth) * window.innerWidth)) *
+      100,
+  );
+
+  const elements = [
+    ...document.querySelectorAll('.lc-results-wrapper'),
+    ...document.querySelectorAll('.lc-result-cards-wrapper'),
+    ...document.querySelectorAll('.zoom-wrapper'),
+  ];
+
+  elements.forEach(element => {
+    if (zoomLevel >= 300) {
+      element.classList.add('high-zoom');
+    } else {
+      element.classList.remove('high-zoom');
+    }
+  });
+};

--- a/src/applications/gi/utils/useSignalFetch.js
+++ b/src/applications/gi/utils/useSignalFetch.js
@@ -1,0 +1,19 @@
+import { useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { fetchLicenseCertificationResults } from '../actions';
+
+export const useSignalFetch = hasFetchedOnce => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (!hasFetchedOnce) {
+      const controller = new AbortController();
+
+      dispatch(fetchLicenseCertificationResults(controller.signal));
+
+      return () => {
+        controller.abort();
+      };
+    }
+    return null;
+  }, []);
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Minor refactor and updates to clean code and increase readability.
    - See commit history for specific changes
- Education Data Migration (EDM)
- Feature toggle in use, to be lifted in April

## Related issue(s)

- No specific ticket for these changes. Cleaning up ahead of staging review

## Testing done

- Unit tests and e2e tests still passing 
- Performed code changes, logic should remain unaffected

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)