### PR TITLE
VACMS-20836 Facility Locator: Change maps link to use Current Location

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/CCProviderResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/CCProviderResult.jsx
@@ -26,7 +26,7 @@ const CCProviderResult = ({ isMobile = false, provider, query }) => {
         <LocationDistance distance={provider.distance} />
         <ProviderTraining provider={provider} />
         <LocationAddress location={provider} />
-        <LocationDirectionsLink location={provider} query={query} />
+        <LocationDirectionsLink location={provider} />
         <LocationPhoneLink
           location={provider}
           from="SearchResult"

--- a/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
+++ b/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
@@ -12,7 +12,7 @@ import LocationOperationStatus from './common/LocationOperationStatus';
 import LocationMarker from './common/LocationMarker';
 import CovidPhoneLink from './common/Covid19PhoneLink';
 
-const Covid19Result = ({ index, isMobile = false, location, query }) => {
+const Covid19Result = ({ index, isMobile = false, location }) => {
   const {
     name,
     website,
@@ -67,7 +67,7 @@ const Covid19Result = ({ index, isMobile = false, location, query }) => {
             <LocationOperationStatus operatingStatus={operatingStatus} />
           )}
         <LocationAddress location={location} />
-        <LocationDirectionsLink location={location} query={query} />
+        <LocationDirectionsLink location={location} />
         {appointmentPhone ? (
           <CovidPhoneLink
             phone={appointmentPhone}
@@ -104,7 +104,6 @@ Covid19Result.propTypes = {
   index: PropTypes.number,
   isMobile: PropTypes.bool,
   location: PropTypes.object,
-  query: PropTypes.object,
   setHeaderHasFocus: PropTypes.func,
 };
 

--- a/src/applications/facility-locator/components/search-results-items/EmergencyCareResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/EmergencyCareResult.jsx
@@ -24,7 +24,7 @@ const EmergencyCareResult = ({ isMobile = false, provider, query }) => {
         <LocationDistance distance={provider.distance} />
         <ProviderTraining provider={provider} />
         <LocationAddress location={provider} />
-        <LocationDirectionsLink location={provider} query={query} />
+        <LocationDirectionsLink location={provider} />
         <LocationPhoneLink
           location={provider}
           from="SearchResult"

--- a/src/applications/facility-locator/components/search-results-items/PharmacyResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/PharmacyResult.jsx
@@ -22,7 +22,7 @@ const PharmacyResult = ({ isMobile = false, provider, query }) => {
         {provider.attributes.orgName && <h6>{provider.attributes.orgName}</h6>}
         <LocationDistance distance={provider.distance} />
         <LocationAddress location={provider} />
-        <LocationDirectionsLink location={provider} query={query} />
+        <LocationDirectionsLink location={provider} />
         <LocationPhoneLink
           location={provider}
           from="SearchResult"

--- a/src/applications/facility-locator/components/search-results-items/UrgentCareResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/UrgentCareResult.jsx
@@ -24,7 +24,7 @@ const UrgentCareResult = ({ isMobile = false, provider, query }) => {
         <LocationDistance distance={provider.distance} />
         <ProviderTraining provider={provider} />
         <LocationAddress location={provider} />
-        <LocationDirectionsLink location={provider} query={query} />
+        <LocationDirectionsLink location={provider} />
         <LocationPhoneLink
           location={provider}
           from="SearchResult"

--- a/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
@@ -62,7 +62,7 @@ const VaFacilityResult = ({
             <LocationOperationStatus operatingStatus={operatingStatus} />
           )}
         <LocationAddress location={location} />
-        <LocationDirectionsLink location={location} query={query} />
+        <LocationDirectionsLink location={location} />
         <LocationPhoneLink
           location={location}
           from="SearchResult"
@@ -81,6 +81,7 @@ const VaFacilityResult = ({
 
 VaFacilityResult.propTypes = {
   index: PropTypes.number,
+  isCemetery: PropTypes.bool,
   isMobile: PropTypes.bool,
   location: PropTypes.object,
   query: PropTypes.object,
@@ -88,7 +89,6 @@ VaFacilityResult.propTypes = {
     PropTypes.string,
     PropTypes.bool,
   ]),
-  isCemetery: PropTypes.bool,
 };
 
 export default VaFacilityResult;

--- a/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationDirectionsLink.jsx
@@ -2,11 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { buildAddressArray } from 'platform/utilities/facilities-and-mapbox';
 
-function LocationDirectionsLink({ location, query = null }) {
+function LocationDirectionsLink({ location }) {
   let address = buildAddressArray(location);
-  const searchString = location?.searchString
-    ? location.searchString
-    : query?.searchString;
 
   if (address.length !== 0) {
     address = address.join(', ');
@@ -19,7 +16,7 @@ function LocationDirectionsLink({ location, query = null }) {
   return (
     <p>
       <va-link
-        href={`https://maps.google.com?saddr=${searchString}&daddr=${address}`}
+        href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
         text="Get directions on Google Maps"
         label={`Get directions on Google Maps to ${location.attributes.name}`}
       />

--- a/src/applications/facility-locator/components/search-results-items/common/ResultMapper.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/ResultMapper.jsx
@@ -36,7 +36,6 @@ export const ResultMapper = (result, searchQuery, index, isMobile = false) => {
           isMobile={isMobile}
           key={result.id}
           location={result}
-          query={searchQuery}
         />
       ) : (
         <VaFacilityResult

--- a/src/applications/facility-locator/tests/components/search-results/Covid19Result.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/Covid19Result.unit.spec.jsx
@@ -3,18 +3,10 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Covid19Result from '../../../components/search-results-items/Covid19Result';
 import testData from '../../../constants/mock-facility-v1-covid19.json';
-import { Covid19Vaccine, LocationType } from '../../../constants';
 
 describe('Covid19Result', () => {
   it('Should render with facility type health', () => {
-    const query = {
-      facilityType: LocationType.HEALTH,
-      serviceType: Covid19Vaccine,
-    };
-
-    const wrapper = shallow(
-      <Covid19Result location={testData.data[0]} query={query} />,
-    );
+    const wrapper = shallow(<Covid19Result location={testData.data[0]} />);
 
     expect(wrapper.find('LocationDistance').length).to.equal(1);
     expect(wrapper.find('LocationMarker').length).to.equal(1);

--- a/src/applications/facility-locator/tests/components/search-results/LocationDirectionsLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationDirectionsLink.unit.spec.jsx
@@ -11,7 +11,6 @@ const verifyLink = data => {
     <LocationDirectionsLink
       location={{
         ...data,
-        ...{ searchString: 'my house' },
       }}
     />,
   );
@@ -21,7 +20,7 @@ const verifyLink = data => {
 
   expect(testProps).to.eql({
     href:
-      'https://maps.google.com?saddr=my house&daddr=7901 Metropolis Drive, Austin, TX 78744-3111',
+      'https://maps.google.com?saddr=Current+Location&daddr=7901 Metropolis Drive, Austin, TX 78744-3111',
   });
   expect(wrapper.find('va-link').prop('text')).to.equal(
     'Get directions on Google Maps',

--- a/src/applications/facility-locator/tests/e2e/helpers/index.js
+++ b/src/applications/facility-locator/tests/e2e/helpers/index.js
@@ -91,7 +91,7 @@ export const findSelectInVaSelect = dropdownName =>
     .find('select');
 
 export const vaSelectSelect = (value, dropdownName) =>
-  findSelectInVaSelect(dropdownName).select(value);
+  findSelectInVaSelect(dropdownName).select(value, { force: true });
 
 export const selectFacilityTypeInDropdown = value =>
   vaSelectSelect(value, FACILITY_TYPE_DROPDOWN);

--- a/src/applications/facility-locator/tests/e2e/mobile-search-list-view.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile-search-list-view.cypress.spec.js
@@ -86,7 +86,7 @@ featureSetsToTest.forEach(featureSet => {
             website:
               'https://www.va.gov/atlanta-health-care/locations/fort-mcpherson-va-clinic/',
             map:
-              'https://maps.google.com?saddr=Atlanta, GA&daddr=1701 Hardee Avenue, Southwest, Atlanta, GA 30310-5110',
+              'https://maps.google.com?saddr=Current+Location&daddr=1701 Hardee Avenue, Southwest, Atlanta, GA 30310-5110',
           },
           0,
         );
@@ -129,7 +129,7 @@ featureSetsToTest.forEach(featureSet => {
             addressLine2: 'TAMPA, FL 33602-5620',
             website: null,
             map:
-              'https://maps.google.com?saddr=Tampa, FL&daddr=564 CHANNELSIDE DR, TAMPA, FL 33602-5620',
+              'https://maps.google.com?saddr=Current+Location&daddr=564 CHANNELSIDE DR, TAMPA, FL 33602-5620',
           },
           0,
         );
@@ -170,7 +170,7 @@ featureSetsToTest.forEach(featureSet => {
             addressLine2: 'NORFOLK, VA 23507-1904',
             website: null,
             map:
-              'https://maps.google.com?saddr=Norfolk, VA&daddr=600 GRESHAM DR, NORFOLK, VA 23507-1904',
+              'https://maps.google.com?saddr=Current+Location&daddr=600 GRESHAM DR, NORFOLK, VA 23507-1904',
           },
           0,
         );
@@ -212,7 +212,7 @@ featureSetsToTest.forEach(featureSet => {
             addressLine2: 'Seattle, WA 98112',
             website: null,
             map:
-              'https://maps.google.com?saddr=Seattle, WA&daddr=203 14th Ave E, Seattle, WA 98112',
+              'https://maps.google.com?saddr=Current+Location&daddr=203 14th Ave E, Seattle, WA 98112',
           },
           0,
         );
@@ -247,7 +247,7 @@ featureSetsToTest.forEach(featureSet => {
             addressLine2: 'RENO, NV 89501',
             website: null,
             map:
-              'https://maps.google.com?saddr=Reno, NV&daddr=750 N VIRGINIA ST, RENO, NV 89501',
+              'https://maps.google.com?saddr=Current+Location&daddr=750 N VIRGINIA ST, RENO, NV 89501',
           },
           0,
         );
@@ -278,7 +278,7 @@ featureSetsToTest.forEach(featureSet => {
             addressLine2: 'Muskogee, OK 74401',
             website: null,
             map:
-              'https://maps.google.com?saddr=Tulsa, OK&daddr=125 South Main Street, Muskogee, OK 74401',
+              'https://maps.google.com?saddr=Current+Location&daddr=125 South Main Street, Muskogee, OK 74401',
           },
           0,
         );
@@ -309,7 +309,7 @@ featureSetsToTest.forEach(featureSet => {
             addressLine2: 'Honolulu, HI 96813-1729',
             website: null,
             map:
-              'https://maps.google.com?saddr=Honolulu, HI&daddr=2177 Puowaina Dr, Honolulu, HI 96813-1729',
+              'https://maps.google.com?saddr=Current+Location&daddr=2177 Puowaina Dr, Honolulu, HI 96813-1729',
           },
           0,
         );
@@ -340,7 +340,7 @@ featureSetsToTest.forEach(featureSet => {
             addressLine2: 'Evanston, IL 60202',
             website: 'https://www.va.gov/evanston-vet-center/',
             map:
-              'https://maps.google.com?saddr=Chicago, IL&daddr=1901 Howard Street, Evanston, IL 60202',
+              'https://maps.google.com?saddr=Current+Location&daddr=1901 Howard Street, Evanston, IL 60202',
           },
           0,
         );

--- a/src/applications/facility-locator/tests/e2e/mobile-search-map-view.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile-search-map-view.cypress.spec.js
@@ -91,7 +91,7 @@ for (const features of featureSetsToTest) {
             website:
               'https://www.va.gov/atlanta-health-care/locations/joseph-maxwell-cleland-atlanta-va-medical-center',
             map:
-              'https://maps.google.com?saddr=Atlanta, GA&daddr=1670 Clairmont Road, Decatur, GA 30033-4004',
+              'https://maps.google.com?saddr=Current+Location&daddr=1670 Clairmont Road, Decatur, GA 30033-4004',
           },
           1,
         );
@@ -125,7 +125,7 @@ for (const features of featureSetsToTest) {
           addressLine2: 'TAMPA, FL 33602-5620',
           website: null,
           map:
-            'https://maps.google.com?saddr=Tampa, FL&daddr=564 CHANNELSIDE DR, TAMPA, FL 33602-5620',
+            'https://maps.google.com?saddr=Current+Location&daddr=564 CHANNELSIDE DR, TAMPA, FL 33602-5620',
         };
 
         cy.visit(h.ROOT_URL);
@@ -179,7 +179,7 @@ for (const features of featureSetsToTest) {
             addressLine2: 'NORFOLK, VA 23507-1904',
             website: null,
             map:
-              'https://maps.google.com?saddr=Norfolk, VA&daddr=600 GRESHAM DR, NORFOLK, VA 23507-1904',
+              'https://maps.google.com?saddr=Current+Location&daddr=600 GRESHAM DR, NORFOLK, VA 23507-1904',
           },
           0,
         );
@@ -225,7 +225,7 @@ for (const features of featureSetsToTest) {
             addressLine2: 'Seattle, WA 98112',
             website: null,
             map:
-              'https://maps.google.com?saddr=Seattle, WA&daddr=203 14th Ave E, Seattle, WA 98112',
+              'https://maps.google.com?saddr=Current+Location&daddr=203 14th Ave E, Seattle, WA 98112',
           },
           0,
         );
@@ -264,7 +264,7 @@ for (const features of featureSetsToTest) {
             addressLine2: 'RENO, NV 89501',
             website: null,
             map:
-              'https://maps.google.com?saddr=Reno, NV&daddr=750 N VIRGINIA ST, RENO, NV 89501',
+              'https://maps.google.com?saddr=Current+Location&daddr=750 N VIRGINIA ST, RENO, NV 89501',
           },
           0,
         );
@@ -299,7 +299,7 @@ for (const features of featureSetsToTest) {
             addressLine2: 'Muskogee, OK 74401',
             website: null,
             map:
-              'https://maps.google.com?saddr=Tulsa, OK&daddr=125 South Main Street, Muskogee, OK 74401',
+              'https://maps.google.com?saddr=Current+Location&daddr=125 South Main Street, Muskogee, OK 74401',
           },
           0,
         );
@@ -334,7 +334,7 @@ for (const features of featureSetsToTest) {
             addressLine2: 'Honolulu, HI 96813-1729',
             website: null,
             map:
-              'https://maps.google.com?saddr=Honolulu, HI&daddr=2177 Puowaina Dr, Honolulu, HI 96813-1729',
+              'https://maps.google.com?saddr=Current+Location&daddr=2177 Puowaina Dr, Honolulu, HI 96813-1729',
           },
           0,
         );
@@ -369,7 +369,7 @@ for (const features of featureSetsToTest) {
             addressLine2: 'Evanston, IL 60202',
             website: 'https://www.va.gov/evanston-vet-center/',
             map:
-              'https://maps.google.com?saddr=Chicago, IL&daddr=1901 Howard Street, Evanston, IL 60202',
+              'https://maps.google.com?saddr=Current+Location&daddr=1901 Howard Street, Evanston, IL 60202',
           },
           0,
         );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In parts of the Facility Locator, we use the search string (for city/state/zip) as the starting location for Google Maps directions. This isn't typical for Google Maps links, and in some cases (specifically Facility Locator detail pages for cemeteries and VBAs), the logic breaks because the search string gets lost along the way.

To make it a more consistent experience with Events and content-build Facilities products, we are going to use the user's current location as a starting point rather than their search term.

We don't need any fallbacks for current location if it cannot be found; Google has tons of logic in place for finding the user's location and will handle it accordingly.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20836

## Testing done / screenshots

### Links

| Facility type | Link - Before | Link - After |
| --- | --- | --- | 
| VA health | <img width="337" alt="Screenshot 2025-03-18 at 9 40 53 AM" src="https://github.com/user-attachments/assets/b3351f69-7fff-4c8a-926f-b6489bdc8d34" /> | <img width="410" alt="Screenshot 2025-03-18 at 9 39 01 AM" src="https://github.com/user-attachments/assets/5f96cfb0-6cc8-4fbe-a3ff-ca40b17897a0" /> |
| Urgent care | <img width="303" alt="Screenshot 2025-03-18 at 9 43 00 AM" src="https://github.com/user-attachments/assets/cfa53a7f-7678-4a9b-a3ef-7e561d695fdb" /> | <img width="407" alt="Screenshot 2025-03-18 at 9 43 08 AM" src="https://github.com/user-attachments/assets/a611cf68-7418-4f7e-b48d-e100ec6f30fd" /> |
| Emergency care | <img width="299" alt="Screenshot 2025-03-18 at 9 45 59 AM" src="https://github.com/user-attachments/assets/8af8cd86-49d6-4787-8982-8ac66cbfc005" /> | <img width="399" alt="Screenshot 2025-03-18 at 9 46 18 AM" src="https://github.com/user-attachments/assets/bf5ee1d5-12c3-4bc6-97e8-7c926a473dfb" /> |
| Community providers | <img width="309" alt="Screenshot 2025-03-18 at 9 47 46 AM" src="https://github.com/user-attachments/assets/28aed8ce-4bd2-4ecb-a69c-d28dacbaa1f8" /> | <img width="399" alt="Screenshot 2025-03-18 at 9 48 02 AM" src="https://github.com/user-attachments/assets/97d6627e-75e3-45ed-843a-5f3f38497c31" /> |
| Community pharmacies | <img width="305" alt="Screenshot 2025-03-18 at 9 49 12 AM" src="https://github.com/user-attachments/assets/323cc6ad-5d7c-4d76-81ef-9e8ffe50a85d" /> | <img width="405" alt="Screenshot 2025-03-18 at 9 49 32 AM" src="https://github.com/user-attachments/assets/de37daad-e536-48d5-a05a-112d1e645056" /> |
| VA benefits | <img width="317" alt="Screenshot 2025-03-18 at 9 50 59 AM" src="https://github.com/user-attachments/assets/d0263c0e-dedf-4990-9a6e-842127b36a36" /> | <img width="420" alt="Screenshot 2025-03-18 at 9 51 15 AM" src="https://github.com/user-attachments/assets/8c466ade-ba93-4f1d-b0c0-4a63ad0be12e" /> |
| VA benefits detail pages | <img width="338" alt="Screenshot 2025-03-18 at 9 56 44 AM" src="https://github.com/user-attachments/assets/a332671a-f2e1-4c6f-a2b1-bf199c67aecc" /> | <img width="442" alt="Screenshot 2025-03-18 at 9 57 35 AM" src="https://github.com/user-attachments/assets/e074f36e-a064-4bb7-9b81-8bf9e39d7526" /> |
| VA cemeteries | <img width="324" alt="Screenshot 2025-03-18 at 9 52 20 AM" src="https://github.com/user-attachments/assets/ce946160-adbc-48e2-969d-3f19c8a47416" /> | <img width="409" alt="Screenshot 2025-03-18 at 9 52 37 AM" src="https://github.com/user-attachments/assets/56c0a392-0b13-498c-9448-61c433ea09d5" /> |
| VA cemeteries detail pages | <img width="337" alt="Screenshot 2025-03-18 at 9 53 40 AM" src="https://github.com/user-attachments/assets/4899f5b3-2fe8-4e0d-b559-6639b7f6ca2e" /> | <img width="336" alt="Screenshot 2025-03-18 at 9 54 00 AM" src="https://github.com/user-attachments/assets/122367ec-53fd-4339-af1b-24148413cd7f" /> |
| Vet Centers | <img width="311" alt="Screenshot 2025-03-18 at 9 55 13 AM" src="https://github.com/user-attachments/assets/1725afc3-5559-4de7-9c0c-49f28b67ec34" /> | <img width="409" alt="Screenshot 2025-03-18 at 9 55 26 AM" src="https://github.com/user-attachments/assets/e6b9d5cc-54ee-45ce-b234-acc86eb7c33d" /> |


### Google Results

| Facility type | Google - Before | Google - After |
| --- | --- | --- |
| VA health | <img width="407" alt="Screenshot 2025-03-18 at 9 41 00 AM" src="https://github.com/user-attachments/assets/42f6299f-3d99-45c0-8393-2da2bb0c95f4" /> | <img width="393" alt="Screenshot 2025-03-18 at 9 39 12 AM" src="https://github.com/user-attachments/assets/b0b0d672-495b-4ea8-8f93-9b93cd60dbb8" /> |
| Urgent care | <img width="407" alt="Screenshot 2025-03-18 at 9 43 35 AM" src="https://github.com/user-attachments/assets/9f17891c-c64b-4b1c-b623-71d84493373d" /> | <img width="405" alt="Screenshot 2025-03-18 at 9 43 51 AM" src="https://github.com/user-attachments/assets/1aaaa716-086c-4fd4-b47e-fbf74c892398" /> |
| Emergency care | <img width="407" alt="Screenshot 2025-03-18 at 9 46 09 AM" src="https://github.com/user-attachments/assets/d2aa5f2f-9352-4f48-bc2e-0f783a25fa45" /> | <img width="406" alt="Screenshot 2025-03-18 at 9 46 31 AM" src="https://github.com/user-attachments/assets/4f7d2a74-1ee4-466a-bf92-d8d7df2efe77" /> |
| Community providers | <img width="407" alt="Screenshot 2025-03-18 at 9 47 54 AM" src="https://github.com/user-attachments/assets/a3777458-14eb-463c-b689-2d8538ccced8" /> | <img width="407" alt="Screenshot 2025-03-18 at 9 48 14 AM" src="https://github.com/user-attachments/assets/c71e3943-18ae-475a-992b-824e8ddd670c" /> |
| Community pharmacies | <img width="407" alt="Screenshot 2025-03-18 at 9 49 19 AM" src="https://github.com/user-attachments/assets/7a9d00a9-8b75-4eb3-9e51-cded3bac0934" /> | <img width="408" alt="Screenshot 2025-03-18 at 9 49 48 AM" src="https://github.com/user-attachments/assets/cb01d500-d524-4f06-b2fe-c05dd644d86c" /> |
| VA benefits | <img width="407" alt="Screenshot 2025-03-18 at 9 51 06 AM" src="https://github.com/user-attachments/assets/5569d431-623d-473e-8f56-5342b14729be" /> | <img width="404" alt="Screenshot 2025-03-18 at 9 51 23 AM" src="https://github.com/user-attachments/assets/0e2124fa-145e-4d66-b34a-2e17db89ee60" /> |
| VA benefits detail pages | <img width="406" alt="Screenshot 2025-03-18 at 9 56 56 AM" src="https://github.com/user-attachments/assets/beba45d1-ea44-4556-8be6-8297549c361b" /> | <img width="409" alt="Screenshot 2025-03-18 at 9 57 47 AM" src="https://github.com/user-attachments/assets/043bef89-500b-44f0-8f28-a32b76354aa1" /> |
| VA cemeteries | <img width="410" alt="Screenshot 2025-03-18 at 9 52 26 AM" src="https://github.com/user-attachments/assets/afe15914-8542-4f15-970d-afae547f5199" /> | <img width="407" alt="Screenshot 2025-03-18 at 9 52 48 AM" src="https://github.com/user-attachments/assets/510943b7-cb6b-4311-b81c-3441794b9e83" /> |
| VA cemeteries detail pages | <img width="406" alt="Screenshot 2025-03-18 at 9 53 50 AM" src="https://github.com/user-attachments/assets/0298ced7-0dec-4d56-bb79-c532acb34817" /> | <img width="406" alt="Screenshot 2025-03-18 at 9 54 13 AM" src="https://github.com/user-attachments/assets/9003a11d-8912-4339-b1fe-ea3a995e3ba4" /> |
| Vet Centers | <img width="405" alt="Screenshot 2025-03-18 at 9 55 19 AM" src="https://github.com/user-attachments/assets/3f721ec1-1d90-40cd-aa8e-af7964aef13e" /> | <img width="406" alt="Screenshot 2025-03-18 at 9 55 39 AM" src="https://github.com/user-attachments/assets/d9988ef0-cf0e-4e0e-92f4-5686fa2e2b17" /> |