### PR TITLE
Dbex 0781ps conflicting error handling

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -521,13 +521,24 @@ export const ALL_BEHAVIOR_CHANGE_DESCRIPTIONS = {
   ...BEHAVIOR_CHANGES_OTHER,
 };
 
+export const BEHAVIOR_LIST_HINTS = Object.freeze({
+  work:
+    'Select any work related behavioral changes you experienced after your traumatic events.',
+  health:
+    'Select any health related behavioral changes you experienced after your traumatic events.',
+  other:
+    'Select any other types of behavioral changes you experienced after your traumatic events.',
+  none:
+    'Select this option if you didn’t experience any behavioral changes after your traumatic events, or prefer not to report them.',
+});
+
 export const SUPPORTING_EVIDENCE_SUBTITLES = Object.freeze({
-  reports: 'Reports about your traumatic events',
+  reports: 'Official reports about traumatic events',
   records: 'Records of receiving care after your traumatic events',
   witness: 'Lay or witness statements (also called buddy statements)',
   other: 'Other supporting documents',
   unlisted: 'Other supporting documents not listed here:',
-  none: 'None',
+  none: 'No supporting documents to include',
 });
 
 export const SUPPORTING_EVIDENCE_REPORT = Object.freeze({
@@ -553,13 +564,15 @@ export const SUPPORTING_EVIDENCE_OTHER = Object.freeze({
   personal: 'Personal diaries or journals',
 });
 
-export const BEHAVIOR_LIST_HINTS = Object.freeze({
-  work:
-    'Select any work related behavioral changes you experienced after your traumatic events.',
-  health:
-    'Select any health related behavioral changes you experienced after your traumatic events.',
+export const SUPPORTING_EVIDENCE_HINTS = Object.freeze({
+  reports: 'Select to include official reports about your traumatic events.',
+  records:
+    'Select to include records of receiving care for your traumatic events.',
+  witness:
+    'Select to include lay or witness statements about your traumatic events.',
   other:
-    'Select any other types of behavioral changes you experienced after your traumatic events.',
+    'Select to include other supporting documents about your traumatic events.',
+  unlisted: 'Other supporting documents not listed here:',
   none:
-    'Select this option if you didn’t experience any behavioral changes after your traumatic events, or prefer not to report them.',
+    'Select this option if you don’t have any supporting documents to include, or prefer not to include them.',
 });

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -463,7 +463,16 @@ export const BEHAVIOR_LIST_SECTION_SUBTITLES = Object.freeze({
 export const TREATMENT_RECEIVED_SUBTITLES = Object.freeze({
   va: 'VA or military treatment providers',
   nonVa: 'Non-VA treatment providers or Vet Centers',
-  none: 'None',
+  none: 'No treatment providers to include',
+});
+
+export const TREATMENT_RECEIVED_HINTS = Object.freeze({
+  va:
+    'Select any VA or military medical provider types where you received treatment for traumatic events.',
+  nonVa:
+    'Select any Non-VA provider types where you received treatment for traumatic events.',
+  none:
+    'Select this option if you didn’t seek treatment for traumatic events with any provider, or prefer not to report them.',
 });
 
 export const TREATMENT_RECEIVED_VA = Object.freeze({

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -457,7 +457,7 @@ export const BEHAVIOR_LIST_SECTION_SUBTITLES = Object.freeze({
   health: 'Behavioral changes related to health',
   other: 'Other behavioral changes',
   unlisted: 'Other behavioral changes not listed here:',
-  none: 'None',
+  none: 'No behavioral changes to include',
 });
 
 export const TREATMENT_RECEIVED_SUBTITLES = Object.freeze({
@@ -551,4 +551,15 @@ export const SUPPORTING_EVIDENCE_WITNESS = Object.freeze({
 
 export const SUPPORTING_EVIDENCE_OTHER = Object.freeze({
   personal: 'Personal diaries or journals',
+});
+
+export const BEHAVIOR_LIST_HINTS = Object.freeze({
+  work:
+    'Select any work related behavioral changes you experienced after your traumatic events.',
+  health:
+    'Select any health related behavioral changes you experienced after your traumatic events.',
+  other:
+    'Select any other types of behavioral changes you experienced after your traumatic events.',
+  none:
+    'Select this option if you didn’t experience any behavioral changes after your traumatic events, or prefer not to report them.',
 });

--- a/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
@@ -173,20 +173,10 @@ export function showConflictingAlert(formData) {
 
 export function validateBehaviorSelections(errors, formData) {
   const isConflicting = showConflictingAlert(formData);
-  const selections = selectedBehaviorSections(formData);
 
-  // add error with no message to each checked section
+  // add error message to none checkbox if conflict exists
   if (isConflicting === true) {
     errors['view:noneCheckbox'].addError(' ');
-    if (selections.workBehaviors === true) {
-      errors.workBehaviors.addError(' ');
-    }
-    if (selections.healthBehaviors === true) {
-      errors.healthBehaviors.addError(' ');
-    }
-    if (selections.otherBehaviors === true) {
-      errors.otherBehaviors.addError(' ');
-    }
   }
 }
 

--- a/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
@@ -176,7 +176,9 @@ export function validateBehaviorSelections(errors, formData) {
 
   // add error message to none checkbox if conflict exists
   if (isConflicting === true) {
-    errors['view:noneCheckbox'].addError(' ');
+    errors['view:noneCheckbox'].addError(
+      'If you select no behavioral changes to include, unselect other behavioral changes before continuing.',
+    );
   }
 }
 

--- a/src/applications/disability-benefits/all-claims/content/form0781/supportingEvidencePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/supportingEvidencePage.jsx
@@ -79,16 +79,6 @@ export const supportingEvidenceAdditionalInformation = (
 export const supportingEvidenceNoneLabel =
   'I don’t have any supporting documents to submit.';
 
-export const supportingEvidenceValidationError = (
-  <va-alert status="error" uswds>
-    <p className="vads-u-font-size--base">
-      You selected one or more types of reports for this event, but you also
-      selected ‘I don’t have any supporting documents to submit.’
-    </p>
-    <p>Revise your selection so they don’t conflict to continue.</p>
-  </va-alert>
-);
-
 /**
  * Returns true if 'none' selected, false otherwise
  * @param {object} formData
@@ -183,22 +173,11 @@ export function showConflictingAlert(formData) {
 
 export function validateSupportingEvidenceSelections(errors, formData) {
   const isConflicting = showConflictingAlert(formData);
-  const selections = selectedDocumentsSections(formData);
 
-  // add error with no message to each checked section
+  // add error message to none checkbox if conflict exists
   if (isConflicting === true) {
-    errors.supportingEvidenceNoneCheckbox.addError(' ');
-    if (selections.supportingEvidenceReports === true) {
-      errors.supportingEvidenceReports.addError(' ');
-    }
-    if (selections.supportingEvidenceRecords === true) {
-      errors.supportingEvidenceRecords.addError(' ');
-    }
-    if (selections.supportingEvidenceWitness === true) {
-      errors.supportingEvidenceWitness.addError(' ');
-    }
-    if (selections.supportingEvidenceOther === true) {
-      errors.supportingEvidenceOther.addError(' ');
-    }
+    errors.supportingEvidenceNoneCheckbox.addError(
+      'If you select no supporting documents to include, unselect other supporting documents before continuing.',
+    );
   }
 }

--- a/src/applications/disability-benefits/all-claims/content/form0781/treatmentReceivedPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/treatmentReceivedPage.jsx
@@ -95,7 +95,7 @@ export function showConflictingAlert(formData) {
 export function validateProviders(errors, formData) {
   const isConflicting = showConflictingAlert(formData);
 
-  // add error message to none checkbox
+  // add error message to none checkbox if conflict exists
   if (isConflicting === true) {
     errors['view:treatmentNoneCheckbox'].addError(
       'If you select no treatment providers to include, unselect other treatment providers before continuing.',

--- a/src/applications/disability-benefits/all-claims/content/form0781/treatmentReceivedPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/treatmentReceivedPage.jsx
@@ -10,8 +10,8 @@ export const treatmentReceivedDescription = (
       of your traumatic events including any behavioral changes you experienced.
     </p>
     <p>
-      If you didn’t receive any treatment for your traumatic events, select{' '}
-      <strong>‘I didn’t receive treatment for my traumatic events.’</strong>
+      You may not have received treatment for your traumatic events. It’s OK if
+      you don’t report receiving treatment at any provider.
     </p>
     <p>
       You’ll be able to upload or request records from these treatment providers
@@ -22,16 +22,6 @@ export const treatmentReceivedDescription = (
 
 export const treatmentReceivedNoneLabel =
   'I didn’t receive treatment for my traumatic events.';
-
-export const providerListValidationError = (
-  <va-alert status="error" uswds>
-    <p className="vads-u-font-size--base">
-      You selected one or more types of reports for this event, but you also
-      selected ‘I don’t have any supporting documents to submit.’
-    </p>
-    <p>Revise your selection so they don’t conflict to continue.</p>
-  </va-alert>
-);
 
 /**
  * Returns true if 'none' selected, false otherwise
@@ -104,16 +94,11 @@ export function showConflictingAlert(formData) {
 
 export function validateProviders(errors, formData) {
   const isConflicting = showConflictingAlert(formData);
-  const selections = treatmentReceivedSections(formData);
 
-  // add error with no message to each checked section
+  // add error message to none checkbox
   if (isConflicting === true) {
-    errors['view:treatmentNoneCheckbox'].addError(' ');
-    if (selections.treatmentReceivedVaProvider === true) {
-      errors.treatmentReceivedVaProvider.addError(' ');
-    }
-    if (selections.treatmentReceivedNonVaProvider === true) {
-      errors.treatmentReceivedNonVaProvider.addError(' ');
-    }
+    errors['view:treatmentNoneCheckbox'].addError(
+      'If you select no treatment providers to include, unselect other treatment providers before continuing.',
+    );
   }
 }

--- a/src/applications/disability-benefits/all-claims/pages/form0781/behaviorListPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/behaviorListPage.js
@@ -14,11 +14,10 @@ import {
   behaviorListAdditionalInformation,
   behaviorListPageTitle,
   validateBehaviorSelections,
-  behaviorListValidationError,
-  showConflictingAlert,
 } from '../../content/form0781/behaviorListPages';
 import {
   BEHAVIOR_LIST_SECTION_SUBTITLES,
+  BEHAVIOR_LIST_HINTS,
   BEHAVIOR_CHANGES_WORK,
   BEHAVIOR_CHANGES_HEALTH,
   BEHAVIOR_CHANGES_OTHER,
@@ -27,15 +26,10 @@ import {
 export const uiSchema = {
   'ui:title': titleWithTag(behaviorListPageTitle, form0781HeadingTag),
   'ui:description': behaviorListDescription,
-  'view:conflictingResponseAlert': {
-    'ui:description': behaviorListValidationError,
-    'ui:options': {
-      hideIf: formData => showConflictingAlert(formData) === false,
-    },
-  },
   workBehaviors: checkboxGroupUI({
     title: BEHAVIOR_LIST_SECTION_SUBTITLES.work,
     labelHeaderLevel: '4',
+    hint: BEHAVIOR_LIST_HINTS.work,
     labels: {
       ...BEHAVIOR_CHANGES_WORK,
     },
@@ -44,6 +38,7 @@ export const uiSchema = {
   healthBehaviors: checkboxGroupUI({
     title: BEHAVIOR_LIST_SECTION_SUBTITLES.health,
     labelHeaderLevel: '4',
+    hint: BEHAVIOR_LIST_HINTS.health,
     labels: {
       ...BEHAVIOR_CHANGES_HEALTH,
     },
@@ -52,6 +47,7 @@ export const uiSchema = {
   otherBehaviors: checkboxGroupUI({
     title: BEHAVIOR_LIST_SECTION_SUBTITLES.other,
     labelHeaderLevel: '4',
+    hint: BEHAVIOR_LIST_HINTS.other,
     labels: {
       ...BEHAVIOR_CHANGES_OTHER,
     },
@@ -63,6 +59,7 @@ export const uiSchema = {
   'view:noneCheckbox': checkboxGroupUI({
     title: BEHAVIOR_LIST_SECTION_SUBTITLES.none,
     labelHeaderLevel: '4',
+    hint: BEHAVIOR_LIST_HINTS.none,
     labels: {
       none: behaviorListNoneLabel,
     },

--- a/src/applications/disability-benefits/all-claims/pages/form0781/supportingEvidencePage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/supportingEvidencePage.js
@@ -11,8 +11,6 @@ import {
   supportingEvidencePageTitle,
   validateSupportingEvidenceSelections,
   supportingEvidenceBuddyStatement,
-  supportingEvidenceValidationError,
-  showConflictingAlert,
 } from '../../content/form0781/supportingEvidencePage';
 import {
   SUPPORTING_EVIDENCE_SUBTITLES,
@@ -20,20 +18,16 @@ import {
   SUPPORTING_EVIDENCE_RECORD,
   SUPPORTING_EVIDENCE_WITNESS,
   SUPPORTING_EVIDENCE_OTHER,
+  SUPPORTING_EVIDENCE_HINTS,
 } from '../../constants';
 
 export const uiSchema = {
   'ui:title': titleWithTag(supportingEvidencePageTitle, form0781HeadingTag),
   'ui:description': supportingEvidenceDescription,
-  'view:conflictingResponseAlert': {
-    'ui:description': supportingEvidenceValidationError,
-    'ui:options': {
-      hideIf: formData => showConflictingAlert(formData) === false,
-    },
-  },
   supportingEvidenceReports: checkboxGroupUI({
     title: SUPPORTING_EVIDENCE_SUBTITLES.reports,
     labelHeaderLevel: '4',
+    hint: SUPPORTING_EVIDENCE_HINTS.reports,
     labels: {
       ...SUPPORTING_EVIDENCE_REPORT,
     },
@@ -42,6 +36,7 @@ export const uiSchema = {
   supportingEvidenceRecords: checkboxGroupUI({
     title: SUPPORTING_EVIDENCE_SUBTITLES.records,
     labelHeaderLevel: '4',
+    hint: SUPPORTING_EVIDENCE_HINTS.records,
     labels: {
       ...SUPPORTING_EVIDENCE_RECORD,
     },
@@ -50,6 +45,7 @@ export const uiSchema = {
   supportingEvidenceWitness: checkboxGroupUI({
     title: SUPPORTING_EVIDENCE_SUBTITLES.witness,
     labelHeaderLevel: '4',
+    hint: SUPPORTING_EVIDENCE_HINTS.witness,
     labels: {
       ...SUPPORTING_EVIDENCE_WITNESS,
     },
@@ -58,6 +54,7 @@ export const uiSchema = {
   supportingEvidenceOther: checkboxGroupUI({
     title: SUPPORTING_EVIDENCE_SUBTITLES.other,
     labelHeaderLevel: '4',
+    hint: SUPPORTING_EVIDENCE_HINTS.other,
     labels: {
       ...SUPPORTING_EVIDENCE_OTHER,
     },
@@ -69,6 +66,7 @@ export const uiSchema = {
   supportingEvidenceNoneCheckbox: checkboxGroupUI({
     title: SUPPORTING_EVIDENCE_SUBTITLES.none,
     labelHeaderLevel: '4',
+    hint: SUPPORTING_EVIDENCE_HINTS.none,
     labels: {
       none: supportingEvidenceNoneLabel,
     },

--- a/src/applications/disability-benefits/all-claims/pages/form0781/treatmentReceivedPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/treatmentReceivedPage.js
@@ -8,11 +8,10 @@ import {
   treatmentReceivedNoneLabel,
   treatmentReceivedTitle,
   validateProviders,
-  providerListValidationError,
-  showConflictingAlert,
 } from '../../content/form0781/treatmentReceivedPage';
 import {
   TREATMENT_RECEIVED_SUBTITLES,
+  TREATMENT_RECEIVED_HINTS,
   TREATMENT_RECEIVED_VA,
   TREATMENT_RECEIVED_NON_VA,
 } from '../../constants';
@@ -20,15 +19,10 @@ import {
 export const uiSchema = {
   'ui:title': titleWithTag(treatmentReceivedTitle, form0781HeadingTag),
   'ui:description': treatmentReceivedDescription,
-  'view:conflictingResponseAlert': {
-    'ui:description': providerListValidationError,
-    'ui:options': {
-      hideIf: formData => showConflictingAlert(formData) === false,
-    },
-  },
   treatmentReceivedVaProvider: checkboxGroupUI({
     title: TREATMENT_RECEIVED_SUBTITLES.va,
     labelHeaderLevel: '4',
+    hint: TREATMENT_RECEIVED_HINTS.va,
     labels: {
       ...TREATMENT_RECEIVED_VA,
     },
@@ -37,6 +31,7 @@ export const uiSchema = {
   treatmentReceivedNonVaProvider: checkboxGroupUI({
     title: TREATMENT_RECEIVED_SUBTITLES.nonVa,
     labelHeaderLevel: '4',
+    hint: TREATMENT_RECEIVED_HINTS.nonVa,
     labels: {
       ...TREATMENT_RECEIVED_NON_VA,
     },
@@ -45,6 +40,7 @@ export const uiSchema = {
   'view:treatmentNoneCheckbox': checkboxGroupUI({
     title: TREATMENT_RECEIVED_SUBTITLES.none,
     labelHeaderLevel: '4',
+    hint: TREATMENT_RECEIVED_HINTS.none,
     labels: {
       none: treatmentReceivedNoneLabel,
     },

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
@@ -141,7 +141,7 @@ describe('validating selections', () => {
       healthBehaviors: { addError: sinon.spy() },
       otherBehaviors: { addError: sinon.spy() },
     };
-    it('should not add errors when none is selected and with no other selected behaviors', () => {
+    it('should not add errors when none is selected with no other selected behaviors', () => {
       const formData = {
         syncModern0781Flow: true,
         workBehaviors: {

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
@@ -108,7 +108,7 @@ describe('validating selections', () => {
       healthBehaviors: { addError: sinon.spy() },
       otherBehaviors: { addError: sinon.spy() },
     };
-    it('should show alert and add errors when none and behaviors are selected', () => {
+    it('should add error to the none checkbox when none and behaviors are selected', () => {
       const formData = {
         syncModern0781Flow: true,
         workBehaviors: {
@@ -124,9 +124,9 @@ describe('validating selections', () => {
       validateBehaviorSelections(errors, formData);
 
       // errors
-      expect(errors.workBehaviors.addError.called).to.be.true;
+      expect(errors.workBehaviors.addError.called).to.be.false;
       expect(errors.healthBehaviors.addError.called).to.be.false;
-      expect(errors.otherBehaviors.addError.called).to.be.true;
+      expect(errors.otherBehaviors.addError.called).to.be.false;
       expect(errors['view:noneCheckbox'].addError.called).to.be.true;
 
       // alert

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/behaviorListPage.unit.spec.js
@@ -123,14 +123,12 @@ describe('validating selections', () => {
 
       validateBehaviorSelections(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.true;
+
       expect(errors.workBehaviors.addError.called).to.be.false;
       expect(errors.healthBehaviors.addError.called).to.be.false;
       expect(errors.otherBehaviors.addError.called).to.be.false;
       expect(errors['view:noneCheckbox'].addError.called).to.be.true;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.true;
     });
   });
 
@@ -143,7 +141,7 @@ describe('validating selections', () => {
       healthBehaviors: { addError: sinon.spy() },
       otherBehaviors: { addError: sinon.spy() },
     };
-    it('should not show alert or add errors when none is selected and with no other selected behaviors', () => {
+    it('should not add errors when none is selected and with no other selected behaviors', () => {
       const formData = {
         syncModern0781Flow: true,
         workBehaviors: {
@@ -155,17 +153,15 @@ describe('validating selections', () => {
 
       validateBehaviorSelections(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.false;
+
       expect(errors.workBehaviors.addError.called).to.be.false;
       expect(errors.healthBehaviors.addError.called).to.be.false;
       expect(errors.otherBehaviors.addError.called).to.be.false;
       expect(errors['view:noneCheckbox'].addError.called).to.be.false;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.false;
     });
 
-    it('should not show alert or add errors when none is unselected and behaviors are selected', () => {
+    it('should add errors when none is unselected and behaviors are selected', () => {
       const formData = {
         syncModern0781Flow: true,
         workBehaviors: {
@@ -177,14 +173,12 @@ describe('validating selections', () => {
 
       validateBehaviorSelections(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.false;
+
       expect(errors.workBehaviors.addError.called).to.be.false;
       expect(errors.healthBehaviors.addError.called).to.be.false;
       expect(errors.otherBehaviors.addError.called).to.be.false;
       expect(errors['view:noneCheckbox'].addError.called).to.be.false;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/supportingEvidencePage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/supportingEvidencePage.unit.spec.js
@@ -140,15 +140,13 @@ describe('validating selections', () => {
 
       validateSupportingEvidenceSelections(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.true;
+
       expect(errors.supportingEvidenceReports.addError.called).to.be.false;
       expect(errors.supportingEvidenceRecords.addError.called).to.be.false;
       expect(errors.supportingEvidenceWitness.addError.called).to.be.false;
       expect(errors.supportingEvidenceOther.addError.called).to.be.false;
       expect(errors.supportingEvidenceNoneCheckbox.addError.called).to.be.true;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.true;
     });
   });
 
@@ -163,7 +161,7 @@ describe('validating selections', () => {
       supportingEvidenceOther: { addError: sinon.spy() },
       supportingEvidenceUnlisted: { addError: sinon.spy() },
     };
-    it('should not show alert or add errors when none is selected and with no other selected supporting evidence', () => {
+    it('should not add errors when none is selected and with no other selected supporting evidence', () => {
       const formData = {
         syncModern0781Flow: true,
         supportingEvidenceReports: {
@@ -175,18 +173,17 @@ describe('validating selections', () => {
 
       validateSupportingEvidenceSelections(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.false;
+
       expect(errors.supportingEvidenceReports.addError.called).to.be.false;
       expect(errors.supportingEvidenceRecords.addError.called).to.be.false;
       expect(errors.supportingEvidenceWitness.addError.called).to.be.false;
       expect(errors.supportingEvidenceOther.addError.called).to.be.false;
       expect(errors.supportingEvidenceNoneCheckbox.addError.called).to.be.false;
       expect(errors.supportingEvidenceUnlisted.addError.called).to.be.false;
-      // alert
-      expect(showConflictingAlert(formData)).to.be.false;
     });
 
-    it('should not show alert or add errors when none is unselected and supporting evidence is selected', () => {
+    it('should not add errors when none is unselected and supporting evidence is selected', () => {
       const formData = {
         syncModern0781Flow: true,
         supportingEvidenceReports: {
@@ -197,16 +194,14 @@ describe('validating selections', () => {
 
       validateSupportingEvidenceSelections(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.false;
+
       expect(errors.supportingEvidenceReports.addError.called).to.be.false;
       expect(errors.supportingEvidenceRecords.addError.called).to.be.false;
       expect(errors.supportingEvidenceWitness.addError.called).to.be.false;
       expect(errors.supportingEvidenceOther.addError.called).to.be.false;
       expect(errors.supportingEvidenceNoneCheckbox.addError.called).to.be.false;
       expect(errors.supportingEvidenceUnlisted.addError.called).to.be.false;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/supportingEvidencePage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/supportingEvidencePage.unit.spec.js
@@ -114,7 +114,7 @@ describe('validating selections', () => {
       supportingEvidenceOther: { addError: sinon.spy() },
       supportingEvidenceUnlisted: { addError: sinon.spy() },
     };
-    it('should show alert and add errors when none and supporting evidence is selected', () => {
+    it('should add error to the none checkbox when none and supporting evidence is selected', () => {
       const formData = {
         syncModern0781Flow: true,
         supportingEvidenceReports: {
@@ -141,10 +141,10 @@ describe('validating selections', () => {
       validateSupportingEvidenceSelections(errors, formData);
 
       // errors
-      expect(errors.supportingEvidenceReports.addError.called).to.be.true;
+      expect(errors.supportingEvidenceReports.addError.called).to.be.false;
       expect(errors.supportingEvidenceRecords.addError.called).to.be.false;
-      expect(errors.supportingEvidenceWitness.addError.called).to.be.true;
-      expect(errors.supportingEvidenceOther.addError.called).to.be.true;
+      expect(errors.supportingEvidenceWitness.addError.called).to.be.false;
+      expect(errors.supportingEvidenceOther.addError.called).to.be.false;
       expect(errors.supportingEvidenceNoneCheckbox.addError.called).to.be.true;
 
       // alert

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/treatmentReceivedPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/treatmentReceivedPage.unit.spec.js
@@ -103,7 +103,7 @@ describe('validating selections', () => {
       treatmentReceivedNonVaProvider: { addError: sinon.spy() },
       treatmentReceivedVaProvider: { addError: sinon.spy() },
     };
-    it('should an error to the none checkbox when none and providers are selected', () => {
+    it('should add error to the none checkbox when none and providers are selected', () => {
       const formData = {
         syncModern0781Flow: true,
         treatmentReceivedNonVaProvider: {
@@ -121,13 +121,11 @@ describe('validating selections', () => {
 
       validateProviders(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.true;
+
       expect(errors.treatmentReceivedNonVaProvider.addError.called).to.be.false;
       expect(errors.treatmentReceivedVaProvider.addError.called).to.be.false;
       expect(errors['view:treatmentNoneCheckbox'].addError.called).to.be.true;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.true;
     });
   });
 
@@ -139,7 +137,7 @@ describe('validating selections', () => {
       treatmentReceivedNonVaProvider: { addError: sinon.spy() },
       treatmentReceivedVaProvider: { addError: sinon.spy() },
     };
-    it('should not show alert or add errors when none is selected and with no other selected providers', () => {
+    it('should not add errors when none is selected and with no other selected providers', () => {
       const formData = {
         syncModern0781Flow: true,
         treatmentReceivedNonVaProvider: {
@@ -151,16 +149,14 @@ describe('validating selections', () => {
 
       validateProviders(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.false;
+
       expect(errors.treatmentReceivedVaProvider.addError.called).to.be.false;
       expect(errors.treatmentReceivedNonVaProvider.addError.called).to.be.false;
       expect(errors['view:treatmentNoneCheckbox'].addError.called).to.be.false;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.false;
     });
 
-    it('should not show alert or add errors when none is unselected and providers are selected', () => {
+    it('should not add errors when none is unselected and providers are selected', () => {
       const formData = {
         syncModern0781Flow: true,
         treatmentReceivedNonVaProvider: {
@@ -172,13 +168,11 @@ describe('validating selections', () => {
 
       validateProviders(errors, formData);
 
-      // errors
+      expect(showConflictingAlert(formData)).to.be.false;
+
       expect(errors.treatmentReceivedVaProvider.addError.called).to.be.false;
       expect(errors.treatmentReceivedNonVaProvider.addError.called).to.be.false;
       expect(errors['view:treatmentNoneCheckbox'].addError.called).to.be.false;
-
-      // alert
-      expect(showConflictingAlert(formData)).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/treatmentReceivedPage.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/treatmentReceivedPage.unit.spec.js
@@ -103,7 +103,7 @@ describe('validating selections', () => {
       treatmentReceivedNonVaProvider: { addError: sinon.spy() },
       treatmentReceivedVaProvider: { addError: sinon.spy() },
     };
-    it('should show alert and add errors when none and providers are selected', () => {
+    it('should an error to the none checkbox when none and providers are selected', () => {
       const formData = {
         syncModern0781Flow: true,
         treatmentReceivedNonVaProvider: {
@@ -122,7 +122,7 @@ describe('validating selections', () => {
       validateProviders(errors, formData);
 
       // errors
-      expect(errors.treatmentReceivedNonVaProvider.addError.called).to.be.true;
+      expect(errors.treatmentReceivedNonVaProvider.addError.called).to.be.false;
       expect(errors.treatmentReceivedVaProvider.addError.called).to.be.false;
       expect(errors['view:treatmentNoneCheckbox'].addError.called).to.be.true;
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
These changes have been made to reflect the new design for handling conflicting error messages.

- _(What is the solution, why is this the solution)_
The new design removes the conflicting error alert from the top of the page and shows an inline message on the checkbox section instead. Hint text has also been added, and some updated content.

- _(Which team do you work for, does your team own the maintenance of this component?)_
DBEX Team 2 Carbs
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
`sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/104596
https://github.com/department-of-veterans-affairs/va.gov-team/issues/104598
https://github.com/department-of-veterans-affairs/va.gov-team/issues/104597

## Testing done

- _Describe what the old behavior was prior to the change_
The previous design for handling conflicting errors was to show an alert message on the top of the page, while adding errors to each checkbox section. 
- _Describe the steps required to verify your changes are working as expected_
Within the modern 0781 flow, navigate to each page and select the 'none' checkbox and any other checkbox, then verify:
   - The error message should display only in the "none" section 
   - Focus is on the error 
   - The user cannot continue until the conflict is resolved 
   - The error displays until the conflict is resolved 

- _Describe the tests completed and the results_:  The corresponding specs are updated with the new behavior. Manually tested each page
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| **Behavioral changes**  | ![Screenshot 2025-03-14 at 9 56 56 AM](https://github.com/user-attachments/assets/5667be52-6ee9-4571-a5dc-6fa624d34420) | ![Screenshot 2025-03-17 at 12 01 13 PM](https://github.com/user-attachments/assets/e8f8467d-d188-4903-8fbc-b61017fb816b) |
| **Treatment providers** | ![Screenshot 2025-03-14 at 9 35 54 AM](https://github.com/user-attachments/assets/c6418fec-caa9-4aa2-8dcd-224015843fe6) |  ![Screenshot 2025-03-14 at 12 54 53 PM](https://github.com/user-attachments/assets/61d69b83-6490-4328-a93f-e6484519ce84) |
| **Supporting docs** | ![Screenshot 2025-03-14 at 12 23 38 PM](https://github.com/user-attachments/assets/2de243fc-e87e-4d5e-baf5-78742a812016) | ![Screenshot 2025-03-14 at 12 41 41 PM](https://github.com/user-attachments/assets/3c40f0da-95c9-42c5-854c-65187934ecab) ![Screenshot 2025-03-14 at 12 41 28 PM](https://github.com/user-attachments/assets/0131a571-af43-4448-afa9-cc75221bcfa3) |



## What areas of the site does it impact?

Form 0781

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
