### PR TITLE
VACMS-19176 Facility Locator: Fix focus management for urgent and emergency care

### DIFF
--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -802,11 +802,17 @@ const FacilitiesMap = props => {
 
   useEffect(
     () => {
-      if (searchResultTitleRef.current && props.resultTime) {
+      const { inProgress, searchStarted } = props.currentQuery;
+
+      if (searchResultTitleRef.current && !inProgress && searchStarted) {
         setFocus(searchResultTitleRef.current);
       }
     },
-    [props.resultTime],
+    [
+      searchResultTitleRef.current,
+      props.currentQuery.inProgress,
+      props.currentQuery.searchStarted,
+    ],
   );
 
   useEffect(

--- a/src/applications/facility-locator/tests/e2e/helpers/index.js
+++ b/src/applications/facility-locator/tests/e2e/helpers/index.js
@@ -91,7 +91,7 @@ export const findSelectInVaSelect = dropdownName =>
     .find('select');
 
 export const vaSelectSelect = (value, dropdownName) =>
-  findSelectInVaSelect(dropdownName).select(value);
+  findSelectInVaSelect(dropdownName).select(value, { force: true });
 
 export const selectFacilityTypeInDropdown = value =>
   vaSelectSelect(value, FACILITY_TYPE_DROPDOWN);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adjust focus management so that on all facility types, the "Results for ___" text is focused after the search is complete.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19176

## Testing done

Tested focus on all facility type searches at `/find-locations`:

<img width="348" alt="Screenshot 2025-03-17 at 1 15 06 PM" src="https://github.com/user-attachments/assets/11506555-0ee2-4735-be47-8b4bb3cd6bcf" />
<img width="346" alt="Screenshot 2025-03-17 at 1 15 00 PM" src="https://github.com/user-attachments/assets/8537d352-07e8-4c9b-9b04-d9ec930f0e2f" />
<img width="346" alt="Screenshot 2025-03-17 at 1 14 55 PM" src="https://github.com/user-attachments/assets/44360fcf-696e-4abc-bc1e-bfc63cbd009e" />
<img width="347" alt="Screenshot 2025-03-17 at 1 14 50 PM" src="https://github.com/user-attachments/assets/e4eefa3b-d227-49c2-b7ba-5df58f3370c8" />
<img width="344" alt="Screenshot 2025-03-17 at 1 14 42 PM" src="https://github.com/user-attachments/assets/9e7f5cc0-528a-4109-83eb-aa98dce1f049" />
<img width="345" alt="Screenshot 2025-03-17 at 1 14 31 PM" src="https://github.com/user-attachments/assets/d1b30b0f-5e2f-41ac-bbec-97f8bb0deceb" />
<img width="355" alt="Screenshot 2025-03-17 at 1 14 22 PM" src="https://github.com/user-attachments/assets/d21729ad-56d3-4ff3-b8c7-68b2809a8c36" />
<img width="357" alt="Screenshot 2025-03-17 at 1 14 17 PM" src="https://github.com/user-attachments/assets/24cd91e0-1452-4ee4-a15b-5794a793eb7e" />