### PR TITLE
Allow update ui schema in array builder item pages - TODO tests

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -615,6 +615,7 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
         properties: {
           [arrayPath]: {
             type: 'array',
+            arrayType: 'ArrayBuilderV1',
             minItems,
             maxItems,
             items: pageConfig.schema,


### PR DESCRIPTION
Add `updateUiSchema` for array builder item pages

Usage:
```
    opts: radioUI({
      title: 'Did you work there?',
      labels: {
        a: 'a',
        b: 'b',
      },
      updateUiSchema: (formData, fullData, index) => {
        if (fullData?.employers?.[index]?.name === 'test') {
          return {
            'ui:options': {
              labels: {
                x: 'x',
                y: 'y',
              },
            },
          };
        }
        return {
          'ui:options': {
            labels: {
              a: 'a',
              b: 'b',
            },
          },
        };
      },
      updateSchema: (formData, schema, uiSchema, index, path, fullData) => {
        if (fullData?.employers?.[index]?.name === 'test') {
          return {
            type: 'string',
            enum: ['x', 'y'],
          };
        }
        return {
          type: 'string',
          enum: ['a', 'b'],
        };
      },
    }),
```
