### PR TITLE
Debt details resolve page

### DIFF
--- a/src/applications/combined-debt-portal/combined/routes.jsx
+++ b/src/applications/combined-debt-portal/combined/routes.jsx
@@ -10,6 +10,7 @@ import DebtDetails from '../debt-letters/containers/DebtDetails';
 import DebtLettersDownload from '../debt-letters/containers/DebtLettersDownload';
 import DebtLettersSummary from '../debt-letters/containers/DebtLettersSummary';
 import ResolvePage from '../medical-copays/containers/ResolvePage';
+import ResolveDebtPage from '../debt-letters/containers/ResolveDebtPage';
 
 const Routes = () => (
   <CombinedPortalApp>
@@ -40,6 +41,11 @@ const Routes = () => (
         }}
       />
       <Route exact path="/debt-balances/details/:id" component={DebtDetails} />
+      <Route
+        exact
+        path="/debt-balances/details/:id/resolve"
+        component={ResolveDebtPage}
+      />
       <Route>
         <Redirect to="/" />
       </Route>

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -3,13 +3,20 @@ import { useDispatch } from 'react-redux';
 import head from 'lodash/head';
 import PropTypes from 'prop-types';
 import recordEvent from '~/platform/monitoring/record-event';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { VaLink } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { deductionCodes } from '../const/deduction-codes';
 import { setActiveDebt } from '../../combined/actions/debts';
 import { currency } from '../utils/page';
 import { debtSummaryText } from '../const/diary-codes/debtSummaryCardContent';
 
