### PR TITLE
update MhvServiceRequiredGuard to prevent children components from rendering prematurely

### DIFF
--- a/src/applications/mhv-landing-page/containers/LandingPageContainer.jsx
+++ b/src/applications/mhv-landing-page/containers/LandingPageContainer.jsx
@@ -16,7 +16,7 @@ import {
   isVAPatient,
   selectProfile,
   signInServiceEnabled,
-  hasMhvAccount,
+  hasMessagingAccess,
   mhvAccountStatusLoading,
 } from '../selectors';
 
@@ -31,7 +31,7 @@ const LandingPageContainer = () => {
   const unreadMessageAriaLabel = resolveUnreadMessageAriaLabel(
     unreadMessageCount,
   );
-  const userHasMhvAccount = useSelector(hasMhvAccount);
+  const userHasMessagingAccess = useSelector(hasMessagingAccess);
 
   const data = useMemo(
     () => {
@@ -55,11 +55,11 @@ const LandingPageContainer = () => {
         const unreadMessages = countUnreadMessages(folders);
         setUnreadMessageCount(unreadMessages);
       }
-      if (userHasMhvAccount) {
+      if (userHasMessagingAccess) {
         loadMessages();
       }
     },
-    [userHasMhvAccount, loading],
+    [userHasMessagingAccess, loading],
   );
 
   useEffect(

--- a/src/applications/mhv-landing-page/selectors/hasMessagingAccess.js
+++ b/src/applications/mhv-landing-page/selectors/hasMessagingAccess.js
@@ -1,0 +1,10 @@
+import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
+/**
+ * Selects the hasMessagingAccess state.
+ * @param {Object} state The current application state.
+ * @returns {boolean} The hasMessagingAccess state.
+ */
+
+export const hasMessagingAccess = state => {
+  return state?.user?.profile?.services.includes(backendServices.MESSAGING);
+};

--- a/src/applications/mhv-landing-page/selectors/index.js
+++ b/src/applications/mhv-landing-page/selectors/index.js
@@ -19,6 +19,7 @@ import { hasMhvAccount } from './hasMhvAccount';
 import { selectGreetingName } from './personalInformation';
 import { showVerifyAndRegisterAlert } from './showVerifyAndRegisterAlert';
 import { hasMhvBasicAccount } from './hasMhvBasicAccount';
+import { hasMessagingAccess } from './hasMessagingAccess';
 
 import {
   mhvAccountStatusLoading,
@@ -38,6 +39,7 @@ import {
 export {
   hasMhvAccount,
   hasMhvBasicAccount,
+  hasMessagingAccess,
   isAuthenticatedWithSSOe,
   isInMPI,
   isLOA1,

--- a/src/applications/mhv-landing-page/tests/containers/LandingPageContainer.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/containers/LandingPageContainer.unit.spec.jsx
@@ -28,6 +28,7 @@ const stateFn = ({
       signIn: {
         serviceName,
       },
+      services: ['messaging'],
     },
     login: {
       currentlyLoggedIn,

--- a/src/applications/mhv-medical-records/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/App.unit.spec.jsx
@@ -110,7 +110,7 @@ describe('App', () => {
       expect(screen.getByTestId('mr-feature-flag-loading-indicator'));
     });
 
-    it('feature flags are done loading', () => {
+    it('feature flags are done loading', async () => {
       const screen = renderWithStoreAndRouter(
         <App>
           <LandingPage />
@@ -124,12 +124,14 @@ describe('App', () => {
           path: `/`,
         },
       );
-      expect(
-        screen.getAllByText('Medical records', {
-          selector: 'h1',
-          exact: true,
-        }),
-      );
+      await waitFor(() => {
+        expect(
+          screen.getAllByText('Medical records', {
+            selector: 'h1',
+            exact: true,
+          }),
+        );
+      });
       expect(
         screen.getAllByText(
           'Review, print, and download your VA medical records.',
@@ -142,7 +144,7 @@ describe('App', () => {
       expect(screen.getByRole('navigation', { name: 'My HealtheVet' }));
     });
 
-    it('renders the global downtime notification', () => {
+    it('renders the global downtime notification', async () => {
       const screen = renderWithStoreAndRouter(<App />, {
         initialState: {
           ...initialState,
@@ -157,12 +159,14 @@ describe('App', () => {
         reducers: reducer,
         path: `/`,
       });
-      expect(
-        screen.getByText('This tool is down for maintenance', {
-          selector: 'h3',
-          exact: true,
-        }),
-      );
+      await waitFor(() => {
+        expect(
+          screen.getByText('This tool is down for maintenance', {
+            selector: 'h3',
+            exact: true,
+          }),
+        );
+      });
       expect(
         screen.getByText('We’re making some updates to this tool', {
           exact: false,
@@ -170,7 +174,7 @@ describe('App', () => {
       );
     });
 
-    it('renders the downtime notification', () => {
+    it('renders the downtime notification', async () => {
       const screen = renderWithStoreAndRouter(<App />, {
         initialState: {
           ...initialState,
@@ -185,12 +189,14 @@ describe('App', () => {
         reducers: reducer,
         path: `/`,
       });
-      expect(
-        screen.getByText('Maintenance on My HealtheVet', {
-          selector: 'h2',
-          exact: true,
-        }),
-      );
+      await waitFor(() => {
+        expect(
+          screen.getByText('Maintenance on My HealtheVet', {
+            selector: 'h2',
+            exact: true,
+          }),
+        );
+      });
       expect(
         screen.getByText(
           'We’re working on this medical records tool right now. The maintenance will last 48 hours.',
@@ -201,7 +207,7 @@ describe('App', () => {
       );
     });
 
-    it('renders the downtime notification for multiple services', () => {
+    it('renders the downtime notification for multiple services', async () => {
       const screen = renderWithStoreAndRouter(<App />, {
         initialState: {
           ...initialState,
@@ -216,12 +222,14 @@ describe('App', () => {
         reducers: reducer,
         path: `/`,
       });
-      expect(
-        screen.getByText('Maintenance on My HealtheVet', {
-          selector: 'h2',
-          exact: true,
-        }),
-      );
+      await waitFor(() => {
+        expect(
+          screen.getByText('Maintenance on My HealtheVet', {
+            selector: 'h2',
+            exact: true,
+          }),
+        );
+      });
       expect(
         screen.getByText(
           'We’re working on this medical records tool right now. The maintenance will last 48 hours.',
@@ -273,7 +281,9 @@ describe('App', () => {
       reducers: reducer,
       path: `/`,
     });
-    expect(screen.getByTestId('breadcrumbs')).to.exist;
+    waitFor(() => {
+      expect(screen.getByTestId('breadcrumbs')).to.exist;
+    });
   });
 
   it('does not render breadcrumbs when downtime and not at the landing page', () => {

--- a/src/applications/mhv-medications/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/App.unit.spec.jsx
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import React from 'react';
+import { waitFor } from '@testing-library/dom';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
@@ -39,7 +40,8 @@ describe('Medications <App>', () => {
             currentlyLoggedIn: true,
           },
           profile: {
-            services: [backendServices.USER_PROFILE],
+            verified: true,
+            services: [backendServices.RX],
           },
         },
         scheduledDowntime: {
@@ -85,17 +87,19 @@ describe('Medications <App>', () => {
     expect(screenFeatureToggle.queryByText('unit test paragraph')).to.be.null;
   });
 
-  it('feature flag set to true', () => {
+  it('feature flag set to true', async () => {
     const screenFeatureToggle = renderWithStoreAndRouter(
       <App>
         <p data-testid="app-unit-test-p">unit test paragraph</p>
       </App>,
       initialStateFeatureFlag(false, true),
     );
-    expect(screenFeatureToggle.queryByText('unit test paragraph')).to.exist;
+    await waitFor(() => {
+      expect(screenFeatureToggle.getByText('unit test paragraph')).to.exist;
+    });
   });
 
-  it('renders the global downtime notification', () => {
+  it('renders the global downtime notification', async () => {
     const screen = renderWithStoreAndRouter(
       <App>
         <p data-testid="app-unit-test-p">unit test paragraph</p>
@@ -112,7 +116,8 @@ describe('Medications <App>', () => {
               currentlyLoggedIn: true,
             },
             profile: {
-              services: [backendServices.USER_PROFILE],
+              verified: true,
+              services: [backendServices.RX],
             },
           },
           scheduledDowntime: {
@@ -125,12 +130,14 @@ describe('Medications <App>', () => {
         },
       },
     );
-    expect(
-      screen.getByText('This tool is down for maintenance', {
-        selector: 'h3',
-        exact: true,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('This tool is down for maintenance', {
+          selector: 'h3',
+          exact: true,
+        }),
+      );
+    });
     expect(
       screen.getByText('We’re making some updates to this tool', {
         exact: false,
@@ -138,7 +145,7 @@ describe('Medications <App>', () => {
     );
   });
 
-  it('renders the downtime notification', () => {
+  it('renders the downtime notification', async () => {
     const screen = renderWithStoreAndRouter(
       <App>
         <p data-testid="app-unit-test-p">unit test paragraph</p>
@@ -155,7 +162,8 @@ describe('Medications <App>', () => {
               currentlyLoggedIn: true,
             },
             profile: {
-              services: [backendServices.USER_PROFILE],
+              verified: true,
+              services: [backendServices.RX],
             },
           },
           scheduledDowntime: {
@@ -168,12 +176,14 @@ describe('Medications <App>', () => {
         },
       },
     );
-    expect(
-      screen.getByText('Maintenance on My HealtheVet', {
-        selector: 'h2',
-        exact: true,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Maintenance on My HealtheVet', {
+          selector: 'h2',
+          exact: true,
+        }),
+      );
+    });
     expect(
       screen.getByText('We’re working on Medications right now', {
         exact: false,
@@ -181,7 +191,7 @@ describe('Medications <App>', () => {
     );
   });
 
-  it('renders the downtime notification for multiple configured services', () => {
+  it('renders the downtime notification for multiple configured services', async () => {
     const screen = renderWithStoreAndRouter(
       <App>
         <p data-testid="app-unit-test-p">unit test paragraph</p>
@@ -198,7 +208,8 @@ describe('Medications <App>', () => {
               currentlyLoggedIn: true,
             },
             profile: {
-              services: [backendServices.USER_PROFILE],
+              verified: true,
+              services: [backendServices.RX],
             },
           },
           scheduledDowntime: {
@@ -211,12 +222,14 @@ describe('Medications <App>', () => {
         },
       },
     );
-    expect(
-      screen.getByText('Maintenance on My HealtheVet', {
-        selector: 'h2',
-        exact: true,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Maintenance on My HealtheVet', {
+          selector: 'h2',
+          exact: true,
+        }),
+      );
+    });
     expect(
       screen.getByText('We’re working on Medications right now', {
         exact: false,
@@ -224,7 +237,7 @@ describe('Medications <App>', () => {
     );
   });
 
-  it('renders the downtime notification for mixed services', () => {
+  it('renders the downtime notification for mixed services', async () => {
     const screen = renderWithStoreAndRouter(
       <App>
         <p data-testid="app-unit-test-p">unit test paragraph</p>
@@ -241,7 +254,8 @@ describe('Medications <App>', () => {
               currentlyLoggedIn: true,
             },
             profile: {
-              services: [backendServices.USER_PROFILE],
+              verified: true,
+              services: [backendServices.RX],
             },
           },
           scheduledDowntime: {
@@ -254,12 +268,14 @@ describe('Medications <App>', () => {
         },
       },
     );
-    expect(
-      screen.getByText('Maintenance on My HealtheVet', {
-        selector: 'h2',
-        exact: false,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Maintenance on My HealtheVet', {
+          selector: 'h2',
+          exact: false,
+        }),
+      );
+    });
     expect(
       screen.getByText('We’re working on Medications right now', {
         exact: false,
@@ -284,7 +300,8 @@ describe('Medications <App>', () => {
               currentlyLoggedIn: true,
             },
             profile: {
-              services: [backendServices.USER_PROFILE],
+              verified: true,
+              services: [backendServices.RX],
             },
           },
           scheduledDowntime: {

--- a/src/applications/mhv-secure-messaging/components/FetchRecipients.jsx
+++ b/src/applications/mhv-secure-messaging/components/FetchRecipients.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { getAllTriageTeamRecipients } from '../actions/recipients';
+
+const FetchRecipients = () => {
+  const dispatch = useDispatch();
+
+  useEffect(
+    () => {
+      dispatch(getAllTriageTeamRecipients());
+    },
+    [dispatch],
+  );
+
+  return null;
+};
+
+export default FetchRecipients;

--- a/src/applications/mhv-secure-messaging/containers/App.jsx
+++ b/src/applications/mhv-secure-messaging/containers/App.jsx
@@ -21,11 +21,11 @@ import { getScheduledDowntime } from 'platform/monitoring/DowntimeNotification/a
 import MhvServiceRequiredGuard from 'platform/mhv/components/MhvServiceRequiredGuard';
 import AuthorizedRoutes from './AuthorizedRoutes';
 import ScrollToTop from '../components/shared/ScrollToTop';
-import { getAllTriageTeamRecipients } from '../actions/recipients';
 import manifest from '../manifest.json';
 import { Actions } from '../util/actionTypes';
 import { downtimeNotificationParams, Paths } from '../util/constants';
 import useTrackPreviousUrl from '../hooks/use-previous-url';
+import FetchRecipients from '../components/FetchRecipients';
 
 const App = ({ isPilot }) => {
   useTrackPreviousUrl();
@@ -62,6 +62,10 @@ const App = ({ isPilot }) => {
     [mhvMockSessionFlag],
   );
 
+  const scheduledDownTimeIsReady = useSelector(
+    state => state.scheduledDowntime?.isReady,
+  );
+
   const scheduledDowntimes = useSelector(
     state => state.scheduledDowntime?.serviceMap || [],
   );
@@ -81,16 +85,11 @@ const App = ({ isPilot }) => {
 
   useEffect(
     () => {
-      const fetchAllData = async () => {
+      if (!scheduledDownTimeIsReady) {
         dispatch(getScheduledDowntime());
-
-        if (user.login.currentlyLoggedIn) {
-          await dispatch(getAllTriageTeamRecipients());
-        }
-      };
-      fetchAllData();
+      }
     },
-    [user.login.currentlyLoggedIn, dispatch],
+    [dispatch, scheduledDownTimeIsReady],
   );
 
   useEffect(
@@ -160,6 +159,7 @@ const App = ({ isPilot }) => {
         user={user}
         serviceRequired={[backendServices.MESSAGING]}
       >
+        <FetchRecipients />
         <MhvSecondaryNav />
         <div className="vads-l-grid-container">
           {mhvSMDown === externalServiceStatus.down ? (

--- a/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
@@ -130,7 +130,7 @@ describe('App', () => {
     );
   });
 
-  it('renders the downtime notification', () => {
+  it('renders the downtime notification', async () => {
     const screen = renderWithStoreAndRouter(<App />, {
       initialState: {
         scheduledDowntime: {
@@ -145,12 +145,14 @@ describe('App', () => {
       reducers: reducer,
       path: `/`,
     });
-    expect(
-      screen.getByText('Maintenance on My HealtheVet', {
-        selector: 'h2',
-        exact: true,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Maintenance on My HealtheVet', {
+          selector: 'h2',
+          exact: true,
+        }),
+      );
+    });
     expect(
       screen.getByText(
         'We’re working on this messaging tool right now. The maintenance will last 48 hours.',
@@ -161,7 +163,7 @@ describe('App', () => {
     );
   });
 
-  it('renders the downtime notification for multiple configured services', () => {
+  it('renders the downtime notification for multiple configured services', async () => {
     const screen = renderWithStoreAndRouter(<App />, {
       initialState: {
         scheduledDowntime: {
@@ -176,12 +178,14 @@ describe('App', () => {
       reducers: reducer,
       path: `/`,
     });
-    expect(
-      screen.getByText('Maintenance on My HealtheVet', {
-        selector: 'h2',
-        exact: true,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Maintenance on My HealtheVet', {
+          selector: 'h2',
+          exact: true,
+        }),
+      );
+    });
     expect(
       screen.getByText(
         'We’re working on this messaging tool right now. The maintenance will last 48 hours.',
@@ -192,7 +196,7 @@ describe('App', () => {
     );
   });
 
-  it('renders the downtime notification for mixed services', () => {
+  it('renders the downtime notification for mixed services', async () => {
     const screen = renderWithStoreAndRouter(<App />, {
       initialState: {
         scheduledDowntime: {
@@ -207,12 +211,14 @@ describe('App', () => {
       reducers: reducer,
       path: `/`,
     });
-    expect(
-      screen.getByText('Maintenance on My HealtheVet', {
-        selector: 'h2',
-        exact: true,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Maintenance on My HealtheVet', {
+          selector: 'h2',
+          exact: true,
+        }),
+      );
+    });
     expect(
       screen.getByText(
         'We’re working on this messaging tool right now. The maintenance will last 48 hours.',
@@ -276,12 +282,15 @@ describe('App', () => {
       `${'mhv_secure_messaging_remove_landing_page'}`
     ] = true;
 
-    renderWithStoreAndRouter(<App />, {
+    await renderWithStoreAndRouter(<App />, {
       initialState: customState,
       reducers: reducer,
       path: `/`,
     });
-    expect(window.location.replace.called).to.be.true;
+
+    await waitFor(() => {
+      expect(window.location.replace.called).to.be.true;
+    });
     expect(window.location.replace.args[0][0]).to.equal(
       '/my-health/secure-messages/inbox/',
     );
@@ -307,17 +316,13 @@ describe('App', () => {
       `${'mhv_secure_messaging_remove_landing_page'}`
     ] = true;
 
-    const { queryByText } = renderWithStoreAndRouter(
-      <App isPilot removeLandingPage />,
-      {
-        initialState: customState,
-        reducers: reducer,
-        path: `/`,
-      },
-    );
+    const { queryByText } = renderWithStoreAndRouter(<App isPilot />, {
+      initialState: customState,
+      reducers: reducer,
+      path: `/`,
+    });
 
     expect(queryByText('Messages', { selector: 'h1', exact: true }));
-    expect(window.location.replace.called).to.be.true;
     await waitFor(() => {
       expect(window.location.replace.args[0][0]).to.equal(
         '/my-health/secure-messages-pilot/inbox/',
@@ -342,8 +347,10 @@ describe('App', () => {
       reducers: reducer,
       path: `/`,
     });
+    await waitFor(() => {
+      expect(getByText('Messages', { selector: 'h1', exact: true })).to.exist;
+    });
 
-    expect(getByText('Messages', { selector: 'h1', exact: true }));
     expect(window.location.replace.called).to.be.false;
     expect(window.location.pathname).to.equal('/secure-messages/');
     expect(global.document.title).to.equal(
@@ -371,7 +378,10 @@ describe('App', () => {
       path: `/`,
     });
 
-    expect(getByText('Messages', { selector: 'h1', exact: true }));
+    await waitFor(() => {
+      expect(getByText('Messages', { selector: 'h1', exact: true })).to.exist;
+    });
+
     expect(window.location.replace.called).to.be.false;
     expect(window.location.pathname).to.equal('/secure-messages-pilot/');
     expect(global.document.title).to.equal(
@@ -407,17 +417,19 @@ describe('App', () => {
     expect(window.location.replace.called).to.be.true;
   });
 
-  it('displays Page Not Found component if bad url', () => {
+  it('displays Page Not Found component if bad url', async () => {
     const screen = renderWithStoreAndRouter(<App />, {
       initialState,
       reducers: reducer,
       path: `/sdfsdf`,
     });
-    expect(
-      screen.getByText(pageNotFoundHeading, {
-        selector: 'h1',
-        exact: true,
-      }),
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(pageNotFoundHeading, {
+          selector: 'h1',
+          exact: true,
+        }),
+      ).to.exist;
+    });
   });
 });

--- a/src/platform/mhv/api/mocks/feature-toggles/index.js
+++ b/src/platform/mhv/api/mocks/feature-toggles/index.js
@@ -163,6 +163,10 @@ const generateFeatureToggles = (toggles = {}) => {
           name: 'mhv_secure_messaging_recipient_opt_groups',
           value: mhvSecureMessagingRecipientOptGroups,
         },
+        {
+          name: 'mhv_secure_messaging_remove_landing_page',
+          value: true,
+        },
       ],
     },
   };

--- a/src/platform/mhv/components/MhvServiceRequiredGuard.jsx
+++ b/src/platform/mhv/components/MhvServiceRequiredGuard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 const MhvServiceRequiredGuard = ({ children, serviceRequired, user }) => {
@@ -7,16 +7,22 @@ const MhvServiceRequiredGuard = ({ children, serviceRequired, user }) => {
   const hasRequiredService = serviceRequired.some(service =>
     userServices.includes(service),
   );
+  const [authorized, setAuthorized] = useState(false);
 
   useEffect(
     () => {
       if (!user.profile.verified || !hasRequiredService) {
         window.location.replace('/my-health');
+      } else {
+        setAuthorized(true);
       }
     },
     [hasRequiredService, user, userServices],
   );
 
+  if (!authorized) {
+    return null;
+  }
   return <>{children}</>;
 };
 

--- a/src/platform/mhv/components/MhvServiceRequiredGuard.jsx
+++ b/src/platform/mhv/components/MhvServiceRequiredGuard.jsx
@@ -4,25 +4,41 @@ import PropTypes from 'prop-types';
 const MhvServiceRequiredGuard = ({ children, serviceRequired, user }) => {
   const userServices = user.profile.services; // mhv_messaging_policy.rb defines if messaging service is avaialble when a user is in Premium status upon structuring user services from the user profile in services.rb
 
-  const hasRequiredService = serviceRequired.some(service =>
-    userServices.includes(service),
-  );
+  const [hasRequiredService, setHasRequiredService] = useState(null);
+  const [isVerified, setIsVerified] = useState(null);
   const [authorized, setAuthorized] = useState(false);
 
   useEffect(
     () => {
-      if (!user.profile.verified || !hasRequiredService) {
-        window.location.replace('/my-health');
-      } else {
-        setAuthorized(true);
+      setHasRequiredService(
+        serviceRequired.some(service => userServices.includes(service)),
+      );
+      setIsVerified(user.profile.verified);
+    },
+    [serviceRequired, userServices, user.profile.verified],
+  );
+
+  useEffect(
+    () => {
+      if (isVerified !== null && hasRequiredService !== null) {
+        if (!isVerified || !hasRequiredService) {
+          window.location.replace('/my-health');
+        } else {
+          setAuthorized(true);
+        }
       }
     },
-    [hasRequiredService, user, userServices],
+    [isVerified, hasRequiredService],
   );
+
+  if (isVerified === null || hasRequiredService === null) {
+    return null; // Do not render children or redirect until values are fetched
+  }
 
   if (!authorized) {
     return null;
   }
+
   return <>{children}</>;
 };
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- primarily this PR is addressing unnecessary API calls made to `/my-health/v1/messaging` endpoints. Clearing up 2 scenarios: 
      1. attempt to fetch recipients when `messaging` service avaialbility is not established yet
      2. `MhvServiceRequiredGuard` component would render children during one of the re-renders causing to fetch folders
- changing the logic of `MhvServiceRequiredGuard` to prevent children props from rendering until all props are fully fetched
- in `mhv-landing-page` changing the logic for fetching folders (which determines the status of unread messages indicator). Perviously, `hasMhvAccount` selector was used which would only indicate if a user has `mhv_correlation_id`. However, for users to have access to Messaging, additional requirements must be met (Premium status, correlations with VA treatment facilities). These requirements are captured in `[mhv_messaging_policy.rb](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/policies/mhv_messaging_policy.rb)` that can be accessed from `user.profile.services` state. 
- updating unit tests in `mhv-medications` and `mhv-medical-records` to account for re-rendering of `MhvServiceRequiredGuard`

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-69467
- https://dsva.slack.com/archives/C044WNQT4P9/p1744375805373879

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
