### PR TITLE
remove aria tag causing duplicate reads by screen reader

### DIFF
--- a/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
+++ b/src/applications/gi/components/LicenseCertificationFilterAccordion.jsx
@@ -37,7 +37,6 @@ export default function LicenseCertificationFilterAccordion({
         <button
           onClick={toggle}
           className="usa-accordion-button vads-u-font-size--md vads-u-padding-right--3"
-          aria-expanded={isExpanded}
           aria-label={`${buttonLabel} ${isExpanded ? 'expanded' : 'collapsed'}`}
           data-testid="update-lc-search"
         >


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Aria tag was causing screen reader to announce the expanded status of an accordion component twice. 
- I removed the tag to stop the duplicate announcements, requested during QA
- Education Data Migration (EDM)
- Flipper in use to be lifted in April

## Related issue(s)

- EDM-861: (Accessibility) Filter your results in Search results

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)