### PR TITLE
107481 - Enable Cypress tests in CI - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
@@ -193,7 +193,7 @@ const testConfig = createTestConfig(
     },
     // Skip tests in CI until the form is released.
     // Remove this setting when the form has a content page in production.
-    skip: Cypress.env('CI'),
+    // skip: Cypress.env('CI'),
   },
   manifest,
   formConfig,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR enables the 10-7959a Cypress tests in CI now that 10-7959a is in [production](https://va.gov/family-and-caregiver-benefits/health-and-disability/file-champva-claim-10-7959a).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107481
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91089

## Testing done

- Cypress

## Screenshots

NA

## What areas of the site does it impact?

IVC CHAMPVA form 10-7959a cypress tests

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
