### PR TITLE
DBEX-19739 / Add aria-describedby text to the 526 introduction page start button

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -15,6 +15,7 @@ import { show526Wizard, isBDD, getPageTitle, getStartText } from '../utils';
 import {
   BDD_INFO_URL,
   DISABILITY_526_V2_ROOT_URL,
+  ITF_NOTICE_TEXT,
   WIZARD_STATUS,
   PAGE_TITLE_SUFFIX,
   DOCUMENT_TITLE_SUFFIX,
@@ -59,6 +60,7 @@ class IntroductionPage extends React.Component {
       downtime: formConfig.downtime,
       retentionPeriod: '1 year',
       ariaDescribedby: 'main-content',
+      buttonAriaDescribedby: ITF_NOTICE_TEXT,
     };
 
     return (

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -23,6 +23,11 @@ export const START_TEXT = {
   BDD: 'Start the Benefits Disability at Discharge Application',
 };
 
+export const ITF_NOTICE_TEXT = `By clicking the button to start the disability application, you’ll declare
+  your intent to file. This will reserve a potential effective date for when
+  you could start getting benefits. You have 1 year from the day you submit
+  your intent to file to complete your application.`;
+
 export const itfStatuses = {
   active: 'active',
   expired: 'expired',

--- a/src/applications/disability-benefits/all-claims/content/introductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/introductionPage.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
+import { ITF_NOTICE_TEXT } from '../constants';
 
 export const itfNotice = (
-  <p className="vads-u-margin-top--0">
-    By clicking the button to start the disability application, you’ll declare
-    your intent to file. This will reserve a potential effective date for when
-    you could start getting benefits. You have 1 year from the day you submit
-    your intent to file to complete your application.
-  </p>
+  <p className="vads-u-margin-top--0">{ITF_NOTICE_TEXT}</p>
 );

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -190,7 +190,12 @@ class SaveInProgressIntro extends React.Component {
         );
       }
     } else if (prefillEnabled && !verifyRequiredPrefill) {
-      const { buttonOnly, retentionPeriod, unauthStartText } = this.props;
+      const {
+        buttonOnly,
+        buttonAriaDescribedby,
+        retentionPeriod,
+        unauthStartText,
+      } = this.props;
       const CustomLink = this.props.customLink;
       const unauthStartButton = CustomLink ? (
         <CustomLink
@@ -207,6 +212,7 @@ class SaveInProgressIntro extends React.Component {
           onClick={this.openLoginModal}
           label={ariaLabel}
           uswds
+          messageAriaDescribedby={buttonAriaDescribedby}
           text={unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
         />
       );
@@ -415,6 +421,7 @@ SaveInProgressIntro.propTypes = {
   alertTitle: PropTypes.string,
   ariaDescribedby: PropTypes.string,
   ariaLabel: PropTypes.string,
+  buttonAriaDescribedby: PropTypes.string,
   buttonOnly: PropTypes.bool,
   children: PropTypes.any,
   continueMsg: PropTypes.string,
@@ -469,6 +476,7 @@ SaveInProgressIntro.defaultProps = {
   headingLevel: 2,
   ariaLabel: null,
   ariaDescribedby: null,
+  buttonAriaDescribedby: null,
   customLink: null,
 };
 
@@ -496,6 +504,7 @@ const mapDispatchToProps = {
  *   alertTitle: string,
  *   ariaDescribedby: string,
  *   ariaLabel: string,
+ *   buttonAriaDescribedby: string,
  *   buttonOnly: boolean,
  *   children: any,
  *   customLink: any,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Following up on an old 508 ticket, that suggested that the Start button on the 526ez introduction page should have an `aria-describedby` linking it to a descriptive paragraph below.
- The `ariaDescribedby` prop already exists on the `SaveInProgressIntro` component and is passed to links, so added the optional prop `buttonAriaDescribedBy` to be passed to the button component.
- The Sign in to start your application button appears 2 times on the introduction page, once at the top inside the blue section, and once at the bottom as just the button.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/19739

## Testing
- Go to the disability/file-disability-claim-form-21-526ez/introduction page 
- Turn on screenreader
- TAB to the Start button
- Listen. You should hear additional text announced besides just the text in the start button.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop first button | <img width="689" alt="Screenshot 2025-03-19 at 12 39 32 PM" src="https://github.com/user-attachments/assets/7191f367-d787-4335-aea7-9ec7b8f182c3" /> | <img width="1208" alt="Screenshot 2025-03-18 at 1 31 27 PM" src="https://github.com/user-attachments/assets/58bf4d96-b2eb-4afa-8245-53b79242cb0d" />|
| Desktop second button |<img width="1368" alt="Screenshot 2025-03-19 at 12 39 50 PM" src="https://github.com/user-attachments/assets/ad3fba1e-8e62-46e0-8c5d-19de4e262341" />|<img width="1217" alt="Screenshot 2025-03-18 at 1 31 46 PM" src="https://github.com/user-attachments/assets/87ab7120-42b9-4fb8-bc3d-3558e9d189d6" />|
| Screenreader |<img width="798" alt="Screenshot 2025-03-19 at 1 05 30 PM" src="https://github.com/user-attachments/assets/a80a2df6-447c-4c7c-8a3a-2a639d767757" />|<img width="987" alt="Screenshot 2025-03-18 at 3 18 52 PM" src="https://github.com/user-attachments/assets/eada17b3-745a-4bdc-8c2c-c5bf885bdc9c" />|


## What areas of the site does it impact?

526 intro page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
