### PR TITLE
[10-10EZ] Update error handling behavior for facility fetch

### DIFF
--- a/src/applications/hca/components/FormAlerts/ServerErrorAlert.jsx
+++ b/src/applications/hca/components/FormAlerts/ServerErrorAlert.jsx
@@ -1,10 +1,19 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const ServerErrorAlert = () => (
+const ServerErrorAlert = ({
+  headline = 'Something went wrong on our end',
+  description = 'We’re sorry. Something went wrong on our end. Please try again.',
+}) => (
   <va-alert status="error" data-testid="hca-server-error-alert" uswds>
-    <h2 slot="headline">Something went wrong on our end</h2>
-    <p>We’re sorry. Something went wrong on our end. Please try again.</p>
+    <h2 slot="headline">{headline}</h2>
+    <p>{description}</p>
   </va-alert>
 );
 
-export default ServerErrorAlert;
+ServerErrorAlert.propTypes = {
+  headline: PropTypes.string,
+  description: PropTypes.string,
+};
+
+export default React.memo(ServerErrorAlert);

--- a/src/applications/hca/components/FormAlerts/ServerErrorAlert.jsx
+++ b/src/applications/hca/components/FormAlerts/ServerErrorAlert.jsx
@@ -12,8 +12,8 @@ const ServerErrorAlert = ({
 );
 
 ServerErrorAlert.propTypes = {
-  headline: PropTypes.string,
   description: PropTypes.string,
+  headline: PropTypes.string,
 };
 
 export default React.memo(ServerErrorAlert);

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -7,6 +7,7 @@ import { focusElement } from 'platform/utilities/ui';
 import { REACT_BINDINGS, STATES_USA } from '../../utils/imports';
 import { API_ENDPOINTS, STATES_WITHOUT_MEDICAL } from '../../utils/constants';
 import { VaMedicalCenterReviewField } from '../FormReview/VaMedicalCenterReviewField';
+import ServerErrorAlert from '../FormAlerts/ServerErrorAlert';
 import content from '../../locales/en/content.json';
 
 // expose React binding for web components
@@ -190,13 +191,7 @@ const VaMedicalCenter = props => {
     <>
       {error && (
         <div className="server-error-message vads-u-margin-top--4">
-          <va-alert status="error" uswds>
-            <h2 slot="headline">Something went wrong on our end</h2>
-            <p>
-              We’re sorry. Something went wrong on our end. Please try selecting
-              your state again.
-            </p>
-          </va-alert>
+          <ServerErrorAlert description="We’re sorry. Something went wrong on our end. Please try selecting your state again." />
         </div>
       )}
       <VaSelect

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -6,7 +6,6 @@ import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from 'platform/utilities/ui';
 import { REACT_BINDINGS, STATES_USA } from '../../utils/imports';
 import { API_ENDPOINTS, STATES_WITHOUT_MEDICAL } from '../../utils/constants';
-import ServerErrorAlert from '../FormAlerts/ServerErrorAlert';
 import { VaMedicalCenterReviewField } from '../FormReview/VaMedicalCenterReviewField';
 import content from '../../locales/en/content.json';
 
@@ -115,6 +114,11 @@ const VaMedicalCenter = props => {
           setFacilities(facilityList);
         } catch (err) {
           setError(true);
+          // Clear out selected state on error
+          setLocalData(prevState => ({
+            ...prevState,
+            'view:facilityState': undefined,
+          }));
           Sentry.withScope(scope => {
             scope.setExtra('state', facilityState);
             scope.setExtra('error', err);
@@ -184,7 +188,13 @@ const VaMedicalCenter = props => {
     <>
       {error && (
         <div className="server-error-message vads-u-margin-top--4">
-          <ServerErrorAlert />
+          <va-alert status="error" uswds>
+            <h2 slot="headline">Something went wrong on our end</h2>
+            <p>
+              We’re sorry. Something went wrong on our end. Please try selecting
+              your state again.
+            </p>
+          </va-alert>
         </div>
       )}
       <VaSelect

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -119,6 +119,8 @@ const VaMedicalCenter = props => {
             ...prevState,
             'view:facilityState': undefined,
           }));
+          // Clear dirty fields to not display state selector error
+          setDirtyFields([]);
           Sentry.withScope(scope => {
             scope.setExtra('state', facilityState);
             scope.setExtra('error', err);

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -6,8 +6,8 @@ import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from 'platform/utilities/ui';
 import { REACT_BINDINGS, STATES_USA } from '../../utils/imports';
 import { API_ENDPOINTS, STATES_WITHOUT_MEDICAL } from '../../utils/constants';
-import { VaMedicalCenterReviewField } from '../FormReview/VaMedicalCenterReviewField';
 import ServerErrorAlert from '../FormAlerts/ServerErrorAlert';
+import { VaMedicalCenterReviewField } from '../FormReview/VaMedicalCenterReviewField';
 import content from '../../locales/en/content.json';
 
 // expose React binding for web components

--- a/src/applications/hca/tests/unit/components/FormAlerts/ServerErrorAlert.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/components/FormAlerts/ServerErrorAlert.unit.spec.jsx
@@ -6,11 +6,32 @@ import ServerErrorAlert from '../../../../components/FormAlerts/ServerErrorAlert
 
 describe('hca <ServerErrorAlert>', () => {
   context('when the component renders', () => {
-    it('should render `va-alert` with status of `error`', () => {
-      const { container } = render(<ServerErrorAlert />);
+    it('should render `va-alert` with status of `error` and default text', () => {
+      const { container, getByText } = render(<ServerErrorAlert />);
       const selector = container.querySelector('va-alert');
       expect(selector).to.exist;
       expect(selector).to.have.attr('status', 'error');
+
+      expect(getByText('Something went wrong on our end')).to.exist;
+      expect(
+        getByText(
+          'We’re sorry. Something went wrong on our end. Please try again.',
+        ),
+      ).to.exist;
+    });
+    it('should render custom description and headline text when provided', () => {
+      const { container, getByText } = render(
+        <ServerErrorAlert
+          headline="My Headline"
+          description="My description"
+        />,
+      );
+      const selector = container.querySelector('va-alert');
+      expect(selector).to.exist;
+      expect(selector).to.have.attr('status', 'error');
+
+      expect(getByText('My Headline')).to.exist;
+      expect(getByText('My description')).to.exist;
     });
   });
 });

--- a/src/applications/hca/tests/unit/components/FormAlerts/ServerErrorAlert.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/components/FormAlerts/ServerErrorAlert.unit.spec.jsx
@@ -7,21 +7,21 @@ import ServerErrorAlert from '../../../../components/FormAlerts/ServerErrorAlert
 describe('hca <ServerErrorAlert>', () => {
   context('when the component renders', () => {
     it('should render `va-alert` with status of `error` and default text', () => {
-      const { container, getByText } = render(<ServerErrorAlert />);
+      const { container, queryByText } = render(<ServerErrorAlert />);
       const selector = container.querySelector('va-alert');
       expect(selector).to.exist;
       expect(selector).to.have.attr('status', 'error');
 
-      expect(getByText('Something went wrong on our end')).to.exist;
+      expect(queryByText('Something went wrong on our end')).to.exist;
       expect(
-        getByText(
+        queryByText(
           'We’re sorry. Something went wrong on our end. Please try again.',
         ),
       ).to.exist;
     });
 
     it('should render custom description and headline text when provided', () => {
-      const { container, getByText } = render(
+      const { container, queryByText } = render(
         <ServerErrorAlert
           headline="My Headline"
           description="My description"
@@ -31,8 +31,8 @@ describe('hca <ServerErrorAlert>', () => {
       expect(selector).to.exist;
       expect(selector).to.have.attr('status', 'error');
 
-      expect(getByText('My Headline')).to.exist;
-      expect(getByText('My description')).to.exist;
+      expect(queryByText('My Headline')).to.exist;
+      expect(queryByText('My description')).to.exist;
     });
   });
 });

--- a/src/applications/hca/tests/unit/components/FormAlerts/ServerErrorAlert.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/components/FormAlerts/ServerErrorAlert.unit.spec.jsx
@@ -19,6 +19,7 @@ describe('hca <ServerErrorAlert>', () => {
         ),
       ).to.exist;
     });
+
     it('should render custom description and headline text when provided', () => {
       const { container, getByText } = render(
         <ServerErrorAlert

--- a/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.jsx
@@ -149,6 +149,7 @@ describe('hca <VaMedicalCenter>', () => {
     await waitFor(() => {
       const { stateField, facilityField, vaAlert } = selectors();
       expect(stateField).to.exist;
+      expect(stateField).to.not.have.attr('error');
       // Clears out the state value
       expect(stateField.getAttribute('value')).to.be.null;
       expect(facilityField).to.exist;

--- a/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.jsx
@@ -149,6 +149,8 @@ describe('hca <VaMedicalCenter>', () => {
     await waitFor(() => {
       const { stateField, facilityField, vaAlert } = selectors();
       expect(stateField).to.exist;
+      // Clears out the state value
+      expect(stateField.getAttribute('value')).to.be.null;
       expect(facilityField).to.exist;
       expect(vaAlert).to.exist;
     });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Previously, when an API request failed while fetching the list of facilities on the facilities page, we displayed a large `va-alert` but retained the selected state value. This required the Veteran to manually reselect their state to retry the request.
- With this update, the `va-alert` message is updated to inform the user that they need to select a new state, and the state value is cleared automatically. This improves the Veteran experience by making it clearer that a new selection is required to retry the request.
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101671
## Testing done

- Updated unit specs for this component

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![Screenshot 2025-04-03 at 3 44 59 PM](https://github.com/user-attachments/assets/11c9e701-c042-4e0f-a1ea-6e581f32d70e)|![Screenshot 2025-04-03 at 3 42 47 PM](https://github.com/user-attachments/assets/09585df6-015f-4488-a635-668a5cd12270)|
| Desktop |![Screenshot 2025-04-03 at 3 44 52 PM](https://github.com/user-attachments/assets/4630d83d-d45c-48c5-9028-763d9fd9ffa9)|![Screenshot 2025-04-03 at 3 42 39 PM](https://github.com/user-attachments/assets/d8144c1f-d593-4519-8b23-d52124c6c834)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
