### PR TITLE
Revert "Revert "Lazy load platform/pdf files to improve page load performance""

### DIFF
--- a/src/applications/mhv-medications/routes.jsx
+++ b/src/applications/mhv-medications/routes.jsx
@@ -1,15 +1,32 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 import { useMyHealthAccessGuard } from '~/platform/mhv/hooks/useMyHealthAccessGuard';
 import App from './containers/App';
-import PrescriptionDetails from './containers/PrescriptionDetails';
 import RxBreadcrumbs from './containers/RxBreadcrumbs';
-import Prescriptions from './containers/Prescriptions';
-import LandingPage from './containers/LandingPage';
-import RefillPrescriptions from './containers/RefillPrescriptions';
-import PrescriptionDetailsDocumentation from './containers/PrescriptionDetailsDocumentation';
+
+// Lazy-loaded components
+const Prescriptions = lazy(() => import('./containers/Prescriptions'));
+const LandingPage = lazy(() => import('./containers/LandingPage'));
+const RefillPrescriptions = lazy(() =>
+  import('./containers/RefillPrescriptions'),
+);
+const PrescriptionDetails = lazy(() =>
+  import('./containers/PrescriptionDetails'),
+);
+const PrescriptionDetailsDocumentation = lazy(() =>
+  import('./containers/PrescriptionDetailsDocumentation'),
+);
+
+// Loading component to display while lazy-loaded components are being fetched
+const Loading = () => (
+  <va-loading-indicator
+    message="Loading..."
+    set-focus
+    data-testid="loading-indicator"
+  />
+);
 
 /**
  * Route that wraps its children within the application component.
@@ -36,39 +53,41 @@ const AccessGuardWrapper = ({ children }) => {
 
 const routes = (
   <AccessGuardWrapper>
-    <Switch>
-      {/* TODO: remove once mhvMedicationsRemoveLandingPage is turned on in prod */}
-      <AppRoute exact path={['/about', '/about/*']} key="LandingPage">
-        <LandingPage />
-      </AppRoute>
-      <AppRoute exact path={['/refill']} key="RefillPage">
-        <div>
-          <RefillPrescriptions />
-        </div>
-      </AppRoute>
-      <AppRoute exact path={['/', '/:page']} key="App">
-        <div>
-          <Prescriptions />
-        </div>
-      </AppRoute>
-      <AppRoute
-        exact
-        path="/prescription/:prescriptionId"
-        key="prescriptionDetails"
-      >
-        <PrescriptionDetails />
-      </AppRoute>
-      <AppRoute
-        exact
-        path="/prescription/:prescriptionId/documentation"
-        key="prescriptionDetailsDocumentation"
-      >
-        <PrescriptionDetailsDocumentation />
-      </AppRoute>
-      <Route>
-        <PageNotFound />
-      </Route>
-    </Switch>
+    <Suspense fallback={<Loading />}>
+      <Switch>
+        {/* TODO: remove once mhvMedicationsRemoveLandingPage is turned on in prod */}
+        <AppRoute exact path={['/about', '/about/*']} key="LandingPage">
+          <LandingPage />
+        </AppRoute>
+        <AppRoute exact path={['/refill']} key="RefillPage">
+          <div>
+            <RefillPrescriptions />
+          </div>
+        </AppRoute>
+        <AppRoute exact path={['/', '/:page']} key="App">
+          <div>
+            <Prescriptions />
+          </div>
+        </AppRoute>
+        <AppRoute
+          exact
+          path="/prescription/:prescriptionId"
+          key="prescriptionDetails"
+        >
+          <PrescriptionDetails />
+        </AppRoute>
+        <AppRoute
+          exact
+          path="/prescription/:prescriptionId/documentation"
+          key="prescriptionDetailsDocumentation"
+        >
+          <PrescriptionDetailsDocumentation />
+        </AppRoute>
+        <Route>
+          <PageNotFound />
+        </Route>
+      </Switch>
+    </Suspense>
   </AccessGuardWrapper>
 );
 

--- a/src/applications/mhv-medications/util/helpers.js
+++ b/src/applications/mhv-medications/util/helpers.js
@@ -1,6 +1,5 @@
 import moment from 'moment-timezone';
 import cheerio from 'cheerio';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import * as Sentry from '@sentry/browser';
 import {
   EMPTY_FIELD,
@@ -10,6 +9,10 @@ import {
   DOWNLOAD_FORMAT,
   dispStatusObj,
 } from './constants';
+
+// Cache the dynamic import promise to avoid redundant network requests
+// and improve performance when generateMedicationsPDF is called multiple times
+let pdfModulePromise = null;
 
 // this function is needed to account for the prescription.trackingList dates coming in this format "Mon, 24 Feb 2025 03:39:11 EST" which is not recognized by momentjs
 const convertToISO = dateString => {
@@ -21,7 +24,7 @@ const convertToISO = dateString => {
   }
   // Return false if the date is invalid
   const date = new Date(dateString);
-  if (isNaN(date.getTime())) {
+  if (Number.isNaN(date.getTime())) {
     return false;
   }
 
@@ -69,8 +72,17 @@ export const generateMedicationsPDF = async (
   pdfData,
 ) => {
   try {
+    // Use cached module promise if available, otherwise create a new one
+    if (!pdfModulePromise) {
+      pdfModulePromise = import('@department-of-veterans-affairs/platform-pdf/exports');
+    }
+
+    // Wait for the module to load and extract the generatePdf function
+    const { generatePdf } = await pdfModulePromise;
     await generatePdf(templateName, generatedFileName, pdfData);
   } catch (error) {
+    // Reset the pdfModulePromise so subsequent calls can try again
+    pdfModulePromise = null;
     Sentry.captureException(error);
     Sentry.captureMessage('vets_mhv_medications_pdf_generation_error');
     throw error;

--- a/src/applications/mhv-medications/util/helpers.js
+++ b/src/applications/mhv-medications/util/helpers.js
@@ -74,7 +74,7 @@ export const generateMedicationsPDF = async (
   try {
     // Use cached module promise if available, otherwise create a new one
     if (!pdfModulePromise) {
-      pdfModulePromise = import('@department-of-veterans-affairs/platform-pdf/exports');
+      pdfModulePromise = import(/* webpackChunkName: "platform-pdf" */ '@department-of-veterans-affairs/platform-pdf/exports');
     }
 
     // Wait for the module to load and extract the generatePdf function


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

## Summary

This is a re-roll of https://github.com/department-of-veterans-affairs/vets-website/pull/35796 with a fix to ensure that the lazy-loaded PDF chunk is deployed.

The Platform/PDF package adds over 3MB (uncompressed) to the app bundle size in dev mode. This PR uses [lazy loading](https://react.dev/reference/react/lazy) to avoid downloading it until a user is actually generating a PDF. This will improve initial load times for all users.

### Local bundle sizes

| File | Before | After |
| -- | -- | -- |
| medications.entry.js | 12.3MB | 9.09MB |
| vendor.entry.js | 2.35MB | 2.35MB |

## Testing done

- Automated tests
- Local testing

## Screenshots

![image](https://github.com/user-attachments/assets/a8fcf608-2eed-4d79-b1ef-b44446a44190)

## What areas of the site does it impact?

Medications app
