### PR TITLE
VACMS-20814 Find Forms: add helper text for DD214 searches

### DIFF
--- a/src/applications/static-pages/find-forms/containers/SearchResults.jsx
+++ b/src/applications/static-pages/find-forms/containers/SearchResults.jsx
@@ -61,6 +61,8 @@ export const SearchResults = ({
   };
 
   const [modalState, setModalState] = useState(initialModalState);
+  const dd214Matcher = new RegExp(/dd-?214/i);
+  const queryIsDd214 = dd214Matcher.test(query);
 
   useEffect(() => {
     const justRefreshed = prevProps?.fetching && !fetching;
@@ -136,20 +138,31 @@ export const SearchResults = ({
 
   if (!results.length) {
     return (
-      <p
-        className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
-        vads-u-margin-top--1p5 vads-u-font-weight--normal va-u-outline--none"
-        data-forms-focus
-      >
-        No results were found for "<strong>{query}</strong>
-        ." Try using fewer words or broadening your search. If you’re looking
-        for non-VA forms, go to the{' '}
-        <va-link
-          href="https://www.gsa.gov/reference/forms"
-          text="GSA Forms Library"
-        />
-        .
-      </p>
+      <>
+        <p
+          className="vads-u-line-height--3 vads-u-margin-top--1p5 va-u-outline--none"
+          data-e2e-id="ff-no-results"
+          data-forms-focus
+        >
+          No results were found for "<strong>{query}</strong>
+          ." Try using fewer words or broadening your search. If you’re looking
+          for non-VA forms, go to the{' '}
+          <va-link
+            href="https://www.gsa.gov/reference/forms"
+            text="GSA Forms Library"
+          />
+          .
+        </p>
+        {queryIsDd214 && (
+          <p>
+            <va-link
+              data-e2e-id="ff-no-results-dd214"
+              href="https://www.va.gov/records/get-military-service-records/"
+              text="Need to request your military records including DD214?"
+            />
+          </p>
+        )}
+      </>
     );
   }
 

--- a/src/applications/static-pages/find-forms/tests/cypress/find-forms-results.cypress.spec.js
+++ b/src/applications/static-pages/find-forms/tests/cypress/find-forms-results.cypress.spec.js
@@ -12,7 +12,7 @@ describe('find forms search results', () => {
     h.clickSearch();
 
     cy.wait('@getFindAForm');
-    cy.get(h.SEARCH_RESULT_TITLE).should('exist');
+    h.verifyElementExists(h.SEARCH_RESULT_TITLE);
 
     h.validateSearchResult(
       '10-252',
@@ -59,6 +59,41 @@ describe('find forms search results', () => {
       .get('option')
       .should('be.selected')
       .should('contain', FAF_SORT_OPTIONS[0]);
+  });
+
+  it('shows proper no results messaging for non-DD214 searches', () => {
+    cy.intercept('GET', '/v0/forms?query=invalid', { data: [] }).as(
+      'getFindAForm',
+    );
+    cy.visit('/find-forms/?q=invalid');
+    cy.injectAxeThenAxeCheck();
+    cy.wait('@getFindAForm');
+
+    h.verifyElementShouldContainText(
+      h.NO_RESULTS,
+      `No results were found for "invalid." Try using fewer words or broadening your search. If you’re looking for non-VA forms, go to the .`,
+    );
+
+    h.verifyElementDoesNotExist(h.NO_RESULTS_DD214);
+  });
+
+  it('shows proper no results messaging for DD214', () => {
+    cy.intercept('GET', '/v0/forms?query=dd214', { data: [] }).as(
+      'getFindAForm',
+    );
+    cy.visit('/find-forms/?q=dd214');
+    cy.injectAxeThenAxeCheck();
+    cy.wait('@getFindAForm');
+
+    h.verifyElementShouldContainText(
+      h.NO_RESULTS,
+      `No results were found for "dd214." Try using fewer words or broadening your search. If you’re looking for non-VA forms, go to the .`,
+    );
+
+    h.verifyTextInsideLink(
+      h.NO_RESULTS_DD214,
+      'Need to request your military records including DD214?',
+    );
   });
 
   it('opens PDF modal', () => {

--- a/src/applications/static-pages/find-forms/tests/cypress/helpers.js
+++ b/src/applications/static-pages/find-forms/tests/cypress/helpers.js
@@ -13,6 +13,8 @@ export const MODAL_DOWNLOAD_LINK = '[data-e2e-id="modal-download-link"]';
 export const MODAL_CLOSE_BUTTON = '.va-modal-close';
 export const MODAL = 'va-modal';
 export const FORM_DETAIL_HEADER = '[data-testid="va_form--downloadable-pdf"]';
+export const NO_RESULTS = '[data-e2e-id="ff-no-results"]';
+export const NO_RESULTS_DD214 = '[data-e2e-id="ff-no-results-dd214"]';
 
 export const goToNextPage = () =>
   cy
@@ -132,3 +134,28 @@ export const validateSearchResult = (
       .and('be.visible');
   }
 };
+
+export const verifyElementExists = selector =>
+  cy
+    .get(selector)
+    .should('exist')
+    .and('be.visible');
+
+export const verifyElementShouldContainText = (selector, text) =>
+  cy
+    .get(selector)
+    .should('exist')
+    .and('be.visible')
+    .and('contain.text', text);
+
+export const verifyTextInsideLink = (selector, text) =>
+  cy
+    .get(selector)
+    .eq(0)
+    .shadow()
+    .find('a')
+    .should('exist')
+    .and('have.text', text);
+
+export const verifyElementDoesNotExist = selector =>
+  cy.get(selector).should('not.exist');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

When a user searches for "dd214" (any capitalization variant and with or without a dash between dd and 214) in Find Forms, we want to show an extra link under the "no results" messaging to properly guide the user to the place where they can request this form.


<img width="500" alt="Screenshot 2025-03-17 at 11 26 57 AM" src="https://github.com/user-attachments/assets/65b24731-1d07-4d39-a2bb-bf63f9b4b0c1" />

<img width="500" alt="Screenshot 2025-03-17 at 11 27 04 AM" src="https://github.com/user-attachments/assets/451edc09-f226-4ef4-815d-16a7e9969735" />

<img width="500" alt="Screenshot 2025-03-17 at 11 27 11 AM" src="https://github.com/user-attachments/assets/24d615f4-2be1-4e56-b320-736e72030ddc" />
<img width="500" alt="Screenshot 2025-03-17 at 2 32 37 PM" src="https://github.com/user-attachments/assets/7fd02560-b260-4d7e-a425-da2f65ba06d0" />
<img width="500" alt="Screenshot 2025-03-17 at 2 31 00 PM" src="https://github.com/user-attachments/assets/917c40b8-6cfb-4918-a342-7f1a2ef2722e" />
<img width="500" alt="Screenshot 2025-03-17 at 2 30 54 PM" src="https://github.com/user-attachments/assets/48b8d993-7729-4fb5-afb5-b7574388d83d" />
<img width="500" alt="Screenshot 2025-03-17 at 2 30 47 PM" src="https://github.com/user-attachments/assets/13141b58-36e9-4e06-be50-3699eb006e4a" />

<hr />

The new link should only appear when a variant of "dd214" is searched. When any other search term that does not return results is searched, we do not show the link.

<img width="500" alt="Screenshot 2025-03-17 at 11 27 21 AM" src="https://github.com/user-attachments/assets/b470aba7-0a04-43a6-9dae-b3057e0b2e25" />

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20814

## Testing done

Tested various searches at `/find-forms`.