### PR TITLE
1454: add google analytics tracking for additional 1095b events

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -58,6 +58,8 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
       apiRequest('/form1095_bs/available_forms')
         .then(response => {
           if (response.errors || response.availableForms.length === 0) {
+            // should this be a system error?
+            recordEvent({ event: '1095b-available-forms-not-found' });
             updateFormError({ error: true, type: errorTypes.NOT_FOUND });
           }
           const mostRecentYearData = response.availableForms[0];
@@ -66,9 +68,11 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
           }
         })
         .catch(() => {
+          recordEvent({ event: '1095b-available-forms-system-error' });
           updateFormError({ error: true, type: errorTypes.SYSTEM_ERROR });
         })
         .finally(() => {
+          recordEvent({ event: '1095b-available-forms-found' });
           setHasLoadedMostRecentYear(true);
         });
     },
@@ -91,6 +95,7 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
         return window.URL.createObjectURL(blob);
       })
       .catch(() => {
+        recordEvent({ event: `1095b-${format}-download-error` });
         updateFormError({ error: true, type: errorTypes.DOWNLOAD_ERROR });
         return false;
       });

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -57,7 +57,7 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
 
       apiRequest('/form1095_bs/available_forms')
         .then(response => {
-          if (response.errors || response.availableForms.length === 0) {
+          if (response.availableForms.length === 0) {
             recordEvent({ event: '1095b-available-forms-not-found' });
             updateFormError({ error: true, type: errorTypes.NOT_FOUND });
           }

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -58,7 +58,6 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
       apiRequest('/form1095_bs/available_forms')
         .then(response => {
           if (response.errors || response.availableForms.length === 0) {
-            // should this be a system error?
             recordEvent({ event: '1095b-available-forms-not-found' });
             updateFormError({ error: true, type: errorTypes.NOT_FOUND });
           }

--- a/src/applications/static-pages/download-1095b/tests/fixtures/500.json
+++ b/src/applications/static-pages/download-1095b/tests/fixtures/500.json
@@ -1,5 +1,5 @@
 {
   "status": 500,
-  "error": "Internal Server Error",
+  "errors": "Internal Server Error",
   "exception": {}
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds google analytics tracking for 1095b download page.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-iir/issues/1454

## Testing done

Ran locally.

## Screenshots

No visual impact.

## What areas of the site does it impact?

Just 1095b ga4 metrics.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
