### PR TITLE
Corrects prop set-focus on <va-loading-indicator /> web-components for Profile

### DIFF
--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
@@ -138,7 +138,7 @@ export class ConnectedApps extends Component {
 
         {loading && (
           <va-loading-indicator
-            setFocus
+            set-focus
             message="Loading your connected apps..."
             data-testid="connected-apps-loading-indicator"
           />

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatus.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatus.jsx
@@ -257,7 +257,7 @@ const ProofOfVeteranStatus = ({
 
         {isLoading ? (
           <va-loading-indicator
-            setFocus
+            set-focus
             message="Checking your eligibility..."
             data-testid="proof-of-status-loading-indicator"
           />


### PR DESCRIPTION
## Summary

- Corrects syntax error with `set-focus` property on `<va-loading-indicator />` web-components for the Profile app
- Syntax fix, no UI changes

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#106212

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

