### PR TITLE
Add more unit test coverage - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
@@ -42,7 +42,7 @@ const yesNoContent = {
 };
 
 /** @type {ArrayBuilderOptions} */
-const options = {
+export const insuranceOptions = {
   arrayPath: 'policies',
   nounSingular: 'policy',
   nounPlural: 'policies',
@@ -109,7 +109,7 @@ const policyPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Policy information',
-      nounSingular: options.nounSingular,
+      nounSingular: insuranceOptions.nounSingular,
     }),
     name: textUI('Name of insurance provider'),
     policyNum: textUI('Policy number'),
@@ -181,7 +181,7 @@ const insuranceProviderPage = {
 const summaryPage = {
   uiSchema: {
     'view:hasPolicies': arrayBuilderYesNoUI(
-      options,
+      insuranceOptions,
       yesNoContent,
       yesNoContent,
     ),
@@ -196,45 +196,48 @@ const summaryPage = {
 };
 
 // Main pages object
-export const insurancePages = arrayBuilderPages(options, pageBuilder => ({
-  insuranceIntro: pageBuilder.introPage({
-    path: 'insurance-intro',
-    title: '[noun plural]',
-    depends: formData => get('hasOhi', formData),
-    uiSchema: {
-      ...titleUI('Health insurance information', ({ formData }) => (
-        <p>
-          Next we’ll ask you to enter information about{' '}
-          {nameWording(formData, true, false, true)} health insurance.
-          <br />
-          <br />
-          You can add up to two health insurances, but do not include CHAMPVA.
-        </p>
-      )),
-    },
-    schema: {
-      type: 'object',
-      properties: {
-        titleSchema,
+export const insurancePages = arrayBuilderPages(
+  insuranceOptions,
+  pageBuilder => ({
+    insuranceIntro: pageBuilder.introPage({
+      path: 'insurance-intro',
+      title: '[noun plural]',
+      depends: formData => get('hasOhi', formData),
+      uiSchema: {
+        ...titleUI('Health insurance information', ({ formData }) => (
+          <p>
+            Next we’ll ask you to enter information about{' '}
+            {nameWording(formData, true, false, true)} health insurance.
+            <br />
+            <br />
+            You can add up to two health insurances, but do not include CHAMPVA.
+          </p>
+        )),
       },
-    },
+      schema: {
+        type: 'object',
+        properties: {
+          titleSchema,
+        },
+      },
+    }),
+    insuranceSummary: pageBuilder.summaryPage({
+      title: 'Review your [noun plural]',
+      path: 'insurance-review',
+      depends: formData => get('hasOhi', formData),
+      ...summaryPage,
+    }),
+    insurancePolicy: pageBuilder.itemPage({
+      title: 'Policy information',
+      path: 'policy-info/:index',
+      depends: formData => get('hasOhi', formData),
+      ...policyPage,
+    }),
+    insuranceType: pageBuilder.itemPage({
+      title: 'Type',
+      path: 'insurance-type/:index',
+      depends: formData => get('hasOhi', formData),
+      ...insuranceProviderPage,
+    }),
   }),
-  insuranceSummary: pageBuilder.summaryPage({
-    title: 'Review your [noun plural]',
-    path: 'insurance-review',
-    depends: formData => get('hasOhi', formData),
-    ...summaryPage,
-  }),
-  insurancePolicy: pageBuilder.itemPage({
-    title: 'Policy information',
-    path: 'policy-info/:index',
-    depends: formData => get('hasOhi', formData),
-    ...policyPage,
-  }),
-  insuranceType: pageBuilder.itemPage({
-    title: 'Type',
-    path: 'insurance-type/:index',
-    depends: formData => get('hasOhi', formData),
-    ...insuranceProviderPage,
-  }),
-}));
+);

--- a/src/applications/ivc-champva/10-7959a/tests/unit/config/form.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959a/tests/unit/config/form.unit.spec.js
@@ -3,6 +3,7 @@ import formConfig from '../../../config/form';
 import { testNumberOfWebComponentFields } from '../../../../shared/tests/pages/pageTests.spec';
 
 import mockData from '../../e2e/fixtures/data/test-data.json';
+import { insuranceOptions } from '../../../chapters/healthInsuranceInformation';
 
 describe('Certifier role page', () => {
   testNumberOfWebComponentFields(
@@ -148,6 +149,77 @@ describe('Insurance status page', () => {
   );
 });
 
+describe('health insurance array builder options isItemIncomplete', () => {
+  it('should return false if all required fields are populated', () => {
+    const completeItem = {
+      type: 'group',
+      name: 'BCBS',
+      policyNum: '123',
+      providerPhone: '1231231234',
+    };
+    expect(insuranceOptions.isItemIncomplete(completeItem)).to.be.false;
+  });
+  it('should return true if required fields are missing', () => {
+    const completeItem = {
+      policyNum: '123',
+      providerPhone: '1231231234',
+    };
+    expect(insuranceOptions.isItemIncomplete(completeItem)).to.be.true;
+  });
+});
+
+describe('health insurance array builder options.text', () => {
+  it('should getItemName when given an item', () => {
+    const completeItem = {
+      type: 'group',
+      name: 'BCBS',
+      policyNum: '123',
+      providerPhone: '1231231234',
+    };
+    expect(insuranceOptions.text.getItemName(completeItem)).to.eq(
+      completeItem.name,
+    );
+  });
+
+  it('should return cardDescription matching otherType when given an item of type other', () => {
+    const completeItem = {
+      type: 'other',
+      otherType: 'some other type',
+      name: 'BCBS',
+      policyNum: '123',
+      providerPhone: '1231231234',
+    };
+    expect(insuranceOptions.text.cardDescription(completeItem)).to.eq(
+      'some other type',
+    );
+  });
+
+  it('should return cardDescription when given an item', () => {
+    const completeItem = {
+      type: 'group',
+      name: 'BCBS',
+      policyNum: '123',
+      providerPhone: '1231231234',
+    };
+    expect(insuranceOptions.text.cardDescription(completeItem)).to.eq(
+      'Employer sponsored insurance (group)',
+    );
+  });
+
+  it('should return summaryTitle when given an item', () => {
+    const completeItem = {
+      type: 'group',
+      name: 'BCBS',
+      policyNum: '123',
+      providerPhone: '1231231234',
+      formData: mockData.data,
+    };
+    expect(insuranceOptions.text.summaryTitle(completeItem)).to.include(
+      'health insurance review',
+    );
+  });
+});
+
 describe('Insurance status (role: other) page', () => {
   testNumberOfWebComponentFields(
     formConfig,
@@ -244,6 +316,17 @@ describe('Sponsor name (role: other) page', () => {
     4,
     'Sponsor name (role: other)',
     { ...mockData.data, certifierRole: 'other' },
+  );
+});
+
+describe('Sponsor name (role: sponsor) page', () => {
+  testNumberOfWebComponentFields(
+    formConfig,
+    formConfig.chapters.sponsorInformation.pages.page2.schema,
+    formConfig.chapters.sponsorInformation.pages.page2.uiSchema,
+    4,
+    'Sponsor name (role: sponsor)',
+    { ...mockData.data, certifierRole: 'sponsor' },
   );
 });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds some unit test coverage for the array builder options methods.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105536

## Testing done

- Added new unit tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| 10-7959a coverage |![before](https://github.com/user-attachments/assets/a6ab69c6-8761-4d7d-8aa2-93dd687fc110)|![after](https://github.com/user-attachments/assets/aa927cbb-fe5e-4ab3-ae0c-9b00ecaa1e55)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA