### PR TITLE
Workflow Choice page - Review and Submit - v2

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -378,16 +378,23 @@ const WorkflowChoicePage = props => {
     setFormData,
     contentBeforeButtons,
     contentAfterButtons,
+    onReviewPage,
+    updatePage,
   } = props;
 
-  const selectionField = 'view:mentalHealthWorkflowChoice';
+  const selectionField = 'view:selectedMentalHealthWorkflowChoice';
   const [previousWorkflowChoice, setPreviousWorkflowChoice] = useState(
     data?.['view:previousMentalHealthWorkflowChoice'] ?? null,
   );
+  const [
+    selectedMentalHealthWorkflowChoice,
+    setSelectedMentalHealthWorkflowChoice,
+  ] = useState(data?.['view:mentalHealthWorkflowChoice'] ?? null);
 
   const [hasError, setHasError] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [showAlert, setShowAlert] = useState(false);
+  const [shouldGoForward, setShouldGoForward] = useState(false);
 
   useEffect(
     () => {
@@ -396,6 +403,20 @@ const WorkflowChoicePage = props => {
       }
     },
     [showAlert],
+  );
+
+  useEffect(
+    () => {
+      if (
+        shouldGoForward &&
+        data?.['view:mentalHealthWorkflowChoice'] ===
+          selectedMentalHealthWorkflowChoice
+      ) {
+        setShouldGoForward(false);
+        goForward(data);
+      }
+    },
+    [data?.['view:mentalHealthWorkflowChoice'], shouldGoForward],
   );
 
   const missingSelectionErrorMessage =
