### PR TITLE
10-10CG | Add Facilities error messaging to DD Logs

### DIFF
--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -210,7 +210,10 @@ const FacilitySearch = props => {
       );
       if (loadedParent) {
         if (hasSupportServices(loadedParent)) return loadedParent;
-
+        window.DD_LOGS?.logger.warn(
+          'DATA ERROR: Selected facility has no valid parent with Caregiver services',
+          { facilityId: loadedParent.id },
+        );
         return setLocalState(prev => ({
           ...prev,
           listError: content['error--facilities-parent-facility'],
@@ -232,6 +235,10 @@ const FacilitySearch = props => {
 
       // check if both the selected and the parent facilities do not offer support services
       if (!hasSupportServices(fetchedParent)) {
+        window.DD_LOGS?.logger.warn(
+          'DATA ERROR: Selected facility has no valid parent with Caregiver services',
+          { facilityId: fetchedParent.id },
+        );
         return setLocalState(prev => ({
           ...prev,
           listError: content['error--facilities-parent-facility'],

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.jsx
@@ -255,6 +255,11 @@ describe('CG <FacilitySearch>', () => {
         facilitiesStub.resolves(
           mockFetchFacilitiesResponseWithoutCaregiverSupport,
         );
+        const mockLogger = { warn: sinon.spy() };
+        Object.defineProperty(window, 'DD_LOGS', {
+          value: { logger: mockLogger },
+          configurable: true,
+        });
 
         await waitFor(() => {
           inputVaSearchInput(container, 'Tampa', selectors().input);
@@ -289,6 +294,7 @@ describe('CG <FacilitySearch>', () => {
             'error',
             content['error--facilities-parent-facility'],
           );
+          expect(mockLogger.warn.calledOnce).to.be.true;
         });
       });
 
@@ -333,6 +339,11 @@ describe('CG <FacilitySearch>', () => {
       it('calls dispatch callback with facility object whose parent is not loaded and does not offer CaregiverSupport', async () => {
         const { props, mockStore } = getData({});
         const { container, selectors } = subject({ props, mockStore });
+        const mockLogger = { warn: sinon.spy() };
+        Object.defineProperty(window, 'DD_LOGS', {
+          value: { logger: mockLogger },
+          configurable: true,
+        });
         mapboxStub.resolves(mapBoxSuccessResponse);
         facilitiesStub.onFirstCall().resolves(mockFetchChildFacilityResponse);
 
@@ -372,6 +383,7 @@ describe('CG <FacilitySearch>', () => {
             'error',
             content['error--facilities-parent-facility'],
           );
+          expect(mockLogger.warn.calledOnce).to.be.true;
         });
       });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR add some logging when a user selects a medical facility in the Caregivers application that does not have support services and whose parent facility does not have support services in the data returned from Lighthouse. This logging is an effort to be alerted to data mismatches in the Lighthouse facilities cache (which has seen some recent issues).

## Related issue(s)

department-of-veterans-affairs/va.gov-team#107746

## Acceptance criteria

- Logging is available to allow for monitors to be set up

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)