### PR TITLE
Burial - Use currency web component pattern

### DIFF
--- a/src/applications/burials-ez/components/ReviewRowView.jsx
+++ b/src/applications/burials-ez/components/ReviewRowView.jsx
@@ -37,19 +37,4 @@ AltReviewRowView.propTypes = {
   }),
 };
 
-export const CurrencyReviewRowView = ({ children }) => {
-  return (
-    <div className="review-row">
-      <dt>{children?.props?.uiSchema?.['ui:title']}</dt>
-      <dd>${children}</dd>
-    </div>
-  );
-};
-
-CurrencyReviewRowView.propTypes = {
-  children: PropTypes.shape({
-    props: PropTypes.object,
-  }),
-};
-
 export default ReviewRowView;

--- a/src/applications/burials-ez/config/chapters/04-benefits-selection/plotAllowancePartOne.js
+++ b/src/applications/burials-ez/config/chapters/04-benefits-selection/plotAllowancePartOne.js
@@ -1,10 +1,9 @@
 import {
+  currencyUI,
+  currencyStringSchema,
   yesNoUI,
   yesNoSchema,
-  numberUI,
-  numberSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { CurrencyReviewRowView } from '../../../components/ReviewRowView';
 import { generateTitle } from '../../../utils/helpers';
 
 export default {
@@ -14,10 +13,8 @@ export default {
       'Did the federal government, state government, or the Veteran’s employer pay any of the burial costs?',
     ),
     amountGovtContribution: {
-      ...numberUI({
+      ...currencyUI({
         title: 'Amount the government or employer paid',
-        hint:
-          'Enter an amount with numbers only. Don\'t include symbols or special characters like "$," commas, or periods.',
         hideIf: form => !form?.govtContributions,
         errorMessages: {
           pattern:
@@ -26,7 +23,6 @@ export default {
         min: 0,
       }),
       'ui:required': form => form?.govtContributions,
-      'ui:reviewField': CurrencyReviewRowView,
     },
   },
   schema: {
@@ -34,7 +30,7 @@ export default {
     required: ['govtContributions'],
     properties: {
       govtContributions: yesNoSchema,
-      amountGovtContribution: numberSchema,
+      amountGovtContribution: currencyStringSchema,
     },
   },
 };

--- a/src/applications/burials-ez/tests/components/ReviewRowView.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/components/ReviewRowView.unit.spec.jsx
@@ -4,7 +4,6 @@ import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import ReviewRowView, {
   AltReviewRowView,
-  CurrencyReviewRowView,
 } from '../../components/ReviewRowView';
 
 const store = {
@@ -52,17 +51,6 @@ describe('All ReviewRowView exported components', () => {
     const { getAllByRole } = render(
       <Provider store={store}>
         <AltReviewRowView />
-      </Provider>,
-    );
-
-    const definitionList = getAllByRole('definition');
-    expect(definitionList).to.exist;
-  });
-
-  it('renders CurrencyReviewRowView component', () => {
-    const { getAllByRole } = render(
-      <Provider store={store}>
-        <CurrencyReviewRowView />
       </Provider>,
     );
 

--- a/src/platform/forms-system/src/js/review/CurrencyWidget.jsx
+++ b/src/platform/forms-system/src/js/review/CurrencyWidget.jsx
@@ -5,9 +5,21 @@ import formatCurrency from '../utilities/data/formatCurrency';
 
 export default function CurrencyWidget(props) {
   const { name = 'currency value', value, ...settings } = props || {};
+
+  let displayValue = value;
+
+  if (typeof value === 'number') {
+    displayValue = formatCurrency(value, settings);
+  } else if (typeof value === 'string') {
+    const numericValue = Number(value);
+    if (!Number.isNaN(numericValue)) {
+      displayValue = formatCurrency(numericValue, settings);
+    }
+  }
+
   return (
-    <span className="dd-privacy-hidden" data-dd-action-name={name || ''}>
-      {typeof value === 'number' ? formatCurrency(value, settings) : value}
+    <span className="dd-privacy-hidden" data-dd-action-name={name}>
+      {displayValue}
     </span>
   );
 }

--- a/src/platform/forms-system/test/js/review/CurrencyWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/CurrencyWidget.unit.spec.jsx
@@ -6,12 +6,14 @@ import CurrencyWidget from '../../../src/js/review/CurrencyWidget';
 
 describe('Schemaform review <CurrencyWidget>', () => {
   const supportsIntl = () => true;
+
   it('should format currency', () => {
     const screen = render(
       <CurrencyWidget value={10} supportsIntl={supportsIntl} />,
     );
     expect(screen.getByText('$10.00')).to.exist;
   });
+
   it('should render empty value', () => {
     const screen = render(
       <div>
@@ -32,6 +34,7 @@ describe('Schemaform review <CurrencyWidget>', () => {
     );
     expect(screen.getByText('12,34 €')).to.exist;
   });
+
   it('should format currency with negative value', () => {
     const screen = render(
       <CurrencyWidget value={-10} supportsIntl={supportsIntl} />,
@@ -45,16 +48,25 @@ describe('Schemaform review <CurrencyWidget>', () => {
     );
     expect(screen.getByText('$0.00')).to.exist;
   });
+
   it('should format currency with large value', () => {
     const screen = render(
       <CurrencyWidget value={1234567890.12} supportsIntl={supportsIntl} />,
     );
     expect(screen.getByText('$1,234,567,890.12')).to.exist;
   });
+
   it('should format currency with small value', () => {
     const screen = render(
       <CurrencyWidget value={0.01} supportsIntl={supportsIntl} />,
     );
     expect(screen.getByText('$0.01')).to.exist;
+  });
+
+  it('should format string numeric value as currency', () => {
+    const screen = render(
+      <CurrencyWidget value="1234.56" supportsIntl={supportsIntl} />,
+    );
+    expect(screen.getByText('$1,234.56')).to.exist;
   });
 });


### PR DESCRIPTION
Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes

## Summary
Update the currency fields in the Burial Benefits form (21P-530EZ) by replacing the currency field(s) with the currency web component pattern.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107318

## Associated Pull Request(s)
- https://github.com/department-of-veterans-affairs/vets-website/pull/35791
- https://github.com/department-of-veterans-affairs/vets-website/pull/35890

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. In your local environment, set the `burial_form_enabled ` flipper to 'enabled' at http://localhost:3000/flipper/features/burial_form_enabled
4. Go to `http://localhost:3001/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/` in your browser

## How to verify
1. Continue to the 'Plot or intermittent allowance' page (/benefits/plot-allowance/contributions)
2. Select 'Yes' to the 'Did the federal government, state government, or the Veteran’s employer pay any of the burial costs?' question
3. Verify that the 'Amount the government or employer paid' field is revealed
4. Verify that it is required to Continue
5. Verify that the 'Amount the government or employer paid' field is hidden when 'No' is selected
6. Enter a valid currency value and verify that `amountGovtContribution` form data is saved as a 'string'
7. Continue to or use the 'SIP' menu to fill out the form with mock data and return to the 'Review and submit' page
8. Verify that the`amountGovtContribution` form data currency 'string' value is formatted correctly

## What areas of the site does it impact?
Burial Benefits Application

## Screenshots
### Plot or interment allowance page
| Before      | After       |
| ----------- | ----------- |
|![Screenshot 2025-04-17 at 9 25 18 AM](https://github.com/user-attachments/assets/7899b92c-f3ab-424d-853c-b52b04ff031a)|![Screenshot 2025-04-18 at 9 08 18 AM](https://github.com/user-attachments/assets/c790d234-dc22-4a10-8191-9c9c799fdd83)|

### Plot or interment allowance page - Required
| Before      | After       |
| ----------- | ----------- |
|![Screenshot 2025-04-18 at 10 33 51 AM](https://github.com/user-attachments/assets/a9e0d236-7483-4fc6-a75c-1bc12cc37a6a)|![Screenshot 2025-04-18 at 9 08 46 AM](https://github.com/user-attachments/assets/a9b0b967-d381-440b-a44e-30c92c8a0809)|

### Plot or interment allowance page - Validation error
![Screenshot 2025-04-18 at 9 09 17 AM](https://github.com/user-attachments/assets/527712c2-3429-4ecb-8433-91f59cfd0264)

### Review and Submit page
![Screenshot 2025-04-17 at 10 00 04 AM](https://github.com/user-attachments/assets/8eff42a9-a818-40ea-ab96-2af634965c56)

### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
