### PR TITLE
106478 - Add screener question - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/mocks/featureToggles.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/mocks/featureToggles.json
@@ -1,6 +1,6 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [{ "name": "form107959a", "value": true }]
+    "features": [{ "name": "form107959c", "value": true }]
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/mocks/featureToggles.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/mocks/featureToggles.json
@@ -1,6 +1,6 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [{ "name": "form107959c", "value": true }]
+    "features": [{ "name": "form107959a", "value": true }]
   }
 }

--- a/src/applications/ivc-champva/10-7959a/chapters/NotEnrolledChampvaPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/chapters/NotEnrolledChampvaPage.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import PropTypes from 'prop-types';
+import { VaLinkAction } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+// eslint-disable-next-line @department-of-veterans-affairs/no-cross-app-imports
+import champvaApplicationManifest from '../../10-10D/manifest.json';
+import { CHAMPVA_ADDRESS, CHAMPVA_FAX_NUMBER } from '../../shared/constants';
+
+export function NotEnrolledChampvaPage({ goBack }) {
+  return (
+    <>
+      {
+        titleUI(
+          'You should wait to receive the CHAMPVA benefits enrollment packet in the mail before submitting this form',
+          'If you have not applied for CHAMPVA benefits you can apply online, by mail, or by fax. Make sure to submit the required supporting documents with your application.',
+        )['ui:title']
+      }
+
+      <div>
+        <br />
+        <va-link
+          href="https://www.va.gov/family-and-caregiver-benefits/health-and-disability/champva/#supporting-documents-for-your-application"
+          text="Find out what supporting documents you need"
+        />
+
+        <h3>Option 1: Online</h3>
+        <p>You can apply online now.</p>
+        <VaLinkAction
+          href={champvaApplicationManifest.rootUrl}
+          text="Apply for CHAMPVA online"
+        />
+
+        <h3>Option 2: By mail or fax</h3>
+        <p>
+          You’ll need to fill out an application for CHAMPVA Benefits (VA Form
+          10-10d).
+        </p>
+        <va-link
+          href="https://www.va.gov/find-forms/about-form-10-10d/"
+          text="Get VA Form 10-10d to download"
+        />
+        <p>
+          Mail your completed form and supporting documents to this address:
+        </p>
+        {CHAMPVA_ADDRESS}
+        <p>
+          Or fax it to: <va-telephone contact={CHAMPVA_FAX_NUMBER} />
+        </p>
+        <va-link
+          href="https://www.va.gov/family-and-caregiver-benefits/health-and-disability/champva/"
+          text="Learn about CHAMPVA benefits"
+        />
+        <div className="vads-u-margin-top--4">
+          <va-button back onClick={goBack} full-width />
+        </div>
+      </div>
+    </>
+  );
+}
+
+NotEnrolledChampvaPage.propTypes = {
+  goBack: PropTypes.func,
+};

--- a/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
@@ -16,6 +16,7 @@ import {
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
 
 const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
 fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
@@ -52,7 +53,7 @@ export const certifierReceivedPacketSchema = {
       } CHAMPVA benefit status`;
     }),
 
-    receivedPacket: {
+    certifierReceivedPacket: {
       ...yesNoUI({
         type: 'radio',
         updateUiSchema: formData => {
@@ -69,12 +70,17 @@ export const certifierReceivedPacketSchema = {
   },
   schema: {
     type: 'object',
-    required: ['receivedPacket'],
+    required: ['certifierReceivedPacket'],
     properties: {
       titleSchema,
-      receivedPacket: yesNoSchema,
+      certifierReceivedPacket: yesNoSchema,
     },
   },
+};
+
+export const certifierNotEnrolledChampvaSchema = {
+  uiSchema: {},
+  schema: blankSchema,
 };
 
 export const certifierNameSchema = {

--- a/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/signerInformation.js
@@ -13,6 +13,8 @@ import {
   phoneSchema,
   emailUI,
   emailSchema,
+  yesNoUI,
+  yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
@@ -38,6 +40,39 @@ export const certifierRoleSchema = {
     properties: {
       titleSchema,
       certifierRole: radioSchema(['applicant', 'sponsor', 'other']),
+    },
+  },
+};
+
+export const certifierReceivedPacketSchema = {
+  uiSchema: {
+    ...titleUI(({ formData }) => {
+      return `${
+        formData?.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
+      } CHAMPVA benefit status`;
+    }),
+
+    receivedPacket: {
+      ...yesNoUI({
+        type: 'radio',
+        updateUiSchema: formData => {
+          return {
+            'ui:title': `${
+              formData?.certifierRole === 'applicant'
+                ? 'Do you'
+                : 'Does the beneficiary'
+            } receive CHAMPVA benefits now?`,
+          };
+        },
+      }),
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['receivedPacket'],
+    properties: {
+      titleSchema,
+      receivedPacket: yesNoSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -11,6 +11,7 @@ import { nameWording } from '../../shared/utilities';
 import { ApplicantAddressCopyPage } from '../../shared/components/applicantLists/ApplicantAddressPage';
 import {
   certifierRoleSchema,
+  certifierReceivedPacketSchema,
   certifierNameSchema,
   certifierAddressSchema,
   certifierContactSchema,
@@ -116,6 +117,11 @@ const formConfig = {
           // initialData: mockData.data,
           // Placeholder data so that we display "beneficiary" in title when `fnp` is used
           ...certifierRoleSchema,
+        },
+        page1a1: {
+          path: 'enrolled-champva',
+          title: 'Your CHAMPVA benefit status',
+          ...certifierReceivedPacketSchema,
         },
         page1a: {
           path: 'signer-info',

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -12,11 +12,13 @@ import { ApplicantAddressCopyPage } from '../../shared/components/applicantLists
 import {
   certifierRoleSchema,
   certifierReceivedPacketSchema,
+  certifierNotEnrolledChampvaSchema,
   certifierNameSchema,
   certifierAddressSchema,
   certifierContactSchema,
   certifierRelationshipSchema,
 } from '../chapters/signerInformation';
+import { NotEnrolledChampvaPage } from '../chapters/NotEnrolledChampvaPage';
 import {
   insuranceStatusSchema,
   insurancePages,
@@ -122,6 +124,14 @@ const formConfig = {
           path: 'enrolled-champva',
           title: 'Your CHAMPVA benefit status',
           ...certifierReceivedPacketSchema,
+        },
+        page1a2: {
+          path: 'not-enrolled-champva',
+          title: 'Wait until you receive CHAMPVA packet',
+          depends: formData => !get('certifierReceivedPacket', formData),
+          CustomPage: NotEnrolledChampvaPage,
+          CustomPageReview: null,
+          ...certifierNotEnrolledChampvaSchema,
         },
         page1a: {
           path: 'signer-info',

--- a/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
@@ -36,6 +36,7 @@ const testConfig = createTestConfig(
       'military-address-no-ohi-pharmacy-work.json',
       'third-party-foreign-address-ohi-medical-claim-work-auto.json',
       'two-ohi-other-type.json',
+      'no-packet.json',
     ],
 
     pageHooks: {
@@ -57,6 +58,24 @@ const testConfig = createTestConfig(
               sig,
               `Submit ${formConfig.customText.appType}`,
             );
+          });
+        });
+      },
+      // When we land on this screener page, progressing through the form is
+      // blocked (by design). To successfully complete the test,
+      // once we land here, change `certifierReceivedPacket` to `true`
+      // and click '<< Back' so that we can proceed past the screener
+      [ALL_PAGES.page1a2.path]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            cy.axeCheck();
+            if (data.certifierReceivedPacket === false) {
+              // eslint-disable-next-line no-param-reassign
+              data.certifierReceivedPacket = true;
+              // This targets the '<< Back' button
+              cy.get('va-button').click();
+            }
           });
         });
       },

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/no-packet.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/no-packet.json
@@ -1,5 +1,5 @@
 {
-  "description": "Military base sponsor address, no OHI, pharmacy claim, work related, NOT auto related",
+  "description": "Has not received CHAMPVA packet, military base sponsor address, no OHI, pharmacy claim, work related, NOT auto related",
   "data": {
     "view:hasPolicies": false,
     "pharmacyUpload": [
@@ -41,7 +41,7 @@
       "suffix": "Sr."
     },
     "certifierRole": "applicant",
-    "certifierReceivedPacket": true,
+    "certifierReceivedPacket": false,
     "missingUploads": [
       {
         "name": "pharmacyUpload",

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/test-data.json
@@ -3,6 +3,7 @@
   "data": {
     "view:hasPolicies": true,
     "certifierRole": "applicant",
+    "certifierReceivedPacket": true,
     "sponsorName": {
       "first": "Sponsor",
       "middle": "Quincy",

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/third-party-foreign-address-ohi-medical-claim-work-auto.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/third-party-foreign-address-ohi-medical-claim-work-auto.json
@@ -54,7 +54,6 @@
       "country": "USA",
       "street": "123 Cert St",
       "street2": "St 2",
-      "street3": "St 3",
       "city": "Certland",
       "state": "AS",
       "postalCode": "12312"
@@ -66,6 +65,7 @@
       "suffix": "Jr."
     },
     "certifierRole": "other",
+    "certifierReceivedPacket": true,
     "policies": [
       {
         "type": "group",

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/two-ohi-other-type.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/two-ohi-other-type.json
@@ -40,6 +40,7 @@
       "suffix": "II"
     },
     "certifierRole": "applicant",
+    "certifierReceivedPacket": true,
     "policies": [
       {
         "type": "other",

--- a/src/applications/ivc-champva/10-7959a/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959a/tests/unit/config/form.unit.spec.jsx
@@ -1,9 +1,12 @@
+import React from 'react';
 import { expect } from 'chai';
+import { render } from '@testing-library/react';
 import formConfig from '../../../config/form';
 import { testNumberOfWebComponentFields } from '../../../../shared/tests/pages/pageTests.spec';
 
 import mockData from '../../e2e/fixtures/data/test-data.json';
 import { insuranceOptions } from '../../../chapters/healthInsuranceInformation';
+import { NotEnrolledChampvaPage } from '../../../chapters/NotEnrolledChampvaPage';
 
 describe('Certifier role page', () => {
   testNumberOfWebComponentFields(
@@ -14,6 +17,35 @@ describe('Certifier role page', () => {
     'Certifier role',
     { ...mockData.data },
   );
+});
+
+describe('Certifier enrolled in CHAMPVA page', () => {
+  testNumberOfWebComponentFields(
+    formConfig,
+    formConfig.chapters.signerInformation.pages.page1a1.schema,
+    formConfig.chapters.signerInformation.pages.page1a1.uiSchema,
+    1,
+    'Certifier enrolled in CHAMPVA page',
+    { ...mockData.data },
+  );
+});
+
+describe('Certifier enrolled in CHAMPVA (role: other) page', () => {
+  testNumberOfWebComponentFields(
+    formConfig,
+    formConfig.chapters.signerInformation.pages.page1a1.schema,
+    formConfig.chapters.signerInformation.pages.page1a1.uiSchema,
+    1,
+    'Certifier enrolled in CHAMPVA page',
+    { ...mockData.data, certifierRole: 'other' },
+  );
+});
+
+describe('NotEnrolledChampvaPage', () => {
+  it('should render', () => {
+    const { container } = render(<NotEnrolledChampvaPage goBack={() => {}} />);
+    expect(container).to.exist;
+  });
 });
 
 describe('Certifier relationship page', () => {

--- a/src/applications/ivc-champva/shared/constants.js
+++ b/src/applications/ivc-champva/shared/constants.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export const ConfirmationPagePropTypes = {
   form: PropTypes.shape({
@@ -24,3 +25,31 @@ export const ConfirmationPagePropTypes = {
 
 export const ADDITIONAL_FILES_HINT =
   'Depending on your response, you may need to submit additional documents with this application.';
+
+// TODO: Audit 10-10d and 10-7959a to make sure they're referencing
+// this address here so we can control from one place.
+export const CHAMPVA_ADDRESS = (
+  <>
+    <address className="va-address-block">
+      VHA Office of Integrated Veteran Care
+      <br />
+      ATTN: CHAMPVA Claims
+      <br />
+      PO Box 500
+      <br />
+      Spring City, PA 19475
+      <br />
+    </address>
+  </>
+);
+
+// TODO: Audit all IVC forms and make sure they're referencing
+// these values so we can control them all in one place.
+export const CHAMPVA_PHONE_NUMBER = '18007338387';
+export const CHAMPVA_FAX_NUMBER = '3033317809';
+export const CHAMPVA_CLAIMS_PHONE_NUMBER = CHAMPVA_PHONE_NUMBER;
+export const CHAMPVA_CLAIMS_FAX_NUMBER = '3033317804';
+export const CHAMPVA_OHI_PHONE_NUMBER = CHAMPVA_PHONE_NUMBER;
+export const CHAMPVA_OHI_FAX_NUMBER = '3033317808';
+export const FMP_PHONE_NUMBER = '3033317590';
+export const FMP_FAX_NUMBER = '3033317803';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds two new pages to form 10-7959a. The pages act as a screener to dissuade users from filling out this form until they have been admitted into the CHAMPVA program.

- Adds screener pages (one yes/no question + a custom page that is just markdown)
- Adds a new end to end test to verify screener question
- Updates existing end to end tests to pass the screener question
- Adds new unit tests for the two new pages added
- Adds some useful constants with address/phone information (to be shared by other IVC forms in an upcoming PR)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106478

## Testing done

- Manual
- E2E
- Unit

## Screenshots

|         | Added |
| ------- | ------ |
| Screener question|![Screenshot 2025-04-02 at 14 16 54](https://github.com/user-attachments/assets/74cf7590-b261-4ef5-b644-61b5c7c663ba)|
| Blocker page |![Screenshot 2025-04-02 at 14 17 14](https://github.com/user-attachments/assets/a376a54d-286d-4cce-9b2c-bb048894e873)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA