### PR TITLE
working progress

### DIFF
--- a/src/applications/claims-status/components/AppInitLoader.jsx
+++ b/src/applications/claims-status/components/AppInitLoader.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+
+export default function AppInitLoader({ children }) {
+  const downtimeLoading = useSelector(
+    state => !state.scheduledDowntime.isReady,
+  );
+
+  useEffect(
+    () => {
+      if (!downtimeLoading) {
+        document.querySelector('h1')?.focus();
+      }
+    },
+    [downtimeLoading],
+  );
+
+  if (downtimeLoading) {
+    return (
+      <div className="claims-init-loader">
+        <va-loading-indicator set-focus message="Loading VA Claim Status..." />
+      </div>
+    );
+  }
+
+  return children;
+}
+
+AppInitLoader.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/applications/claims-status/components/CustomRequiredLoginView.jsx
+++ b/src/applications/claims-status/components/CustomRequiredLoginView.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
+
+// Custom loader component that uses the same message as our AppInitLoader
+const CustomRequiredLoginLoader = () => (
+  <div className="vads-u-margin-y--5" data-testid="req-loader">
+    <va-loading-indicator set-focus message="Loading VA Claim Status..." />
+  </div>
+);
+
+// Override the default RequiredLoginView with custom loading UI
+const CustomRequiredLoginView = props => {
+  // Intercept the user profile loading state to show our custom loader
+  if (props.user.profile.loading) {
+    return <CustomRequiredLoginLoader />;
+  }
+
+  // Otherwise, use the standard RequiredLoginView behavior
+  return <RequiredLoginView {...props} />;
+};
+
+CustomRequiredLoginView.propTypes = {
+  serviceRequired: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]).isRequired,
+  user: PropTypes.object.isRequired,
+  showProfileErrorMessage: PropTypes.bool,
+  useSiS: PropTypes.bool,
+  verify: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+export default CustomRequiredLoginView;

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -7,11 +7,11 @@ import DowntimeNotification, {
   externalServices,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
-import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 
 import { setLastPage } from '../actions';
 import ClaimsAppealsUnavailable from '../components/ClaimsAppealsUnavailable';
+import CustomRequiredLoginView from '../components/CustomRequiredLoginView';
 import { isLoadingFeatures } from '../selectors';
 import { useBrowserMonitoring } from '../utils/datadog-rum/useBrowserMonitoring';
 
@@ -27,7 +27,7 @@ function AppContent({ featureFlagsLoading, isDataAvailable }) {
       <div className="vads-u-margin-y--5">
         <va-loading-indicator
           data-testid="feature-flags-loading"
-          message="Loading your information..."
+          message="Loading VA Claim Status..."
         />
       </div>
     );
@@ -70,7 +70,7 @@ function ClaimsStatusApp({
   });
 
   return (
-    <RequiredLoginView
+    <CustomRequiredLoginView
       verify
       serviceRequired={[
         backendServices.EVSS_CLAIMS,
@@ -93,7 +93,7 @@ function ClaimsStatusApp({
           <AppContent featureFlagsLoading={featureFlagsLoading} />
         </DowntimeNotification>
       </div>
-    </RequiredLoginView>
+    </CustomRequiredLoginView>
   );
 }
 

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -189,7 +189,9 @@ class YourClaimsPageV2 extends React.Component {
     const emptyList = !(list && list.length);
     if (allRequestsLoading || (atLeastOneRequestLoading && emptyList)) {
       content = (
-        <va-loading-indicator message="Loading your claims and appeals..." />
+        <div className="claims-list-container" aria-busy="true">
+          <va-loading-indicator message="Loading your claims and appeals..." />
+        </div>
       );
     } else if (!emptyList) {
       const listLen = list.length;
@@ -212,7 +214,9 @@ class YourClaimsPageV2 extends React.Component {
           {pageInfo}
           <div className="claim-list">
             {atLeastOneRequestLoading && (
-              <va-loading-indicator message="Loading your claims and appeals..." />
+              <div className="claims-list-container" aria-busy="true">
+                <va-loading-indicator message="Loading your claims and appeals..." />
+              </div>
             )}
             {pageItems.map(claim => this.renderListItem(claim))}
             {shouldPaginate && (
@@ -249,8 +253,8 @@ class YourClaimsPageV2 extends React.Component {
               trigger="Find out why we sometimes combine claims."
             >
               <div>
-                If you turn in a new claim while we’re reviewing another one
-                from you, we’ll add any new information to the original claim
+                If you turn in a new claim while we're reviewing another one
+                from you, we'll add any new information to the original claim
                 and close the new claim, with no action required from you.
               </div>
             </va-additional-info>

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -1203,3 +1203,20 @@ va-icon.phase-current {
 .bullet-disc {
   list-style-type: disc;
 }
+
+.claims-init-loader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  // background: #fff;   /* prevents CLS */
+  z-index: 9999;
+}
+
+.claims-list-container {
+  min-height: 400px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/applications/claims-status/tests/components/AppInitLoader.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AppInitLoader.unit.spec.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+import AppInitLoader from '../../components/AppInitLoader';
+
+describe('AppInitLoader', () => {
+  it('should render the spinner when loading feature toggles', () => {
+    const mockStore = configureStore({
+      reducer: () => ({
+        featureToggles: {
+          loading: true,
+        },
+        scheduledDowntime: {
+          isReady: true,
+        },
+      }),
+    });
+
+    render(
+      <Provider store={mockStore}>
+        <AppInitLoader>
+          <div>Child content</div>
+        </AppInitLoader>
+      </Provider>,
+    );
+
+    expect(screen.getByText('Loading VA Claim Status...')).to.exist;
+    expect(screen.queryByText('Child content')).to.not.exist;
+  });
+
+  it('should render the spinner when downtime check is loading', () => {
+    const mockStore = configureStore({
+      reducer: () => ({
+        featureToggles: {
+          loading: false,
+        },
+        scheduledDowntime: {
+          isReady: false,
+        },
+      }),
+    });
+
+    render(
+      <Provider store={mockStore}>
+        <AppInitLoader>
+          <div>Child content</div>
+        </AppInitLoader>
+      </Provider>,
+    );
+
+    expect(screen.getByText('Loading VA Claim Status...')).to.exist;
+    expect(screen.queryByText('Child content')).to.not.exist;
+  });
+
+  it('should render children when not loading', () => {
+    const mockStore = configureStore({
+      reducer: () => ({
+        featureToggles: {
+          loading: false,
+        },
+        scheduledDowntime: {
+          isReady: true,
+        },
+      }),
+    });
+
+    render(
+      <Provider store={mockStore}>
+        <AppInitLoader>
+          <div>Child content</div>
+        </AppInitLoader>
+      </Provider>,
+    );
+
+    expect(screen.queryByText('Loading VA Claim Status...')).to.not.exist;
+    expect(screen.getByText('Child content')).to.exist;
+  });
+});

--- a/src/applications/claims-status/tests/components/AppInitLoader.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AppInitLoader.unit.spec.jsx
@@ -1,36 +1,13 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
 import AppInitLoader from '../../components/AppInitLoader';
 
 describe('AppInitLoader', () => {
-  it('should render the spinner when loading feature toggles', () => {
-    const mockStore = configureStore({
-      reducer: () => ({
-        featureToggles: {
-          loading: true,
-        },
-        scheduledDowntime: {
-          isReady: true,
-        },
-      }),
-    });
-
-    render(
-      <Provider store={mockStore}>
-        <AppInitLoader>
-          <div>Child content</div>
-        </AppInitLoader>
-      </Provider>,
-    );
-
-    expect(screen.getByText('Loading VA Claim Status...')).to.exist;
-    expect(screen.queryByText('Child content')).to.not.exist;
-  });
-
   it('should render the spinner when downtime check is loading', () => {
     const mockStore = configureStore({
       reducer: () => ({
@@ -43,7 +20,7 @@ describe('AppInitLoader', () => {
       }),
     });
 
-    render(
+    const { container, queryByText } = render(
       <Provider store={mockStore}>
         <AppInitLoader>
           <div>Child content</div>
@@ -51,11 +28,15 @@ describe('AppInitLoader', () => {
       </Provider>,
     );
 
-    expect(screen.getByText('Loading VA Claim Status...')).to.exist;
-    expect(screen.queryByText('Child content')).to.not.exist;
+    const loadingIndicator = $('va-loading-indicator', container);
+    expect(loadingIndicator).to.exist;
+    expect(loadingIndicator.getAttribute('message')).to.equal(
+      'Loading VA Claim Status...',
+    );
+    expect(queryByText('Child content')).to.not.exist;
   });
 
-  it('should render children when not loading', () => {
+  it('should render children when downtime check is ready', () => {
     const mockStore = configureStore({
       reducer: () => ({
         featureToggles: {
@@ -67,7 +48,7 @@ describe('AppInitLoader', () => {
       }),
     });
 
-    render(
+    const { container, getByText } = render(
       <Provider store={mockStore}>
         <AppInitLoader>
           <div>Child content</div>
@@ -75,7 +56,8 @@ describe('AppInitLoader', () => {
       </Provider>,
     );
 
-    expect(screen.queryByText('Loading VA Claim Status...')).to.not.exist;
-    expect(screen.getByText('Child content')).to.exist;
+    const loadingIndicator = $('va-loading-indicator', container);
+    expect(loadingIndicator).to.not.exist;
+    expect(getByText('Child content')).to.exist;
   });
 });


### PR DESCRIPTION
## Summary

### Experiment 
- Show one spinner only until the Claim‑Status shell is ready


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#107782


## Testing done

- Unit to verify loader is functional 


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|            |           |
| ------- | ------ | 
| Problem |   Solution   |
![image](https://github.com/user-attachments/assets/8ab925e8-36db-433f-bd51-e98852a69d71)      |   TBD |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

- Users see one full‑screen spinner from first paint until the JS bundle hydrates and any required feature‑toggle / downtime checks complete.
- After the spinner disappears, the page shell (header, H1) and the existing list‑level spinner (“Loading your claims and appeals…”) are visible while claim/appeal APIs load.
- Lighthouse reports 0 CLS attributable to loaders.
- axe‑core shows no focus‑order or landmark violations.
- Implementation aligns with the My VA Dashboard loading pattern.

### Quality Assurance & Testing

- [ ] NA

