### PR TITLE
Update outdated twitter branding to reflect current X branding

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -173,10 +173,10 @@
     },
     {
       "column": 3,
-      "href": "https://www.twitter.com/DeptVetAffairs/",
+      "href": "https://www.x.com/DeptVetAffairs/",
       "order": 6,
       "target": "_blank",
-      "title": "Twitter",
+      "title": "X",
       "rel": "noopener noreferrer"
     },
     {


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates branding in footer from "Twitter" to "X".

