### PR TITLE
Refactor VA appointment location id

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -271,17 +271,14 @@ export function getVAAppointmentLocationId(appointment) {
   if (
     appointment?.vaos.isVideo &&
     appointment?.vaos.appointmentType === APPOINTMENT_TYPES.vaAppointment &&
-    !isClinicVideoAppointment(appointment)
+    !isClinicVideoAppointment(appointment) &&
+    appointment.location.vistaId === '612'
   ) {
     // 612 doesn't exist in the facilities api, but it's a valid VistA site
     // So, we want to show the facility information for the actual parent location
     // in that system, which is 612A4. This is really only visible for at home
     // video appointments, as the facility we direct users to in order to cancel
-    if (appointment.location.vistaId === '612') {
-      return '612A4';
-    }
-
-    return appointment?.location?.vistaId;
+    return '612A4';
   }
 
   return appointment?.location?.stationId;

--- a/src/applications/vaos/services/appointment/index.unit.spec.js
+++ b/src/applications/vaos/services/appointment/index.unit.spec.js
@@ -16,6 +16,7 @@ import {
   getLongTermAppointmentHistoryV2,
   isUpcomingAppointmentOrRequest,
   isValidPastAppointment,
+  getVAAppointmentLocationId,
 } from '.';
 import {
   APPOINTMENT_STATUS,
@@ -845,6 +846,48 @@ describe('VAOS Services: Appointment ', () => {
       const filtered = hiddenAppts.filter(isUpcomingAppointmentOrRequest);
       expect(hiddenAppts.length).to.equal(2);
       expect(filtered.length).to.equal(0);
+    });
+  });
+
+  describe('getVAAppointmentLocationId', () => {
+    it('should return null for undefined appointment', () => {
+      expect(getVAAppointmentLocationId(undefined)).to.be.null;
+    });
+
+    it('should return 612A4 for Vista Site 612', () => {
+      const appointment = {
+        location: {
+          vistaId: '612',
+          stationId: '612Fake',
+        },
+        videoData: {
+          kind: VIDEO_TYPES.mobile,
+        },
+        vaos: {
+          isUpcomingAppointment: true,
+          isVideo: true,
+          appointmentType: APPOINTMENT_TYPES.vaAppointment,
+        },
+      };
+      expect(getVAAppointmentLocationId(appointment)).to.equal('612A4');
+    });
+
+    it('should return sta6aid for regular appointments', () => {
+      const appointment = {
+        location: {
+          vistaId: '983',
+          stationId: '983GC',
+        },
+        videoData: {
+          kind: VIDEO_TYPES.mobile,
+        },
+        vaos: {
+          isUpcomingAppointment: true,
+          isVideo: true,
+          appointmentType: APPOINTMENT_TYPES.vaAppointment,
+        },
+      };
+      expect(getVAAppointmentLocationId(appointment)).to.equal('983GC');
     });
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR updates appointments to use facility id (sta6aid) instead of vista id (sta3n) as the location id for telehealth appointments
- Details regarding the original bug and how to reproduce it is in the linked issue.
- Appointments tools team
- This is not behind a Flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/97862

## Testing done

- Tested locally, see screenshots
- Added unit tests

## Screenshots

WIP

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    ![image](https://github.com/user-attachments/assets/f99090a6-abc7-42d9-8458-35008ffcef1b)   |   ![image](https://github.com/user-attachments/assets/c46a124f-9ff4-4226-aa62-8667fc1de4e8)   |

## What areas of the site does it impact?

Appointments tools

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

