### PR TITLE
MHV-65368 Custom date range includes all conditions (GH 99389)

### DIFF
--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
@@ -241,7 +241,7 @@ const DownloadFileType = props => {
               : null,
           conditions:
             conditions && recordFilter?.includes('conditions')
-              ? conditions
+              ? conditions.filter(rec => filterByDate(rec.date))
               : null,
           vitals:
             vitals && recordFilter?.includes('vitals')


### PR DESCRIPTION
## Summary

- Updated records filter for Health Conditions. 
  - I added a filter method to the conditions within the record data memo. 
- The bug was a lack of some logic that I think was meant to be there.
- I added a object.filter(() => blah blah) method to the conditions within the record data memo. 
 
- MHV Medical Records.

## Related issue(s)
### [MHV-65368](https://jira.devops.va.gov/browse/MHV-65368) Custom date range includes all conditions (GH 99389)
![Screenshot 2025-03-31 at 2 54 49 PM](https://github.com/user-attachments/assets/e0885d91-3821-4e55-94ff-8cbbfcd0a70c)

## Screenshot
2021 - 2023
![Screenshot 2025-03-31 at 2 55 12 PM](https://github.com/user-attachments/assets/3bddc4a9-b4c5-49f6-b655-5e8937dfc5e6)

2020 - 2024
![Screenshot 2025-03-31 at 2 56 13 PM](https://github.com/user-attachments/assets/20b3017b-97cf-4ea7-931c-190be19e9ffb)


## Testing done

-  Tests are passing.

## What areas of the site does it impact?
MHV Medical Records
