### PR TITLE
[SIMPLE-FORMS] fix: update 4138 URL and links to expected format

### DIFF
--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -140,7 +140,7 @@ export const OTHER_REASONS = Object.freeze({
 export const ESCAPE_HATCH = Object.freeze(
   <div className="vads-u-margin-y--4">
     If you’d like to use VA Form 21-4138 for your statement instead, you can{' '}
-    <a href="/supporting-forms-for-claims/statement-to-support-claim-form-21-4138/personal-information">
+    <a href="/supporting-forms-for-claims/submit-statement-form-21-4138/personal-information">
       go to VA Form 21-4138 now.
     </a>
   </div>,

--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -87,8 +87,7 @@ const formConfig = {
         label: 'Supporting forms for VA claims',
       },
       {
-        href:
-          '/supporting-forms-for-claims/statement-to-support-claim-form-21-4138',
+        href: '/supporting-forms-for-claims/submit-statement-form-21-4138',
         label: 'Submit a statement to support a claim',
       },
     ],
@@ -112,7 +111,7 @@ const formConfig = {
         layWitnessStatementPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.BUDDY_STATEMENT,
-          path: 'lay-witness-statement',
+          path: 'statement-type/recommend-lay-witness-statement-form-21-10210',
           title: "There's a better way to submit your statement",
           uiSchema: layWitnessStatementPage.uiSchema,
           schema: layWitnessStatementPage.schema,

--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -111,7 +111,7 @@ const formConfig = {
         layWitnessStatementPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.BUDDY_STATEMENT,
-          path: 'statement-type/recommend-lay-witness-statement-form-21-10210',
+          path: 'lay-witness-statement',
           title: "There's a better way to submit your statement",
           uiSchema: layWitnessStatementPage.uiSchema,
           schema: layWitnessStatementPage.schema,

--- a/src/applications/simple-forms/21-4138/manifest.json
+++ b/src/applications/simple-forms/21-4138/manifest.json
@@ -2,6 +2,6 @@
   "appName": "Submit a statement to support a claim",
   "entryFile": "./app-entry.jsx",
   "entryName": "4138-ss",
-  "rootUrl": "/supporting-forms-for-claims/statement-to-support-claim-form-21-4138",
+  "rootUrl": "/supporting-forms-for-claims/submit-statement-form-21-4138",
   "productId": "11f151bf-bec3-436c-8779-2a13dc0886d8"
 }

--- a/src/applications/static-pages/simple-forms/21-4138/App.js
+++ b/src/applications/static-pages/simple-forms/21-4138/App.js
@@ -16,7 +16,7 @@ const App = ({ formEnabled }) => {
         <p>You can submit this form online or by mail.</p>
         <a
           className="vads-c-action-link--blue"
-          href="/supporting-forms-for-claims/statement-to-support-claim-form-21-4138"
+          href="/supporting-forms-for-claims/submit-statement-form-21-4138"
         >
           Submit a Statement in support of your claim online
         </a>

--- a/src/platform/forms-system/src/js/patterns/minimal-header/README.md
+++ b/src/platform/forms-system/src/js/patterns/minimal-header/README.md
@@ -65,7 +65,7 @@ const formConfig = {
       },
       {
         href:
-          '/supporting-forms-for-claims/statement-to-support-claim-form-21-4138',
+          '/supporting-forms-for-claims/submit-statement-form-21-4138',
         label: 'Submit a statement to support a claim',
       },
     ],


### PR DESCRIPTION
## Summary

- This work changes all occurences of "statement-to-support-claim-form-21-4138" to be "submit-statement-form-21-4138"
- The previous link was rejected by IA
- I work for the Veteran Facing Forms team who owns this form

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1631

## Testing done

- Browser testing succeeds
- Unit and E2E tests pass

## Screenshots

![Screenshot 2025-03-28 at 11 28 44 AM](https://github.com/user-attachments/assets/08a1a4dd-19f1-4671-997e-0adb54ad10a4)


## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Any
