### PR TITLE
(Experimental) Refocus array builder summary view alerts when save-in-progress updates

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -207,23 +207,32 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
         let timeout;
         let focusRef;
 
+        let maxItemsCondition = isMaxItemsReached && maxItemsAlertRef;
+        if (isReviewPage) {
+          // we don't mind focusing the max items alert every time on
+          // the summary page going back and forward, but if they are
+          // on the review page, and the alert was already present, we
+          // don't want to focus it again.
+          maxItemsCondition =
+            isMaxItemsReached && !maxItemsAlertSeen && maxItemsAlertRef;
+        }
+
         if (
           showUpdatedAlert &&
           updateItemIndex != null &&
           updatedAlertRef.current
         ) {
           focusRef = updatedAlertRef;
-        } else if (
-          isMaxItemsReached &&
-          !maxItemsAlertSeen &&
-          maxItemsAlertRef
-        ) {
+        } else if (maxItemsCondition) {
           focusRef = maxItemsAlertRef;
         }
 
         maxItemsAlertSeen = isMaxItemsReached;
 
         if (focusRef) {
+          if (timeout) {
+            clearTimeout(timeout);
+          }
           timeout = setTimeout(() => {
             if (focusRef.current) {
               scrollAndFocus(focusRef.current);
@@ -233,7 +242,15 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
 
         return () => timeout && clearTimeout(timeout);
       },
-      [showUpdatedAlert, updateItemIndex, updatedAlertRef, isMaxItemsReached],
+      [
+        showUpdatedAlert,
+        updateItemIndex,
+        updatedAlertRef,
+        isMaxItemsReached,
+        // Also refocus when save-in-progress changes.
+        // This isn't present on the review page.
+        props.contentAfterButtons,
+      ],
     );
 
     useEffect(


### PR DESCRIPTION
## Summary

- Refocus array builder summary view alerts when save-in-progress updates

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#105061

## Testing done

- Browser testing summary page with max items and review page on 10207 logged in

## What areas of the site does it impact?

array builder max items

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
