### PR TITLE
update button text on address validation view

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -145,15 +145,19 @@ class AddressValidationView extends React.Component {
       validationKey,
       isLoading,
       confirmedSuggestions,
+      selectedAddressId,
     } = this.props;
 
-    let buttonText = 'Use this address';
+    let buttonText = 'Use address you entered';
 
     if (confirmedSuggestions.length === 0 && validationKey) {
-      buttonText = 'Use this address';
+      buttonText = 'Use address you entered';
     }
 
-    if (confirmedSuggestions.length === 1 && !validationKey) {
+    if (
+      confirmedSuggestions.length === 1 &&
+      selectedAddressId !== 'userEntered'
+    ) {
       buttonText = 'Use suggested address';
     }
 

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
@@ -1,13 +1,68 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import configureMockStore from 'redux-mock-store';
 import { expect } from 'chai';
 import TOGGLE_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
+import { createStore } from 'redux';
 import AddressValidationView from '../../containers/AddressValidationView';
 
-const mockStore = configureMockStore([]);
-
+const baseData = {
+  vapService: {
+    fieldTransactionMap: {
+      mailingAddress: {
+        isPending: false,
+      },
+    },
+    modal: 'addressValidation',
+    addressValidation: {
+      addressFromUser: {
+        addressLine1: '12345 1st Ave',
+        addressLine2: 'bldg 2',
+        addressLine3: 'apt 23',
+        city: 'Tampa',
+        stateCode: 'FL',
+        zipCode: '12346',
+      },
+      isAddressValidationModalVisible: true,
+      addressValidationError: '',
+      addressValidationType: 'mailingAddress',
+      userEnteredAddress: {},
+      validationKey: 1234,
+      confirmedSuggestions: [],
+      suggestedAddresses: [
+        {
+          addressLine1: '12345 1st Ave',
+          addressLine2: 'bldg 2',
+          addressLine3: 'apt 23',
+          city: 'Tampa',
+          stateCode: 'FL',
+          zipCode: '12346',
+          addressMetaData: {
+            confidenceScore: 100.0,
+            addressType: 'Domestic',
+            deliveryPointValidation: 'CONFIRMED',
+            residentialDeliveryIndicator: 'MIXED',
+          },
+        },
+        {
+          addressLine1: '22222 1st Ave',
+          addressLine2: 'bldg 2',
+          addressLine3: 'apt 23',
+          city: 'Saint Petersburg',
+          stateCode: 'FL',
+          zipCode: '55555',
+          addressMetaData: {
+            confidenceScore: 100.0,
+            addressType: 'Domestic',
+            deliveryPointValidation: 'CONFIRMED',
+            residentialDeliveryIndicator: 'MIXED',
+          },
+        },
+      ],
+    },
+  },
+};
+const getStore = data => createStore(() => data);
 // Helper function to check multiple buttons
 function expectButtons(container, expectedButtons) {
   const buttons = container.querySelectorAll('button');
@@ -28,67 +83,10 @@ function expectButtons(container, expectedButtons) {
 }
 
 describe('<AddressValidationView/>', () => {
-  const store = mockStore({
-    vapService: {
-      fieldTransactionMap: {
-        mailingAddress: {
-          isPending: false,
-        },
-      },
-      modal: 'addressValidation',
-      addressValidation: {
-        addressFromUser: {
-          addressLine1: '12345 1st Ave',
-          addressLine2: 'bldg 2',
-          addressLine3: 'apt 23',
-          city: 'Tampa',
-          stateCode: 'FL',
-          zipCode: '12346',
-        },
-        isAddressValidationModalVisible: true,
-        addressValidationError: '',
-        addressValidationType: 'mailingAddress',
-        userEnteredAddress: {},
-        validationKey: 1234,
-        confirmedSuggestions: [],
-        suggestedAddresses: [
-          {
-            addressLine1: '12345 1st Ave',
-            addressLine2: 'bldg 2',
-            addressLine3: 'apt 23',
-            city: 'Tampa',
-            stateCode: 'FL',
-            zipCode: '12346',
-            addressMetaData: {
-              confidenceScore: 100.0,
-              addressType: 'Domestic',
-              deliveryPointValidation: 'CONFIRMED',
-              residentialDeliveryIndicator: 'MIXED',
-            },
-          },
-          {
-            addressLine1: '22222 1st Ave',
-            addressLine2: 'bldg 2',
-            addressLine3: 'apt 23',
-            city: 'Saint Petersburg',
-            stateCode: 'FL',
-            zipCode: '55555',
-            addressMetaData: {
-              confidenceScore: 100.0,
-              addressType: 'Domestic',
-              deliveryPointValidation: 'CONFIRMED',
-              residentialDeliveryIndicator: 'MIXED',
-            },
-          },
-        ],
-      },
-    },
-  });
-
   it('renders VaAlert component and address elements in AddressValidationView component', async () => {
     const { getByRole, getByText, getByTestId } = render(
-      <Provider store={store}>
-        <AddressValidationView store={store} />
+      <Provider store={getStore(baseData)}>
+        <AddressValidationView />
       </Provider>,
     );
 
@@ -104,15 +102,15 @@ describe('<AddressValidationView/>', () => {
 
   it('renders va-button and confirm address button with correct attributes and text', () => {
     const { container } = render(
-      <Provider store={store}>
-        <AddressValidationView store={store} />
+      <Provider store={getStore(baseData)}>
+        <AddressValidationView />
       </Provider>,
     );
 
     expectButtons(container, [
       {
         type: 'submit',
-        text: 'Use this address',
+        text: 'Use address you entered',
         dataTestId: 'confirm-address-button',
       },
       { text: 'Go back to edit', type: 'button' },
@@ -120,33 +118,21 @@ describe('<AddressValidationView/>', () => {
   });
 
   it('renders two primary va-button components with correct text when no validationKey and suggestedAddress are present', () => {
-    const newStore = mockStore({
+    const newData = {
       vapService: {
-        fieldTransactionMap: { mailingAddress: { isPending: false } },
-        modal: 'addressValidation',
+        ...baseData.vapService,
         addressValidation: {
-          addressFromUser: {
-            addressLine1: '12345 1st Ave',
-            addressLine2: 'bldg 2',
-            addressLine3: 'apt 23',
-            city: 'Tampa',
-            stateCode: 'FL',
-            zipCode: '12346',
-          },
-          isAddressValidationModalVisible: true,
-          addressValidationError: '',
-          addressValidationType: 'mailingAddress',
-          userEnteredAddress: {},
-          validationKey: null,
+          ...baseData.vapService.addressValidation,
           confirmedSuggestions: [],
           suggestedAddresses: [],
+          validationKey: null,
         },
       },
-    });
+    };
 
     const { container } = render(
-      <Provider store={newStore}>
-        <AddressValidationView store={newStore} />
+      <Provider store={getStore(newData)}>
+        <AddressValidationView />
       </Provider>,
     );
 
@@ -157,97 +143,43 @@ describe('<AddressValidationView/>', () => {
   });
 
   it('does not render Go back to edit button while pending transaction', () => {
-    const newStore = mockStore({
+    const newData = {
       vapService: {
+        ...baseData.vapService,
         fieldTransactionMap: {
           mailingAddress: {
             isPending: true,
           },
         },
-        modal: 'addressValidation',
         addressValidation: {
-          addressFromUser: {
-            addressLine1: '12345 1st Ave',
-            addressLine2: 'bldg 2',
-            addressLine3: 'apt 23',
-            city: 'Tampa',
-            stateCode: 'FL',
-            zipCode: '12346',
-          },
-          isAddressValidationModalVisible: true,
-          addressValidationError: '',
-          addressValidationType: 'mailingAddress',
-          userEnteredAddress: {},
+          ...baseData.vapService.addressValidation,
           validationKey: null,
-          confirmedSuggestions: [],
-          suggestedAddresses: [],
         },
       },
-    });
+    };
 
     const { container } = render(
-      <Provider store={newStore}>
-        <AddressValidationView store={newStore} />
+      <Provider store={getStore(newData)}>
+        <AddressValidationView />
       </Provider>,
     );
 
     expectButtons(container, [{ text: 'Edit Address', type: 'submit' }]);
   });
 
-  describe('AddressValidationView with TWO suggestions', () => {
-    const baseStore = {
+  it('renders "Use suggested address" button when a suggested address is selected', () => {
+    const newData = {
       vapService: {
-        fieldTransactionMap: { mailingAddress: { isPending: false } },
-        modal: 'addressValidation',
-        addressValidation: {
-          addressFromUser: {
-            addressLine1: '1600 Pennsylvania Avenue NW',
-            addressPou: 'RESIDENCE/CHOICE',
-            addressType: 'DOMESTIC',
-            city: 'Washington',
-            countryCodeIso3: 'USA',
-            stateCode: 'DC',
-            zipCode: '00000',
+        ...baseData.vapService,
+        fieldTransactionMap: {
+          mailingAddress: {
+            isPending: false,
           },
-          isAddressValidationModalVisible: true,
-          addressValidationError: false,
-          addressValidationType: 'mailingAddress',
-          userEnteredAddress: {},
+        },
+        addressValidation: {
+          ...baseData.vapService.addressValidation,
+          validationKey: null,
           selectedAddressId: '0',
-          suggestedAddresses: [
-            {
-              addressLine1: '1600 Pennsylvania Ave NW',
-              addressType: 'DOMESTIC',
-              city: 'Washington',
-              countryName: 'United States',
-              countryCodeIso3: 'USA',
-              stateCode: 'DC',
-              zipCode: '20500',
-              zipCodeSuffix: '0005',
-              addressMetaData: {
-                confidenceScore: 100.0,
-                addressType: 'Domestic',
-                deliveryPointValidation: 'CONFIRMED',
-                residentialDeliveryIndicator: 'BUSINESS',
-              },
-            },
-            {
-              addressLine1: '1600 Pennsylvania Ave NW',
-              addressType: 'DOMESTIC',
-              city: 'Washington',
-              countryName: 'United States',
-              countryCodeIso3: 'USA',
-              stateCode: 'DC',
-              zipCode: '20502',
-              zipCodeSuffix: '0001',
-              addressMetaData: {
-                confidenceScore: 100.0,
-                addressType: 'Domestic',
-                deliveryPointValidation: 'CONFIRMED',
-                residentialDeliveryIndicator: 'BUSINESS',
-              },
-            },
-          ],
           confirmedSuggestions: [
             {
               addressLine1: '1600 Pennsylvania Ave NW',
@@ -267,44 +199,81 @@ describe('<AddressValidationView/>', () => {
                 residentialDeliveryIndicator: 'BUSINESS',
               },
             },
-            {
-              addressLine1: '1600 Pennsylvania Ave NW',
-              addressType: 'DOMESTIC',
-              city: 'Washington',
-              countryName: 'United States',
-              countryCodeIso3: 'USA',
-              countyCode: '11001',
-              countyName: 'District of Columbia',
-              stateCode: 'DC',
-              zipCode: '20502',
-              zipCodeSuffix: '0001',
-              addressMetaData: {
-                confidenceScore: 100.0,
-                addressType: 'Domestic',
-                deliveryPointValidation: 'CONFIRMED',
-                residentialDeliveryIndicator: 'BUSINESS',
-              },
-            },
           ],
         },
       },
     };
 
+    const { container } = render(
+      <Provider store={getStore(newData)}>
+        <AddressValidationView />
+      </Provider>,
+    );
+
+    expectButtons(container, [
+      {
+        type: 'submit',
+        text: 'Use suggested address',
+        dataTestId: 'confirm-address-button',
+      },
+      { text: 'Go back to edit', type: 'button' },
+    ]);
+  });
+
+  describe('AddressValidationView with TWO suggestions', () => {
     it('renders correct labels, buttons, and 2 radio buttons for suggested addresses when validationKey is null', () => {
-      const newStore = mockStore({
-        ...baseStore,
+      const newData = {
         vapService: {
-          ...baseStore.vapService,
+          ...baseData.vapService,
           addressValidation: {
-            ...baseStore.vapService.addressValidation,
+            ...baseData.vapService.addressValidation,
             validationKey: null,
+            selectedAddressId: '0',
+            confirmedSuggestions: [
+              {
+                addressLine1: '1600 Pennsylvania Ave NW',
+                addressType: 'DOMESTIC',
+                city: 'Washington',
+                countryName: 'United States',
+                countryCodeIso3: 'USA',
+                countyCode: '11001',
+                countyName: 'District of Columbia',
+                stateCode: 'DC',
+                zipCode: '20500',
+                zipCodeSuffix: '0005',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'BUSINESS',
+                },
+              },
+              {
+                addressLine1: '1600 Pennsylvania Ave NW',
+                addressType: 'DOMESTIC',
+                city: 'Washington',
+                countryName: 'United States',
+                countryCodeIso3: 'USA',
+                countyCode: '11001',
+                countyName: 'District of Columbia',
+                stateCode: 'DC',
+                zipCode: '20502',
+                zipCodeSuffix: '0001',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'BUSINESS',
+                },
+              },
+            ],
           },
         },
-      });
+      };
 
       const { container, getAllByRole, getByText, getAllByText } = render(
-        <Provider store={newStore}>
-          <AddressValidationView store={newStore} />
+        <Provider store={getStore(newData)}>
+          <AddressValidationView />
         </Provider>,
       );
 
@@ -324,7 +293,7 @@ describe('<AddressValidationView/>', () => {
       expectButtons(container, [
         {
           type: 'submit',
-          text: 'Use this address',
+          text: 'Use address you entered',
           dataTestId: 'confirm-address-button',
         },
         { text: 'Go back to edit', type: 'button' },
@@ -332,20 +301,56 @@ describe('<AddressValidationView/>', () => {
     });
 
     it('renders 3 radio buttons when validationKey is present', () => {
-      const newStoreWithKey = mockStore({
-        ...baseStore,
+      const newData = {
         vapService: {
-          ...baseStore.vapService,
+          ...baseData.vapService,
           addressValidation: {
-            ...baseStore.vapService.addressValidation,
+            ...baseData.vapService.addressValidation,
+            confirmedSuggestions: [
+              {
+                addressLine1: '1600 Pennsylvania Ave NW',
+                addressType: 'DOMESTIC',
+                city: 'Washington',
+                countryName: 'United States',
+                countryCodeIso3: 'USA',
+                countyCode: '11001',
+                countyName: 'District of Columbia',
+                stateCode: 'DC',
+                zipCode: '20500',
+                zipCodeSuffix: '0005',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'BUSINESS',
+                },
+              },
+              {
+                addressLine1: '1600 Pennsylvania Ave NW',
+                addressType: 'DOMESTIC',
+                city: 'Washington',
+                countryName: 'United States',
+                countryCodeIso3: 'USA',
+                countyCode: '11001',
+                countyName: 'District of Columbia',
+                stateCode: 'DC',
+                zipCode: '20502',
+                zipCodeSuffix: '0001',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'BUSINESS',
+                },
+              },
+            ],
             validationKey: 1234,
           },
         },
-      });
-
+      };
       const { getAllByRole } = render(
-        <Provider store={newStoreWithKey}>
-          <AddressValidationView store={newStoreWithKey} />
+        <Provider store={getStore(newData)}>
+          <AddressValidationView />
         </Provider>,
       );
 
@@ -354,27 +359,25 @@ describe('<AddressValidationView/>', () => {
     });
 
     it('renders the alert with the correct headline and message for NO validationKey and NO suggestedAddresses', () => {
-      const newStoreWithoutSuggestions = mockStore({
-        ...baseStore,
+      const newData = {
         featureToggles: {
           [TOGGLE_NAMES.profileShowNoValidationKeyAddressAlert]: true,
           profileShowNoValidationKeyAddressAlert: true,
         },
         isNoValidationKeyAlertEnabled: true,
         vapService: {
-          ...baseStore.vapService,
+          ...baseData.vapService,
           addressValidation: {
-            ...baseStore.vapService.addressValidation,
-            validationKey: null,
-            suggestedAddresses: [],
+            ...baseData.vapService.addressValidation,
             confirmedSuggestions: [],
+            suggestedAddresses: [],
+            validationKey: null,
           },
         },
-      });
-
+      };
       const { container, getByRole, getByText } = render(
-        <Provider store={newStoreWithoutSuggestions}>
-          <AddressValidationView store={newStoreWithoutSuggestions} />
+        <Provider store={getStore(newData)}>
+          <AddressValidationView />
         </Provider>,
       );
 
@@ -396,14 +399,13 @@ describe('<AddressValidationView/>', () => {
     });
 
     it('renders the alert with the correct headline and message for NO validationKey and has suggestedAddresses', () => {
-      const newStoreWithSingleSuggestion = mockStore({
-        ...baseStore,
+      const newData = {
         featureToggles: { profileShowNoValidationKeyAddressAlert: true },
         isNoValidationKeyAlertEnabled: true,
         vapService: {
-          ...baseStore.vapService,
+          ...baseData.vapService,
           addressValidation: {
-            ...baseStore.vapService.addressValidation,
+            ...baseData.vapService.addressValidation,
             validationKey: null,
             suggestedAddresses: [
               {
@@ -445,11 +447,11 @@ describe('<AddressValidationView/>', () => {
             ],
           },
         },
-      });
+      };
 
       const { container, getByRole, getByText } = render(
-        <Provider store={newStoreWithSingleSuggestion}>
-          <AddressValidationView store={newStoreWithSingleSuggestion} />
+        <Provider store={getStore(newData)}>
+          <AddressValidationView />
         </Provider>,
       );
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder



2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update the logic to render button text on address validation view

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/105724

## Testing done

testing locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |     
![Screenshot 2025-03-21 at 3 58 49 PM](https://github.com/user-attachments/assets/919e0f34-eb38-4853-ac78-5fc8ef24e729)
   |    
![Screenshot 2025-03-21 at 3 56 04 PM](https://github.com/user-attachments/assets/34e51a56-5e16-4447-8487-a3eb459bc524)
   |
| Desktop | 
<img width="855" alt="Screenshot 2025-03-25 at 2 52 35 PM" src="https://github.com/user-attachments/assets/e00ca847-9176-4ce0-adc2-da767fd42894" />

       |  
![image](https://github.com/user-attachments/assets/627baed4-7c8e-42d1-bc1e-6d1880bf0df7)
     |

## What areas of the site does it impact?

Screen that uses address validation view from profile code 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