@@ -410,7 +431,7 @@ const WorkflowChoicePage = props => {
   const checkErrors = (formData = data) => {
     const error = checkValidations(
       [missingSelection],
-      data?.['view:mentalHealthWorkflowChoice'],
+      data?.['view:selectedMentalHealthWorkflowChoice'],
       formData,
     );
 
@@ -420,7 +441,7 @@ const WorkflowChoicePage = props => {
     return result;
   };
 
-  const selectedChoice = data?.['view:mentalHealthWorkflowChoice'] ?? null;
+  const selectedChoice = selectedMentalHealthWorkflowChoice ?? null;
 
   const {
     primaryText,
@@ -460,24 +481,23 @@ const WorkflowChoicePage = props => {
   const setPreviousData = () => {
     const formData = {
       ...data,
-      'view:previousMentalHealthWorkflowChoice':
-        data?.['view:mentalHealthWorkflowChoice'],
+      'view:previousMentalHealthWorkflowChoice': selectedMentalHealthWorkflowChoice,
+      'view:mentalHealthWorkflowChoice': selectedMentalHealthWorkflowChoice,
     };
-    setPreviousWorkflowChoice(data?.['view:mentalHealthWorkflowChoice']);
+    setPreviousWorkflowChoice(selectedMentalHealthWorkflowChoice);
     setFormData(formData);
-    goForward(data);
+    setShouldGoForward(true);
   };
 
   const handlers = {
     onSelection: event => {
       const { value } = event?.detail || {};
       if (value) {
-        const formData = {
+        setSelectedMentalHealthWorkflowChoice(value);
+        setFormData({
           ...data,
-          'view:mentalHealthWorkflowChoice': value,
-        };
-        setFormData(formData);
-        checkErrors(formData);
+          'view:selectedMentalHealthWorkflowChoice': value,
+        });
       }
     },
     onSubmit: event => {
@@ -485,13 +505,36 @@ const WorkflowChoicePage = props => {
       if (checkErrors()) {
         scrollToFirstError({ focusOnAlertRole: true });
       } else if (
-        previousWorkflowChoice !== data?.['view:mentalHealthWorkflowChoice'] &&
+        previousWorkflowChoice !== selectedMentalHealthWorkflowChoice &&
         checkMentalHealthData(data)
       ) {
         setShowModal(true);
       } else {
         setShowAlert(false);
         setPreviousData();
+      }
+    },
+    onUpdatePage: event => {
+      event.preventDefault();
+      if (checkErrors()) {
+        scrollToFirstError({ focusOnAlertRole: true });
+      } else if (
+        previousWorkflowChoice !== selectedMentalHealthWorkflowChoice &&
+        checkMentalHealthData(data)
+      ) {
+        setShowModal(true);
+      } else {
+        setShowAlert(false);
+        const formData = {
+          ...data,
+          'view:previousMentalHealthWorkflowChoice': selectedMentalHealthWorkflowChoice,
+          'view:mentalHealthWorkflowChoice': selectedMentalHealthWorkflowChoice,
+        };
+        setPreviousWorkflowChoice(selectedMentalHealthWorkflowChoice);
+        setFormData(formData);
+        setTimeout(() => {
+          updatePage(event);
+        }, 100);
       }
     },
     onCloseModal: () => {
@@ -557,7 +600,7 @@ const WorkflowChoicePage = props => {
                 name="private"
                 value={form0781WorkflowChoices.COMPLETE_ONLINE_FORM}
                 checked={
-                  data?.['view:mentalHealthWorkflowChoice'] ===
+                  selectedMentalHealthWorkflowChoice ===
                   form0781WorkflowChoices.COMPLETE_ONLINE_FORM
                 }
               />
@@ -570,7 +613,7 @@ const WorkflowChoicePage = props => {
                 name="private"
                 value={form0781WorkflowChoices.SUBMIT_PAPER_FORM}
                 checked={
-                  data?.['view:mentalHealthWorkflowChoice'] ===
+                  selectedMentalHealthWorkflowChoice ===
                   form0781WorkflowChoices.SUBMIT_PAPER_FORM
                 }
               />
@@ -583,7 +626,7 @@ const WorkflowChoicePage = props => {
                 name="private"
                 value={form0781WorkflowChoices.OPT_OUT_OF_FORM0781}
                 checked={
-                  data?.['view:mentalHealthWorkflowChoice'] ===
+                  selectedMentalHealthWorkflowChoice ===
                   form0781WorkflowChoices.OPT_OUT_OF_FORM0781
                 }
               />
@@ -607,13 +650,25 @@ const WorkflowChoicePage = props => {
           {modalContent}
         </VaModal>
       </fieldset>
-      {contentBeforeButtons}
-      <FormNavButtons
-        goBack={handlers.onGoBack}
-        goForward={handlers.onSubmit}
-        submitToContinue
-      />
-      {contentAfterButtons}
+      {onReviewPage ? (
+        <button
+          className="usa-button-primary"
+          type="button"
+          onClick={event => handlers.onUpdatePage(event)}
+        >
+          Update page
+        </button>
+      ) : (
+        <>
+          {contentBeforeButtons}
+          <FormNavButtons
+            goBack={handlers.onGoBack}
+            goForward={handlers.onSubmit}
+            submitToContinue
+          />
+          {contentAfterButtons}
+        </>
+      )}
     </form>
   );
 };
@@ -625,6 +680,8 @@ WorkflowChoicePage.propTypes = {
   goBack: PropTypes.func,
   goForward: PropTypes.func,
   setFormData: PropTypes.func,
+  updatePage: PropTypes.bool,
+  onReviewPage: PropTypes.func,
 };
 
 export default WorkflowChoicePage;

--- a/src/applications/disability-benefits/all-claims/tests/pages/form0781/workflowChoicePage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/form0781/workflowChoicePage.unit.spec.jsx
@@ -56,6 +56,8 @@ describe('WorkflowChoicePage', () => {
     const data = {
       'view:mentalHealthWorkflowChoice':
         form0781WorkflowChoices.COMPLETE_ONLINE_FORM,
+      'view:selectedMentalHealthWorkflowChoice':
+        form0781WorkflowChoices.COMPLETE_ONLINE_FORM,
     };
 
     const { container } = render(page({ data, goForward: goForwardSpy }));
@@ -67,8 +69,12 @@ describe('WorkflowChoicePage', () => {
   it('opens modal when mental health data is present and choice changes', () => {
     const goForwardSpy = sinon.spy();
     const data = {
+      'view:selectedMentalHealthWorkflowChoice':
+        form0781WorkflowChoices.OPT_OUT_OF_FORM0781,
       'view:mentalHealthWorkflowChoice':
         form0781WorkflowChoices.OPT_OUT_OF_FORM0781,
+      'view:previousMentalHealthWorkflowChoice':
+        form0781WorkflowChoices.COMPLETE_ONLINE_FORM,
       treatmentReceivedVaProvider: {
         vaPaid: true,
       },
@@ -89,7 +95,7 @@ describe('WorkflowChoicePage', () => {
     const data = {
       'view:previousMentalHealthWorkflowChoice':
         form0781WorkflowChoices.COMPLETE_ONLINE_FORM,
-      'view:mentalHealthWorkflowChoice':
+      'view:selectedMentalHealthWorkflowChoice':
         form0781WorkflowChoices.OPT_OUT_OF_FORM0781,
       treatmentReceivedVaProvider: { vaPaid: true },
       supportingEvidenceReports: { police: true },


### PR DESCRIPTION
This ticket adds the destructive modal to the review and submit page for 0781.
http://localhost:3001/disability/file-disability-claim-form-21-526ez/review-and-submit

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When a user changes their answer inside of the Mental Health Statement section from doing a form online or opting out of the form, a modal is shown to the user which alerts them to their previous data being deleted

## Related issue(s)

- [[0781 PS] Scope change - Review & Submit - Opt out of 0781 destructive action modals](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104031)
- [[0781 PS] Scope change - Review & Submit - Opt out of 0781 file upload destructive modal](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104368)

## Testing done

- Previous behavior was that the user would not be alerted to their data being deleted if the user changed their workflow choice.
- Cypress testing
- Unit testing
- Local testing

## Screenshots
<img width="808" alt="Screenshot 2025-04-11 at 12 16 07 PM" src="https://github.com/user-attachments/assets/a2d5a9f1-4d59-49ea-9ceb-b27ad0bfc97d" />
<img width="910" alt="Screenshot 2025-04-11 at 11 59 06 AM" src="https://github.com/user-attachments/assets/d96c0ba8-a0a7-4d65-b516-ad8b01bcc90b" />
<img width="903" alt="Screenshot 2025-04-11 at 11 57 58 AM" src="https://github.com/user-attachments/assets/de45c323-e72b-41ea-bc0a-59cfb0af8d7e" />
<img width="703" alt="Screenshot 2025-04-11 at 11 55 37 AM" src="https://github.com/user-attachments/assets/c9c0bf03-6f80-4ef6-87b0-899bdedf209b" />
<img width="906" alt="Screenshot 2025-04-11 at 11 55 21 AM" src="https://github.com/user-attachments/assets/b8eacd6b-34eb-49c2-960e-4ae54a45163d" />



## What areas of the site does it impact?

Review page for 0781

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
