### PR TITLE
10-10CG | Fix axe violation in secondary two e2e test

### DIFF
--- a/src/applications/caregivers/locales/en/content.json
+++ b/src/applications/caregivers/locales/en/content.json
@@ -103,6 +103,7 @@
   "secondary-two-info-title--address-home": "Additional Secondary Family Caregiver\u2019s home address",
   "secondary-two-info-title--address-mailing": "Additional Secondary Family Caregiver\u2019s mailing address",
   "secondary-two-info-title--contact": "Additional Secondary Family Caregiver\u2019s contact information",
+  "secondary-two-info-title--id": "Additional Secondary Family Caregiver\u2019s identification information",
   "secondary-two-info-title--personal": "Additional Secondary Family Caregiver information",
   "secondary-two-intro-title": "Add another Secondary Family Caregiver",
   "secondary-two-intro-description": "You can have up to two Secondary Family Caregivers at any one time.",

--- a/src/applications/caregivers/tests/unit/config/secondaryTwo/contactInformation.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/config/secondaryTwo/contactInformation.unit.spec.jsx
@@ -7,11 +7,11 @@ import formConfig from '../../../../config/form';
 const {
   chapters: {
     secondaryCaregiverInformation: {
-      pages: { secondaryOneContactInformation },
+      pages: { secondaryTwoContactInformation },
     },
   },
 } = formConfig;
-const { title: pageTitle, schema, uiSchema } = secondaryOneContactInformation;
+const { title: pageTitle, schema, uiSchema } = secondaryTwoContactInformation;
 
 // run test for correct number of fields on the page
 const expectedNumberOfWebComponentFields = 3;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

There is an initiative within the DST to reduce the number of a11y findings at Staging review. It was found that 2.2 AA is not being tested in axe on e2e tests currently. This causes heading structure issues to pass through automated testing, leaving it up to manual review to catch. This PR fixes a failure in a single Cypress test for lack of heading text on a page in the application.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#105714

## Testing done

- See [this branch](https://github.com/department-of-veterans-affairs/vets-website/compare/main...axe-headings) and add the rules to your local repo.
- Run Cypress test suite to ensure no failures exist with the new rules in place

## Screenshots

![Screenshot 2025-03-26 at 11 18 41](https://github.com/user-attachments/assets/5b9e595f-9a90-4eb8-93fd-26d98d148be5)

## Acceptance criteria

 - Automated axe testing will be updated to check heading structures for non-compliance

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution