### PR TITLE
[10-10EZ] Update button styling on confirmation page

### DIFF
--- a/src/applications/hca/components/ConfirmationPage/ConfirmationScreenView.jsx
+++ b/src/applications/hca/components/ConfirmationPage/ConfirmationScreenView.jsx
@@ -52,7 +52,7 @@ const ConfirmationScreenView = ({ name, timestamp }) => {
         <h4>Confirmation for your records</h4>
         <p>You can print this confirmation page for your records.</p>
 
-        <div className="vads-u-margin-top--2">
+        <div className="vads-u-margin-y--2">
           <va-button
             text="Print this page"
             onClick={() => window.print()}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updating css class to add margin below print button on 10-10EZ confirmation screen
- This adds space between new download pdf link
- There is currently extra visible margin when the download pdf link toggle is turned off, but we plan to turn this on permanently soon. 
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/102901

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="343" alt="Screenshot 2025-04-07 at 9 45 59 AM" src="https://github.com/user-attachments/assets/a420b453-ff8c-473c-bb74-4e2d2a8fb588" />|<img width="406" alt="Screenshot 2025-04-07 at 9 45 10 AM" src="https://github.com/user-attachments/assets/85f93fcc-d9b9-4048-b579-c7e15080e889" /><img width="343" alt="Screenshot 2025-04-07 at 9 45 41 AM" src="https://github.com/user-attachments/assets/5bc8ffe0-f1f2-4088-be0b-66cfa5572710" />|
| Desktop |<img width="606" alt="Screenshot 2025-04-07 at 9 46 05 AM" src="https://github.com/user-attachments/assets/830194b6-1036-48ff-bd6e-13347b04e91c" />|<img width="574" alt="Screenshot 2025-04-07 at 9 45 02 AM" src="https://github.com/user-attachments/assets/3cc6d767-c4a6-46d9-951f-d6ad78d10352" /><img width="613" alt="Screenshot 2025-04-07 at 9 45 34 AM" src="https://github.com/user-attachments/assets/6cc8beef-c974-43bd-9080-5281f39388ba" />|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
