### PR TITLE
[#104854] Travel Pay, Claim appeal on details

### DIFF
--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { useFeatureToggle } from 'platform/utilities/feature-toggles/useFeatureToggle';
+
 import { formatDateTime } from '../util/dates';
 import { STATUSES } from '../constants';
 
@@ -12,6 +14,11 @@ export default function ClaimDetailsContent({
   facilityName,
   modifiedOn,
 }) {
+  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
+  const claimsMgmtToggle = useToggleValue(
+    TOGGLE_NAMES.travelPayClaimsManagement,
+  );
+
   const [appointmentDate, appointmentTime] = formatDateTime(
     appointmentDateTime,
     true,
@@ -29,7 +36,8 @@ export default function ClaimDetailsContent({
         Claim number: {claimNumber}
       </span>
       <h2 className="vads-u-font-size--h3">Claim status: {claimStatus}</h2>
-      {claimStatus === STATUSES.Denied.name && <AppealContent />}
+      {claimsMgmtToggle &&
+        claimStatus === STATUSES.Denied.name && <AppealContent />}
       <h2 className="vads-u-font-size--h3">Claim information</h2>
       <p className="vads-u-font-weight--bold vads-u-margin-bottom--0">Where</p>
       <p className="vads-u-margin-y--0">

--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -2,17 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { formatDateTime } from '../util/dates';
+import { STATUSES } from '../constants';
 
-export default function ClaimDetailsContent(props) {
-  const {
-    createdOn,
-    claimStatus,
-    claimNumber,
-    appointmentDateTime,
-    facilityName,
-    modifiedOn,
-  } = props;
-
+export default function ClaimDetailsContent({
+  createdOn,
+  claimStatus,
+  claimNumber,
+  appointmentDateTime,
+  facilityName,
+  modifiedOn,
+}) {
   const [appointmentDate, appointmentTime] = formatDateTime(
     appointmentDateTime,
     true,
@@ -29,12 +28,14 @@ export default function ClaimDetailsContent(props) {
       >
         Claim number: {claimNumber}
       </span>
-      <h2 className="vads-u-font-size--h3">Where</h2>
-      <p className="vads-u-margin-bottom--0">
+      <h2 className="vads-u-font-size--h3">Claim status: {claimStatus}</h2>
+      {claimStatus === STATUSES.Denied.name && <AppealContent />}
+      <h2 className="vads-u-font-size--h3">Claim information</h2>
+      <p className="vads-u-font-weight--bold vads-u-margin-bottom--0">Where</p>
+      <p className="vads-u-margin-y--0">
         {appointmentDate} at {appointmentTime} appointment
       </p>
       <p className="vads-u-margin-y--0">{facilityName}</p>
-      <h2 className="vads-u-font-size--h3">Claim status: {claimStatus}</h2>
       <p className="vads-u-margin-bottom--0">
         Submitted on {createDate} at {createTime}
       </p>
@@ -53,3 +54,28 @@ ClaimDetailsContent.propTypes = {
   facilityName: PropTypes.string.isRequired,
   modifiedOn: PropTypes.string.isRequired,
 };
+
+function AppealContent() {
+  return (
+    <>
+      <va-link text="Appeal the claim decision" href="/decision-reviews" />
+      <va-additional-info
+        class="vads-u-margin-y--3"
+        trigger="What to expect when you appeal"
+      >
+        When appealing this decision you can:
+        <ul>
+          <li>Submit an appeal via the Board of Appeals.</li>
+          <li>
+            Send a secure message to the Beneficiary Travel team of the VA
+            facility that provided your care or of you home VA facility.
+          </li>
+          <li>
+            Mail a printed version of Form 10-0998 with the appropriate
+            documentation.
+          </li>
+        </ul>
+      </va-additional-info>
+    </>
+  );
+}

--- a/src/applications/travel-pay/constants.js
+++ b/src/applications/travel-pay/constants.js
@@ -5,66 +5,31 @@ export const FIND_FACILITY_TP_CONTACT_LINK =
 export const TRAVEL_PAY_INFO_LINK =
   '/health-care/get-reimbursed-for-travel-pay/';
 
-export const STATUS_GROUPINGS = [
-  {
-    name: 'Saved or Incomplete',
-    description:
-      'These are claims that the Beneficiary Travel office cannot process. Either you have not submitted the claim, or you submitted a claim without required information.',
-    includes: ['Incomplete', 'Saved'],
-  },
-  {
-    name: 'Under VA Review',
-    description:
-      'These claims require action from VA. If VA needs more information from you, your Travel Clerk will contact you.',
-    includes: [
-      'In process',
-      'Claim submitted',
-      'In manual review',
-      'On hold',
-      'Appealed',
-    ],
-  },
-  {
-    name: 'Closed',
-    description:
-      'The Beneficiary Travel office finished their review of your claim and closed it. In some situations you can appeal Beneficiary Travel department’s decision and re-open a claim. If you have questions about why your claim has one of the following statuses, contact your local VAMC and ask for the Beneficiary Travel department.',
-    includes: [
-      'Partial payment',
-      'Denied',
-      'Approved for payment',
-      'Submitted for payment',
-      'Fiscal rescinded',
-      'Claim paid',
-      'Payment canceled',
-    ],
-  },
-];
-
-export const STATUSES = [
-  {
+export const STATUSES = {
+  Incomplete: {
     name: 'Incomplete',
     description:
       'You submitted a claim without required expense information. You must provide the required information for BTSSS to process the claim.',
     reasons: null,
   },
-  {
+  Saved: {
     name: 'Saved',
     description:
       'You saved changes to your claim, but you did not submit it to BTSSS for review. Submit the claim so BTSSS can begin processing your claim.',
     reasons: null,
   },
-  {
+  InProcess: {
     name: 'In process',
     description:
       'You submitted a claim, and now BTSSS is reviewing your claim.',
     reasons: null,
   },
-  {
+  ClaimSubmitted: {
     name: 'Claim submitted',
     description: 'You submitted a claim for a completed appointment.',
     reasons: null,
   },
-  {
+  InManualReview: {
     name: 'In manual review',
     description:
       'Your claim requires a manual review by a Travel Clerk due to one or more of the following reasons:',
@@ -74,25 +39,25 @@ export const STATUSES = [
       'Your travel does not meet the eligibility requirements. For detailed information about your claim, contact your local VAMC and ask for the Beneficiary Travel department.',
     ],
   },
-  {
+  OnHold: {
     name: 'On hold',
     description:
       'You must provide the needed information for the claim to be processed. Your Travel Clerk will contact you when they put your claim on hold and tell you what additional information is required. For more information about your claim, please contact your local VAMC and ask for the Beneficiary Travel department.',
     reasons: null,
   },
-  {
+  Appealed: {
     name: 'Appealed',
     description:
       'You appealed the denial of your claim. The Travel Clerk will review your appeal.',
     reasons: null,
   },
-  {
+  PartialPayment: {
     name: 'Partial payment',
     description:
       'The Travel Clerk determined the claim does not qualify for a full reimbursement. Instead, they approved a partial payment and a Partial Payment letter was sent to you.',
     reasons: null,
   },
-  {
+  Denied: {
     name: 'Denied',
     description:
       'The Travel Clerk denied your claim for one or more of the following reasons:',
@@ -103,34 +68,69 @@ export const STATUSES = [
       'The Travel Clerk sent you a denial letter. The letter contains information on how to appeal the decision.',
     ],
   },
-  {
+  ApprovedForPayment: {
     name: 'Approved for payment',
     description:
       'The Travel Clerk approved your claim for payment. The payment is pending and has not been paid.',
     reasons: null,
   },
-  {
+  SubmittedForPayment: {
     name: 'Submitted for payment',
     description:
       'The approved claim payment is assigned to the Financial Service Center (FSC) so that you can receive reimbursement.',
     reasons: null,
   },
-  {
+  FiscalRescinded: {
     name: 'Fiscal rescinded',
     description:
       'The Financial Service Center (FSC) rejected payment. You will not be able to appeal this decision. For more detailed information about your claim, please contact your local VAMC and ask for the Beneficiary Travel department.',
     reasons: null,
   },
-  {
+  ClaimPaid: {
     name: 'Claim paid',
     description:
       'The reimbursement on the approved claim is paid to the submitter. Note that reimbursements for claims submitted by a Caregiver on behalf of a Veteran claimant are sent to the Caregiver’s address or deposited in the Caregiver’s account.',
     reasons: null,
   },
-  {
+  PaymentCanceled: {
     name: 'Payment canceled',
     description:
       'The fund transfer did not complete because of the claimant’s bank. Payment has been canceled. You may create a new claim and reference the original claim number in the Notes section of the new claim.',
     reasons: null,
+  },
+};
+
+export const STATUS_GROUPINGS = [
+  {
+    name: 'Saved or Incomplete',
+    description:
+      'These are claims that the Beneficiary Travel office cannot process. Either you have not submitted the claim, or you submitted a claim without required information.',
+    includes: [STATUSES.Incomplete.name, STATUSES.Saved.name],
+  },
+  {
+    name: 'Under VA Review',
+    description:
+      'These claims require action from VA. If VA needs more information from you, your Travel Clerk will contact you.',
+    includes: [
+      STATUSES.InProcess.name,
+      STATUSES.ClaimSubmitted.name,
+      STATUSES.InManualReview.name,
+      STATUSES.OnHold.name,
+      STATUSES.Appealed.name,
+    ],
+  },
+  {
+    name: 'Closed',
+    description:
+      'The Beneficiary Travel office finished their review of your claim and closed it. In some situations you can appeal Beneficiary Travel department’s decision and re-open a claim. If you have questions about why your claim has one of the following statuses, contact your local VAMC and ask for the Beneficiary Travel department.',
+    includes: [
+      STATUSES.PartialPayment.name,
+      STATUSES.Denied.name,
+      STATUSES.ApprovedForPayment.name,
+      STATUSES.SubmittedForPayment.name,
+      STATUSES.FiscalRescinded.name,
+      STATUSES.ClaimPaid.name,
+      STATUSES.PaymentCanceled.name,
+    ],
   },
 ];

--- a/src/applications/travel-pay/containers/pages/ClaimStatusExplainerPage.jsx
+++ b/src/applications/travel-pay/containers/pages/ClaimStatusExplainerPage.jsx
@@ -70,8 +70,9 @@ const ClaimStatusExplainerPage = () => {
                 <h2 className="vads-u-font-size--h3">{grouping.name}</h2>
                 <p>{grouping.description}</p>
                 <ul>
-                  {STATUSES.map(
-                    status =>
+                  {Object.keys(STATUSES).map(s => {
+                    const status = STATUSES[s];
+                    return (
                       grouping.includes.includes(status.name) && (
                         <li key={status.name}>
                           <b>{status.name} — </b> {status.description}
@@ -83,8 +84,9 @@ const ClaimStatusExplainerPage = () => {
                             </ul>
                           )}
                         </li>
-                      ),
-                  )}
+                      )
+                    );
+                  })}
                 </ul>
               </React.Fragment>
             ))}

--- a/src/applications/travel-pay/services/mocks/index.js
+++ b/src/applications/travel-pay/services/mocks/index.js
@@ -23,6 +23,7 @@ const responses = {
         { name: `${TOGGLE_NAMES.travelPayPowerSwitch}`, value: true },
         { name: `${TOGGLE_NAMES.travelPayViewClaimDetails}`, value: true },
         { name: `${TOGGLE_NAMES.travelPaySubmitMileageExpense}`, value: true },
+        { name: `${TOGGLE_NAMES.travelPayClaimsManagement}`, value: true },
       ],
     },
   },

--- a/src/applications/travel-pay/tests/components/TravelClaimDetails.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/TravelClaimDetails.unit.spec.jsx
@@ -23,12 +23,14 @@ describe('TravelClaimDetails', () => {
     featureTogglesAreLoading = false,
     hasStatusFeatureFlag = true,
     hasDetailsFeatureFlag = true,
+    hasClaimsManagementFlag = true,
   } = {}) => ({
     featureToggles: {
       loading: featureTogglesAreLoading,
       /* eslint-disable camelcase */
       travel_pay_power_switch: hasStatusFeatureFlag,
       travel_pay_view_claim_details: hasDetailsFeatureFlag,
+      travel_pay_claims_management: hasClaimsManagementFlag,
       /* eslint-enable camelcase */
     },
   });
@@ -104,5 +106,19 @@ describe('TravelClaimDetails', () => {
     expect(
       $('va-link[text="Appeal the claim decision"][href="/decision-reviews"]'),
     ).to.exist;
+  });
+
+  it('does not render claims management content with flag off', async () => {
+    global.fetch.restore();
+    mockApiRequest({ ...claimDetailsProps, claimStatus: 'Denied' });
+
+    const screen = renderWithStoreAndRouter(<TravelClaimDetails />, {
+      initialState: getState({ hasClaimsManagementFlag: false }),
+    });
+
+    expect(await screen.findByText('Claim status: Denied')).to.exist;
+    expect(
+      $('va-link[text="Appeal the claim decision"][href="/decision-reviews"]'),
+    ).to.not.exist;
   });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -260,6 +260,7 @@
   "travelPayPowerSwitch": "travel_pay_power_switch",
   "travelPayViewClaimDetails": "travel_pay_view_claim_details",
   "travelPaySubmitMileageExpense": "travel_pay_submit_mileage_expense",
+  "travelPayClaimsManagement": "travel_pay_claims_management",
   "useFacilitiesApiV2ForCernerCTA": "use_facilities_api_v2_for_cerner_cta",
   "useLighthouseFormsSearchLogic": "new_va_forms_search",
   "vaDependentsV2": "va_dependents_v2",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding an appeal link for claims with a `Denied` status.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/104854

## Testing done

Prior to the changes there was a slightly different order of headings on the claim details and there was no `Denied`-specific behavior. A unit test was added to cover this case.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![before_mobile_denied](https://github.com/user-attachments/assets/9d5a643b-62e8-4924-8c93-791e35574b64) | ![after_mobile_denied](https://github.com/user-attachments/assets/f4b0410e-ca7d-42ed-96f3-69bf0ea35af7) |
| Desktop | ![before_desktop_denied](https://github.com/user-attachments/assets/4629a3ed-8c80-4f57-929d-4fad2826c37f) | ![after_desktop_denied](https://github.com/user-attachments/assets/7d0c8417-b3f4-4eff-9b94-4e122724cd9f) |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user