### PR TITLE
fix: add new jq command to account for double quotes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1936,7 +1936,7 @@ jobs:
           --arg ref "${{ github.ref }}" \
           --arg msg "${{ github.event.head_commit.message }}" \
           --arg entry "${{ needs.build.outputs.entry_names }}" \
-          '{event_type: "cd-production-deploy", client_payload: {github_sha: $sha, github_ref: $ref, github_message: ($msg | split("\n")[0]), entry_app: $entry}}')"     
+          '{event_type: "cd-production-deploy", client_payload: {github_sha: $sha, github_ref: $ref, github_message: ($msg | gsub("\""; "\\\"") | split("\n")[0]), entry_app: $entry}}')"     
                 
   notify-failure:
     name: Notify Failure


### PR DESCRIPTION
## Summary

- Adds gsub command to existing jq logic to account for double quotes in commit messages.

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1335/views/12?pane=issue&itemId=99907755&issue=department-of-veterans-affairs%7Cva.gov-team%7C104147

## Testing done

- Unfortunately impossible to test without this being merged into production.

