### PR TITLE
[mhv-landing-page] Updates copy, link for AlertUnregistered

### DIFF
--- a/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.jsx
@@ -1,11 +1,18 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
-import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaAlert,
+  VaLink,
+  VaTelephone,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { datadogRum } from '@datadog/browser-rum';
 
-const AlertUnregistered = ({ headline, recordEvent, testId }) => {
+const AlertUnregistered = ({ headline, recordEvent, ssoe, testId }) => {
+  const mhvHomeUrl = mhvUrl(ssoe, 'home');
+
   useEffect(
     () => {
       recordEvent({
@@ -23,32 +30,33 @@ const AlertUnregistered = ({ headline, recordEvent, testId }) => {
     <VaAlert status="warning" data-testid={testId} disableAnalytics>
       <h2 slot="headline">{headline}</h2>
       <div>
-        <p className="vads-u-margin-y--0">
-          To access My HealtheVet, <b>at least one</b> of these descriptions
-          must be true:
-        </p>
-        <ul>
-          <li>
-            You’ve received care at a VA facility, <b>or</b>
-          </li>
-          <li>You’ve applied for VA health care</li>
-        </ul>
-        <p className="vads-u-margin-y--0">
-          If you’ve received care at a VA health facility, call the facility and
-          ask if you’re registered.
+        <p>
+          This could be because you haven’t received care at a VA health
+          facility. Or there could be a problem with our records.
         </p>
         <p>
-          <a href="/find-locations/?&facilityType=health">
-            Find your nearest VA health facility
-          </a>
-        </p>
-        <p className="vads-u-margin-y--0">
-          If you’re not enrolled in VA health care, you can apply now.
+          <strong>If you’ve received care at a VA health facility</strong>, call
+          us at <VaTelephone contact="877-327-0022" /> (
+          <VaTelephone contact="800-877-8339" tty />
+          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. Ask
+          the representative to confirm in your records that you’re registered
+          at a VA health facility.
         </p>
         <p>
-          <a href="/health-care/how-to-apply/">
-            Find out how to apply for VA health care
-          </a>
+          <strong>
+            If you haven’t received care at a VA facility and you’ve used My
+            HealtheVet in the past to keep track of your own personal health
+            data
+          </strong>
+          , you can continue to use the previous version of My HealtheVet at
+          this time. Please know that we’ll soon be retiring self-entered data
+          from the My HealtheVet experience.
+        </p>
+        <p>
+          <VaLink
+            href={mhvHomeUrl}
+            text="Go to the previous version of My HealtheVet"
+          />
         </p>
       </div>
     </VaAlert>
@@ -56,14 +64,16 @@ const AlertUnregistered = ({ headline, recordEvent, testId }) => {
 };
 
 AlertUnregistered.defaultProps = {
-  headline: 'You don’t have access to My HealtheVet',
+  headline: 'Our records don’t show any VA health data for you right now',
   recordEvent: recordEventFn,
+  ssoe: false,
   testId: 'mhv-alert--unregistered',
 };
 
 AlertUnregistered.propTypes = {
   headline: PropTypes.string,
   recordEvent: PropTypes.func,
+  ssoe: PropTypes.bool,
   testId: PropTypes.string,
 };
 

--- a/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.jsx
@@ -41,6 +41,10 @@ const AlertUnregistered = ({ headline, recordEvent, ssoe, testId }) => {
           ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. Ask
           the representative to confirm in your records that you’re registered
           at a VA health facility.
+          <strong>
+            They can then help fix the problem or connect you with your facility
+            to register.
+          </strong>
         </p>
         <p>
           <strong>

--- a/src/applications/mhv-landing-page/containers/Alerts.jsx
+++ b/src/applications/mhv-landing-page/containers/Alerts.jsx
@@ -10,6 +10,7 @@ import {
 
 import {
   hasMhvBasicAccount,
+  isAuthenticatedWithSSOe,
   isLOA3,
   isVAPatient,
   mhvAccountStatusUserError,
@@ -25,6 +26,7 @@ const Alerts = () => {
   const userHasMhvBasicAccount = useSelector(hasMhvBasicAccount);
   const renderVerifyAndRegisterAlert = useSelector(showVerifyAndRegisterAlert);
   const cspId = useSelector(signInServiceName);
+  const ssoe = useSelector(isAuthenticatedWithSSOe);
 
   const mhvAccountStatusUserErrors = useSelector(mhvAccountStatusUserError);
   const mhvAccountStatusSortedErrors = useSelector(
@@ -40,7 +42,7 @@ const Alerts = () => {
   }
 
   if (!userRegistered) {
-    return <AlertUnregistered />;
+    return <AlertUnregistered ssoe={ssoe} />;
   }
 
   if (mhvAccountStatusSortedErrors.length > 0) {

--- a/src/applications/mhv-landing-page/tests/e2e/alerts/unregistered.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/alerts/unregistered.cypress.spec.js
@@ -1,10 +1,10 @@
 import { appName } from '../../../manifest.json';
 import ApiInitializer from '../utilities/ApiInitializer';
 import LandingPage from '../pages/LandingPage';
+import AlertUnregistered from '../../../components/alerts/AlertUnregistered';
 
+const { headline } = AlertUnregistered.defaultProps;
 const viewportSizes = ['va-top-desktop-1', 'va-top-mobile-1'];
-
-const noHealthDataHeading = /You don’t have access to My HealtheVet/i;
 
 describe(appName, () => {
   describe('Display content based on patient registration', () => {
@@ -21,9 +21,7 @@ describe(appName, () => {
         cy.injectAxeThenAxeCheck();
 
         // Test that the no health data message is present
-        cy.findByRole('heading', {
-          name: noHealthDataHeading,
-        }).should.exist;
+        cy.findByRole('heading', { name: headline }).should.exist;
 
         // Check the cards are not visible
         cy.findAllByTestId(/^mhv-link-group-card-/).should('not.exist');
@@ -52,9 +50,7 @@ describe(appName, () => {
           .exist;
 
         // Test that the no health data message is NOT present
-        cy.findByRole('heading', {
-          name: noHealthDataHeading,
-        }).should('not.exist');
+        cy.findByRole('heading', { name: headline }).should('not.exist');
       });
     });
   });


### PR DESCRIPTION
## Summary

- **Priority: Urgent**
- Updates copy, link for AlertUnregistered for the mhv-landing-page

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#105097

## Testing done

- local
- unit
- e2e

## Screenshots

**In progress**

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   ![Screenshot 2025-03-12 at 18-08-08 My HealtheVet Veterans Affairs](https://github.com/user-attachments/assets/c4e3a987-82cb-4683-9a19-8bcb659a5e8e)     |    ![Screenshot 2025-03-12 at 18-06-07 My HealtheVet Veterans Affairs](https://github.com/user-attachments/assets/c9b57c51-add1-4a62-8dd6-02fa43fd9fe1)   |
| Desktop |    ![Screenshot 2025-03-12 at 18-07-57 My HealtheVet Veterans Affairs](https://github.com/user-attachments/assets/48e8701f-97c5-4030-ad51-ed3344a3664a)    | ![Screenshot 2025-03-12 at 18-06-24 My HealtheVet Veterans Affairs](https://github.com/user-attachments/assets/f65f3e7a-ca6d-4129-bcd4-50a0970517f9)      |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario
