### PR TITLE
MHV-68471: Made sure Need Help component is always present on Meds List page

### DIFF
--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -821,7 +821,6 @@ const Prescriptions = () => {
                             <BeforeYouDownloadDropdown page={pageType.LIST} />
                           </>
                         )}
-                      {removeLandingPage && <NeedHelp page={pageType.LIST} />}
                     </>
                   ) : (
                     <>
@@ -874,6 +873,7 @@ const Prescriptions = () => {
             )}
           </>
         )}
+        {removeLandingPage && !isLoading && <NeedHelp page={pageType.LIST} />}
       </div>
     );
   };

--- a/src/applications/mhv-medications/tests/e2e/medications-need-help-section-list-page-api-call-failure.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-need-help-section-list-page-api-call-failure.cypress.spec.js
@@ -1,0 +1,20 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsListPage from './pages/MedicationsListPage';
+import { Alerts, Data } from './utils/constants';
+
+describe('Medications List Page Need Help Section API Call Failure', () => {
+  it('visits Medications List Need Help Section', () => {
+    const listPage = new MedicationsListPage();
+    const site = new MedicationsSite();
+    site.login();
+    cy.visit('/my-health/medications');
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.verifyNeedHelpSectionOnListPage(Data.HELP_TEXT);
+    listPage.verifyGoToUseMedicationLinkOnListPage();
+    listPage.verifyStartANewMessageLinkOnListPage();
+    listPage.verifyErroMessageforFailedAPICallListPage(
+      Alerts.NO_ACCESS_TO_MEDICATIONS_ERROR,
+    );
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-need-help-section-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-need-help-section-list-page.cypress.spec.js
@@ -1,7 +1,8 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import prescriptions from './fixtures/listOfPrescriptions.json';
 import MedicationsListPage from './pages/MedicationsListPage';
-import { Data } from './utils/constants';
+import { Alerts, Data } from './utils/constants';
+import noPrescriptions from './fixtures/empty-prescriptions-list.json';
 
 describe('Medications List Page Need Help Section', () => {
   beforeEach(() => {
@@ -23,5 +24,15 @@ describe('Medications List Page Need Help Section', () => {
     listPage.verifyTitleNotesOnListPage(Data.LIST_PAGE_TITLE_NOTES);
     cy.injectAxe();
     cy.axeCheck('main');
+  });
+  it('visits Medications List Need Help Section for Empty Med List', () => {
+    const listPage = new MedicationsListPage();
+    listPage.visitMedicationsListPageURL(noPrescriptions);
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.verifyNeedHelpSectionOnListPage(Data.HELP_TEXT);
+    listPage.verifyGoToUseMedicationLinkOnListPage();
+    listPage.verifyStartANewMessageLinkOnListPage();
+    listPage.verifyEmptyMedicationsListAlertOnListPage(Alerts.EMPTY_MED_LIST);
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -983,6 +983,10 @@ class MedicationsListPage {
         expect(res.body.counter).to.eq(0);
       });
   };
+
+  verifyErroMessageforFailedAPICallListPage = text => {
+    cy.get('[data-testid="no-medications-list"]').should('contain', text);
+  };
 }
 
 export default MedicationsListPage;


### PR DESCRIPTION
## Summary

- Rx: Move NeedHelp component to the bottom of the tree to make sure it is always present

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-68471

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Need Help component on the Meds list needs to be present if there are no meds in the list, for all different errors, if the users don't have access, etc.. IT SHOULD ALWAYS BE PRESENT ON THE MEDS LIST NO MATTER WHAT

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

