### PR TITLE
Add feature flag to ARP people search (#98332)

### DIFF
--- a/src/applications/accredited-representative-portal/components/Header/Nav.jsx
+++ b/src/applications/accredited-representative-portal/components/Header/Nav.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLoaderData } from 'react-router-dom';
-
+import { Toggler } from 'platform/utilities/feature-toggles';
 import { getSignInUrl } from '../../utilities/constants';
 import UserNav from './UserNav';
 
@@ -50,6 +50,26 @@ export const Nav = () => {
       {profile && (
         <div className="nav__container-secondary" data-testid="desktop-nav-row">
           <div className="nav__container vads-u-display--flex">
+            <Toggler
+              toggleName={
+                Toggler.TOGGLE_NAMES.accreditedRepresentativePortalSearch
+              }
+            >
+              <Toggler.Enabled>
+                <Link
+                  className="nav__btn desktop"
+                  to="/poa-search"
+                  data-testid="desktop-search-link"
+                >
+                  <va-icon
+                    icon="search"
+                    size={2}
+                    className="people-search-icon"
+                  />
+                  Search People
+                </Link>
+              </Toggler.Enabled>
+            </Toggler>
             <Link
               className="nav__btn desktop"
               to="/poa-requests"

--- a/src/applications/accredited-representative-portal/components/Header/UserNav.jsx
+++ b/src/applications/accredited-representative-portal/components/Header/UserNav.jsx
@@ -116,6 +116,7 @@ function UserNav({ profile }) {
           closeIcon="close"
           view="mobile"
           size={2}
+          data-testid="menu-toggle-dropdown-mobile"
         >
           <UserHelpLinks />
         </NavDropdown>

--- a/src/applications/accredited-representative-portal/components/Header/UserNav.jsx
+++ b/src/applications/accredited-representative-portal/components/Header/UserNav.jsx
@@ -1,12 +1,28 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-
+import { Toggler } from 'platform/utilities/feature-toggles';
 import { SIGN_OUT_URL } from '../../utilities/constants';
 import NavDropdown from './NavDropdown';
 
 const UserHelpLinks = () => {
   return (
     <>
+      <Toggler
+        toggleName={Toggler.TOGGLE_NAMES.accreditedRepresentativePortalSearch}
+      >
+        <Toggler.Enabled>
+          <li>
+            <Link
+              data-testid="user-nav-poa-search-link"
+              className="vads-u-color--white"
+              to="/poa-search"
+            >
+              <va-icon icon="search" size={2} className="people-search-icon" />
+              Search People
+            </Link>
+          </li>
+        </Toggler.Enabled>
+      </Toggler>
       <li>
         <Link
           data-testid="user-nav-poa-requests-link"

--- a/src/applications/accredited-representative-portal/containers/POARequestIndividualSearchPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestIndividualSearchPage.jsx
@@ -4,10 +4,13 @@ import {
   VaTextInput,
   VaDate,
   VaLoadingIndicator,
+  VaBreadcrumbs,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import SsnField from 'platform/forms-system/src/js/web-component-fields/SsnField';
 import { useSearchParams, useNavigation } from 'react-router-dom';
+import { Toggler, useFeatureToggle } from 'platform/utilities/feature-toggles';
 import api from '../utilities/api';
+import { SEARCH_BC_LABEL, searchPeopleBC } from '../utilities/poaRequests';
 import POARequestSearchCard from '../components/POARequestSearchCard';
 
 const SearchResults = ({ poaRequests, searchData }) => {
@@ -71,7 +74,7 @@ const POARequestIndividualSearchPage = () => {
         .then(response => {
           return response.json();
         })
-        .then(function(data) {
+        .then(data => {
           setSearchPerformed(true);
           setPoaRequests(data);
         });
@@ -106,8 +109,21 @@ const POARequestIndividualSearchPage = () => {
     };
   };
 
+  const { useToggleValue } = useFeatureToggle();
+  if (
+    !useToggleValue(Toggler.TOGGLE_NAMES.accreditedRepresentativePortalSearch)
+  ) {
+    window.location = '/representative';
+    return null;
+  }
+
   return (
-    <section className="poa-request">
+    <section className="poa-search">
+      <VaBreadcrumbs
+        breadcrumbList={searchPeopleBC}
+        label={SEARCH_BC_LABEL}
+        homeVeteransAffairs={false}
+      />
       <h1
         data-testid="poa-requests-heading"
         className="poa-request__search-header"

--- a/src/applications/accredited-representative-portal/sass/accredited-representative-portal.scss
+++ b/src/applications/accredited-representative-portal/sass/accredited-representative-portal.scss
@@ -278,3 +278,7 @@
     height: 40px;
   }
 }
+.poa-search {
+  max-width: 660px;
+  margin-bottom: 20px;
+}

--- a/src/applications/accredited-representative-portal/tests/e2e/intercepts/feature-toggles.js
+++ b/src/applications/accredited-representative-portal/tests/e2e/intercepts/feature-toggles.js
@@ -11,6 +11,10 @@ export const setFeatureToggles = toggles => {
           name: 'accredited_representative_portal_pilot',
           value: toggles.isInPilot,
         },
+        {
+          name: 'accredited_representative_portal_search',
+          value: toggles.isSearchEnabled,
+        },
       ],
     },
   });

--- a/src/applications/accredited-representative-portal/tests/e2e/poa-request-individual-search.cypress.spec.js
+++ b/src/applications/accredited-representative-portal/tests/e2e/poa-request-individual-search.cypress.spec.js
@@ -25,7 +25,13 @@ Cypress.Commands.add('loginArpUser', () => {
 
 const setUpInterceptsAndVisit = (featureToggles, url) => {
   cy.intercept('GET', '/data/cms/vamc-ehr.json', vamcUser).as('vamcUser');
-  setFeatureToggles(featureToggles || { isAppEnabled: true, isInPilot: true });
+  setFeatureToggles(
+    featureToggles || {
+      isAppEnabled: true,
+      isInPilot: true,
+      isSearchEnabled: true,
+    },
+  );
   cy.visit(url || '/representative');
   cy.injectAxeThenAxeCheck();
 };
@@ -46,11 +52,20 @@ describe('Accredited Representative Portal', () => {
     });
   });
 
-  describe('App feature toggle is enabled, but Pilot feature toggle is not enabled', () => {
+  describe('App feature toggle is enabled, but search feature toggle is not enabled', () => {
     beforeEach(() => {
-      setUpInterceptsAndVisit({
-        isAppEnabled: true,
-        isInPilot: false,
+      setUpInterceptsAndVisit(
+        {
+          isAppEnabled: true,
+          isInPilot: true,
+          isSearchEnabled: false,
+        },
+        POA_SEARCH,
+      );
+
+      it('redirects to representative home', () => {
+        cy.injectAxeThenAxeCheck();
+        cy.location('pathname').should('eq', '/representative');
       });
     });
   });

--- a/src/applications/accredited-representative-portal/tests/unit/components/Header.unit.spec.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/components/Header.unit.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import { fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 import Header from '../../../components/Header';
 import UserNav from '../../../components/Header/UserNav';
 import { renderTestComponent } from '../helpers';
@@ -13,6 +15,14 @@ const profile = {
     serviceName: 'idme',
   },
 };
+const getStore = () =>
+  createStore(() => ({
+    featureToggles: {
+      // eslint-disable-next-line camelcase
+      accredited_representative_portal_search: true,
+    },
+  }));
+
 describe('Header', () => {
   it('renders header', () => {
     const { getByTestId } = renderTestComponent(<Header />);
@@ -41,7 +51,11 @@ describe('Header', () => {
   });
 
   it('mobile menu exists and toggles dropdown with poa requests link', () => {
-    const { getByTestId } = renderTestComponent(<UserNav profile={profile} />);
+    const { getByTestId } = renderTestComponent(
+      <Provider store={getStore()}>
+        <UserNav profile={profile} />
+      </Provider>,
+    );
     fireEvent.click(getByTestId('menu-toggle-dropdown-mobile'));
     expect(getByTestId('menu-toggle-dropdown-mobile-list')).to.exist;
     const poaRequestsLink = getByTestId('user-nav-poa-requests-link');

--- a/src/applications/accredited-representative-portal/utilities/poaRequests.js
+++ b/src/applications/accredited-representative-portal/utilities/poaRequests.js
@@ -99,6 +99,16 @@ export const poaSearchBC = [
     label: 'Power of attorney requests',
   },
 ];
+export const searchPeopleBC = [
+  {
+    href: '/representative',
+    label: 'VA.gov/representative home',
+  },
+  {
+    href: window.location.href,
+    label: 'Search People',
+  },
+];
 export const poaDetailsBreadcrumbs = [
   {
     href: 'https://va.gov/representative',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -1,6 +1,7 @@
 {
   "accreditedRepresentativePortalFrontend": "accredited_representative_portal_frontend",
   "accreditedRepresentativePortalPilot": "accredited_representative_portal_pilot",
+  "accreditedRepresentativePortalSearch": "accredited_representative_portal_search",
   "aedpVADX": "aedp_vadx",
   "aedpPrefill": "aedp_prefill",
   "appointARepresentativeEnableFrontend": "appoint_a_representative_enable_frontend",


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Added feature flags, feature flag tests, nav links, breadcrumbs, and spacing to ARP people search.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/98332
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
People search showed for all reps.
- _Describe the steps required to verify your changes are working as expected_
Set feature flag 'accredited_representative_portal_search' to on, People search nav link should appear in ARP. 
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
<img width="978" alt="Screenshot 2025-04-07 at 5 13 56 PM" src="https://github.com/user-attachments/assets/bcf7e0ec-8f13-4ca8-89a5-b300fe0f87f9" />

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
