### PR TITLE
[ART/104061] - update home links

### DIFF
--- a/src/applications/accredited-representative-portal/containers/LandingPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/LandingPage.jsx
@@ -39,14 +39,10 @@ const LandingPage = () => {
             <p>
               <strong>Note</strong>: POA requests need to be submitted using the
               digital{' '}
-              <a
+              <va-link
                 href="https://www.va.gov/get-help-from-accredited-representative/appoint-rep/introduction/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                VA Form 21-22 (opens in a new tab)
-              </a>
-              .
+                text="VA Form 21-22"
+              />
             </p>
           </div>
           <div className="home__content-copy">
@@ -58,13 +54,10 @@ const LandingPage = () => {
               (VSO) representatives who accept POA requests on behalf of their
               organizations. In the future, the portal will support accredited
               VSOs, attorneys, and claims agents.
-              <a
+              <va-link
                 href="https://www.va.gov/resources/va-accredited-representative-faqs/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Learn more about accredited representatives (opens in a new tab)
-              </a>
+                text="Learn more about accredited representatives"
+              />
             </p>
           </div>
 
@@ -84,9 +77,11 @@ const LandingPage = () => {
             <p>
               If you’re interested in having your organization join our test
               program, email us at{' '}
-              <a href="mailto:RepresentativePortalHelp@va.gov">
-                RepresentativePortalHelp@va.gov
-              </a>
+              <va-link
+                class="home__link--email"
+                href="mailto:RepresentativePortalHelp@va.gov"
+                text="RepresentativePortalHelp@va.gov"
+              />
               .
             </p>
           </va-banner>
@@ -103,14 +98,11 @@ const LandingPage = () => {
               Organization (VSO) representative can help you file a claim or
               request a decision review.
             </p>
-            <a
-              href="https://www.va.gov/get-help-from-accredited-representative/"
-              className="home__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Get help from an accredited representative (opens in a new tab)
-            </a>
+            <va-link
+              class="home__link"
+              href="https://www.va.gov/get-help-from-accredited-representative"
+              text="Get help from an accredited representative"
+            />
           </div>
         </div>
       </div>
@@ -136,14 +128,12 @@ const LandingPage = () => {
               the portal. If you’d like to give us feedback, you can sign up to
               be invited to future feedback sessions with our VA research team.
             </p>
-            <a
+            <va-link
+              class="home__link"
+              reverse
               href="https://docs.google.com/forms/d/1VvExHYQWsNgSho5zu9nCgF_l7AYFyun-B6-2EHOr8MA/edit?ts=6759c5e9"
-              className="home__link"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Sign up to participate in feedback sessions (opens in a new tab)
-            </a>
+              text="Sign up to participate in feedback sessions"
+            />
           </div>
         </div>
       </div>

--- a/src/applications/accredited-representative-portal/sass/accredited-representative-portal.scss
+++ b/src/applications/accredited-representative-portal/sass/accredited-representative-portal.scss
@@ -75,12 +75,6 @@
 .home {
   -webkit-font-smoothing: antialiased;
 
-  &__banner {
-    a {
-      word-break: break-all;
-    }
-  }
-
   &__container {
     max-width: 1000px;
     margin: 0 auto;
@@ -172,6 +166,10 @@
 
     .vads-u-background-color--primary & {
       color: $vads-color-base-lightest;
+    }
+
+    &--email {
+      word-break: break-all;
     }
   }
 

--- a/src/applications/accredited-representative-portal/tests/unit/containers/LandingPage.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/containers/LandingPage.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('LandingPage', () => {
         'Who the portal is for',
       );
       expect(getByTestId('landing-page-portal-for-text').textContent).to.eq(
-        'Currently, the portal is only for Veterans Service Organization (VSO) representatives who accept POA requests on behalf of their organizations. In the future, the portal will support accredited VSOs, attorneys, and claims agents.Learn more about accredited representatives (opens in a new tab)',
+        'Currently, the portal is only for Veterans Service Organization (VSO) representatives who accept POA requests on behalf of their organizations. In the future, the portal will support accredited VSOs, attorneys, and claims agents.',
       );
     });
   });


### PR DESCRIPTION
Removing "opens in a new tab" from home page links, see [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104061) 

![image](https://github.com/user-attachments/assets/f589ee7b-e738-433d-885b-adcb006fd27e)
