### PR TITLE
[#104861] Travel Pay, Claim reimbursement amount

### DIFF
--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -16,6 +16,7 @@ export default function ClaimDetailsContent({
   appointmentDateTime,
   facilityName,
   modifiedOn,
+  reimbursementAmount,
 }) {
   useSetPageTitle(title);
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
@@ -49,8 +50,14 @@ export default function ClaimDetailsContent({
       <p className="vads-u-margin-y--0">
         {appointmentDate} at {appointmentTime} appointment
       </p>
-      <p className="vads-u-margin-y--0">{facilityName}</p>
-      <p className="vads-u-margin-bottom--0">
+      <p className="vads-u-margin-top--0">{facilityName}</p>
+      {claimsMgmtToggle &&
+        reimbursementAmount > 0 && (
+          <p className="vads-u-margin-bottom--0">
+            Reimbursement amount of ${reimbursementAmount}
+          </p>
+        )}
+      <p className="vads-u-margin-y--0">
         Submitted on {createDate} at {createTime}
       </p>
       <p className="vads-u-margin-y--0">
@@ -67,6 +74,7 @@ ClaimDetailsContent.propTypes = {
   createdOn: PropTypes.string.isRequired,
   facilityName: PropTypes.string.isRequired,
   modifiedOn: PropTypes.string.isRequired,
+  reimbursementAmount: PropTypes.number,
 };
 
 function AppealContent() {

--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -80,7 +80,11 @@ ClaimDetailsContent.propTypes = {
 function AppealContent() {
   return (
     <>
-      <va-link text="Appeal the claim decision" href="/decision-reviews" />
+      <va-link
+        external
+        text="Appeal the claim decision"
+        href="/decision-reviews"
+      />
       <va-additional-info
         class="vads-u-margin-y--3"
         trigger="What to expect when you appeal"

--- a/src/applications/travel-pay/services/mocks/travel-claims-31.json
+++ b/src/applications/travel-pay/services/mocks/travel-claims-31.json
@@ -7,7 +7,9 @@
       "appointmentDateTime": "2022-08-03T17:14:41.248Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2022-08-04T17:14:41.248Z",
-      "modifiedOn": "2022-08-09T17:14:41.248Z"
+      "modifiedOn": "2022-08-09T17:14:41.248Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "352b37f2-3566-4642-98b2-6a2bc0e63757",
@@ -16,7 +18,9 @@
       "appointmentDateTime": "2023-08-16T06:01:52.748Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2023-08-17T06:01:52.748Z",
-      "modifiedOn": "2023-08-19T06:01:52.748Z"
+      "modifiedOn": "2023-08-19T06:01:52.748Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "16cbc3d0-56de-4d86-abf3-ed0f6908ee53",
@@ -25,7 +29,9 @@
       "appointmentDateTime": "2023-02-23T22:22:52.549Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2023-02-24T22:22:52.549Z",
-      "modifiedOn": "2023-02-26T22:22:52.549Z"
+      "modifiedOn": "2023-02-26T22:22:52.549Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "498d60a7-fe33-4ea8-80a6-80a27d9fc212",
@@ -34,7 +40,9 @@
       "appointmentDateTime": "2024-05-15T17:56:49.440Z",
       "facilityName": "Minnepolis VA Medical Center",
       "createdOn": "2024-05-16T17:56:49.440Z",
-      "modifiedOn": "2024-05-19T17:56:49.440Z"
+      "modifiedOn": "2024-05-19T17:56:49.440Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "a3e6fb0d-5d30-48d7-9b4b-129b44d46088",
@@ -43,7 +51,9 @@
       "appointmentDateTime": "2022-02-05T20:03:42.624Z",
       "facilityName": "Dubuque VA Clinic",
       "createdOn": "2022-02-06T20:03:42.624Z",
-      "modifiedOn": "2022-02-09T20:03:42.624Z"
+      "modifiedOn": "2022-02-09T20:03:42.624Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "a455f4d9-9d41-4810-8b11-625df84c27cb",
@@ -52,7 +62,9 @@
       "appointmentDateTime": "2023-01-12T03:59:43.074Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2023-01-13T03:59:43.074Z",
-      "modifiedOn": "2023-01-18T03:59:43.074Z"
+      "modifiedOn": "2023-01-18T03:59:43.074Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "3158ca03-e28b-49f9-ab6f-10ad809de7a4",
@@ -61,7 +73,9 @@
       "appointmentDateTime": "2023-05-21T03:51:41.364Z",
       "facilityName": "Minnepolis VA Medical Center",
       "createdOn": "2023-05-22T03:51:41.364Z",
-      "modifiedOn": "2023-05-28T03:51:41.364Z"
+      "modifiedOn": "2023-05-28T03:51:41.364Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "6091a6b0-3277-4d93-85f5-f7c0d027a7d7",
@@ -70,7 +84,9 @@
       "appointmentDateTime": "2023-12-28T22:00:57.915Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2023-12-29T22:00:57.915Z",
-      "modifiedOn": "2024-01-03T22:00:57.915Z"
+      "modifiedOn": "2024-01-03T22:00:57.915Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "10776be0-6d84-4a34-a0b1-3ae9671a696f",
@@ -79,7 +95,9 @@
       "appointmentDateTime": "2023-05-17T17:14:31.111Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2023-05-18T17:14:31.111Z",
-      "modifiedOn": "2023-05-21T17:14:31.111Z"
+      "modifiedOn": "2023-05-21T17:14:31.111Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "cd758e94-2b33-4557-b265-df5fb2c60ac7",
@@ -88,7 +106,9 @@
       "appointmentDateTime": "2022-08-11T17:06:37.779Z",
       "facilityName": "Dubuque VA Clinic",
       "createdOn": "2022-08-12T17:06:37.779Z",
-      "modifiedOn": "2022-08-17T17:06:37.779Z"
+      "modifiedOn": "2022-08-17T17:06:37.779Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "4b99039f-208f-4c07-90b8-498f8466233e",
@@ -97,7 +117,9 @@
       "appointmentDateTime": "2023-06-09T02:15:33.073Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2023-06-10T02:15:33.073Z",
-      "modifiedOn": "2023-06-14T02:15:33.073Z"
+      "modifiedOn": "2023-06-14T02:15:33.073Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "8fdc7561-f644-44ef-bae0-0c0febb87223",
@@ -106,7 +128,9 @@
       "appointmentDateTime": "2024-02-11T17:43:08.022Z",
       "facilityName": "Minnepolis VA Medical Center",
       "createdOn": "2024-02-12T17:43:08.022Z",
-      "modifiedOn": "2024-02-15T17:43:08.022Z"
+      "modifiedOn": "2024-02-15T17:43:08.022Z",
+      "totalCostRequested": 2.48,
+      "reimbursementAmount": 1.32
     },
     {
       "id": "487b542c-9012-4361-8c8b-bc5e74b39fbc",
@@ -115,7 +139,9 @@
       "appointmentDateTime": "2022-02-02T22:05:35.445Z",
       "facilityName": "Dubuque VA Clinic",
       "createdOn": "2022-02-03T22:05:35.445Z",
-      "modifiedOn": "2022-02-09T22:05:35.445Z"
+      "modifiedOn": "2022-02-09T22:05:35.445Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "f5e7e044-454f-4388-8905-dec3ede6dc3b",
@@ -124,7 +150,9 @@
       "appointmentDateTime": "2022-11-16T19:15:30.638Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2022-11-17T19:15:30.638Z",
-      "modifiedOn": "2022-11-22T19:15:30.638Z"
+      "modifiedOn": "2022-11-22T19:15:30.638Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "38caecd8-7e6a-4b8b-b1a6-4ed5ee9bd1ec",
@@ -133,7 +161,9 @@
       "appointmentDateTime": "2023-06-22T04:41:45.517Z",
       "facilityName": "Dubuque VA Clinic",
       "createdOn": "2023-06-23T04:41:45.517Z",
-      "modifiedOn": "2023-06-27T04:41:45.517Z"
+      "modifiedOn": "2023-06-27T04:41:45.517Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "1ae5ae4a-eb17-4405-9bae-a5cf5205499e",
@@ -142,7 +172,9 @@
       "appointmentDateTime": "2022-03-27T11:28:34.656Z",
       "facilityName": "Dubuque VA Clinic",
       "createdOn": "2022-03-28T11:28:34.656Z",
-      "modifiedOn": "2022-04-01T11:28:34.656Z"
+      "modifiedOn": "2022-04-01T11:28:34.656Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "d3df2f2f-df82-47f6-a7de-cfadd15c8a32",
@@ -151,7 +183,9 @@
       "appointmentDateTime": "2022-12-05T19:56:45.678Z",
       "facilityName": "Dubuque VA Clinic",
       "createdOn": "2022-12-06T19:56:45.678Z",
-      "modifiedOn": "2022-12-08T19:56:45.678Z"
+      "modifiedOn": "2022-12-08T19:56:45.678Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "7519378a-e9ef-4a84-8673-591776c8f06b",
@@ -160,7 +194,9 @@
       "appointmentDateTime": "2022-12-05T16:53:31.770Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2022-12-06T16:53:31.770Z",
-      "modifiedOn": "2022-12-12T16:53:31.770Z"
+      "modifiedOn": "2022-12-12T16:53:31.770Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "e0c80c02-a877-42dc-a79f-309f667aba6c",
@@ -169,7 +205,9 @@
       "appointmentDateTime": "2022-11-21T11:37:34.744Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2022-11-22T11:37:34.744Z",
-      "modifiedOn": "2022-11-28T11:37:34.744Z"
+      "modifiedOn": "2022-11-28T11:37:34.744Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "8b0b1410-a1b8-4110-aa49-6ed8dee0f6f8",
@@ -178,7 +216,9 @@
       "appointmentDateTime": "2023-06-06T18:07:11.788Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2023-06-07T18:07:11.788Z",
-      "modifiedOn": "2023-06-11T18:07:11.788Z"
+      "modifiedOn": "2023-06-11T18:07:11.788Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "20d73591-ff18-4b66-9838-1429ebbf1b6e",
@@ -187,7 +227,9 @@
       "appointmentDateTime": "2024-05-26T16:40:45.781Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2024-05-27T16:40:45.781Z",
-      "modifiedOn": "2024-05-31T16:40:45.781Z"
+      "modifiedOn": "2024-05-31T16:40:45.781Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "15c3c8ca-f203-42f2-952d-377319c938fe",
@@ -196,7 +238,9 @@
       "appointmentDateTime": "2023-04-10T00:05:00.807Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2023-04-11T00:05:00.807Z",
-      "modifiedOn": "2023-04-13T00:05:00.807Z"
+      "modifiedOn": "2023-04-13T00:05:00.807Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "6c3ce588-53ea-402e-824f-3360950a6071",
@@ -205,7 +249,9 @@
       "appointmentDateTime": "2023-09-02T02:15:48.558Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2023-09-03T02:15:48.558Z",
-      "modifiedOn": "2023-09-05T02:15:48.558Z"
+      "modifiedOn": "2023-09-05T02:15:48.558Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "7eef3e51-ef2d-4913-92e5-02e9981563e2",
@@ -214,7 +260,9 @@
       "appointmentDateTime": "2023-11-30T10:49:02.019Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2023-12-01T10:49:02.019Z",
-      "modifiedOn": "2023-12-03T10:49:02.019Z"
+      "modifiedOn": "2023-12-03T10:49:02.019Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "a54d75aa-82c2-4896-964b-59cbd8f2e7ea",
@@ -223,7 +271,9 @@
       "appointmentDateTime": "2024-03-30T20:21:26.086Z",
       "facilityName": "Dubuque VA Clinic",
       "createdOn": "2024-03-31T20:21:26.086Z",
-      "modifiedOn": "2024-04-03T20:21:26.086Z"
+      "modifiedOn": "2024-04-03T20:21:26.086Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "27555077-cdb9-48f4-a4af-2f0df5b3313b",
@@ -232,7 +282,9 @@
       "appointmentDateTime": "2023-05-08T21:53:31.155Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2023-05-09T21:53:31.155Z",
-      "modifiedOn": "2023-05-11T21:53:31.155Z"
+      "modifiedOn": "2023-05-11T21:53:31.155Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "894a6a37-c238-4203-b8d2-5afc9f4d2f37",
@@ -241,7 +293,9 @@
       "appointmentDateTime": "2022-10-22T06:12:32.848Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2022-10-23T06:12:32.848Z",
-      "modifiedOn": "2022-10-26T06:12:32.848Z"
+      "modifiedOn": "2022-10-26T06:12:32.848Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "bccd3b13-e10d-4995-b86f-1fb501e7c533",
@@ -250,7 +304,9 @@
       "appointmentDateTime": "2022-03-08T03:52:33.303Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2022-03-09T03:52:33.303Z",
-      "modifiedOn": "2022-03-13T03:52:33.303Z"
+      "modifiedOn": "2022-03-13T03:52:33.303Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "8a1e5156-5c5f-41ac-a8be-83c8ec290bf9",
@@ -259,7 +315,9 @@
       "appointmentDateTime": "2024-02-26T11:43:11.048Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2024-02-27T11:43:11.048Z",
-      "modifiedOn": "2024-03-04T11:43:11.048Z"
+      "modifiedOn": "2024-03-04T11:43:11.048Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "6a5302bb-f6ee-4cf9-89b7-7b2775f056bd",
@@ -268,7 +326,9 @@
       "appointmentDateTime": "2023-03-08T07:09:22.642Z",
       "facilityName": "Cheyenne VA Medical Center",
       "createdOn": "2023-03-09T07:09:22.642Z",
-      "modifiedOn": "2023-03-14T06:09:22.642Z"
+      "modifiedOn": "2023-03-14T06:09:22.642Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     },
     {
       "id": "63bd7bc9-5ac4-41af-9f2d-4c1a7ce33b1d",
@@ -277,7 +337,9 @@
       "appointmentDateTime": "2022-11-09T18:51:47.341Z",
       "facilityName": "Tomah VA Medical Center",
       "createdOn": "2022-11-10T18:51:47.341Z",
-      "modifiedOn": "2022-11-13T18:51:47.341Z"
+      "modifiedOn": "2022-11-13T18:51:47.341Z",
+      "totalCostRequested": 0.0,
+      "reimbursementAmount": 0.0
     }
   ]
 }

--- a/src/applications/travel-pay/tests/components/TravelClaimDetails.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/TravelClaimDetails.unit.spec.jsx
@@ -94,6 +94,18 @@ describe('TravelClaimDetails', () => {
     });
   });
 
+  it('renders reimbursement amount if one is provided', async () => {
+    global.fetch.restore();
+    mockApiRequest({ ...claimDetailsProps, reimbursementAmount: 46.93 });
+
+    const screen = renderWithStoreAndRouter(<TravelClaimDetails />, {
+      initialState: getState(),
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Reimbursement amount of $46.93')).to.exist;
+    });
+  });
+
   it('renders appeal link for denied claims', async () => {
     global.fetch.restore();
     mockApiRequest({ ...claimDetailsProps, claimStatus: 'Denied' });
@@ -110,7 +122,11 @@ describe('TravelClaimDetails', () => {
 
   it('does not render claims management content with flag off', async () => {
     global.fetch.restore();
-    mockApiRequest({ ...claimDetailsProps, claimStatus: 'Denied' });
+    mockApiRequest({
+      ...claimDetailsProps,
+      claimStatus: 'Denied',
+      reimbursementAmount: 1.0,
+    });
 
     const screen = renderWithStoreAndRouter(<TravelClaimDetails />, {
       initialState: getState({ hasClaimsManagementFlag: false }),
@@ -120,5 +136,6 @@ describe('TravelClaimDetails', () => {
     expect(
       $('va-link[text="Appeal the claim decision"][href="/decision-reviews"]'),
     ).to.not.exist;
+    expect(screen.queryByText('Reimbursement amount of $1.00')).to.not.exist;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding a reimbursement amount render for travel claims if there is a value and the `travel_pay_claims_management` flag is on.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/104861

## Testing done



## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![before_mobile](https://github.com/user-attachments/assets/fef8a022-9f6b-4f9b-aba5-bde0b30698d0) | ![after_mobile](https://github.com/user-attachments/assets/ece6c5b8-a837-490f-981b-284b4e3778f3) |
| Desktop | ![before_desktop](https://github.com/user-attachments/assets/aea9395d-b6e3-4b2f-aab3-8f4a57e33b1c) | ![after_desktop](https://github.com/user-attachments/assets/f3cd5b7b-b4ef-4a3f-9fa1-410f810f90f3) |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user