### PR TITLE
VEBT-1428: 22-10215/16 - Remove (hyphen) for Non-Accredited

### DIFF
--- a/src/applications/edu-benefits/10215/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10215/containers/IntroductionPage.jsx
@@ -196,8 +196,8 @@ const IntroductionPage = ({ route }) => {
             is NOT necessary to complete OR submit VA Form 22-10215.
           </p>
           <p>
-            <strong>Non-accredited schools: </strong> must complete and submit
-            VA Form 22-10215 with the 35 percent Exemption request.
+            <strong>Nonaccredited schools: </strong> must complete and submit VA
+            Form 22-10215 with the 35 percent Exemption request.
           </p>
         </va-accordion-item>
       </va-accordion>

--- a/src/applications/edu-benefits/10215/tests/10215-edu-benefits.cypress.spec.js
+++ b/src/applications/edu-benefits/10215/tests/10215-edu-benefits.cypress.spec.js
@@ -20,7 +20,7 @@ const testConfig = createTestConfig(
 
     dataDir: path.join(__dirname, 'fixtures', 'data'),
 
-    dataSets: ['maximal-test.json'],
+    dataSets: ['maximal-test', 'test-data'],
 
     pageHooks: {
       introduction: ({ afterHook }) => {

--- a/src/applications/edu-benefits/10216/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10216/containers/IntroductionPage.jsx
@@ -39,7 +39,7 @@ const IntroductionPage = ({ route }) => {
           />
         </li>
         <li>
-          Non-accredited schools: Submit both VA Form 22-10216 and VA Form
+          Nonaccredited schools: Submit both VA Form 22-10216 and VA Form
           22-10215 (Statement of Assurance of Compliance with 85% Enrollment
           Ratios) for the corresponding term to the{' '}
           <va-link
@@ -48,7 +48,7 @@ const IntroductionPage = ({ route }) => {
           />
         </li>
         <li>
-          <strong>Note for non-accredited schools:</strong> This exemption
+          <strong>Note for nonaccredited schools:</strong> This exemption
           applies only to the submission of routine reports. Your Educational &
           Training Institution must maintain compliance with the provisions of
           the 85/15 Rule for all programs approved to receive GI Bill Benefits
@@ -71,8 +71,8 @@ const IntroductionPage = ({ route }) => {
             and any required documentaion, before continuing.
           </p>
           <p>
-            <strong>Note for non-accredited schools: </strong>
-            If you are submitting on behalf of a non-accredited institution, you
+            <strong>Note for nonaccredited schools: </strong>
+            If you are submitting on behalf of a nonaccredited institution, you
             will need to complete and submit both the exemption request form, VA
             Form 22-10216, and VA Form 22-10215 (Statement of Assurance of
             Compliance with 85% Enrollment Ratios) for the corresponding term.
@@ -91,7 +91,7 @@ const IntroductionPage = ({ route }) => {
         <va-process-list-item header="Upload your PDF to the VA Educational portal">
           <p>
             Finally, upload your completed exemption request PDF. For
-            non-accredited schools, upload both VA Form 22-10216 and VA Form
+            nonaccredited schools, upload both VA Form 22-10216 and VA Form
             22-10215.
           </p>
         </va-process-list-item>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This is a spelling change to remove the hyphen from `non-accredited` to `nonaccredited` across the 22-10215 and 22-10216 forms
- The 22-10215 Cypress test datasets were also updated

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-1428

**As a...**

VEBT Business User

**I want…**

To remove (hyphen) for Non-Accredited 

**So that…**

Form more accurately represents the Step details

**Acceptance Criteria**

15-> https://www.figma.com/design/f9TussyZYnC5UVSnqBPJqC/VEBT-Form-22-10215%3A-Statement-of-Assurance?node-id=728-18768&p=f&t=fjBsohSN5i3rxQKQ-0

16-> https://www.figma.com/design/69FpDTQN5UErSV27txIKFh/VEBT-Form-22-10216%3A-35%25-Exemption?node-id=763-76558&p=f&t=Df4lM6RK91f4Cwuu-0

The word Non-accredited should be displayed as Nonaccredited by removing the hyphen and keeping as 1 word. 
On the Intro Page, there are 5 occurrences. 
 

On the 10215 form intro page, there is 1 occurrence. This ticket will address that change as its only in 1 place. 

**Technical Details:**

Dependencies: No

Feature Flag needed: Yes

Demo needed: No

UAT needed: Yes

Additional Notes: 

**Testing Details:**

(  ) Quick Turn Around/Direct to Production

( X ) Remains in Staging

(  ) Staging Environment unavailable, coordinate w/ developer

**Requested by and when:**

15/16 Walkthrough, 3/12

**Definition of Done:** 

( )  UAT completed with EDU

(  )  Passed all internal testing in Staging

( )  Passed all internal testing in Production

(  )  All work documented in Jira ticket

## Testing done

- Unit tests and Cypress tests were rerun for both the 22-10215 and 22-10216 with the same code coverage

## Screenshots

**Before:**

![22-10215 Intro Page (Before)](https://github.com/user-attachments/assets/6781038b-ad27-44a8-a96b-bcd4d45c868f)
![22-10216 Intro Page (Before)](https://github.com/user-attachments/assets/149bbda0-f93f-4d9c-8f6b-fcd17acee69f)

**After:**

![22-10215 Intro Page (After)](https://github.com/user-attachments/assets/1223a3da-66c2-41c9-a2e4-530e8552e81d)
![22-10216 Intro Page (After)](https://github.com/user-attachments/assets/83d4a246-54d5-4f1a-824b-a0de06e74968)

## What areas of the site does it impact?

- Form 22-10215 Introduction Page
- Form 22-10216 Introduction Page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
