### PR TITLE
increase timeout of feedback-tool that fails sometimes

### DIFF
--- a/src/applications/edu-benefits/feedback-tool/tests/00.feedback-tool.cypress.spec.js
+++ b/src/applications/edu-benefits/feedback-tool/tests/00.feedback-tool.cypress.spec.js
@@ -12,7 +12,7 @@ describe('Feedback Tool Test', () => {
     cy.visit('/education/submit-school-feedback');
     cy.get('body').should('be.visible');
     cy.get('.schemaform-title').should('be.visible', {
-      timeout: Timeouts.slow,
+      timeout: 10000,
     });
     cy.get('.schemaform-start-button')
       .first()


### PR DESCRIPTION
## Summary

- Seeing failure on multiple PRs related to this, so try increasing timeout from `4000`/`5000` to `10000`

## Testing done

- cypress

## Screenshots

n/a

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
