### PR TITLE
Ask VA - Fix undefined for school info

### DIFF
--- a/src/applications/ask-va/config/prefill-transformer.js
+++ b/src/applications/ask-va/config/prefill-transformer.js
@@ -28,7 +28,7 @@ export default function prefillTransformer(pages, formData, metadata) {
     const contactInfo = data?.contactInformation || {};
     const avaProfile = data?.avaProfile || {};
 
-    const { phone, email, ...restContactInfo } = contactInfo;
+    const { phone, email, workPhone, ...restContactInfo } = contactInfo;
     const { businessPhone } = avaProfile;
 
     return {
@@ -36,7 +36,7 @@ export default function prefillTransformer(pages, formData, metadata) {
       ...avaProfile,
       phoneNumber: phone || '',
       emailAddress: email || '',
-      businessPhone: businessPhone || '',
+      businessPhone: workPhone || businessPhone || '',
       businessEmail: email || '',
     };
   };

--- a/src/applications/ask-va/config/schema-helpers/formFlowHelper.js
+++ b/src/applications/ask-va/config/schema-helpers/formFlowHelper.js
@@ -197,7 +197,7 @@ export const ch3Pages = {
     schema: schoolInYourProfilePage.schema,
     depends: form =>
       // Reference: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/ask-va/design/Fields,%20options%20and%20labels/Field%20rules.md#school-fields
-      (form.school || form.schoolInfo?.schoolName) &&
+      form.schoolInfo?.schoolName &&
       ((form.selectCategory === CategoryDebt &&
         form.selectTopic === TopicEducationBenefitOverpayments) ||
         (form.yourRole === yourRoleOptionsEducation.SCO ||


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add work phone to pre fill data and fix undefined school info
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- Ticket: [1708](https://github.com/orgs/department-of-veterans-affairs/projects/1033/views/1?pane=issue&itemId=103899042&issue=department-of-veterans-affairs%7Cask-va%7C1708)

## Testing done

- School info is undefined when going back after picking a school
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

UI did not change

## What areas of the site does it impact?

Only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

