### PR TITLE
Fix alert header level on debt letters summary page

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -56,9 +56,9 @@ const renderOtherVA = (mcpLength, mcpError) => {
       <>
         <h2>Your VA copay bills</h2>
         <va-alert data-testid={alertInfo.testID} status={alertInfo.alertStatus}>
-          <h4 slot="headline" className="vads-u-font-size--h3">
+          <h3 slot="headline" className="vads-u-font-size--h3">
             {alertInfo.header}
-          </h4>
+          </h3>
           {alertInfo.secondBody}
         </va-alert>
       </>


### PR DESCRIPTION
## Summary
- There was an issue with heading levels on the debt letters summary page, an alert header was an h4 immediately following an h3.
- These changes have to do with the changes that will be coming as a part of [this](https://github.com/department-of-veterans-affairs/vets-website/compare/main...axe-headings) branch.
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106009#issue-2947177084

## Testing done

- Verified heading level is now correct
- Reran cypress AXE tests locally and verified that they work

## Screenshots
Before fix (Note h2 -> h4 visible in the dev tools): 
<img width="1540" alt="Screenshot 2025-03-31 at 3 21 43 PM" src="https://github.com/user-attachments/assets/40c7e219-083d-4377-a984-e0737bee0802" />

After modifying to h3
<img width="1302" alt="Screenshot 2025-03-31 at 3 20 51 PM" src="https://github.com/user-attachments/assets/187ff817-1b71-4842-8c55-a49fbf82fc37" />


## What areas of the site does it impact?

Debt letters summary page

## Acceptance criteria

-New axe checks pass on debt-alerts

### Quality Assurance & Testing

- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


