### PR TITLE
105556 Update attachment ID info for supporting docs - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
@@ -305,7 +305,7 @@ export const pharmacyClaimUploadSchema = {
           <li>Cost of the medication and the copay amount.</li>
           <li>
             National Drug Code (NDC) for each medication. This is an 11-digit
-            number that’s different froom the Rx number.
+            number that’s different from the Rx number.
           </li>
           <li>Date the pharmacy filled the prescription.</li>
           <li>Name of the provider who wrote the prescription.</li>

--- a/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
@@ -34,7 +34,7 @@ export default function transformForSubmit(formConfig, form) {
   // ---
   // Add type/category info to file uploads:
   const pharmacyUpload = copyOfData?.pharmacyUpload?.map(el => {
-    return { ...el, attachmentId: '1500' };
+    return { ...el, attachmentId: 'MEDDOCS' };
   });
   copyOfData.pharmacyUpload = pharmacyUpload;
 

--- a/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
@@ -38,7 +38,6 @@ export default function transformForSubmit(formConfig, form) {
   });
   copyOfData.pharmacyUpload = pharmacyUpload;
 
-  // TODO: why does medical upload not show up in the final object?
   const medicalUpload = copyOfData?.medicalUpload?.map(el => {
     return { ...el, attachmentId: 'MEDDOCS' };
   });

--- a/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
@@ -33,18 +33,24 @@ export default function transformForSubmit(formConfig, form) {
 
   // ---
   // Add type/category info to file uploads:
+  const pharmacyUpload = copyOfData?.pharmacyUpload?.map(el => {
+    return { ...el, attachmentId: '1500' };
+  });
+  copyOfData.pharmacyUpload = pharmacyUpload;
+
+  // TODO: why does medical upload not show up in the final object?
   const medicalUpload = copyOfData?.medicalUpload?.map(el => {
-    return { ...el, documentType: 'itemized billing statement' };
+    return { ...el, attachmentId: 'MEDDOCS' };
   });
   copyOfData.medicalUpload = medicalUpload;
 
   const primaryEob = copyOfData?.primaryEob?.map(el => {
-    return { ...el, documentType: 'Eob' };
+    return { ...el, attachmentId: 'EOB' };
   });
   copyOfData.primaryEob = primaryEob;
 
   const secondaryEob = copyOfData?.secondaryEob?.map(el => {
-    return { ...el, documentType: 'Eob' };
+    return { ...el, attachmentId: 'EOB' };
   });
   copyOfData.secondaryEob = secondaryEob;
   // ---

--- a/src/applications/ivc-champva/10-7959a/tests/unit/config/transformers.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959a/tests/unit/config/transformers.unit.spec.js
@@ -7,26 +7,10 @@ import transformForSubmit from '../../../config/submitTransformer';
 describe('Submit transformer', () => {
   it('should add the file type to submitted files', () => {
     const result = JSON.parse(transformForSubmit(formConfig, mockData));
-    expect(result.medicalUpload[0].documentType).to.equal(
-      'itemized billing statement',
-    );
-    expect(result.primaryEob[0].documentType).to.equal('Eob');
-    expect(result.secondaryEob[0].documentType).to.equal('Eob');
-  });
-
-  it('should set primary contact name to false if not present', () => {
-    const result = JSON.parse(
-      transformForSubmit(formConfig, {
-        ...mockData,
-        certifierName: undefined,
-        applicantName: undefined,
-      }),
-    );
-    expect(result.medicalUpload[0].documentType).to.equal(
-      'itemized billing statement',
-    );
-    expect(result.primaryEob[0].documentType).to.equal('Eob');
-    expect(result.secondaryEob[0].documentType).to.equal('Eob');
+    const attachmentIds = result.supportingDocs.map(o => o.attachmentId);
+    expect(attachmentIds.length).to.eq(3); // 'EOB', 'EOB', and 'MEDDOCS'
+    expect(attachmentIds.includes('MEDDOCS')).to.be.true;
+    expect(attachmentIds.includes('EOB')).to.be.true;
   });
 
   it('should set primaryContact name to false if none present', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates the attachment IDs associated with the supporting document uploads, also updates the associated unit test.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105556

## Testing done

- Unit testing

## Screenshots

NA

## What areas of the site does it impact?

Form 10-7959a only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA