### PR TITLE
Dependents 105738 | Fix expandUnder focus

### DIFF
--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFive.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFive.js
@@ -1,9 +1,8 @@
 import {
-  textUI,
-  textSchema,
   radioUI,
   radioSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import { separationLabelArr, separationLabels } from './helpers';
 
 export const schema = {
@@ -15,8 +14,11 @@ export const schema = {
         currentSpouseReasonForSeparation: {
           ...radioSchema(separationLabelArr),
         },
-        other: textSchema,
+        other: {
+          type: 'string',
+        },
       },
+      required: ['currentSpouseReasonForSeparation'],
     },
   },
 };
@@ -27,23 +29,30 @@ export const uiSchema = {
       title: 'Reason you live separately from your spouse',
       labelHeaderLevel: '3',
       labels: separationLabels,
-      required: () => true,
       classNames: 'vads-u-margin-top--4',
     }),
-    other: textUI({
-      title: 'Briefly describe why you live separately from your spouse',
-      required: formData =>
-        formData?.doesLiveWithSpouse?.currentSpouseReasonForSeparation ===
-        'OTHER',
-      expandUnder: 'currentSpouseReasonForSeparation',
-      expandUnderCondition: 'OTHER',
-      preserveHiddenData: true,
-      hideIf: formData =>
-        formData?.doesLiveWithSpouse?.currentSpouseReasonForSeparation !==
-        'OTHER',
-      showFieldLabel: true,
-      keepInPageOnReview: true,
-      classNames: 'vads-u-margin-top--2',
-    }),
+    other: {
+      'ui:title': 'Briefly describe why you live separately from your spouse',
+      'ui:webComponentField': VaTextInputField,
+      'ui:options': {
+        expandUnder: 'currentSpouseReasonForSeparation',
+        expandUnderCondition: 'OTHER',
+        preserveHiddenData: true,
+      },
+    },
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        if (formSchema.properties.other['ui:collapsed']) {
+          return {
+            ...formSchema,
+            required: ['currentSpouseReasonForSeparation'],
+          };
+        }
+        return {
+          ...formSchema,
+          required: ['currentSpouseReasonForSeparation', 'other'],
+        };
+      },
+    },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFour.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFour.js
@@ -2,9 +2,8 @@ import React from 'react';
 import {
   radioSchema,
   radioUI,
-  textUI,
-  textSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import { addSpouse } from '../../../utilities';
 import {
   marriageTypeLabels,
@@ -20,8 +19,10 @@ export const schema = {
     currentMarriageInformation: {
       type: 'object',
       properties: {
-        type: radioSchema(marriageTypeArr),
-        typeOther: textSchema,
+        typeOfMarriage: radioSchema(marriageTypeArr),
+        typeOther: {
+          type: 'string',
+        },
         'view:marriageTypeInformation':
           currentMarriageInformation.properties['view:marriageTypeInformation'],
       },
@@ -31,30 +32,37 @@ export const schema = {
 
 export const uiSchema = {
   currentMarriageInformation: {
-    type: radioUI({
+    typeOfMarriage: radioUI({
       title: 'How did you get married?',
       labels: marriageTypeLabels,
-      required: () => true,
       labelHeaderLevel: '3',
       errorMessages: {
         required: 'Select the type of marriage',
       },
       classNames: 'vads-u-margin-bottom--2 vads-u-margin-top--5',
     }),
-    typeOther: textUI({
-      title: 'Other type of marriage',
-      required: formData =>
-        formData?.currentMarriageInformation?.type === 'OTHER',
-      expandUnder: 'type',
-      expandUnderCondition: 'OTHER',
-      preserveHiddenData: true,
-      showFieldLabel: true,
-      keepInPageOnReview: true,
-      hideIf: formData =>
-        formData?.currentMarriageInformation?.type !== 'OTHER',
-    }),
+    typeOther: {
+      'ui:title': 'Other type of marriage',
+      'ui:webComponentField': VaTextInputField,
+      'ui:options': {
+        expandUnder: 'typeOfMarriage',
+        expandUnderCondition: 'OTHER',
+        preserveHiddenData: true,
+      },
+    },
     'view:marriageTypeInformation': {
       'ui:description': <SupportingEvidenceNeeded />,
+    },
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        if (formSchema.properties.typeOther['ui:collapsed']) {
+          return { ...formSchema, required: ['typeOfMarriage'] };
+        }
+        return {
+          ...formSchema,
+          required: ['typeOfMarriage', 'typeOther'],
+        };
+      },
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFour.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFour.js
@@ -26,6 +26,7 @@ export const schema = {
         'view:marriageTypeInformation':
           currentMarriageInformation.properties['view:marriageTypeInformation'],
       },
+      required: ['typeOfMarriage'],
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFour.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformationPartFour.js
@@ -48,6 +48,7 @@ export const uiSchema = {
       'ui:options': {
         expandUnder: 'typeOfMarriage',
         expandUnderCondition: 'OTHER',
+        expandedContentFocus: true,
         preserveHiddenData: true,
       },
     },

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
@@ -1,8 +1,6 @@
 import { capitalize } from 'lodash';
 import {
   titleUI,
-  relationshipToVeteranUI,
-  relationshipToVeteranSchema,
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,
@@ -118,14 +116,12 @@ export const formerMarriageEndReasonPage = {
     ...arrayBuilderItemSubsequentPageTitleUI(() => {
       return 'Spouse’s former marriage';
     }),
-    reasonMarriageEnded: {
-      ...radioUI({
-        title: 'How did their marriage end?',
-        labels: spouseFormerMarriageLabels,
-        labelHeaderLevel: '3',
-      }),
-    },
-    reasonMarriageEndedOther: {
+    reasonMarriageEnded: radioUI({
+      title: 'How did their marriage end?',
+      labels: spouseFormerMarriageLabels,
+      labelHeaderLevel: '3',
+    }),
+    otherReasonMarriageEnded: {
       'ui:title': 'Briefly describe how their marriage ended',
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
@@ -135,16 +131,15 @@ export const formerMarriageEndReasonPage = {
         preserveHiddenData: true,
       },
     },
-    testProperty: relationshipToVeteranUI(),
     'ui:options': {
       // Use updateSchema to set
       updateSchema: (formData, formSchema) => {
-        if (formSchema.properties.reasonMarriageEndedOther['ui:collapsed']) {
+        if (formSchema.properties.otherReasonMarriageEnded['ui:collapsed']) {
           return { ...formSchema, required: ['reasonMarriageEnded'] };
         }
         return {
           ...formSchema,
-          required: ['reasonMarriageEnded', 'reasonMarriageEndedOther'],
+          required: ['reasonMarriageEnded', 'otherReasonMarriageEnded'],
         };
       },
     },
@@ -154,10 +149,9 @@ export const formerMarriageEndReasonPage = {
     required: ['reasonMarriageEnded'],
     properties: {
       reasonMarriageEnded: radioSchema(marriageEnums),
-      reasonMarriageEndedOther: {
+      otherReasonMarriageEnded: {
         type: 'string',
       },
-      testProperty: relationshipToVeteranSchema,
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
@@ -1,8 +1,10 @@
 import { capitalize } from 'lodash';
 import {
   titleUI,
-  textUI,
-  textSchema,
+  relationshipToVeteranUI,
+  relationshipToVeteranSchema,
+  // textUI,
+  // textSchema,
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,
@@ -121,38 +123,43 @@ export const formerMarriageEndReasonPage = {
     reasonMarriageEnded: {
       ...radioUI({
         title: 'How did their marriage end?',
-        required: () => true,
         labels: spouseFormerMarriageLabels,
+        labelHeaderLevel: '3',
       }),
     },
     reasonMarriageEndedOther: {
-      ...textUI('Briefly describe how their marriage ended'),
-      'ui:required': (formData, index) => {
-        const isEditMode = formData?.reasonMarriageEnded === 'Other';
-        const isAddMode =
-          formData?.spouseMarriageHistory?.[index]?.reasonMarriageEnded ===
-          'Other';
-
-        return isEditMode || isAddMode;
-      },
+      'ui:title': 'Briefly describe how their marriage ended',
+      'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'reasonMarriageEnded',
         expandUnderCondition: 'Other',
+        expandedContentFocus: true,
         preserveHiddenData: true,
-        hideIf: (formData, index) =>
-          !(
-            formData?.spouseMarriageHistory?.[index]?.reasonMarriageEnded ===
-              'Other' || formData?.reasonMarriageEnded === 'Other'
-          ),
-        keepInPageOnReview: true,
+      },
+    },
+    testProperty: relationshipToVeteranUI(),
+    'ui:options': {
+      // Use updateSchema to set
+      updateSchema: (formData, formSchema) => {
+        if (formSchema.properties.reasonMarriageEndedOther['ui:collapsed']) {
+          return { ...formSchema, required: ['reasonMarriageEnded'] };
+        }
+        return {
+          ...formSchema,
+          required: ['reasonMarriageEnded', 'reasonMarriageEndedOther'],
+        };
       },
     },
   },
   schema: {
     type: 'object',
+    required: ['reasonMarriageEnded'],
     properties: {
       reasonMarriageEnded: radioSchema(marriageEnums),
-      reasonMarriageEndedOther: textSchema,
+      reasonMarriageEndedOther: {
+        type: 'string',
+      },
+      testProperty: relationshipToVeteranSchema,
     },
   },
 };

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
@@ -3,8 +3,6 @@ import {
   titleUI,
   relationshipToVeteranUI,
   relationshipToVeteranSchema,
-  // textUI,
-  // textSchema,
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.js
@@ -122,7 +122,7 @@ export const vetFormerMarriageEndReasonPage = {
         labels: veteranFormerMarriageLabels,
       }),
     },
-    reasonMarriageEndedOther: {
+    otherReasonMarriageEnded: {
       'ui:title': 'Briefly describe how your marriage ended',
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
@@ -134,12 +134,12 @@ export const vetFormerMarriageEndReasonPage = {
     },
     'ui:options': {
       updateSchema: (formData, formSchema) => {
-        if (formSchema.properties.reasonMarriageEndedOther['ui:collapsed']) {
+        if (formSchema.properties.otherReasonMarriageEnded['ui:collapsed']) {
           return { ...formSchema, required: ['reasonMarriageEnded'] };
         }
         return {
           ...formSchema,
-          required: ['reasonMarriageEnded', 'reasonMarriageEndedOther'],
+          required: ['reasonMarriageEnded', 'otherReasonMarriageEnded'],
         };
       },
     },
@@ -148,7 +148,7 @@ export const vetFormerMarriageEndReasonPage = {
     type: 'object',
     properties: {
       reasonMarriageEnded: radioSchema(marriageEnums),
-      reasonMarriageEndedOther: {
+      otherReasonMarriageEnded: {
         type: 'string',
       },
     },

--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.js
@@ -1,7 +1,5 @@
 import { capitalize } from 'lodash';
 import {
-  textUI,
-  textSchema,
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderYesNoSchema,
   arrayBuilderYesNoUI,
@@ -121,30 +119,28 @@ export const vetFormerMarriageEndReasonPage = {
     reasonMarriageEnded: {
       ...radioUI({
         title: 'How did your marriage end?',
-        required: () => true,
         labels: veteranFormerMarriageLabels,
       }),
     },
     reasonMarriageEndedOther: {
-      ...textUI('Briefly describe how your marriage ended'),
-      'ui:required': (formData, index) => {
-        const isEditMode = formData?.reasonMarriageEnded === 'Other';
-        const isAddMode =
-          formData?.veteranMarriageHistory?.[index]?.reasonMarriageEnded ===
-          'Other';
-
-        return isEditMode || isAddMode;
-      },
+      'ui:title': 'Briefly describe how your marriage ended',
+      'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'reasonMarriageEnded',
         expandUnderCondition: 'Other',
+        expandedContentFocus: true,
         preserveHiddenData: true,
-        hideIf: (formData, index) =>
-          !(
-            formData?.veteranMarriageHistory?.[index]?.reasonMarriageEnded ===
-              'Other' || formData?.reasonMarriageEnded === 'Other'
-          ),
-        keepInPageOnReview: true,
+      },
+    },
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        if (formSchema.properties.reasonMarriageEndedOther['ui:collapsed']) {
+          return { ...formSchema, required: ['reasonMarriageEnded'] };
+        }
+        return {
+          ...formSchema,
+          required: ['reasonMarriageEnded', 'reasonMarriageEndedOther'],
+        };
       },
     },
   },
@@ -152,8 +148,11 @@ export const vetFormerMarriageEndReasonPage = {
     type: 'object',
     properties: {
       reasonMarriageEnded: radioSchema(marriageEnums),
-      reasonMarriageEndedOther: textSchema,
+      reasonMarriageEndedOther: {
+        type: 'string',
+      },
     },
+    required: ['reasonMarriageEnded'],
   },
 };
 

--- a/src/applications/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartTwo.js
+++ b/src/applications/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartTwo.js
@@ -1,7 +1,5 @@
 import {
   titleUI,
-  textUI,
-  textSchema,
   currentOrPastDateUI,
   currentOrPastDateSchema,
   radioUI,
@@ -21,8 +19,11 @@ export const schema = {
         date: currentOrPastDateSchema,
         divorceLocation: customLocationSchema,
         reasonMarriageEnded: radioSchema(['Divorce', 'Other']),
-        explanationOfOther: textSchema,
+        explanationOfOther: {
+          type: 'string',
+        },
       },
+      required: ['reasonMarriageEnded'],
     },
   },
 };
@@ -79,23 +80,30 @@ export const uiSchema = {
     },
     reasonMarriageEnded: radioUI({
       title: 'Reason marriage ended',
-      required: () => true,
       labels: {
         Divorce: 'Divorce',
         Other: 'Annulment or other',
       },
     }),
     explanationOfOther: {
-      ...textUI('Briefly describe how the marriage ended'),
-      'ui:required': formData =>
-        formData?.reportDivorce?.reasonMarriageEnded === 'Other',
+      'ui:title': 'Briefly describe how the marriage ended',
+      'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'reasonMarriageEnded',
         expandUnderCondition: 'Other',
+        expandedContentFocus: true,
         preserveHiddenData: true,
-        keepInPageOnReview: true,
-        hideIf: formData =>
-          formData?.reportDivorce?.reasonMarriageEnded !== 'Other',
+      },
+    },
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        if (formSchema.properties.explanationOfOther['ui:collapsed']) {
+          return { ...formSchema, required: ['reasonMarriageEnded'] };
+        }
+        return {
+          ...formSchema,
+          required: ['reasonMarriageEnded', 'explanationOfOther'],
+        };
       },
     },
   },

--- a/src/applications/686c-674/tests/config/chapters/report-add-a-spouse/currentMarriageInformation.unit.spec.jsx
+++ b/src/applications/686c-674/tests/config/chapters/report-add-a-spouse/currentMarriageInformation.unit.spec.jsx
@@ -12,7 +12,7 @@ const defaultStore = createCommonStore();
 const formData = (
   isMilitary = false,
   outsideUsa = false,
-  type = undefined,
+  typeOfMarriage = undefined,
   currentSpouseReasonForSeparation = undefined,
 ) => {
   return {
@@ -28,7 +28,7 @@ const formData = (
     },
     currentMarriageInformation: {
       outsideUsa,
-      type,
+      typeOfMarriage,
     },
   };
 };

--- a/src/applications/686c-674/tests/e2e/fixtures/spouse-child-all-fields.json
+++ b/src/applications/686c-674/tests/e2e/fixtures/spouse-child-all-fields.json
@@ -117,7 +117,7 @@
         "country": "AUS"
       },
       "date": "2009-04-01",
-      "type": "CIVIL",
+      "typeOfMarriage": "CIVIL",
       "view:marriageTypeInformation": {}
     },
     "spouseInformation": {

--- a/src/applications/686c-674/tests/e2e/fixtures/spouse-report-divorce.json
+++ b/src/applications/686c-674/tests/e2e/fixtures/spouse-report-divorce.json
@@ -76,7 +76,7 @@
         "country": "AUS"
       },
       "date": "2009-04-01",
-      "type": "CIVIL",
+      "typeOfMarriage": "CIVIL",
       "view:marriageTypeInformation": {}
     },
     "spouseInformation": {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Changes keynames for expandUnders

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105738

## Testing done

- Manual / Unit / E2E

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
