### PR TITLE
DBEX 0781ps content updates

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/BehaviorIntroCombatPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/BehaviorIntroCombatPage.jsx
@@ -148,12 +148,7 @@ const BehaviorIntroCombatPage = ({
     onConfirmDeleteBehavioralAnswers: () => {
       deleteBehavioralAnswers();
       handlers.onCloseModal();
-
-      if (onReviewPage) {
-        updatePage();
-      } else {
-        setShowDeletedAnswerConfirmation(true);
-      }
+      setShowDeletedAnswerConfirmation(true);
     },
     onCancelDeleteBehavioralAnswers: () => {
       handlers.onCloseModal();
@@ -196,15 +191,12 @@ const BehaviorIntroCombatPage = ({
           <p className="vads-u-margin-y--0">
             We’ve removed information about your behavioral changes.
           </p>
-          <p>
-            <button
-              type="button"
-              className="va-button-link"
+          {!onReviewPage ? (
+            <va-link
+              text="Continue with your claim"
               onClick={() => goForward(data)}
-            >
-              Continue with your claim
-            </button>{' '}
-          </p>
+            />
+          ) : null}
         </VaAlert>
       </div>
 

--- a/src/applications/disability-benefits/all-claims/components/BehaviorListPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/BehaviorListPage.jsx
@@ -355,27 +355,15 @@ const BehaviorListPage = ({
           uswds
           tabIndex="-1"
         >
+          <p className="vads-u-margin-y--0">
+            We’ve removed optional descriptions about your behavioral changes.
+          </p>
           {!onReviewPage ? (
-            <>
-              <p className="vads-u-margin-y--0">
-                We’ve removed optional descriptions about your behavioral
-                changes.
-              </p>
-              <p>
-                <va-link
-                  text="Continue with your claim"
-                  onClick={handlers.onSubmit}
-                />
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="vads-u-margin-y--0">
-                We’ve removed optional descriptions about your behavioral
-                changes.
-              </p>
-            </>
-          )}
+            <va-link
+              text="Continue with your claim"
+              onClick={handlers.onSubmit}
+            />
+          ) : null}
         </VaAlert>
       </div>
 

--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -566,10 +566,12 @@ const WorkflowChoicePage = props => {
       >
         {alertContent}
         <p>
-          <va-link
-            text="Continue with your claim"
-            onClick={handlers.onSubmit}
-          />
+          {!onReviewPage ? (
+            <va-link
+              text="Continue with your claim"
+              onClick={handlers.onSubmit}
+            />
+          ) : null}
         </p>
       </VaAlert>
       <fieldset className="vads-u-margin-bottom--2">
@@ -632,8 +634,12 @@ const WorkflowChoicePage = props => {
               />
             </VaRadio>
           </div>
-          {traumaticEventsExamples}
-          {mstAlert()}
+          {!onReviewPage ? (
+            <>
+              {traumaticEventsExamples}
+              {mstAlert()}
+            </>
+          ) : null}
         </div>
         <VaModal
           clickToClose

--- a/src/applications/disability-benefits/all-claims/pages/form0781/supportingEvidencePage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/supportingEvidencePage.js
@@ -3,7 +3,11 @@ import {
   checkboxGroupUI,
   textUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { titleWithTag, form0781HeadingTag } from '../../content/form0781';
+import {
+  titleWithTag,
+  form0781HeadingTag,
+  mentalHealthSupportAlert,
+} from '../../content/form0781';
 import {
   supportingEvidenceDescription,
   supportingEvidenceNoneLabel,
@@ -78,6 +82,9 @@ export const uiSchema = {
   'view:supportingEvidenceAdditionalInformation': {
     'ui:description': supportingEvidenceAdditionalInformation,
   },
+  'view:mentalHealthSupportAlert': {
+    'ui:description': mentalHealthSupportAlert,
+  },
   'ui:validations': [validateSupportingEvidenceSelections],
 };
 
@@ -109,6 +116,10 @@ export const schema = {
       properties: {},
     },
     'view:supportingEvidenceAdditionalInformation': {
+      type: 'object',
+      properties: {},
+    },
+    'view:mentalHealthSupportAlert': {
       type: 'object',
       properties: {},
     },

--- a/src/applications/disability-benefits/all-claims/pages/form0781/treatmentReceivedPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/treatmentReceivedPage.js
@@ -2,7 +2,11 @@ import {
   checkboxGroupSchema,
   checkboxGroupUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { titleWithTag, form0781HeadingTag } from '../../content/form0781';
+import {
+  titleWithTag,
+  form0781HeadingTag,
+  mentalHealthSupportAlert,
+} from '../../content/form0781';
 import {
   treatmentReceivedDescription,
   treatmentReceivedNoneLabel,
@@ -46,6 +50,9 @@ export const uiSchema = {
     },
     required: false,
   }),
+  'view:mentalHealthSupportAlert': {
+    'ui:description': mentalHealthSupportAlert,
+  },
   'ui:validations': [validateProviders],
 };
 
@@ -63,5 +70,9 @@ export const schema = {
       Object.keys(TREATMENT_RECEIVED_NON_VA),
     ),
     treatmentNoneCheckbox: checkboxGroupSchema(['none']),
+    'view:mentalHealthSupportAlert': {
+      type: 'object',
+      properties: {},
+    },
   },
 };

--- a/src/applications/disability-benefits/all-claims/tests/components/BehaviorIntroCombatPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/BehaviorIntroCombatPage.unit.spec.jsx
@@ -473,7 +473,7 @@ describe('BehaviorIntroCombatPage', () => {
                 expect(updateSpy.notCalled).to.be.true;
               });
 
-              it('displays a modal prompt to delete the answers, updates the page if deletion is confirmed, and deletes the data', () => {
+              it('displays a modal prompt to delete the answers, updates the page if deletion is confirmed, deletes the data, and displays a confirmation alert message', () => {
                 const updateSpy = sinon.spy();
                 const setFormDataSpy = sinon.spy();
 
@@ -504,7 +504,17 @@ describe('BehaviorIntroCombatPage', () => {
                     behaviorsDetails: {},
                   }),
                 );
-                expect(updateSpy.called).to.be.true;
+
+                // updatePage exits out of edit mode; we want the alert to show in edit mode without a continue link
+                expect(updateSpy.called).to.be.false;
+                expect(
+                  $(confirmationAlertSelector, container).innerHTML,
+                ).to.contain(
+                  'We’ve removed information about your behavioral changes',
+                );
+                expect(
+                  $(confirmationAlertSelector, container).innerHTML,
+                ).to.not.contain('Continue with your claim');
               });
             });
 
@@ -551,7 +561,7 @@ describe('BehaviorIntroCombatPage', () => {
             const modal = container.querySelector('va-modal');
             modal.__events.primaryButtonClick();
 
-            fireEvent.click($('button.va-button-link', container));
+            fireEvent.click($('va-link', container));
             expect(goForwardSpy.called).to.be.true;
           });
         });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
This PR addresses three issues that were identified to update or add content to existing 0781ps pages.

- _(Which team do you work for, does your team own the maintenance of this component?)_
DBEX Team 2 Carbs

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
`sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107406
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107407
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107842

## Testing done

- _Describe what the old behavior was prior to the change_
The 0781 section had content that was inconsistent with the updated designs

- _Describe the steps required to verify your changes are working as expected_

  -  Navigate to the supporting docs page -> verify the presence of the mental health alert
  - Navigate to the treatment received page -> verify the presence of the mental health alert
  - Navigate to the review and submit page -> verify the presence of the confirmation alert for the workflow choice modal changes, with no link for "continue"
  - Navigate to the review and submit page -> verify the presence of the confirmation alert for removing answers to questions for behavioral changes, with no link for "continue"

- _Describe the tests completed and the results_
Manual testing done, specs updated

## Screenshots

### Workflow choice review and submit page: remove link from confirmation alert message
![Screenshot 2025-04-18 at 12 58 55 PM](https://github.com/user-attachments/assets/f3fcdb00-7010-4405-9a07-47c6f7cb58a4)

### Workflow choice review and submit page: remove accordions 
![Screenshot 2025-04-18 at 12 57 16 PM](https://github.com/user-attachments/assets/5ecff89f-2146-42c5-8d88-64a032e083c4)

### Behavior combat only review and submit page: add confirmation alert message
![Screenshot 2025-04-18 at 12 58 29 PM](https://github.com/user-attachments/assets/322b7d19-7b0d-4fae-a0f3-9961aed4a5fc)

### Add mental health alert to supporting docs page
![Screenshot 2025-04-18 at 12 56 24 PM](https://github.com/user-attachments/assets/3e2b12da-793c-461a-a196-4b3b0fb8e0bc)

### Add mental health alert to treatment received page
![Screenshot 2025-04-18 at 12 56 35 PM](https://github.com/user-attachments/assets/a329e128-8bbc-49f5-99fb-06db40283b5e)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
