### PR TITLE
VACMS-105299 Sitewide: remove unused redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1629,46 +1629,6 @@
   },
   {
     "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/hbco_basic_eligibility.asp",
-    "dest": "/health-care/eligibility/"
-  },
-  {
-    "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/hbco_enrollment_eligibility.asp",
-    "dest": "/health-care/eligibility/"
-  },
-  {
-    "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/hbco_copayments.asp",
-    "dest": "/health-care/copay-rates/"
-  },
-  {
-    "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/hbco_additional_health_programs.asp",
-    "dest": "/family-and-caregiver-benefits/"
-  },
-  {
-    "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/index.asp",
-    "dest": "/health-care"
-  },
-  {
-    "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/hbco_aca.asp",
-    "dest": "/health-care/about-affordable-care-act/"
-  },
-  {
-    "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/hbco_medical_benefits_package.asp",
-    "dest": "/health-care/about-va-health-benefits/"
-  },
-  {
-    "domain": "www.va.gov",
-    "src": "/healthbenefits/resources/publications/hbco/hbco_va_other_insurance.asp",
-    "dest": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance/"
-  },
-  {
-    "domain": "www.va.gov",
     "src": "/healthbenefits/resources/glossary.asp",
     "dest": "/health-care"
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removes client-side redirects that did not work (because the pages were already removed from the TeamSites servers). We implemented server-side redirects instead [here](https://github.com/department-of-veterans-affairs/vsp-platform-revproxy/pull/883).

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/105299