### PR TITLE
10-10CG | Migrate apiRequest mock to sinon

### DIFF
--- a/src/applications/caregivers/tests/unit/components/ApplicationDownloadLink.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/components/ApplicationDownloadLink.unit.spec.jsx
@@ -3,10 +3,7 @@ import { Provider } from 'react-redux';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import {
-  mockApiRequest,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import * as api from 'platform/utilities/api';
 import * as recordEventModule from 'platform/monitoring/record-event';
 import ApplicationDownloadLink from '../../../components/ApplicationDownloadLink';
 import content from '../../../locales/en/content.json';
@@ -34,13 +31,19 @@ describe('CG <ApplicationDownloadLink>', () => {
     });
     return { selectors };
   };
+  let apiRequestStub;
+  let recordEventStub;
 
   beforeEach(() => {
     localStorage.setItem('csrfToken', 'my-token');
+    apiRequestStub = sinon.stub(api, 'apiRequest');
+    recordEventStub = sinon.stub(recordEventModule, 'default');
   });
 
   afterEach(() => {
     localStorage.clear();
+    apiRequestStub.restore();
+    recordEventStub.restore();
   });
 
   context('default behavior', () => {
@@ -53,27 +56,13 @@ describe('CG <ApplicationDownloadLink>', () => {
     });
   });
 
-  context('when clicking the download file button', () => {
-    const triggerError = ({ link, status }) => {
-      mockApiRequest({}, false);
-      setFetchJSONResponse(
-        global.fetch.onCall(0),
-        // eslint-disable-next-line prefer-promise-reject-errors
-        Promise.reject({ errors: [{ status }] }),
-      );
+  context('when the download button has been clicked', () => {
+    const triggerError = ({ link, status = '503' }) => {
+      apiRequestStub.onFirstCall().rejects({ errors: [{ status }] });
       fireEvent.click(link);
     };
-    let recordEventStub;
 
-    beforeEach(() => {
-      recordEventStub = sinon.stub(recordEventModule, 'default');
-    });
-
-    afterEach(() => {
-      recordEventStub.restore();
-    });
-
-    it('should record `success` event when button is clicked', async () => {
+    it('should record the correct event when the request succeeds', async () => {
       const { selectors } = subject();
       const { vaLink: link } = selectors();
       const createObjectStub = sinon
@@ -81,7 +70,7 @@ describe('CG <ApplicationDownloadLink>', () => {
         .returns('my_stubbed_url.com');
       const revokeObjectStub = sinon.stub(URL, 'revokeObjectURL');
 
-      mockApiRequest({
+      apiRequestStub.onFirstCall().resolves({
         blob: () => new Blob(['my blob'], { type: 'application/pdf' }),
       });
       fireEvent.click(link);
@@ -105,10 +94,10 @@ describe('CG <ApplicationDownloadLink>', () => {
       revokeObjectStub.restore();
     });
 
-    it('should record `error` event when the request fails', async () => {
+    it('should record the correct event when the request fails', async () => {
       const { selectors } = subject();
       const { vaLink: link } = selectors();
-      triggerError({ link, status: '503' });
+      triggerError({ link });
 
       await waitFor(() => {
         const { vaLoadingIndicator } = selectors();
@@ -128,7 +117,7 @@ describe('CG <ApplicationDownloadLink>', () => {
     it('should display `downtime` error message when error has status of `5xx`', async () => {
       const { selectors } = subject();
       const { vaLink: link } = selectors();
-      triggerError({ link, status: '503' });
+      triggerError({ link });
 
       await waitFor(() => {
         const { vaLoadingIndicator } = selectors();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR performs a minor update to the unit tests in the Caregivers application to migrate the mocking of the `apiRequest` method to utilize sinon. This keeps our mocking consistent across the application and cleans up the handling of rejected requests.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#105037

## Acceptance criteria

 - Mocking is consistent throughout the application
 - Unit tests have maximum coverage

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution