### PR TITLE
Add default sort option

### DIFF
--- a/src/applications/representative-search/components/results/SearchResultsHeader.jsx
+++ b/src/applications/representative-search/components/results/SearchResultsHeader.jsx
@@ -166,7 +166,9 @@ export const SearchResultsHeader = props => {
                   name="sort"
                   value={selectedSortType}
                   label="Sort by"
-                  onVaSelect={e => setSelectedSortType(e.target.value)}
+                  onVaSelect={e => {
+                    setSelectedSortType(e.target.value || options[0].key);
+                  }}
                   uswds
                 >
                   {options}


### PR DESCRIPTION
We're running into a bug when users choose "Select" as a choice in the select dropdown.  It doesn't set a value on e.target.value.  This change gives us a default sort so doing so doesn't cause an error.

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_:This just adds a default value to the representative sort options in `find-a-representative`.
- _(If bug, how to reproduce)_: On the find a rep results page there is a `VaSelect` with a default value selected.  If a user chooses the "Select" at the top of the dropdown instead and submits the form it breaks the page until a hard refresh is performed.
- _(What is the solution, why is this the solution)_: This ensures that a default sort type is always applied.
- _(Which team do you work for, does your team own the maintenance of this component?)_: FAR/ARM, yes we own the maintenance.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/105465
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_: Choosing select would break the page, `vets-api` couldn't handle the missing sort type.
- _Describe the steps required to verify your changes are working as expected_: On the find a rep results page choose the "Select" option in the select dropdown and submit.  It will reload with the default sort type.
- _Describe the tests completed and the results_: Same as above.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing: Same as above.
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
No visual changes.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
Just the `find-a-representative` app.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
