### PR TITLE
MHV-68800: Refill warning alert logic changes

### DIFF
--- a/src/applications/mhv-medications/components/shared/RefillAlert.jsx
+++ b/src/applications/mhv-medications/components/shared/RefillAlert.jsx
@@ -13,6 +13,10 @@ const RefillAlert = props => {
     state => state.rx.prescriptions?.refillAlertList,
   );
 
+  const refillNotification = useSelector(
+    state => state.rx.prescriptions?.refillNotification,
+  );
+
   useEffect(() => {
     if (!refillAlertList) {
       dispatch(getRefillAlertList());
@@ -22,7 +26,7 @@ const RefillAlert = props => {
   return (
     <VaAlert
       status="warning"
-      visible={!!refillAlertList?.length}
+      visible={!!refillAlertList?.length && !refillNotification}
       uswds
       className={refillAlertList?.length ? 'vads-u-margin-bottom--3' : ''}
       data-testid="alert-banner"

--- a/src/applications/mhv-medications/tests/e2e/medications-alert-after-refill-confirmation-and-page-reload-refill-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-alert-after-refill-confirmation-and-page-reload-refill-page.cypress.spec.js
@@ -1,0 +1,88 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import prescriptions from './fixtures/listOfPrescriptions.json';
+import MedicationsRefillPage from './pages/MedicationsRefillPage';
+import { Alerts, Data } from './utils/constants';
+import rxDetails from './fixtures/prescription-tracking-details.json';
+import rxSubmitted from './fixtures/active-submitted-prescription-details.json';
+import rxActive from './fixtures/active-prescriptions-with-refills.json';
+import successRequest from './fixtures/refill-success.json';
+import failedRequest from './fixtures/failed-request-prescription.json';
+import failedRefill from './fixtures/refill-failure.json';
+
+describe('Medications Refill Page Delay Alert Behavior', () => {
+  const refillPage = new MedicationsRefillPage();
+  beforeEach(() => {
+    const site = new MedicationsSite();
+    site.login();
+    refillPage.loadRefillPage(prescriptions);
+  });
+  it('visits Medications Refill Request Success and Page Delay Alert', () => {
+    refillPage.verifyRefillPageTitle();
+    cy.injectAxe();
+    cy.axeCheck('main');
+
+    refillPage.verifyRefillDelayAlertBannerOnRefillPage(
+      Data.DELAY_ALERT_BANNER,
+    );
+    refillPage.verifyRefillDetailsLinkVisibleOnDelayAlertBanner(
+      rxDetails.data.attributes.prescriptionName,
+    );
+    refillPage.verifyRefillDetailsLinkVisibleOnDelayAlertBanner(
+      rxSubmitted.data.attributes.prescriptionName,
+    );
+    refillPage.clickPrescriptionRefillCheckboxForSuccessfulRequest(rxActive);
+    refillPage.clickRequestRefillButtonforSuccessfulRequests(
+      rxActive.data.attributes.prescriptionId,
+      successRequest,
+    );
+    refillPage.verifyRefillRequestSuccessConfirmationMessage();
+    refillPage.verifyRefillDelayAlertNotVisibleOnRefillPage(
+      Data.DELAY_ALERT_BANNER,
+    );
+    cy.reload();
+    refillPage.verifyRefillDelayAlertBannerOnRefillPage(
+      Data.DELAY_ALERT_BANNER,
+    );
+    refillPage.verifyRefillDetailsLinkVisibleOnDelayAlertBanner(
+      rxDetails.data.attributes.prescriptionName,
+    );
+    refillPage.verifySuccessAlertTextDoesNotExistOnRefillPage(
+      Alerts.REFILL_SUBMIT_SUCCESS,
+    );
+  });
+
+  it('visits Medications Refill Request Failure and Page Delay Alert', () => {
+    refillPage.verifyRefillPageTitle();
+    cy.injectAxe();
+    cy.axeCheck('main');
+
+    refillPage.verifyRefillDelayAlertBannerOnRefillPage(
+      Data.DELAY_ALERT_BANNER,
+    );
+    refillPage.verifyRefillDetailsLinkVisibleOnDelayAlertBanner(
+      rxDetails.data.attributes.prescriptionName,
+    );
+    refillPage.verifyRefillDetailsLinkVisibleOnDelayAlertBanner(
+      rxSubmitted.data.attributes.prescriptionName,
+    );
+    refillPage.clickPrescriptionRefillCheckbox(failedRequest);
+    refillPage.clickRequestRefillButtonForFailedRequest(
+      failedRequest.data.attributes.prescriptionId,
+      failedRefill,
+    );
+    refillPage.verifyFailedRequestMessageAlertOnRefillPage();
+    refillPage.verifyRefillDelayAlertNotVisibleOnRefillPage(
+      Data.DELAY_ALERT_BANNER,
+    );
+    cy.reload();
+    refillPage.verifyRefillDelayAlertBannerOnRefillPage(
+      Data.DELAY_ALERT_BANNER,
+    );
+    refillPage.verifyRefillDetailsLinkVisibleOnDelayAlertBanner(
+      rxDetails.data.attributes.prescriptionName,
+    );
+    refillPage.verifyFailedAlertTextDoesNotExistOnRefillPage(
+      Alerts.REFILL_SUBMIT_FAILURE,
+    );
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -486,6 +486,12 @@ class MedicationsRefillPage {
     cy.get('[data-testid="rxDelay-alert-message"]').should('have.text', text);
   };
 
+  verifyRefillDelayAlertNotVisibleOnRefillPage(text) {
+    cy.get('[data-testid="rxDelay-alert-message"]')
+      .should('have.text', text)
+      .and('not.be.visible');
+  }
+
   verifyRefillDetailsLinkVisibleOnDelayAlertBanner = rxName => {
     cy.get('[data-testid="alert-banner"]').should('contain', rxName);
   };

--- a/src/applications/mhv-medications/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-medications/tests/e2e/utils/constants.js
@@ -122,4 +122,7 @@ export const Alerts = {
   EMPTY_MED_LIST: 'You don’t have any VA prescriptions or medication records',
   NO_FILTER_RESULTS: 'We didn’t find any matches for this filter',
   NO_ACCESS_TO_MEDICATIONS_ERROR: 'We can’t access your medications right now',
+  REFILL_SUBMIT_SUCCESS: 'Refills requested',
+  REFILL_SUBMIT_FAILURE:
+    'We’re sorry. There’s a problem with our system. We couldn’t submit these refill requests:',
 };


### PR DESCRIPTION
## Summary

- Rx: `RefillAlert` is not visible when `RefillNotification` is

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-68800

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: After the user presses “Request refills” from the Refill prescriptions page, refill confirmation success and/or error alert(s) appears under the h1. If there is a “Some refills are taking longer than expected” warning alert, it will be removed and only the success and/or error alert(s) will appear. Upon the page refresh, the warning alert will reappear and the success and/or error alert(s) will disappear.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

