### PR TITLE
MHV-64831: Rx documentation table semantics

### DIFF
--- a/src/applications/mhv-medications/util/helpers.js
+++ b/src/applications/mhv-medications/util/helpers.js
@@ -504,6 +504,11 @@ export const sanitizeKramesHtmlStr = htmlString => {
     }
   });
 
+  // This section is to address all table tags and add role="presentation" to them
+  tempDiv.querySelectorAll('table').forEach(table => {
+    table.setAttribute('role', 'presentation');
+  });
+
   return tempDiv.innerHTML;
 };
 


### PR DESCRIPTION
## Summary

- `<table>` now gets `role="presentation"` when Rx documentation is parsed

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-64831

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

If it's possible to strip out the table, tr, td, etc entirely and display the warning as a div instead, that would be ideal. If that's not practical from the source data for these pages, then the next best thing would be to insert a role="presentation" attribute for the table. That will instruct screen readers to ignore the table semantics and just announce it as straight content.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

