### PR TITLE
Add pdfSupport to dashboard / my_va mocks

### DIFF
--- a/src/applications/personalization/dashboard/mocks/benefit-applications/index.js
+++ b/src/applications/personalization/dashboard/mocks/benefit-applications/index.js
@@ -17,6 +17,7 @@ const createApplications = (updatedDaysAgo = 1) => {
           status: 'received',
           createdAt: '2023-12-15T20:40:47.583Z',
           updatedAt: formatISO(daysAgo),
+          pdfSupport: true,
         },
       },
       {
@@ -30,6 +31,7 @@ const createApplications = (updatedDaysAgo = 1) => {
           status: 'vbms',
           createdAt: '2023-12-15T20:40:47.583Z',
           updatedAt: formatISO(daysAgo),
+          pdfSupport: false,
         },
       },
     ],


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- A new property of `pdfSupport` was added to the `/v0/my_va/submission_statuses` endpoint but it was not added to the data mock
- This PR adds those properties to the data mock that returns when running `yarn mock-api --responses src/applications/personalization/dashboard/mocks/server.js`
- Authenticated Experience Team Authentiknights

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/98369

## Testing done

- No change to testing as this property was simply not present in the previous mocks
- Run the above `yarn mock-api` command and check the output of the request to `/v0/my_va/submission_statuses`
- `pdfSupport` should be present with one value true and one false. Those boolean values should match up with the logic found in `vets-api` relating to the [form type](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/forms/submission_statuses/pdf_urls.rb#L8).

## What areas of the site does it impact?

My VA Dashboard only when mocking the API responses locally.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user