### PR TITLE
MHV-68794: Download success alert fix

### DIFF
--- a/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
@@ -12,11 +12,10 @@ import PropTypes from 'prop-types';
 import { ALERT_TYPE_SUCCESS } from '../../util/constants';
 
 const DownloadSuccessAlert = props => {
-  const { className, ccd, visibility } = props;
+  const { className, ccd } = props;
   return (
     <VaAlert
       status={ALERT_TYPE_SUCCESS}
-      visible={visibility}
       class={`vads-u-margin-top--4 no-print ${className}`}
       role="alert"
       data-testid="alert-download-started"

--- a/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import { ALERT_TYPE_SUCCESS } from '../../util/constants';
 
 const DownloadSuccessAlert = props => {
-  const { className, ccd } = props;
+  const { className, type } = props;
   return (
     <VaAlert
       status={ALERT_TYPE_SUCCESS}
@@ -21,7 +21,7 @@ const DownloadSuccessAlert = props => {
       data-testid="alert-download-started"
     >
       <h2 slot="headline" data-testid="download-success-alert-message">
-        {ccd ? 'Continuity of Care Document download' : 'Download'} started
+        {`${type || 'Download'} started`}
       </h2>
       <p className="vads-u-margin--0">
         Check your device’s downloads location for your file.
@@ -33,8 +33,8 @@ const DownloadSuccessAlert = props => {
 export default DownloadSuccessAlert;
 
 DownloadSuccessAlert.propTypes = {
-  ccd: PropTypes.any,
   className: PropTypes.any,
   completed: PropTypes.any,
+  type: PropTypes.any,
   visibility: PropTypes.any,
 };

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -287,6 +287,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
           on {lastSuccessfulUpdate.date}
         </va-card>
       )}
+      <h2>Download your VA Blue Button report</h2>
       {activeAlert?.type === ALERT_TYPE_BB_ERROR && (
         <AccessTroubleAlertBox
           alertType={accessAlertTypes.DOCUMENT}
@@ -303,11 +304,13 @@ const DownloadReportPage = ({ runningUnitTest }) => {
               BB_DOMAIN_DISPLAY_MAP,
             )}
           />
-          <DownloadSuccessAlert className="vads-u-margin-bottom--1" />
+          <DownloadSuccessAlert
+            type="Your VA Blue Button report download has"
+            className="vads-u-margin-bottom--1"
+          />
         </>
       )}
-      <h2>Download your VA Blue Button report</h2>
-      <p className="vads-u-margin--0 vads-u-margin-bottom--1">
+      <p className="vads-u-margin--0 vads-u-margin-top--3 vads-u-margin-bottom--1">
         First, select the types of records you want in your report. Then
         download.
       </p>
@@ -324,7 +327,10 @@ const DownloadReportPage = ({ runningUnitTest }) => {
 
       {(generatingCCD || ccdDownloadSuccess) &&
         !ccdError && (
-          <DownloadSuccessAlert ccd className="vads-u-margin-bottom--1" />
+          <DownloadSuccessAlert
+            type="Continuity of Care Document download"
+            className="vads-u-margin-bottom--1"
+          />
         )}
 
       {accessErrors()}
@@ -354,7 +360,10 @@ const DownloadReportPage = ({ runningUnitTest }) => {
               SEI_DOMAIN_DISPLAY_MAP,
             )}
           />
-          <DownloadSuccessAlert className="vads-u-margin-bottom--1" />
+          <DownloadSuccessAlert
+            type="Self-entered health information report download"
+            className="vads-u-margin-bottom--1"
+          />
         </>
       )}
       <va-accordion bordered>

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -75,6 +75,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
     mr: {
       downloads: {
         generatingCCD,
+        ccdDownloadSuccess,
         error: ccdError,
         bbDownloadSuccess: successfulBBDownload,
       },
@@ -320,13 +321,11 @@ const DownloadReportPage = ({ runningUnitTest }) => {
       />
 
       <h2>Other reports you can download</h2>
-      <div id="generating-ccd-downloading-indicator">
-        <DownloadSuccessAlert
-          ccd
-          className="vads-u-margin-bottom--1"
-          visibility={generatingCCD}
-        />
-      </div>
+
+      {(generatingCCD || ccdDownloadSuccess) &&
+        !ccdError && (
+          <DownloadSuccessAlert ccd className="vads-u-margin-bottom--1" />
+        )}
 
       {accessErrors()}
 

--- a/src/applications/mhv-medical-records/reducers/downloads.js
+++ b/src/applications/mhv-medical-records/reducers/downloads.js
@@ -31,6 +31,7 @@ export const downloadsReducer = (state = initialState, action) => {
       return {
         ...state,
         generatingCCD: false,
+        ccdDownloadSuccess: true,
         timestampCCD: action.response,
       };
     }

--- a/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadReportPage.unit.spec.jsx
@@ -206,3 +206,51 @@ describe('DownloadRecordsPage with a general BB download error', () => {
     });
   });
 });
+
+describe('DownloadRecordsPage with successful Blue Button download alert', () => {
+  const stateWithBBSuccess = {
+    user,
+    mr: {
+      downloads: {
+        generatingCCD: false,
+        ccdError: false,
+        bbDownloadSuccess: true, // set success flag to true
+      },
+      blueButton: {
+        failedDomains: [],
+      },
+      selfEntered: {
+        failedDomains: [],
+        // Provide empty arrays for SEI domains if needed
+        activityJournal: [],
+        allergies: [],
+        demographics: [],
+        familyHistory: [],
+        foodJournal: [],
+        providers: [],
+        healthInsurance: [],
+        testEntries: [],
+        medicalEvents: [],
+        medications: [],
+        militaryHistory: [],
+        treatmentFacilities: [],
+        vaccines: [],
+        vitals: [],
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<DownloadReportPage />, {
+      initialState: stateWithBBSuccess,
+      reducers: reducer,
+      path: '/download-all',
+    });
+  });
+
+  it('renders the Blue Button download success alert', () => {
+    expect(screen.getByText('Your VA Blue Button report download has started'))
+      .to.exist;
+  });
+});


### PR DESCRIPTION
## Summary
- Removed unnecessary and faulty "visibility" property from download success alert component. This should fix the faulty download success alert for all domains. 
- Replicated existing rendering functionality where visibility property was being used
- Added a new state to the download reducer to mark the completion of download CCD API calls and the start of client download
- Download success messaging content updated for download page

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-68794

> ### Success/Error alerts are not appearing for most download options
> Description
> Success alerts are not appearing for most download options
> 
>  
> Here is the intended user flow:
> Individual domains (list and details pages): * User clicks on download
> 
> Then success (“[Page name] download started”) OR error alert appears under header (h1)
> Alert stays present until user refreshes or leaves page
> Blue Button: * User is on the “Download your medical records reports” page and clicks on download
> 
> User is taken to “Select records and download report” flow.
> After going through all steps, spinner appears and focus lands on spinner
> Then user is taken back to “Download your medical records reports” page and either a success (“Your VA Blue Button report download has started” OR error alert appears under “Download your VA Blue Button report” header
> If certain PARTS of the report fail, we will have an error alert stacked above the download started success alert, and focus will land on the error alert.
> Alerts stay present until user refreshes or leaves page
> CCD/self-entered: * User is on the “Download your medical records reports” page and opens CCD and/or self-entered health records accordion, and clicks download link
> 
> Spinner appears and focus lands on spinner
> Then success alert (“Continuity of Care Document download started” or “Self-entered health information report download started”) OR error alert appears under “Other reports you can download” header
> If certain PARTS of the self-entered report fail, we will have an error alert stacked above the download started success alert, and focus will land on the error alert.
> Alert stays present until user refreshes or leaves page
> –
> Here is a link to the Source of Truth for downloading records, which shows the placement and content for the success or error messages: https://www.figma.com/design/SGP1z2LejUWqDZyT61po5J/Medical-Records---Phase-1?node-id=14676-65202&t=DBWtixtyYzL8mPeo-1

## Testing done
Unit test written for download page download success alert

## Screenshots
<img width="797" alt="Screenshot 2025-03-24 at 10 26 57 AM" src="https://github.com/user-attachments/assets/430eb3b7-f708-47f2-87a8-64371c62ecd2" />
<img width="807" alt="Screenshot 2025-03-24 at 10 09 14 AM" src="https://github.com/user-attachments/assets/fbde9d37-f707-4ac9-abe4-435b48198847" />
<img width="870" alt="Screenshot 2025-03-23 at 6 32 26 PM" src="https://github.com/user-attachments/assets/0d58d11c-8a74-41b9-b3df-f57f07735e84" />

## What areas of the site does it impact?
MHV medical records - downloads

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
