### PR TITLE
Add unit test coverage report workflow

### DIFF
--- a/.github/workflows/unit-test-coverage-report.yml
+++ b/.github/workflows/unit-test-coverage-report.yml
@@ -1,0 +1,121 @@
+name: Unit Test HTML Coverage Report Generator
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *'
+    
+jobs:
+    list-apps:
+      runs-on: ubuntu-latest
+      outputs:
+          apps: ${{ steps.get-apps.outputs.apps }}
+      steps:
+        - uses: actions/checkout@v3
+        - name: List apps
+          id: list-apps
+          run: |
+            node -e "
+            const glob = require('glob');
+            const path = require('path');
+            const allUnitTests = glob.sync('./{src,script}/**/*.unit.spec.js?(x)');
+            const apps = Array.from(new Set(
+              allUnitTests.map(spec => {
+                const parts = path.dirname(spec).split('/');
+                return parts.slice(2, 4).join('/');
+              })
+            )).filter(Boolean);
+            console.log('apps=' + JSON.stringify(apps));
+            process.stdout.write('apps=' + JSON.stringify(apps));" >> $GITHUB_OUTPUT
+
+    create-unit-test-coverage-reports:
+      name: Create Unit Test Coverage Reports
+      needs: [list-apps]
+      timeout-minutes: 30
+      runs-on: ubuntu-16-cores-22.04
+      strategy:
+        matrix:
+          app: ${{ fromJson(needs.list-apps.outputs.apps) }}
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+          with:
+            fetch-depth: 0
+
+        - name: Install dependencies
+          uses: ./.github/workflows/install
+          timeout-minutes: 30
+          with:
+            key: ${{ hashFiles('yarn.lock') }}
+            yarn_cache_folder: .cache/yarn
+            path: |
+              .cache/yarn
+              node_modules
+
+        - name: Configure AWS credentials
+          uses: ./.github/workflows/configure-aws-credentials
+          with:
+            aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws_region: us-gov-west-1
+
+        - name: Get va-vsp-bot token
+          uses: ./.github/workflows/inject-secrets
+          with:
+            ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+            env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+        - name: Create coverage results folder
+          run: mkdir -p coverage-results
+
+        - name: Run unit test coverage report
+          run: yarn test:coverage-app ${{ matrix.app }} --report-dir=coverage-results/${{ matrix.app }}
+      
+        - name: Upload Coverage Report Artifact
+          uses: ./.github/workflows/upload-artifact
+          if: ${{ always() && env.NO_APPS_TO_RUN == 'false' }}
+          with:
+            name: unit-test-coverage-${{ matrix.app }}
+            path: coverage-results/${{ matrix.app }}
+        
+    publish-coverage-reports-to-s3:
+      name: Publish Unit Test Coverage Reports to S3
+      needs: [create-unit-test-coverage-reports]
+      runs-on: ubuntu-latest
+      permissions: write-all
+      strategy:
+        matrix:
+          app: ${{ fromJson(needs.list-apps.outputs.apps) }}
+      outputs:
+        ECR_USERNAME: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+        ECR_PASSWORD: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+      steps:
+        - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v4.0.0
+          with:
+             aws-region: us-gov-west-1
+             role-to-assume: arn:aws-us-gov:iam::008577686731:role/gha-frontend-nonprod-role
+        
+        - name: Login to Amazon ECR
+          id: login-ecr
+          uses: aws-actions/amazon-ecr-login@v2    
+          with:
+            mask-password: false
+            
+        - name: Download Coverage Reports
+          uses: ./.github/workflows/download-artifact
+          with:
+            pattern: unit-test-coverage-${{ matrix.app }}
+            path: coverage-results/${{ matrix.app }} 
+
+        - name: Rename coverage results directory
+          id: rename
+          run: |
+            TIMESTAMP=$(date +'%Y-%m-%d_%H-%M-%S')
+            NEW_DIR="coverage-results/${{ matrix.app }}-${TIMESTAMP}"
+            mv coverage-results/${{ matrix.app }} $NEW_DIR
+            echo "new_dir=$NEW_DIR" >> $GITHUB_OUTPUT
+
+        - name: Upload HTML coverage reports to s3
+          run: aws s3 cp ${{ steps.rename.outputs.new_dir }} s3://testing-tools-testing-reports/html-unit-test-coverage-reports --acl public-read --region us-gov-west-1 --recursive

