### PR TITLE
[SIMPLE-FORMS] fix: componentize existing alert and apply to 21-4138

### DIFF
--- a/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { isLOA3, isLoggedIn } from 'platform/user/selectors';
-import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 import { SUBTITLE, TITLE } from '../config/constants';
+import IdNotVerifiedAlert from '../../shared/components/IdNotVerified';
 
 const ombInfo = {
   resBurden: '5',
@@ -79,20 +79,7 @@ export const IntroductionPage = ({ route, userIdVerified, userLoggedIn }) => {
 
       {userLoggedIn &&
       !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
-          <div className="id-not-verified-content vads-u-margin-top--4">
-            <VerifyAlert headingLevel={3} />
-            <p className="vads-u-margin-top--3">
-              If you don’t want to verify your identity right now, you can still
-              download and complete the PDF version of this request.
-            </p>
-            <p className="vads-u-margin-y--3">
-              <va-link
-                download
-                href="https://www.vba.va.gov/pubs/forms/VBA-20-10206-ARE.pdf"
-                text="Get VA Form 20-10206 to download"
-              />
-            </p>
-          </div>
+          <IdNotVerifiedAlert formNumber="20-10206" />
         )}
     </>
   );

--- a/src/applications/simple-forms/20-10207/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/20-10207/containers/IntroductionPage.jsx
@@ -6,7 +6,7 @@ import { setData } from '~/platform/forms-system/src/js/actions';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 
 import { isLOA3, isLoggedIn } from 'platform/user/selectors';
-import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
+import IdNotVerifiedAlert from '../../shared/components/IdNotVerified';
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 
 import { TITLE, SUBTITLE } from '../config/constants';
@@ -250,23 +250,7 @@ const IntroductionPage = props => {
       </div>
       {userLoggedIn &&
       !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
-          <div
-            className="id-not-verified-content vads-u-margin-top--4"
-            data-testid="verifyIdAlert"
-          >
-            <VerifyAlert headingLevel={3} />
-            <p className="vads-u-margin-top--3">
-              If you don’t want to verify your identity right now, you can still
-              download and complete the PDF version of this request.
-            </p>
-            <p className="vads-u-margin-y--3">
-              <va-link
-                download
-                href="https://www.vba.va.gov/pubs/forms/VBA-20-10207-ARE.pdf"
-                text="Get VA Form 20-10207 to download"
-              />
-            </p>
-          </div>
+          <IdNotVerifiedAlert formNumber="20-10207" />
         )}
     </>
   );

