### PR TITLE
Edm 439 fix launch blockers 2

### DIFF
--- a/src/applications/gi/components/FilterControls.jsx
+++ b/src/applications/gi/components/FilterControls.jsx
@@ -12,11 +12,13 @@ function FilterControls({
 }) {
   return (
     <div>
-      <fieldset role="group" aria-label="Category type">
-        <legend className="vads-u-visibility--screen-reader">
-          Category type
-        </legend>
-        <h3 className="vads-u-margin-bottom--3 vads-u-margin-top--0p5">
+      <fieldset role="group" aria-labelledby="category-type-heading">
+        <h3
+          className="vads-u-margin-bottom--3 vads-u-margin-top--0p5"
+          id="category-type-heading"
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex="0"
+        >
           Category type
         </h3>
         {categoryCheckboxes.map((option, index) => {
@@ -33,9 +35,16 @@ function FilterControls({
         })}
       </fieldset>
 
-      <fieldset role="group" aria-label="State">
-        <legend className="vads-u-visibility--screen-reader">State</legend>
-        <h3 className="vads-u-margin-bottom--2">State</h3>
+      <fieldset role="group" aria-labelledby="state-heading">
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <h3
+          className="vads-u-margin-bottom--2"
+          id="state-heading"
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex="0"
+        >
+          State
+        </h3>
         <Dropdown
           label="Applies to only license and prep course category type. Certifications are available nationwide."
           name={dropdown.label}

--- a/src/applications/gi/components/FilterControls.jsx
+++ b/src/applications/gi/components/FilterControls.jsx
@@ -36,7 +36,6 @@ function FilterControls({
       </fieldset>
 
       <fieldset role="group" aria-labelledby="state-heading">
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
         <h3
           className="vads-u-margin-bottom--2"
           id="state-heading"

--- a/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
+++ b/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
@@ -39,6 +39,7 @@ export default function LicenseCertificationFilterAccordion({
           className="usa-accordion-button vads-u-font-size--md vads-u-padding-right--3"
           aria-expanded={isExpanded}
           aria-label={`${buttonLabel} ${isExpanded ? 'expanded' : 'collapsed'}`}
+          data-testid="update-lc-search"
         >
           <div className="vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between">
             <span className="vads-u-font-family--serif accordion-button-text">

--- a/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
+++ b/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
@@ -3,11 +3,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import ClearFiltersBtn from './ClearFiltersBtn';
+import { createId } from '../utils/helpers';
 
-// Consider using redux actions, as in SearchAccordion -- ok to use local state, since state is limited to this page?
-// Examine use of/need for 'id', 'buttonId', and 'isProductionOrTestProdEnv' in SearchAccordion-- for testing or anyalytics? Necessary here?
-// Upon answering these questions, assess the reusability of the original SearchAccordion component to avoid repetion.
-
+// TODO: Assess the reusability of the SearchAccordion component to avoid repetion.
 export default function LicenseCertificationFilterAccordion({
   children,
   buttonLabel,
@@ -19,7 +17,9 @@ export default function LicenseCertificationFilterAccordion({
   expanded,
   resetSearch,
 }) {
-  const [isExpanded, setExpanded] = useState(expanded);
+  const [isExpanded, setExpanded] = useState(expanded || false);
+  const [id] = useState(`${createId(button)}-accordion`);
+  const [buttonId] = useState(`update-${createId(button)}-button`);
 
   const toggle = () => {
     setExpanded(!isExpanded);
@@ -40,19 +40,17 @@ export default function LicenseCertificationFilterAccordion({
       <h2 className={headerClasses}>
         {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component, react/button-has-type */}
         <button
-          // id={`${id}-button`}
+          id={`${id}-button`}
           onClick={toggle}
           className="usa-accordion-button vads-u-font-size--md vads-u-padding-right--3"
-          // aria-isExpanded={isExpanded}
-          // aria-controls={id}
+          aria-expanded={isExpanded}
+          aria-controls={id}
           data-testid="update-lc-search"
         >
           <div className="vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between">
             <span className="vads-u-font-family--serif accordion-button-text">
               {buttonLabel}
             </span>
-
-            <va-icon icon={isExpanded ? 'remove' : 'add'} size={3} />
           </div>
         </button>
       </h2>
@@ -88,10 +86,12 @@ export default function LicenseCertificationFilterAccordion({
   );
 
   return (
-    <div className="usa-accordion-item">
+    <div className="usa-accordion-item" id={id}>
       {renderHeader()}
       <div
-        className="usa-accordion-content update-results-form vads-u-padding-top--5 vads-u-padding-bottom--3 "
+        id={`${id}-content`}
+        className={`usa-accordion-content ${isExpanded &&
+          `update-results-form vads-u-padding-top--5 vads-u-padding-bottom--3`} `}
         aria-hidden={!isExpanded}
         hidden={!isExpanded}
       >
@@ -100,6 +100,7 @@ export default function LicenseCertificationFilterAccordion({
       {isExpanded && (
         <div className={updateResultsButtonsWrapper}>
           <VaButton
+            id={buttonId}
             className={`update-results-button-after ${updateResultsButton}`}
             onClick={buttonOnClick}
             aria-describedby={ariaDescribedBy}

--- a/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
+++ b/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import ClearFiltersBtn from './ClearFiltersBtn';
-import { createId } from '../utils/helpers';
 
-// TODO: Assess the reusability of the SearchAccordion component to avoid repetion.
+// TODO: Assess reusability of SearchAccordion component to avoid repetition.
 export default function LicenseCertificationFilterAccordion({
   children,
   buttonLabel,
@@ -13,13 +12,10 @@ export default function LicenseCertificationFilterAccordion({
   buttonOnClick, // update results
   onClick,
   headerClass,
-  ariaDescribedBy,
   expanded,
   resetSearch,
 }) {
   const [isExpanded, setExpanded] = useState(expanded || false);
-  const [id] = useState(`${createId(button)}-accordion`);
-  const [buttonId] = useState(`update-${createId(button)}-button`);
 
   const toggle = () => {
     setExpanded(!isExpanded);
@@ -38,14 +34,11 @@ export default function LicenseCertificationFilterAccordion({
 
     return (
       <h2 className={headerClasses}>
-        {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component, react/button-has-type */}
         <button
-          id={`${id}-button`}
           onClick={toggle}
           className="usa-accordion-button vads-u-font-size--md vads-u-padding-right--3"
           aria-expanded={isExpanded}
-          aria-controls={id}
-          data-testid="update-lc-search"
+          aria-label={`${buttonLabel} ${isExpanded ? 'expanded' : 'collapsed'}`}
         >
           <div className="vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between">
             <span className="vads-u-font-family--serif accordion-button-text">
@@ -86,26 +79,22 @@ export default function LicenseCertificationFilterAccordion({
   );
 
   return (
-    <div className="usa-accordion-item" id={id}>
+    <div className="usa-accordion-item">
       {renderHeader()}
       <div
-        id={`${id}-content`}
         className={`usa-accordion-content ${isExpanded &&
           `update-results-form vads-u-padding-top--5 vads-u-padding-bottom--3`} `}
         aria-hidden={!isExpanded}
         hidden={!isExpanded}
         role="region"
-        aria-labelledby={`${id}-button`}
       >
         {isExpanded ? children : null}
       </div>
       {isExpanded && (
         <div className={updateResultsButtonsWrapper}>
           <VaButton
-            id={buttonId}
             className={`update-results-button-after ${updateResultsButton}`}
             onClick={buttonOnClick}
-            aria-describedby={ariaDescribedBy}
             text={button}
           />
           <ClearFiltersBtn
@@ -119,7 +108,6 @@ export default function LicenseCertificationFilterAccordion({
 }
 
 LicenseCertificationFilterAccordion.propTypes = {
-  ariaDescribedBy: PropTypes.string,
   button: PropTypes.string.isRequired,
   buttonLabel: PropTypes.string.isRequired,
   buttonOnClick: PropTypes.func.isRequired,

--- a/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
+++ b/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
@@ -94,6 +94,8 @@ export default function LicenseCertificationFilterAccordion({
           `update-results-form vads-u-padding-top--5 vads-u-padding-bottom--3`} `}
         aria-hidden={!isExpanded}
         hidden={!isExpanded}
+        role="region"
+        aria-labelledby={`${id}-button`}
       >
         {isExpanded ? children : null}
       </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes to minor accessibility issues found in QA:
    - Changes include pdated aria attributes and element focus states so screen reader correctly announces relevant text while moving thorugh the page.
- Education Data Migration (EDM)
- The changes are behind a feature toggle; to be lifted in April.

## Related issue(s)

- EDM-439: Assess launch blocking issues from staging review

## Testing done

- Changes did not effect unit or e2e tests

## Acceptance criteria

### Quality Assurance & Testing
 QA testing will commence once changes are merged
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
