### PR TITLE
VEBT-1429: 22-10215 - Edit Program not giving error when Number of FTE students are not provided

### DIFF
--- a/src/applications/edu-benefits/10215/pages/program-info.js
+++ b/src/applications/edu-benefits/10215/pages/program-info.js
@@ -9,6 +9,16 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import Calcs from './calcs';
 
+/**
+ * On the review page, the *formData* contains a single *program*
+ * object at the top-level when editing an existing program.
+ */
+const getSupportedStudents = (formData, index) =>
+  Number(
+    formData?.programs?.[index]?.supportedStudents ||
+      formData?.supportedStudents,
+  );
+
 const programInfo = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
@@ -61,8 +71,8 @@ const programInfo = {
           },
         }),
         {
-          'ui:required': (formData, _index) =>
-            Number(formData?.programs?.[_index]?.supportedStudents) >= 10,
+          'ui:required': (formData, index) =>
+            getSupportedStudents(formData, index) >= 10,
         },
       ),
       nonSupported: _.merge(
@@ -73,8 +83,8 @@ const programInfo = {
           },
         }),
         {
-          'ui:required': (formData, _index) =>
-            Number(formData?.programs?.[_index]?.supportedStudents) >= 10,
+          'ui:required': (formData, index) =>
+            getSupportedStudents(formData, index) >= 10,
         },
       ),
     },

--- a/src/applications/edu-benefits/10215/tests/pages/program-info.unit.spec.jsx
+++ b/src/applications/edu-benefits/10215/tests/pages/program-info.unit.spec.jsx
@@ -31,8 +31,16 @@ describe('programInfo configuration', () => {
       const nonSupportedRequiredFn = uiSchema.fte.nonSupported['ui:required'];
       expect(nonSupportedRequiredFn).to.be.a('function');
 
+      // Scenario 1-a: supportedStudents more than 10 on "program" creation
       let formData = {
         programs: [{ supportedStudents: 15 }],
+      };
+      expect(supportedRequiredFn(formData, 0)).to.equal(true);
+      expect(nonSupportedRequiredFn(formData, 0)).to.equal(true);
+
+      // Scenario 1-b: supportedStudents more than 10 on "program" edit
+      formData = {
+        supportedStudents: 15,
       };
       expect(supportedRequiredFn(formData, 0)).to.equal(true);
       expect(nonSupportedRequiredFn(formData, 0)).to.equal(true);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- The *programs* array is provided differently within the *formData* object when editing a single *program* on the Review Page in the 22-10215
- This adds a validation check for both the *supportedStudents* field when looking at both *programs* array or a singular *program* object

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-1429

When filling in the form 10215, if Total number of supported students enrolled is more than 10 Total enrolled FTE and supported student FTE numbers are required. Error message will be thrown if you click "Continue" button. However, when editing it on Review your programs step, it doesn't throw error message and lets the application continue. 

It should do the same in editing the form.

Steps to reproduce:

-Click "Edit" link on Review your programs step

-Provide Total number of supported students enrolled more than 10

Click "Continue"

## Testing done

- Manual testing of program changes when both creating during the regular form flow and editing/creating on the Review Page
- Unit tests for singular *program* object added

![Unit Test Coverage](https://github.com/user-attachments/assets/25b738f2-1fe9-4e28-8a75-2f4919095641)

## Screenshots

**Before:**

![Edit Program (Before)](https://github.com/user-attachments/assets/44a24583-6a67-4fa9-928d-63f52690350e)

**After:**

![Edit Program (After)](https://github.com/user-attachments/assets/c304c78b-c842-4038-a0c3-07109b5ae62c)

## What areas of the site does it impact?

- 22-10215 Program information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