+export const TOGGLE_NAMES = {
+  showVHAPaymentHistory: 'vha_show_payment_history',
+};
+
 const DebtSummaryCard = ({ debt }) => {
+  const { useToggleValue } = useFeatureToggle();
+  const showResolveLinks = useToggleValue(TOGGLE_NAMES.showVHAPaymentHistory);
   const dispatch = useDispatch();
   const mostRecentHistory = head(debt?.debtHistory);
   const debtCardTotal = currency.format(parseFloat(debt.currentAr));
@@ -36,34 +43,54 @@ const DebtSummaryCard = ({ debt }) => {
           <strong>{debtCardTotal} </strong>
         </p>
         {debtCardSubHeading}
-        <VaLink
-          active
-          data-testid="debt-details-button"
-          onClick={() => {
-            recordEvent({ event: 'cta-link-click-debt-summary-card' });
-            dispatch(setActiveDebt(debt));
-          }}
-          href={`/manage-va-debt/summary/debt-balances/details/${
-            debt.compositeDebtId
-          }`}
-          text="Review details"
-          aria-label={`Check details for ${debtCardHeading}`}
-        />
-        <div className="vads-u-margin-top--1">
-          <VaLink
-            active
-            data-testid="debt-details-resolve-button"
-            onClick={() => {
-              recordEvent({ event: 'cta-link-click-debt-summary-card' });
-              dispatch(setActiveDebt(debt));
-            }}
-            href={`/manage-va-debt/summary/debt-balances/details/${
-              debt.compositeDebtId
-            }/resolve`}
-            text="Resolve this debt"
-            aria-label={`Resolve ${debtCardHeading}`}
-          />
-        </div>
+        {showResolveLinks ? (
+          <>
+            <VaLink
+              active
+              data-testid="debt-details-button"
+              onClick={() => {
+                recordEvent({ event: 'cta-link-click-debt-summary-card' });
+                dispatch(setActiveDebt(debt));
+              }}
+              href={`/manage-va-debt/summary/debt-balances/details/${
+                debt.compositeDebtId
+              }`}
+              text="Review details"
+              aria-label={`Check details for ${debtCardHeading}`}
+            />
+            <div className="vads-u-margin-top--1">
+              <VaLink
+                active
+                data-testid="debt-details-resolve-button"
+                onClick={() => {
+                  recordEvent({ event: 'cta-link-click-debt-summary-card' });
+                  dispatch(setActiveDebt(debt));
+                }}
+                href={`/manage-va-debt/summary/debt-balances/details/${
+                  debt.compositeDebtId
+                }/resolve`}
+                text="Resolve this debt"
+                aria-label={`Resolve ${debtCardHeading}`}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <VaLink
+              active
+              data-testid="debt-details-button"
+              onClick={() => {
+                recordEvent({ event: 'cta-link-click-debt-summary-card' });
+                dispatch(setActiveDebt(debt));
+              }}
+              href={`/manage-va-debt/summary/debt-balances/details/${
+                debt.compositeDebtId
+              }`}
+              text="Check details and resolve this debt"
+              aria-label={`Check details and resolve this ${debtCardHeading}`}
+            />
+          </>
+        )}
       </va-card>
     </li>
   );

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -10,12 +10,8 @@ import { setActiveDebt } from '../../combined/actions/debts';
 import { currency } from '../utils/page';
 import { debtSummaryText } from '../const/diary-codes/debtSummaryCardContent';
 
-export const TOGGLE_NAMES = {
-  showVHAPaymentHistory: 'vha_show_payment_history',
-};
-
 const DebtSummaryCard = ({ debt }) => {
-  const { useToggleValue } = useFeatureToggle();
+  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const showResolveLinks = useToggleValue(TOGGLE_NAMES.showVHAPaymentHistory);
   const dispatch = useDispatch();
   const mostRecentHistory = head(debt?.debtHistory);

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -46,9 +46,24 @@ const DebtSummaryCard = ({ debt }) => {
           href={`/manage-va-debt/summary/debt-balances/details/${
             debt.compositeDebtId
           }`}
-          text="Check details and resolve this debt"
-          aria-label={`Check details and resolve this ${debtCardHeading}`}
+          text="Review details"
+          aria-label={`Check details for ${debtCardHeading}`}
         />
+        <div className="vads-u-margin-top--1">
+          <VaLink
+            active
+            data-testid="debt-details-resolve-button"
+            onClick={() => {
+              recordEvent({ event: 'cta-link-click-debt-summary-card' });
+              dispatch(setActiveDebt(debt));
+            }}
+            href={`/manage-va-debt/summary/debt-balances/details/${
+              debt.compositeDebtId
+            }/resolve`}
+            text="Resolve this debt"
+            aria-label={`Resolve ${debtCardHeading}`}
+          />
+        </div>
       </va-card>
     </li>
   );

--- a/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
@@ -68,10 +68,37 @@ const HowDoIPay = ({ userData }) => {
         </ul>
       )}
 
+      <va-additional-info trigger="Here's what the above terms mean:">
+        <ul>
+          <li>
+            <strong>File Number</strong> is your VA claim number. This field
+            must be 8 or 9 characters long.
+          </li>
+          <li>
+            <strong>Payee Number</strong> tells us whether the debtor is a
+            veteran or service member, a child, a spouse, a vendee or parent of
+            the veteran.
+          </li>
+          <li>
+            <strong>Person Entitled</strong> is the first initial, middle
+            initial (if there is one) and first four letters of the debtor’s
+            last name. If the entry on the collection letter after Person
+            Entitled does not have a middle initial, a blank will appear where
+            the middle initial would be. Please leave the same space blank on
+            this form.
+          </li>
+          <li>
+            <strong>Deduction Code</strong> is a number that tells us what type
+            of benefit the debtor received when the debt was established.
+          </li>
+        </ul>
+      </va-additional-info>
+
       <va-link-action
         href="https://www.pay.va.gov/"
         message-aria-describedby="Opens pay.va.gov"
         text="Pay at pay.va.gov"
+        class="vads-u-margin-top--2"
       />
 
       <h3>Pay by phone</h3>

--- a/src/applications/combined-debt-portal/debt-letters/containers/ResolveDebtPage.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/ResolveDebtPage.jsx
@@ -41,11 +41,15 @@ const ResolveDebtPage = ({ match }) => {
           { href: '/manage-va-debt/summary', label: 'Your VA debt and bills' },
           {
             href: '/manage-va-debt/summary/debt-balances',
-            label: 'Debt details',
+            label: 'Current debts',
+          },
+          {
+            href: `/manage-va-debt/summary/debt-balances/details/${selectedId}`,
+            label: `Debt details`,
           },
           {
             href: `/manage-va-debt/summary/balances/details/${selectedId}/resolve`,
-            label: 'Resolve your debt',
+            label: `${title}`,
           },
         ]}
         label="Breadcrumb"

