### PR TITLE
VEBT-1593

### DIFF
--- a/src/applications/gi/components/CompareHeader.jsx
+++ b/src/applications/gi/components/CompareHeader.jsx
@@ -10,6 +10,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import Checkbox from './Checkbox';
 import SchoolClassification from './SchoolClassification';
 import CompareScroller from './CompareScroller';
+import { capitalizeFirstLetter } from '../utils/helpers';
 
 export default function CompareHeader({
   currentScroll,
@@ -125,7 +126,7 @@ export default function CompareHeader({
                           aria-label={`${institution.name}, `}
                           id={`${institution.facilityCode}-label`}
                         >
-                          {institution.name}
+                          {capitalizeFirstLetter(institution.name)}
                         </span>
                       </Link>
                     </div>

--- a/src/applications/gi/containers/CompareDrawer.jsx
+++ b/src/applications/gi/containers/CompareDrawer.jsx
@@ -7,7 +7,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { useHistory } from 'react-router-dom';
 import { removeCompareInstitution, compareDrawerOpened } from '../actions';
 import RemoveCompareSelectedModal from '../components/RemoveCompareSelectedModal';
-import { isSmallScreen } from '../utils/helpers';
+import { capitalizeFirstLetter, isSmallScreen } from '../utils/helpers';
 
 export function CompareDrawer({
   compare,
@@ -131,7 +131,7 @@ export function CompareDrawer({
           >
             <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-align-items--start vads-u-justify-content--flex-start vads-u-padding-y--0 vads-u-padding-x--1px">
               <div className="compare-name">
-                {institutions[facilityCode].name}
+                {capitalizeFirstLetter(institutions[facilityCode].name)}
               </div>
               <div className="vads-u-padding-top--1p5">
                 {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component, react/button-has-type */}

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -12,7 +12,11 @@ import { fetchProfile, setPageTitle, showModal, hideModal } from '../actions';
 import VetTecInstitutionProfile from '../components/vet-tec/InstitutionProfile';
 import InstitutionProfile from '../components/profile/InstitutionProfile';
 import ServiceError from '../components/ServiceError';
-import { isSmallScreen, useQueryParams } from '../utils/helpers';
+import {
+  capitalizeFirstLetter,
+  isSmallScreen,
+  useQueryParams,
+} from '../utils/helpers';
 
 export function ProfilePage({
   constants,
@@ -48,7 +52,9 @@ export function ProfilePage({
   useEffect(
     () => {
       if (institutionName) {
-        document.title = `${institutionName}: GI Bill® Comparison Tool | Veterans Affairs`;
+        document.title = `${capitalizeFirstLetter(
+          institutionName,
+        )}: GI Bill® Comparison Tool | Veterans Affairs`;
       }
     },
     [institutionName],

--- a/src/applications/gi/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi/containers/ProfilePageHeader.jsx
@@ -59,7 +59,7 @@ const ProfilePageHeader = ({
 
   const lowerType = type && type.toLowerCase();
   const formattedAddress = locationInfo(
-    capitalizeFirstLetter(physicalCity),
+    physicalCity,
     physicalState,
     physicalCountry,
   );

--- a/src/applications/gi/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi/containers/ProfilePageHeader.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
 
 import {
+  capitalizeFirstLetter,
   convertRatingToStars,
   createId,
   formatNumber,
@@ -318,7 +319,7 @@ const ProfilePageHeader = ({
       />
       <div className="vads-u-padding-left--2">
         <h1 tabIndex={-1} className={titleClasses}>
-          {name}
+          {capitalizeFirstLetter(name)}
         </h1>
         <p>{formattedAddress}</p>
         <div className="vads-u-padding-bottom--1p5">

--- a/src/applications/gi/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi/containers/ProfilePageHeader.jsx
@@ -59,7 +59,7 @@ const ProfilePageHeader = ({
 
   const lowerType = type && type.toLowerCase();
   const formattedAddress = locationInfo(
-    physicalCity,
+    capitalizeFirstLetter(physicalCity),
     physicalState,
     physicalCountry,
   );

--- a/src/applications/gi/containers/search/ResultCard.jsx
+++ b/src/applications/gi/containers/search/ResultCard.jsx
@@ -173,14 +173,14 @@ export function ResultCard({
           >
             {capitalizeFirstLetter(name)}
             <span className="vads-u-visibility--screen-reader">
-              {city}
+              {capitalizeFirstLetter(city)}
               {state && `, ${state}`}
             </span>
           </Link>
         </h3>
       </div>
       <p className="vads-u-padding--0">
-        {city}
+        {capitalizeFirstLetter(city)}
         {state && `, ${state}`}
       </p>
     </>

--- a/src/applications/gi/containers/search/ResultCard.jsx
+++ b/src/applications/gi/containers/search/ResultCard.jsx
@@ -173,14 +173,14 @@ export function ResultCard({
           >
             {capitalizeFirstLetter(name)}
             <span className="vads-u-visibility--screen-reader">
-              {capitalizeFirstLetter(city)}
+              {city}
               {state && `, ${state}`}
             </span>
           </Link>
         </h3>
       </div>
       <p className="vads-u-padding--0">
-        {capitalizeFirstLetter(city)}
+        {city}
         {state && `, ${state}`}
       </p>
     </>

--- a/src/applications/gi/containers/search/ResultCard.jsx
+++ b/src/applications/gi/containers/search/ResultCard.jsx
@@ -20,6 +20,7 @@ import {
   createId,
   convertRatingToStars,
   showSchoolContentBasedOnType,
+  capitalizeFirstLetter,
 } from '../../utils/helpers';
 import { CautionFlagAdditionalInfo } from '../../components/CautionFlagAdditionalInfo';
 import RatingsStars from '../../components/profile/schoolRatings/RatingsStars';
@@ -170,7 +171,7 @@ export function ResultCard({
               })
             }
           >
-            {name}
+            {capitalizeFirstLetter(name)}
             <span className="vads-u-visibility--screen-reader">
               {city}
               {state && `, ${state}`}

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -555,13 +555,34 @@ export const getGIBillHeaderText = (automatedTest = false) => {
 export function capitalizeFirstLetter(string, customExceptions = []) {
   if (!string) return null;
 
-  const exceptions = ['NW', 'SW', 'NE', 'SE', 'of', 'and', ...customExceptions];
+  const exceptions = [
+    'NW',
+    'SW',
+    'NE',
+    'SE',
+    'NYC',
+    'of',
+    'and',
+    ...customExceptions,
+  ];
 
   return string
     .split(' ')
     .map(word => {
       if (exceptions.includes(word)) {
         return word;
+      }
+
+      if (word.includes('-')) {
+        return word
+          .split('-')
+          .map(w => {
+            if (exceptions.includes(w)) {
+              return w;
+            }
+            return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+          })
+          .join('-');
       }
 
       if (word === 'OF') {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Refactored a utility function used to format text capitalization and applied it to institution names within:
    - search result cards
    - the comparison drawer
    - the comparison page
    - the institution details page
    - the browser page title.
- The solution was to expand the list of words excluded from capitalization rules (handling exceptions like "of", "and", "NYC", hyphenated titles, etc) and apply this function to the text displayed, rather than using the value returned from the initial API call. 
- There are likely remaining edge cases where casing may be incorrect for institutions containing unique acronyms.
    - This change was made to satisfy platform requirements, but without an exhaustive list of properly cased titles from business or formatting source data, the edge cases can't be resolved.
- I work for Veteran Education Benefit Tools.

## Related issue(s)

https://jira.devops.va.gov/browse/VEBT-1593

## Testing done

- Spot checked by searching for different institutions.


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before |  
|
<img width="664" alt="Screenshot 2025-04-17 at 11 18 53 AM" src="https://github.com/user-attachments/assets/1743dfc0-b3c2-4fe4-afc4-ce7eb26d6a56" />
|
<img width="788" alt="Screenshot 2025-04-17 at 11 22 44 AM" src="https://github.com/user-attachments/assets/89503f40-c0a7-4bfd-948d-71003dde8c81" />
|
<img width="1014" alt="Screenshot 2025-04-17 at 2 27 46 PM" src="https://github.com/user-attachments/assets/bc73ef80-f2ed-400b-a75a-dbfe0ca924ed" />

| After |
|
<img width="672" alt="Screenshot 2025-04-17 at 2 19 30 PM" src="https://github.com/user-attachments/assets/cf458215-17de-4720-9e24-8964ee21856a" />
| 
<img width="787" alt="Screenshot 2025-04-17 at 2 20 18 PM" src="https://github.com/user-attachments/assets/f42492e7-3455-4ea7-a216-99d99b1834d1" />
|
<img width="1001" alt="Screenshot 2025-04-17 at 2 20 41 PM" src="https://github.com/user-attachments/assets/cd4d9d0e-2434-4ff3-a170-8697ad9bbdc4" />


## What areas of the site does it impact?

Comparison Tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

No authentication required.
