### PR TITLE
VACMS-20862 Facility Locator: update services autosuggest to default when map search button is used

### DIFF
--- a/src/applications/facility-locator/components/search-form/index.jsx
+++ b/src/applications/facility-locator/components/search-form/index.jsx
@@ -30,7 +30,9 @@ export const SearchForm = props => {
     mobileMapUpdateEnabled,
     onChange,
     onSubmit,
+    searchInitiated,
     selectMobileMapPin,
+    setSearchInitiated,
     suppressPPMS,
     useProgressiveDisclosure,
     vamcAutoSuggestEnabled,
@@ -39,7 +41,6 @@ export const SearchForm = props => {
   const [selectedServiceType, setSelectedServiceType] = useState(null);
   const locationInputFieldRef = useRef(null);
   const lastQueryRef = useRef(null);
-  const [searchInitiated, setSearchInitiated] = useState(false);
 
   const handleFacilityTypeChange = e => {
     onChange({

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -77,6 +77,7 @@ const FacilitiesMap = props => {
   );
   const [isSearching, setIsSearching] = useState(false);
   const [selectedTab, setSelectedTab] = useState(0);
+  const [searchInitiated, setSearchInitiated] = useState(false);
 
   // refs
   const mapboxContainerRef = useRef(null);
@@ -231,11 +232,14 @@ const FacilitiesMap = props => {
 
   const handleSearchArea = () => {
     if (!map) return;
+
     resetMapElements();
-    const { currentQuery } = props;
     lastZoom = null;
+
+    const { currentQuery } = props;
     const center = map.getCenter().wrap();
     const bounds = map.getBounds();
+
     recordEvent({
       event: 'fl-search',
       'fl-search-fac-type': currentQuery.facilityType,
@@ -244,6 +248,7 @@ const FacilitiesMap = props => {
 
     const currentMapBoundsDistance = calculateSearchArea();
 
+    setSearchInitiated(true);
     props.genSearchAreaFromCenter({
       lat: center.lat,
       lng: center.lng,
@@ -467,7 +472,9 @@ const FacilitiesMap = props => {
               mobileMapUpdateEnabled={mobileMapUpdateEnabled}
               onChange={props.updateSearchQuery}
               onSubmit={handleSearch}
+              searchInitiated={searchInitiated}
               selectMobileMapPin={props.selectMobileMapPin}
+              setSearchInitiated={setSearchInitiated}
               suppressPPMS={props.suppressPPMS}
               useProgressiveDisclosure={useProgressiveDisclosure}
               vamcAutoSuggestEnabled={vamcAutoSuggestEnabled}

--- a/src/applications/facility-locator/types/index.js
+++ b/src/applications/facility-locator/types/index.js
@@ -229,7 +229,9 @@ export const SearchFormTypes = {
   geolocateUser: PropTypes.func,
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
+  searchInitiated: PropTypes.bool,
   selectMobileMapPin: PropTypes.func,
+  setSearchInitiated: PropTypes.func,
   suppressPPMS: PropTypes.bool,
   vamcServiceDisplay: PropTypes.string,
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

For the Facility Locator services autosuggest component, we coded the below behavior:

- User enters a location (city/state or zip) and selects "VA health" as the Facility type
- User types some characters but does not select something from the autosuggest dropdown
- User clicks "Search" / types "Enter" to execute a search from the search form

AND

- User enters a location (city/state or zip) and selects "VA health" as the Facility type
- User does not interact with the autosuggest dropdown and leaves it blank
- User clicks "Search" / types "Enter" to execute a search from the search form

In either of these cases, we populate the text "All VA health services" into the input (it's the first option from the dropdown) and search for that in the API.

https://github.com/user-attachments/assets/8ca4ff2e-0934-4de0-ad9c-e2a421c96cd6

**The focus of this PR** was to add similar functionality for the search form when the "Search this area of the map" button is used (on the map). It should autofill the autosuggest dropdown with "All VA health services" if a valid service has not been selected from the dropdown.

https://github.com/user-attachments/assets/11bf9e38-0b6c-4d20-9975-e35b6433597c

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20862

## Testing done

Tested some test cases from [this test plan](https://docs.google.com/spreadsheets/d/1wgIM4oIwAQk-E151z07P3hhZuQJ6mhepv7U5tZjdpEI/edit?gid=239023473#gid=239023473).