### PR TITLE
VACMS-18078 Homepage Email Signup: remove custom styling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -139,6 +139,7 @@ src/applications/static-pages/BTSSS-login @department-of-veterans-affairs/vfs-pu
 src/applications/static-pages/events @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/find-forms @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/homepage @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/static-pages/homepage-email-signup @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/homepage-veteran-banner @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/i18select @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/resources-and-support @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend

--- a/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
+++ b/src/applications/static-pages/homepage-email-signup/EmailSignup.jsx
@@ -85,7 +85,7 @@ const EmailSignup = () => {
   };
 
   return (
-    <div className="email-signup-form form-panel">
+    <div className="email-signup-form">
       <form
         acceptCharset="UTF-8"
         action="https://public.govdelivery.com/accounts/USVACHOOSE/subscribers/qualify"
@@ -129,7 +129,7 @@ const EmailSignup = () => {
         />
         <va-button
           disable-analytics
-          class="vads-u-width--auto vads-u-margin-bottom--2 vads-u-margin-top--1p5"
+          class="vads-u-margin-y--2p5"
           onClick={event => {
             event.preventDefault();
             onSignup();

--- a/src/applications/static-pages/homepage-email-signup/email-signup.scss
+++ b/src/applications/static-pages/homepage-email-signup/email-signup.scss
@@ -1,17 +1,10 @@
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/mixins";
 
 .email-signup-form {
-  &.form-panel {
-    margin: 0 auto;
+  margin: 0 auto;
+  max-width: 30rem;
 
-    @media screen and (max-width: 767px) {
-      max-width: 30rem;
-    }
-  }
-
-  #email-signup-form {
-    .homepage-email-input::part(form-header) {
-      font-size: 1.25rem;
-    }
+  @media screen and (min-width: $medium-screen) {
+    max-width: 34rem;
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Remove custom styling from email signup component per UX/a11y request.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18078

## Testing done / screenshots

Tested on the homepage.

### 320px
<img width="319" alt="Screenshot 2025-03-17 at 12 32 43 PM" src="https://github.com/user-attachments/assets/87b27f45-dd5e-4448-a027-a0fdda6f656f" />

### 480px
<img width="480" alt="Screenshot 2025-03-17 at 12 32 56 PM" src="https://github.com/user-attachments/assets/c84d21d7-df9b-41b1-bc52-5b2dc8dc0600" />

### 767px
<img width="767" alt="Screenshot 2025-03-17 at 12 36 25 PM" src="https://github.com/user-attachments/assets/e0b2b339-d39d-45e0-8de2-c74d09453ee8" />

### 768px
<img width="767" alt="Screenshot 2025-03-17 at 12 36 39 PM" src="https://github.com/user-attachments/assets/b4f7106b-1321-4d53-8220-e68446e1b81e" />

### 1024px
<img width="1022" alt="Screenshot 2025-03-17 at 12 36 48 PM" src="https://github.com/user-attachments/assets/1e6c4cf6-579c-4bf3-b425-4c55f10413b4" />

### 1200px
<img width="1199" alt="Screenshot 2025-03-17 at 12 37 14 PM" src="https://github.com/user-attachments/assets/2d17a103-a7e8-4b60-b1a2-2c87e85c7f83" />