### PR TITLE
Ask VA - Review page focus

### DIFF
--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -105,7 +105,6 @@ const ReviewPage = props => {
     if (storedFiles.length > 0) {
       setAttachments(storedFiles);
     }
-    focusElement('h2');
   };
 
   const deleteFile = async fileID => {
@@ -221,8 +220,9 @@ const ReviewPage = props => {
     );
   };
 
-  useEffect(() => {
-    getUploadedFiles();
+  useEffect(async () => {
+    await getUploadedFiles();
+    focusElement('h2');
   }, []);
 
   return (
@@ -1280,56 +1280,50 @@ const ReviewPage = props => {
                     />
                   </>
                 )}
-                {props.formData.allowAttachments &&
-                  props.isUserLOA3 && (
-                    <div
-                      className="schemaform-chapter-accordion-content vads-u-padding-top--0"
-                      aria-hidden="false"
-                    >
-                      <div className="form-review-panel-page vads-u-margin-bottom--0">
-                        <div name="questionScrollElement" />
-                        <form className="rjsf">
-                          <div className="vads-u-width--full vads-u-justify-content--space-between vads-u-align-items--center">
-                            <dl className="review vads-u-margin-top--0 vads-u-margin-bottom--0">
-                              <dl className="review-row vads-u-border-top--0 vads-u-margin-top--0 vads-u-margin-bottom--0">
-                                {!editAttachments ? (
-                                  nonEditAttachmentsMode()
-                                ) : (
-                                  <>
-                                    {attachments.map(file => (
-                                      <div
-                                        key={`${file.fileID}-${
-                                          file.fileName
-                                        }-edit`}
-                                        className="review-page-attachments"
-                                      >
-                                        <dt className="form-review-panel-page-header">
-                                          {`${file.fileName} (${
-                                            file.fileSize
-                                          })`}
-                                        </dt>
-                                        <dd className="vads-u-margin-right--0">
-                                          <va-button-icon
-                                            button-type="delete"
-                                            onClick={() =>
-                                              deleteFile(file.fileID)
-                                            }
-                                          />
-                                        </dd>
-                                      </div>
-                                    ))}
-                                    <div className="vads-u-margin-y--2">
-                                      <FileUpload />
-                                    </div>
-                                  </>
-                                )}
-                              </dl>
-                            </dl>
-                          </div>
-                        </form>
+                {/* {props.formData.allowAttachments &&
+                  props.isUserLOA3 && ( */}
+                <div
+                  className="schemaform-chapter-accordion-content vads-u-padding-top--0"
+                  aria-hidden="false"
+                >
+                  <div className="form-review-panel-page vads-u-margin-bottom--0">
+                    <div name="questionScrollElement" />
+                    <form className="rjsf">
+                      <div className="vads-u-width--full vads-u-justify-content--space-between vads-u-align-items--center">
+                        <dl className="review vads-u-margin-top--0 vads-u-margin-bottom--0">
+                          <dl className="review-row vads-u-border-top--0 vads-u-margin-top--0 vads-u-margin-bottom--0">
+                            {!editAttachments ? (
+                              nonEditAttachmentsMode()
+                            ) : (
+                              <>
+                                {attachments.map(file => (
+                                  <div
+                                    key={`${file.fileID}-${file.fileName}-edit`}
+                                    className="review-page-attachments"
+                                  >
+                                    <dt className="form-review-panel-page-header">
+                                      {`${file.fileName} (${file.fileSize})`}
+                                    </dt>
+                                    <dd className="vads-u-margin-right--0">
+                                      <va-button-icon
+                                        button-type="delete"
+                                        onClick={() => deleteFile(file.fileID)}
+                                      />
+                                    </dd>
+                                  </div>
+                                ))}
+                                <div className="vads-u-margin-y--2">
+                                  <FileUpload />
+                                </div>
+                              </>
+                            )}
+                          </dl>
+                        </dl>
                       </div>
-                    </div>
-                  )}
+                    </form>
+                  </div>
+                </div>
+                {/* )} */}
               </VaAccordionItem>
             );
           })}

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -1280,50 +1280,56 @@ const ReviewPage = props => {
                     />
                   </>
                 )}
-                {/* {props.formData.allowAttachments &&
-                  props.isUserLOA3 && ( */}
-                <div
-                  className="schemaform-chapter-accordion-content vads-u-padding-top--0"
-                  aria-hidden="false"
-                >
-                  <div className="form-review-panel-page vads-u-margin-bottom--0">
-                    <div name="questionScrollElement" />
-                    <form className="rjsf">
-                      <div className="vads-u-width--full vads-u-justify-content--space-between vads-u-align-items--center">
-                        <dl className="review vads-u-margin-top--0 vads-u-margin-bottom--0">
-                          <dl className="review-row vads-u-border-top--0 vads-u-margin-top--0 vads-u-margin-bottom--0">
-                            {!editAttachments ? (
-                              nonEditAttachmentsMode()
-                            ) : (
-                              <>
-                                {attachments.map(file => (
-                                  <div
-                                    key={`${file.fileID}-${file.fileName}-edit`}
-                                    className="review-page-attachments"
-                                  >
-                                    <dt className="form-review-panel-page-header">
-                                      {`${file.fileName} (${file.fileSize})`}
-                                    </dt>
-                                    <dd className="vads-u-margin-right--0">
-                                      <va-button-icon
-                                        button-type="delete"
-                                        onClick={() => deleteFile(file.fileID)}
-                                      />
-                                    </dd>
-                                  </div>
-                                ))}
-                                <div className="vads-u-margin-y--2">
-                                  <FileUpload />
-                                </div>
-                              </>
-                            )}
-                          </dl>
-                        </dl>
+                {props.formData.allowAttachments &&
+                  props.isUserLOA3 && (
+                    <div
+                      className="schemaform-chapter-accordion-content vads-u-padding-top--0"
+                      aria-hidden="false"
+                    >
+                      <div className="form-review-panel-page vads-u-margin-bottom--0">
+                        <div name="questionScrollElement" />
+                        <form className="rjsf">
+                          <div className="vads-u-width--full vads-u-justify-content--space-between vads-u-align-items--center">
+                            <dl className="review vads-u-margin-top--0 vads-u-margin-bottom--0">
+                              <dl className="review-row vads-u-border-top--0 vads-u-margin-top--0 vads-u-margin-bottom--0">
+                                {!editAttachments ? (
+                                  nonEditAttachmentsMode()
+                                ) : (
+                                  <>
+                                    {attachments.map(file => (
+                                      <div
+                                        key={`${file.fileID}-${
+                                          file.fileName
+                                        }-edit`}
+                                        className="review-page-attachments"
+                                      >
+                                        <dt className="form-review-panel-page-header">
+                                          {`${file.fileName} (${
+                                            file.fileSize
+                                          })`}
+                                        </dt>
+                                        <dd className="vads-u-margin-right--0">
+                                          <va-button-icon
+                                            button-type="delete"
+                                            onClick={() =>
+                                              deleteFile(file.fileID)
+                                            }
+                                          />
+                                        </dd>
+                                      </div>
+                                    ))}
+                                    <div className="vads-u-margin-y--2">
+                                      <FileUpload />
+                                    </div>
+                                  </>
+                                )}
+                              </dl>
+                            </dl>
+                          </div>
+                        </form>
                       </div>
-                    </form>
-                  </div>
-                </div>
-                {/* )} */}
+                    </div>
+                  )}
               </VaAccordionItem>
             );
           })}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Review page focus moved to h2 when editing attachments
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- Ticket: [1652](https://github.com/orgs/department-of-veterans-affairs/projects/1033/views/1?pane=issue&itemId=100350243&issue=department-of-veterans-affairs%7Cask-va%7C1652)
## Testing done

- Test focus
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

UI did not change

## What areas of the site does it impact?

Only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

