### PR TITLE
Where: Semantic Tag addition on Events Pages Online events

### DIFF
--- a/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
+++ b/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
@@ -9,7 +9,11 @@ const WhereContent = ({
   derivedLocations,
 }) => {
   if (fieldType === 'online') {
-    return 'This is an online event.';
+    return (
+      <p className="vads-u-margin--0" data-testid="event-online">
+        This is an online event.
+      </p>
+    );
   }
 
   const locationAddress = derivedLocations?.length

--- a/src/applications/static-pages/events/components/Results/ResultsWhereContent.unit.spec.jsx
+++ b/src/applications/static-pages/events/components/Results/ResultsWhereContent.unit.spec.jsx
@@ -5,16 +5,17 @@ import ResultsWhereContent from './ResultsWhereContent';
 
 describe('ResultsWhereContent', () => {
   describe('when it is an online event', () => {
-    it('should render the component as expected', () => {
+    it('should render the component with semantic p tag', () => {
       const event = {
         fieldLocationType: 'online',
       };
 
       const screen = render(<ResultsWhereContent event={event} />);
 
-      expect(screen.getByTestId('events-where-content').textContent).to.equal(
-        'This is an online event.',
-      );
+      const onlineText = screen.getByTestId('event-online');
+      expect(onlineText.tagName.toLowerCase()).to.equal('p');
+      expect(onlineText.classList.contains('vads-u-margin--0')).to.be.true;
+      expect(onlineText.textContent).to.equal('This is an online event.');
     });
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added a semantic `<p>` tag on the Where area and tried to keep a consistent margin
- Fixing a defect ticket 
- CMS team owns these static pages

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#20597](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20597)

## Testing done

- Loaded up this path locally http://localhost:3999/outreach-and-events/events/
- Checked spacing manually
- Added a test

## Screenshots
Before: 
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/d56087b0-f2a3-4ce7-b9d6-560bd0493866" />

After:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a39e1897-96c6-47f9-ae07-a6d2c7fbac99" />
<img width="869" alt="image" src="https://github.com/user-attachments/assets/1f379949-68c9-4a1e-9f61-3788070bdafb" />

## What areas of the site does it impact?
http://localhost:3999/outreach-and-events/events/

## Acceptance criteria
- In ticket
### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
