### PR TITLE
Update to use api as source of truth for CC appointments

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -9,6 +9,7 @@ import {
   selectFeatureVAOSServiceRequests,
   selectFeatureVAOSServiceVAAppointments,
   selectFeatureFeSourceOfTruth,
+  selectFeatureFeSourceOfTruthCC,
   selectSystemIds,
 } from '../../redux/selectors';
 import {
@@ -98,6 +99,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
     );
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const patientFacilities = selectPatientFacilities(state);
 
     const includeEPS = getIsInCCPilot(
@@ -134,6 +136,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             .format('YYYY-MM-DD'),
           includeEPS,
           useFeSourceOfTruth,
+          useFeSourceOfTruthCC,
         }),
       ];
       if (includeRequests) {
@@ -148,6 +151,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             useV2: featureVAOSServiceRequests,
             includeEPS,
             useFeSourceOfTruth,
+            useFeSourceOfTruthCC,
           })
             .then(requests => {
               dispatch({
@@ -251,15 +255,14 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
 
 export function fetchPastAppointments(startDate, endDate, selectedIndex) {
   return async (dispatch, getState) => {
+    const state = getState();
     const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
-      getState(),
+      state,
     );
-
-    const featureCCDirectScheduling = selectFeatureCCDirectScheduling(
-      getState(),
-    );
-    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(getState());
-    const patientFacilities = selectPatientFacilities(getState());
+    const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
+    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+    const patientFacilities = selectPatientFacilities(state);
     const includeEPS = getIsInCCPilot(
       featureCCDirectScheduling,
       patientFacilities || [],
@@ -282,6 +285,7 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
         fetchClaimStatus: true,
         includeEPS,
         useFeSourceOfTruth,
+        useFeSourceOfTruthCC,
       });
       const appointments = results.filter(appt => !appt.hasOwnProperty('meta'));
       const backendServiceFailures =
@@ -338,6 +342,7 @@ export function fetchRequestDetails(id) {
     try {
       const state = getState();
       const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+      const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
 
       let request = selectAppointmentById(state, id, [
         APPOINTMENT_TYPES.ccRequest,
@@ -353,7 +358,11 @@ export function fetchRequestDetails(id) {
       }
 
       if (!request) {
-        request = await fetchRequestById({ id, useFeSourceOfTruth });
+        request = await fetchRequestById({
+          id,
+          useFeSourceOfTruth,
+          useFeSourceOfTruthCC,
+        });
         facilityId = getVAAppointmentLocationId(request);
         facility = state.appointments.facilityData?.[facilityId];
       }
@@ -397,6 +406,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
           ? featureVAOSServiceCCAppointments
           : featureVAOSServiceVAAppointments;
       const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+      const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
 
       let appointment = selectAppointmentById(state, id, [
         type === 'cc'
@@ -419,6 +429,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
           type,
           useV2,
           useFeSourceOfTruth,
+          useFeSourceOfTruthCC,
         });
       }
 
@@ -485,6 +496,7 @@ export function confirmCancelAppointment() {
     const state = getState();
     const appointment = state.appointments.appointmentToCancel;
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
 
     try {
       dispatch({
@@ -494,6 +506,7 @@ export function confirmCancelAppointment() {
       const updatedAppointment = await cancelAppointment({
         appointment,
         useFeSourceOfTruth,
+        useFeSourceOfTruthCC,
       });
 
       dispatch({

--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -11,6 +11,7 @@ import {
   selectSystemIds,
   selectFeatureBreadcrumbUrlUpdate,
   selectFeatureFeSourceOfTruth,
+  selectFeatureFeSourceOfTruthCC,
 } from '../../redux/selectors';
 import { getAvailableHealthcareServices } from '../../services/healthcare-service';
 import {
@@ -382,6 +383,7 @@ export function confirmAppointment(history) {
     const state = getState();
     const featureBreadcrumbUrlUpdate = selectFeatureBreadcrumbUrlUpdate(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
 
     dispatch({
       type: FORM_SUBMIT,
@@ -401,6 +403,7 @@ export function confirmAppointment(history) {
       const appointment = await createAppointment({
         appointment: transformFormToVAOSAppointment(getState()),
         useFeSourceOfTruth,
+        useFeSourceOfTruthCC,
       });
 
       const data = selectCovid19VaccineFormData(getState());

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -17,7 +17,10 @@ import {
   startDirectScheduleFlow,
 } from '../../redux/actions';
 import { selectTypeOfCarePage } from '../../redux/selectors';
-import { selectFeatureFeSourceOfTruth } from '../../../redux/selectors';
+import {
+  selectFeatureFeSourceOfTruth,
+  selectFeatureFeSourceOfTruthCC,
+} from '../../../redux/selectors';
 import { resetDataLayer } from '../../../utils/events';
 
 import { PODIATRY_ID, TYPES_OF_CARE } from '../../../utils/constants';
@@ -32,6 +35,9 @@ export default function TypeOfCarePage() {
   const pageTitle = useSelector(state => getPageTitle(state, pageKey));
   const useFeSourceOfTruth = useSelector(state =>
     selectFeatureFeSourceOfTruth(state),
+  );
+  const useFeSourceOfTruthCC = useSelector(state =>
+    selectFeatureFeSourceOfTruthCC(state),
   );
 
   const dispatch = useDispatch();
@@ -144,7 +150,10 @@ export default function TypeOfCarePage() {
             // This could get called multiple times, but the function is memoized
             // and returns the previous promise if it eixsts
             if (showDirectScheduling) {
-              getLongTermAppointmentHistoryV2(useFeSourceOfTruth);
+              getLongTermAppointmentHistoryV2(
+                useFeSourceOfTruth,
+                useFeSourceOfTruthCC,
+              );
             }
 
             setData(newData);

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -16,6 +16,7 @@ import {
   selectFeatureClinicFilter,
   selectFeatureBreadcrumbUrlUpdate,
   selectFeatureFeSourceOfTruth,
+  selectFeatureFeSourceOfTruthCC,
   selectFeatureRecentLocationsFilter,
 } from '../../redux/selectors';
 import {
@@ -307,6 +308,7 @@ export function checkEligibility({ location, showModal, isCerner }) {
     );
     const featureClinicFilter = selectFeatureClinicFilter(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
 
     dispatch({
       type: FORM_ELIGIBILITY_CHECKS,
@@ -324,6 +326,7 @@ export function checkEligibility({ location, showModal, isCerner }) {
             typeOfCare,
             directSchedulingEnabled,
             useFeSourceOfTruth,
+            useFeSourceOfTruthCC,
             isCerner: true,
           });
 
@@ -360,6 +363,7 @@ export function checkEligibility({ location, showModal, isCerner }) {
           useV2: featureVAOSServiceVAAppointments,
           featureClinicFilter,
           useFeSourceOfTruth,
+          useFeSourceOfTruthCC,
         });
 
         if (showModal) {
@@ -911,6 +915,7 @@ export function submitAppointmentOrRequest(history) {
     );
     const featureBreadcrumbUrlUpdate = selectFeatureBreadcrumbUrlUpdate(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const newAppointment = getNewAppointment(state);
     const data = newAppointment?.data;
     const typeOfCare = getTypeOfCare(getFormData(state))?.name;
@@ -937,6 +942,7 @@ export function submitAppointmentOrRequest(history) {
         appointment = await createAppointment({
           appointment: transformFormToVAOSAppointment(getState()),
           useFeSourceOfTruth,
+          useFeSourceOfTruthCC,
         });
 
         dispatch({
@@ -1025,20 +1031,15 @@ export function submitAppointmentOrRequest(history) {
       });
 
       try {
-        let requestData;
-        if (isCommunityCare) {
-          requestBody = transformFormToVAOSCCRequest(getState());
-          requestData = await createAppointment({
-            appointment: requestBody,
-            useFeSourceOfTruth,
-          });
-        } else {
-          requestBody = transformFormToVAOSVARequest(getState());
-          requestData = await createAppointment({
-            appointment: requestBody,
-            useFeSourceOfTruth,
-          });
-        }
+        requestBody = isCommunityCare
+          ? transformFormToVAOSCCRequest(getState())
+          : transformFormToVAOSVARequest(getState());
+
+        const requestData = await createAppointment({
+          appointment: requestBody,
+          useFeSourceOfTruth,
+          useFeSourceOfTruthCC,
+        });
 
         dispatch({
           type: FORM_SUBMIT_SUCCEEDED,

--- a/src/applications/vaos/redux/actions.js
+++ b/src/applications/vaos/redux/actions.js
@@ -13,6 +13,7 @@ import {
   selectFeatureCCDirectScheduling,
   selectFeatureVAOSServiceRequests,
   selectFeatureFeSourceOfTruth,
+  selectFeatureFeSourceOfTruthCC,
 } from './selectors';
 import { getIsInCCPilot } from '../referral-appointments/utils/pilot';
 
@@ -86,6 +87,7 @@ export function fetchPendingAppointments() {
       );
       const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
       const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
+      const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
       const patientFacilities = selectPatientFacilities(state);
       const includeEPS = getIsInCCPilot(
         featureCCDirectScheduling,
@@ -101,6 +103,7 @@ export function fetchPendingAppointments() {
           .format('YYYY-MM-DD'),
         includeEPS,
         useFeSourceOfTruth,
+        useFeSourceOfTruthCC,
       });
 
       const data = pendingAppointments?.filter(

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -69,6 +69,7 @@ function apptRequestSort(a, b) {
  * @param {Boolean} fetchClaimStatus Boolean to fetch travel claim data
  * @param {Boolean} includeEPS Boolean to include EPS appointments
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
+ * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @returns {Appointment[]} A FHIR searchset of booked Appointment resources
  */
 export async function fetchAppointments({
@@ -78,6 +79,7 @@ export async function fetchAppointments({
   fetchClaimStatus = false,
   includeEPS = false,
   useFeSourceOfTruth = false,
+  useFeSourceOfTruthCC = false,
 }) {
   try {
     const appointments = [];
@@ -99,7 +101,11 @@ export async function fetchAppointments({
     });
 
     appointments.push(
-      ...transformVAOSAppointments(filteredAppointments, useFeSourceOfTruth),
+      ...transformVAOSAppointments(
+        filteredAppointments,
+        useFeSourceOfTruth,
+        useFeSourceOfTruthCC,
+      ),
       {
         meta: allAppointments.backendSystemFailures,
       },
@@ -124,6 +130,7 @@ export async function fetchAppointments({
  * @param {String} endDate Date in YYYY-MM-DD format
  * @param {Boolean} includeEPS Boolean to include EPS appointments
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
+ * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @returns {Appointment[]} A FHIR searchset of pending Appointment resources
  */
 export async function getAppointmentRequests({
@@ -131,6 +138,7 @@ export async function getAppointmentRequests({
   endDate,
   includeEPS = false,
   useFeSourceOfTruth = false,
+  useFeSourceOfTruthCC = false,
 }) {
   try {
     const appointments = await getAppointments({
@@ -153,6 +161,7 @@ export async function getAppointmentRequests({
     const transformRequests = transformVAOSAppointments(
       requestsWithoutAppointments,
       useFeSourceOfTruth,
+      useFeSourceOfTruthCC,
     );
 
     transformRequests.push({
@@ -176,13 +185,22 @@ export async function getAppointmentRequests({
  * @async
  * @param {string} id Appointment request id
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
+ * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @returns {Appointment} An Appointment object for the given request id
  */
-export async function fetchRequestById({ id, useFeSourceOfTruth = false }) {
+export async function fetchRequestById({
+  id,
+  useFeSourceOfTruth = false,
+  useFeSourceOfTruthCC = false,
+}) {
   try {
     const appointment = await getAppointment(id);
 
-    return transformVAOSAppointment(appointment, useFeSourceOfTruth);
+    return transformVAOSAppointment(
+      appointment,
+      useFeSourceOfTruth,
+      useFeSourceOfTruthCC,
+    );
   } catch (e) {
     if (e.errors) {
       throw mapToFHIRErrors(e.errors);
@@ -200,6 +218,7 @@ export async function fetchRequestById({ id, useFeSourceOfTruth = false }) {
  * @param {avs} Boolean to fetch avs data
  * @param {fetchClaimStatus} Boolean to fetch travel claim data
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
+ * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @returns {Appointment} A transformed appointment with the given id
  */
 export async function fetchBookedAppointment({
@@ -207,10 +226,15 @@ export async function fetchBookedAppointment({
   avs = true,
   fetchClaimStatus = true,
   useFeSourceOfTruth = true,
+  useFeSourceOfTruthCC = false,
 }) {
   try {
     const appointment = await getAppointment(id, avs, fetchClaimStatus);
-    return transformVAOSAppointment(appointment, useFeSourceOfTruth);
+    return transformVAOSAppointment(
+      appointment,
+      useFeSourceOfTruth,
+      useFeSourceOfTruthCC,
+    );
   } catch (e) {
     if (e.errors) {
       throw mapToFHIRErrors(e.errors);
@@ -543,12 +567,21 @@ export function groupAppointmentsByMonth(appointments) {
  * @param {Object} params
  * @param {VAOSAppointment} params.appointment The appointment to send
  * @param {Boolean} params.useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
+ * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @returns {Appointment} The created appointment
  */
-export async function createAppointment({ appointment, useFeSourceOfTruth }) {
+export async function createAppointment({
+  appointment,
+  useFeSourceOfTruth,
+  useFeSourceOfTruthCC,
+}) {
   const result = await postAppointment(appointment);
 
-  return transformVAOSAppointment(result, useFeSourceOfTruth);
+  return transformVAOSAppointment(
+    result,
+    useFeSourceOfTruth,
+    useFeSourceOfTruthCC,
+  );
 }
 
 const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
@@ -560,9 +593,14 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  * @param {Object} params
  * @param {Appointment} params.appointment The appointment to cancel
  * @param {Boolean} params.useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
+ * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @returns {?Appointment} Returns either null or the updated appointment data
  */
-export async function cancelAppointment({ appointment, useFeSourceOfTruth }) {
+export async function cancelAppointment({
+  appointment,
+  useFeSourceOfTruth,
+  useFeSourceOfTruthCC,
+}) {
   const additionalEventData = {
     appointmentType:
       appointment.status === APPOINTMENT_STATUS.proposed
@@ -587,7 +625,11 @@ export async function cancelAppointment({ appointment, useFeSourceOfTruth }) {
     });
     resetDataLayer();
 
-    return transformVAOSAppointment(updatedAppointment, useFeSourceOfTruth);
+    return transformVAOSAppointment(
+      updatedAppointment,
+      useFeSourceOfTruth,
+      useFeSourceOfTruthCC,
+    );
   } catch (e) {
     captureError(e, true);
     recordEvent({
@@ -623,7 +665,6 @@ export function getCalendarData({ appointment, facility }) {
   const isVideo = appointment?.vaos.isVideo;
   const isCommunityCare = appointment?.vaos.isCommunityCare;
   const isPhone = isVAPhoneAppointment(appointment);
-  // const isInPersonVAAppointment = !isVideo && !isCommunityCare && !isPhone;
   const signinText =
     'Sign in to https://va.gov/health-care/schedule-view-va-appointments/appointments to get details about this appointment';
 
@@ -774,7 +815,7 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
   const batch = [];
   let promise = null;
 
-  return useFeSourceOfTruth => {
+  return (useFeSourceOfTruth, useFeSourceOfTruthCC) => {
     if (!promise || navigator.userAgent === 'node.js') {
       // Creating an array of start and end dates for each chunk
       const ranges = Array.from(Array(chunks).keys()).map(i => {
@@ -808,9 +849,8 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
         const p1 = await fetchAppointments({
           startDate: curr.start,
           endDate: curr.end,
-          useV2VA: true,
-          useV2CC: true,
           useFeSourceOfTruth,
+          useFeSourceOfTruthCC,
         });
         batch.push(p1);
         return Promise.resolve([...batch].flat());

--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -676,7 +676,7 @@ describe('VAOS Services: Appointment ', () => {
         });
       });
 
-      await getLongTermAppointmentHistoryV2(true);
+      await getLongTermAppointmentHistoryV2(true, true);
       expect(global.fetch.callCount).to.equal(3);
       expect(global.fetch.firstCall.args[0]).to.contain(dateRanges[0].start);
       expect(global.fetch.firstCall.args[0]).to.contain(dateRanges[0].end);

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -6,7 +6,7 @@ describe('getAppointmentType util', () => {
     const appointment = {
       id: 'CERN123',
     };
-    const result = getAppointmentType(appointment);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('request');
   });
   it('should return appointment type as vaAppointment for cerner appointment', async () => {
@@ -14,16 +14,24 @@ describe('getAppointmentType util', () => {
       id: 'CERN123',
       end: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('vaAppointment');
   });
-  it('should return appointment type as ccAppointment', async () => {
+  it('should return appointment type as ccAppointment, useFeSourceOfTruthCC=false', async () => {
     const appointment = {
       id: '123',
       kind: 'cc',
       start: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment);
+    const result = getAppointmentType(appointment, false);
+    expect(result).to.equal('ccAppointment');
+  });
+  it('should return appointment type as ccAppointment, useFeSourceOfTruthCC=true', async () => {
+    const appointment = {
+      id: '123',
+      type: 'COMMUNITY_CARE_APPOINTMENT',
+    };
+    const result = getAppointmentType(appointment, true);
     expect(result).to.equal('ccAppointment');
   });
   it('should return appointment type as ccRequest', async () => {
@@ -36,7 +44,7 @@ describe('getAppointmentType util', () => {
         },
       ],
     };
-    const result = getAppointmentType(appointment);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('ccRequest');
   });
   it('should return appointment type as vaAppointment', async () => {
@@ -45,7 +53,7 @@ describe('getAppointmentType util', () => {
       kind: 'clinic',
       start: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('vaAppointment');
   });
 });

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1104,6 +1104,8 @@
           }
         ],
         "kind": "cc",
+        "type": "COMMUNITY_CARE_APPOINTMENT",
+        "modality": "communityCare",
         "status": "booked",
         "description": "Eye Care Examination SEOC 1.3.10 PRCT",
         "patientIcn": "1013124304V115761",
@@ -1207,6 +1209,8 @@
           }
         ],
         "kind": "cc",
+        "type": "COMMUNITY_CARE_APPOINTMENT",
+        "modality": "communityCare",
         "status": "cancelled",
         "description": "Podiatry DS SEOC 1.0.8 PRCT",
         "patientIcn": "1013124304V115761",
@@ -1883,6 +1887,8 @@
           }
         ],
         "kind": "cc",
+        "type": "COMMUNITY_CARE_APPOINTMENT",
+        "modality": "communityCare",
         "status": "booked",
         "patientIcn": "1013120820V528557",
         "locationId": "984",
@@ -1969,6 +1975,8 @@
           }
         ],
         "kind": "cc",
+        "type": "COMMUNITY_CARE_APPOINTMENT",
+        "modality": "communityCare",
         "status": "cancelled",
         "patientIcn": "1013120820V528557",
         "locationId": "984",
@@ -4403,6 +4411,8 @@
           }
         ],
         "kind": "cc",
+        "type": "COMMUNITY_CARE_APPOINTMENT",
+        "modality": "communityCare",
         "status": "booked",
         "serviceTypes": [
           {

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -249,6 +249,7 @@ function logEligibilityExplanation(
  * @param {boolean} [params.useV2=false] Use the v2 apis when making eligibility calls
  * @param {boolean} [params.featureClinicFilter=false] feature flag to filter clinics based on VATS
  * @param {boolean} [params.useFeSourceOfTruth=false] whether to use vets-api payload as the FE source of truth
+ * @param {boolean} [params.useFeSourceOfTruthCC=false] whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @returns {FlowEligibilityReturnData} Eligibility results, plus clinics and past appointments
  *   so that they can be cache and reused later
  */
@@ -259,6 +260,7 @@ export async function fetchFlowEligibilityAndClinics({
   useV2 = false,
   featureClinicFilter = false,
   useFeSourceOfTruth = false,
+  useFeSourceOfTruthCC = false,
   isCerner = false,
 }) {
   const directSchedulingAvailable =
@@ -293,6 +295,7 @@ export async function fetchFlowEligibilityAndClinics({
     if (isDirectAppointmentHistoryRequired) {
       apiCalls.pastAppointments = getLongTermAppointmentHistoryV2(
         useFeSourceOfTruth,
+        useFeSourceOfTruthCC,
       ).catch(createErrorHandler('direct-no-matching-past-clinics-error'));
     }
   }

--- a/src/applications/vaos/tests/e2e/fixtures/MockAppointmentResponse.js
+++ b/src/applications/vaos/tests/e2e/fixtures/MockAppointmentResponse.js
@@ -41,6 +41,7 @@ export default class MockAppointmentResponse {
     id = '1',
     cancellable = true,
     kind = TYPE_OF_VISIT_ID.clinic,
+    type = 'VA',
     patientHasMobileGfe = false,
     serviceType = 'primaryCare',
     status = 'booked',
@@ -75,6 +76,7 @@ export default class MockAppointmentResponse {
         patientHasMobileGfe,
       },
       kind,
+      type,
       localStartTime: timestamp.format('YYYY-MM-DDTHH:mm:ss.000Z'),
       preferredDates: [
         moment()
@@ -135,6 +137,7 @@ export default class MockAppointmentResponse {
           new MockAppointmentResponse({
             id: index,
             kind: 'cc',
+            type: 'COMMUNITY_CARE_APPOINTMENT',
             localStartTime,
             future,
           }),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated FE to use data from vets-api as source of truth for CC appointments (via the `type` field)
- Appointments tool team
- This is behind the [`va_online_scheduling_fe_source_of_truth_cc`](https://dev-api.va.gov/flipper/features/va_online_scheduling_fe_source_of_truth_cc) feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103758

## Testing done

- Tested locally, see screenshot. No changes are observed since this is a data layer level change without any UI difference
- Updated unit and e2e tests

## Screenshots

|         | Before | After (toggle on) | After (toggle off) |
| ------- | ------ | ----- | ----- |
| past cc appointments |  ![image](https://github.com/user-attachments/assets/55527b99-6d55-484c-9620-3aa3eb30deee)  |  ![image](https://github.com/user-attachments/assets/20a7b2f6-ffc7-40d6-bd69-1cb6cf8340b1)   | ![image](https://github.com/user-attachments/assets/c2fd6216-f364-43d0-bf80-284ebc346af6) |

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