--- a/src/applications/combined-debt-portal/debt-letters/containers/ResolveDebtPage.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/ResolveDebtPage.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/web-components/react-bindings';
+import { useLocation } from 'react-router-dom';
+import HowDoIPay from '../components/HowDoIPay';
+import NeedHelp from '../components/NeedHelp';
+import { setPageFocus } from '../../combined/utils/helpers';
+import useHeaderPageTitle from '../../combined/hooks/useHeaderPageTitle';
+import { getCurrentDebt } from '../utils/page';
+import { deductionCodes } from '../const/deduction-codes';
+
+const ResolveDebtPage = ({ match }) => {
+  const { selectedDebt, debts } = useSelector(
+    ({ combinedPortal }) => combinedPortal.debtLetters,
+  );
+  const location = useLocation();
+  const currentDebt = getCurrentDebt(selectedDebt, debts, location);
+  const selectedId = currentDebt?.id || match?.params?.id;
+
+  const howToUserData = {
+    fileNumber: currentDebt.fileNumber,
+    payeeNumber: currentDebt.payeeNumber,
+    personEntitled: currentDebt.personEntitled,
+    deductionCode: currentDebt.deductionCode,
+  };
+
+  const title = `Resolve your ${deductionCodes[currentDebt.deductionCode]}`;
+
+  useHeaderPageTitle(title);
+
+  useEffect(() => {
+    setPageFocus('h1');
+  }, []);
+
+  return (
+    <>
+      <VaBreadcrumbs
+        breadcrumbList={[
+          { href: '/', label: 'VA.gov Home' },
+          { href: '/manage-va-debt/summary', label: 'Your VA debt and bills' },
+          {
+            href: '/manage-va-debt/summary/debt-balances',
+            label: 'Debt details',
+          },
+          {
+            href: `/manage-va-debt/summary/balances/details/${selectedId}/resolve`,
+            label: 'Resolve your debt',
+          },
+        ]}
+        label="Breadcrumb"
+        wrapping
+      />
+      <div className="medium-screen:vads-l-col--10 small-desktop-screen:vads-l-col--8">
+        <h1 data-testid="detail-page-title" className="vads-u-margin-bottom--2">
+          {title}
+        </h1>
+        <h3 className="vads-u-margin-top--1p5 vads-u-margin-bottom--0 vads-u-font-size--h3 vads-u-font-weight--normal">
+          You can pay your balance, request financial help, or dispute this
+          overpayment
+        </h3>
+        <va-on-this-page class="medium-screen:vads-u-margin-top--0" />
+        <HowDoIPay userData={howToUserData} />
+        <NeedHelp />
+      </div>
+    </>
+  );
+};
+
+ResolveDebtPage.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }),
+};
+
+export default ResolveDebtPage;

--- a/src/applications/combined-debt-portal/debt-letters/tests/ResolveDebtPage.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/tests/ResolveDebtPage.unit.spec.jsx
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import { deductionCodes } from '../const/deduction-codes';
+
+describe('ResolveDebtPage', () => {
+  it('should map deduction codes correctly', () => {
+    expect(deductionCodes['30']).to.equal(
+      'Disability compensation and pension debt',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Match the new VHA designs have a dedicated "resolve" page that includes debt specific data at the new URL `manage-va-debt/summary/debt-balances/details/{debtID}/resolve`


## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#103320

VHA MVP - Add Resolve Copay page
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#102826


## Testing done

- _Manual
-  Unit


## Screenshots (Resolve Links  flag `vha_show_payment_history`)

| Summary Cards  | Resolve Page |
|---------|---------|
| <img src="https://github.com/user-attachments/assets/2aaaf640-9436-4a3f-9924-1229e6fbb074" width="300"><img src="https://github.com/user-attachments/assets/38398253-79c0-418d-9e92-b985b6a03cea" width="300"> | <img src="https://github.com/user-attachments/assets/b3141336-daca-466e-905f-5350a7e741db" width="300">  |


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).


### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution

