### PR TITLE
Add canceled appointments to past appointment list

### DIFF
--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
@@ -398,7 +398,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
     expect(screen.baseElement).to.contain.text('Details');
   });
-  it('should display past cancel appt when feature toggle is on', async () => {
+  it('should display past cancel appt, vaOnlineSchedulingDisplayPastCancelledAppointments = true', async () => {
     const yesterday = moment(testDates().now)
       .utc()
       .subtract(1, 'day');

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.jsx
@@ -70,8 +70,8 @@ export default function UpcomingAppointmentsDetailsPage() {
       let pageTitle = 'VA appointment on';
       let prefix = 'Upcoming';
 
-      if (isPast) prefix = 'Past';
-      else if (selectIsCanceled(appointment)) prefix = 'Canceled';
+      if (isCanceled) prefix = 'Canceled';
+      else if (isPast) prefix = 'Past';
 
       if (isCommunityCare)
         pageTitle = `${prefix} Community Care Appointment On`;

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.unit.spec.jsx
@@ -390,6 +390,78 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
           );
         });
       });
+      it('should display document tile for canceled past phone appointment when toggle is on', async () => {
+        // Arrange
+        const defaultState = {
+          ...initialState,
+          featureToggles: {
+            ...initialState.featureToggles,
+            vaOnlineSchedulingDisplayPastCancelledAppointments: true,
+          },
+        };
+        const yesterday = moment().subtract(1, 'day');
+        const responses = MockAppointmentResponse.createPhoneResponses({
+          localStartTime: yesterday,
+          past: true,
+        });
+        responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
+        mockAppointmentApi({
+          response: responses[0],
+          avs: true,
+          fetchClaimStatus: true,
+        });
+
+        // Act
+        renderWithStoreAndRouter(<AppointmentList />, {
+          initialState: defaultState,
+          path: `/${responses[0].id}`,
+        });
+
+        // Assert
+        await waitFor(() => {
+          expect(global.document.title).to.equal(
+            `Canceled Phone Appointment On ${yesterday.format(
+              'dddd, MMMM D, YYYY',
+            )} | Veterans Affairs`,
+          );
+        });
+      });
+      it('should display document tile for canceled past community care appointment when toggle is on', async () => {
+        // Arrange
+        const defaultState = {
+          ...initialState,
+          featureToggles: {
+            ...initialState.featureToggles,
+            vaOnlineSchedulingDisplayPastCancelledAppointments: true,
+          },
+        };
+        const yesterday = moment().subtract(1, 'day');
+        const responses = MockAppointmentResponse.createCCResponses({
+          localStartTime: yesterday,
+          past: true,
+        });
+        responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
+        mockAppointmentApi({
+          response: responses[0],
+          avs: true,
+          fetchClaimStatus: true,
+        });
+
+        // Act
+        renderWithStoreAndRouter(<AppointmentList />, {
+          initialState: defaultState,
+          path: `/${responses[0].id}`,
+        });
+
+        // Assert
+        await waitFor(() => {
+          expect(global.document.title).to.equal(
+            `Canceled Community Care Appointment On ${yesterday.format(
+              'dddd, MMMM D, YYYY',
+            )} | Veterans Affairs`,
+          );
+        });
+      });
     });
   });
 

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.unit.spec.jsx
@@ -133,7 +133,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     });
 
     describe('Document titles', () => {
-      it('should display document tile for ATLAS video appointment', async () => {
+      it('should display document title for ATLAS video appointment', async () => {
         // Arrange
         const today = moment();
         const responses = MockAppointmentResponse.createAtlasResponses({
@@ -161,7 +161,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for past ATLAS video appointment', async () => {
+      it('should display document title for past ATLAS video appointment', async () => {
         // Arrange
         const yesterday = moment().subtract(1, 'day');
         const responses = MockAppointmentResponse.createAtlasResponses({
@@ -190,7 +190,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for canceled ATLAS video appointment', async () => {
+      it('should display document title for canceled ATLAS video appointment', async () => {
         // Arrange
         const today = moment();
         const responses = MockAppointmentResponse.createAtlasResponses({
@@ -219,7 +219,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for video appointment', async () => {
+      it('should display document title for video appointment', async () => {
         // Arrange
         const today = moment();
         const responses = MockAppointmentResponse.createGfeResponses({
@@ -247,7 +247,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for past video appointment', async () => {
+      it('should display document title for past video appointment', async () => {
         // Arrange
         const yesterday = moment().subtract(1, 'day');
         const responses = MockAppointmentResponse.createGfeResponses({
@@ -276,7 +276,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for canceled video appointment', async () => {
+      it('should display document title for canceled video appointment', async () => {
         // Arrange
         const today = moment();
         const responses = MockAppointmentResponse.createGfeResponses({
@@ -305,7 +305,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for video at VA location appointment', async () => {
+      it('should display document title for video at VA location appointment', async () => {
         // Arrange
         const today = moment();
         const responses = MockAppointmentResponse.createClinicResponses({
@@ -333,7 +333,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for past video at VA location appointment', async () => {
+      it('should display document title for past video at VA location appointment', async () => {
         // Arrange
         const yesterday = moment().subtract(1, 'day');
         const responses = MockAppointmentResponse.createClinicResponses({
@@ -362,7 +362,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         });
       });
 
-      it('should display document tile for canceled video at VA location appointment', async () => {
+      it('should display document title for canceled video at VA location appointment', async () => {
         // Arrange
         const today = moment();
         const responses = MockAppointmentResponse.createClinicResponses({
@@ -390,76 +390,66 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
           );
         });
       });
-      it('should display document tile for canceled past phone appointment when toggle is on', async () => {
-        // Arrange
-        const defaultState = {
-          ...initialState,
-          featureToggles: {
-            ...initialState.featureToggles,
-            vaOnlineSchedulingDisplayPastCancelledAppointments: true,
-          },
-        };
-        const yesterday = moment().subtract(1, 'day');
-        const responses = MockAppointmentResponse.createPhoneResponses({
-          localStartTime: yesterday,
-          past: true,
-        });
-        responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
-        mockAppointmentApi({
-          response: responses[0],
-          avs: true,
-          fetchClaimStatus: true,
-        });
 
-        // Act
-        renderWithStoreAndRouter(<AppointmentList />, {
-          initialState: defaultState,
-          path: `/${responses[0].id}`,
-        });
+      describe('when appointment is canceled and in the past', () => {
+        it('should display document title for canceled past phone appointment', async () => {
+          // Arrange
+          const yesterday = moment().subtract(1, 'day');
+          const responses = MockAppointmentResponse.createPhoneResponses({
+            localStartTime: yesterday,
+            past: true,
+          });
+          responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
+          mockAppointmentApi({
+            response: responses[0],
+            avs: true,
+            fetchClaimStatus: true,
+          });
 
-        // Assert
-        await waitFor(() => {
-          expect(global.document.title).to.equal(
-            `Canceled Phone Appointment On ${yesterday.format(
-              'dddd, MMMM D, YYYY',
-            )} | Veterans Affairs`,
-          );
-        });
-      });
-      it('should display document tile for canceled past community care appointment when toggle is on', async () => {
-        // Arrange
-        const defaultState = {
-          ...initialState,
-          featureToggles: {
-            ...initialState.featureToggles,
-            vaOnlineSchedulingDisplayPastCancelledAppointments: true,
-          },
-        };
-        const yesterday = moment().subtract(1, 'day');
-        const responses = MockAppointmentResponse.createCCResponses({
-          localStartTime: yesterday,
-          past: true,
-        });
-        responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
-        mockAppointmentApi({
-          response: responses[0],
-          avs: true,
-          fetchClaimStatus: true,
-        });
+          // Act
+          renderWithStoreAndRouter(<AppointmentList />, {
+            initialState,
+            path: `/${responses[0].id}`,
+          });
 
-        // Act
-        renderWithStoreAndRouter(<AppointmentList />, {
-          initialState: defaultState,
-          path: `/${responses[0].id}`,
+          // Assert
+          await waitFor(() => {
+            expect(global.document.title).to.equal(
+              `Canceled Phone Appointment On ${yesterday.format(
+                'dddd, MMMM D, YYYY',
+              )} | Veterans Affairs`,
+            );
+          });
         });
+        it('should display document title for canceled past CC appointment', async () => {
+          // Arrange
 
-        // Assert
-        await waitFor(() => {
-          expect(global.document.title).to.equal(
-            `Canceled Community Care Appointment On ${yesterday.format(
-              'dddd, MMMM D, YYYY',
-            )} | Veterans Affairs`,
-          );
+          const yesterday = moment().subtract(1, 'day');
+          const responses = MockAppointmentResponse.createCCResponses({
+            localStartTime: yesterday,
+            past: true,
+          });
+          responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
+          mockAppointmentApi({
+            response: responses[0],
+            avs: true,
+            fetchClaimStatus: true,
+          });
+
+          // Act
+          renderWithStoreAndRouter(<AppointmentList />, {
+            initialState,
+            path: `/${responses[0].id}`,
+          });
+
+          // Assert
+          await waitFor(() => {
+            expect(global.document.title).to.equal(
+              `Canceled Community Care Appointment On ${yesterday.format(
+                'dddd, MMMM D, YYYY',
+              )} | Veterans Affairs`,
+            );
+          });
         });
       });
     });

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -29,6 +29,7 @@ import {
   selectFeatureVAOSServiceVAAppointments,
   selectFeatureVAOSServiceCCAppointments,
   selectFeatureFeSourceOfTruth,
+  selectFeatureDisplayPastCancelledAppointments,
 } from '../../redux/selectors';
 import { TYPE_OF_CARE_ID as VACCINE_TYPE_OF_CARE_ID } from '../../covid-19-vaccine/utils';
 import { getTypeOfCareById } from '../../utils/appointment';
@@ -148,7 +149,12 @@ export const selectPastAppointmentsV2 = state => {
       }
 
       const sortedAppointments = past
-        .filter(isValidPastAppointment)
+        .filter(item =>
+          isValidPastAppointment(
+            item,
+            selectFeatureDisplayPastCancelledAppointments(state),
+          ),
+        )
         .sort(sortByDateDescending);
 
       return groupAppointmentsByMonth(sortedAppointments);

--- a/src/applications/vaos/components/layouts/CCLayout.jsx
+++ b/src/applications/vaos/components/layouts/CCLayout.jsx
@@ -43,10 +43,9 @@ export default function CCLayout({ data: appointment }) {
   const { patientComments } = appointment || {};
 
   let heading = 'Community care appointment';
-  if (isPastAppointment) heading = 'Past community care appointment';
-  else if (APPOINTMENT_STATUS.cancelled === status)
+  if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled community care appointment';
-  else heading = 'Community care appointment';
+  else if (isPastAppointment) heading = 'Past community care appointment';
 
   recordAppointmentDetailsNullStates(
     {

--- a/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
@@ -350,7 +350,7 @@ describe('VAOS Component: CCLayout', () => {
   });
 
   describe('When viewing canceled appointment details', () => {
-    it('should display CC layout', async () => {
+    it('should display CC layout when in the future', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -475,6 +475,118 @@ describe('VAOS Component: CCLayout', () => {
           'va-link[text="Find a full list of things to bring to your appointment"]',
         ),
       ).to.be.ok;
+
+      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+        .ok;
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).not.exist;
+    });
+    it('should display CC layout when in the past', async () => {
+      // Arrange
+      const store = createTestStore(initialState);
+      const appointment = {
+        patientComments: 'This is a test:Additional information',
+        communityCareProvider: {
+          address: {
+            line: ['line 1'],
+            city: 'City',
+            state: 'State',
+            postalCode: 'Postal code',
+          },
+          telecom: [{ system: 'phone', value: '123-456-7890' }],
+          providers: [
+            {
+              name: {
+                familyName: 'Test',
+                lastName: 'User',
+              },
+              providerName: 'Test User',
+            },
+          ],
+          providerName: ['Test User'],
+          treatmentSpecialty: 'Optometrist',
+        },
+        location: {},
+        videoData: {},
+        vaos: {
+          isCommunityCare: true,
+          isCompAndPenAppointment: false,
+          isCOVIDVaccine: false,
+          isPastAppointment: true,
+          isPendingAppointment: false,
+          isUpcomingAppointment: false,
+          apiData: {
+            serviceType: 'primaryCare',
+          },
+        },
+        start: moment()
+          .subtract(2, 'day')
+          .format('YYYY-MM-DDTHH:mm:ss'),
+        status: 'cancelled',
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(<CCLayout data={appointment} />, {
+        store,
+      });
+
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /Canceled community care appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /If you want to reschedule, call us or schedule a new appointment online/i,
+        ),
+      );
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /After visit summary/i,
+        }),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /When/i }));
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /What/i }));
+      expect(screen.getByText(/Primary care/i));
+
+      expect(screen.getByRole('heading', { level: 2, name: /Provider/ }));
+      expect(screen.getByText(/Test User/i));
+      expect(screen.getByText(/Optometrist/i));
+      expect(screen.getByText(/line 1/i));
+      screen.getByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === 'span' &&
+          content === 'City, State Postal code'
+        );
+      });
+
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be
+        .ok;
+
+      expect(
+        screen.container.querySelector('va-telephone[contact="123-456-7890"]'),
+      ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Details you shared with your provider/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Other details: This is a test:Additional information/i,
+        ),
+      );
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.jsx
@@ -51,9 +51,8 @@ export default function ClaimExamLayout({ data: appointment }) {
 
   let heading = 'Claim exam';
   const facilityId = locationId;
-  if (isPastAppointment) heading = 'Past claim exam';
-  else if (APPOINTMENT_STATUS.cancelled === status)
-    heading = 'Canceled claim exam';
+  if (APPOINTMENT_STATUS.cancelled === status) heading = 'Canceled claim exam';
+  else if (isPastAppointment) heading = 'Past claim exam';
 
   recordAppointmentDetailsNullStates(
     {

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.jsx
@@ -562,7 +562,7 @@ describe('VAOS Component: ClaimExamLayout', () => {
   });
 
   describe('When viewing canceled appointment details', () => {
-    it('should display claim exam layout', async () => {
+    it('should display claim exam layout when in the future', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -666,6 +666,102 @@ describe('VAOS Component: ClaimExamLayout', () => {
       ).to.be.ok;
       expect(screen.getByText(/Learn more about claim exam appointments/i));
 
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /Need to make changes/i,
+        }),
+      ).not.to.exist;
+      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+        .ok;
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).to.not.exist;
+    });
+    it('should display claim exam layout when in the past', async () => {
+      // Arrange
+      const store = createTestStore(initialState);
+      const appointment = {
+        location: {
+          stationId: '983',
+          clinicName: 'Clinic 1',
+          clinicPhysicalLocation: 'CHEYENNE',
+          clinicPhone: '500-500-5000',
+          clinicPhoneExtension: '1234',
+        },
+        videoData: {},
+        vaos: {
+          isCompAndPenAppointment: true,
+          isPastAppointment: true,
+          apiData: {
+            localStartTime: moment()
+              .subtract(2, 'day')
+              .format('YYYY-MM-DDTHH:mm:ss'),
+            serviceType: 'primaryCare',
+          },
+        },
+        status: 'cancelled',
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(
+        <ClaimExamLayout data={appointment} />,
+        {
+          store,
+        },
+      );
+
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /Canceled claim exam/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /If you want to reschedule, call us or schedule a new appointment online/i,
+        ),
+      );
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /After visit summary/i,
+        }),
+      ).not.to.exist;
+      expect(
+        screen.queryByRole('heading', { level: 2, name: /How to prepare/i }),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /When/i }));
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /What/i }));
+      expect(screen.getByText(/Primary care/i));
+
+      expect(screen.getByRole('heading', { level: 2, name: /Where/i }));
+      expect(screen.getByText(/2360 East Pershing Boulevard/i));
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be
+        .ok;
+
+      expect(screen.getByText(/Location:/i));
+      expect(screen.getByText(/CHEYENNE/));
+
+      expect(screen.getByText(/Clinic:/i));
+      expect(screen.getByText(/Clinic 1/i));
+      expect(screen.getByText(/Clinic phone:/i));
+      expect(
+        screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
+      ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Scheduling facility/i,
+        }),
+      );
       expect(
         screen.queryByRole('heading', {
           level: 2,

--- a/src/applications/vaos/components/layouts/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.jsx
@@ -52,9 +52,9 @@ export default function InPersonLayout({ data: appointment }) {
   const facilityId = locationId;
 
   let heading = 'In-person appointment';
-  if (isPastAppointment) heading = 'Past in-person appointment';
-  else if (APPOINTMENT_STATUS.cancelled === status)
+  if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled in-person appointment';
+  else if (isPastAppointment) heading = 'Past in-person appointment';
 
   recordAppointmentDetailsNullStates(
     {

--- a/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
@@ -579,7 +579,7 @@ describe('VAOS Component: InPersonLayout', () => {
   });
 
   describe('When viewing past appointment details', () => {
-    it('should display in-person layout', async () => {
+    it('should display past in-person layout', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -672,7 +672,7 @@ describe('VAOS Component: InPersonLayout', () => {
   });
 
   describe('When viewing canceled appointment details', () => {
-    it('should display in-person layout', async () => {
+    it('should display in-person when appointment is in the future', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -766,6 +766,96 @@ describe('VAOS Component: InPersonLayout', () => {
         screen.container.querySelector(
           'va-link[text="Find a full list of things to bring to your appointment"]',
         ),
+      ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Details you shared with your provider/i,
+        }),
+      );
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
+
+      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+        .ok;
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).not.exist;
+    });
+    it('should display in-person when appointment is in the past', async () => {
+      const store = createTestStore(initialState);
+      const appointment = {
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
+        location: {
+          stationId: '983',
+          clinicName: 'Clinic 1',
+          clinicPhysicalLocation: 'CHEYENNE',
+          clinicPhone: '500-500-5000',
+          clinicPhoneExtension: '1234',
+        },
+        videoData: {},
+        vaos: {
+          isPastAppointment: true,
+          apiData: {
+            localStartTime: moment()
+              .subtract(2, 'day')
+              .format('YYYY-MM-DDTHH:mm:ss'),
+            serviceType: 'primaryCare',
+          },
+        },
+        status: 'cancelled',
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(
+        <InPersonLayout data={appointment} />,
+        {
+          store,
+        },
+      );
+
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /Canceled in-person appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /If you want to reschedule, call us or schedule a new appointment online/i,
+        ),
+      );
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /After visit summary/i,
+        }),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /When/i }));
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /What/i }));
+      expect(screen.getByText(/Primary care/i));
+
+      expect(screen.getByRole('heading', { level: 2, name: /Where/i }));
+      expect(screen.getByText(/2360 East Pershing Boulevard/i));
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be
+        .ok;
+
+      expect(screen.getByText(/Location:/i));
+      expect(screen.getByText(/CHEYENNE/));
+
+      expect(screen.getByText(/Clinic:/i));
+      expect(screen.getByText(/Clinic 1/i));
+      expect(screen.getByText(/Phone:/i));
+      expect(
+        screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
       ).to.be.ok;
 
       expect(

--- a/src/applications/vaos/components/layouts/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.jsx
@@ -45,9 +45,9 @@ export default function PhoneLayout({ data: appointment }) {
   const { reasonForAppointment, patientComments } = appointment || {};
 
   let heading = 'Phone appointment';
-  if (isPastAppointment) heading = 'Past phone appointment';
-  else if (APPOINTMENT_STATUS.cancelled === status)
+  if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled phone appointment';
+  else if (isPastAppointment) heading = 'Past phone appointment';
 
   recordAppointmentDetailsNullStates(
     {

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
@@ -587,7 +587,7 @@ describe('VAOS Component: PhoneLayout', () => {
   });
 
   describe('When viewing canceled appointment details', () => {
-    it('should display in-person layout', async () => {
+    it('should display phone when in the future', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -604,7 +604,9 @@ describe('VAOS Component: PhoneLayout', () => {
         vaos: {
           isUpcomingAppointment: true,
           apiData: {
-            localStartTime: moment().format('YYYY-MM-DDTHH:mm:ss'),
+            localStartTime: moment()
+              .add(2, 'day')
+              .format('YYYY-MM-DDTHH:mm:ss'),
             serviceType: 'primaryCare',
           },
         },
@@ -693,6 +695,100 @@ describe('VAOS Component: PhoneLayout', () => {
           'va-link[text="Find a full list of things to bring to your appointment"]',
         ),
       ).to.be.ok;
+
+      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+        .ok;
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).not.exist;
+    });
+    it('should display phone when in the past', async () => {
+      // Arrange
+      const store = createTestStore(initialState);
+      const appointment = {
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
+        location: {
+          stationId: '983',
+          clinicName: 'Clinic 1',
+          clinicPhysicalLocation: 'CHEYENNE',
+          clinicPhone: '500-500-5000',
+          clinicPhoneExtension: '1234',
+        },
+        videoData: {},
+        vaos: {
+          isPastAppointment: true,
+          apiData: {
+            localStartTime: moment()
+              .subtract(2, 'day')
+              .format('YYYY-MM-DDTHH:mm:ss'),
+            serviceType: 'primaryCare',
+          },
+        },
+        status: 'cancelled',
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(
+        <PhoneLayout data={appointment} />,
+        {
+          store,
+        },
+      );
+      screen.debug();
+
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /Canceled phone appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /If you want to reschedule, call us or schedule a new appointment online/i,
+        ),
+      );
+      expect(screen.queryByRole('heading', { level: 2, name: /How to join/ }))
+        .not.to.exist;
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /After visit summary/i,
+        }),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /When/i }));
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).not.to.exist;
+
+      expect(screen.getByRole('heading', { level: 2, name: /What/i }));
+      expect(screen.getByText(/Primary care/i));
+
+      expect(
+        screen.getByRole('heading', { level: 2, name: /Scheduling facility/i }),
+      );
+      expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(screen.getByText(/2360 East Pershing Boulevard/i));
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).not
+        .to.exist;
+
+      expect(screen.getByText(/Clinic:/i));
+      expect(screen.getByText(/Clinic 1/i));
+      expect(screen.getByText(/Phone:/i));
+      expect(
+        screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
+      ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Details you shared with your provider/i,
+        }),
+      );
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
@@ -735,7 +735,6 @@ describe('VAOS Component: PhoneLayout', () => {
           store,
         },
       );
-      screen.debug();
 
       // Assert
       expect(

--- a/src/applications/vaos/components/layouts/VideoLayout.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.jsx
@@ -58,9 +58,9 @@ export default function VideoLayout({ data: appointment }) {
 
   const address = facility?.address;
   let heading = 'Video appointment';
-  if (isPastAppointment) heading = 'Past video appointment';
-  else if (APPOINTMENT_STATUS.cancelled === status)
+  if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment';
+  else if (isPastAppointment) heading = 'Past video appointment';
 
   recordAppointmentDetailsNullStates(
     {

--- a/src/applications/vaos/components/layouts/VideoLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.unit.spec.jsx
@@ -546,6 +546,140 @@ describe('VAOS Component: VideoLayout', () => {
   });
 
   describe('When viewing canceled appointment details', () => {
+    describe('And the appointment is in the past', () => {
+      it('should display video layout ', async () => {
+        // Arrange
+        const store = createTestStore(initialState);
+        const appointment = {
+          location: {
+            stationId: '983',
+            clinicName: 'Clinic 1',
+            clinicPhysicalLocation: 'CHEYENNE',
+            clinicPhone: '500-500-5000',
+            clinicPhoneExtension: '1234',
+          },
+          videoData: {
+            isVideo: true,
+            facilityId: '983',
+            kind: VIDEO_TYPES.adhoc,
+            extension: {
+              patientHasMobileGfe: true,
+            },
+            providers: [
+              {
+                name: {
+                  firstName: ['TEST'],
+                  lastName: 'PROV',
+                },
+                display: 'TEST PROV',
+              },
+            ],
+          },
+          vaos: {
+            isCommunityCare: false,
+            isCompAndPenAppointment: false,
+            isCOVIDVaccine: false,
+            isPastAppointment: true,
+            isPendingAppointment: false,
+            isUpcomingAppointment: false,
+            isVideo: true,
+            apiData: {
+              serviceType: 'primaryCare',
+            },
+          },
+          status: 'cancelled',
+        };
+
+        // Act
+        const screen = renderWithStoreAndRouter(
+          <VideoLayout data={appointment} />,
+          {
+            store,
+          },
+        );
+
+        // Assert
+        expect(
+          screen.getByRole('heading', {
+            level: 1,
+            name: /Canceled video appointment/i,
+          }),
+        );
+
+        expect(
+          screen.getByText(
+            /If you want to reschedule, call us or schedule a new appointment online/i,
+          ),
+        );
+        expect(
+          screen.queryByRole('heading', {
+            level: 2,
+            name: /After visit summary/i,
+          }),
+        ).not.to.exist;
+
+        expect(
+          screen.queryByRole('heading', {
+            level: 2,
+            name: /How to join/i,
+          }),
+        ).not.to.exist;
+
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: /When/i,
+          }),
+        );
+        expect(
+          screen.container.querySelector('va-button[text="Add to calendar"]'),
+        ).not.to.exist;
+
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: /What/i,
+          }),
+        );
+        expect(screen.getByText(/Primary care/i));
+
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: /Who/i,
+          }),
+        );
+
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: /Scheduling facility/i,
+          }),
+        );
+        expect(screen.getByText(/Cheyenne VA Medical Center/i));
+        expect(screen.queryByText(/2360 East Pershing Boulevard/i)).not.to
+          .exist;
+
+        expect(screen.getByText(/Clinic: Clinic 1/i));
+        expect(screen.getByText(/Phone:/i));
+        expect(
+          screen.container.querySelector(
+            'va-telephone[contact="500-500-5000"]',
+          ),
+        ).to.be.ok;
+        expect(screen.container.querySelector('va-telephone[extension="1234"]'))
+          .to.be.ok;
+
+        expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+          .ok;
+        expect(
+          screen.container.querySelector(
+            'va-button[text="Cancel appointment"]',
+          ),
+        ).not.to.exist;
+      });
+    });
+
     describe('And video type is mobile', () => {
       it('should display video layout', async () => {
         // Arrange

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
@@ -49,10 +49,10 @@ export default function VideoLayoutAtlas({ data: appointment }) {
 
   const address = facility?.address;
   let heading = 'Video appointment at an ATLAS location';
-  if (isPastAppointment)
-    heading = 'Past video appointment at an ATLAS location';
-  else if (APPOINTMENT_STATUS.cancelled === status)
+  if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment at an ATLAS location';
+  else if (isPastAppointment)
+    heading = 'Past video appointment at an ATLAS location';
 
   recordAppointmentDetailsNullStates(
     {

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.jsx
@@ -338,7 +338,6 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
           store,
         },
       );
-
       // Assert
       expect(
         screen.getByRole('heading', {
@@ -555,7 +554,6 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
           store,
         },
       );
-
       // Assert
       expect(
         screen.getByRole('heading', {
@@ -636,7 +634,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
   });
 
   describe('When viewing canceled appointment details', () => {
-    it('should display VA video layout', async () => {
+    it('should display VA video layout when in the future', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -801,6 +799,142 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
           'va-additional-info[trigger="How to setup your device"]',
         ),
       ).to.be.ok;
+    });
+    it('should display VA video layout when in the past', async () => {
+      // Arrange
+      const store = createTestStore(initialState);
+      const appointment = {
+        location: {
+          stationId: '983',
+          clinicName: 'Clinic 1',
+          clinicPhysicalLocation: 'CHEYENNE',
+          clinicPhone: '500-500-5000',
+          clinicPhoneExtension: '1234',
+        },
+        videoData: {
+          atlasConfirmationCode: '1234',
+          atlasLocation: {
+            address: {
+              line: ['5929 Georgia Ave NW'],
+              city: 'Washington',
+              state: 'DC',
+              postalCode: '20011',
+            },
+          },
+          isVideo: true,
+          facilityId: '983',
+          isAtlas: true,
+          kind: VIDEO_TYPES.adhoc,
+          extension: {
+            patientHasMobileGfe: false,
+          },
+          providers: [
+            {
+              name: {
+                firstName: ['TEST'],
+                lastName: 'PROV',
+              },
+              display: 'TEST PROV',
+            },
+          ],
+        },
+        vaos: {
+          isCommunityCare: false,
+          isCompAndPenAppointment: false,
+          isCOVIDVaccine: false,
+          isPastAppointment: true,
+          isPendingAppointment: false,
+          isVideo: true,
+          apiData: {
+            serviceType: 'primaryCare',
+          },
+        },
+        status: 'cancelled',
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(
+        <VideoLayoutAtlas data={appointment} />,
+        {
+          store,
+        },
+      );
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /Canceled video appointment at an Atlas location/i,
+        }),
+      );
+
+      expect(
+        screen.getByText(
+          /If you want to reschedule, call us or schedule a new appointment online/i,
+        ),
+      );
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /After visit summary/i,
+        }),
+      ).not.to.exist;
+
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /How to join/i,
+        }),
+      ).not.to.exist;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /When/i,
+        }),
+      );
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).not.to.exist;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /What/i,
+        }),
+      );
+      expect(screen.getByText(/Primary care/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Who/i,
+        }),
+      );
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: 'Where',
+        }),
+      );
+      // expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(screen.getByText(/5929 Georgia Ave NW/i));
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be
+        .ok;
+
+      expect(screen.getByRole('heading', { name: /Scheduling facility/i }));
+      expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(
+        screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
+      ).to.be.ok;
+      expect(screen.queryByRole('heading', { name: /Need to make changes/i }))
+        .not.to.exist;
+
+      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+        .ok;
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).not.to.exist;
     });
   });
 });

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
@@ -47,9 +47,9 @@ export default function VideoLayoutVA({ data: appointment }) {
 
   let heading = 'Video appointment at a VA location';
   const facilityId = locationId;
-  if (isPastAppointment) heading = 'Past video appointment at VA location';
-  else if (APPOINTMENT_STATUS.cancelled === status)
+  if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled video appointment at VA location';
+  else if (isPastAppointment) heading = 'Past video appointment at VA location';
 
   recordAppointmentDetailsNullStates(
     {

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
+import moment from 'moment';
+
 import {
   createTestStore,
   renderWithStoreAndRouter,
@@ -803,7 +805,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
   });
 
   describe('When viewing canceled appointment details', () => {
-    it('should display VA video layout', async () => {
+    it('should display VA video layout when in the future', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -944,6 +946,135 @@ describe('VAOS Component: VideoLayoutVA', () => {
         screen.container.querySelector(
           'va-link[text="Find a full list of things to bring to your appointment"]',
         ),
+      ).to.be.ok;
+
+      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+        .ok;
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).not.to.exist;
+    });
+    it('should display VA video layout when in the past', async () => {
+      // Arrange
+      const store = createTestStore(initialState);
+      const appointment = {
+        location: {
+          stationId: '983',
+          clinicName: 'Clinic 1',
+          clinicPhysicalLocation: 'CHEYENNE',
+          clinicPhone: '500-500-5000',
+          clinicPhoneExtension: '1234',
+        },
+        videoData: {
+          isVideo: true,
+          facilityId: '983',
+          kind: VIDEO_TYPES.clinic,
+          extension: {
+            patientHasMobileGfe: true,
+          },
+          providers: [
+            {
+              name: {
+                firstName: ['TEST'],
+                lastName: 'PROV',
+              },
+              display: 'TEST PROV',
+            },
+          ],
+        },
+        vaos: {
+          isCommunityCare: false,
+          isCompAndPenAppointment: false,
+          isCOVIDVaccine: false,
+          isPastAppointment: true,
+          isPendingAppointment: false,
+          isUpcomingAppointment: false,
+          isVideo: true,
+          apiData: {
+            serviceType: 'primaryCare',
+          },
+        },
+        status: 'cancelled',
+        start: moment()
+          .subtract(2, 'day')
+          .format('YYYY-MM-DDTHH:mm:ss'),
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(
+        <VideoLayoutVA data={appointment} />,
+        {
+          store,
+        },
+      );
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /Canceled video appointment at VA location/i,
+        }),
+      );
+
+      expect(
+        screen.getByText(
+          /If you want to reschedule, call us or schedule a new appointment online/i,
+        ),
+      );
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /After visit summary/i,
+        }),
+      ).not.to.exist;
+
+      expect(
+        screen.queryByRole('heading', {
+          level: 2,
+          name: /How to join/i,
+        }),
+      ).not.to.exist;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /When/i,
+        }),
+      );
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).not.to.exist;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /What/i,
+        }),
+      );
+      expect(screen.getByText(/Primary care/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Who/i,
+        }),
+      );
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Where/i,
+        }),
+      );
+      expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(screen.getByText(/2360 East Pershing Boulevard/i));
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be
+        .ok;
+
+      expect(screen.getByText(/Clinic: Clinic 1/i));
+      expect(screen.getByText(/Location: CHEYENNE/i));
+      expect(screen.getByText(/Phone:/i));
+      expect(
+        screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
       ).to.be.ok;
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -311,23 +311,25 @@ export function hasValidCovidPhoneNumber(facility) {
  * list
  *
  * @param {Appointment} appt A FHIR appointment resource
+ * @param {boolean} useDisplayPastCancel whether to display past canceled appointments
  * @returns {boolean} Whether or not the appt should be shown
  */
-export function isValidPastAppointment(appt) {
-  return (
-    CONFIRMED_APPOINTMENT_TYPES.has(appt.vaos.appointmentType) &&
-    appt.status !== APPOINTMENT_STATUS.cancelled &&
-    // Show confirmed appointments that don't have vista statuses in the exclude
-    // list
-    (!PAST_APPOINTMENTS_HIDDEN_SET.has(appt.description) ||
-      // Show video appointments that have the default FUTURE status,
-      // since we can't infer anything about the video appt from that status
-      (appt.videoData?.isVideo && appt.description === DEFAULT_VIDEO_STATUS) ||
-      // Some CC appointments can have a null status because they're not from VistA
-      // And we want to show those
-      (appt.vaos.appointmentType === APPOINTMENT_TYPES.ccAppointment &&
-        !appt.description))
-  );
+export function isValidPastAppointment(appt, useDisplayPastCancel) {
+  return useDisplayPastCancel
+    ? CONFIRMED_APPOINTMENT_TYPES.has(appt.vaos.appointmentType)
+    : CONFIRMED_APPOINTMENT_TYPES.has(appt.vaos.appointmentType) &&
+        appt.status !== APPOINTMENT_STATUS.cancelled &&
+        // Show confirmed appointments that don't have vista statuses in the exclude
+        // list
+        (!PAST_APPOINTMENTS_HIDDEN_SET.has(appt.description) ||
+          // Show video appointments that have the default FUTURE status,
+          // since we can't infer anything about the video appt from that status
+          (appt.videoData?.isVideo &&
+            appt.description === DEFAULT_VIDEO_STATUS) ||
+          // Some CC appointments can have a null status because they're not from VistA
+          // And we want to show those
+          (appt.vaos.appointmentType === APPOINTMENT_TYPES.ccAppointment &&
+            !appt.description));
 }
 
 /**

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -307,29 +307,44 @@ export function hasValidCovidPhoneNumber(facility) {
 }
 
 /**
- * Checks to see if an appointment should be shown in the past appointment
- * list
+ * Checks if an appointment should be shown in the past appointment list
+ * - Show appointments that don't have vista statuses in the exclude list
+ * - Show video appointments that have the default FUTURE status
+ * - Show CC appointments that have a null description status,
+ *    because these appointments are not from VistA, but we want to show them
  *
  * @param {Appointment} appt A FHIR appointment resource
  * @param {boolean} useDisplayPastCancel whether to display past canceled appointments
  * @returns {boolean} Whether or not the appt should be shown
  */
 export function isValidPastAppointment(appt, useDisplayPastCancel) {
-  return useDisplayPastCancel
-    ? CONFIRMED_APPOINTMENT_TYPES.has(appt.vaos.appointmentType)
-    : CONFIRMED_APPOINTMENT_TYPES.has(appt.vaos.appointmentType) &&
-        appt.status !== APPOINTMENT_STATUS.cancelled &&
-        // Show confirmed appointments that don't have vista statuses in the exclude
-        // list
-        (!PAST_APPOINTMENTS_HIDDEN_SET.has(appt.description) ||
-          // Show video appointments that have the default FUTURE status,
-          // since we can't infer anything about the video appt from that status
-          (appt.videoData?.isVideo &&
-            appt.description === DEFAULT_VIDEO_STATUS) ||
-          // Some CC appointments can have a null status because they're not from VistA
-          // And we want to show those
-          (appt.vaos.appointmentType === APPOINTMENT_TYPES.ccAppointment &&
-            !appt.description));
+  const isConfirmedAppointment = CONFIRMED_APPOINTMENT_TYPES.has(
+    appt.vaos.appointmentType,
+  );
+  const isNotCanceled = appt.status !== APPOINTMENT_STATUS.cancelled;
+  const isNotInHiddenList = !PAST_APPOINTMENTS_HIDDEN_SET.has(appt.description);
+  const isVideoWithDefaultStatus =
+    appt.videoData?.isVideo && appt.description === DEFAULT_VIDEO_STATUS;
+  const isCommunityCareWithNullDescription =
+    appt.vaos.appointmentType === APPOINTMENT_TYPES.ccAppointment &&
+    !appt.description;
+
+  if (useDisplayPastCancel) {
+    return (
+      isConfirmedAppointment &&
+      (isNotInHiddenList ||
+        isVideoWithDefaultStatus ||
+        isCommunityCareWithNullDescription)
+    );
+  }
+
+  return (
+    isConfirmedAppointment &&
+    isNotCanceled &&
+    (isNotInHiddenList ||
+      isVideoWithDefaultStatus ||
+      isCommunityCareWithNullDescription)
+  );
 }
 
 /**


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds cancelled appointments to the past appointments list view behind the feature flag `va_online_scheduling_display_past_cancelled_appointments` . It updates the H1 and title document in the details page to indicate it is a cancel appointment. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#105468


## Testing done

unit test

## Screenshots


|         | toggle Off | toggle On |
| ------- | ------ | ----- |
| Past list view  |     ![past](https://github.com/user-attachments/assets/ff180720-23b8-4554-b4f6-5f856281db7d)   |  ![cancel_past](https://github.com/user-attachments/assets/2214979c-78c9-40d9-8088-08ba24be117a)     |
| In-person |        |    ![InPerson_past](https://github.com/user-attachments/assets/b589e5c9-f180-49ec-9658-ab44d78a434c)   |
| Phone |        |    ![Phone_past](https://github.com/user-attachments/assets/b68f03ff-c7f9-4232-b37f-5e26402f6d95)   |
| Claims |        |   ![Claims_past](https://github.com/user-attachments/assets/74c7ab77-aaf2-4e4b-af43-049389e493f5)  |
| Video |        |   ![Video_past](https://github.com/user-attachments/assets/4701b9fa-6500-4486-a356-82543f6b45f0)  |
| Video at VA |        |   ![VideoAtVa_past](https://github.com/user-attachments/assets/1d45b1dc-b19c-4836-bef1-997d098d5d5f)   |
| Video ATLAS |        |  ![VideoATLAS_past](https://github.com/user-attachments/assets/20d8a259-96e4-4a58-9099-29126d33b4b7)   |
| CC |        |    ![CC_past](https://github.com/user-attachments/assets/3c588eb2-6b08-4d5f-9edc-fd814c1e57de)   |

## What areas of the site does it impact?
past appointment list view and details view


## Acceptance criteria

- [ ] Cancelled past appointments are visible in the past appointment list
- [ ] H1 and document title indicates it is a canceled appointment on the details page, 
- [ ] Exclude the section "Prepare for your appointment" on the details page for canceled past appointments

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
