### PR TITLE
1454: move 1095b forms found analytics to correct location

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -60,10 +60,12 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
           if (response.availableForms.length === 0) {
             recordEvent({ event: '1095b-available-forms-not-found' });
             updateFormError({ error: true, type: errorTypes.NOT_FOUND });
-          }
-          const mostRecentYearData = response.availableForms[0];
-          if (mostRecentYearData?.year) {
-            updateYear(mostRecentYearData.year);
+          } else {
+            recordEvent({ event: '1095b-available-forms-found' });
+            const mostRecentYearData = response.availableForms[0];
+            if (mostRecentYearData.year) {
+              updateYear(mostRecentYearData.year);
+            }
           }
         })
         .catch(() => {
@@ -71,7 +73,6 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
           updateFormError({ error: true, type: errorTypes.SYSTEM_ERROR });
         })
         .finally(() => {
-          recordEvent({ event: '1095b-available-forms-found' });
           setHasLoadedMostRecentYear(true);
         });
     },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Corrects an error regarding where we track "available forms found". This should not be happening in the finally block.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va-iir/issues/1454

## Testing done

Local. Will test on staging.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

Only 1095b metrics.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback


