### PR TITLE
Cc/103374/handle complete page refresh

### DIFF
--- a/src/applications/vaos/referral-appointments/CompleteReferral.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.jsx
@@ -50,6 +50,7 @@ export default function CompleteReferral() {
     () => {
       if (
         !appointmentInfoError &&
+        !appointmentInfoTimeout &&
         !appointmentInfoLoading &&
         referralAppointmentInfo?.appointment?.status !== 'booked'
       ) {

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
@@ -121,6 +121,8 @@ const ReviewAndConfirm = props => {
     );
   };
 
+  // handle routing to the next page once the appointment is created
+  // and the appointment id is available
   useEffect(
     () => {
       if (

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -6,20 +6,14 @@ import {
   Redirect,
   useLocation,
 } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 import ScheduleReferral from './ScheduleReferral';
 import ReviewAndConfirm from './ReviewAndConfirm';
 import ChooseDateAndTime from './ChooseDateAndTime';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 import { useIsInCCPilot } from './hooks/useIsInCCPilot';
-import { FETCH_STATUS } from '../utils/constants';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import CompleteReferral from './CompleteReferral';
 import ReferralLayout from './components/ReferralLayout';
-import {
-  getAppointmentCreateStatus,
-  getReferralAppointmentInfo,
-} from './redux/selectors';
 import { useGetReferralByIdQuery } from '../redux/api/vaosApi';
 
 export default function ReferralAppointments() {
@@ -30,8 +24,6 @@ export default function ReferralAppointments() {
   const params = new URLSearchParams(search);
   const id = params.get('id');
   const [, appointmentId] = pathname.split('/schedule-referral/complete/');
-  const { appointmentInfoLoading } = useSelector(getReferralAppointmentInfo);
-  const appointmentCreateStatus = useSelector(getAppointmentCreateStatus);
   const { data: referral, error, isLoading } = useGetReferralByIdQuery(id, {
     skip: !id,
   });
@@ -56,16 +48,6 @@ export default function ReferralAppointments() {
     return <ReferralLayout apiFailure hasEyebrow heading="Referral Error" />;
   }
 
-  if (
-    appointmentId &&
-    appointmentInfoLoading &&
-    appointmentCreateStatus === FETCH_STATUS.succeeded
-  ) {
-    return (
-      <ReferralLayout loadingMessage="Confirming your appointment. This may take up to 30 seconds. Please don’t refresh the page." />
-    );
-  }
-
   if ((!referral || isLoading) && !appointmentId) {
     return (
       <ReferralLayout
@@ -75,20 +57,13 @@ export default function ReferralAppointments() {
     );
   }
 
-  if (appointmentId) {
-    return (
+  return (
+    <>
       <Switch>
         <Route
           path={`${basePath.url}/complete/:appointmentId`}
           component={CompleteReferral}
         />
-      </Switch>
-    );
-  }
-
-  return (
-    <>
-      <Switch>
         <Route path={`${basePath.url}/review/`} search={id}>
           <ReviewAndConfirm currentReferral={referral} />
         </Route>

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -209,14 +209,6 @@ export function createReferralAppointment({
         type: CREATE_REFERRAL_APPOINTMENT_SUCCEEDED,
       });
 
-      dispatch(
-        pollFetchAppointmentInfo(draftApppointmentId, {
-          timeOut: 30000,
-          retryCount: 3,
-          retryDelay: 1000,
-        }),
-      );
-
       return appointmentInfo;
     } catch (error) {
       dispatch({

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -463,6 +463,9 @@ const responses = {
 
     if (appointmentId === 'timeout-appointment-id') {
       // Set a very high poll count to simulate a timeout
+      draftAppointments[
+        appointmentId
+      ] = providerUtils.createDraftAppointmentInfo(5);
       successPollCount = 1000;
     }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Changes some api call stuff so that the polling is a useEffect on the complete view instead of being dispatched as part of the create appointment action.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#103374](https://github.com/department-of-veterans-affairs/va.gov-team/issues/103374)

## Testing done

- The polling would be called before routing to the complete page
- Now you should see that it happens after the route change and that you can refresh the complete page to start the polling process again.
- http://localhost:3001/my-health/appointments/schedule-referral/complete/eps-error-appointment-id should show the appropriate error for [getAppointmentInfo error](https://www.figma.com/design/DsRXEFiYLCFnY5nBkp9Dc4/CC-Referral-%7C-Appointments-FE?node-id=7539-41198&t=B0kMNw5kq7zQ34kS-0)
- http://localhost:3001/my-health/appointments/schedule-referral/complete/timeout-appointment-id should show the [timeout error](https://www.figma.com/design/DsRXEFiYLCFnY5nBkp9Dc4/CC-Referral-%7C-Appointments-FE?node-id=7539-41197&t=B0kMNw5kq7zQ34kS-0)

## What areas of the site does it impact?

Community care appointment scheduling

## Acceptance criteria

- [ ] polling works as expected
- [ ] You can refresh the page and it will refetch the appointment data
- [ ] You can see the appropriate errors using the error ids `eps-error-appointment-id` and `timeout-appointment-id`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
