### PR TITLE
Refactor minimal header to use dom instead of session storage

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -510,10 +510,7 @@ describe('ArrayBuilderSummaryPage', () => {
   it('radio should have h1 label-header-level if 0 items with minimal header', () => {
     dom = document.createElement('div');
     dom.id = 'header-minimal';
-    dom.setAttribute(
-      'data-exclude-paths',
-      '[&quot;/introduction&quot;,&quot;/confirmation&quot;]',
-    );
+    dom.setAttribute('data-exclude-paths', '["/introduction","/confirmation"]');
     document.body.appendChild(dom);
 
     const { container } = setupArrayBuilderSummaryPage({
@@ -540,10 +537,7 @@ describe('ArrayBuilderSummaryPage', () => {
   it('title should be h1, card should have h2, and radio should have h2 label-header-level if 1+ items with minimal header', () => {
     dom = document.createElement('div');
     dom.id = 'header-minimal';
-    dom.setAttribute(
-      'data-exclude-paths',
-      '[&quot;/introduction&quot;,&quot;/confirmation&quot;]',
-    );
+    dom.setAttribute('data-exclude-paths', '["/introduction","/confirmation"]');
     document.body.appendChild(dom);
 
     const { container } = setupArrayBuilderSummaryPage({

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -97,7 +97,10 @@ describe('ArrayBuilderSummaryPage', () => {
       getIndexStub.restore();
       getIndexStub = null;
     }
-    dom = null;
+    if (dom) {
+      document.body.removeChild(dom);
+      dom = null;
+    }
     cleanup();
   });
 
@@ -506,11 +509,11 @@ describe('ArrayBuilderSummaryPage', () => {
 
   it('radio should have h1 label-header-level if 0 items with minimal header', () => {
     dom = document.createElement('div');
-    dom.innerHTML += `
-      <div id="header-minimal" data-exclude-paths="[&quot;/introduction&quot;,&quot;/confirmation&quot;]">
-        Minimal header
-      </div>
-    `;
+    dom.id = 'header-minimal';
+    dom.setAttribute(
+      'data-exclude-paths',
+      '[&quot;/introduction&quot;,&quot;/confirmation&quot;]',
+    );
     document.body.appendChild(dom);
 
     const { container } = setupArrayBuilderSummaryPage({
@@ -536,11 +539,11 @@ describe('ArrayBuilderSummaryPage', () => {
 
   it('title should be h1, card should have h2, and radio should have h2 label-header-level if 1+ items with minimal header', () => {
     dom = document.createElement('div');
-    dom.innerHTML += `
-      <div id="header-minimal" data-exclude-paths="[&quot;/introduction&quot;,&quot;/confirmation&quot;]">
-        Minimal header
-      </div>
-    `;
+    dom.id = 'header-minimal';
+    dom.setAttribute(
+      'data-exclude-paths',
+      '[&quot;/introduction&quot;,&quot;/confirmation&quot;]',
+    );
     document.body.appendChild(dom);
 
     const { container } = setupArrayBuilderSummaryPage({

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -74,7 +74,7 @@ const mockRedux = ({
 describe('ArrayBuilderSummaryPage', () => {
   let getArrayUrlSearchParamsStub;
   let getIndexStub;
-  let dom;
+  let minimalHeader;
 
   function stubUrlParams(str) {
     getArrayUrlSearchParamsStub = sinon
@@ -97,9 +97,9 @@ describe('ArrayBuilderSummaryPage', () => {
       getIndexStub.restore();
       getIndexStub = null;
     }
-    if (dom) {
-      document.body.removeChild(dom);
-      dom = null;
+    if (minimalHeader) {
+      document.body.removeChild(minimalHeader);
+      minimalHeader = null;
     }
     cleanup();
   });
@@ -508,10 +508,13 @@ describe('ArrayBuilderSummaryPage', () => {
   });
 
   it('radio should have h1 label-header-level if 0 items with minimal header', () => {
-    dom = document.createElement('div');
-    dom.id = 'header-minimal';
-    dom.setAttribute('data-exclude-paths', '["/introduction","/confirmation"]');
-    document.body.appendChild(dom);
+    minimalHeader = document.createElement('div');
+    minimalHeader.id = 'header-minimal';
+    minimalHeader.setAttribute(
+      'data-exclude-paths',
+      '["/introduction","/confirmation"]',
+    );
+    document.body.appendChild(minimalHeader);
 
     const { container } = setupArrayBuilderSummaryPage({
       arrayData: [],
@@ -535,10 +538,13 @@ describe('ArrayBuilderSummaryPage', () => {
   });
 
   it('title should be h1, card should have h2, and radio should have h2 label-header-level if 1+ items with minimal header', () => {
-    dom = document.createElement('div');
-    dom.id = 'header-minimal';
-    dom.setAttribute('data-exclude-paths', '["/introduction","/confirmation"]');
-    document.body.appendChild(dom);
+    minimalHeader = document.createElement('div');
+    minimalHeader.id = 'header-minimal';
+    minimalHeader.setAttribute(
+      'data-exclude-paths',
+      '["/introduction","/confirmation"]',
+    );
+    document.body.appendChild(minimalHeader);
 
     const { container } = setupArrayBuilderSummaryPage({
       arrayData: [{ name: 'Test' }],

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -74,6 +74,7 @@ const mockRedux = ({
 describe('ArrayBuilderSummaryPage', () => {
   let getArrayUrlSearchParamsStub;
   let getIndexStub;
+  let dom;
 
   function stubUrlParams(str) {
     getArrayUrlSearchParamsStub = sinon
@@ -96,6 +97,7 @@ describe('ArrayBuilderSummaryPage', () => {
       getIndexStub.restore();
       getIndexStub = null;
     }
+    dom = null;
     cleanup();
   });
 
@@ -503,11 +505,13 @@ describe('ArrayBuilderSummaryPage', () => {
   });
 
   it('radio should have h1 label-header-level if 0 items with minimal header', () => {
-    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
-    sessionStorage.setItem(
-      'MINIMAL_HEADER_EXCLUDE_PATHS',
-      '["/introduction","/confirmation"]',
-    );
+    dom = document.createElement('div');
+    dom.innerHTML += `
+      <div id="header-minimal" data-exclude-paths="[&quot;/introduction&quot;,&quot;/confirmation&quot;]">
+        Minimal header
+      </div>
+    `;
+    document.body.appendChild(dom);
 
     const { container } = setupArrayBuilderSummaryPage({
       arrayData: [],
@@ -517,9 +521,6 @@ describe('ArrayBuilderSummaryPage', () => {
 
     const vaRadio = container.querySelector('va-radio');
     expect(vaRadio.getAttribute('label-header-level')).to.equal('1');
-
-    sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
-    sessionStorage.removeItem('MINIMAL_HEADER_EXCLUDE_PATHS');
   });
 
   it('radio should have h3 label-header-level if 0 items without minimal header', () => {
@@ -534,11 +535,13 @@ describe('ArrayBuilderSummaryPage', () => {
   });
 
   it('title should be h1, card should have h2, and radio should have h2 label-header-level if 1+ items with minimal header', () => {
-    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
-    sessionStorage.setItem(
-      'MINIMAL_HEADER_EXCLUDE_PATHS',
-      '["/introduction","/confirmation"]',
-    );
+    dom = document.createElement('div');
+    dom.innerHTML += `
+      <div id="header-minimal" data-exclude-paths="[&quot;/introduction&quot;,&quot;/confirmation&quot;]">
+        Minimal header
+      </div>
+    `;
+    document.body.appendChild(dom);
 
     const { container } = setupArrayBuilderSummaryPage({
       arrayData: [{ name: 'Test' }],
@@ -552,9 +555,6 @@ describe('ArrayBuilderSummaryPage', () => {
     expect(card.querySelector('h2')).to.exist;
     const vaRadio = container.querySelector('va-radio');
     expect(vaRadio.getAttribute('label-header-level')).to.equal('2');
-
-    sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
-    sessionStorage.removeItem('MINIMAL_HEADER_EXCLUDE_PATHS');
   });
 
   it('title should be h3, card should have h4, and radio should have h4 label-header-level if 1+ items without minimal header', () => {

--- a/src/platform/forms-system/src/js/patterns/minimal-header/index.js
+++ b/src/platform/forms-system/src/js/patterns/minimal-header/index.js
@@ -7,31 +7,27 @@ import { createBreadcrumbListFromPath } from '../../routing';
 /**
  * If the minimal header is applicable to the current app regardless of excluded paths.
  *
- * Note: Not reliable to use in a .js file load. Should be used in
- * a component or function to allow for session storage to load first.
- *
  * @returns {boolean}
  */
 export function isMinimalHeaderApp() {
-  return sessionStorage.getItem('MINIMAL_HEADER_APPLICABLE') === 'true';
+  return document.getElementById('header-minimal') !== null;
 }
 
 /**
  * If the minimal header is applicable to the current app and the
  * current window path is not a excluded
  *
- * Note: Not reliable to use in a .js file load. Should be used in
- * a component or function to allow for session storage to load first.
- *
  * @param {string} [pathname] Defaults to `window.location.pathname` if not provided
  * @returns {boolean}
  */
 export function isMinimalHeaderPath(pathname = window?.location?.pathname) {
-  if (!isMinimalHeaderApp()) {
+  const minimalHeader = document.getElementById('header-minimal');
+
+  if (!minimalHeader) {
     return false;
   }
 
-  let excludePaths = sessionStorage.getItem('MINIMAL_HEADER_EXCLUDE_PATHS');
+  let excludePaths = minimalHeader.dataset?.excludePaths;
   excludePaths = excludePaths ? JSON.parse(excludePaths) : [];
   const isExcludedPath =
     pathname && excludePaths.some(path => pathname.endsWith(path));

--- a/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
@@ -37,10 +37,7 @@ describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
 
     dom = document.createElement('div');
     dom.id = 'header-minimal';
-    dom.setAttribute(
-      'data-exclude-paths',
-      '[&quot;/introduction&quot;,&quot;/confirmation&quot;]',
-    );
+    dom.setAttribute('data-exclude-paths', '["/introduction","/confirmation"]');
     document.body.appendChild(dom);
 
     locationStub.value({

--- a/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
@@ -1,41 +1,44 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { afterEach } from 'mocha';
+import { cleanup } from '@testing-library/react';
 import { isMinimalHeaderApp, isMinimalHeaderPath } from '.';
 
 describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
+  let dom;
+
   afterEach(() => {
-    sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
-    sessionStorage.removeItem('MINIMAL_HEADER_EXCLUDE_PATHS');
+    cleanup();
+    dom = null;
   });
 
-  it('sessionStorage should not be populated with minimal header values - this indicates a test sessionStorage leak', () => {
-    const minimalHeaderValue = sessionStorage.getItem(
-      'MINIMAL_HEADER_APPLICABLE',
-    );
-    const minimalHeaderExcludePathsValue = sessionStorage.getItem(
-      'MINIMAL_HEADER_EXCLUDE_PATHS',
-    );
-
-    expect(minimalHeaderValue).to.eql(null);
-    expect(minimalHeaderExcludePathsValue).to.eql(null);
-  });
-
-  it('should return a boolean if minimal header is applicable', () => {
-    expect(isMinimalHeaderApp()).to.eql(false);
-    expect(isMinimalHeaderPath()).to.eql(false);
-    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
+  it('should return a boolean true if minimal header is applicable', () => {
+    dom = document.createElement('div');
+    dom.innerHTML += `
+      <div id="header-minimal">
+        Minimal header
+      </div>
+    `;
+    document.body.appendChild(dom);
     expect(isMinimalHeaderApp()).to.eql(true);
     expect(isMinimalHeaderPath()).to.eql(true);
   });
 
+  it('should return a boolean false by default if no minimal header dom', () => {
+    expect(isMinimalHeaderApp()).to.eql(false);
+    expect(isMinimalHeaderPath()).to.eql(false);
+  });
+
   it('should not be applicable on excluded paths', () => {
     const locationStub = sinon.stub(window, 'location');
-    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
-    sessionStorage.setItem(
-      'MINIMAL_HEADER_EXCLUDE_PATHS',
-      '["/introduction","/confirmation"]',
-    );
+
+    dom = document.createElement('div');
+    dom.innerHTML += `
+      <div id="header-minimal" data-exclude-paths="[&quot;/introduction&quot;,&quot;/confirmation&quot;]">
+        Minimal header
+      </div>
+    `;
+    document.body.appendChild(dom);
 
     locationStub.value({
       pathname: '/introduction',

--- a/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
@@ -8,8 +8,11 @@ describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
   let dom;
 
   afterEach(() => {
+    if (dom) {
+      document.body.removeChild(dom);
+      dom = null;
+    }
     cleanup();
-    dom = null;
   });
 
   it('should return a boolean true if minimal header is applicable', () => {
@@ -33,11 +36,11 @@ describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
     const locationStub = sinon.stub(window, 'location');
 
     dom = document.createElement('div');
-    dom.innerHTML += `
-      <div id="header-minimal" data-exclude-paths="[&quot;/introduction&quot;,&quot;/confirmation&quot;]">
-        Minimal header
-      </div>
-    `;
+    dom.id = 'header-minimal';
+    dom.setAttribute(
+      'data-exclude-paths',
+      '[&quot;/introduction&quot;,&quot;/confirmation&quot;]',
+    );
     document.body.appendChild(dom);
 
     locationStub.value({

--- a/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
@@ -17,11 +17,7 @@ describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
 
   it('should return a boolean true if minimal header is applicable', () => {
     dom = document.createElement('div');
-    dom.innerHTML += `
-      <div id="header-minimal">
-        Minimal header
-      </div>
-    `;
+    dom.id = 'header-minimal';
     document.body.appendChild(dom);
     expect(isMinimalHeaderApp()).to.eql(true);
     expect(isMinimalHeaderPath()).to.eql(true);

--- a/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/minimal-header/minimalHeader.unit.spec.jsx
@@ -5,25 +5,25 @@ import { cleanup } from '@testing-library/react';
 import { isMinimalHeaderApp, isMinimalHeaderPath } from '.';
 
 describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
-  let dom;
+  let minimalHeader;
 
   afterEach(() => {
-    if (dom) {
-      document.body.removeChild(dom);
-      dom = null;
+    if (minimalHeader) {
+      document.body.removeChild(minimalHeader);
+      minimalHeader = null;
     }
     cleanup();
   });
 
   it('should return a boolean true if minimal header is applicable', () => {
-    dom = document.createElement('div');
-    dom.id = 'header-minimal';
-    document.body.appendChild(dom);
+    minimalHeader = document.createElement('div');
+    minimalHeader.id = 'header-minimal';
+    document.body.appendChild(minimalHeader);
     expect(isMinimalHeaderApp()).to.eql(true);
     expect(isMinimalHeaderPath()).to.eql(true);
   });
 
-  it('should return a boolean false by default if no minimal header dom', () => {
+  it('should return a boolean false by default if no minimal header minimalHeader', () => {
     expect(isMinimalHeaderApp()).to.eql(false);
     expect(isMinimalHeaderPath()).to.eql(false);
   });
@@ -31,10 +31,13 @@ describe('isMinimalHeaderApp and isMinimalHeaderPath', () => {
   it('should not be applicable on excluded paths', () => {
     const locationStub = sinon.stub(window, 'location');
 
-    dom = document.createElement('div');
-    dom.id = 'header-minimal';
-    dom.setAttribute('data-exclude-paths', '["/introduction","/confirmation"]');
-    document.body.appendChild(dom);
+    minimalHeader = document.createElement('div');
+    minimalHeader.id = 'header-minimal';
+    minimalHeader.setAttribute(
+      'data-exclude-paths',
+      '["/introduction","/confirmation"]',
+    );
+    document.body.appendChild(minimalHeader);
 
     locationStub.value({
       pathname: '/introduction',

--- a/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
@@ -48,7 +48,10 @@ describe('Schemaform review: ReviewPage', () => {
   };
 
   afterEach(() => {
-    dom = null;
+    if (dom) {
+      document.body.removeChild(dom);
+      dom = null;
+    }
     cleanup();
   });
 
@@ -72,11 +75,7 @@ describe('Schemaform review: ReviewPage', () => {
 
   it('should render h1 header if minimal header is present', () => {
     dom = document.createElement('div');
-    dom.innerHTML += `
-      <div id="header-minimal">
-        Minimal header
-      </div>
-    `;
+    dom.id = 'header-minimal';
     document.body.appendChild(dom);
 
     const treeWithMinimalHeader = shallow(

--- a/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
@@ -94,7 +94,7 @@ describe('Schemaform review: ReviewPage', () => {
   });
 
   it('should not contain the h1 if header-minimal is not present', () => {
-    const treeWithMinimalHeader = shallow(
+    const treeWithoutMinimalHeader = shallow(
       <ReviewPage
         form={form}
         openChapters={{}}
@@ -105,8 +105,8 @@ describe('Schemaform review: ReviewPage', () => {
       />,
     );
 
-    expect(treeWithMinimalHeader.find('h1').exists()).to.be.false;
-    treeWithMinimalHeader.unmount();
+    expect(treeWithoutMinimalHeader.find('h1').exists()).to.be.false;
+    treeWithoutMinimalHeader.unmount();
   });
 
   it('should appropriately render a downtime notification', () => {

--- a/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
@@ -6,7 +6,7 @@ import { cleanup } from '@testing-library/react';
 import { ReviewPage } from '../../../src/js/review/ReviewPage';
 
 describe('Schemaform review: ReviewPage', () => {
-  let dom;
+  let minimalHeader;
 
   const location = {
     pathname: '/testing/0',
@@ -48,9 +48,9 @@ describe('Schemaform review: ReviewPage', () => {
   };
 
   afterEach(() => {
-    if (dom) {
-      document.body.removeChild(dom);
-      dom = null;
+    if (minimalHeader) {
+      document.body.removeChild(minimalHeader);
+      minimalHeader = null;
     }
     cleanup();
   });
@@ -74,9 +74,9 @@ describe('Schemaform review: ReviewPage', () => {
   });
 
   it('should render h1 header if minimal header is present', () => {
-    dom = document.createElement('div');
-    dom.id = 'header-minimal';
-    document.body.appendChild(dom);
+    minimalHeader = document.createElement('div');
+    minimalHeader.id = 'header-minimal';
+    document.body.appendChild(minimalHeader);
 
     const treeWithMinimalHeader = shallow(
       <ReviewPage

--- a/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
+import { cleanup } from '@testing-library/react';
 import { ReviewPage } from '../../../src/js/review/ReviewPage';
 
 describe('Schemaform review: ReviewPage', () => {
+  let dom;
+
   const location = {
     pathname: '/testing/0',
   };
@@ -44,6 +47,11 @@ describe('Schemaform review: ReviewPage', () => {
     data: {},
   };
 
+  afterEach(() => {
+    dom = null;
+    cleanup();
+  });
+
   it('should render chapters', () => {
     const tree = shallow(
       <ReviewPage
@@ -62,8 +70,14 @@ describe('Schemaform review: ReviewPage', () => {
     tree.unmount();
   });
 
-  it('should render h1 header if MINIMAL_HEADER_APPLICABLE is true', () => {
-    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
+  it('should render h1 header if minimal header is present', () => {
+    dom = document.createElement('div');
+    dom.innerHTML += `
+      <div id="header-minimal">
+        Minimal header
+      </div>
+    `;
+    document.body.appendChild(dom);
 
     const treeWithMinimalHeader = shallow(
       <ReviewPage
@@ -78,10 +92,10 @@ describe('Schemaform review: ReviewPage', () => {
 
     expect(treeWithMinimalHeader.find('h1').exists()).to.be.true;
     treeWithMinimalHeader.unmount();
+  });
 
-    sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
-
-    const treeWithoutMinimalHeader = shallow(
+  it('should not contain the h1 if header-minimal is not present', () => {
+    const treeWithMinimalHeader = shallow(
       <ReviewPage
         form={form}
         openChapters={{}}
@@ -92,8 +106,8 @@ describe('Schemaform review: ReviewPage', () => {
       />,
     );
 
-    expect(treeWithoutMinimalHeader.find('h1').exists()).to.be.false;
-    treeWithoutMinimalHeader.unmount();
+    expect(treeWithMinimalHeader.find('h1').exists()).to.be.false;
+    treeWithMinimalHeader.unmount();
   });
 
   it('should appropriately render a downtime notification', () => {

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
@@ -77,8 +77,10 @@ describe('Schemaform save in progress: RoutedSavableReviewPage', () => {
     tree.unmount();
   });
 
-  it('should render h1 header if MINIMAL_HEADER_APPLICABLE is true', () => {
-    sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
+  it('should render h1 header if minimal header is present', () => {
+    const minimalHeader = document.createElement('div');
+    minimalHeader.id = 'header-minimal';
+    document.body.appendChild(minimalHeader);
 
     const formConfig = {
       chapters: {
@@ -124,8 +126,7 @@ describe('Schemaform save in progress: RoutedSavableReviewPage', () => {
 
     expect(treeWithMinimalHeader.find('h1').exists()).to.be.true;
     treeWithMinimalHeader.unmount();
-
-    sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
+    document.body.removeChild(minimalHeader);
 
     const treeWithoutMinimalHeader = shallow(
       <RoutedSavableReviewPage

--- a/src/platform/site-wide/header/index.js
+++ b/src/platform/site-wide/header/index.js
@@ -1,34 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import environment from 'platform/utilities/environment';
 import './components/LogoRow/styles.scss';
 import './components/OfficialGovtWebsite/styles.scss';
 import './components/Search/styles.scss';
 import './containers/Menu/styles.scss';
 import App from './components/App';
 import { createShouldShowMinimal } from './helpers';
-
-const setSessionStorage = (headerMinimal, excludePathsString) => {
-  if (!environment.isUnitTest()) {
-    // Set this manually if you want to unit test it - otherwise session
-    // storage could potentially leak to other tests
-    if (headerMinimal) {
-      sessionStorage.setItem('MINIMAL_HEADER_APPLICABLE', 'true');
-    } else {
-      sessionStorage.removeItem('MINIMAL_HEADER_APPLICABLE');
-    }
-
-    if (excludePathsString) {
-      sessionStorage.setItem(
-        'MINIMAL_HEADER_EXCLUDE_PATHS',
-        excludePathsString,
-      );
-    } else {
-      sessionStorage.removeItem('MINIMAL_HEADER_EXCLUDE_PATHS');
-    }
-  }
-};
 
 const setupMinimalHeader = () => {
   // #header-minimal will not be in the DOM unless specified in content-build
@@ -42,12 +20,8 @@ const setupMinimalHeader = () => {
     if (headerMinimal.dataset?.excludePaths) {
       excludePathsString = headerMinimal.dataset.excludePaths;
       excludePaths = JSON.parse(excludePathsString);
-      // Remove the data attribute from the DOM since it's no longer needed
-      headerMinimal.removeAttribute('data-exclude-paths');
     }
   }
-
-  setSessionStorage(enabled, excludePathsString);
 
   return createShouldShowMinimal({
     enabled,

--- a/src/platform/site-wide/va-footer/index.js
+++ b/src/platform/site-wide/va-footer/index.js
@@ -21,8 +21,6 @@ export const setupMinimalFooter = () => {
 
   if (footer?.dataset?.minimalExcludePaths) {
     excludePaths = JSON.parse(footer.dataset.minimalExcludePaths);
-    // Remove the data attribute from the DOM since it's no longer needed
-    footer.removeAttribute('data-minimal-exclude-paths');
   }
 
   return createShouldShowMinimal({


### PR DESCRIPTION
## Summary

Refactor minimal header to use dom instead of session storage. This is due to an issue with being able to navigate to another app and back, and losing storage, but the browser trying to rely on a cached page, thus not retrigger session storage.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#2039

## Testing done

- Unit, regression, Cypress

## Screenshots

n/a

## What areas of the site does it impact?

Removes an flaky/unnecessary session storage.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
