### PR TITLE
Update to use api as source of truth for VA appointments

### DIFF
--- a/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
@@ -168,7 +168,7 @@ describe('VAOS Backend Service Alert', () => {
       .exist;
   });
 
-  it('should display BackendAppointmentServiceAlert if there is a failure returned on the past appointments list', async () => {
+  it('should display BackendAppointmentServiceAlert if there is a failure returned on the past appointments list, useFeSourceOfTruthVA=false', async () => {
     const now = moment().startOf('day');
     const start = moment(now).subtract(3, 'months');
     const end = moment()
@@ -180,7 +180,6 @@ describe('VAOS Backend Service Alert', () => {
     appointment.id = '123';
     appointment.attributes = {
       ...appointment.attributes,
-      type: 'VA',
       minutesDuration: 30,
       status: 'booked',
       localStartTime: yesterday.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
@@ -226,6 +225,68 @@ describe('VAOS Backend Service Alert', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('backend-appointment-service-alert')).to
+        .exist;
+    });
+  });
+
+  it('should not display BackendAppointmentServiceAlert if there is no failure returned on the past appointments list, useFeSourceOfTruthVA=true', async () => {
+    const now = moment().startOf('day');
+    const start = moment(now).subtract(3, 'months');
+    const end = moment()
+      .minutes(0)
+      .add(30, 'minutes');
+
+    const yesterday = moment.utc().subtract(1, 'day');
+    const appointment = getVAOSAppointmentMock();
+    appointment.id = '123';
+    appointment.attributes = {
+      ...appointment.attributes,
+      type: 'VA',
+      minutesDuration: 30,
+      status: 'booked',
+      localStartTime: yesterday.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
+      start: yesterday.format(),
+      locationId: '983',
+      location: {
+        id: '983',
+        type: 'appointments',
+        attributes: {
+          id: '983',
+          vistaSite: '983',
+          name: 'Cheyenne VA Medical Center',
+          lat: 39.744507,
+          long: -104.830956,
+          phone: { main: '307-778-7550' },
+          physicalAddress: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
+          },
+        },
+      },
+    };
+
+    mockVAOSAppointmentsFetch({
+      start: start.format('YYYY-MM-DD'),
+      end: end.format('YYYY-MM-DD'),
+      requests: [appointment],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      backendServiceFailures: false,
+      avs: true,
+      fetchClaimStatus: true,
+    });
+
+    const screen = renderWithStoreAndRouter(<PastAppointmentsPage />, {
+      initialState,
+    });
+
+    await waitFor(() => {
+      expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('backend-appointment-service-alert')).to.not
         .exist;
     });
   });

--- a/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
@@ -180,6 +180,7 @@ describe('VAOS Backend Service Alert', () => {
     appointment.id = '123';
     appointment.attributes = {
       ...appointment.attributes,
+      type: 'VA',
       minutesDuration: 30,
       status: 'booked',
       localStartTime: yesterday.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
@@ -241,6 +242,7 @@ describe('VAOS Backend Service Alert', () => {
     appointment.id = '123';
     appointment.attributes = {
       ...appointment.attributes,
+      type: 'VA',
       minutesDuration: 30,
       status: 'booked',
       localStartTime: yesterday.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),

--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
@@ -118,6 +118,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     const data = {
       id: '1234',
       kind: 'clinic',
+      type: 'VA',
       clinic: 'fake',
       localStartTime: pastDate.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
       start: pastDate.format(),
@@ -165,6 +166,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       id: '1234',
       currentStatus: 'CHECKED OUT',
       kind: 'clinic',
+      type: 'VA',
       clinic: 'fake',
       localStartTime: pastDate.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
       start: pastDate.format(),
@@ -290,6 +292,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
       clinicId: null,
       facilityId: '983',
       kind: 'telehealth',
+      type: 'VA',
       locationId: '983',
       localStartTime: pastDate.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
       start: pastDate.format(),
@@ -352,6 +355,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     appointment.id = '1';
     appointment.attributes = {
       ...appointment.attributes,
+      type: 'VA',
       minutesDuration: 30,
       status: 'booked',
       localStartTime: yesterday.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
@@ -407,6 +411,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     appointment.id = '1';
     appointment.attributes = {
       ...appointment.attributes,
+      type: 'VA',
       minutesDuration: 30,
       status: 'cancelled',
       localStartTime: yesterday.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),

--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
@@ -159,7 +159,96 @@ describe('VAOS Page: PastAppointmentsList api', () => {
     expect(timeHeader).to.contain.text('MT');
   });
 
-  it('should show information with facility name', async () => {
+  it('should show information with facility name, useFeSourceOfTruthVA=false', async () => {
+    const pastDate = moment(testDates().now).subtract(3, 'days');
+
+    const data = {
+      id: '1234',
+      currentStatus: 'CHECKED OUT',
+      kind: 'clinic',
+      clinic: 'fake',
+      localStartTime: pastDate.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
+      start: pastDate.format(),
+      locationId: '983GC',
+      status: 'fulfilled',
+      location: {
+        id: '983',
+        type: 'appointments',
+        attributes: {
+          id: '983',
+          vistaSite: '983',
+          vastParent: '983',
+          type: 'va_facilities',
+          name: 'Cheyenne VA Medical Center',
+          classification: 'VA Medical Center (VAMC)',
+          timezone: {
+            timeZoneId: 'America/Denver',
+          },
+          lat: 39.744507,
+          long: -104.830956,
+          website: 'https://www.denver.va.gov/locations/directions.asp',
+          phone: {
+            main: '307-778-7550',
+            fax: '307-778-7381',
+            pharmacy: '866-420-6337',
+            afterHours: '307-778-7550',
+            patientAdvocate: '307-778-7550 x7517',
+            mentalHealthClinic: '307-778-7349',
+            enrollmentCoordinator: '307-778-7550 x7579',
+          },
+          physicalAddress: {
+            type: 'physical',
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
+          },
+          mobile: false,
+          healthService: [],
+          operatingStatus: {
+            code: 'NORMAL',
+          },
+        },
+      },
+    };
+    const appointment = createMockAppointment({
+      ...data,
+    });
+
+    mockVAOSAppointmentsFetch({
+      start: testDates().start.format('YYYY-MM-DD'),
+      end: testDates().end.format('YYYY-MM-DD'),
+      requests: [appointment],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
+      fetchClaimStatus: true,
+    });
+
+    const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
+      initialState,
+    });
+
+    await screen.findAllByLabelText(
+      new RegExp(pastDate.format('dddd, MMMM D'), 'i'),
+    );
+
+    const firstCard = screen.getAllByRole('listitem')[0];
+
+    expect(
+      within(firstCard).getByText(
+        new RegExp(`^${pastDate.format('h:mm')}`, 'i'),
+      ),
+    ).to.exist;
+    // TODO: Skipping until api call is made to get facility data on page load.
+    // Currently, facility data is only retrieved when viewing appointment details
+    // await waitFor(() => {
+    //   expect(within(firstCard).getByText(/Cheyenne VA Medical Center/i)).to
+    //     .exist;
+    // });
+    // expect(screen.baseElement).not.to.contain.text('VA appointment');
+  });
+
+  it('should show information with facility name, useFeSourceOfTruthVA=true', async () => {
     const pastDate = moment(testDates().now).subtract(3, 'days');
 
     const data = {

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
@@ -48,6 +48,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     appointment.attributes = {
       ...appointment.attributes,
       kind: 'clinic',
+      type: 'VA',
       status: 'booked',
       locationId: '983',
       location: {
@@ -171,6 +172,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     appointment.attributes = {
       ...appointment.attributes,
       kind: 'telehealth',
+      type: 'VA',
       status: 'booked',
       localStartTime: now.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
       start: now.format('YYYY-MM-DDTHH:mm:ss'),
@@ -223,6 +225,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     appointment.attributes = {
       ...appointment.attributes,
       kind: 'phone',
+      type: 'VA',
       status: 'booked',
       localStartTime: now.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
       start: now.format('YYYY-MM-DDTHH:mm:ss'),
@@ -330,6 +333,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     appointment.attributes = {
       ...appointment.attributes,
       kind: 'telehealth',
+      type: 'VA',
       status: 'booked',
       locationId: '983',
       location: {

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
@@ -31,7 +31,77 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     MockDate.reset();
   });
 
-  it('should show VA appointment text', async () => {
+  it('should show VA appointment text, useFeSourceOfTruthVA=false', async () => {
+    const myInitialState = {
+      ...initialState,
+      featureToggles: {
+        ...initialState.featureToggles,
+        vaOnlineSchedulingVAOSServiceVAAppointments: true,
+        vaOnlineSchedulingVAOSServiceCCAppointments: true,
+      },
+    };
+    const now = moment();
+    const start = moment(now).subtract(30, 'days');
+    const end = moment(now).add(395, 'days');
+    const appointment = getVAOSAppointmentMock();
+    appointment.id = '123';
+    appointment.attributes = {
+      ...appointment.attributes,
+      kind: 'clinic',
+      status: 'booked',
+      locationId: '983',
+      location: {
+        id: '983',
+        type: 'appointments',
+        attributes: {
+          id: '983',
+          vistaSite: '983',
+          name: 'Cheyenne VA Medical Center',
+          lat: 39.744507,
+          long: -104.830956,
+          phone: { main: '307-778-7550' },
+          physicalAddress: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
+          },
+        },
+      },
+      localStartTime: now.format('YYYY-MM-DDTHH:mm:ss.000ZZ'),
+      start: now.format('YYYY-MM-DDTHH:mm:ss'),
+      end: now.format('YYYY-MM-DDTHH:mm:ss'),
+      future: true,
+    };
+
+    mockAppointmentsApi({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      response: [],
+    });
+
+    mockVAOSAppointmentsFetch({
+      start: start.format('YYYY-MM-DD'),
+      end: end.format('YYYY-MM-DD'),
+      requests: [appointment],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+    });
+
+    const screen = renderWithStoreAndRouter(<UpcomingAppointmentsPage />, {
+      initialState: myInitialState,
+      reducers,
+    });
+
+    await screen.findAllByLabelText(
+      new RegExp(now.format('dddd, MMMM D'), 'i'),
+    );
+    expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
+  });
+
+  it('should show VA appointment text, useFeSourceOfTruthVA=true', async () => {
     const myInitialState = {
       ...initialState,
       featureToggles: {

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -10,6 +10,7 @@ import {
   selectFeatureVAOSServiceVAAppointments,
   selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
+  selectFeatureFeSourceOfTruthVA,
   selectSystemIds,
 } from '../../redux/selectors';
 import {
@@ -100,6 +101,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+    const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const patientFacilities = selectPatientFacilities(state);
 
     const includeEPS = getIsInCCPilot(
@@ -137,6 +139,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
           includeEPS,
           useFeSourceOfTruth,
           useFeSourceOfTruthCC,
+          useFeSourceOfTruthVA,
         }),
       ];
       if (includeRequests) {
@@ -152,6 +155,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             includeEPS,
             useFeSourceOfTruth,
             useFeSourceOfTruthCC,
+            useFeSourceOfTruthVA,
           })
             .then(requests => {
               dispatch({
@@ -262,6 +266,7 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+    const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const patientFacilities = selectPatientFacilities(state);
     const includeEPS = getIsInCCPilot(
       featureCCDirectScheduling,
@@ -286,6 +291,7 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
         includeEPS,
         useFeSourceOfTruth,
         useFeSourceOfTruthCC,
+        useFeSourceOfTruthVA,
       });
       const appointments = results.filter(appt => !appt.hasOwnProperty('meta'));
       const backendServiceFailures =
@@ -343,6 +349,7 @@ export function fetchRequestDetails(id) {
       const state = getState();
       const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
       const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+      const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
 
       let request = selectAppointmentById(state, id, [
         APPOINTMENT_TYPES.ccRequest,
@@ -362,6 +369,7 @@ export function fetchRequestDetails(id) {
           id,
           useFeSourceOfTruth,
           useFeSourceOfTruthCC,
+          useFeSourceOfTruthVA,
         });
         facilityId = getVAAppointmentLocationId(request);
         facility = state.appointments.facilityData?.[facilityId];
@@ -407,6 +415,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
           : featureVAOSServiceVAAppointments;
       const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
       const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+      const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
 
       let appointment = selectAppointmentById(state, id, [
         type === 'cc'
@@ -430,6 +439,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
           useV2,
           useFeSourceOfTruth,
           useFeSourceOfTruthCC,
+          useFeSourceOfTruthVA,
         });
       }
 
@@ -497,6 +507,7 @@ export function confirmCancelAppointment() {
     const appointment = state.appointments.appointmentToCancel;
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+    const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
 
     try {
       dispatch({
@@ -507,6 +518,7 @@ export function confirmCancelAppointment() {
         appointment,
         useFeSourceOfTruth,
         useFeSourceOfTruthCC,
+        useFeSourceOfTruthVA,
       });
 
       dispatch({

--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -12,6 +12,7 @@ import {
   selectFeatureBreadcrumbUrlUpdate,
   selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
+  selectFeatureFeSourceOfTruthVA,
 } from '../../redux/selectors';
 import { getAvailableHealthcareServices } from '../../services/healthcare-service';
 import {
@@ -384,6 +385,7 @@ export function confirmAppointment(history) {
     const featureBreadcrumbUrlUpdate = selectFeatureBreadcrumbUrlUpdate(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+    const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
 
     dispatch({
       type: FORM_SUBMIT,
@@ -404,6 +406,7 @@ export function confirmAppointment(history) {
         appointment: transformFormToVAOSAppointment(getState()),
         useFeSourceOfTruth,
         useFeSourceOfTruthCC,
+        useFeSourceOfTruthVA,
       });
 
       const data = selectCovid19VaccineFormData(getState());

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -20,6 +20,7 @@ import { selectTypeOfCarePage } from '../../redux/selectors';
 import {
   selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
+  selectFeatureFeSourceOfTruthVA,
 } from '../../../redux/selectors';
 import { resetDataLayer } from '../../../utils/events';
 
@@ -38,6 +39,9 @@ export default function TypeOfCarePage() {
   );
   const useFeSourceOfTruthCC = useSelector(state =>
     selectFeatureFeSourceOfTruthCC(state),
+  );
+  const useFeSourceOfTruthVA = useSelector(state =>
+    selectFeatureFeSourceOfTruthVA(state),
   );
 
   const dispatch = useDispatch();
@@ -153,6 +157,7 @@ export default function TypeOfCarePage() {
               getLongTermAppointmentHistoryV2(
                 useFeSourceOfTruth,
                 useFeSourceOfTruthCC,
+                useFeSourceOfTruthVA,
               );
             }
 

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -17,6 +17,7 @@ import {
   selectFeatureBreadcrumbUrlUpdate,
   selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
+  selectFeatureFeSourceOfTruthVA,
   selectFeatureRecentLocationsFilter,
 } from '../../redux/selectors';
 import {
@@ -309,6 +310,7 @@ export function checkEligibility({ location, showModal, isCerner }) {
     const featureClinicFilter = selectFeatureClinicFilter(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+    const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
 
     dispatch({
       type: FORM_ELIGIBILITY_CHECKS,
@@ -327,6 +329,7 @@ export function checkEligibility({ location, showModal, isCerner }) {
             directSchedulingEnabled,
             useFeSourceOfTruth,
             useFeSourceOfTruthCC,
+            useFeSourceOfTruthVA,
             isCerner: true,
           });
 
@@ -364,6 +367,7 @@ export function checkEligibility({ location, showModal, isCerner }) {
           featureClinicFilter,
           useFeSourceOfTruth,
           useFeSourceOfTruthCC,
+          useFeSourceOfTruthVA,
         });
 
         if (showModal) {
@@ -911,6 +915,7 @@ export function submitAppointmentOrRequest(history) {
     const featureBreadcrumbUrlUpdate = selectFeatureBreadcrumbUrlUpdate(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+    const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const newAppointment = getNewAppointment(state);
     const data = newAppointment?.data;
     const typeOfCare = getTypeOfCare(getFormData(state))?.name;
@@ -938,6 +943,7 @@ export function submitAppointmentOrRequest(history) {
           appointment: transformFormToVAOSAppointment(getState()),
           useFeSourceOfTruth,
           useFeSourceOfTruthCC,
+          useFeSourceOfTruthVA,
         });
 
         dispatch({
@@ -1034,6 +1040,7 @@ export function submitAppointmentOrRequest(history) {
           appointment: requestBody,
           useFeSourceOfTruth,
           useFeSourceOfTruthCC,
+          useFeSourceOfTruthVA,
         });
 
         dispatch({

--- a/src/applications/vaos/redux/actions.js
+++ b/src/applications/vaos/redux/actions.js
@@ -14,6 +14,7 @@ import {
   selectFeatureVAOSServiceRequests,
   selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
+  selectFeatureFeSourceOfTruthVA,
 } from './selectors';
 import { getIsInCCPilot } from '../referral-appointments/utils/pilot';
 
@@ -88,6 +89,7 @@ export function fetchPendingAppointments() {
       const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
       const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
       const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
+      const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
       const patientFacilities = selectPatientFacilities(state);
       const includeEPS = getIsInCCPilot(
         featureCCDirectScheduling,
@@ -104,6 +106,7 @@ export function fetchPendingAppointments() {
         includeEPS,
         useFeSourceOfTruth,
         useFeSourceOfTruthCC,
+        useFeSourceOfTruthVA,
       });
 
       const data = pendingAppointments?.filter(

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -69,7 +69,8 @@ function apptRequestSort(a, b) {
  * @param {Boolean} fetchClaimStatus Boolean to fetch travel claim data
  * @param {Boolean} includeEPS Boolean to include EPS appointments
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
- * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {Appointment[]} A FHIR searchset of booked Appointment resources
  */
 export async function fetchAppointments({
@@ -80,6 +81,7 @@ export async function fetchAppointments({
   includeEPS = false,
   useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
+  useFeSourceOfTruthVA = false,
 }) {
   try {
     const appointments = [];
@@ -95,8 +97,10 @@ export async function fetchAppointments({
     const filteredAppointments = allAppointments.data.filter(appt => {
       // Filter out appointments that are not VA or CC appointments
       return (
-        getAppointmentType(appt) === APPOINTMENT_TYPES.vaAppointment ||
-        getAppointmentType(appt) === APPOINTMENT_TYPES.ccAppointment
+        getAppointmentType(appt, useFeSourceOfTruthCC, useFeSourceOfTruthVA) ===
+          APPOINTMENT_TYPES.vaAppointment ||
+        getAppointmentType(appt, useFeSourceOfTruthCC, useFeSourceOfTruthVA) ===
+          APPOINTMENT_TYPES.ccAppointment
       );
     });
 
@@ -105,6 +109,7 @@ export async function fetchAppointments({
         filteredAppointments,
         useFeSourceOfTruth,
         useFeSourceOfTruthCC,
+        useFeSourceOfTruthVA,
       ),
       {
         meta: allAppointments.backendSystemFailures,
@@ -131,6 +136,7 @@ export async function fetchAppointments({
  * @param {Boolean} includeEPS Boolean to include EPS appointments
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {Appointment[]} A FHIR searchset of pending Appointment resources
  */
 export async function getAppointmentRequests({
@@ -139,6 +145,7 @@ export async function getAppointmentRequests({
   includeEPS = false,
   useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
+  useFeSourceOfTruthVA = false,
 }) {
   try {
     const appointments = await getAppointments({
@@ -152,8 +159,16 @@ export async function getAppointmentRequests({
       // Filter out appointments that are not requests
       return useFeSourceOfTruth
         ? appt.pending
-        : getAppointmentType(appt) === APPOINTMENT_TYPES.request ||
-            getAppointmentType(appt) === APPOINTMENT_TYPES.ccRequest;
+        : getAppointmentType(
+            appt,
+            useFeSourceOfTruthCC,
+            useFeSourceOfTruthVA,
+          ) === APPOINTMENT_TYPES.request ||
+            getAppointmentType(
+              appt,
+              useFeSourceOfTruthCC,
+              useFeSourceOfTruthVA,
+            ) === APPOINTMENT_TYPES.ccRequest;
     });
 
     requestsWithoutAppointments.sort(apptRequestSort);
@@ -162,6 +177,7 @@ export async function getAppointmentRequests({
       requestsWithoutAppointments,
       useFeSourceOfTruth,
       useFeSourceOfTruthCC,
+      useFeSourceOfTruthVA,
     );
 
     transformRequests.push({
@@ -186,12 +202,14 @@ export async function getAppointmentRequests({
  * @param {string} id Appointment request id
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {Appointment} An Appointment object for the given request id
  */
 export async function fetchRequestById({
   id,
   useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
+  useFeSourceOfTruthVA = false,
 }) {
   try {
     const appointment = await getAppointment(id);
@@ -200,6 +218,7 @@ export async function fetchRequestById({
       appointment,
       useFeSourceOfTruth,
       useFeSourceOfTruthCC,
+      useFeSourceOfTruthVA,
     );
   } catch (e) {
     if (e.errors) {
@@ -219,6 +238,7 @@ export async function fetchRequestById({
  * @param {fetchClaimStatus} Boolean to fetch travel claim data
  * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {Appointment} A transformed appointment with the given id
  */
 export async function fetchBookedAppointment({
@@ -227,6 +247,7 @@ export async function fetchBookedAppointment({
   fetchClaimStatus = true,
   useFeSourceOfTruth = true,
   useFeSourceOfTruthCC = false,
+  useFeSourceOfTruthVA = false,
 }) {
   try {
     const appointment = await getAppointment(id, avs, fetchClaimStatus);
@@ -234,6 +255,7 @@ export async function fetchBookedAppointment({
       appointment,
       useFeSourceOfTruth,
       useFeSourceOfTruthCC,
+      useFeSourceOfTruthVA,
     );
   } catch (e) {
     if (e.errors) {
@@ -585,12 +607,14 @@ export function groupAppointmentsByMonth(appointments) {
  * @param {VAOSAppointment} params.appointment The appointment to send
  * @param {Boolean} params.useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {Boolean} params.useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {Appointment} The created appointment
  */
 export async function createAppointment({
   appointment,
   useFeSourceOfTruth,
   useFeSourceOfTruthCC,
+  useFeSourceOfTruthVA,
 }) {
   const result = await postAppointment(appointment);
 
@@ -598,6 +622,7 @@ export async function createAppointment({
     result,
     useFeSourceOfTruth,
     useFeSourceOfTruthCC,
+    useFeSourceOfTruthVA,
   );
 }
 
@@ -611,12 +636,14 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  * @param {Appointment} params.appointment The appointment to cancel
  * @param {Boolean} params.useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {Boolean} params.useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {?Appointment} Returns either null or the updated appointment data
  */
 export async function cancelAppointment({
   appointment,
   useFeSourceOfTruth,
   useFeSourceOfTruthCC,
+  useFeSourceOfTruthVA,
 }) {
   const additionalEventData = {
     appointmentType:
@@ -646,6 +673,7 @@ export async function cancelAppointment({
       updatedAppointment,
       useFeSourceOfTruth,
       useFeSourceOfTruthCC,
+      useFeSourceOfTruthVA,
     );
   } catch (e) {
     captureError(e, true);
@@ -832,7 +860,7 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
   const batch = [];
   let promise = null;
 
-  return (useFeSourceOfTruth, useFeSourceOfTruthCC) => {
+  return (useFeSourceOfTruth, useFeSourceOfTruthCC, useFeSourceOfTruthVA) => {
     if (!promise || navigator.userAgent === 'node.js') {
       // Creating an array of start and end dates for each chunk
       const ranges = Array.from(Array(chunks).keys()).map(i => {
@@ -868,6 +896,7 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
           endDate: curr.end,
           useFeSourceOfTruth,
           useFeSourceOfTruthCC,
+          useFeSourceOfTruthVA,
         });
         batch.push(p1);
         return Promise.resolve([...batch].flat());

--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -676,7 +676,7 @@ describe('VAOS Services: Appointment ', () => {
         });
       });
 
-      await getLongTermAppointmentHistoryV2(true, true);
+      await getLongTermAppointmentHistoryV2(true, true, true);
       expect(global.fetch.callCount).to.equal(3);
       expect(global.fetch.firstCall.args[0]).to.contain(dateRanges[0].start);
       expect(global.fetch.firstCall.args[0]).to.contain(dateRanges[0].end);

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -6,7 +6,7 @@ describe('getAppointmentType util', () => {
     const appointment = {
       id: 'CERN123',
     };
-    const result = getAppointmentType(appointment, false);
+    const result = getAppointmentType(appointment, false, false);
     expect(result).to.equal('request');
   });
   it('should return appointment type as vaAppointment for cerner appointment', async () => {
@@ -14,7 +14,7 @@ describe('getAppointmentType util', () => {
       id: 'CERN123',
       end: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment, false);
+    const result = getAppointmentType(appointment, false, false);
     expect(result).to.equal('vaAppointment');
   });
   it('should return appointment type as ccAppointment, useFeSourceOfTruthCC=false', async () => {
@@ -23,7 +23,7 @@ describe('getAppointmentType util', () => {
       kind: 'cc',
       start: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment, false);
+    const result = getAppointmentType(appointment, false, false);
     expect(result).to.equal('ccAppointment');
   });
   it('should return appointment type as ccAppointment, useFeSourceOfTruthCC=true', async () => {
@@ -31,7 +31,7 @@ describe('getAppointmentType util', () => {
       id: '123',
       type: 'COMMUNITY_CARE_APPOINTMENT',
     };
-    const result = getAppointmentType(appointment, true);
+    const result = getAppointmentType(appointment, true, false);
     expect(result).to.equal('ccAppointment');
   });
   it('should return appointment type as ccRequest, useFeSourceOfTruthCC=false', async () => {
@@ -44,7 +44,7 @@ describe('getAppointmentType util', () => {
         },
       ],
     };
-    const result = getAppointmentType(appointment, false);
+    const result = getAppointmentType(appointment, false, false);
     expect(result).to.equal('ccRequest');
   });
   it('should return appointment type as ccRequest, useFeSourceOfTruthCC=true', async () => {
@@ -52,16 +52,24 @@ describe('getAppointmentType util', () => {
       id: '123',
       type: 'COMMUNITY_CARE_REQUEST',
     };
-    const result = getAppointmentType(appointment, true);
+    const result = getAppointmentType(appointment, true, false);
     expect(result).to.equal('ccRequest');
   });
-  it('should return appointment type as vaAppointment', async () => {
+  it('should return appointment type as vaAppointment, useFeSourceOfTruthVA=false', async () => {
     const appointment = {
       id: '123',
       kind: 'clinic',
       start: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment, false);
+    const result = getAppointmentType(appointment, false, false);
+    expect(result).to.equal('vaAppointment');
+  });
+  it('should return appointment type as vaAppointment, useFeSourceOfTruthVA=true', async () => {
+    const appointment = {
+      id: '123',
+      type: 'VA',
+    };
+    const result = getAppointmentType(appointment, false, true);
     expect(result).to.equal('vaAppointment');
   });
 });

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -105,6 +105,7 @@ const responses = {
           patientComments = token.substring('comments:'.length);
         }
       }
+      type = pending ? 'REQUEST' : 'VA';
     }
 
     const submittedAppt = {

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -18,6 +18,7 @@
         "end": "2024-10-13T16:00:00Z",
         "id": "00C891va",
         "kind": "clinic",
+        "type": "VA",
         "locationId": "983",
         "minutesDuration": 30,
         "patientIcn": null,
@@ -56,6 +57,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "outpatientMentalHealth",
         "serviceCategory": [
@@ -87,7 +89,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["CHECKED OUT"],
+          "vistaStatus": [
+            "CHECKED OUT"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": true
         },
@@ -122,7 +126,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -172,6 +178,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceCategory": [
           {
@@ -202,7 +209,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["CHECKED OUT"],
+          "vistaStatus": [
+            "CHECKED OUT"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": true
         },
@@ -237,7 +246,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -287,6 +298,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceCategory": [
           {
@@ -317,7 +329,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["CHECKED OUT"],
+          "vistaStatus": [
+            "CHECKED OUT"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": true
         },
@@ -351,7 +365,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -401,6 +417,7 @@
           }
         ],
         "kind": "phone",
+        "type": "VA",
         "status": "booked",
         "serviceType": "primaryCare",
         "serviceTypes": [
@@ -442,7 +459,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["ACT REQ/CHECKED OUT"],
+          "vistaStatus": [
+            "ACT REQ/CHECKED OUT"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {}
@@ -479,7 +498,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -532,6 +553,7 @@
         "end": "2022-11-09T20:30:00Z",
         "id": "04aa456vvs",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "minutesDuration": 30,
         "patientIcn": null,
@@ -546,7 +568,9 @@
             ],
             "name": {
               "family": "Smith",
-              "given": ["Megan"]
+              "given": [
+                "Megan"
+              ]
             },
             "practiceName": null
           },
@@ -559,7 +583,9 @@
             ],
             "name": {
               "family": "Dali",
-              "given": ["Salvador"]
+              "given": [
+                "Salvador"
+              ]
             },
             "practiceName": null
           }
@@ -606,6 +632,7 @@
         "end": "2022-12-27T18:19:34",
         "id": "10aa456vvs",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "localStartTime": "2023-11-22T18:00:00.000-06:00",
         "minutesDuration": 30,
@@ -620,7 +647,9 @@
             ],
             "name": {
               "family": "Nightingale",
-              "given": ["Florence"]
+              "given": [
+                "Florence"
+              ]
             }
           }
         ],
@@ -660,6 +689,7 @@
         "end": "2023-12-21T18:19:34",
         "id": "00C893va",
         "kind": "clinic",
+        "type": "VA",
         "locationId": "983",
         "minutesDuration": 30,
         "patientIcn": null,
@@ -693,6 +723,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "booked",
         "serviceType": "outpatientMentalHealth",
         "patientIcn": "1012845331V153043",
@@ -708,7 +739,9 @@
             ],
             "name": {
               "family": "NADEAU",
-              "given": ["MARCY"]
+              "given": [
+                "MARCY"
+              ]
             },
             "practiceName": "Dayton OH VAMC"
           }
@@ -767,7 +800,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -815,6 +850,7 @@
         "end": "2024-06-08T17:30:00Z",
         "id": "09aa456vvs",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "localStartTime": "2024-06-08T17:00:00.000-06:00",
         "minutesDuration": 30,
@@ -830,7 +866,9 @@
             ],
             "name": {
               "family": "Jones",
-              "given": ["Peter"]
+              "given": [
+                "Peter"
+              ]
             }
           }
         ],
@@ -863,6 +901,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceTypes": [
           {
@@ -881,7 +920,10 @@
           {
             "name": {
               "family": "Everett",
-              "given": ["CERNER", "DO"]
+              "given": [
+                "CERNER",
+                "DO"
+              ]
             }
           }
         ],
@@ -927,11 +969,19 @@
             },
             "mailingAddress": {
               "type": "postal",
-              "line": [null, null, null]
+              "line": [
+                null,
+                null,
+                null
+              ]
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["420 North James Road", null, null],
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
               "city": "Columbus",
               "state": "OH",
               "postalCode": "43219-1834"
@@ -978,6 +1028,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "booked",
         "serviceType": "outpatientMentalHealth",
         "serviceTypes": [
@@ -1015,7 +1066,9 @@
             ],
             "name": {
               "family": "ZZZPPP",
-              "given": ["LLL"]
+              "given": [
+                "LLL"
+              ]
             }
           }
         ],
@@ -1033,7 +1086,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"],
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {
@@ -1069,7 +1124,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4337 North Union Road"],
+              "line": [
+                "4337 North Union Road"
+              ],
               "city": "Middletown",
               "state": "OH",
               "postalCode": "45005-5211"
@@ -1114,7 +1171,9 @@
           {
             "name": {
               "family": "BERMEL",
-              "given": ["MICHAEL"]
+              "given": [
+                "MICHAEL"
+              ]
             }
           }
         ],
@@ -1126,7 +1185,9 @@
         "extension": {
           "ccLocation": {
             "address": {
-              "line": ["10640 MAIN ST ; STE 100"],
+              "line": [
+                "10640 MAIN ST ; STE 100"
+              ],
               "city": "FAIRFAX",
               "state": "VA",
               "postalCode": "22030",
@@ -1164,7 +1225,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -1215,7 +1278,9 @@
         "description": "Podiatry DS SEOC 1.0.8 PRCT",
         "patientIcn": "1013124304V115761",
         "locationId": "984",
-        "practitioners": [{}],
+        "practitioners": [
+          {}
+        ],
         "start": "2024-08-22T12:00:00Z",
         "created": "2024-08-22T20:33:54Z",
         "localStartTime": "2024-08-21T09:00:00.000-06:00",
@@ -1224,7 +1289,9 @@
         "extension": {
           "ccLocation": {
             "address": {
-              "line": ["1323 W 3RD ST"],
+              "line": [
+                "1323 W 3RD ST"
+              ],
               "city": "DAYTON",
               "state": "OH",
               "postalCode": "45402",
@@ -1262,7 +1329,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -1310,6 +1379,7 @@
         "end": "2024-08-22T14:00:00Z",
         "id": "05aa456vvc",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "localStartTime": "2024-08-22T09:00:00.000-06:00",
         "physicalLocation": "PHYSICAL LOCATION TESTING",
@@ -1353,6 +1423,7 @@
         "end": "2024-08-22T15:00:00Z",
         "id": "05aa456vvd",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "localStartTime": "2024-08-22T10:00:00.000-06:00",
         "physicalLocation": "PHYSICAL LOCATION TESTING",
@@ -1389,6 +1460,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "audiology",
         "serviceTypes": [
@@ -1425,7 +1497,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"]
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ]
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
@@ -1450,7 +1524,9 @@
               "main": "970-224-1550"
             },
             "physicalAddress": {
-              "line": ["2509 Research Boulevard"],
+              "line": [
+                "2509 Research Boulevard"
+              ],
               "city": "Fort Collins",
               "state": "CO",
               "postalCode": "80526-8108"
@@ -1480,6 +1556,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "audiology",
         "serviceTypes": [
@@ -1516,7 +1593,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"]
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ]
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
@@ -1541,7 +1620,9 @@
               "main": "970-224-1550"
             },
             "physicalAddress": {
-              "line": ["2509 Research Boulevard"],
+              "line": [
+                "2509 Research Boulevard"
+              ],
               "city": "Fort Collins",
               "state": "CO",
               "postalCode": "80526-8108"
@@ -1571,6 +1652,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "audiology",
         "serviceTypes": [
@@ -1607,7 +1689,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"]
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ]
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
@@ -1632,7 +1716,9 @@
               "main": "970-224-1550"
             },
             "physicalAddress": {
-              "line": ["2509 Research Boulevard"],
+              "line": [
+                "2509 Research Boulevard"
+              ],
               "city": "Fort Collins",
               "state": "CO",
               "postalCode": "80526-8108"
@@ -1662,6 +1748,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "cancelled",
         "serviceType": "audiology",
         "serviceTypes": [
@@ -1698,7 +1785,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"]
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ]
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
@@ -1723,7 +1812,9 @@
               "main": "970-224-1550"
             },
             "physicalAddress": {
-              "line": ["2509 Research Boulevard"],
+              "line": [
+                "2509 Research Boulevard"
+              ],
               "city": "Fort Collins",
               "state": "CO",
               "postalCode": "80526-8108"
@@ -1760,6 +1851,7 @@
         "end": "2024-09-23T20:00:00Z",
         "id": "02aa456vvs",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "localStartTime": "2024-09-22T09:00:00.000-06:00",
         "minutesDuration": 30,
@@ -1775,7 +1867,9 @@
             ],
             "name": {
               "family": "Normal",
-              "given": ["Abbey"]
+              "given": [
+                "Abbey"
+              ]
             }
           }
         ],
@@ -1827,6 +1921,7 @@
         "end": "2024-09-23T21:00:00Z",
         "id": "02aa456vvt",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "localStartTime": "2024-09-22T10:00:00.000-06:00",
         "minutesDuration": 30,
@@ -1842,7 +1937,9 @@
             ],
             "name": {
               "family": "Normal",
-              "given": ["Abbey"]
+              "given": [
+                "Abbey"
+              ]
             }
           }
         ],
@@ -1902,7 +1999,9 @@
         "extension": {
           "ccLocation": {
             "address": {
-              "line": ["1 E NATIONAL RD ; STE 300"],
+              "line": [
+                "1 E NATIONAL RD ; STE 300"
+              ],
               "city": "VANDALIA",
               "state": "OH",
               "postalCode": "45377",
@@ -1934,7 +2033,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -1990,7 +2091,9 @@
         "extension": {
           "ccLocation": {
             "address": {
-              "line": ["1 E NATIONAL RD ; STE 300"],
+              "line": [
+                "1 E NATIONAL RD ; STE 300"
+              ],
               "city": "VANDALIA",
               "state": "OH",
               "postalCode": "45377",
@@ -2022,7 +2125,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -2057,6 +2162,7 @@
       "attributes": {
         "id": "CERN53943037",
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "reasonCode": {
           "coding": [],
@@ -2077,7 +2183,9 @@
         "station": null,
         "ien": null,
         "avsPath": null,
-        "preferredDates": ["Wed, August 21, 2024 in the afternoon"],
+        "preferredDates": [
+          "Wed, August 21, 2024 in the afternoon"
+        ],
         "location": {
           "id": "668",
           "type": "appointments",
@@ -2143,7 +2251,11 @@
             ],
             "physicalAddress": {
               "type": "physical",
-              "line": ["4815 North Assembly Street", null, null],
+              "line": [
+                "4815 North Assembly Street",
+                null,
+                null
+              ],
               "city": "Spokane",
               "state": "WA",
               "postalCode": "99205-6185"
@@ -2239,6 +2351,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "covid",
         "serviceTypes": [
@@ -2276,7 +2389,9 @@
             ],
             "name": {
               "family": "BERNARDO",
-              "given": ["KENNETH J"]
+              "given": [
+                "KENNETH J"
+              ]
             }
           }
         ],
@@ -2294,7 +2409,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["FUTURE"],
+          "vistaStatus": [
+            "FUTURE"
+          ],
           "preCheckinAllowed": true,
           "eCheckinAllowed": true,
           "clinic": {
@@ -2332,7 +2449,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -2378,6 +2497,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "booked",
         "patientIcn": "1013124304V115761",
         "locationId": "983",
@@ -2391,7 +2511,9 @@
             ],
             "name": {
               "family": "Poldass",
-              "given": ["Aarathi"]
+              "given": [
+                "Aarathi"
+              ]
             },
             "practiceName": "Cheyenne VA Medical Center"
           }
@@ -2457,7 +2579,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -2507,6 +2631,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "cancelled",
         "serviceType": "covid",
         "serviceTypes": [
@@ -2544,7 +2669,9 @@
             ],
             "name": {
               "family": "BERNARDO",
-              "given": ["KENNETH J"]
+              "given": [
+                "KENNETH J"
+              ]
             }
           }
         ],
@@ -2562,7 +2689,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["FUTURE"],
+          "vistaStatus": [
+            "FUTURE"
+          ],
           "preCheckinAllowed": true,
           "eCheckinAllowed": true,
           "clinic": {
@@ -2600,7 +2729,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -2650,6 +2781,7 @@
           }
         ],
         "kind": "phone",
+        "type": "VA",
         "status": "booked",
         "serviceCategory": [
           {
@@ -2681,7 +2813,9 @@
             ],
             "name": {
               "family": "ISS",
-              "given": ["PROVIDERONE"]
+              "given": [
+                "PROVIDERONE"
+              ]
             }
           }
         ],
@@ -2699,7 +2833,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"],
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {
@@ -2733,7 +2869,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -2776,6 +2914,7 @@
           }
         ],
         "kind": "phone",
+        "type": "VA",
         "status": "cancelled",
         "serviceCategory": [
           {
@@ -2802,7 +2941,9 @@
             ],
             "name": {
               "family": "ISS",
-              "given": ["PROVIDERONE"]
+              "given": [
+                "PROVIDERONE"
+              ]
             }
           }
         ],
@@ -2820,7 +2961,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"],
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {
@@ -2854,7 +2997,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -2893,6 +3038,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "booked",
         "patientIcn": "1012846043V576341",
         "locationId": "983",
@@ -2906,7 +3052,9 @@
             ],
             "name": {
               "family": "Chapman",
-              "given": ["Jeremy"]
+              "given": [
+                "Jeremy"
+              ]
             },
             "practiceName": "Cheyenne VA Medical Center"
           }
@@ -2957,7 +3105,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -3007,6 +3157,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "audiology",
         "serviceTypes": [
@@ -3048,7 +3199,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["FUTURE"],
+          "vistaStatus": [
+            "FUTURE"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {
@@ -3079,7 +3232,9 @@
               "main": "970-224-1550"
             },
             "physicalAddress": {
-              "line": ["2509 Research Boulevard"],
+              "line": [
+                "2509 Research Boulevard"
+              ],
               "city": "Fort Collins",
               "state": "CO",
               "postalCode": "80526-8108"
@@ -3109,6 +3264,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceTypes": [
           {
@@ -3132,7 +3288,10 @@
           {
             "name": {
               "family": "Everett",
-              "given": ["CERNER", "DO"]
+              "given": [
+                "CERNER",
+                "DO"
+              ]
             }
           }
         ],
@@ -3214,7 +3373,11 @@
             ],
             "physicalAddress": {
               "type": "physical",
-              "line": ["420 North James Road", null, null],
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
               "city": "Columbus",
               "state": "OH",
               "postalCode": "43219-1834"
@@ -3294,6 +3457,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceTypes": [
           {
@@ -3317,7 +3481,9 @@
           {
             "name": {
               "family": "Bones",
-              "given": ["Dr."]
+              "given": [
+                "Dr."
+              ]
             }
           }
         ],
@@ -3399,7 +3565,11 @@
             ],
             "physicalAddress": {
               "type": "physical",
-              "line": ["420 North James Road", null, null],
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
               "city": "Columbus",
               "state": "OH",
               "postalCode": "43219-1834"
@@ -3486,6 +3656,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceTypes": [
           {
@@ -3509,7 +3680,9 @@
           {
             "name": {
               "family": "Bones",
-              "given": ["Dr."]
+              "given": [
+                "Dr."
+              ]
             }
           }
         ],
@@ -3591,7 +3764,11 @@
             ],
             "physicalAddress": {
               "type": "physical",
-              "line": ["420 North James Road", null, null],
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
               "city": "Columbus",
               "state": "OH",
               "postalCode": "43219-1834"
@@ -3687,6 +3864,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "cancelled",
         "serviceTypes": [
           {
@@ -3705,7 +3883,10 @@
           {
             "name": {
               "family": "Everett",
-              "given": ["CERNER", "DO"]
+              "given": [
+                "CERNER",
+                "DO"
+              ]
             }
           }
         ],
@@ -3787,7 +3968,11 @@
             ],
             "physicalAddress": {
               "type": "physical",
-              "line": ["420 North James Road", null, null],
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
               "city": "Columbus",
               "state": "OH",
               "postalCode": "43219-1834"
@@ -3871,6 +4056,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "booked",
         "serviceType": "foodAndNutrition",
         "serviceTypes": [
@@ -3915,7 +4101,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["FUTURE"],
+          "vistaStatus": [
+            "FUTURE"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {
@@ -3951,7 +4139,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street"],
+              "line": [
+                "4100 West Third Street"
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -3977,7 +4167,6 @@
             "ehrSystem": "VistA"
           }
         },
-        "type": "VA",
         "modality": "vaInPerson",
         "past": false,
         "future": true,
@@ -4010,6 +4199,7 @@
         "end": "2025-01-13T20:00:00Z",
         "id": "03aa456vvs",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "minutesDuration": 30,
         "patientIcn": null,
@@ -4024,7 +4214,9 @@
             ],
             "name": {
               "family": "Smith",
-              "given": ["Meg"]
+              "given": [
+                "Meg"
+              ]
             }
           }
         ],
@@ -4082,6 +4274,7 @@
         "end": "2025-01-13T21:00:00Z",
         "id": "03aa456vvt",
         "kind": "telehealth",
+        "type": "VA",
         "locationId": "983",
         "minutesDuration": 30,
         "patientIcn": null,
@@ -4096,7 +4289,9 @@
             ],
             "name": {
               "family": "Smith",
-              "given": ["Meg"]
+              "given": [
+                "Meg"
+              ]
             }
           }
         ],
@@ -4155,6 +4350,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "booked",
         "serviceType": "outpatientMentalHealth",
         "serviceTypes": [
@@ -4192,7 +4388,9 @@
             ],
             "name": {
               "family": "ALSAHHAR",
-              "given": ["SAMI"]
+              "given": [
+                "SAMI"
+              ]
             }
           }
         ],
@@ -4215,7 +4413,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"],
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
           "patientHasMobileGfe": true,
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
@@ -4246,7 +4446,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4337 North Union Road"],
+              "line": [
+                "4337 North Union Road"
+              ],
               "city": "Middletown",
               "state": "OH",
               "postalCode": "45005-5211"
@@ -4285,6 +4487,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "cancelled",
         "serviceType": "outpatientMentalHealth",
         "serviceTypes": [
@@ -4322,7 +4525,9 @@
             ],
             "name": {
               "family": "ALSAHHAR",
-              "given": ["SAMI"]
+              "given": [
+                "SAMI"
+              ]
             }
           }
         ],
@@ -4345,7 +4550,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["NO ACTION TAKEN"],
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
           "patientHasMobileGfe": true,
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
@@ -4376,7 +4583,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["4337 North Union Road"],
+              "line": [
+                "4337 North Union Road"
+              ],
               "city": "Middletown",
               "state": "OH",
               "postalCode": "45005-5211"
@@ -4426,7 +4635,9 @@
           {
             "name": {
               "family": "HEALTH CARE PROFS",
-              "given": ["A & D"]
+              "given": [
+                "A & D"
+              ]
             }
           }
         ],
@@ -4436,7 +4647,9 @@
         "extension": {
           "ccLocation": {
             "address": {
-              "line": ["1601 NEEDMORE RD ; STE 1 &amp; 2"],
+              "line": [
+                "1601 NEEDMORE RD ; STE 1 &amp; 2"
+              ],
               "city": "DAYTON",
               "state": "OH",
               "postalCode": "45414",
@@ -4520,7 +4733,11 @@
             ],
             "physicalAddress": {
               "type": "physical",
-              "line": ["4100 West Third Street", null, null],
+              "line": [
+                "4100 West Third Street",
+                null,
+                null
+              ],
               "city": "Dayton",
               "state": "OH",
               "postalCode": "45428-9000"
@@ -4622,6 +4839,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "optometry",
         "serviceTypes": [
@@ -4668,7 +4886,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["FUTURE"],
+          "vistaStatus": [
+            "FUTURE"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {}
@@ -4703,7 +4923,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -4760,6 +4982,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "optometry",
         "serviceTypes": [
@@ -4806,7 +5029,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["FUTURE"],
+          "vistaStatus": [
+            "FUTURE"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {}
@@ -4841,7 +5066,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -4898,6 +5125,7 @@
           }
         ],
         "kind": "clinic",
+        "type": "VA",
         "status": "booked",
         "serviceType": "optometry",
         "serviceTypes": [
@@ -4944,7 +5172,9 @@
           "ccLocation": {
             "address": {}
           },
-          "vistaStatus": ["FUTURE"],
+          "vistaStatus": [
+            "FUTURE"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {}
@@ -4979,7 +5209,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"
@@ -5041,6 +5273,7 @@
           }
         ],
         "kind": "telehealth",
+        "type": "VA",
         "status": "booked",
         "patientIcn": "1013124304V115761",
         "locationId": "983",
@@ -5054,7 +5287,9 @@
             ],
             "name": {
               "family": "NADEAU",
-              "given": ["MARCY"]
+              "given": [
+                "MARCY"
+              ]
             },
             "practiceName": "Cheyenne VA Medical Center"
           }
@@ -5105,7 +5340,9 @@
             },
             "physicalAddress": {
               "type": "physical",
-              "line": ["2360 East Pershing Boulevard"],
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
               "city": "Cheyenne",
               "state": "WY",
               "postalCode": "82001-5356"

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -250,6 +250,7 @@ function logEligibilityExplanation(
  * @param {boolean} [params.featureClinicFilter=false] feature flag to filter clinics based on VATS
  * @param {boolean} [params.useFeSourceOfTruth=false] whether to use vets-api payload as the FE source of truth
  * @param {boolean} [params.useFeSourceOfTruthCC=false] whether to use vets-api payload as the FE source of truth for CC appointments and requests
+ * @param {boolean} [params.useFeSourceOfTruthVA=false] whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {FlowEligibilityReturnData} Eligibility results, plus clinics and past appointments
  *   so that they can be cache and reused later
  */
@@ -261,6 +262,7 @@ export async function fetchFlowEligibilityAndClinics({
   featureClinicFilter = false,
   useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
+  useFeSourceOfTruthVA = false,
   isCerner = false,
 }) {
   const directSchedulingAvailable =
@@ -296,6 +298,7 @@ export async function fetchFlowEligibilityAndClinics({
       apiCalls.pastAppointments = getLongTermAppointmentHistoryV2(
         useFeSourceOfTruth,
         useFeSourceOfTruthCC,
+        useFeSourceOfTruthVA,
       ).catch(createErrorHandler('direct-no-matching-past-clinics-error'));
     }
   }

--- a/src/applications/vaos/tests/mocks/fetch.js
+++ b/src/applications/vaos/tests/mocks/fetch.js
@@ -114,6 +114,7 @@ export function mockEligibilityFetches({
       ...appt,
       attributes: {
         ...appt.attributes,
+        type: 'VA',
         clinic: clinic.id,
         locationId: facilityId.substr(0, 3),
       },

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -26,7 +26,7 @@ module.exports = [
   { name: 'vaosOnlineSchedulingUseVADate', value: true },
   { name: 'vaOnlineSchedulingPastApptDateRange', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruth', value: true },
-  { name: 'vaOnlineSchedulingFeSourceOfTruthVA', value: false },
+  { name: 'vaOnlineSchedulingFeSourceOfTruthVA', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthCC', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthModality', value: false },
   { name: 'vaOnlineSchedulingFeSourceOfTruthTelehealth', value: false },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated FE to use data from vets-api as source of truth for VA appointments (via the `type` field)
- Appointments tool team
- This is behind the [`va_online_scheduling_fe_source_of_truth_va`](https://dev-api.va.gov/flipper/features/va_online_scheduling_fe_source_of_truth_va) feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103760

## Testing done

- Tested locally, see screenshot. No changes are observed since this is a data layer level change without any UI difference
- Updated unit and e2e tests

## Screenshots

|         | Before | After (toggle on) | After (toggle off) |
| ------- | ------ | ----- | ----- |
| va appointments | ![image](https://github.com/user-attachments/assets/c90338eb-077c-4512-9140-ead9651c755a)  |  ![image](https://github.com/user-attachments/assets/d158b3e8-83b2-421d-8b98-3d83d5874bb0)  |  ![image](https://github.com/user-attachments/assets/99452d42-6661-4519-a712-a08369c5221e)  |

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
