### PR TITLE
Income & Asset | Fix list & loop summary card visibility

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/03-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-unassociated-incomes/unassociatedIncomePages.js
@@ -18,6 +18,7 @@ import {
   otherRecipientRelationshipExplanationRequired,
   otherIncomeTypeExplanationRequired,
   recipientNameRequired,
+  isDefined,
 } from '../../../helpers';
 import { relationshipLabels, incomeTypeLabels } from '../../../labels';
 
@@ -28,15 +29,15 @@ export const options = {
   nounPlural: 'recurring incomes not associated with accounts or assets',
   required: false,
   isItemIncomplete: item =>
-    !item?.recipientRelationship ||
-    !item.incomeType ||
-    !item.grossMonthlyIncome ||
-    !item.payer, // include all required fields here
+    !isDefined(item?.recipientRelationship) ||
+    !isDefined(item.incomeType) ||
+    !isDefined(item.grossMonthlyIncome) ||
+    !isDefined(item.payer), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: item => relationshipLabels[item.recipientRelationship],
     cardDescription: item =>
-      item?.grossMonthlyIncome && (
+      isDefined(item?.grossMonthlyIncome) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Income type:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/04-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/04-associated-incomes/associatedIncomePages.js
@@ -18,6 +18,7 @@ import {
   otherRecipientRelationshipExplanationRequired,
   otherIncomeTypeExplanationRequired,
   recipientNameRequired,
+  isDefined,
 } from '../../../helpers';
 import { relationshipLabels, incomeTypeEarnedLabels } from '../../../labels';
 
@@ -28,16 +29,16 @@ export const options = {
   nounPlural: 'incomes and net worth associated with financial accounts',
   required: false,
   isItemIncomplete: item =>
-    !item?.recipientRelationship ||
-    !item.incomeType ||
-    !item.grossMonthlyIncome ||
-    !item.accountValue ||
-    !item.payer, // include all required fields here
+    !isDefined(item?.recipientRelationship) ||
+    !isDefined(item.incomeType) ||
+    !isDefined(item.grossMonthlyIncome) ||
+    !isDefined(item.accountValue) ||
+    !isDefined(item.payer), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: item => relationshipLabels[item.recipientRelationship],
     cardDescription: item =>
-      item?.grossMonthlyIncome && (
+      isDefined(item?.grossMonthlyIncome) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Income type:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/05-owned-assets/ownedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/05-owned-assets/ownedAssetPages.js
@@ -17,6 +17,7 @@ import {
   formatCurrency,
   otherRecipientRelationshipExplanationRequired,
   recipientNameRequired,
+  isDefined,
 } from '../../../helpers';
 import { relationshipLabels, ownedAssetTypeLabels } from '../../../labels';
 import {
@@ -31,16 +32,16 @@ export const options = {
   nounPlural: 'incomes and net worth associated with owned assets',
   required: false,
   isItemIncomplete: item =>
-    !item?.recipientRelationship ||
-    !item.grossMonthlyIncome ||
-    !item.ownedPortionValue ||
-    !item.assetType, // include all required fields here
+    !isDefined(item?.recipientRelationship) ||
+    !isDefined(item.grossMonthlyIncome) ||
+    !isDefined(item.ownedPortionValue) ||
+    !isDefined(item.assetType), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: item => relationshipLabels[item.recipientRelationship],
     cardDescription: item =>
-      item?.grossMonthlyIncome &&
-      item?.ownedPortionValue && (
+      isDefined(item?.grossMonthlyIncome) &&
+      isDefined(item?.ownedPortionValue) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Asset type:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
@@ -22,6 +22,7 @@ import {
   otherRecipientRelationshipExplanationRequired,
   otherGeneratedIncomeTypeExplanationRequired,
   recipientNameRequired,
+  isDefined,
 } from '../../../helpers';
 import { relationshipLabels, generatedIncomeTypeLabels } from '../../../labels';
 
@@ -32,17 +33,17 @@ export const options = {
   nounPlural: 'royalties and other properties',
   required: false,
   isItemIncomplete: item =>
-    !item?.recipientRelationship ||
+    !isDefined(item?.recipientRelationship) ||
     typeof item.canBeSold !== 'boolean' ||
-    !item.grossMonthlyIncome ||
-    !item.fairMarketValue ||
-    !item.incomeGenerationMethod, // include all required fields here
+    !isDefined(item.grossMonthlyIncome) ||
+    !isDefined(item.fairMarketValue) ||
+    !isDefined(item.incomeGenerationMethod), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: item => relationshipLabels[item.recipientRelationship],
     cardDescription: item =>
-      item?.grossMonthlyIncome &&
-      item?.fairMarketValue && (
+      isDefined(item?.grossMonthlyIncome) &&
+      isDefined(item?.fairMarketValue) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Income Generation Method:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/07-asset-transfers/assetTransferPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/07-asset-transfers/assetTransferPages.js
@@ -26,6 +26,7 @@ import {
   formatCurrency,
   otherNewOwnerRelationshipExplanationRequired,
   otherTransferMethodExplanationRequired,
+  isDefined,
 } from '../../../helpers';
 
 /** @type {ArrayBuilderOptions} */
@@ -35,22 +36,22 @@ export const options = {
   nounPlural: 'asset transfers',
   required: false,
   isItemIncomplete: item =>
-    !item?.originalOwnerRelationship ||
-    !item.transferMethod ||
-    !item.assetType ||
-    !item.newOwnerName ||
-    !item.newOwnerRelationship ||
+    !isDefined(item?.originalOwnerRelationship) ||
+    !isDefined(item.transferMethod) ||
+    !isDefined(item.assetType) ||
+    !isDefined(item.newOwnerName) ||
+    !isDefined(item.newOwnerRelationship) ||
     typeof item.saleReportedToIrs !== 'boolean' ||
-    !item.transferDate ||
+    !isDefined(item.transferDate) ||
     typeof item.assetTransferredUnderFairMarketValue !== 'boolean' ||
-    !item.fairMarketValue ||
-    !item.capitalGainValue, // include all required fields here
+    !isDefined(item.fairMarketValue) ||
+    !isDefined(item.capitalGainValue), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: item => item.assetType,
     cardDescription: item =>
-      item?.fairMarketValue &&
-      item?.capitalGainValue && (
+      isDefined(item?.fairMarketValue) &&
+      isDefined(item?.capitalGainValue) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Transfer Method:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/08-trusts/trustPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/08-trusts/trustPages.js
@@ -21,6 +21,7 @@ import {
   annualReceivedIncomeFromTrustRequired,
   formatCurrency,
   monthlyMedicalReimbursementAmountRequired,
+  isDefined,
 } from '../../../helpers';
 
 /** @type {ArrayBuilderOptions} */
@@ -30,9 +31,9 @@ export const options = {
   nounPlural: 'trusts',
   required: false,
   isItemIncomplete: item =>
-    !item?.establishedDate ||
-    !item.marketValueAtEstablishment ||
-    !item.trustType ||
+    !isDefined(item?.establishedDate) ||
+    !isDefined(item.marketValueAtEstablishment) ||
+    !isDefined(item.trustType) ||
     typeof item.addedFundsAfterEstablishment !== 'boolean' ||
     typeof item.trustUsedForMedicalExpenses !== 'boolean' ||
     typeof item.trustEstablishedForVeteransChild !== 'boolean' ||
@@ -41,7 +42,7 @@ export const options = {
   text: {
     getItemName: () => 'Trust',
     cardDescription: item =>
-      item?.marketValueAtEstablishment && (
+      isDefined(item?.marketValueAtEstablishment) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Established date:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/09-annuities/annuityPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/09-annuities/annuityPages.js
@@ -17,6 +17,7 @@ import {
   formatCurrency,
   annualReceivedIncomeFromAnnuityRequired,
   surrenderValueRequired,
+  isDefined,
 } from '../../../helpers';
 
 /** @type {ArrayBuilderOptions} */
@@ -26,8 +27,8 @@ export const options = {
   nounPlural: 'Annuities',
   required: false,
   isItemIncomplete: item =>
-    !item?.establishedDate ||
-    !item.marketValueAtEstablishment ||
+    !isDefined(item?.establishedDate) ||
+    !isDefined(item.marketValueAtEstablishment) ||
     typeof item.addedFundsAfterEstablishment !== 'boolean' ||
     typeof item.revocable !== 'boolean' ||
     typeof item.receivingIncomeFromAnnuity !== 'boolean' ||
@@ -36,7 +37,7 @@ export const options = {
   text: {
     getItemName: () => 'Annuity',
     cardDescription: item =>
-      item?.marketValueAtEstablishment && (
+      isDefined(item?.marketValueAtEstablishment) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Established date:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/10-unreported-assets/unreportedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/10-unreported-assets/unreportedAssetPages.js
@@ -16,6 +16,7 @@ import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array
 import {
   formatCurrency,
   otherAssetOwnerRelationshipExplanationRequired,
+  isDefined,
 } from '../../../helpers';
 import { relationshipLabels } from '../../../labels';
 
@@ -26,15 +27,15 @@ export const options = {
   nounPlural: 'assets previously not reported',
   required: false,
   isItemIncomplete: item =>
-    !item?.assetOwnerRelationship ||
-    !item.ownedPortionValue ||
-    !item.assetType ||
-    !item.assetLocation, // include all required fields here
+    !isDefined(item?.assetOwnerRelationship) ||
+    !isDefined(item.ownedPortionValue) ||
+    !isDefined(item.assetType) ||
+    !isDefined(item.assetLocation), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: () => 'Unreported Asset',
     cardDescription: item =>
-      item?.ownedPortionValue && (
+      isDefined(item?.ownedPortionValue) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Asset type:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/11-discontinued-incomes/discontinuedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/11-discontinued-incomes/discontinuedIncomePages.js
@@ -19,6 +19,7 @@ import {
   formatCurrency,
   otherRecipientRelationshipExplanationRequired,
   recipientNameRequired,
+  isDefined,
 } from '../../../helpers';
 import { incomeFrequencyLabels, relationshipLabels } from '../../../labels';
 
@@ -29,17 +30,17 @@ export const options = {
   nounPlural: 'discontinued incomes',
   required: false,
   isItemIncomplete: item =>
-    !item?.recipientRelationship ||
-    !item.payer ||
-    !item.incomeType ||
-    !item.incomeFrequency ||
-    !item.incomeLastReceivedDate ||
-    !item.grossAnnualAmount, // include all required fields here
+    !isDefined(item?.recipientRelationship) ||
+    !isDefined(item.payer) ||
+    !isDefined(item.incomeType) ||
+    !isDefined(item.incomeFrequency) ||
+    !isDefined(item.incomeLastReceivedDate) ||
+    !isDefined(item.grossAnnualAmount), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: () => 'Discontinued income',
     cardDescription: item =>
-      item?.grossAnnualAmount && (
+      isDefined(item?.grossAnnualAmount) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Income relationship:{' '}

--- a/src/applications/income-and-asset-statement/config/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.js
@@ -22,6 +22,7 @@ import {
   formatCurrency,
   otherRecipientRelationshipExplanationRequired,
   recipientNameRequired,
+  isDefined,
 } from '../../../helpers';
 import { relationshipLabels } from '../../../labels';
 
@@ -32,14 +33,14 @@ export const options = {
   nounPlural: 'income receipt waivers',
   required: false,
   isItemIncomplete: item =>
-    !item?.recipientRelationship ||
-    !item.payer ||
-    !item.waivedGrossMonthlyIncome, // include all required fields here
+    !isDefined(item?.recipientRelationship) ||
+    !isDefined(item.payer) ||
+    !isDefined(item.waivedGrossMonthlyIncome), // include all required fields here
   maxItems: 5,
   text: {
     getItemName: () => 'Income receipt waiver',
     cardDescription: item =>
-      item?.waivedGrossMonthlyIncome && (
+      isDefined(item?.waivedGrossMonthlyIncome) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
           <li>
             Recipient relationship:{' '}

--- a/src/applications/income-and-asset-statement/helpers.js
+++ b/src/applications/income-and-asset-statement/helpers.js
@@ -8,6 +8,8 @@ export const annualReceivedIncomeFromTrustRequired = (form, index) =>
 
 export const formatCurrency = num => `$${num.toLocaleString()}`;
 
+export const isDefined = value => value !== '' && typeof value !== 'undefined';
+
 export const monthlyMedicalReimbursementAmountRequired = (form, index) =>
   get(['trusts', index, 'monthlyMedicalReimbursementAmount'], form);
 

--- a/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data-all-zeroes.json
+++ b/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data-all-zeroes.json
@@ -1,0 +1,140 @@
+{
+  "data": {
+    "incomeNetWorthDateRange": {
+      "from": "2023-07-01",
+      "to": "2024-01-01"
+    },
+    "veteranFullName": {
+      "first": "John",
+      "last": "Doe"
+    },
+    "veteranSocialSecurityNumber": "321654987",
+    "view:applicantIsVeteran": false,
+    "claimantFullName": {
+      "first": "Jane",
+      "last": "Doe"
+    },
+    "claimantSocialSecurityNumber": "321654987",
+    "claimantType": "SPOUSE",
+    "view:isAddingUnassociatedIncomes": true,
+    "unassociatedIncomes": [
+      {
+        "recipientRelationship": "SPOUSE",
+        "incomeType": "SOCIAL_SECURITY",
+        "grossMonthlyIncome": 0,
+        "payer": "Business name"
+      }
+    ],
+    "view:isAddingAssociatedIncomes": true,
+    "associatedIncomes": [
+      {
+        "recipientRelationship": "SPOUSE",
+        "incomeType": "INTEREST",
+        "grossMonthlyIncome": 0,
+        "accountValue": 0,
+        "payer": "Financial name"
+      }
+    ],
+    "view:isAddingOwnedAssets": true,
+    "ownedAssets": [
+      {
+        "recipientRelationship": "SPOUSE",
+        "recipientName": "Recipient name",
+        "grossMonthlyIncome": 0,
+        "ownedPortionValue": 0,
+        "assetType": "BUSINESS"
+      }
+    ],
+    "view:isAddingRoyalties": true,
+    "royaltiesAndOtherProperties": [
+      {
+        "recipientRelationship": "SPOUSE",
+        "canBeSold": true,
+        "fairMarketValue": 0,
+        "grossMonthlyIncome": 0,
+        "incomeGenerationMethod": "INTELLECTUAL_PROPERTY"
+      }
+    ],
+    "view:isAddingAssetTransfers": true,
+    "assetTransfers": [
+      {
+        "originalOwnerRelationship": "SPOUSE",
+        "transferMethod": "SOLD",
+        "assetType": "Real Estate Property",
+        "newOwnerName": { "first": "Alice", "last": "Johnson" },
+        "newOwnerRelationship": "Friend",
+        "saleReportedToIrs": true,
+        "transferDate": "2023-05-15",
+        "assetTransferredUnderFairMarketValue": false,
+        "fairMarketValue": 0,
+        "saleValue": 0,
+        "capitalGainValue": 0
+      }
+    ],
+    "view:isAddingTrusts": true,
+    "trusts": [
+      {
+        "establishedDate": "2020-03-15",
+        "marketValueAtEstablishment": 0,
+        "trustType": "REVOCABLE",
+        "addedFundsAfterEstablishment": true,
+        "addedFundsDate": "2021-05-10",
+        "addedFundsAmount": 0,
+        "receivingIncomeFromTrust": true,
+        "annualReceivedIncome": 0,
+        "trustUsedForMedicalExpenses": false,
+        "monthlyMedicalReimbursementAmount": 0,
+        "trustEstablishedForVeteransChild": false,
+        "haveAuthorityOrControlOfTrust": true
+      }
+    ],
+    "view:isAddingAnnuities": true,
+    "annuities": [
+      {
+        "establishedDate": "2018-06-15",
+        "marketValueAtEstablishment": 0,
+        "addedFundsAfterEstablishment": true,
+        "addedFundsDate": "2020-09-22",
+        "addedFundsAmount": 0,
+        "revocable": false,
+        "receivingIncomeFromAnnuity": true,
+        "annualReceivedIncome": 0,
+        "canBeLiquidated": true,
+        "surrenderValue": 0
+      }
+    ],
+    "view:isAddingUnreportedAssets": true,
+    "unreportedAssets": [
+      {
+        "assetOwnerRelationship": "SPOUSE",
+        "ownedPortionValue": 0,
+        "assetType": "Investment Portfolio",
+        "assetLocation": "Global Investments LLC, Portfolio ID #987654321"
+      }
+    ],
+    "view:isAddingDiscontinuedIncomes": true,
+    "discontinuedIncomes": [
+      {
+        "recipientRelationship": "SPOUSE",
+        "payer": "Social Security Administration",
+        "incomeType": "Social Security",
+        "incomeFrequency": "RECURRING",
+        "incomeLastReceivedDate": "2023-05-15",
+        "grossAnnualAmount": 0
+      }
+    ],
+    "view:isAddingIncomeReceiptWaivers": true,
+    "incomeReceiptWaivers": [
+      {
+        "recipientRelationship": "SPOUSE",
+        "payer": "Social Security Administration",
+        "expectedIncome": 0,
+        "view:paymentsWillResume": true,
+        "paymentResumeDate": "2024-06-01",
+        "waivedGrossMonthlyIncome": 0
+      }
+    ],
+    "statementOfTruthSignature": "Jane Doe",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/03-unassociated-incomes/unassociatedIncomePages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/03-unassociated-incomes/unassociatedIncomePages.unit.spec.jsx
@@ -6,8 +6,11 @@ import {
 import { incomeTypeLabels } from '../../../../labels';
 
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextGetItemName,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
@@ -26,6 +29,11 @@ describe('unassociated income list and loop pages', () => {
     testOptionsIsItemIncomplete(options, baseItem);
   });
 
+  describe('isItemIncomplete function tested with zeroes', () => {
+    const baseItem = testDataZeroes.data.unassociatedIncomes[0];
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  });
+
   describe('text getItemName function', () => {
     testOptionsTextGetItemName(options);
   });
@@ -36,6 +44,15 @@ describe('unassociated income list and loop pages', () => {
       recipientRelationship,
       ...baseItem
     } = testData.data.unassociatedIncomes[0];
+    testOptionsTextCardDescription(options, baseItem, incomeTypeLabels);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    const {
+      // eslint-disable-next-line no-unused-vars
+      recipientRelationship,
+      ...baseItem
+    } = testDataZeroes.data.unassociatedIncomes[0];
     testOptionsTextCardDescription(options, baseItem, incomeTypeLabels);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/04-associated-incomes/associatedIncomePages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/04-associated-incomes/associatedIncomePages.unit.spec.jsx
@@ -6,8 +6,11 @@ import {
 import { incomeTypeEarnedLabels } from '../../../../labels';
 
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextGetItemName,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
@@ -26,14 +29,35 @@ describe('associated income list and loop pages', () => {
     testOptionsIsItemIncomplete(options, baseItem);
   });
 
+  describe('isItemIncomplete function tested with zeroes', () => {
+    const baseItem = testDataZeroes.data.associatedIncomes[0];
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  });
+
   describe('text getItemName function', () => {
     testOptionsTextGetItemName(options);
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { accountValue, recipientRelationship, ...baseItem } = testData.data.associatedIncomes[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      accountValue,
+      recipientRelationship,
+      ...baseItem
+    } = testData.data.associatedIncomes[0];
+    /* eslint-enable no-unused-vars */
+
+    testOptionsTextCardDescription(options, baseItem, incomeTypeEarnedLabels);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      accountValue,
+      recipientRelationship,
+      ...baseItem
+    } = testDataZeroes.data.associatedIncomes[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(options, baseItem, incomeTypeEarnedLabels);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/05-owned-assets/ownedAssetPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/05-owned-assets/ownedAssetPages.unit.spec.jsx
@@ -5,8 +5,11 @@ import {
 } from '../../../../config/chapters/05-owned-assets/ownedAssetPages';
 import { ownedAssetTypeLabels } from '../../../../labels';
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextGetItemName,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
@@ -26,14 +29,35 @@ describe('owned asset list and loop pages', () => {
     testOptionsIsItemIncomplete(options, baseItem);
   });
 
+  describe('isItemIncomplete function tested with zeroes', () => {
+    // eslint-disable-next-line no-unused-vars
+    const { recipientName, ...baseItem } = testDataZeroes.data.ownedAssets[0];
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  });
+
   describe('text getItemName function', () => {
     testOptionsTextGetItemName(options);
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { recipientRelationship, recipientName, ...baseItem } = testData.data.ownedAssets[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      recipientRelationship,
+      recipientName,
+      ...baseItem
+    } = testData.data.ownedAssets[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsTextCardDescription(options, baseItem, ownedAssetTypeLabels);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      recipientRelationship,
+      recipientName,
+      ...baseItem
+    } = testDataZeroes.data.ownedAssets[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(options, baseItem, ownedAssetTypeLabels);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
@@ -6,8 +6,11 @@ import {
 import { generatedIncomeTypeLabels } from '../../../../labels';
 
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextGetItemName,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
@@ -26,14 +29,38 @@ describe('royalties list and loop pages', () => {
     testOptionsIsItemIncomplete(options, baseItem);
   });
 
+  describe('isItemIncomplete function tested with zeroes', () => {
+    const baseItem = testDataZeroes.data.royaltiesAndOtherProperties[0];
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  });
+
   describe('text getItemName function', () => {
     testOptionsTextGetItemName(options);
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { recipientRelationship, canBeSold, ...baseItem} = testData.data.royaltiesAndOtherProperties[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      recipientRelationship,
+      canBeSold,
+      ...baseItem
+    } = testData.data.royaltiesAndOtherProperties[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsTextCardDescription(
+      options,
+      baseItem,
+      generatedIncomeTypeLabels,
+    );
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      recipientRelationship,
+      canBeSold,
+      ...baseItem
+    } = testDataZeroes.data.royaltiesAndOtherProperties[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(
       options,
       baseItem,

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/07-asset-transfers/assetTransferPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/07-asset-transfers/assetTransferPages.unit.spec.jsx
@@ -7,8 +7,11 @@ import {
 import { transferMethodLabels } from '../../../../labels';
 
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
 import {
@@ -27,6 +30,12 @@ describe('asset transfer list and loop pages', () => {
     testOptionsIsItemIncomplete(options, baseItem);
   });
 
+  describe('isItemIncomplete function tested with zeroes', () => {
+    // eslint-disable-next-line no-unused-vars
+    const { saleValue, ...baseItem } = testDataZeroes.data.assetTransfers[0];
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  });
+
   describe('text getItemName function', () => {
     it('should return asset type text', () => {
       const item = { assetType: 'Real Estate Property' };
@@ -35,9 +44,34 @@ describe('asset transfer list and loop pages', () => {
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { originalOwnerRelationship, assetType, newOwnerName, newOwnerRelationship, saleReportedToIrs, assetTransferredUnderFairMarketValue, saleValue, ...baseItem } = testData.data.assetTransfers[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      originalOwnerRelationship,
+      assetType,
+      newOwnerName,
+      newOwnerRelationship,
+      saleReportedToIrs,
+      assetTransferredUnderFairMarketValue,
+      saleValue,
+      ...baseItem
+    } = testData.data.assetTransfers[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsTextCardDescription(options, baseItem, transferMethodLabels);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      originalOwnerRelationship,
+      assetType,
+      newOwnerName,
+      newOwnerRelationship,
+      saleReportedToIrs,
+      assetTransferredUnderFairMarketValue,
+      saleValue,
+      ...baseItem
+    } = testDataZeroes.data.assetTransfers[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(options, baseItem, transferMethodLabels);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/08-trusts/trustPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/08-trusts/trustPages.unit.spec.jsx
@@ -5,8 +5,11 @@ import {
   options,
 } from '../../../../config/chapters/08-trusts/trustPages';
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
 import {
@@ -20,10 +23,31 @@ describe('trust list and loop pages', () => {
   const { trustPagesSummary } = trustPages;
 
   describe('isItemIncomplete function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { addedFundsDate, addedFundsAmount, receivingIncomeFromTrust, annualReceivedIncome, monthlyMedicalReimbursementAmount, ...baseItem } = testData.data.trusts[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      addedFundsDate,
+      addedFundsAmount,
+      receivingIncomeFromTrust,
+      annualReceivedIncome,
+      monthlyMedicalReimbursementAmount,
+      ...baseItem
+    } = testData.data.trusts[0];
+    /* eslint-enable no-unused-vars */
     testOptionsIsItemIncomplete(options, baseItem);
+  });
+
+  describe('isItemIncomplete function tested with zeroes', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      addedFundsDate,
+      addedFundsAmount,
+      receivingIncomeFromTrust,
+      annualReceivedIncome,
+      monthlyMedicalReimbursementAmount,
+      ...baseItem
+    } = testDataZeroes.data.trusts[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
   });
 
   describe('text getItemName function', () => {
@@ -33,9 +57,40 @@ describe('trust list and loop pages', () => {
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { trustType, addedFundsAfterEstablishment, addedFundsDate, addedFundsAmount, receivingIncomeFromTrust, annualReceivedIncome, trustUsedForMedicalExpenses, monthlyMedicalReimbursementAmount, trustEstablishedForVeteransChild, haveAuthorityOrControlOfTrust, ...baseItem } = testData.data.trusts[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      trustType,
+      addedFundsAfterEstablishment,
+      addedFundsDate,
+      addedFundsAmount,
+      receivingIncomeFromTrust,
+      annualReceivedIncome,
+      trustUsedForMedicalExpenses,
+      monthlyMedicalReimbursementAmount,
+      trustEstablishedForVeteransChild,
+      haveAuthorityOrControlOfTrust,
+      ...baseItem
+    } = testData.data.trusts[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsTextCardDescription(options, baseItem);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      trustType,
+      addedFundsAfterEstablishment,
+      addedFundsDate,
+      addedFundsAmount,
+      receivingIncomeFromTrust,
+      annualReceivedIncome,
+      trustUsedForMedicalExpenses,
+      monthlyMedicalReimbursementAmount,
+      trustEstablishedForVeteransChild,
+      haveAuthorityOrControlOfTrust,
+      ...baseItem
+    } = testDataZeroes.data.trusts[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(options, baseItem);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/09-annuities/annuityPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/09-annuities/annuityPages.unit.spec.jsx
@@ -5,8 +5,11 @@ import {
   options,
 } from '../../../../config/chapters/09-annuities/annuityPages';
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
 import {
@@ -20,10 +23,29 @@ describe('annuity list and loop pages', () => {
   const { annuityPagesSummary } = annuityPages;
 
   describe('isItemIncomplete function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { addedFundsDate, addedFundsAmount, annualReceivedIncome, surrenderValue, ...baseItem } = testData.data.annuities[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      addedFundsDate,
+      addedFundsAmount,
+      annualReceivedIncome,
+      surrenderValue,
+      ...baseItem
+    } = testData.data.annuities[0];
+    /* eslint-enable no-unused-vars */
     testOptionsIsItemIncomplete(options, baseItem);
+  });
+
+  describe('isItemIncomplete function tested with zeroes', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      addedFundsDate,
+      addedFundsAmount,
+      annualReceivedIncome,
+      surrenderValue,
+      ...baseItem
+    } = testDataZeroes.data.annuities[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
   });
 
   describe('text getItemName function', () => {
@@ -33,9 +55,36 @@ describe('annuity list and loop pages', () => {
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { addedFundsAfterEstablishment, addedFundsDate, addedFundsAmount, revocable, receivingIncomeFromAnnuity, annualReceivedIncome, canBeLiquidated, surrenderValue, ...baseItem } = testData.data.annuities[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      addedFundsAfterEstablishment,
+      addedFundsDate,
+      addedFundsAmount,
+      revocable,
+      receivingIncomeFromAnnuity,
+      annualReceivedIncome,
+      canBeLiquidated,
+      surrenderValue,
+      ...baseItem
+    } = testData.data.annuities[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsTextCardDescription(options, baseItem);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      addedFundsAfterEstablishment,
+      addedFundsDate,
+      addedFundsAmount,
+      revocable,
+      receivingIncomeFromAnnuity,
+      annualReceivedIncome,
+      canBeLiquidated,
+      surrenderValue,
+      ...baseItem
+    } = testDataZeroes.data.annuities[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(options, baseItem);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/10-unreported-assets/unreportedAssetPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/10-unreported-assets/unreportedAssetPages.unit.spec.jsx
@@ -5,8 +5,11 @@ import {
   options,
 } from '../../../../config/chapters/10-unreported-assets/unreportedAssetPages';
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
 import {
@@ -24,6 +27,11 @@ describe('unreported asset list and loop pages', () => {
     testOptionsIsItemIncomplete(options, baseItem);
   });
 
+  describe('isItemIncomplete function tested with zeroes', () => {
+    const baseItem = testDataZeroes.data.unreportedAssets[0];
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  });
+
   describe('text getItemName function', () => {
     it('should return text', () => {
       expect(options.text.getItemName()).to.equal('Unreported Asset');
@@ -36,6 +44,15 @@ describe('unreported asset list and loop pages', () => {
       assetOwnerRelationship,
       ...baseItem
     } = testData.data.unreportedAssets[0];
+    testOptionsTextCardDescription(options, baseItem);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    const {
+      // eslint-disable-next-line no-unused-vars
+      assetOwnerRelationship,
+      ...baseItem
+    } = testDataZeroes.data.unreportedAssets[0];
     testOptionsTextCardDescription(options, baseItem);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/11-discontinued-incomes/discontinuedIncomePages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/11-discontinued-incomes/discontinuedIncomePages.unit.spec.jsx
@@ -7,8 +7,11 @@ import {
 import { relationshipLabels } from '../../../../labels';
 
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
 import {
@@ -26,6 +29,11 @@ describe('discontinued income list and loop pages', () => {
     testOptionsIsItemIncomplete(options, baseItem);
   });
 
+  describe('isItemIncomplete function tested with zeroes', () => {
+    const baseItem = testDataZeroes.data.discontinuedIncomes[0];
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
+  });
+
   describe('text getItemName function', () => {
     it('should return text', () => {
       expect(options.text.getItemName()).to.equal('Discontinued income');
@@ -33,9 +41,26 @@ describe('discontinued income list and loop pages', () => {
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { payer, incomeFrequency, incomeLastReceivedDate, ...baseItem } = testData.data.discontinuedIncomes[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      payer,
+      incomeFrequency,
+      incomeLastReceivedDate,
+      ...baseItem
+    } = testData.data.discontinuedIncomes[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsTextCardDescription(options, baseItem, relationshipLabels);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      payer,
+      incomeFrequency,
+      incomeLastReceivedDate,
+      ...baseItem
+    } = testDataZeroes.data.discontinuedIncomes[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(options, baseItem, relationshipLabels);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages.unit.spec.jsx
@@ -6,8 +6,11 @@ import {
 } from '../../../../config/chapters/12-income-receipt-waivers/incomeReceiptWaiverPages';
 import { relationshipLabels } from '../../../../labels';
 import testData from '../../../e2e/fixtures/data/test-data.json';
+import testDataZeroes from '../../../e2e/fixtures/data/test-data-all-zeroes.json';
+
 import {
   testOptionsIsItemIncomplete,
+  testOptionsIsItemIncompleteWithZeroes,
   testOptionsTextCardDescription,
 } from '../multiPageTests.spec';
 import {
@@ -21,10 +24,27 @@ describe('income receipt waiver list and loop pages', () => {
   const { incomeReceiptWaiverPagesSummary } = incomeReceiptWaiverPages;
 
   describe('isItemIncomplete function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { expectedIncome, 'view:paymentsWillResume': _, paymentResumeDate, ...baseItem } = testData.data.incomeReceiptWaivers[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      expectedIncome,
+      'view:paymentsWillResume': _,
+      paymentResumeDate,
+      ...baseItem
+    } = testData.data.incomeReceiptWaivers[0];
+    /* eslint-enable no-unused-vars */
     testOptionsIsItemIncomplete(options, baseItem);
+  });
+
+  describe('isItemIncomplete function tested with zeroes', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      expectedIncome,
+      'view:paymentsWillResume': _,
+      paymentResumeDate,
+      ...baseItem
+    } = testDataZeroes.data.incomeReceiptWaivers[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsIsItemIncompleteWithZeroes(options, baseItem);
   });
 
   describe('text getItemName function', () => {
@@ -34,9 +54,26 @@ describe('income receipt waiver list and loop pages', () => {
   });
 
   describe('text cardDescription function', () => {
-    // prettier-ignore
-    // eslint-disable-next-line no-unused-vars
-    const { expectedIncome, 'view:paymentsWillResume': _, paymentResumeDate, ...baseItem } = testData.data.incomeReceiptWaivers[0];
+    /* eslint-disable no-unused-vars */
+    const {
+      expectedIncome,
+      'view:paymentsWillResume': _,
+      paymentResumeDate,
+      ...baseItem
+    } = testData.data.incomeReceiptWaivers[0];
+    /* eslint-enable no-unused-vars */
+    testOptionsTextCardDescription(options, baseItem, relationshipLabels);
+  });
+
+  describe('text cardDescription function with zero values', () => {
+    /* eslint-disable no-unused-vars */
+    const {
+      expectedIncome,
+      'view:paymentsWillResume': _,
+      paymentResumeDate,
+      ...baseItem
+    } = testDataZeroes.data.incomeReceiptWaivers[0];
+    /* eslint-enable no-unused-vars */
     testOptionsTextCardDescription(options, baseItem, relationshipLabels);
   });
 

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/multiPageTests.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/multiPageTests.spec.jsx
@@ -19,6 +19,14 @@ export const testOptionsIsItemIncomplete = (options, baseItem) => {
   });
 };
 
+export const testOptionsIsItemIncompleteWithZeroes = (options, baseItem) => {
+  describe('isItemIncomplete function', () => {
+    it('should return false if all required fields are present and values are zeroes', () => {
+      expect(options.isItemIncomplete(baseItem)).to.be.false;
+    });
+  });
+};
+
 export const testOptionsTextGetItemName = options => {
   describe('text getItemName function', () => {
     const testCases = [
@@ -53,11 +61,11 @@ export const testOptionsTextCardDescription = (
 ) => {
   describe('text cardDescription function', () => {
     it('should return a description list when item exists', () => {
-      const { container, getByText } = render(
+      const { container, getAllByText } = render(
         options.text.cardDescription(baseItem),
       );
 
-      expect(container.querySelector('ul')).to.exist;
+      expect(container.querySelector('li')).to.exist;
 
       // Define key-based formatters
       const formatters = {
@@ -79,7 +87,7 @@ export const testOptionsTextCardDescription = (
 
       Object.entries(baseItem).forEach(([key, value]) => {
         const formattedValue = formatters[key] ? formatters[key](value) : value;
-        expect(getByText(formattedValue)).to.exist;
+        expect(getAllByText(formattedValue)).to.exist;
       });
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > When a value (usually income or other numeric value) is entered in a list loop, the summary page card would only show the zero. This PR checks if the value is defined, then shows the card content.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Pension & Burial Program (PBP)
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/106979

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated test data & unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| summary  | ![summary card only showing a zero when it should be showing income type, income label & recipient](https://github.com/user-attachments/assets/4b19e108-d3d2-42f3-87da-ff9b6d4ee55f) | ![summary card showing all labels and a gross monthly income of zero dollars](https://github.com/user-attachments/assets/4c096f1b-f436-4b61-b0ac-b99ee20941ff) |

## What areas of the site does it impact?

Income and Asset Statement Form (VA 21P-0969)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
