### PR TITLE
10-10EZ | Fix failing Cypress tests

### DIFF
--- a/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.household.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.household.json
@@ -39,7 +39,7 @@
           "hasAttemptedSubmit": false
       },
       "createdAt": 1739200226,
-      "expiresAt": 1744384257,
+      "expiresAt": 32472162000,
       "lastUpdated": 1739200257,
       "inProgressFormId": 12345
     }

--- a/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.insurance.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/prefill.inProgress.insurance.json
@@ -38,7 +38,7 @@
           "hasAttemptedSubmit": false
       },
       "createdAt": 1739200226,
-      "expiresAt": 1744384257,
+      "expiresAt": 32472162000,
       "lastUpdated": 1739200257,
       "inProgressFormId": 12345
     }

--- a/src/applications/hca/tests/e2e/fixtures/mocks/save-in-progress.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/save-in-progress.json
@@ -11,7 +11,7 @@
         "metadata": {
           "version": 0,
           "returnUrl": "/check-your-personal-information",
-          "savedAt": 1735707600000,
+          "savedAt": 1739200257608,
           "submission": {
             "status": false,
             "errorMessage": false,
@@ -19,9 +19,9 @@
             "timestamp": false,
             "hasAttemptedSubmit": false
           },
-          "createdAt": 1735707600000,
-          "expiresAt": 1740805200000,
-          "lastUpdated": 1735707600000,
+          "createdAt": 1739200226,
+          "expiresAt": 32472162000,
+          "lastUpdated": 1739200257,
           "inProgressFormId": 12345
         }
       }

--- a/src/applications/hca/tests/e2e/fixtures/mocks/user.inProgressForm.json
+++ b/src/applications/hca/tests/e2e/fixtures/mocks/user.inProgressForm.json
@@ -37,7 +37,7 @@
               "hasAttemptedSubmit": false
             },
             "createdAt": 1739200226,
-            "expiresAt": 1744384257,
+            "expiresAt": 32472162000,
             "lastUpdated": 1739200257,
             "inProgressFormId": 12345
           },


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes failing Cypress tests in the Health Care application. The test failures were due to mock data containing an expiration timestamp that would not allow access to the form. This PR bumps the expiration date to 2999-01-01 to ensure none of us will still be alive when that value finally is reached.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#100726

## Acceptance criteria

 - Mock data cannot expire

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution