### PR TITLE
Increase timeout of feedback-tool test

### DIFF
--- a/src/applications/edu-benefits/feedback-tool/tests/00.feedback-tool.cypress.spec.js
+++ b/src/applications/edu-benefits/feedback-tool/tests/00.feedback-tool.cypress.spec.js
@@ -11,9 +11,9 @@ describe('Feedback Tool Test', () => {
 
     cy.visit('/education/submit-school-feedback');
     cy.get('body').should('be.visible');
-    cy.get('.schemaform-title').should('be.visible', {
+    cy.get('.schemaform-title', {
       timeout: 10000,
-    });
+    }).should('be.visible');
     cy.get('.schemaform-start-button')
       .first()
       .click();


### PR DESCRIPTION
## Summary

- Increase timeout of feedback tool to try to avoid test failures, where the page doesn't load in time, and the test fails.

## Testing done

- cypress

## Screenshots

n/a

## What areas of the site does it impact?

feedback-tool cypress

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
