### PR TITLE
MHV-66237: Details page hierarchy changes

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/GroupedMedications.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/GroupedMedications.jsx
@@ -54,7 +54,7 @@ const GroupedMedications = props => {
   return (
     <div className="vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-margin-bottom--3 vads-u-margin-top--3">
       <section className="vads-u-margin-y--3" data-testid="previous-rx">
-        <h3>Previous prescriptions</h3>
+        <h2 className="vads-u-font-size--lg">Previous prescriptions</h2>
         <p
           className="vads-u-font-family--sans"
           id="list-showing-info"
@@ -76,7 +76,9 @@ const GroupedMedications = props => {
                 key={rx.prescriptionId}
               >
                 <dt className="vads-u-margin-top--3" data-dd-privacy="mask">
-                  <h4>Prescription number: {rx.prescriptionNumber}</h4>
+                  <h3 className="vads-u-font-size--md">
+                    Prescription number: {rx.prescriptionNumber}
+                  </h3>
                 </dt>
                 <dd className="last-filled-info-grouped-rx">
                   <LastFilledInfo {...rx} />


### PR DESCRIPTION
## Summary

- Accessibility/semantics updates for `GroupedMedications`

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-66237

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Remove: Divider above “Refill history” 
AC2: Change: "Previous prescriptions" header is now an h2
AC3: Change: Individual previous prescriptions are now styled as body bold, but coded as h3s

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

