### PR TITLE
Edm 439 fix launch blockers

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -196,7 +196,7 @@ export function filterLcResults(
   };
 }
 
-export function fetchLicenseCertificationResults(signal) {
+export function fetchLicenseCertificationResults() {
   const url = `${api.url}/lcpe/lacs`;
 
   return async dispatch => {
@@ -205,7 +205,6 @@ export function fetchLicenseCertificationResults(signal) {
     try {
       const res = await fetch(url, {
         ...api.settings,
-        signal,
       });
 
       if (!res.ok) {
@@ -228,7 +227,7 @@ export function fetchLicenseCertificationResults(signal) {
   };
 }
 
-export function fetchLcResult(id, signal) {
+export function fetchLcResult(id) {
   return async dispatch => {
     const url = `${api.url}/lcpe/lacs/${id}`;
     dispatch({ type: FETCH_LC_RESULT_STARTED });
@@ -236,7 +235,6 @@ export function fetchLcResult(id, signal) {
     try {
       const res = await fetch(url, {
         ...api.settings,
-        signal,
       });
 
       if (!res.ok) {

--- a/src/applications/gi/components/Dropdown.jsx
+++ b/src/applications/gi/components/Dropdown.jsx
@@ -1,86 +1,94 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import { handleScrollOnInputFocus } from '../utils/helpers';
 
-const Dropdown = ({
-  alt,
-  ariaLabel,
-  boldLabel,
-  className,
-  disabled,
-  hideArrows,
-  label,
-  name,
-  options,
-  onChange,
-  onFocus,
-  selectClassName,
-  value,
-  visible,
-  required,
-  children,
-}) => {
-  if (!visible) {
-    return null;
-  }
+const Dropdown = forwardRef(
+  (
+    {
+      alt,
+      ariaLabel,
+      boldLabel,
+      className,
+      disabled,
+      hideArrows,
+      label,
+      name,
+      options,
+      onChange,
+      onFocus,
+      selectClassName,
+      value,
+      visible,
+      required,
+      children,
+    },
+    ref,
+  ) => {
+    if (!visible) {
+      return null;
+    }
 
-  const dropdownId = `${name}-dropdown`;
-  const labelElement = boldLabel ? (
-    <strong>
+    const dropdownId = `${name}-dropdown`;
+    const labelElement = boldLabel ? (
+      <strong>
+        <label htmlFor={name}>
+          {label}{' '}
+          {required ? (
+            <span className="required-label">(*Required)</span>
+          ) : null}{' '}
+          {children}
+        </label>
+      </strong>
+    ) : (
       <label htmlFor={name}>
         {label}{' '}
         {required ? <span className="required-label">(*Required)</span> : null}{' '}
         {children}
       </label>
-    </strong>
-  ) : (
-    <label htmlFor={name}>
-      {label}{' '}
-      {required ? <span className="required-label">(*Required)</span> : null}{' '}
-      {children}
-    </label>
-  );
+    );
 
-  const selectClasses = classNames('vads-u-color--gray', selectClassName, {
-    hideArrows,
-  });
+    const selectClasses = classNames('vads-u-color--gray', selectClassName, {
+      hideArrows,
+    });
 
-  return (
-    <div className={classNames(className, { disabled })} id={dropdownId}>
-      {label && labelElement}
-      <select
-        aria-label={ariaLabel}
-        className={selectClasses}
-        id={name}
-        name={name}
-        alt={alt}
-        value={value}
-        onChange={onChange}
-        disabled={disabled}
-        onFocus={() => onFocus(dropdownId)}
-      >
-        {options.map(
-          ({ optionValue, optionLabel, optionDisabled }, index) =>
-            optionLabel && (
-              <option
-                key={index}
-                value={optionValue}
-                disabled={optionDisabled}
-                className={
-                  optionValue === value
-                    ? 'vads-u-font-weight--bold'
-                    : 'vads-u-font-weight--normal'
-                }
-              >
-                {optionLabel}
-              </option>
-            ),
-        )}
-      </select>
-    </div>
-  );
-};
+    return (
+      <div className={classNames(className, { disabled })} id={dropdownId}>
+        {label && labelElement}
+        <select
+          ref={ref}
+          aria-label={ariaLabel}
+          className={selectClasses}
+          id={name}
+          name={name}
+          alt={alt}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          onFocus={() => onFocus(dropdownId)}
+        >
+          {options.map(
+            ({ optionValue, optionLabel, optionDisabled }, index) =>
+              optionLabel && (
+                <option
+                  key={index}
+                  value={optionValue}
+                  disabled={optionDisabled}
+                  className={
+                    optionValue === value
+                      ? 'vads-u-font-weight--bold'
+                      : 'vads-u-font-weight--normal'
+                  }
+                >
+                  {optionLabel}
+                </option>
+              ),
+          )}
+        </select>
+      </div>
+    );
+  },
+);
 
 Dropdown.propTypes = {
   alt: PropTypes.string.isRequired,

--- a/src/applications/gi/components/Dropdown.jsx
+++ b/src/applications/gi/components/Dropdown.jsx
@@ -1,94 +1,86 @@
 import PropTypes from 'prop-types';
-import React, { forwardRef } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { handleScrollOnInputFocus } from '../utils/helpers';
 
-const Dropdown = forwardRef(
-  (
-    {
-      alt,
-      ariaLabel,
-      boldLabel,
-      className,
-      disabled,
-      hideArrows,
-      label,
-      name,
-      options,
-      onChange,
-      onFocus,
-      selectClassName,
-      value,
-      visible,
-      required,
-      children,
-    },
-    ref,
-  ) => {
-    if (!visible) {
-      return null;
-    }
+const Dropdown = ({
+  alt,
+  ariaLabel,
+  boldLabel,
+  className,
+  disabled,
+  hideArrows,
+  label,
+  name,
+  options,
+  onChange,
+  onFocus,
+  selectClassName,
+  value,
+  visible,
+  required,
+  children,
+}) => {
+  if (!visible) {
+    return null;
+  }
 
-    const dropdownId = `${name}-dropdown`;
-    const labelElement = boldLabel ? (
-      <strong>
-        <label htmlFor={name}>
-          {label}{' '}
-          {required ? (
-            <span className="required-label">(*Required)</span>
-          ) : null}{' '}
-          {children}
-        </label>
-      </strong>
-    ) : (
+  const dropdownId = `${name}-dropdown`;
+  const labelElement = boldLabel ? (
+    <strong>
       <label htmlFor={name}>
         {label}{' '}
         {required ? <span className="required-label">(*Required)</span> : null}{' '}
         {children}
       </label>
-    );
+    </strong>
+  ) : (
+    <label htmlFor={name}>
+      {label}{' '}
+      {required ? <span className="required-label">(*Required)</span> : null}{' '}
+      {children}
+    </label>
+  );
 
-    const selectClasses = classNames('vads-u-color--gray', selectClassName, {
-      hideArrows,
-    });
+  const selectClasses = classNames('vads-u-color--gray', selectClassName, {
+    hideArrows,
+  });
 
-    return (
-      <div className={classNames(className, { disabled })} id={dropdownId}>
-        {label && labelElement}
-        <select
-          ref={ref}
-          aria-label={ariaLabel}
-          className={selectClasses}
-          id={name}
-          name={name}
-          alt={alt}
-          value={value}
-          onChange={onChange}
-          disabled={disabled}
-          onFocus={() => onFocus(dropdownId)}
-        >
-          {options.map(
-            ({ optionValue, optionLabel, optionDisabled }, index) =>
-              optionLabel && (
-                <option
-                  key={index}
-                  value={optionValue}
-                  disabled={optionDisabled}
-                  className={
-                    optionValue === value
-                      ? 'vads-u-font-weight--bold'
-                      : 'vads-u-font-weight--normal'
-                  }
-                >
-                  {optionLabel}
-                </option>
-              ),
-          )}
-        </select>
-      </div>
-    );
-  },
-);
+  return (
+    <div className={classNames(className, { disabled })} id={dropdownId}>
+      {label && labelElement}
+      <select
+        aria-label={ariaLabel}
+        className={selectClasses}
+        id={name}
+        name={name}
+        alt={alt}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        onFocus={() => onFocus(dropdownId)}
+      >
+        {options.map(
+          ({ optionValue, optionLabel, optionDisabled }, index) =>
+            optionLabel && (
+              <option
+                key={index}
+                value={optionValue}
+                disabled={optionDisabled}
+                className={
+                  optionValue === value
+                    ? 'vads-u-font-weight--bold'
+                    : 'vads-u-font-weight--normal'
+                }
+              >
+                {optionLabel}
+              </option>
+            ),
+        )}
+      </select>
+    </div>
+  );
+};
 
 Dropdown.propTypes = {
   alt: PropTypes.string.isRequired,

--- a/src/applications/gi/components/FilterControls.jsx
+++ b/src/applications/gi/components/FilterControls.jsx
@@ -12,7 +12,10 @@ function FilterControls({
 }) {
   return (
     <div>
-      <>
+      <fieldset role="group" aria-label="Category type">
+        <legend className="vads-u-visibility--screen-reader">
+          Category type
+        </legend>
         <h3 className="vads-u-margin-bottom--3 vads-u-margin-top--0p5">
           Category type
         </h3>
@@ -28,9 +31,10 @@ function FilterControls({
             />
           );
         })}
-      </>
+      </fieldset>
 
-      <>
+      <fieldset role="group" aria-label="State">
+        <legend className="vads-u-visibility--screen-reader">State</legend>
         <h3 className="vads-u-margin-bottom--2">State</h3>
         <Dropdown
           label="Applies to only license and prep course category type. Certifications are available nationwide."
@@ -43,7 +47,7 @@ function FilterControls({
           visible
           boldLabel
         />
-      </>
+      </fieldset>
     </div>
   );
 }

--- a/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useSignalFetch } from '../utils/useSignalFetch';
-
 import {
+  focusElement,
   capitalizeFirstLetter,
   handleLcResultsSearch,
   showLcParams,
@@ -21,6 +21,8 @@ import LicesnseCertificationServiceError from '../components/LicesnseCertificati
 export default function LicenseCertificationSearchForm() {
   const history = useHistory();
   const location = useLocation();
+
+  const inputRef = useRef(null);
 
   const { nameParam, categoryParams } = showLcParams(location);
 
@@ -82,6 +84,7 @@ export default function LicenseCertificationSearchForm() {
     history.replace('/licenses-certifications-and-prep-courses');
     setName('');
     setDropdown(updateCategoryDropdown());
+    focusElement(inputRef.current, 0);
   };
 
   const handleChange = e => {
@@ -117,6 +120,7 @@ export default function LicenseCertificationSearchForm() {
               alt={dropdown.alt}
               selectClassName="dropdown-filter"
               required={dropdown.label === 'category'}
+              ref={inputRef}
             />
             <div>
               <LicenseCertificationKeywordSearch

--- a/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -24,8 +24,7 @@ export default function LicenseCertificationSearchForm() {
 
   const [dropdown, setDropdown] = useState(updateCategoryDropdown());
   const [name, setName] = useState('');
-
-  const inputRef = useRef(null);
+  const [shouldFocusDropdown, setShouldFocusDropdown] = useState(false);
 
   const dispatch = useDispatch();
 
@@ -53,6 +52,19 @@ export default function LicenseCertificationSearchForm() {
       return dispatch(filterLcResults(name, dropdown.current.optionValue));
     },
     [name, dropdown.current.optionValue],
+  );
+
+  useEffect(
+    () => {
+      if (shouldFocusDropdown) {
+        const selectElement = document.getElementById(dropdown.label);
+        if (selectElement) {
+          focusElement(selectElement, 0);
+        }
+        setShouldFocusDropdown(false);
+      }
+    },
+    [shouldFocusDropdown, dropdown.label],
   );
 
   // If available, use url query params to assign initial values ONLY on mount
@@ -87,7 +99,7 @@ export default function LicenseCertificationSearchForm() {
     history.replace('/licenses-certifications-and-prep-courses');
     setName('');
     setDropdown(updateCategoryDropdown());
-    focusElement(inputRef.current, 0);
+    setShouldFocusDropdown(true);
   };
 
   const handleChange = e => {
@@ -123,7 +135,6 @@ export default function LicenseCertificationSearchForm() {
               alt={dropdown.alt}
               selectClassName="dropdown-filter"
               required={dropdown.label === 'category'}
-              ref={inputRef}
             />
             <div>
               <LicenseCertificationKeywordSearch

--- a/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchForm.jsx
@@ -2,17 +2,15 @@ import React, { useEffect, useState, useRef } from 'react';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
-import { useSignalFetch } from '../utils/useSignalFetch';
 import {
   focusElement,
-  capitalizeFirstLetter,
   handleLcResultsSearch,
   showLcParams,
   updateCategoryDropdown,
   updateQueryParam,
 } from '../utils/helpers';
 
-import { filterLcResults } from '../actions';
+import { fetchLicenseCertificationResults, filterLcResults } from '../actions';
 
 import LicenseCertificationKeywordSearch from '../components/LicenseCertificationKeywordSearch';
 import Dropdown from '../components/Dropdown';
@@ -22,14 +20,14 @@ export default function LicenseCertificationSearchForm() {
   const history = useHistory();
   const location = useLocation();
 
-  const inputRef = useRef(null);
-
   const { nameParam, categoryParams } = showLcParams(location);
-
-  const dispatch = useDispatch();
 
   const [dropdown, setDropdown] = useState(updateCategoryDropdown());
   const [name, setName] = useState('');
+
+  const inputRef = useRef(null);
+
+  const dispatch = useDispatch();
 
   const { hasFetchedOnce, fetchingLc, filteredResults, error } = useSelector(
     state => state.licenseCertificationSearch,
@@ -43,7 +41,12 @@ export default function LicenseCertificationSearchForm() {
     ...filteredResults,
   ];
 
-  useSignalFetch(hasFetchedOnce);
+  useEffect(() => {
+    if (!hasFetchedOnce) {
+      dispatch(fetchLicenseCertificationResults());
+    }
+    return null;
+  }, []);
 
   useEffect(
     () => {
@@ -111,7 +114,7 @@ export default function LicenseCertificationSearchForm() {
           <form>
             <Dropdown
               disabled={false}
-              label={capitalizeFirstLetter(dropdown.label)}
+              label="Category type"
               visible
               name={dropdown.label}
               options={dropdown.options}

--- a/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
@@ -5,9 +5,8 @@ import { useSelector, useDispatch } from 'react-redux';
 import ADDRESS_DATA from 'platform/forms/address/data';
 
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { useSignalFetch } from '../utils/useSignalFetch';
 
-import { filterLcResults } from '../actions';
+import { fetchLicenseCertificationResults, filterLcResults } from '../actions';
 import {
   handleLcResultsSearch,
   isSmallScreen,
@@ -75,7 +74,12 @@ export default function LicenseCertificationSearchResults() {
     currentPage * itemsPerPage,
   );
 
-  useSignalFetch(hasFetchedOnce);
+  useEffect(() => {
+    if (!hasFetchedOnce) {
+      dispatch(fetchLicenseCertificationResults());
+    }
+    return null;
+  }, []);
 
   useEffect(
     () => {

--- a/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
+++ b/src/applications/gi/containers/LicenseCertificationSearchResults.jsx
@@ -16,6 +16,7 @@ import {
   createCheckboxes,
   updateStateDropdown,
   handleZoom,
+  focusElement,
 } from '../utils/helpers';
 import { lacpCategoryList } from '../constants';
 
@@ -167,6 +168,7 @@ export default function LicenseCertificationSearchResults() {
       state,
       initialCategoryParam,
     );
+    focusElement(searchInfoWrapperRef.current, 0);
   };
 
   const handleStateChange = e => {
@@ -189,11 +191,7 @@ export default function LicenseCertificationSearchResults() {
       page,
     );
     setCurrentPage(page);
-    setTimeout(() => {
-      if (searchInfoWrapperRef.current) {
-        searchInfoWrapperRef.current.focus();
-      }
-    }, 500);
+    focusElement(searchInfoWrapperRef.current, 500);
   };
 
   const handleGoToDetails = (e, id, name) => {
@@ -268,6 +266,7 @@ export default function LicenseCertificationSearchResults() {
       'all',
       initialCategoryParam,
     );
+    focusElement(searchInfoWrapperRef.current, 0);
   };
 
   if (fetchingLc) {

--- a/src/applications/gi/tests/actions/index.unit.spec.jsx
+++ b/src/applications/gi/tests/actions/index.unit.spec.jsx
@@ -809,7 +809,6 @@ describe('actionCreators', () => {
 
       it('dispatches FETCH_LC_RESULT_SUCCEEDED on successful fetch (res.ok)', async () => {
         const mockDispatch = sinon.spy();
-        const mockSignal = new AbortController().signal;
         const mockResponse = {
           ok: true,
           json: sinon.stub().resolves({
@@ -819,7 +818,7 @@ describe('actionCreators', () => {
         const fetchStub = sinon.stub(global, 'fetch').resolves(mockResponse);
 
         const testId = '123';
-        await actions.fetchLcResult(testId, mockSignal)(mockDispatch);
+        await actions.fetchLcResult(testId)(mockDispatch);
 
         expect(mockDispatch.firstCall.args[0]).to.deep.equal({
           type: actions.FETCH_LC_RESULT_STARTED,
@@ -834,7 +833,6 @@ describe('actionCreators', () => {
         expect(
           fetchStub.calledWithMatch(expectedURL, {
             ...api.settings,
-            signal: mockSignal,
           }),
         ).to.be.true;
 
@@ -843,7 +841,6 @@ describe('actionCreators', () => {
 
       it('dispatches FETCH_LC_RESULT_FAILED when response is not ok', async () => {
         const mockDispatch = sinon.spy();
-        const mockSignal = new AbortController().signal;
         const errorMessage = 'Internal Server Error';
         const mockResponse = new Response(null, {
           status: 500,
@@ -851,7 +848,7 @@ describe('actionCreators', () => {
         });
         const fetchStub = sinon.stub(global, 'fetch').resolves(mockResponse);
 
-        await actions.fetchLcResult('999', mockSignal)(mockDispatch);
+        await actions.fetchLcResult('999')(mockDispatch);
 
         expect(mockDispatch.firstCall.args[0]).to.deep.equal({
           type: actions.FETCH_LC_RESULT_STARTED,
@@ -866,13 +863,12 @@ describe('actionCreators', () => {
 
       it('dispatches FETCH_LC_RESULT_FAILED on fetch error (promise rejection)', async () => {
         const mockDispatch = sinon.spy();
-        const mockSignal = new AbortController().signal;
         const fetchError = new Error('Network Failed');
 
         const fetchStub = sinon.stub(global, 'fetch').rejects(fetchError);
 
         await actions
-          .fetchLcResult('555', mockSignal)(mockDispatch)
+          .fetchLcResult('555')(mockDispatch)
           .catch(() => {});
 
         expect(mockDispatch.firstCall.args[0]).to.deep.equal({
@@ -888,14 +884,13 @@ describe('actionCreators', () => {
 
       it('does not dispatch FETCH_LC_RESULT_FAILED on AbortError', async () => {
         const mockDispatch = sinon.spy();
-        const mockSignal = new AbortController().signal;
         const abortError = new Error('Aborted');
         abortError.name = 'AbortError';
 
         const fetchStub = sinon.stub(global, 'fetch').rejects(abortError);
 
         await actions
-          .fetchLcResult('555', mockSignal)(mockDispatch)
+          .fetchLcResult('555')(mockDispatch)
           .catch(() => {});
 
         expect(mockDispatch.firstCall.args[0]).to.deep.equal({

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -1126,3 +1126,11 @@ export const handleZoom = () => {
     }
   });
 };
+
+export const focusElement = (ref, delay = 0) => {
+  setTimeout(() => {
+    if (ref) {
+      ref.focus();
+    }
+  }, delay);
+};

--- a/src/applications/gi/utils/useSignalFetch.js
+++ b/src/applications/gi/utils/useSignalFetch.js
@@ -1,19 +1,15 @@
 import { useDispatch } from 'react-redux';
 import { useEffect } from 'react';
-import { fetchLicenseCertificationResults } from '../actions';
 
-export const useSignalFetch = hasFetchedOnce => {
+export const useSignalFetch = performFetch => {
   const dispatch = useDispatch();
   useEffect(() => {
-    if (!hasFetchedOnce) {
-      const controller = new AbortController();
+    const controller = new AbortController();
 
-      dispatch(fetchLicenseCertificationResults(controller.signal));
+    dispatch(performFetch(controller.signal));
 
-      return () => {
-        controller.abort();
-      };
-    }
-    return null;
+    return () => {
+      controller.abort();
+    };
   }, []);
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixed launch blocking issues given from staging review.
- A couple of minor accessibility issues dealing with element focus states and misc code cleanup.
- I'm with Education Data Migration (EDM). VEBT has ownership of Comparison Tool.
- These changes are behind a flipper, to be lifted in April

## Related issue(s)

- EDM-439: address launch blocking issues from platform staging review
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- Current unit and cypress tests maintain sufficient coverage

## What areas of the site does it impact?

Comparison Tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

No authentication required to view these changes
