### PR TITLE
Handle Mapbox key failure

### DIFF
--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -72,6 +72,7 @@ const FacilitiesMap = props => {
   const [isSmallDesktop, setIsSmallDesktop] = useState(
     window.innerWidth >= 1024,
   );
+  const [mapboxTokenValid, setMapboxTokenValid] = useState(true);
   const [isTablet, setIsTablet] = useState(
     window.innerWidth > 481 && window.innerWidth <= 1023,
   );
@@ -391,7 +392,44 @@ const FacilitiesMap = props => {
       ? !!props.currentQuery.serviceType
       : true);
 
+  const mapboxTokenHealth = async () => {
+    const response = await fetch(
+      `https://api.mapbox.com/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2.json?secure&access_token=${mapboxToken}`,
+      { method: 'HEAD' },
+    );
+
+    return response.ok;
+  };
+
+  useEffect(() => {
+    (async () => {
+      let tokenHealth = false;
+      try {
+        tokenHealth = await mapboxTokenHealth();
+      } catch {
+        // do nothing - prevent from escalating error
+      }
+      if (!tokenHealth) {
+        setMapboxTokenValid(false);
+      }
+    })();
+  }, []);
+
   const renderView = () => {
+    if (!mapboxTokenValid) {
+      return (
+        <div className="vads-u-margin-x--2 medium-screen:vads-u-margin-x--2 vads-u-margin-bottom--4">
+          <p>
+            <strong>Facility Locator is down for maintenance</strong>
+          </p>
+          <p>
+            We’re making some updates to Facility Locator. We’re sorry it’s not
+            working right now. Please check back soon.
+          </p>
+        </div>
+      );
+    }
+
     // This block renders the desktop and mobile view. It ensures that the desktop map
     // gets re-loaded when resizing from mobile to desktop.
     const {
@@ -877,13 +915,15 @@ const FacilitiesMap = props => {
       <h1 className="vads-u-margin-x--2 medium-screen:vads-u-margin-x--2">
         Find VA locations
       </h1>
-      <p className="vads-u-margin-x--2 medium-screen:vads-u-margin-x--2 vads-u-margin-bottom--4">
-        Find a VA location or in-network community care provider. For same-day
-        care for minor illnesses or injuries, select Urgent care for facility
-        type.
-      </p>
+      {mapboxTokenValid && (
+        <p className="vads-u-margin-x--2 medium-screen:vads-u-margin-x--2 vads-u-margin-bottom--4">
+          Find a VA location or in-network community care provider. For same-day
+          care for minor illnesses or injuries, select Urgent care for facility
+          type.
+        </p>
+      )}
       {renderView()}
-      {otherToolsLink()}
+      {mapboxTokenValid && otherToolsLink()}
     </>
   );
 };


### PR DESCRIPTION
## Summary

Handles scenario where Mapbox token is not valid.

<img width="1349" alt="Screenshot 2025-04-01 at 1 25 30 PM" src="https://github.com/user-attachments/assets/3d2c7cdd-8877-4f9f-aefd-768b8a0206bf" />

## Related issue(s)

No related ticket.

Slack discussion: https://dsva.slack.com/archives/C0FQSS30V/p1743459338671059

## Testing done

Can only be tested locally. You must remove your `MAPBOX_TOKEN` from your local `env` file so the call will error, producing this warning message instead. If you have a valid `MAPBOX_TOKEN`, you will still be able to see the Facility Locator as-is.