### PR TITLE
test change to 686c-674 with new selection method for stability review

### DIFF
--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -290,9 +290,9 @@ function main() {
       )
     : [];
 
-  console.log(changedAppsForStressTest);
+  console.log('Changed Apps For Stress Test: ', changedAppsForStressTest);
   const existingTestsToStressTest = allAllowListSpecs.filter(specPath =>
-    changedAppsForStressTest.some(filePath => specPath.includes(`${filePath}`)),
+    changedAppsForStressTest.some(filePath => specPath.includes(filePath)),
   );
 
   const newTestsToStressTest = CHANGED_FILE_PATHS.filter(

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -292,7 +292,12 @@ function main() {
 
   console.log('Changed Apps For Stress Test: ', changedAppsForStressTest);
   const existingTestsToStressTest = allAllowListSpecs.filter(specPath =>
-    changedAppsForStressTest.some(filePath => specPath.includes(filePath)),
+    changedAppsForStressTest.some(
+      filePath =>
+        (!filePath.startsWith('src/applications') &&
+          specPath.includes(filePath)) ||
+        specPath.includes(`${filePath}/`),
+    ),
   );
 
   const newTestsToStressTest = CHANGED_FILE_PATHS.filter(

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -282,11 +282,17 @@ function main() {
   );
 
   const changedAppsForStressTest = CHANGED_FILE_PATHS
-    ? CHANGED_FILE_PATHS.map(filePath =>
-        filePath
-          .split('/')
-          .slice(0, 4)
-          .join('/'),
+    ? CHANGED_FILE_PATHS.map(
+        filePath =>
+          filePath.startsWith('src/applications')
+            ? filePath
+                .split('/')
+                .slice(0, 3)
+                .join('/')
+            : `${filePath
+                .split('/')
+                .slice(0, 3)
+                .join('/')}/`,
       )
     : [];
 

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -290,9 +290,10 @@ function main() {
       )
     : [];
 
+  console.log(changedAppsForStressTest);
   const existingTestsToStressTest = allAllowListSpecs.filter(specPath =>
     changedAppsForStressTest.some(filePath =>
-      specPath.includes(`/${filePath}/`),
+      specPath.includes(`${filePath}/`),
     ),
   );
 

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -285,16 +285,14 @@ function main() {
     ? CHANGED_FILE_PATHS.map(filePath =>
         filePath
           .split('/')
-          .slice(0, 3)
+          .slice(0, 4)
           .join('/'),
       )
     : [];
 
   console.log(changedAppsForStressTest);
   const existingTestsToStressTest = allAllowListSpecs.filter(specPath =>
-    changedAppsForStressTest.some(filePath =>
-      specPath.includes(`${filePath}/`),
-    ),
+    changedAppsForStressTest.some(filePath => specPath.includes(`${filePath}`)),
   );
 
   const newTestsToStressTest = CHANGED_FILE_PATHS.filter(

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -291,7 +291,9 @@ function main() {
     : [];
 
   const existingTestsToStressTest = allAllowListSpecs.filter(specPath =>
-    changedAppsForStressTest.some(filePath => specPath.includes(filePath)),
+    changedAppsForStressTest.some(filePath =>
+      specPath.includes(`/${filePath}/`),
+    ),
   );
 
   const newTestsToStressTest = CHANGED_FILE_PATHS.filter(

--- a/src/applications/686c-674/components/AdditionalEvidence.jsx
+++ b/src/applications/686c-674/components/AdditionalEvidence.jsx
@@ -9,7 +9,7 @@ export const AdditionalEvidence = Component => (
         We can only accept <strong>JPEG, JPG, PNG or PDF</strong> file types
       </li>
       <li>
-        You can upload one or more files, but they have to add up to{' '}
+        You can upload oneee or more files, but they have to add up to{' '}
         <strong>10 MB or less</strong>
       </li>
     </ul>

--- a/src/applications/686c-674/components/AdditionalEvidence.jsx
+++ b/src/applications/686c-674/components/AdditionalEvidence.jsx
@@ -9,7 +9,7 @@ export const AdditionalEvidence = Component => (
         We can only accept <strong>JPEG, JPG, PNG or PDF</strong> file types
       </li>
       <li>
-        You can upload oneee or more files, but they have to add up to{' '}
+        You can upload one or more files, but they have to add up to{' '}
         <strong>10 MB or less</strong>
       </li>
     </ul>


### PR DESCRIPTION
## Summary

- Alter test stability review matching logic to ensure that the app name ends at the end of its matching with a forward slash to avoid extended appnames from falsely matching.

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1335/views/12?pane=issue&itemId=101583276&issue=department-of-veterans-affairs%7Cva.gov-team%7C105029

## Testing done

- Forced a change to 686c-674 app to ensure that with this change only their expected tests ran and not the additional application that was running when they originally reported the issue.