--- a/.github/workflows/unit-test-coverage-report.yml
+++ b/.github/workflows/unit-test-coverage-report.yml
@@ -6,116 +6,116 @@ on:
     - cron: '0 5 * * *'
     
 jobs:
-    list-apps:
-      runs-on: ubuntu-latest
-      outputs:
-          apps: ${{ steps.get-apps.outputs.apps }}
-      steps:
-        - uses: actions/checkout@v3
-        - name: List apps
-          id: list-apps
-          run: |
-            node -e "
-            const glob = require('glob');
-            const path = require('path');
-            const allUnitTests = glob.sync('./{src,script}/**/*.unit.spec.js?(x)');
-            const apps = Array.from(new Set(
-              allUnitTests.map(spec => {
-                const parts = path.dirname(spec).split('/');
-                return parts.slice(2, 4).join('/');
-              })
-            )).filter(Boolean);
-            console.log('apps=' + JSON.stringify(apps));
-            process.stdout.write('apps=' + JSON.stringify(apps));" >> $GITHUB_OUTPUT
+  list-apps:
+    runs-on: ubuntu-latest
+    outputs:
+        apps: ${{ steps.get-apps.outputs.apps }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: List apps
+        id: list-apps
+        run: |
+          node -e "
+          const glob = require('glob');
+          const path = require('path');
+          const allUnitTests = glob.sync('./{src,script}/**/*.unit.spec.js?(x)');
+          const apps = Array.from(new Set(
+            allUnitTests.map(spec => {
+              const parts = path.dirname(spec).split('/');
+              return parts.slice(2, 4).join('/');
+            })
+          )).filter(Boolean);
+          console.log('apps=' + JSON.stringify(apps));
+          process.stdout.write('apps=' + JSON.stringify(apps));" >> $GITHUB_OUTPUT
 
-    create-unit-test-coverage-reports:
-      name: Create Unit Test Coverage Reports
-      needs: [list-apps]
-      timeout-minutes: 30
-      runs-on: ubuntu-16-cores-22.04
-      strategy:
-        matrix:
-          app: ${{ fromJson(needs.list-apps.outputs.apps) }}
+  create-unit-test-coverage-reports:
+    name: Create Unit Test Coverage Reports
+    needs: [list-apps]
+    timeout-minutes: 30
+    runs-on: ubuntu-16-cores-22.04
+    strategy:
+      matrix:
+        app: ${{ fromJson(needs.list-apps.outputs.apps) }}
 
-      steps:
-        - name: Checkout
-          uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-          with:
-            fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
+        with:
+          fetch-depth: 0
 
-        - name: Install dependencies
-          uses: ./.github/workflows/install
-          timeout-minutes: 30
-          with:
-            key: ${{ hashFiles('yarn.lock') }}
-            yarn_cache_folder: .cache/yarn
-            path: |
-              .cache/yarn
-              node_modules
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
 
-        - name: Configure AWS credentials
-          uses: ./.github/workflows/configure-aws-credentials
-          with:
-            aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            aws_region: us-gov-west-1
+      - name: Configure AWS credentials
+        uses: ./.github/workflows/configure-aws-credentials
+        with:
+          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-gov-west-1
 
-        - name: Get va-vsp-bot token
-          uses: ./.github/workflows/inject-secrets
-          with:
-            ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-            env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+      - name: Get va-vsp-bot token
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-        - name: Create coverage results folder
-          run: mkdir -p coverage-results
+      - name: Create coverage results folder
+        run: mkdir -p coverage-results
 
-        - name: Run unit test coverage report
-          run: yarn test:coverage-app ${{ matrix.app }} --report-dir=coverage-results/${{ matrix.app }}
+      - name: Run unit test coverage report
+        run: yarn test:coverage-app ${{ matrix.app }} --report-dir=coverage-results/${{ matrix.app }}
       
-        - name: Upload Coverage Report Artifact
-          uses: ./.github/workflows/upload-artifact
-          if: ${{ always() && env.NO_APPS_TO_RUN == 'false' }}
-          with:
-            name: unit-test-coverage-${{ matrix.app }}
-            path: coverage-results/${{ matrix.app }}
+      - name: Upload Coverage Report Artifact
+        uses: ./.github/workflows/upload-artifact
+        if: ${{ always() && env.NO_APPS_TO_RUN == 'false' }}
+        with:
+          name: unit-test-coverage-${{ matrix.app }}
+          path: coverage-results/${{ matrix.app }}
         
-    publish-coverage-reports-to-s3:
-      name: Publish Unit Test Coverage Reports to S3
-      needs: [create-unit-test-coverage-reports]
-      runs-on: ubuntu-latest
-      permissions: write-all
-      strategy:
-        matrix:
-          app: ${{ fromJson(needs.list-apps.outputs.apps) }}
-      outputs:
-        ECR_USERNAME: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-        ECR_PASSWORD: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-      steps:
-        - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@v4.0.0
-          with:
-             aws-region: us-gov-west-1
-             role-to-assume: arn:aws-us-gov:iam::008577686731:role/gha-frontend-nonprod-role
+  publish-coverage-reports-to-s3:
+    name: Publish Unit Test Coverage Reports to S3
+    needs: [create-unit-test-coverage-reports]
+    runs-on: ubuntu-latest
+    permissions: write-all
+    strategy:
+      matrix:
+        app: ${{ fromJson(needs.list-apps.outputs.apps) }}
+    outputs:
+      ECR_USERNAME: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+      ECR_PASSWORD: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.0
+        with:
+           aws-region: us-gov-west-1
+           role-to-assume: arn:aws-us-gov:iam::008577686731:role/gha-frontend-nonprod-role
         
-        - name: Login to Amazon ECR
-          id: login-ecr
-          uses: aws-actions/amazon-ecr-login@v2    
-          with:
-            mask-password: false
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2    
+        with:
+          mask-password: false
             
-        - name: Download Coverage Reports
-          uses: ./.github/workflows/download-artifact
-          with:
-            pattern: unit-test-coverage-${{ matrix.app }}
-            path: coverage-results/${{ matrix.app }} 
+      - name: Download Coverage Reports
+        uses: ./.github/workflows/download-artifact
+        with:
+          pattern: unit-test-coverage-${{ matrix.app }}
+          path: coverage-results/${{ matrix.app }} 
 
-        - name: Rename coverage results directory
-          id: rename
-          run: |
-            TIMESTAMP=$(date +'%Y-%m-%d_%H-%M-%S')
-            NEW_DIR="coverage-results/${{ matrix.app }}-${TIMESTAMP}"
-            mv coverage-results/${{ matrix.app }} $NEW_DIR
-            echo "new_dir=$NEW_DIR" >> $GITHUB_OUTPUT
+      - name: Rename coverage results directory
+        id: rename
+        run: |
+          TIMESTAMP=$(date +'%Y-%m-%d_%H-%M-%S')
+          NEW_DIR="coverage-results/${{ matrix.app }}-${TIMESTAMP}"
+          mv coverage-results/${{ matrix.app }} $NEW_DIR
+          echo "new_dir=$NEW_DIR" >> $GITHUB_OUTPUT
 
-        - name: Upload HTML coverage reports to s3
-          run: aws s3 cp ${{ steps.rename.outputs.new_dir }} s3://testing-tools-testing-reports/html-unit-test-coverage-reports --acl public-read --region us-gov-west-1 --recursive
+      - name: Upload HTML coverage reports to s3
+        run: aws s3 cp ${{ steps.rename.outputs.new_dir }} s3://testing-tools-testing-reports/html-unit-test-coverage-reports --acl public-read --region us-gov-west-1 --recursive


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _Added a new workflow that independently generates unit test coverage reports overnight or on demand._
- _This will provide a more thorough coverage report for VFS teams to use to evaluate their code coverage than the aggregate app numbers in the FE dashboard, as the reports provide specific data per file and line if needed._
- _This may be the first step in providing unit test coverage data outside of regular CI workflow runs._
- _This work is being done on behalf of the Platform SRE Team._

## Related issue(s)

- [SRE Team board ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1335/views/12?pane=issue&itemId=95142213&issue=department-of-veterans-affairs%7Cva.gov-team%7C65077)


## Testing done

- _Testing and refinement of the workflow will need to happen post-merge, as there is no effective way to run GHA workflows locally._

## What areas of the site does it impact?

*None, only adds a workflow accessible through the Github organization.*

henticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _All feedback on design is welcome._
