### PR TITLE
10-10CG | Organize 'external' imports

### DIFF
--- a/src/applications/caregivers/components/ConfirmationPage/ConfirmationFAQ.jsx
+++ b/src/applications/caregivers/components/ConfirmationPage/ConfirmationFAQ.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { CONTACTS } from '../../utils/imports';
 
 const ConfirmationFAQ = () => {
   const directoryLink = useMemo(

--- a/src/applications/caregivers/components/FormAlerts/SubmissionErrorAlert.jsx
+++ b/src/applications/caregivers/components/FormAlerts/SubmissionErrorAlert.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { focusElement } from 'platform/utilities/ui';
+import { CONTACTS } from '../../utils/imports';
 import ApplicationDownloadLink from '../ApplicationDownloadLink';
 
 const SubmissionErrorAlert = () => {

--- a/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
+++ b/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
@@ -5,11 +5,13 @@ import { AddressWithAutofillReviewField } from '../FormReview/AddressWithAutofil
 import { CaregiverCountyDescription } from '../FormDescriptions/AddressCountyDescriptions';
 import { REQUIRED_ADDRESS_FIELDS } from '../../utils/constants';
 import { replaceStrValues } from '../../utils/helpers';
-import { REACT_BINDINGS, STATES_USA } from '../../utils/imports';
+import {
+  STATES_USA,
+  VaCheckbox,
+  VaSelect,
+  VaTextInput,
+} from '../../utils/imports';
 import content from '../../locales/en/content.json';
-
-// define react binding components
-const { VaCheckbox, VaSelect, VaTextInput } = REACT_BINDINGS;
 
 // define our custom error messages
 const errorMessages = {

--- a/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
+++ b/src/applications/caregivers/components/FormFields/AddressWithAutofill.jsx
@@ -1,17 +1,15 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import {
-  VaCheckbox,
-  VaSelect,
-  VaTextInput,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { AddressWithAutofillReviewField } from '../FormReview/AddressWithAutofillReviewField';
 import { CaregiverCountyDescription } from '../FormDescriptions/AddressCountyDescriptions';
 import { REQUIRED_ADDRESS_FIELDS } from '../../utils/constants';
 import { replaceStrValues } from '../../utils/helpers';
-import { STATES_USA } from '../../utils/imports';
+import { REACT_BINDINGS, STATES_USA } from '../../utils/imports';
 import content from '../../locales/en/content.json';
+
+// define react binding components
+const { VaCheckbox, VaSelect, VaTextInput } = REACT_BINDINGS;
 
 // define our custom error messages
 const errorMessages = {

--- a/src/applications/caregivers/components/FormFields/FacilityList.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilityList.jsx
@@ -1,10 +1,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { REACT_BINDINGS } from '../../utils/imports';
+import { VaRadio, VaRadioOption } from '../../utils/imports';
 import content from '../../locales/en/content.json';
-
-// define react binding components
-const { VaRadio, VaRadioOption } = REACT_BINDINGS;
 
 const FacilityList = props => {
   const { facilities, onChange, query, value, error } = props;

--- a/src/applications/caregivers/components/FormFields/FacilityList.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilityList.jsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import {
-  VaRadio,
-  VaRadioOption,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { REACT_BINDINGS } from '../../utils/imports';
 import content from '../../locales/en/content.json';
+
+// define react binding components
+const { VaRadio, VaRadioOption } = REACT_BINDINGS;
 
 const FacilityList = props => {
   const { facilities, onChange, query, value, error } = props;

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -8,12 +8,9 @@ import { focusElement } from 'platform/utilities/ui';
 import { fetchMapBoxGeocoding } from '../../actions/fetchMapBoxGeocoding';
 import { fetchFacilities } from '../../actions/fetchFacilities';
 import { replaceStrValues } from '../../utils/helpers';
-import { REACT_BINDINGS } from '../../utils/imports';
+import { VaSearchInput } from '../../utils/imports';
 import FacilityList from './FacilityList';
 import content from '../../locales/en/content.json';
-
-// define react binding components
-const { VaSearchInput } = REACT_BINDINGS;
 
 const FacilitySearch = props => {
   const { data: formData, goBack, goForward, goToPath } = props;

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -2,15 +2,18 @@ import React, { useMemo, useState } from 'react';
 import * as Sentry from '@sentry/browser';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { VaSearchInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { setData } from 'platform/forms-system/src/js/actions';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { focusElement } from 'platform/utilities/ui';
 import { fetchMapBoxGeocoding } from '../../actions/fetchMapBoxGeocoding';
 import { fetchFacilities } from '../../actions/fetchFacilities';
-import FacilityList from './FacilityList';
 import { replaceStrValues } from '../../utils/helpers';
+import { REACT_BINDINGS } from '../../utils/imports';
+import FacilityList from './FacilityList';
 import content from '../../locales/en/content.json';
+
+// define react binding components
+const { VaSearchInput } = REACT_BINDINGS;
 
 const FacilitySearch = props => {
   const { data: formData, goBack, goForward, goToPath } = props;

--- a/src/applications/caregivers/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/caregivers/components/FormFields/VaMedicalCenter.jsx
@@ -2,12 +2,14 @@ import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import * as Sentry from '@sentry/browser';
-
-import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from 'platform/utilities/ui';
+import { REACT_BINDINGS } from '../../utils/imports';
 import GeneralErrorAlert from '../FormAlerts/GeneralErrorAlert';
+
+// define react binding components
+const { VaSelect } = REACT_BINDINGS;
 
 const apiRequestWithUrl = `${
   environment.API_URL

--- a/src/applications/caregivers/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/caregivers/components/FormFields/VaMedicalCenter.jsx
@@ -5,11 +5,8 @@ import * as Sentry from '@sentry/browser';
 import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from 'platform/utilities/ui';
-import { REACT_BINDINGS } from '../../utils/imports';
+import { VaSelect } from '../../utils/imports';
 import GeneralErrorAlert from '../FormAlerts/GeneralErrorAlert';
-
-// define react binding components
-const { VaSelect } = REACT_BINDINGS;
 
 const apiRequestWithUrl = `${
   environment.API_URL

--- a/src/applications/caregivers/components/GetHelp.jsx
+++ b/src/applications/caregivers/components/GetHelp.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { CONTACTS } from '../utils/imports';
 
 const GetHelp = () => (
   <>

--- a/src/applications/caregivers/components/IntroductionPage/ProcessTimeline.jsx
+++ b/src/applications/caregivers/components/IntroductionPage/ProcessTimeline.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { CONTACTS } from '../../utils/imports';
 
 const ProcessTimeline = () => (
   <>

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -2,12 +2,9 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 import { normalizeFullName, replaceStrValues } from '../../utils/helpers';
-import { REACT_BINDINGS } from '../../utils/imports';
+import { VaCheckbox } from '../../utils/imports';
 import SignatureInput from './SignatureInput';
 import content from '../../locales/en/content.json';
-
-// define react binding components
-const { VaCheckbox } = REACT_BINDINGS;
 
 const SignatureCheckbox = props => {
   const {

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import recordEvent from 'platform/monitoring/record-event';
 import { normalizeFullName, replaceStrValues } from '../../utils/helpers';
+import { REACT_BINDINGS } from '../../utils/imports';
 import SignatureInput from './SignatureInput';
 import content from '../../locales/en/content.json';
+
+// define react binding components
+const { VaCheckbox } = REACT_BINDINGS;
 
 const SignatureCheckbox = props => {
   const {

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-
-import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { REACT_BINDINGS } from '../../utils/imports';
 import { replaceStrValues } from '../../utils/helpers';
 import content from '../../locales/en/content.json';
+
+// define react binding components
+const { VaTextInput } = REACT_BINDINGS;
 
 const SignatureInput = props => {
   const {

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -1,11 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { REACT_BINDINGS } from '../../utils/imports';
+import { VaTextInput } from '../../utils/imports';
 import { replaceStrValues } from '../../utils/helpers';
 import content from '../../locales/en/content.json';
-
-// define react binding components
-const { VaTextInput } = REACT_BINDINGS;
 
 const SignatureInput = props => {
   const {

--- a/src/applications/caregivers/config/chapters/primary/contactInformation.js
+++ b/src/applications/caregivers/config/chapters/primary/contactInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { emailUI, phoneUI } from '../../../definitions/sharedUI';
 import CaregiverContactInfoDescription from '../../../components/FormDescriptions/CaregiverContactInfoDescription';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { email, phone } = fullSchema.definitions;
+const { email, phone } = FULL_SCHEMA.definitions;
 const inputLabel = content['primary-input-label'];
 
 const primaryContactInformation = {

--- a/src/applications/caregivers/config/chapters/primary/homeAddress.js
+++ b/src/applications/caregivers/config/chapters/primary/homeAddress.js
@@ -6,10 +6,10 @@ import {
 import { addressWithAutofillSchema } from '../../../definitions/sharedSchema';
 import { addressWithAutofillUI } from '../../../definitions/sharedUI';
 import { replaceStrValues } from '../../../utils/helpers';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { address } = fullSchema.definitions;
+const { address } = FULL_SCHEMA.definitions;
 const inputLabel = content['primary-input-label'];
 
 const primaryHomeAddress = {

--- a/src/applications/caregivers/config/chapters/primary/identityInformation.js
+++ b/src/applications/caregivers/config/chapters/primary/identityInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { ssnUI } from '../../../definitions/sharedUI';
 import CaregiverSsnDescription from '../../../components/FormDescriptions/CaregiverSsnDescription';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { ssn } = fullSchema.definitions;
+const { ssn } = FULL_SCHEMA.definitions;
 const inputLabel = content['primary-input-label'];
 
 const primaryIdentityInformation = {

--- a/src/applications/caregivers/config/chapters/primary/mailingAddress.js
+++ b/src/applications/caregivers/config/chapters/primary/mailingAddress.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { addressUI } from '../../../definitions/sharedUI';
 import { addressSchema } from '../../../definitions/sharedSchema';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { mailingAddress } = fullSchema.definitions;
+const { mailingAddress } = FULL_SCHEMA.definitions;
 const inputLabel = content['primary-input-label'];
 
 const primaryMailingAddress = {

--- a/src/applications/caregivers/config/chapters/primary/personalInformation.js
+++ b/src/applications/caregivers/config/chapters/primary/personalInformation.js
@@ -6,10 +6,10 @@ import {
   fullNameUI,
   vetRelationshipUI,
 } from '../../../definitions/sharedUI';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { fullName, date, gender, vetRelationship } = fullSchema.definitions;
+const { fullName, date, gender, vetRelationship } = FULL_SCHEMA.definitions;
 const inputLabel = content['primary-input-label'];
 const hintLabel = content['primary-hint-label'];
 

--- a/src/applications/caregivers/config/chapters/secondaryOne/contactInformation.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/contactInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { emailUI, phoneUI } from '../../../definitions/sharedUI';
 import CaregiverContactInfoDescription from '../../../components/FormDescriptions/CaregiverContactInfoDescription';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { email, phone } = fullSchema.definitions;
+const { email, phone } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-one-input-label'];
 
 const secondaryOneContactInformation = {

--- a/src/applications/caregivers/config/chapters/secondaryOne/homeAddress.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/homeAddress.js
@@ -6,10 +6,10 @@ import {
 import { addressWithAutofillSchema } from '../../../definitions/sharedSchema';
 import { addressWithAutofillUI } from '../../../definitions/sharedUI';
 import { replaceStrValues } from '../../../utils/helpers';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { address } = fullSchema.definitions;
+const { address } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-one-input-label'];
 
 const secondaryOneHomeAddress = {

--- a/src/applications/caregivers/config/chapters/secondaryOne/identityInformation.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/identityInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { ssnUI } from '../../../definitions/sharedUI';
 import CaregiverSsnDescription from '../../../components/FormDescriptions/CaregiverSsnDescription';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { ssn } = fullSchema.definitions;
+const { ssn } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-one-input-label'];
 
 const secondaryOneIdentityInformation = {

--- a/src/applications/caregivers/config/chapters/secondaryOne/mailingAddress.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/mailingAddress.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { addressUI } from '../../../definitions/sharedUI';
 import { addressSchema } from '../../../definitions/sharedSchema';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { mailingAddress } = fullSchema.definitions;
+const { mailingAddress } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-one-input-label'];
 
 const secondaryOneMailingAddress = {

--- a/src/applications/caregivers/config/chapters/secondaryOne/personalInformation.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/personalInformation.js
@@ -6,10 +6,10 @@ import {
   fullNameUI,
   vetRelationshipUI,
 } from '../../../definitions/sharedUI';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { fullName, date, gender, vetRelationship } = fullSchema.definitions;
+const { fullName, date, gender, vetRelationship } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-one-input-label'];
 const hintLabel = content['secondary-hint-label'];
 

--- a/src/applications/caregivers/config/chapters/secondaryTwo/contactInformation.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/contactInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { emailUI, phoneUI } from '../../../definitions/sharedUI';
 import CaregiverContactInfoDescription from '../../../components/FormDescriptions/CaregiverContactInfoDescription';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { email, phone } = fullSchema.definitions;
+const { email, phone } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-two-input-label'];
 
 const secondaryTwoContactInformation = {

--- a/src/applications/caregivers/config/chapters/secondaryTwo/homeAddress.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/homeAddress.js
@@ -6,10 +6,10 @@ import {
 import { addressWithAutofillSchema } from '../../../definitions/sharedSchema';
 import { addressWithAutofillUI } from '../../../definitions/sharedUI';
 import { replaceStrValues } from '../../../utils/helpers';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { address } = fullSchema.definitions;
+const { address } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-two-input-label'];
 
 const secondaryTwoHomeAddress = {

--- a/src/applications/caregivers/config/chapters/secondaryTwo/identityInformation.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/identityInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { ssnUI } from '../../../definitions/sharedUI';
 import CaregiverSsnDescription from '../../../components/FormDescriptions/CaregiverSsnDescription';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { ssn } = fullSchema.definitions;
+const { ssn } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-two-input-label'];
 
 const secondaryTwoIdentityInformation = {

--- a/src/applications/caregivers/config/chapters/secondaryTwo/mailingAddress.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/mailingAddress.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { addressUI } from '../../../definitions/sharedUI';
 import { addressSchema } from '../../../definitions/sharedSchema';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { mailingAddress } = fullSchema.definitions;
+const { mailingAddress } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-two-input-label'];
 
 const secondaryTwoMailingAddress = {

--- a/src/applications/caregivers/config/chapters/secondaryTwo/personalInformation.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/personalInformation.js
@@ -6,10 +6,10 @@ import {
   fullNameUI,
   vetRelationshipUI,
 } from '../../../definitions/sharedUI';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { fullName, date, gender, vetRelationship } = fullSchema.definitions;
+const { fullName, date, gender, vetRelationship } = FULL_SCHEMA.definitions;
 const inputLabel = content['secondary-two-input-label'];
 const hintLabel = content['secondary-hint-label'];
 

--- a/src/applications/caregivers/config/chapters/veteran/contactInformation.js
+++ b/src/applications/caregivers/config/chapters/veteran/contactInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { emailUI, phoneUI } from '../../../definitions/sharedUI';
 import ContactInfoDescription from '../../../components/FormDescriptions/VeteranContactInfoDescription';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { email, phone } = fullSchema.definitions;
+const { email, phone } = FULL_SCHEMA.definitions;
 const inputLabel = content['vet-input-label'];
 
 const veteranHomeAddress = {

--- a/src/applications/caregivers/config/chapters/veteran/homeAddress.js
+++ b/src/applications/caregivers/config/chapters/veteran/homeAddress.js
@@ -2,10 +2,10 @@ import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { VeteranCountyDescription } from '../../../components/FormDescriptions/AddressCountyDescriptions';
 import { addressUI } from '../../../definitions/sharedUI';
 import { addressSchema } from '../../../definitions/sharedSchema';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { address } = fullSchema.definitions;
+const { address } = FULL_SCHEMA.definitions;
 const inputLabel = content['vet-input-label'];
 const inputHint = content['vet-address-street-hint'];
 

--- a/src/applications/caregivers/config/chapters/veteran/identityInformation.js
+++ b/src/applications/caregivers/config/chapters/veteran/identityInformation.js
@@ -1,9 +1,9 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { ssnUI } from '../../../definitions/sharedUI';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { ssn } = fullSchema.definitions;
+const { ssn } = FULL_SCHEMA.definitions;
 const inputLabel = content['vet-input-label'];
 
 const veteranIdentityInformation = {

--- a/src/applications/caregivers/config/chapters/veteran/personalInformation.js
+++ b/src/applications/caregivers/config/chapters/veteran/personalInformation.js
@@ -1,10 +1,10 @@
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import { fullNameSchema } from '../../../definitions/sharedSchema';
 import { dobUI, genderUI, fullNameUI } from '../../../definitions/sharedUI';
-import { fullSchema } from '../../../utils/imports';
+import { FULL_SCHEMA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { fullName, date, gender } = fullSchema.definitions;
+const { fullName, date, gender } = FULL_SCHEMA.definitions;
 const inputLabel = content['vet-input-label'];
 
 const veteranPersonalInformation = {

--- a/src/applications/caregivers/config/chapters/veteran/vaMedicalCenter_json.js
+++ b/src/applications/caregivers/config/chapters/veteran/vaMedicalCenter_json.js
@@ -9,10 +9,10 @@ import {
   MED_CENTERS_BY_STATE,
   setPlannedClinics,
 } from '../../../utils/helpers';
-import { fullSchema, STATES_USA } from '../../../utils/imports';
+import { FULL_SCHEMA, STATES_USA } from '../../../utils/imports';
 import content from '../../../locales/en/content.json';
 
-const { veteran } = fullSchema.properties;
+const { veteran } = FULL_SCHEMA.properties;
 const { plannedClinic } = veteran.properties;
 
 const STATE_LABELS = createUSAStateLabels(states);

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -17,7 +17,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import GetHelpFooter from '../components/GetHelp';
 import PreSubmitInfo from '../components/PreSubmitInfo';
 import SubmissionErrorAlert from '../components/FormAlerts/SubmissionErrorAlert';
-import { fullSchema } from '../utils/imports';
+import { FULL_SCHEMA } from '../utils/imports';
 import content from '../locales/en/content.json';
 import manifest from '../manifest.json';
 
@@ -68,7 +68,7 @@ const {
   fullName,
   uuid,
   signature,
-} = fullSchema.definitions;
+} = FULL_SCHEMA.definitions;
 
 /* Chapters
  * 1 - Vet/Service Member (required)

--- a/src/applications/caregivers/tests/unit/components/FormFields/AddressWithAutofill.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/components/FormFields/AddressWithAutofill.unit.spec.jsx
@@ -5,12 +5,12 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { inputVaTextInput } from 'platform/testing/unit/helpers';
-import { fullSchema } from '../../../../utils/imports';
+import { FULL_SCHEMA } from '../../../../utils/imports';
 import { addressWithAutofillSchema } from '../../../../definitions/sharedSchema';
 import AddressWithAutofill from '../../../../components/FormFields/AddressWithAutofill';
 import content from '../../../../locales/en/content.json';
 
-const { address } = fullSchema.definitions;
+const { address } = FULL_SCHEMA.definitions;
 
 const errorSchemas = {
   empty: { __errors: [] },

--- a/src/applications/caregivers/utils/helpers/schema.js
+++ b/src/applications/caregivers/utils/helpers/schema.js
@@ -1,6 +1,6 @@
 import { mapValues } from 'lodash';
 import get from 'platform/utilities/data/get';
-import { caregiverProgramFacilities as facilities } from '../imports';
+import { CAREGIVER_FACILITIES as facilities } from '../imports';
 
 export const MED_CENTERS_BY_STATE = mapValues(facilities, val =>
   val.map(c => c.code),

--- a/src/applications/caregivers/utils/imports.js
+++ b/src/applications/caregivers/utils/imports.js
@@ -1,7 +1,8 @@
 import FULL_SCHEMA from 'vets-json-schema/dist/10-10CG-schema.json';
 import SCHEMA_CONSTANTS from 'vets-json-schema/dist/constants.json';
 import CAREGIVER_FACILITIES from 'vets-json-schema/dist/caregiverProgramFacilities.json';
-import {
+
+export {
   VaCheckbox,
   VaRadio,
   VaRadioOption,
@@ -15,14 +16,5 @@ export {
 } from '@department-of-veterans-affairs/component-library/contacts';
 
 export const STATES_USA = SCHEMA_CONSTANTS.states.USA;
-
-export const REACT_BINDINGS = {
-  VaCheckbox,
-  VaRadio,
-  VaRadioOption,
-  VaSearchInput,
-  VaSelect,
-  VaTextInput,
-};
 
 export { FULL_SCHEMA, CAREGIVER_FACILITIES };

--- a/src/applications/caregivers/utils/imports.js
+++ b/src/applications/caregivers/utils/imports.js
@@ -1,9 +1,25 @@
 import FULL_SCHEMA from 'vets-json-schema/dist/10-10CG-schema.json';
 import SCHEMA_CONSTANTS from 'vets-json-schema/dist/constants.json';
 import CAREGIVER_FACILITIES from 'vets-json-schema/dist/caregiverProgramFacilities.json';
-import REACT_BINDINGS from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import {
+  VaCheckbox,
+  VaRadio,
+  VaRadioOption,
+  VaSearchInput,
+  VaSelect,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 export const STATES_USA = SCHEMA_CONSTANTS.states.USA;
 
-export { CONTACTS, FULL_SCHEMA, REACT_BINDINGS, CAREGIVER_FACILITIES };
+export const REACT_BINDINGS = {
+  VaCheckbox,
+  VaRadio,
+  VaRadioOption,
+  VaSearchInput,
+  VaSelect,
+  VaTextInput,
+};
+
+export { CONTACTS, FULL_SCHEMA, CAREGIVER_FACILITIES };

--- a/src/applications/caregivers/utils/imports.js
+++ b/src/applications/caregivers/utils/imports.js
@@ -1,7 +1,6 @@
 import FULL_SCHEMA from 'vets-json-schema/dist/10-10CG-schema.json';
 import SCHEMA_CONSTANTS from 'vets-json-schema/dist/constants.json';
 import CAREGIVER_FACILITIES from 'vets-json-schema/dist/caregiverProgramFacilities.json';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import {
   VaCheckbox,
   VaRadio,
@@ -10,6 +9,10 @@ import {
   VaSelect,
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+export {
+  CONTACTS,
+} from '@department-of-veterans-affairs/component-library/contacts';
 
 export const STATES_USA = SCHEMA_CONSTANTS.states.USA;
 
@@ -22,4 +25,4 @@ export const REACT_BINDINGS = {
   VaTextInput,
 };
 
-export { CONTACTS, FULL_SCHEMA, CAREGIVER_FACILITIES };
+export { FULL_SCHEMA, CAREGIVER_FACILITIES };

--- a/src/applications/caregivers/utils/imports.js
+++ b/src/applications/caregivers/utils/imports.js
@@ -1,7 +1,9 @@
-import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
+import FULL_SCHEMA from 'vets-json-schema/dist/10-10CG-schema.json';
 import SCHEMA_CONSTANTS from 'vets-json-schema/dist/constants.json';
-import caregiverProgramFacilities from 'vets-json-schema/dist/caregiverProgramFacilities.json';
+import CAREGIVER_FACILITIES from 'vets-json-schema/dist/caregiverProgramFacilities.json';
+import REACT_BINDINGS from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export const STATES_USA = SCHEMA_CONSTANTS.states.USA;
 
-export { fullSchema, caregiverProgramFacilities };
+export { CONTACTS, FULL_SCHEMA, REACT_BINDINGS, CAREGIVER_FACILITIES };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

While reviewing the caregiver app for performance and readability, it was noticed there were external imports scattered throughout the directory. This PR takes those external imports and utilizes the `imports` directory to manage these from a singular location.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#105032

## Acceptance criteria

- External imports are housed in a single source

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors
- [x] Events are being sent to the appropriate logging solution