### PR TITLE
[686c-674] Update "submit evidence" header levels

### DIFF
--- a/src/applications/686c-674/components/ChildAdditionalEvidence.jsx
+++ b/src/applications/686c-674/components/ChildAdditionalEvidence.jsx
@@ -78,7 +78,7 @@ export const ChildAdditionalEvidence = () => {
           )}
         </va-accordion-item>
       </va-accordion>
-      <h3>Submit your files online</h3>
+      <h4>Submit your files online</h4>
       <p>You can upload your files now.</p>
       <va-additional-info trigger="Document upload instructions" disable-border>
         <div>

--- a/src/applications/686c-674/components/ChildAdditionalEvidence.jsx
+++ b/src/applications/686c-674/components/ChildAdditionalEvidence.jsx
@@ -38,7 +38,7 @@ export const ChildAdditionalEvidence = () => {
         <va-accordion-item
           id="supporting-evidence"
           header="Supporting evidence you need to submit"
-          level="3"
+          level="4"
         >
           {showBirthCertificate && (
             <ul>

--- a/src/applications/686c-674/tests/components/ChildAdditionalEvidence.unit.spec.jsx
+++ b/src/applications/686c-674/tests/components/ChildAdditionalEvidence.unit.spec.jsx
@@ -107,7 +107,7 @@ describe('ChildAdditionalEvidence', () => {
 
   it('should render the submit your files section with online submission details', () => {
     const { container } = renderComponent();
-    const submitFilesHeader = container.querySelector('h3');
+    const submitFilesHeader = container.querySelector('h4');
     expect(submitFilesHeader).to.not.be.null;
     expect(submitFilesHeader.textContent).to.include(
       'Submit your files online',

--- a/src/applications/686c-674/tests/components/ChildAdditionalEvidence.unit.spec.jsx
+++ b/src/applications/686c-674/tests/components/ChildAdditionalEvidence.unit.spec.jsx
@@ -37,6 +37,7 @@ describe('ChildAdditionalEvidence', () => {
     expect(evidenceAccordion.getAttribute('header')).to.equal(
       'Supporting evidence you need to submit',
     );
+    expect(evidenceAccordion.getAttribute('level')).to.equal('4');
     expect(evidenceAccordion.parentElement.getAttribute('open-single')).to.eq(
       'true',
     );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates the accordion and the "submit evidence" headers from `h3`s to `h4`s

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107964

## Testing done

- Visited http://localhost:3001/view-change-dependents/add-remove-form-21-686c-v2/add-child-evidence and confirm the  headings are correct
- Updated unit tests

## Screenshots

<img width="1280" alt="Screenshot 2025-04-21 at 1 56 58 PM" src="https://github.com/user-attachments/assets/55b9d38d-894b-4d2e-91da-3ba56014e1d5" />

## What areas of the site does it impact?

Dependents

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
