### PR TITLE
Remove 'And' from Beginning of Sentence

### DIFF
--- a/src/applications/fry-dea/containers/IntroductionPage.jsx
+++ b/src/applications/fry-dea/containers/IntroductionPage.jsx
@@ -162,8 +162,7 @@ class IntroductionPage extends React.Component {
                 <strong>Note</strong>: In some cases, we may need more time to
                 make a decision. If you don’t get an automatic decision right
                 after you apply, you’ll receive a decision letter in the mail in
-                about 30 days. And we’ll contact you if we need more
-                information.
+                about 30 days. We’ll contact you if we need more information.
               </p>
             </va-additional-info>
           </va-process-list-item>

--- a/src/applications/my-education-benefits/components/IntroductionProcessList.jsx
+++ b/src/applications/my-education-benefits/components/IntroductionProcessList.jsx
@@ -56,7 +56,7 @@ function IntroductionProcessList() {
             <strong>Note</strong>: In some cases, we may need more time to make
             a decision. If you don’t get an automatic decision right after you
             apply, you’ll receive a decision letter in the mail in about 30
-            days. And we’ll contact you if we need more information.
+            days. We’ll contact you if we need more information.
           </p>
         </va-additional-info>
       </va-process-list-item>

--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/IntroductionPage.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/IntroductionPage.jsx
@@ -142,8 +142,7 @@ export const IntroductionPage = ({
                 <strong>Note:</strong> In some cases, we may need more time to
                 make a decision. If you don’t get an automatic decision right
                 after you apply, you’ll receive a decision letter in the mail in
-                about 30 days. And we’ll contact you if we need more
-                information.
+                about 30 days. We’ll contact you if we need more information.
               </li>
             </ul>
           </va-additional-info>

--- a/src/applications/toe/containers/IntroductionPage.jsx
+++ b/src/applications/toe/containers/IntroductionPage.jsx
@@ -76,8 +76,7 @@ export const IntroductionPage = ({ route, user }) => {
                 <strong>Note</strong>: In some cases, we may need more time to
                 make a decision. If you don’t get an automatic decision right
                 after you apply, you’ll receive a decision letter in the mail in
-                about 30 days. And we’ll contact you if we need more
-                information.
+                about 30 days. We’ll contact you if we need more information.
               </p>
             </va-additional-info>
           </li>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removed "And" from beginning of sentences.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96683
- Internal tracking: SA-111433

## Testing done

Navigated to introduction page and reviewed content.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user