### PR TITLE
fix 4138 rerouting issue

### DIFF
--- a/src/applications/simple-forms/21-4138/helpers.js
+++ b/src/applications/simple-forms/21-4138/helpers.js
@@ -22,7 +22,7 @@ export const isEligibleForDecisionReview = decisionDate => {
 
 export const isEligibleToSubmitStatement = formData => {
   if (!formData?.statementType) {
-    return false;
+    return true;
   }
 
   return [

--- a/src/applications/simple-forms/21-4138/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4138/tests/unit/config/form.unit.spec.jsx
@@ -65,7 +65,6 @@ describe('formConfig', () => {
           } = formConfig.chapters.statementTypeChapter.pages;
           it('should have required properties', () => {
             expect(statementTypePage).to.include.keys(
-              'initialData',
               'pageClass',
               'path',
               'schema',

--- a/src/applications/simple-forms/21-4138/tests/unit/helpers.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4138/tests/unit/helpers.unit.spec.jsx
@@ -92,31 +92,31 @@ describe('isEligibleForDecisionReview', () => {
 describe('isEligibleToSubmitStatement', () => {
   let formData = { statementType: STATEMENT_TYPES.NOT_LISTED };
 
-  it('returns true when statementType is NOT_LISTED', () => {
+  it('returns true when statementType is specified and is NOT_LISTED', () => {
     expect(isEligibleToSubmitStatement(formData)).to.equal(true);
   });
 
-  it('returns true when statementType is PRIORITY_PROCESSING', () => {
+  it('returns true when statementType is specified and is PRIORITY_PROCESSING', () => {
     formData = { statementType: STATEMENT_TYPES.PRIORITY_PROCESSING };
     expect(isEligibleToSubmitStatement(formData)).to.equal(true);
   });
 
-  it('returns false when statementType is not in the allowed list', () => {
+  it('is ineligible when statementType is specified and not in the allowed list', () => {
     formData = { statementType: 'OTHER_TYPE' };
     expect(isEligibleToSubmitStatement(formData)).to.equal(false);
   });
 
-  it('returns false when statementType is missing', () => {
+  it('is not ineligible if statementType is not specified - user may have been redirected', () => {
     formData = {};
-    expect(isEligibleToSubmitStatement(formData)).to.equal(false);
+    expect(isEligibleToSubmitStatement(formData)).to.equal(true);
   });
 
-  it('returns false when formData is null', () => {
+  it('is not ineligible if formData is null - user may have been redirected', () => {
     formData = null;
-    expect(isEligibleToSubmitStatement(formData)).to.equal(false);
+    expect(isEligibleToSubmitStatement(formData)).to.equal(true);
   });
-  it('returns false when formData is undefined', () => {
+  it('is not ineligible if formData is undefined - user may have been redirected', () => {
     formData = undefined;
-    expect(isEligibleToSubmitStatement(formData)).to.equal(false);
+    expect(isEligibleToSubmitStatement(formData)).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary

- Fix 21-4138 not allowing to go to `/personal-information` page from rerouting, which is common throughout this form.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#2087

## Testing done

- Browser, unit, cypress

## Screenshots

![image](https://github.com/user-attachments/assets/32207642-dff1-4188-8725-3934da442b83)
![image](https://github.com/user-attachments/assets/bf0aaf37-acdf-48fb-a7be-73fb063f78c9)

## What areas of the site does it impact?

21-4138

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
