### PR TITLE
Conditions 740 CFI and New Prototypes Secondary Flow Follow Up Refinements

### DIFF
--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/config/form.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/config/form.js
@@ -1,6 +1,6 @@
+import FormFooter from 'platform/forms/components/FormFooter';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 
-import FormFooter from 'platform/forms/components/FormFooter';
 import GetFormHelp from '../components/GetFormHelp';
 import { SUBTITLE, TITLE } from '../constants';
 import ConfirmationPage from '../containers/ConfirmationPage';

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/content/conditions.jsx
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/content/conditions.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
-import { Link } from 'react-router';
-import { getArrayIndexFromPathName } from 'platform/forms-system/src/js/patterns/array-builder/helpers';
+import { format } from 'date-fns';
 
-import { ARRAY_PATH } from '../constants';
+import { createSecondaryEnhancedDescriptionString } from './secondaryEnhanced';
 
 export const ConditionsIntroDescription = () => (
   <p>
@@ -31,66 +29,8 @@ export const NewConditionDescription = () => (
   </>
 );
 
-export const SecondaryEnhancedNotListedAlert = () => {
-  const formData = useSelector(state => state.form.data);
-  const currentIndex = getArrayIndexFromPathName();
-  const newCondition = formData?.[ARRAY_PATH]?.[currentIndex]?.newCondition;
-  const capitalNewCondition =
-    newCondition.charAt(0).toUpperCase() + newCondition.slice(1);
-  const demoLabel = window.location.pathname
-    .split('conditions-')[1]
-    ?.split('/')[0];
-  const targetIndex = formData?.[ARRAY_PATH]?.length;
-
-  return (
-    <va-alert status="warning">
-      <p>
-        Tell us the service-connected disability or condition that caused{' '}
-        {newCondition}. You may add it now and your progress will be saved.{' '}
-        {capitalNewCondition} will be marked as incomplete until that condition
-        is added.
-      </p>
-      <Link
-        to={`conditions-${demoLabel}/${targetIndex}/new-condition?add=true`}
-      >
-        Add new condition now
-      </Link>
-    </va-alert>
-  );
-};
-
-export const SecondaryEnhancedOptionsConflictingAlert = () => (
-  <va-alert status="error">
-    <p>
-      You selected "My condition is not listed" along with one or more
-      conditions. Revise your selection so they don’t conflict to continue.
-    </p>
-  </va-alert>
-);
-
-const createSecondaryEnhancedDescriptionString = causedByCondition => {
-  const conditions = Object.keys(causedByCondition || {}).filter(
-    key => causedByCondition[key],
-  );
-
-  let conditionsString = '';
-
-  if (conditions.length === 1) {
-    const [condition] = conditions;
-    conditionsString = condition;
-  } else if (conditions.length === 2) {
-    conditionsString = conditions.join(' and ');
-  } else if (conditions.length > 2) {
-    conditionsString = `${conditions.slice(0, -1).join(', ')}, and ${
-      conditions[conditions.length - 1]
-    }`;
-  }
-
-  return `caused by ${conditionsString ||
-    'a missing service-connected condition'}`;
-};
-
 const createSecondaryDescriptionString = causedByCondition => {
+  // Just for SecondaryEnhanced demo
   if (typeof causedByCondition === 'object') {
     return createSecondaryEnhancedDescriptionString(causedByCondition);
   }
@@ -113,8 +53,24 @@ const createCauseFollowUpDescriptions = item => {
   return causeFollowUpDescriptions[cause];
 };
 
-export const NewConditionCardDescription = (item, date) => {
+const formatDateString = dateString => {
+  if (!dateString) {
+    return '';
+  }
+
+  const [year, month, day] = dateString.split('-').map(Number);
+  if (day) {
+    return format(new Date(year, month - 1, day), 'MMMM d, yyyy');
+  }
+  if (month) {
+    return format(new Date(year, month - 1), 'MMMM yyyy');
+  }
+  return year;
+};
+
+export const NewConditionCardDescription = item => {
   const causeFollowUpDescription = createCauseFollowUpDescriptions(item);
+  const date = formatDateString(item?.conditionDate);
 
   return (
     <p>
@@ -126,10 +82,11 @@ export const NewConditionCardDescription = (item, date) => {
   );
 };
 
-export const RatedDisabilityCardDescription = (item, fullData, date) => {
+export const RatedDisabilityCardDescription = (item, fullData) => {
   const ratingPercentage = fullData?.ratedDisabilities?.find(
     ratedDisability => ratedDisability?.name === item?.ratedDisability,
   )?.ratingPercentage;
+  const date = formatDateString(item?.conditionDate);
 
   return (
     <>

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/content/conditions.jsx
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/content/conditions.jsx
@@ -73,10 +73,6 @@ const createSecondaryEnhancedDescriptionString = causedByCondition => {
     key => causedByCondition[key],
   );
 
-  if (conditions.length === 0) {
-    return '';
-  }
-
   let conditionsString = '';
 
   if (conditions.length === 1) {
@@ -90,7 +86,8 @@ const createSecondaryEnhancedDescriptionString = causedByCondition => {
     }`;
   }
 
-  return `caused by ${conditionsString}`;
+  return `caused by ${conditionsString ||
+    'a missing service-connected condition'}`;
 };
 
 const createSecondaryDescriptionString = causedByCondition => {
@@ -99,7 +96,7 @@ const createSecondaryDescriptionString = causedByCondition => {
   }
 
   return `caused by ${causedByCondition ||
-    'another service-connected condition'}`;
+    'a missing service-connected condition'}`;
 };
 
 const createCauseFollowUpDescriptions = item => {

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/content/secondaryEnhanced.jsx
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/content/secondaryEnhanced.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router';
+import { getArrayIndexFromPathName } from 'platform/forms-system/src/js/patterns/array-builder/helpers';
+
+import { ARRAY_PATH } from '../constants';
+
+export const SecondaryEnhancedNotListedAlert = () => {
+  const formData = useSelector(state => state.form.data);
+  const currentIndex = getArrayIndexFromPathName();
+  const newCondition = formData?.[ARRAY_PATH]?.[currentIndex]?.newCondition;
+  const capitalNewCondition =
+    newCondition.charAt(0).toUpperCase() + newCondition.slice(1);
+  const demoLabel = window.location.pathname
+    .split('conditions-')[1]
+    ?.split('/')[0];
+  const targetIndex = formData?.[ARRAY_PATH]?.length;
+
+  return (
+    <va-alert status="warning">
+      <p>
+        Tell us the service-connected disability or condition that caused{' '}
+        {newCondition}. You may add it now and your progress will be saved.{' '}
+        {capitalNewCondition} will be marked as incomplete until that condition
+        is added.
+      </p>
+      <Link
+        to={`conditions-${demoLabel}/${targetIndex}/new-condition?add=true`}
+      >
+        Add new condition now
+      </Link>
+    </va-alert>
+  );
+};
+
+export const SecondaryEnhancedOptionsConflictingAlert = () => (
+  <va-alert status="error">
+    <p>
+      You selected "My condition is not listed" along with one or more
+      conditions. Revise your selection so they don’t conflict to continue.
+    </p>
+  </va-alert>
+);
+
+export const createSecondaryEnhancedDescriptionString = causedByCondition => {
+  const conditions = Object.keys(causedByCondition || {}).filter(
+    key => causedByCondition[key],
+  );
+
+  let conditionsString = '';
+
+  if (conditions.length === 1) {
+    const [condition] = conditions;
+    conditionsString = condition;
+  } else if (conditions.length === 2) {
+    conditionsString = conditions.join(' and ');
+  } else if (conditions.length > 2) {
+    conditionsString = `${conditions.slice(0, -1).join(', ')}, and ${
+      conditions[conditions.length - 1]
+    }`;
+  }
+
+  return `caused by ${conditionsString ||
+    'a missing service-connected condition'}`;
+};

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/conditionTypeRadio/conditionType.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/conditionTypeRadio/conditionType.js
@@ -8,7 +8,7 @@ import { arrayBuilderOptions } from '../shared/utils';
 
 const conditionTypeOptions = {
   RATED:
-    'A service-connected disability I have already received a rating for, but has gotten worse since the rating  decision.',
+    'A service-connected disability I have already received a rating for, but has worsened since the rating decision.',
   NEW: 'A condition I have not applied for before.',
 };
 

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/conditionTypeRadio/index.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/conditionTypeRadio/index.js
@@ -16,7 +16,7 @@ const conditionTypeRadioPages = arrayBuilderPages(
   (pageBuilder, helpers) => ({
     ...introAndSummaryPages(demo, pageBuilder),
     [`${demo.name}conditionType`]: pageBuilder.itemPage({
-      title: 'Select condition type',
+      title: 'Type of condition',
       path: `conditions-${demo.label}/:index/condition-type`,
       depends: (formData, index) =>
         isActiveDemo(formData, demo.name) &&
@@ -25,7 +25,7 @@ const conditionTypeRadioPages = arrayBuilderPages(
       schema: conditionTypePage.schema,
     }),
     [`${demo.name}RatedDisability`]: pageBuilder.itemPage({
-      title: 'Select which existing disability has worsened.',
+      title: 'Service-connected disabilities',
       path: `conditions-${demo.label}/:index/rated-disability`,
       depends: (formData, index) =>
         isActiveDemo(formData, demo.name) &&

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/conditionTypeRadio/ratedDisability.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/conditionTypeRadio/ratedDisability.js
@@ -18,7 +18,7 @@ const ratedDisabilityPage = {
     ...arrayBuilderItemSubsequentPageTitleUI('Service-connected disabilities'),
     ratedDisability: radioUI({
       title:
-        'Select which of your service-connected disabilities have gotten worse.',
+        'Select which of your service-connected disabilities have worsened.',
       hint:
         'Choose one, you will return to this screen if you need to add more.',
       updateUiSchema: (_formData, fullData) => ({

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/ratedOrNewNextPage/condition.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/ratedOrNewNextPage/condition.js
@@ -26,7 +26,7 @@ const conditionPage = {
     }),
     ratedDisability: radioUI({
       title:
-        'Select if you’d like to add a new condition or select which of your service-connected disabilities have gotten worse.',
+        'Select if you’d like to add a new condition or select which of your service-connected disabilities have worsened.',
       hint:
         'Choose one, you will return to this screen if you need to add more.',
       updateUiSchema: (_formData, fullData) => ({

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/ratedOrNewNextPage/index.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/ratedOrNewNextPage/index.js
@@ -14,7 +14,7 @@ const ratedOrNewNextPagePages = arrayBuilderPages(
   (pageBuilder, helpers) => ({
     ...introAndSummaryPages(demo, pageBuilder),
     [`${demo.name}Condition`]: pageBuilder.itemPage({
-      title: 'Select rated disability or new condition',
+      title: 'Type of condition',
       path: `conditions-${demo.label}/:index/condition`,
       depends: (formData, index) =>
         isActiveDemo(formData, demo.name) &&

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/ratedOrNewNextPageSecondaryEnhanced/causeSecondaryEnhanced.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/ratedOrNewNextPageSecondaryEnhanced/causeSecondaryEnhanced.js
@@ -8,7 +8,7 @@ import {
 import {
   SecondaryEnhancedNotListedAlert,
   SecondaryEnhancedOptionsConflictingAlert,
-} from '../../content/conditions';
+} from '../../content/secondaryEnhanced';
 import { arrayBuilderOptions, createNewConditionName } from '../shared/utils';
 import { CONDITION_NOT_LISTED_OPTION } from '../../constants';
 

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
@@ -68,6 +68,7 @@ const clearSideOfBody = (formData, index, setFormData) => {
   });
 };
 
+// Just for SecondaryEnhanced demo
 const clearConditionNotListed = (formData, setFormData) => {
   setFormData({
     ...formData,

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
@@ -36,6 +36,29 @@ export const introAndSummaryPages = (demo, pageBuilder) => ({
   }),
 });
 
+const clearNewConditionData = (formData, index, setFormData) => {
+  setFormData({
+    ...formData,
+    [ARRAY_PATH]: formData[ARRAY_PATH].map(
+      (item, i) =>
+        i === index
+          ? {
+              ...item,
+              newCondition: undefined,
+              cause: undefined,
+              primaryDescription: undefined,
+              causedByCondition: undefined,
+              causedByConditionDescription: undefined,
+              vaMistreatmentDescription: undefined,
+              vaMistreatmentLocation: undefined,
+              worsenedDescription: undefined,
+              worsenedEffects: undefined,
+            }
+          : item,
+    ),
+  });
+};
+
 const clearSideOfBody = (formData, index, setFormData) => {
   setFormData({
     ...formData,
@@ -79,6 +102,13 @@ export const remainingSharedPages = (
       hasRatedDisabilitiesAndIsRatedDisability(formData, index),
     uiSchema: ratedDisabilityDatePage.uiSchema,
     schema: ratedDisabilityDatePage.schema,
+    onNavForward: props => {
+      const { formData, index, setFormData } = props;
+
+      clearNewConditionData(formData, Number(index), setFormData);
+
+      return helpers.navForwardFinishedItem(props);
+    },
   }),
   [`${demo.name}NewCondition`]: pageBuilder.itemPage({
     title: 'Add a new condition',

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
@@ -96,7 +96,7 @@ export const remainingSharedPages = (
   isSecondaryEnhanced,
 ) => ({
   [`${demo.name}RatedDisabilityDate`]: pageBuilder.itemPage({
-    title: 'Approximate date of service-connected disability getting worse',
+    title: 'Approximate date of service-connected disability worsening',
     path: `conditions-${demo.label}/:index/rated-disability-date`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) &&

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/index.js
@@ -95,7 +95,7 @@ export const remainingSharedPages = (
   isSecondaryEnhanced,
 ) => ({
   [`${demo.name}RatedDisabilityDate`]: pageBuilder.itemPage({
-    title: 'Start date of rated disability worsening',
+    title: 'Approximate date of service-connected disability getting worse',
     path: `conditions-${demo.label}/:index/rated-disability-date`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) &&
@@ -111,7 +111,7 @@ export const remainingSharedPages = (
     },
   }),
   [`${demo.name}NewCondition`]: pageBuilder.itemPage({
-    title: 'Add a new condition',
+    title: 'Add new condition',
     path: `conditions-${demo.label}/:index/new-condition`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) && isNewCondition(formData, index),
@@ -128,7 +128,7 @@ export const remainingSharedPages = (
     },
   }),
   [`${demo.name}SideOfBody`]: pageBuilder.itemPage({
-    title: 'Side of body of new condition',
+    title: 'Side of the body for new condition',
     path: `conditions-${demo.label}/:index/side-of-body`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) &&
@@ -138,7 +138,7 @@ export const remainingSharedPages = (
     schema: sideOfBodyPage.schema,
   }),
   [`${demo.name}NewConditionDate`]: pageBuilder.itemPage({
-    title: 'Start date of new condition',
+    title: 'Approximate start date of new condition',
     path: `conditions-${demo.label}/:index/new-condition-date`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) && isNewCondition(formData, index),
@@ -167,7 +167,8 @@ export const remainingSharedPages = (
     schema: causePage.schema,
   }),
   [`${demo.name}CauseNew`]: pageBuilder.itemPage({
-    title: 'Follow-up of cause new',
+    title:
+      'Details of the injury, event, disease or exposure that caused new condition',
     path: `conditions-${demo.label}/:index/cause-new`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) &&
@@ -177,7 +178,8 @@ export const remainingSharedPages = (
     schema: causeNewPage.schema,
   }),
   [`${demo.name}CauseSecondary`]: pageBuilder.itemPage({
-    title: 'Follow-up of cause secondary condition',
+    title:
+      'Details of the service-connected disability or condition that caused new condition',
     path: `conditions-${demo.label}/:index/cause-secondary`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) &&
@@ -206,7 +208,8 @@ export const remainingSharedPages = (
     },
   }),
   [`${demo.name}CauseWorsened`]: pageBuilder.itemPage({
-    title: 'Follow-up of cause worsened because of my service',
+    title:
+      'Details of the injury, event or exposure that worsened new condition',
     path: `conditions-${demo.label}/:index/cause-worsened`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) &&
@@ -216,7 +219,8 @@ export const remainingSharedPages = (
     schema: causeWorsenedPage.schema,
   }),
   [`${demo.name}CauseVA`]: pageBuilder.itemPage({
-    title: 'Follow-up of cause VA care',
+    title:
+      'Details of the injury or event in VA care that caused new condition',
     path: `conditions-${demo.label}/:index/cause-va`,
     depends: (formData, index) =>
       isActiveDemo(formData, demo.name) &&

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/ratedDisabilityDate.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/ratedDisabilityDate.js
@@ -10,7 +10,7 @@ const ratedDisabilityDatePage = {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
         `Approximate date of ${formData?.ratedDisability ||
-          'service-connected disability'} getting worse`,
+          'service-connected disability'} worsening`,
     ),
     conditionDate: currentOrPastDateUI({
       title: 'Around what date did your disability get worse?',

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/ratedDisabilityDate.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/ratedDisabilityDate.js
@@ -9,7 +9,8 @@ const ratedDisabilityDatePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `Approximate date of ${formData?.ratedDisability} getting worse`,
+        `Approximate date of ${formData?.ratedDisability ||
+          'service-connected disability'} getting worse`,
     ),
     conditionDate: currentOrPastDateUI({
       title: 'Around what date did your disability get worse?',

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/sideOfBody.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/sideOfBody.js
@@ -15,7 +15,7 @@ const sideOfBodyPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `Side of the body for ${formData?.condition || 'new condition'}`,
+        `Side of the body for ${formData?.newCondition || 'new condition'}`,
     ),
     sideOfBody: radioUI({
       title: 'Which side of the body is your condition on?',

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/sideOfBody.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/sideOfBody.js
@@ -15,7 +15,7 @@ const sideOfBodyPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `Side of the body for ${formData?.condition || 'condition'}`,
+        `Side of the body for ${formData?.condition || 'new condition'}`,
     ),
     sideOfBody: radioUI({
       title: 'Which side of the body is your condition on?',

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/utils.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/utils.js
@@ -158,7 +158,7 @@ const capitalizeFirstLetter = string =>
 export const createNewConditionName = (item, capFirstLetter = false) => {
   const newCondition = capFirstLetter
     ? capitalizeFirstLetter(item?.newCondition)
-    : item?.newCondition || 'condition';
+    : item?.newCondition || 'new condition';
 
   if (item?.sideOfBody) {
     return `${newCondition}, ${item?.sideOfBody.toLowerCase()}`;

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/utils.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/utils.js
@@ -24,12 +24,8 @@ export const isEdit = () => {
   return !!hasEdit;
 };
 
-export const createAddAndEditTitles = (addTitle, editTitle) => {
-  if (isEdit()) {
-    return editTitle;
-  }
-  return addTitle;
-};
+export const createAddAndEditTitles = (addTitle, editTitle) =>
+  isEdit() ? editTitle : addTitle;
 
 export const createRatedDisabilityDescriptions = fullData => {
   return fullData.ratedDisabilities.reduce((acc, disability) => {
@@ -172,13 +168,10 @@ export const createNewConditionName = (item, capFirstLetter = false) => {
   return newCondition;
 };
 
-const getItemName = item => {
-  if (isNewCondition(item)) {
-    return createNewConditionName(item, true);
-  }
-
-  return item?.ratedDisability;
-};
+const getItemName = item =>
+  isNewCondition(item)
+    ? createNewConditionName(item, true)
+    : item?.ratedDisability;
 
 const causeFollowUpChecks = {
   NEW: item => !item?.primaryDescription,
@@ -202,13 +195,10 @@ const isItemIncomplete = item => {
   return !item?.ratedDisability;
 };
 
-const cardDescription = (item, _index, formData) => {
-  if (isNewCondition(item)) {
-    return NewConditionCardDescription(item);
-  }
-
-  return RatedDisabilityCardDescription(item, formData);
-};
+const cardDescription = (item, _index, formData) =>
+  isNewCondition(item)
+    ? NewConditionCardDescription(item)
+    : RatedDisabilityCardDescription(item, formData);
 
 /** @type {ArrayBuilderOptions} */
 export const arrayBuilderOptions = {

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/utils.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/utils.js
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import {
   getArrayIndexFromPathName,
   getArrayUrlSearchParams,
@@ -15,6 +14,7 @@ import {
   RatedDisabilityCardDescription,
 } from '../../content/conditions';
 
+// Just for user testing demo functionality
 export const isActiveDemo = (formData, currentDemo) =>
   formData?.demo === currentDemo;
 
@@ -45,6 +45,7 @@ export const createRatedDisabilityDescriptions = fullData => {
   }, {});
 };
 
+// Just for ConditionTypeRadio demo
 const isNewConditionForConditionTypeRadio = (formData, index) => {
   if (formData?.[ARRAY_PATH]) {
     const conditionType = formData[ARRAY_PATH]?.[index]?.['view:conditionType'];
@@ -58,6 +59,7 @@ const isNewConditionForConditionTypeRadio = (formData, index) => {
   );
 };
 
+// Just for ConditionTypeRadio demo
 const isRatedDisabilityForConditionTypeRadio = (formData, index) => {
   if (formData?.[ARRAY_PATH]) {
     const conditionType = formData[ARRAY_PATH]?.[index]?.['view:conditionType'];
@@ -68,9 +70,11 @@ const isRatedDisabilityForConditionTypeRadio = (formData, index) => {
   return formData?.['view:conditionType'] === 'RATED';
 };
 
+// Just for RatedOrNewNextPage demo
 const isNewConditionOption = ratedDisability =>
   ratedDisability === NEW_CONDITION_OPTION;
 
+// Just for RatedOrNewNextPage demo
 const isNewConditionForRatedOrNewNextPage = (formData, index) => {
   if (formData?.[ARRAY_PATH]) {
     const ratedDisability = formData?.[ARRAY_PATH]?.[index]?.ratedDisability;
@@ -84,6 +88,7 @@ const isNewConditionForRatedOrNewNextPage = (formData, index) => {
   );
 };
 
+// Just for RatedOrNewNextPage demo
 const isRatedDisabilityForRatedOrNewNextPage = (formData, index) => {
   if (formData?.[ARRAY_PATH]) {
     const ratedDisability = formData?.[ARRAY_PATH]?.[index]?.ratedDisability;
@@ -197,26 +202,12 @@ const isItemIncomplete = item => {
   return !item?.ratedDisability;
 };
 
-const formatDateString = dateString => {
-  if (!dateString) {
-    return '';
-  }
-
-  const [year, month, day] = dateString.split('-').map(Number);
-  if (day) {
-    return format(new Date(year, month - 1, day), 'MMMM d, yyyy');
-  }
-  return format(new Date(year, month - 1), 'MMMM yyyy');
-};
-
 const cardDescription = (item, _index, formData) => {
-  const date = formatDateString(item?.conditionDate);
-
   if (isNewCondition(item)) {
-    return NewConditionCardDescription(item, date);
+    return NewConditionCardDescription(item);
   }
 
-  return RatedDisabilityCardDescription(item, formData, date);
+  return RatedDisabilityCardDescription(item, formData);
 };
 
 /** @type {ArrayBuilderOptions} */


### PR DESCRIPTION
## Summary
- Summarize the changes that have been made to the platform
  -  [Add back clearNewConditionData since it enables switching condition type](https://github.com/department-of-veterans-affairs/vets-website/commit/93ad65fff73b5cfe1b92723fab8b423fb662b160) - it will then be removed in the upcoming PR [Update edit flows so that cannot change condition type or rated disability #35858](https://github.com/department-of-veterans-affairs/vets-website/pull/35858) when the ability to switch condition types is removed
  - [Refine caused by message when no secondary condition](https://github.com/department-of-veterans-affairs/vets-website/commit/25aa730b66b35c1730fb581bbb5b0dc8f061606b)
  - [Update title property to align with page titles](https://github.com/department-of-veterans-affairs/vets-website/commit/15e538190763f37a74b9429ef623674fb40d90e0)
  - [Provide fallback for missing data in titles](https://github.com/department-of-veterans-affairs/vets-website/commit/a4df5436929a2b42ec5082c334154171367fdee8)
  - [Update new condition title fallback from 'condition' to 'new condition'](https://github.com/department-of-veterans-affairs/vets-website/commit/6fb03fe703f727e7c59fde2300ff4422dc6afc72)
  - [Move secondary enhanced components into own file; refine date as prop since already passing date in item data](https://github.com/department-of-veterans-affairs/vets-website/commit/41040b43783df000189180458d2777455a5b1dd9) 
  - [Update simple if/else util logic to ternaries](https://github.com/department-of-veterans-affairs/vets-website/commit/6d25fd08afc91fa839e9715e75eba1b24b98d62b)
  - [Fix bug in side of body title from outdated key](https://github.com/department-of-veterans-affairs/vets-website/pull/35878/commits/5a34689d913440d752271300c9a456a196b93da5)
  - [Update from gotten worse to worsening to match design update](https://github.com/department-of-veterans-affairs/vets-website/pull/35878/commits/614d894dba3c11402d30f864050c0b17755e4ad2)
- Which team do you work for, does your team own the maintenance of this component? Conditions Team and Yes

## Related issue(s)
- [Add Secondary Flow in its own Prototype Demo Flow #740](https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/740)

## Screenshots (PR on the Left and then Figma on the Right)
<img width="754" alt="Screenshot 2025-04-15 at 8 58 15 AM" src="https://github.com/user-attachments/assets/e474930b-b8de-4656-846f-53fcee74af04" />
<img width="763" alt="Screenshot 2025-04-15 at 8 58 56 AM" src="https://github.com/user-attachments/assets/3095295d-89e6-4007-9bc7-8a96207e7f8d" />
<img width="834" alt="Screenshot 2025-04-15 at 8 46 13 AM" src="https://github.com/user-attachments/assets/457ac2bb-a55a-4f20-8e33-2ed09a3f257a" />
<img width="821" alt="Screenshot 2025-04-15 at 8 46 41 AM" src="https://github.com/user-attachments/assets/a04f2463-aaa6-4e95-b663-f47063144971" />
<img width="803" alt="Screenshot 2025-04-15 at 8 47 49 AM" src="https://github.com/user-attachments/assets/14aac7d6-a270-424e-8847-42e08d2afccb" />
<img width="781" alt="Screenshot 2025-04-15 at 8 48 17 AM" src="https://github.com/user-attachments/assets/ceeb54b1-389c-43f5-8c89-f1f335ba7a60" />
<img width="813" alt="Screenshot 2025-04-15 at 8 49 13 AM" src="https://github.com/user-attachments/assets/8f84a53f-c8a2-4bc2-b296-8b82cf4e3e40" />
<img width="702" alt="Screenshot 2025-04-15 at 8 50 57 AM" src="https://github.com/user-attachments/assets/b04d5075-c799-47ac-9bc5-5c2ccb1b5095" />
<img width="717" alt="Screenshot 2025-04-15 at 8 51 16 AM" src="https://github.com/user-attachments/assets/05ddab7f-51da-4251-85e1-8593e4e16c86" />
<img width="813" alt="Screenshot 2025-04-15 at 8 51 39 AM" src="https://github.com/user-attachments/assets/3b8f506c-67ec-4822-8d50-ac17cfc38316" />
<img width="816" alt="Screenshot 2025-04-15 at 8 52 16 AM" src="https://github.com/user-attachments/assets/f1a8b533-05ce-4ceb-a632-35cd5b34930b" />
<img width="717" alt="Screenshot 2025-04-15 at 8 53 17 AM" src="https://github.com/user-attachments/assets/6c2cb9d7-5974-429c-a638-2d717a59fa0a" />
<img width="716" alt="Screenshot 2025-04-15 at 8 53 56 AM" src="https://github.com/user-attachments/assets/48fd3e56-bd38-4e38-9e08-7a174309b683" />
<img width="812" alt="Screenshot 2025-04-15 at 8 55 26 AM" src="https://github.com/user-attachments/assets/b2ec87f9-7fe2-47c3-ab16-f0e9bbe668c2" />
