### PR TITLE
MEB: Split Contact and Notification Questions into Two Pages

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/components/ObfuscateReviewField.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/components/ObfuscateReviewField.jsx
@@ -5,7 +5,7 @@ import { obfuscate } from '../helpers';
 function ObfuscateReviewField({ children, uiSchema }) {
   const { formData } = children.props; // Extract form data
   const maskedValue = obfuscate(formData); // Generate obfuscated value
-  const visibleLastDigits = formData.slice(-4); // Extract last 4 digits for accessibility
+  const visibleLastDigits = formData?.slice(-4); // Extract last 4 digits for accessibility
 
   return (
     <dl

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -1221,6 +1221,22 @@ const formConfig = {
                 })(),
               },
             },
+          },
+          schema: {
+            type: 'object',
+            required: ['contactMethod'],
+            properties: {
+              contactMethod: {
+                type: 'string',
+                enum: ['email', 'mobilePhone', 'homePhone', 'mail'],
+              },
+            },
+          },
+        },
+        chooseNotificationMethod: {
+          title: 'Choose your contact method for follow-up questions',
+          path: 'contact-information/notification-method',
+          uiSchema: {
             'view:subHeadings': {
               'ui:description': (
                 <>
@@ -1450,12 +1466,7 @@ const formConfig = {
           },
           schema: {
             type: 'object',
-            required: ['contactMethod'],
             properties: {
-              contactMethod: {
-                type: 'string',
-                enum: ['email', 'mobilePhone', 'homePhone', 'mail'],
-              },
               'view:subHeadings': {
                 type: 'object',
                 properties: {},

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.jsx
@@ -562,7 +562,7 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
     form.unmount();
   });
 
-  it('should fill out the contact method fields', () => {
+  it('should fill out the contact method field', () => {
     const initialState = {
       featureToggles: {
         showMeb5490MaintenanceAlert: true,
@@ -603,16 +603,60 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
     );
 
     selectRadio(form, 'root_contactMethod', 'Email');
+
+    expect(
+      form.find('input[name="root_contactMethod"][value="Email"]').props()
+        .checked,
+    ).to.be.true;
+    form.unmount();
+  });
+
+  it('should fill out the notification method field', () => {
+    const initialState = {
+      featureToggles: {
+        showMeb5490MaintenanceAlert: true,
+      },
+      user: {
+        profile: {
+          userFullName: {
+            first: 'john',
+            middle: 't',
+            last: 'test',
+          },
+          dob: '1990-01-01',
+          loa: {
+            current: 3,
+          },
+        },
+      },
+    };
+    const mockStore = configureStore();
+    const store = mockStore(initialState);
+    const {
+      schema,
+      uiSchema,
+    } = formConfig.chapters.contactInformationChapter.pages.chooseNotificationMethod;
+    const form = mount(
+      <Provider store={store}>
+        <DefinitionTester
+          schema={schema}
+          uiSchema={uiSchema}
+          definitions={formConfig.defaultDefinitions}
+          data={{ title: 'test form', mobilePhone: { phone: '4138675309' } }}
+          formData={{
+            title: 'test form',
+            mobilePhone: { phone: '4138675309' },
+          }}
+        />
+      </Provider>,
+    );
+
     selectRadio(
       form,
       'root_notificationMethod',
       'No, just send me email notifications',
     );
 
-    expect(
-      form.find('input[name="root_contactMethod"][value="Email"]').props()
-        .checked,
-    ).to.be.true;
     expect(
       form
         .find(
@@ -622,6 +666,7 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
     ).to.be.true;
     form.unmount();
   });
+
   it('should fill out the direct deposit fields', () => {
     const {
       schema,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Split the contact and notification preferences questions into two pages.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96666
- Internal tracking: SA-110991

## Testing done

- Filled in form and verified validation and the logic for displaying alert messages was maintained.
- Completed form and reviewed questions on review page in view and edit mode.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user