### PR TITLE
Travel Pay / BUG /claim details action

### DIFF
--- a/src/applications/travel-pay/redux/actions.js
+++ b/src/applications/travel-pay/redux/actions.js
@@ -61,7 +61,7 @@ export function getClaimDetails(id) {
       const claimsUrl = `${environment.API_URL}/travel_pay/v0/claims/${id}`;
       const response = await apiRequest(claimsUrl);
 
-      dispatch(fetchClaimDetailsSuccess(id, response.data));
+      dispatch(fetchClaimDetailsSuccess(id, response));
     } catch (error) {
       dispatch(fetchClaimDetailsFailure(error));
     }

--- a/src/applications/travel-pay/services/mocks/travel-claim-details-v1.json
+++ b/src/applications/travel-pay/services/mocks/travel-claim-details-v1.json
@@ -1,50 +1,48 @@
 {
-  "data": {
-    "claimId": "73611905-71bf-46ed-b1ec-e790593b8565",
-    "claimNumber": "TC0000000000001",
-    "claimantFirstName": "Nolle",
-    "claimantMiddleName": "Polite",
-    "claimantLastName": "Barakat",
-    "claimStatus": "Pre approved for payment",
+  "claimId": "73611905-71bf-46ed-b1ec-e790593b8565",
+  "claimNumber": "TC0000000000001",
+  "claimantFirstName": "Nolle",
+  "claimantMiddleName": "Polite",
+  "claimantLastName": "Barakat",
+  "claimStatus": "Pre approved for payment",
+  "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+  "facilityName": "Cheyenne VA Medical Center",
+  "totalCostRequested": 20.0,
+  "reimbursementAmount": 14.52,
+  "createdOn": "2025-03-12T20:27:14.088Z",
+  "modifiedOn": "2025-03-12T20:27:14.088Z",
+  "appointment": {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "appointmentSource": "API",
     "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+    "appointmentType": "EnvironmentalHealth",
+    "facilityId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "facilityName": "Cheyenne VA Medical Center",
-    "totalCostRequested": 20.0,
-    "reimbursementAmount": 14.52,
-    "createdOn": "2025-03-12T20:27:14.088Z",
-    "modifiedOn": "2025-03-12T20:27:14.088Z",
-    "appointment": {
+    "serviceConnectedDisability": 30,
+    "appointmentStatus": "Complete",
+    "externalAppointmentId": "12345",
+    "associatedClaimId": "73611905-71bf-46ed-b1ec-e790593b8565",
+    "associatedClaimNumber": "TC0000000000001",
+    "isCompleted": true
+  },
+  "expenses": [
+    {
       "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      "appointmentSource": "API",
-      "appointmentDateTime": "2024-01-01T16:45:34.465Z",
-      "appointmentType": "EnvironmentalHealth",
-      "facilityId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      "facilityName": "Cheyenne VA Medical Center",
-      "serviceConnectedDisability": 30,
-      "appointmentStatus": "Complete",
-      "externalAppointmentId": "12345",
-      "associatedClaimId": "73611905-71bf-46ed-b1ec-e790593b8565",
-      "associatedClaimNumber": "TC0000000000001",
-      "isCompleted": true
+      "expenseType": "Mileage",
+      "name": "",
+      "dateIncurred": "2024-01-01T16:45:34.465Z",
+      "description": "mileage-expense",
+      "costRequested": 10.0,
+      "costSubmitted": 10.0
     },
-    "expenses": [
-      {
-        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        "expenseType": "Mileage",
-        "name": "",
-        "dateIncurred": "2024-01-01T16:45:34.465Z",
-        "description": "mileage-expense",
-        "costRequested": 10.0,
-        "costSubmitted": 10.0
-      },
-      {
-        "id": "4da85f64-5717-4562-b3fc-2c963f66afa6",
-        "expenseType": "Mileage",
-        "name": "",
-        "dateIncurred": "2024-01-01T16:45:34.465Z",
-        "description": "mileage-expense",
-        "costRequested": 10.0,
-        "costSubmitted": 10.0
-      }
-    ]
-  }
+    {
+      "id": "4da85f64-5717-4562-b3fc-2c963f66afa6",
+      "expenseType": "Mileage",
+      "name": "",
+      "dateIncurred": "2024-01-01T16:45:34.465Z",
+      "description": "mileage-expense",
+      "costRequested": 10.0,
+      "costSubmitted": 10.0
+    }
+  ]
 }

--- a/src/applications/travel-pay/services/mocks/travel-claim-details-v2.json
+++ b/src/applications/travel-pay/services/mocks/travel-claim-details-v2.json
@@ -1,56 +1,54 @@
 {
-  "data": {
-    "claimId": "73611905-71bf-46ed-b1ec-e790593b8565",
-    "claimNumber": "TC0000000000001",
-    "claimantFirstName": "Nolle",
-    "claimantMiddleName": "Polite",
-    "claimantLastName": "Barakat",
-    "claimStatus": "Pre approved for payment",
+  "claimId": "73611905-71bf-46ed-b1ec-e790593b8565",
+  "claimNumber": "TC0000000000001",
+  "claimantFirstName": "Nolle",
+  "claimantMiddleName": "Polite",
+  "claimantLastName": "Barakat",
+  "claimStatus": "Pre approved for payment",
+  "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+  "facilityName": "Cheyenne VA Medical Center",
+  "totalCostRequested": 20.0,
+  "reimbursementAmount": 14.52,
+  "createdOn": "2025-03-12T20:27:14.088Z",
+  "modifiedOn": "2025-03-12T20:27:14.088Z",
+  "appointment": {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "appointmentSource": "API",
     "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+    "appointmentType": "EnvironmentalHealth",
+    "facilityId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "facilityName": "Cheyenne VA Medical Center",
-    "totalCostRequested": 20.0,
-    "reimbursementAmount": 14.52,
-    "createdOn": "2025-03-12T20:27:14.088Z",
-    "modifiedOn": "2025-03-12T20:27:14.088Z",
-    "appointment": {
+    "serviceConnectedDisability": 30,
+    "appointmentStatus": "Complete",
+    "externalAppointmentId": "12345",
+    "associatedClaimId": "73611905-71bf-46ed-b1ec-e790593b8565",
+    "associatedClaimNumber": "TC0000000000001",
+    "isCompleted": true
+  },
+  "expenses": [
+    {
       "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      "appointmentSource": "API",
-      "appointmentDateTime": "2024-01-01T16:45:34.465Z",
-      "appointmentType": "EnvironmentalHealth",
-      "facilityId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      "facilityName": "Cheyenne VA Medical Center",
-      "serviceConnectedDisability": 30,
-      "appointmentStatus": "Complete",
-      "externalAppointmentId": "12345",
-      "associatedClaimId": "73611905-71bf-46ed-b1ec-e790593b8565",
-      "associatedClaimNumber": "TC0000000000001",
-      "isCompleted": true
+      "expenseType": "Mileage",
+      "name": "",
+      "dateIncurred": "2024-01-01T16:45:34.465Z",
+      "description": "mileage-expense",
+      "costRequested": 20.0,
+      "costSubmitted": 20.0
     },
-    "expenses": [
-      {
-        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        "expenseType": "Mileage",
-        "name": "",
-        "dateIncurred": "2024-01-01T16:45:34.465Z",
-        "description": "mileage-expense",
-        "costRequested": 20.0,
-        "costSubmitted": 20.0
-      },
-      {
-        "id": "4da85f64-5717-4562-b3fc-2c963f66afa6",
-        "expenseType": "Mileage",
-        "name": "",
-        "dateIncurred": "2024-01-01T16:45:34.465Z",
-        "description": "mileage-expense",
-        "costRequested": 10.0,
-        "costSubmitted": 10.0
-      }
-    ],
-    "rejectionReason": {
-      "rejectionReasonId": "12345",
-      "rejectionReasonName": "Because",
-      "rejectionReasonTitle": "Just because",
-      "rejectionReasonDescription": "Because I said so"
+    {
+      "id": "4da85f64-5717-4562-b3fc-2c963f66afa6",
+      "expenseType": "Mileage",
+      "name": "",
+      "dateIncurred": "2024-01-01T16:45:34.465Z",
+      "description": "mileage-expense",
+      "costRequested": 10.0,
+      "costSubmitted": 10.0
     }
+  ],
+  "rejectionReason": {
+    "rejectionReasonId": "12345",
+    "rejectionReasonName": "Because",
+    "rejectionReasonTitle": "Just because",
+    "rejectionReasonDescription": "Because I said so"
   }
 }

--- a/src/applications/travel-pay/tests/fixtures/travel-claim-details-v1.json
+++ b/src/applications/travel-pay/tests/fixtures/travel-claim-details-v1.json
@@ -1,41 +1,39 @@
 {
-  "data": {
-    "claimId": "73611905-71bf-46ed-b1ec-e790593b8565",
-    "claimNumber": "TC0000000000001",
-    "claimantFirstName": "Nolle",
-    "claimantMiddleName": "Polite",
-    "claimantLastName": "Barakat",
-    "claimStatus": "Pre approved for payment",
+  "claimId": "73611905-71bf-46ed-b1ec-e790593b8565",
+  "claimNumber": "TC0000000000001",
+  "claimantFirstName": "Nolle",
+  "claimantMiddleName": "Polite",
+  "claimantLastName": "Barakat",
+  "claimStatus": "Pre approved for payment",
+  "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+  "facilityName": "Cheyenne VA Medical Center",
+  "totalCostRequested": 20.0,
+  "reimbursementAmount": 14.52,
+  "createdOn": "2025-03-12T20:27:14.088Z",
+  "modifiedOn": "2025-03-12T20:27:14.088Z",
+  "appointment": {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "appointmentSource": "API",
     "appointmentDateTime": "2024-01-01T16:45:34.465Z",
+    "appointmentType": "EnvironmentalHealth",
+    "facilityId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "facilityName": "Cheyenne VA Medical Center",
-    "totalCostRequested": 20.0,
-    "reimbursementAmount": 14.52,
-    "createdOn": "2025-03-12T20:27:14.088Z",
-    "modifiedOn": "2025-03-12T20:27:14.088Z",
-    "appointment": {
+    "serviceConnectedDisability": 30,
+    "appointmentStatus": "Complete",
+    "externalAppointmentId": "12345",
+    "associatedClaimId": "73611905-71bf-46ed-b1ec-e790593b8565",
+    "associatedClaimNumber": "TC0000000000001",
+    "isCompleted": true
+  },
+  "expenses": [
+    {
       "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      "appointmentSource": "API",
-      "appointmentDateTime": "2024-01-01T16:45:34.465Z",
-      "appointmentType": "EnvironmentalHealth",
-      "facilityId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      "facilityName": "Cheyenne VA Medical Center",
-      "serviceConnectedDisability": 30,
-      "appointmentStatus": "Complete",
-      "externalAppointmentId": "12345",
-      "associatedClaimId": "73611905-71bf-46ed-b1ec-e790593b8565",
-      "associatedClaimNumber": "TC0000000000001",
-      "isCompleted": true
-    },
-    "expenses": [
-      {
-        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        "expenseType": "Mileage",
-        "name": "",
-        "dateIncurred": "2024-01-01T16:45:34.465Z",
-        "description": "mileage-expense",
-        "costRequested": 20.0,
-        "costSubmitted": 20.0
-      }
-    ]
-  }
+      "expenseType": "Mileage",
+      "name": "",
+      "dateIncurred": "2024-01-01T16:45:34.465Z",
+      "description": "mileage-expense",
+      "costRequested": 20.0,
+      "costSubmitted": 20.0
+    }
+  ]
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Initial `claimDetails` redux action was looking for response.data, however the claim details object is a top-level object without the `data` property, so this removes it from the dispatch.
- _(If bug, how to reproduce)_
  - On staging, visit the claim summary list page, and click on a "details" link, it will reload in a loop because the action is not setting the data property correctly so it keeps making the API call due to it not being present.
- _(What is the solution, why is this the solution)_
  - This removes the extraneous `data` property and stores just the top level object in redux.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- Travel Pay
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- Phased rollout to begin June 2025.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[#104860](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104860)
- _Link to previous change of the code/bug (if applicable)_
#35299 
- _Link to epic if not included in ticket_
[#104845](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104845)

## Testing done

- _Describe what the old behavior was prior to the change_
- Looping loading
- _Describe the steps required to verify your changes are working as expected_
- Once merged it should set the redux store data properly (using redux devtools you can see the `claimDetails` object with a property of the claim ID with the full claim details object as the value)
- _Describe the tests completed and the results_
- updated and ran all unit tests
- removed the `data` object from the mock data as well

## Screenshots
Data adjustments only


## What areas of the site does it impact?

Travel Pay

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

