### PR TITLE
Add 21-0966 fallback if expiration date is missing

### DIFF
--- a/src/applications/simple-forms/21-0966/config/helpers.js
+++ b/src/applications/simple-forms/21-0966/config/helpers.js
@@ -418,9 +418,13 @@ export const confirmationPageAlertParagraphV2 = ({
       );
     }
     if (submissionApi === submissionApis.INTENT_TO_FILE) {
-      return `You have until ${formatDate(
-        expirationDate,
-      )} to file for ${benefitSelectionStr}`;
+      if (expirationDate) {
+        return `You have until ${formatDate(
+          expirationDate,
+        )} to file for ${benefitSelectionStr}`;
+      }
+
+      return `You have one year to file for ${benefitSelectionStr}`;
     }
   }
 


### PR DESCRIPTION
## Summary
This PR handles 21-0966 confirmation pages where `expirationDate` is missing with a non-specific fallback.

## Related issue(s)
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2089
