### PR TITLE
Lazy load platform/pdf files to improve page load performance

### DIFF
--- a/src/applications/mhv-medical-records/routes.jsx
+++ b/src/applications/mhv-medical-records/routes.jsx
@@ -1,30 +1,57 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 import { useMyHealthAccessGuard } from '~/platform/mhv/hooks/useMyHealthAccessGuard';
 import FeatureFlagRoute from './components/shared/FeatureFlagRoute';
 import AppRoute from './components/shared/AppRoute';
-import HealthConditions from './containers/HealthConditions';
-import VaccineDetails from './containers/VaccineDetails';
-import Vaccines from './containers/Vaccines';
-import VitalDetails from './containers/VitalDetails';
-import Vitals from './containers/Vitals';
-import LandingPage from './containers/LandingPage';
-import LabsAndTests from './containers/LabsAndTests';
-import CareSummariesAndNotes from './containers/CareSummariesAndNotes';
-import ConditionDetails from './containers/ConditionDetails';
-import LabAndTestDetails from './containers/LabAndTestDetails';
-import Allergies from './containers/Allergies';
-import AllergyDetails from './containers/AllergyDetails';
-import CareSummariesDetails from './containers/CareSummariesDetails';
-import SettingsPage from './containers/SettingsPage';
-import RadiologyImagesList from './containers/RadiologyImagesList';
-import RadiologySingleImage from './containers/RadiologySingleImage';
-import DownloadReportPage from './containers/DownloadReportPage';
-import DownloadDateRange from './components/DownloadRecords/DownloadDateRange';
-import DownloadRecordType from './components/DownloadRecords/DownloadRecordType';
-import DownloadFileType from './components/DownloadRecords/DownloadFileType';
+
+// Lazy-loaded components
+const HealthConditions = lazy(() => import('./containers/HealthConditions'));
+const VaccineDetails = lazy(() => import('./containers/VaccineDetails'));
+const Vaccines = lazy(() => import('./containers/Vaccines'));
+const VitalDetails = lazy(() => import('./containers/VitalDetails'));
+const Vitals = lazy(() => import('./containers/Vitals'));
+const LandingPage = lazy(() => import('./containers/LandingPage'));
+const LabsAndTests = lazy(() => import('./containers/LabsAndTests'));
+const CareSummariesAndNotes = lazy(() =>
+  import('./containers/CareSummariesAndNotes'),
+);
+const ConditionDetails = lazy(() => import('./containers/ConditionDetails'));
+const LabAndTestDetails = lazy(() => import('./containers/LabAndTestDetails'));
+const Allergies = lazy(() => import('./containers/Allergies'));
+const AllergyDetails = lazy(() => import('./containers/AllergyDetails'));
+const CareSummariesDetails = lazy(() =>
+  import('./containers/CareSummariesDetails'),
+);
+const SettingsPage = lazy(() => import('./containers/SettingsPage'));
+const RadiologyImagesList = lazy(() =>
+  import('./containers/RadiologyImagesList'),
+);
+const RadiologySingleImage = lazy(() =>
+  import('./containers/RadiologySingleImage'),
+);
+const DownloadReportPage = lazy(() =>
+  import('./containers/DownloadReportPage'),
+);
+const DownloadDateRange = lazy(() =>
+  import('./components/DownloadRecords/DownloadDateRange'),
+);
+const DownloadRecordType = lazy(() =>
+  import('./components/DownloadRecords/DownloadRecordType'),
+);
+const DownloadFileType = lazy(() =>
+  import('./components/DownloadRecords/DownloadFileType'),
+);
+
+// Loading component to display while lazy-loaded components are being fetched
+const Loading = () => (
+  <va-loading-indicator
+    message="Loading..."
+    set-focus
+    data-testid="loading-indicator"
+  />
+);
 
 const AccessGuardWrapper = ({ children }) => {
   const redirectToMyHealth = useMyHealthAccessGuard();
@@ -36,136 +63,138 @@ const AccessGuardWrapper = ({ children }) => {
 
 const routes = (
   <AccessGuardWrapper>
-    <Switch>
-      <AppRoute exact path="/" key="Medical Records Home">
-        <LandingPage />
-      </AppRoute>
-      <AppRoute exact path="/allergies" key="Allergies">
-        <Allergies />
-      </AppRoute>
-      <AppRoute exact path="/allergies/:allergyId" key="AllergyDetails">
-        <AllergyDetails />
-      </AppRoute>
-      <FeatureFlagRoute
-        exact
-        path="/vaccines"
-        key="Vaccines"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVaccines}
-      >
-        <Vaccines />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/vaccines/:vaccineId"
-        key="Vaccine"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVaccines}
-      >
-        <VaccineDetails />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/summaries-and-notes"
-        key="CareSummariesAndNotes"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayNotes}
-      >
-        <CareSummariesAndNotes />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/summaries-and-notes/:summaryId"
-        key="CareSummaryAndNotesDetails"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayNotes}
-      >
-        <CareSummariesDetails />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/conditions"
-        key="Health Conditions"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayConditions}
-      >
-        <HealthConditions />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/conditions/:conditionId"
-        key="Condition Details"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayConditions}
-      >
-        <ConditionDetails />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/vitals"
-        key="Vitals"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVitals}
-      >
-        <Vitals />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/vitals/:vitalType-history"
-        key="VitalDetails"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVitals}
-      >
-        <VitalDetails />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/labs-and-tests"
-        key="LabsAndTests"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
-      >
-        <LabsAndTests />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/labs-and-tests/:labId"
-        key="LabAndTestDetails"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
-      >
-        <LabAndTestDetails />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/labs-and-tests/:labId/images"
-        key="RadiologyImagesList"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
-      >
-        <RadiologyImagesList />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/labs-and-tests/:labId/images/:imageId"
-        key="RadiologySingleImage"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
-      >
-        <RadiologySingleImage />
-      </FeatureFlagRoute>
-      <FeatureFlagRoute
-        exact
-        path="/settings"
-        key="Settings"
-        featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplaySettingsPage}
-      >
-        <SettingsPage />
-      </FeatureFlagRoute>
-      <AppRoute exact path="/download" key="Download">
-        <DownloadReportPage />
-      </AppRoute>
-      <AppRoute exact path="/download/date-range" key="Download-date-range">
-        <DownloadDateRange />
-      </AppRoute>
-      <AppRoute exact path="/download/record-type" key="Download-record-type">
-        <DownloadRecordType />
-      </AppRoute>
-      <AppRoute exact path="/download/file-type" key="Download-file-type">
-        <DownloadFileType />
-      </AppRoute>
-      <Route>
-        <PageNotFound />
-      </Route>
-    </Switch>
+    <Suspense fallback={<Loading />}>
+      <Switch>
+        <AppRoute exact path="/" key="Medical Records Home">
+          <LandingPage />
+        </AppRoute>
+        <AppRoute exact path="/allergies" key="Allergies">
+          <Allergies />
+        </AppRoute>
+        <AppRoute exact path="/allergies/:allergyId" key="AllergyDetails">
+          <AllergyDetails />
+        </AppRoute>
+        <FeatureFlagRoute
+          exact
+          path="/vaccines"
+          key="Vaccines"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVaccines}
+        >
+          <Vaccines />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/vaccines/:vaccineId"
+          key="Vaccine"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVaccines}
+        >
+          <VaccineDetails />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/summaries-and-notes"
+          key="CareSummariesAndNotes"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayNotes}
+        >
+          <CareSummariesAndNotes />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/summaries-and-notes/:summaryId"
+          key="CareSummaryAndNotesDetails"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayNotes}
+        >
+          <CareSummariesDetails />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/conditions"
+          key="Health Conditions"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayConditions}
+        >
+          <HealthConditions />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/conditions/:conditionId"
+          key="Condition Details"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayConditions}
+        >
+          <ConditionDetails />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/vitals"
+          key="Vitals"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVitals}
+        >
+          <Vitals />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/vitals/:vitalType-history"
+          key="VitalDetails"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVitals}
+        >
+          <VitalDetails />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/labs-and-tests"
+          key="LabsAndTests"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
+        >
+          <LabsAndTests />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/labs-and-tests/:labId"
+          key="LabAndTestDetails"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
+        >
+          <LabAndTestDetails />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/labs-and-tests/:labId/images"
+          key="RadiologyImagesList"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
+        >
+          <RadiologyImagesList />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/labs-and-tests/:labId/images/:imageId"
+          key="RadiologySingleImage"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
+        >
+          <RadiologySingleImage />
+        </FeatureFlagRoute>
+        <FeatureFlagRoute
+          exact
+          path="/settings"
+          key="Settings"
+          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplaySettingsPage}
+        >
+          <SettingsPage />
+        </FeatureFlagRoute>
+        <AppRoute exact path="/download" key="Download">
+          <DownloadReportPage />
+        </AppRoute>
+        <AppRoute exact path="/download/date-range" key="Download-date-range">
+          <DownloadDateRange />
+        </AppRoute>
+        <AppRoute exact path="/download/record-type" key="Download-record-type">
+          <DownloadRecordType />
+        </AppRoute>
+        <AppRoute exact path="/download/file-type" key="Download-file-type">
+          <DownloadFileType />
+        </AppRoute>
+        <Route>
+          <PageNotFound />
+        </Route>
+      </Switch>
+    </Suspense>
   </AccessGuardWrapper>
 );
 

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
@@ -41,9 +41,9 @@ class Vitals {
   };
 
   goToVitalPage = () => {
-    cy.get('[data-testid="vitals-landing-page-link"]')
-      .should('be.visible')
-      .click();
+    cy.get('[data-testid="vitals-landing-page-link"]').as('vitals-link');
+    cy.get('@vitals-link').should('be.visible');
+    cy.get('@vitals-link').click();
   };
 
   checkUrl = ({ timeFrame }) => {

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -2,7 +2,6 @@ import moment from 'moment-timezone';
 import * as Sentry from '@sentry/browser';
 import { datadogRum } from '@datadog/browser-rum';
 import { snakeCase } from 'lodash';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { format as dateFnsFormat, parseISO, isValid } from 'date-fns';
@@ -70,6 +69,7 @@ export const dateFormatWithoutTimezone = (
 
   return null;
 };
+
 /**
  * @param {Object} nameObject {first, middle, last, suffix}
  * @returns {String} formatted timestamp
@@ -173,6 +173,12 @@ export const macroCase = str => {
 };
 
 /**
+ * Cache the dynamic import promise to avoid redundant network requests
+ * and improve performance when makePdf is called multiple times.
+ */
+let pdfModulePromise = null;
+
+/**
  * Create a pdf using the platform pdf generator tool
  * @param {Boolean} pdfName what the pdf file should be named
  * @param {Object} pdfData data to be passed to pdf generator
@@ -188,10 +194,21 @@ export const makePdf = async (
   templateId,
 ) => {
   try {
+    // Use cached module promise if available, otherwise create a new one
+    if (!pdfModulePromise) {
+      pdfModulePromise = import('@department-of-veterans-affairs/platform-pdf/exports');
+    }
+
+    // Wait for the module to load and extract the generatePdf function
+    const { generatePdf } = await pdfModulePromise;
+
     if (!runningUnitTest) {
       await generatePdf(templateId || 'medicalRecords', pdfName, pdfData);
     }
   } catch (error) {
+    // Reset the pdfModulePromise so subsequent calls can try again
+    pdfModulePromise = null;
+
     sendErrorToSentry(error, sentryError);
   }
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

## Summary

The Platform/PDF package adds over 3MB (uncompressed) to the app bundle size in dev mode. This PR uses [lazy loading](https://react.dev/reference/react/lazy) to avoid downloading it until a user is actually generating a PDF. This will improve initial load times for all users.

### Local bundle sizes

| File | Before | After |
| -- | -- | -- |
| medications.entry.js | 12.3MB | 8.56MB |
| vendor.entry.js | 2.35MB | 2.35MB |

## Testing done

- Automated tests
- Local testing

## Screenshots

![image](https://github.com/user-attachments/assets/08698aff-5e42-4d93-9f86-c2445692f955)

## What areas of the site does it impact?

Medical Records app
