### PR TITLE
Dependents 105745 | Add radio option for Pension questions

### DIFF
--- a/src/applications/686c-674/config/chapters/674/addStudentsArrayPages.js
+++ b/src/applications/686c-674/config/chapters/674/addStudentsArrayPages.js
@@ -13,6 +13,8 @@ import {
   arrayBuilderItemSubsequentPageTitleUI,
   yesNoUI,
   yesNoSchema,
+  radioUI,
+  radioSchema,
   fullNameNoSuffixUI,
   fullNameNoSuffixSchema,
   ssnUI,
@@ -167,17 +169,21 @@ export const studentIDInformationPage = {
 export const studentIncomePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(() => 'Student’s information'),
-    studentIncome: {
-      ...yesNoUI('Did this student earn an income in the last 365 days?'),
-      'ui:description': generateHelpText(
+    studentIncome: radioUI({
+      title: 'Did this student have an income in the last 365 days?',
+      hint:
         'Answer this question only if you are adding this dependent to your pension.',
-      ),
-    },
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+        NA: 'This question doesn’t apply to me',
+      },
+    }),
   },
   schema: {
     type: 'object',
     properties: {
-      studentIncome: yesNoSchema,
+      studentIncome: radioSchema(['Y', 'N', 'NA']),
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartTwo.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartTwo.js
@@ -1,9 +1,8 @@
 import {
   titleUI,
-  yesNoUI,
-  yesNoSchema,
+  radioUI,
+  radioSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { generateHelpText } from '../../../helpers';
 
 export const schema = {
   type: 'object',
@@ -11,7 +10,7 @@ export const schema = {
     doesLiveWithSpouse: {
       type: 'object',
       properties: {
-        spouseIncome: yesNoSchema,
+        spouseIncome: radioSchema(['Y', 'N', 'NA']),
       },
     },
   },
@@ -20,11 +19,15 @@ export const schema = {
 export const uiSchema = {
   ...titleUI('Information about your marriage'),
   doesLiveWithSpouse: {
-    spouseIncome: {
-      ...yesNoUI('Did your spouse have income in the last 365 days?'),
-      'ui:description': generateHelpText(
+    spouseIncome: radioUI({
+      title: 'Did your spouse have an income in the last 365 days?',
+      hint:
         'Answer this question only if you are adding this dependent to your pension.',
-      ),
-    },
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+        NA: 'This question doesn’t apply to me',
+      },
+    }),
   },
 };

--- a/src/applications/686c-674/config/chapters/report-add-child/additionalInformationPartTwo.js
+++ b/src/applications/686c-674/config/chapters/report-add-child/additionalInformationPartTwo.js
@@ -1,28 +1,27 @@
 import {
   titleUI,
-  yesNoUI,
-  yesNoSchema,
+  radioUI,
+  radioSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 export const additionalInformationPartTwo = {
   uiSchema: {
     ...titleUI('Additional information about this child'),
-    incomeInLastYear: yesNoUI({
-      title:
-        'Did this child have income in the last 365 days? Answer this question only if you are adding this dependent to your pension.',
+    incomeInLastYear: radioUI({
+      title: 'Did this child have an income in the last 365 days?',
+      hint:
+        'Answer this question only if you are adding this dependent to your pension.',
       labels: {
         Y: 'Yes',
         N: 'No',
-      },
-      errorMessages: {
-        required: 'Please select an option.',
+        NA: 'This question doesn’t apply to me',
       },
     }),
   },
   schema: {
     type: 'object',
     properties: {
-      incomeInLastYear: yesNoSchema,
+      incomeInLastYear: radioSchema(['Y', 'N', 'NA']),
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.js
@@ -5,8 +5,8 @@ import {
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,
   arrayBuilderItemSubsequentPageTitleUI,
-  yesNoUI,
-  yesNoSchema,
+  radioUI,
+  radioSchema,
   fullNameNoSuffixUI,
   fullNameNoSuffixSchema,
   ssnUI,
@@ -125,16 +125,21 @@ export const dateChildLeftSchoolPage = {
 export const childIncomeQuestionPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(() => 'Child’s income'),
-    dependentIncome: {
-      ...yesNoUI(
-        'Did this child earn an income in the last 365 days? Answer this question only if you are adding this dependent to your pension.',
-      ),
-    },
+    dependentIncome: radioUI({
+      title: 'Did this child have an income in the last 365 days?',
+      hint:
+        'Answer this question only if you are adding this dependent to your pension.',
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+        NA: 'This question doesn’t apply to me',
+      },
+    }),
   },
   schema: {
     type: 'object',
     properties: {
-      dependentIncome: yesNoSchema,
+      dependentIncome: radioSchema(['Y', 'N', 'NA']),
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-dependent-death/deceasedDependentArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-dependent-death/deceasedDependentArrayPages.js
@@ -9,8 +9,6 @@ import {
   fullNameNoSuffixSchema,
   radioUI,
   radioSchema,
-  yesNoUI,
-  yesNoSchema,
   checkboxGroupUI,
   checkboxGroupSchema,
   ssnUI,
@@ -281,14 +279,21 @@ export const deceasedDependentLocationOfDeathPage = {
 export const deceasedDependentIncomePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(() => 'Dependent’s income'),
-    deceasedDependentIncome: yesNoUI(
-      'Did this dependent earn an income in the last 365 days? Answer this question only if you are adding this dependent to your pension.',
-    ),
+    deceasedDependentIncome: radioUI({
+      title: 'Did this dependent have an income in the last 365 days?',
+      hint:
+        'Answer this question only if you are adding this dependent to your pension.',
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+        NA: 'This question doesn’t apply to me',
+      },
+    }),
   },
   schema: {
     type: 'object',
     properties: {
-      deceasedDependentIncome: yesNoSchema,
+      deceasedDependentIncome: radioSchema(['Y', 'N', 'NA']),
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartThree.js
+++ b/src/applications/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartThree.js
@@ -1,7 +1,7 @@
 import {
   titleUI,
-  yesNoUI,
-  yesNoSchema,
+  radioUI,
+  radioSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 export const schema = {
@@ -10,7 +10,7 @@ export const schema = {
     reportDivorce: {
       type: 'object',
       properties: {
-        spouseIncome: yesNoSchema,
+        spouseIncome: radioSchema(['Y', 'N', 'NA']),
       },
     },
   },
@@ -19,8 +19,15 @@ export const schema = {
 export const uiSchema = {
   reportDivorce: {
     ...titleUI('Divorced spouse’s income'),
-    spouseIncome: yesNoUI(
-      'Did this dependent earn an income in the last 365 days? Answer this question only if you are adding this dependent to your pension.',
-    ),
+    spouseIncome: radioUI({
+      title: 'Did this dependent have an income in the last 365 days?',
+      hint:
+        'Answer this question only if you are adding this dependent to your pension.',
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+        NA: 'This question doesn’t apply to me',
+      },
+    }),
   },
 };

--- a/src/applications/686c-674/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.js
@@ -5,8 +5,8 @@ import {
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,
   arrayBuilderItemSubsequentPageTitleUI,
-  yesNoUI,
-  yesNoSchema,
+  radioUI,
+  radioSchema,
   fullNameNoSuffixUI,
   fullNameNoSuffixSchema,
   ssnUI,
@@ -122,16 +122,21 @@ export const dateChildMarriedPage = {
 export const marriedChildIncomeQuestionPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(() => 'Child’s income'),
-    dependentIncome: {
-      ...yesNoUI(
-        'Did this child earn an income in the last 365 days? Answer this question only if you are adding this dependent to your pension.',
-      ),
-    },
+    dependentIncome: radioUI({
+      title: 'Did this child have an income in the last 365 days?',
+      hint:
+        'Answer this question only if you are adding this dependent to your pension.',
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+        NA: 'This question doesn’t apply to me',
+      },
+    }),
   },
   schema: {
     type: 'object',
     properties: {
-      dependentIncome: yesNoSchema,
+      dependentIncome: radioSchema(['Y', 'N', 'NA']),
     },
   },
 };

--- a/src/applications/686c-674/config/helpers.js
+++ b/src/applications/686c-674/config/helpers.js
@@ -142,14 +142,6 @@ export const customLocationSchemaStatePostal = {
   },
 };
 
-export const PensionIncomeRemovalQuestionTitle = (
-  <p>
-    Did this dependent earn an income in the last 365 days? Answer this question{' '}
-    <strong>only</strong> if you are removing this dependent from your{' '}
-    <strong>pension</strong>.
-  </p>
-);
-
 export const generateHelpText = (text, className = 'vads-u-color--gray') => {
   return <span className={className}>{text}</span>;
 };

--- a/src/applications/686c-674/tests/config/chapters/report-add-a-spouse/currentMarriageInformation.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/report-add-a-spouse/currentMarriageInformation.unit.spec.jsx
@@ -93,7 +93,7 @@ describe('686 current marriage information: Spouse income', () => {
     );
 
     expect($$('va-radio', container).length).to.equal(1);
-    expect($$('va-radio-option', container).length).to.equal(2);
+    expect($$('va-radio-option', container).length).to.equal(3);
   });
 });
 

--- a/src/applications/686c-674/tests/config/chapters/report-add-child/additionalInformationPartTwo.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/report-add-child/additionalInformationPartTwo.unit.spec.jsx
@@ -38,6 +38,6 @@ describe('686 add child additional information part two', () => {
     );
 
     const formDOM = getFormDOM(form);
-    expect(formDOM.querySelectorAll('va-radio-option').length).to.eq(2);
+    expect(formDOM.querySelectorAll('va-radio-option').length).to.eq(3);
   });
 });

--- a/src/applications/686c-674/tests/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.unit.spec.jsx
@@ -240,7 +240,7 @@ describe('686 report child who stopped attending school: Date child stopped atte
   });
 });
 
-describe('686 report child who stopped attending school: Date child stopped attending', () => {
+describe('686 report child who stopped attending school: Income', () => {
   const {
     schema,
     uiSchema,
@@ -261,6 +261,6 @@ describe('686 report child who stopped attending school: Date child stopped atte
     );
 
     expect($$('va-radio', container).length).to.equal(1);
-    expect($$('va-radio-option', container).length).to.equal(2);
+    expect($$('va-radio-option', container).length).to.equal(3);
   });
 });

--- a/src/applications/686c-674/tests/config/chapters/report-dependent-death/deceasedDependentsArray.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/report-dependent-death/deceasedDependentsArray.unit.spec.jsx
@@ -434,6 +434,6 @@ describe('686 report death: Dependent income', () => {
 
     expect(queryByText(/Dependent’s income/i)).to.not.be.null;
     expect($$('va-radio', container).length).to.equal(1);
-    expect($$('va-radio-option', container).length).to.equal(2);
+    expect($$('va-radio-option', container).length).to.equal(3);
   });
 });

--- a/src/applications/686c-674/tests/config/chapters/report-divorce/formerSpouseInformation.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/report-divorce/formerSpouseInformation.unit.spec.jsx
@@ -111,6 +111,6 @@ describe('686 report divorce: Former spouse income', () => {
     );
 
     expect($$('va-radio', container).length).to.equal(1);
-    expect($$('va-radio-option', container).length).to.equal(2);
+    expect($$('va-radio-option', container).length).to.equal(3);
   });
 });

--- a/src/applications/686c-674/tests/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.unit.spec.jsx
@@ -203,6 +203,6 @@ describe('686 report child who was married: Child income', () => {
     );
 
     expect($$('va-radio', container).length).to.equal(1);
-    expect($$('va-radio-option', container).length).to.equal(2);
+    expect($$('va-radio-option', container).length).to.equal(3);
   });
 });

--- a/src/applications/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
@@ -311,7 +311,7 @@ describe('674 Add students: Student income the past year ', () => {
     );
 
     expect($$('va-radio', container).length).to.equal(1);
-    expect($$('va-radio-option', container).length).to.equal(2);
+    expect($$('va-radio-option', container).length).to.equal(3);
   });
 });
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds third option for "Does not apply" to all dependent income pages

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105745

## Testing done

- Manual / Unit / E2E

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
