### PR TITLE
Add Datadog RUM unique user tracking

### DIFF
--- a/src/applications/mhv-medications/containers/App.jsx
+++ b/src/applications/mhv-medications/containers/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
@@ -13,6 +13,7 @@ import {
 import {
   MHVDowntime,
   useDatadogRum,
+  setDatadogRumUser,
   MhvSecondaryNav,
   useBackToTop,
 } from '@department-of-veterans-affairs/mhv/exports';
@@ -54,6 +55,12 @@ const App = ({ children }) => {
     defaultPrivacyLevel: 'mask-user-input',
   };
   useDatadogRum(datadogRumConfig);
+  useEffect(
+    () => {
+      setDatadogRumUser({ id: user?.profile?.accountUuid });
+    },
+    [user],
+  );
 
   if (featureTogglesLoading) {
     return (

--- a/src/applications/mhv-medications/mocks/api/user/index.js
+++ b/src/applications/mhv-medications/mocks/api/user/index.js
@@ -29,6 +29,9 @@ const defaultUser = {
       },
       in_progress_forms: [],
       prefills_available: ['21-526EZ'],
+      account: {
+        accountUuid: '6af59b36-f14d-482e-88b4-3d7820422343',
+      },
       services: [
         'facilities',
         'hca',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary
Adds unique user tracking to RUM for medications as was done for SM in #28214 - this is to support OCTO KPI tracking.

## Testing done

- Tested locally and confirmed that unique ID is sent to RUM
- Added unit test 
