### PR TITLE
10-10EZ | Migrate apiRequest mock to sinon

### DIFF
--- a/src/applications/hca/components/ApplicationDownloadLink.jsx
+++ b/src/applications/hca/components/ApplicationDownloadLink.jsx
@@ -65,7 +65,7 @@ const ApplicationDownloadLink = ({ formConfig }) => {
         handlePdfDownload(blob);
         recordEvent({ event: 'hca-pdf-download--success' });
       } catch (error) {
-        setErrors(error.errors || []);
+        setErrors(error.errors);
         recordEvent({ event: 'hca-pdf-download--failure' });
       } finally {
         setLoading(false);

--- a/src/applications/hca/tests/unit/utils/actions/disability-rating.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/utils/actions/disability-rating.unit.spec.jsx
@@ -1,9 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import {
-  mockApiRequest,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import * as api from 'platform/utilities/api';
 import { fetchTotalDisabilityRating } from '../../../../utils/actions';
 import { DISABILITY_RATING_ACTIONS } from '../../../../utils/constants';
 
@@ -13,18 +10,24 @@ describe('hca `fetchTotalDisabilityRating` action', () => {
     FETCH_DISABILITY_RATING_FAILED,
     FETCH_DISABILITY_RATING_SUCCEEDED,
   } = DISABILITY_RATING_ACTIONS;
+  let apiRequestStub;
   let dispatch;
   let mockData;
   let thunk;
 
   beforeEach(() => {
+    apiRequestStub = sinon.stub(api, 'apiRequest');
     dispatch = sinon.spy();
     mockData = { data: { attributes: { key: 'value' } } };
     thunk = fetchTotalDisabilityRating();
   });
 
-  it('should dispatch a fetch started action when fetch operation starts', done => {
-    mockApiRequest(mockData);
+  afterEach(() => {
+    apiRequestStub.restore();
+  });
+
+  it('should dispatch the correct action when fetch operation starts', done => {
+    apiRequestStub.onFirstCall().resolves(mockData);
     thunk(dispatch)
       .then(() => {
         const { type } = dispatch.firstCall.args[0];
@@ -33,8 +36,8 @@ describe('hca `fetchTotalDisabilityRating` action', () => {
       .then(done, done);
   });
 
-  it('should dispatch a fetch succeeded action with data when fetch operation succeeds', done => {
-    mockApiRequest(mockData);
+  it('should dispatch the correct action with data when fetch operation succeeds', done => {
+    apiRequestStub.onFirstCall().resolves(mockData);
     thunk(dispatch)
       .then(() => {
         const { type, response } = dispatch.secondCall.args[0];
@@ -44,43 +47,8 @@ describe('hca `fetchTotalDisabilityRating` action', () => {
       .then(done, done);
   });
 
-  it('should dispatch a fetch failed action when the response code is in the 500s', done => {
-    mockApiRequest(mockData, false);
-    setFetchJSONResponse(
-      global.fetch.onCall(0),
-      // eslint-disable-next-line prefer-promise-reject-errors
-      Promise.reject({ status: 503, error: 'error' }),
-    );
-    thunk(dispatch)
-      .then(() => {
-        const { type } = dispatch.secondCall.args[0];
-        expect(type).to.eq(FETCH_DISABILITY_RATING_FAILED);
-      })
-      .then(done, done);
-  });
-
-  it('should dispatch a fetch failed action when the response code is in the 400s', done => {
-    mockApiRequest(mockData, false);
-    setFetchJSONResponse(
-      global.fetch.onCall(0),
-      // eslint-disable-next-line prefer-promise-reject-errors
-      Promise.reject({ status: 403, error: 'error' }),
-    );
-    thunk(dispatch)
-      .then(() => {
-        const { type } = dispatch.secondCall.args[0];
-        expect(type).to.eq(FETCH_DISABILITY_RATING_FAILED);
-      })
-      .then(done, done);
-  });
-
-  it('should dispatch a fetch failed action when the response code is in the 300s', done => {
-    mockApiRequest(mockData, false);
-    setFetchJSONResponse(
-      global.fetch.onCall(0),
-      // eslint-disable-next-line prefer-promise-reject-errors
-      Promise.reject({ status: 301, error: 'error' }),
-    );
+  it('should dispatch the correct action when fetch operation fails', done => {
+    apiRequestStub.onFirstCall().rejects({ status: 503, error: 'error' });
     thunk(dispatch)
       .then(() => {
         const { type } = dispatch.secondCall.args[0];

--- a/src/applications/hca/tests/unit/utils/helpers/enrollment-status.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/utils/helpers/enrollment-status.unit.spec.jsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { mockApiRequest } from 'platform/testing/unit/helpers';
+import * as api from 'platform/utilities/api';
 import {
   callAPI,
   callFake404,
@@ -8,15 +8,21 @@ import {
 } from '../../../../utils/helpers';
 
 describe('hca enrollment status helpers', () => {
+  let apiRequestStub;
   let dispatch;
 
   beforeEach(() => {
+    apiRequestStub = sinon.stub(api, 'apiRequest');
     dispatch = sinon.spy();
+  });
+
+  afterEach(() => {
+    apiRequestStub.restore();
   });
 
   context('when `callAPI` executes', done => {
     it('should execute the dispatch function', () => {
-      mockApiRequest({ data: 'data' });
+      apiRequestStub.onFirstCall().resolves({ data: 'data' });
       callAPI(dispatch)
         .then(() => {
           expect(dispatch).to.be.called;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR performs a minor update to the unit tests in the Health Care application to migrate the mocking of the `apiRequest` method to utilize sinon. This keeps our mocking consistent across the application and cleans up the handling of rejected requests.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#105037

## Acceptance criteria

 - Mocking is consistent throughout the application
 - Unit tests have maximum coverage

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution