### PR TITLE
VEBT-1416: 22-10215 - Update Privacy Act and Respondent Burden - Intro page

### DIFF
--- a/src/applications/edu-benefits/10215/components/OmbInfo.jsx
+++ b/src/applications/edu-benefits/10215/components/OmbInfo.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+const OmbInfo = () => {
+  const ombNumber = '2900-0897';
+
+  return (
+    <va-omb-info res-burden={60} omb-number={ombNumber} exp-date="1/31/2028">
+      <p>
+        <strong>Respondent Burden:</strong> An agency may not conduct or
+        sponsor, and a person is not required to respond to, a collection of
+        information unless it displays a currently valid OMB control number. The
+        OMB control number for this project is {ombNumber}, and it expires
+        01/31/2028. Public reporting burden for this collection of information
+        is estimated to average 1 hour per respondent, per year, including the
+        time for reviewing instructions, searching existing data sources,
+        gathering and maintaining the data needed, and completing and reviewing
+        the collection of information. Send comments regarding this burden
+        estimate and any other aspect of this collection of information,
+        including suggestions for reducing the burden, to VA Reports Clearance
+        Officer at{' '}
+        <a
+          href="mailto:VACOPaperworkReduAct@va.gov"
+          target="_blank"
+          rel="noreferrer"
+        >
+          VACOPaperworkReduAct@va.gov
+        </a>
+        . Please refer to OMB Control No. {ombNumber} in any correspondence. Do
+        not send your completed VA Form 22-10215 to this email address.
+      </p>
+
+      <p>
+        <strong>Privacy Act Notice:</strong> VA will not disclose information
+        collected on this form to any source other than what has been authorized
+        under the Privacy Act of 1974 or Title 38, Code of Federal Regulations
+        1.576 for routine uses as identified in the VA system of records,
+        58VA21/22/28, Compensation, Pension, Education, Veteran Readiness and
+        Employment Records - VA, published in the Federal Register. An example
+        of a routine use (e.g., VA sends educational forms or letters with a
+        Veteran’s identifying information to the Veteran’s school or training
+        establishment to (1) assist the Veteran in the completion of claims
+        forms or (2) for VA to obtain further information as may be necessary
+        from the school for VA to properly process the Veteran’s education claim
+        or to monitor his or her progress during training). Your obligation to
+        respond is required to obtain or retain education benefits. The
+        responses you provide are considered confidential (38 U.S.C. 5701). Any
+        information provided by applicants, recipients, and others is subject to
+        verification through computer matching programs with other agencies.
+      </p>
+    </va-omb-info>
+  );
+};
+
+export default OmbInfo;

--- a/src/applications/edu-benefits/10215/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10215/containers/IntroductionPage.jsx
@@ -6,6 +6,8 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 
+import OmbInfo from '../components/OmbInfo';
+
 const IntroductionPage = ({ route }) => {
   useEffect(() => {
     focusElement('.schemaform-title > h1');
@@ -215,11 +217,7 @@ const IntroductionPage = ({ route }) => {
       />
       <p className="vads-u-padding-bottom--0 mobile-lg:vads-u-padding-bottom--0p5" />
 
-      <va-omb-info
-        res-burden={60}
-        omb-number="2900-0897"
-        exp-date="01/31/2028"
-      />
+      <OmbInfo />
     </article>
   );
 };

--- a/src/applications/edu-benefits/10215/tests/components/OmbInfo.unit.spec.jsx
+++ b/src/applications/edu-benefits/10215/tests/components/OmbInfo.unit.spec.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import OmbInfo from '../../components/OmbInfo';
+
+describe('<OmbInfo>', () => {
+  it('should render a `va-omb-info` component', () => {
+    const { container } = render(<OmbInfo />);
+    const selector = container.querySelector('va-omb-info');
+    expect(selector).to.exist;
+  });
+
+  it('should contain the correct props to populate the web component', () => {
+    const { container } = render(<OmbInfo />);
+    const selector = container.querySelector('va-omb-info');
+    expect(selector).to.have.attr('exp-date');
+    expect(selector).to.have.attr('omb-number');
+    expect(selector).to.have.attr('res-burden');
+  });
+});

--- a/src/applications/edu-benefits/10215/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/10215/tests/containers/IntroductionPage.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import IntroductionPage from '../../containers/IntroductionPage';
+import OmbInfo from '../../components/OmbInfo';
 
 describe('22-10215 <IntroductionPage>', () => {
   const fakeStore = {
@@ -86,7 +87,7 @@ describe('22-10215 <IntroductionPage>', () => {
   it('should render omb info', () => {
     const wrapper = shallow(<IntroductionPage {...fakeStore.getState()} />);
 
-    expect(wrapper.find('va-omb-info').length).to.equal(1);
+    expect(wrapper.find(OmbInfo).length).to.equal(1);
 
     wrapper.unmount();
   });

--- a/src/applications/edu-benefits/10282/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/10282/tests/containers/IntroductionPage.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+
 import IntroductionPage from '../../containers/IntroductionPage';
 import OmbInfo from '../../components/OmbInfo';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This is an update to the `Privacy Act Statement` modal on the 22-10215 Introduction Page which includes updates both to the `Respondent Burden` and `Privacy Act Notice` sections

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-1416

**As a...**

VEBT Business User

**I want…**

To update Privacy Act and Respondent Burden 

**So that…**

Form OMB standards are accurate

**Acceptance Criteria**

15-> https://www.figma.com/design/f9TussyZYnC5UVSnqBPJqC/VEBT-Form-22-10215%3A-Statement-of-Assurance?node-id=728-18768&p=f&t=fjBsohSN5i3rxQKQ-0

16-> https://www.figma.com/design/69FpDTQN5UErSV27txIKFh/VEBT-Form-22-10216%3A-35%25-Exemption?node-id=763-76558&p=f&t=Df4lM6RK91f4Cwuu-0

On the Intro Page update the verbiage for the Privacy Act and Respondent Burden.
Replace the entire verbiage as follows
For Privacy Act 
VA will not disclose information collected on this form to any source other than what has been authorized under the Privacy Act of 1974 or Title 38, Code of Federal Regulations 1.576 for routine uses as identified in the VA system of records, 58VA21/22/28, Compensation, Pension, Education, Veteran Readiness and Employment Records - VA, published in the Federal Register. An example of a routine use (e.g., VA sends educational forms or letters with a Veteran's identifying information to the Veteran's school or training establishment to (1) assist the Veteran in the completion of claims forms or (2) for VA to obtain further information as may be necessary from the school for VA to properly process the Veteran's education claim or to monitor his or her progress during training). Your obligation to respond is required to obtain or retain education benefits. The responses you provide are considered confidential (38 U.S.C. 5701). Any information provided by applicants, recipients, and others is subject to verification through computer matching programs with other agencies. 

For Respondent Burden 
An agency may not conduct or sponsor, and a person is not required to respond to, a collection of information unless it displays a currently valid OMB control number. The OMB control number for this project is 2900-0897, and it expires 01/31/2028. Public reporting burden for this collection of information is estimated to average 1 hour per respondent, per year, including the time for reviewing instructions, searching existing data sources, gathering and maintaining the data needed, and completing and reviewing the collection of information. Send comments regarding this burden estimate and any other aspect of this collection of information, including suggestions for reducing the burden, to VA Reports Clearance Officer at VACOPaperworkReduAct@va.gov. Please refer to OMB Control No. 2900-0897 in any correspondence. Do not send your completed VA Form 22-10215 to this email address.

 

**Technical Details:**

Dependencies: No

Feature Flag needed: Yes

Demo needed: No

UAT needed: Yes

Additional Notes: 

**Testing Details:**

(  ) Quick Turn Around/Direct to Production

( X ) Remains in Staging

(  ) Staging Environment unavailable, coordinate w/ developer

**Requested by and when:**

15/16 Walkthrough, 3/12

**Definition of Done:** 

( )  UAT completed with EDU

(  )  Passed all internal testing in Staging

( )  Passed all internal testing in Production

(  )  All work documented in Jira ticket

## Testing done

- Manual testing on local machine that `va-omb-info` component displays in the same manner on the 22-10215 Introduction Page and the verbiage has been updated in the modal
- Unit tests updated for the `IntroductionPage` component
- Unit tests added for the `OmbInfo` component

## Screenshots

**Before:**

![22-10215 Privacy Act Statement (Before)](https://github.com/user-attachments/assets/814448a3-3c15-4b9b-8625-34b5bf137fbd)

**After:**

![22-10215 Privacy Act Statement (After)](https://github.com/user-attachments/assets/c4484b29-a6e1-4c1c-80af-52bf7c11bd09)

## What areas of the site does it impact?

- 22-10215 Introduction Page and `Privacy Act Statement` modal

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
