### PR TITLE
Form system | Align submit again button

### DIFF
--- a/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
@@ -32,15 +32,12 @@ export default function GenericError(props) {
 
   if (process.env.NODE_ENV !== 'production') {
     submitButton = (
-      <Column classNames="small-6 usa-width-one-half medium-6">
-        <button
-          type="button"
-          className="usa-button-secondary"
-          onClick={onSubmit}
-        >
-          Submit again
-        </button>
-      </Column>
+      <va-button
+        secondary
+        class="vads-u-margin--0"
+        onClick={onSubmit}
+        text="Submit again"
+      />
     );
   }
 
@@ -52,14 +49,15 @@ export default function GenericError(props) {
         </Column>
       </Row>
       <PreSubmitSection formConfig={formConfig} />
-      <Row classNames="form-progress-buttons schemaform-back-buttons vads-u-margin-y--2">
-        <Column classNames="small-6 usa-width-one-half medium-6">
-          <a href="/" className="vads-c-action-link--green">
-            Go Back to VA.gov
-          </a>
-        </Column>
+      <div className="vads-u-display--flex vads-u-margin-y--4">
+        <va-link-action
+          type="primary"
+          href="/"
+          class="vads-u-margin-right--2"
+          text="Go Back to VA.gov"
+        />
         {submitButton}
-      </Row>
+      </div>
     </>
   );
 }

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -125,7 +125,9 @@ describe('Schemaform review: <GenericError />', () => {
       </Provider>,
     );
 
-    const submitButton = tree.getByText('Submit again');
+    const submitButton = tree.container.querySelector(
+      'va-button[text="Submit again"]',
+    );
     expect(submitButton).to.not.be.null;
     fireEvent.click(submitButton);
     expect(onSubmit.called).to.be.true;
@@ -161,7 +163,9 @@ describe('Schemaform review: <GenericError />', () => {
     );
 
     expect(tree.getByTestId('12345')).to.have.attribute('role', 'alert');
-    expect(tree.getByText('Go Back to VA.gov')).to.not.be.null;
+    expect(
+      tree.container.querySelector('va-link-action[text="Go Back to VA.gov"]'),
+    ).to.not.be.null;
 
     tree.unmount();
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Fix alignment of "Submit again" button - only visible outside of production
  > Update to use `va-button`
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Lifestages
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/107973

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit test
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Review page submit again | <img width="687" alt="before: submit again button is below and aligned to the right of the go back action link" src="https://github.com/user-attachments/assets/9480fcc9-99d6-4540-89bf-1883b6b63a40" /> | <img width="668" alt="after: submit again and go back link are on the same line" src="https://github.com/user-attachments/assets/700a5751-b751-42c2-8e98-5946df195871" /> |

## What areas of the site does it impact?

Non-production all forms that use the review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