--- a/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0845/containers/IntroductionPage.jsx
@@ -6,10 +6,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { isLOA3, isLoggedIn } from 'platform/user/selectors';
-import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import IdNotVerifiedAlert from '../../shared/components/IdNotVerified';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -72,21 +72,7 @@ class IntroductionPage extends React.Component {
         </p>
         {userLoggedIn &&
         !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
-            <div className="id-not-verified-content vads-u-margin-top--4">
-              <VerifyAlert headingLevel={3} />
-              <p className="vads-u-margin-top--3">
-                If you don’t want to verify your identity right now, you can
-                still download and complete the PDF version of this
-                authorization.
-              </p>
-              <p className="vads-u-margin-y--3">
-                <va-link
-                  download
-                  href="https://www.vba.va.gov/pubs/forms/VBA-21-0845-ARE.pdf"
-                  text="Get VA Form 21-0845 to download"
-                />
-              </p>
-            </div>
+            <IdNotVerifiedAlert formNumber="21-0845" formType="authorization" />
           )}
         {(!userLoggedIn || userIdVerified) && (
           <SaveInProgressIntro

--- a/src/applications/simple-forms/21-0966/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0966/containers/IntroductionPage.jsx
@@ -7,7 +7,7 @@ import { isLOA3, isLoggedIn } from 'platform/user/selectors';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
+import IdNotVerifiedAlert from '../../shared/components/IdNotVerified';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -118,20 +118,7 @@ class IntroductionPage extends React.Component {
         </ul>
         {userLoggedIn &&
         !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
-            <div className="id-not-verified-content vads-u-margin-top--4">
-              <VerifyAlert headingLevel={2} />
-              <p className="vads-u-margin-top--3">
-                If you don’t want to verify your identity right now, you can
-                still download and complete the PDF version of this request.
-              </p>
-              <p className="vads-u-margin-y--3">
-                <va-link
-                  download
-                  href="https://www.vba.va.gov/pubs/forms/VBA-21-0966-ARE.pdf"
-                  text="Get VA Form 21-0966 to download"
-                />
-              </p>
-            </div>
+            <IdNotVerifiedAlert headingLevel={2} formNumber="21-0966" />
           )}
         {(!userLoggedIn || userIdVerified) && (
           <SaveInProgressIntro

--- a/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { isLOA3, isLoggedIn } from 'platform/user/selectors';
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 import { TITLE, SUBTITLE, PrimaryActionLink } from '../config/constants';
+import IdNotVerifiedAlert from '../../shared/components/IdNotVerified';
 
 const IntroductionPage = props => {
   const { route } = props;
@@ -62,6 +63,10 @@ const IntroductionPage = props => {
         </li>
       </ul>
       <h2>Start your statement</h2>
+      {userLoggedIn &&
+      !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
+          <IdNotVerifiedAlert formNumber="21-4138" formType="form" />
+        )}
     </>
   );
 

--- a/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4142/containers/IntroductionPage.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { isLOA3, isLoggedIn } from 'platform/user/selectors';
-import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
+import IdNotVerifiedAlert from '../../shared/components/IdNotVerified';
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 
 const ombInfo = {
@@ -52,20 +52,7 @@ export const IntroductionPage = ({ route, userIdVerified, userLoggedIn }) => {
       </ul>
       {userLoggedIn &&
       !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (
-          <div className="id-not-verified-content vads-u-margin-top--4">
-            <VerifyAlert headingLevel={3} />
-            <p className="vads-u-margin-top--3">
-              If you don’t want to verify your identity right now, you can still
-              download and complete the PDF version of this authorization.
-            </p>
-            <p className="vads-u-margin-y--3">
-              <va-link
-                download
-                href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf"
-                text="Get VA Form 21-4142 to download"
-              />
-            </p>
-          </div>
+          <IdNotVerifiedAlert formNumber="21-4142" formType="authorization" />
         )}
     </>
   );

--- a/src/applications/simple-forms/shared/components/IdNotVerified.jsx
+++ b/src/applications/simple-forms/shared/components/IdNotVerified.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
+
+const getDefaultDownloadLink = formNumber =>
+  `https://www.vba.va.gov/pubs/forms/VBA-${formNumber}-ARE.pdf`;
+
+const getContent = formType => {
+  return `If you don’t want to verify your identity right now, you can still download and complete the PDF version of this ${formType}.`;
+};
+
+const IdNotVerifiedAlert = ({
+  headingLevel,
+  formType,
+  formNumber,
+  downloadLink,
+  content,
+}) => (
+  <div
+    className="id-not-verified-content vads-u-margin-top--4"
+    data-testid="verifyIdAlert"
+  >
+    <VerifyAlert headingLevel={headingLevel} />
+    <p className="vads-u-margin-top--3">{content || getContent(formType)}</p>
+    <p className="vads-u-margin-y--3">
+      <va-link
+        download
+        href={downloadLink || getDefaultDownloadLink(formNumber)}
+        text={`Get VA Form ${formNumber} to download`}
+      />
+    </p>
+  </div>
+);
+
+IdNotVerifiedAlert.propTypes = {
+  formNumber: PropTypes.string.isRequired,
+  content: PropTypes.node,
+  downloadLink: PropTypes.string,
+  formType: PropTypes.string,
+  headingLevel: PropTypes.number,
+};
+
+IdNotVerifiedAlert.defaultProps = {
+  headingLevel: 3,
+  formType: 'request',
+};
+
+export default React.memo(IdNotVerifiedAlert);


### PR DESCRIPTION
## Summary

- This work consolidates several nearly identical components into one reusable one.
- This work also implements this new component within form 21-4138 introduction page.
- Log in as a user without LOA3 access. The ID not found alert should not display on the introduction page.
- The solution was to add the alert
- I work for the Veteran Facing Forms team who owns these forms

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#2098

## Testing done

- All tests pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any