### PR TITLE
DBEX-106136 / Add check for title before rendering h4 in ObjectField component

### DIFF
--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -184,7 +184,8 @@ class ObjectField extends React.Component {
         {!formContext?.hideHeaderRow && (
           <div className="form-review-panel-page-header-row">
             {((titleString && title.trim()) || !titleString) &&
-            !formContext?.hideTitle ? (
+            !formContext?.hideTitle &&
+            title ? (
               <h4 className="form-review-panel-page-header vads-u-font-size--h5">
                 {title}
               </h4>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The addition of new accessibility rules to the Cypress tests flagged a few issues for the 526 form. This PR addresses the [“empty-heading” rule](https://dequeuniversity.com/rules/axe/4.9/empty-heading).
- The `ObjectField` component that is used on the 526 review page handles empty `title` strings fine, but has a problem when the `title` is `undefined`. When `title`  is undefined, `((titleString && title.trim()) || !titleString)` evaluates as true and loads an empty heading level 4, which leads to the axeCheck “empty heading” issue.
- This PR adds a check for `title` before rendering the container h4. When there is no title to show, a div loads instead of the h4.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106136

## Testing done
To test this you can add periods of confinement to a user in the 526, and then go to the final review-and-submit page for the form. There, run an [Axe Devtools full page scan](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US) or inspect the period of confinement element on the 526 review page. See screenshots. OR since the actual ticket is about the failing Cypress tests, you can run the tests and see that they pass. See below:

- Add the following rule below to the Cypress rules in `src/platform/testing/e2e/cypress/support/commands/axeCheck.js` on line 56.

```jsx
      'empty-heading': {
        enabled: true,
      },
```

- Run vets-website with`yarn watch --env entry=auth,static-pages,526EZ-all-claims`
- In another tab on vets-website Run the mock api responses with:
    `yarn mock-api --responses src/applications/disability-benefits/all-claims/local-dev-mock-api/index.js`
    
- In a third terminal tab open vets-website again. Run the Cypress tests with `yarn cy:open`
- In the browser Cypress UI select the following tests to run them. On the main branch (without title check) they will fail, on this branch they will pass.
    - http://localhost:3001/__/#/specs/runner?file=src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
        - newOnly-test fails
        - maximal-test fails
    - http://localhost:3001/__/#/specs/runner?file=src/applications/disability-benefits/all-claims/tests/modern-0781.cypress.spec.js
        - maximal-modern-0781-test
    - http://localhost:3001/__/#/specs/runner?file=src/applications/disability-benefits/all-claims/tests/toxic-exposure.cypress.spec.js
        - maximal-toxic-exposure-test

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
|526 review page uses h4 on periods of confinement  |<img width="1489" alt="Screenshot 2025-04-07 at 12 03 35 PM" src="https://github.com/user-attachments/assets/aa0b9d25-ff41-444e-a78c-727aabb379e9" />| <img width="1511" alt="Screenshot 2025-04-07 at 12 02 31 PM" src="https://github.com/user-attachments/assets/4a9e71c3-81c5-4354-bafb-6d92b5a79620" />|
| Cypress tests |    <img width="1284" alt="Screenshot 2025-04-07 at 3 44 14 PM" src="https://github.com/user-attachments/assets/c366c97a-add0-4226-90d1-2a8157957028" />    |    <img width="1502" alt="Screenshot 2025-04-07 at 6 20 45 PM" src="https://github.com/user-attachments/assets/ef4849cb-4602-4766-804e-594f4dddec7b" />   |

## What areas of the site does it impact?

- ObjectField component
