### PR TITLE
ChapterSectionCollection page level confirmation field support and 0966 fix

### DIFF
--- a/src/applications/simple-forms/21-0966/pages/confirmVeteranPersonalInformation.js
+++ b/src/applications/simple-forms/21-0966/pages/confirmVeteranPersonalInformation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import { reviewEntry } from 'platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection';
 
 /** @type {PageSchema} */
 
@@ -41,6 +42,49 @@ export default {
           </p>
         </>
       ),
+    ),
+    'ui:confirmationField': ({ formData }) => (
+      <>
+        {reviewEntry(
+          null,
+          'confirm-first-name',
+          {},
+          'First name',
+          formData['view:veteranPrefillStore']?.fullName?.first,
+        )}
+        {formData?.['view:veteranPrefillStore']?.fullName?.middle &&
+          reviewEntry(
+            null,
+            'confirm-middle-name',
+            {},
+            'Middle name',
+            formData['view:veteranPrefillStore']?.fullName?.middle,
+          )}
+        {reviewEntry(
+          null,
+          'confirm-last-name',
+          {},
+          'Last name',
+          formData['view:veteranPrefillStore']?.fullName?.last,
+        )}
+        {reviewEntry(
+          null,
+          'confirm-ssn',
+          {},
+          'Social Security number',
+          `●●●–●●–${formData['view:veteranPrefillStore']?.ssn?.slice(5)}`,
+        )}
+        {reviewEntry(
+          null,
+          'confirm-dob',
+          {},
+          'Date of birth',
+          moment(
+            formData?.['view:veteranPrefillStore']?.dateOfBirth,
+            'YYYY-MM-DD',
+          ).format('MM/DD/YYYY'),
+        )}
+      </>
     ),
     'view:confirmVeteranPersonalInformation': {
       'ui:options': {

--- a/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
@@ -68,7 +68,7 @@ const generateReviewEntryKey = (key, label, data) => {
   return keyString;
 };
 
-const reviewEntry = (description, key, uiSchema, label, data) => {
+export const reviewEntry = (description, key, uiSchema, label, data) => {
   if (!data) return null;
 
   const keyString = generateReviewEntryKey(key, label, data);
@@ -224,6 +224,19 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
 
 export const buildFields = (chapter, formData, pagesFromState) => {
   return chapter.expandedPages.flatMap(page => {
+    // page level ui:confirmationField
+    const ConfirmationField = page.uiSchema['ui:confirmationField'];
+
+    if (ConfirmationField) {
+      if (isReactComponent(ConfirmationField)) {
+        return <ConfirmationField formData={formData} />;
+      }
+
+      throw new Error(
+        'Page level ui:confirmationField must be a React component',
+      );
+    }
+
     return Object.entries(page.uiSchema).flatMap(
       ([uiSchemaKey, uiSchemaValue]) => {
         const data = formData[uiSchemaKey];

--- a/src/platform/forms-system/test/js/components/ConfirmationView/ChapterSectionCollection.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ConfirmationView/ChapterSectionCollection.unit.spec.jsx
@@ -29,6 +29,7 @@ import {
   buildFields,
   ChapterSectionCollection,
   getChapterTitle,
+  reviewEntry,
 } from 'platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection';
 
 const mockChapterRadio = {
@@ -607,5 +608,53 @@ describe('Component ChapterSectionCollection', () => {
     expect(getByText('Date range start')).to.exist;
     expect(getByText('Date range end')).to.exist;
     expect(getByText('January 1, 2023')).to.exist;
+  });
+
+  it('should display chapter level ui:confirmationField', () => {
+    const { mockStore } = mockRedux({
+      formData: {
+        ...mockChapterRadioData,
+      },
+    });
+
+    const { getByText } = render(
+      <Provider store={mockStore}>
+        <ChapterSectionCollection
+          formConfig={{
+            chapters: {
+              radioChapter: {
+                ...mockChapterRadio,
+                pages: {
+                  ...mockChapterRadio.pages,
+                  radioPage: {
+                    ...mockChapterRadio.pages.radioPage,
+                    uiSchema: {
+                      ...mockChapterRadio.pages.radioPage.uiSchema,
+                      'ui:confirmationField': ({ formData }) => (
+                        <>
+                          {formData.webComponentYesNo &&
+                            reviewEntry(
+                              null,
+                              'mock-key',
+                              {},
+                              'Radio page confirmation field',
+                              'Page level confirmation field rendered',
+                            )}
+                        </>
+                      ),
+                    },
+                  },
+                },
+              },
+            },
+          }}
+          header="Information you submitted on this form"
+        />
+        ,
+      </Provider>,
+    );
+
+    expect(getByText('Radio page confirmation field')).to.exist;
+    expect(getByText('Page level confirmation field rendered')).to.exist;
   });
 });


### PR DESCRIPTION
## Summary

This pull request adds support to ChapterSectionCollection for page level `ui:confirmationField` overrides. This lets developers customize the confirmation page renderings at a page level instead of just at an individual field level.

This also updates the confirm veteran personal information page in form 0966 to use this page level confirmation field.

## Related issue(s)

department-of-veterans-affairs/va.gov-team-forms#2089

## Testing done

Updated ChapterSectionCollection unit tests.

## Screenshots

![Screenshot 2025-03-21 at 7 57 37 AM](https://github.com/user-attachments/assets/274721aa-2863-4684-8207-8ecf2cbfc0d7)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).