### PR TITLE
VACMS-20983 Facilities: Fix sidebar display at 768px width

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -173,7 +173,7 @@
       margin-top: 2.3em;
       &:first-child {
         margin-top: 0.75em; // the wrapper already has top padding, so we don't need as much space here
-        @media (max-width: $medium-screen) {
+        @media (max-width: 767px) {
           margin-top: 2em; // to accomodate mobile menu
         }
       }

--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -173,7 +173,8 @@
       margin-top: 2.3em;
       &:first-child {
         margin-top: 0.75em; // the wrapper already has top padding, so we don't need as much space here
-        @media (max-width: 767px) {
+
+        @media (max-width: calc($medium-screen - 1px)) {
           margin-top: 2em; // to accomodate mobile menu
         }
       }

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -32,7 +32,7 @@ class SideNav extends Component {
   }
 
   getDesktop = () => {
-    return window.innerWidth > 768;
+    return window.innerWidth >= 768;
   };
 
   setIsDesktop = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

We had some logic in the React widget for the facilities sidebar that was not including the 768px breakpoint properly, causing it to render an empty sidebar at that width specifically. Normally this would seem sort of edge case-y, but 768 is a specific breakpoint in our DS and the supposed width for at least iPad Mini, and likely other devices. Plus, it was a simple fix.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20983

## Testing done / screenshots

### Before
| 767px | 768px | 769px |
| --- | --- | --- |
| <img width="767" alt="Screenshot 2025-03-25 at 4 37 36 PM" src="https://github.com/user-attachments/assets/0d056303-b2b1-4494-9b17-076a39430070" /> | <img width="768" alt="Screenshot 2025-03-25 at 4 37 43 PM" src="https://github.com/user-attachments/assets/29770f9e-5d0e-4dfd-8199-1de8f21b003b" /> | <img width="769" alt="Screenshot 2025-03-25 at 4 37 49 PM" src="https://github.com/user-attachments/assets/c92786d4-400b-4d62-b95b-46ebcb463bcc" /> |


### After
| 767px | 768px | 769px |
| --- | --- | --- |
| <img width="764" alt="Screenshot 2025-03-26 at 3 24 07 PM" src="https://github.com/user-attachments/assets/58e37bbf-9ba4-477c-888d-65b4b41e59b2" /> | <img width="767" alt="Screenshot 2025-03-26 at 3 24 14 PM" src="https://github.com/user-attachments/assets/e2bc4304-ff9b-4cb4-b491-685b9f42e7e2" /> | <img width="770" alt="Screenshot 2025-03-26 at 3 24 20 PM" src="https://github.com/user-attachments/assets/7b62cfa8-924a-4874-8180-a05088ce09a1" /> |

## Acceptance criteria
- [x] Adjust logic and styles so Facilities sidebar appears correctly at 768px width