### PR TITLE
95922 - Removes VAOS breadcrumb url update flag removal from new appointment flow

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/VA.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/VA.jsx
@@ -19,7 +19,6 @@ import {
 import DateTimeRequestOptions from './DateTimeRequestOptions';
 import SelectedIndicator, { getSelectedLabel } from './SelectedIndicator';
 import { FETCH_STATUS, FLOW_TYPES } from '../../../utils/constants';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
 
 const pageKey = 'requestDateTime';
 const pageTitle = 'When would you like an appointment?';
@@ -48,10 +47,6 @@ function goForward({ dispatch, data, history, setSubmitted }) {
 }
 
 export default function VARequest({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
-
   const { data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
     shallowEqual,
@@ -68,9 +63,7 @@ export default function VARequest({ changeCrumb }) {
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
+    changeCrumb(pageTitle);
   }, []);
 
   const { selectedDates } = data;

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/index.jsx
@@ -19,7 +19,6 @@ import {
 import DateTimeRequestOptions from './DateTimeRequestOptions';
 import SelectedIndicator, { getSelectedLabel } from './SelectedIndicator';
 import { FETCH_STATUS, FLOW_TYPES } from '../../../utils/constants';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
 
 const pageKey = 'requestDateTime';
 const pageTitle = 'Choose an appointment day and time';
@@ -48,10 +47,6 @@ function goForward({ dispatch, data, history, setSubmitted }) {
 }
 
 export default function DateTimeRequestPage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
-
   const { data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
     shallowEqual,
@@ -68,9 +63,7 @@ export default function DateTimeRequestPage({ changeCrumb }) {
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
+    changeCrumb(pageTitle);
   }, []);
 
   const { selectedDates } = data;

--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -21,10 +21,7 @@ import {
   routeToPreviousAppointmentPage,
   updateReasonForAppointmentData,
 } from '../redux/actions';
-import {
-  selectFeatureVAOSServiceRequests,
-  selectFeatureBreadcrumbUrlUpdate,
-} from '../../redux/selectors';
+import { selectFeatureVAOSServiceRequests } from '../../redux/selectors';
 import { getPageTitle } from '../newAppointmentFlow';
 
 function isValidComment(value) {
@@ -72,9 +69,6 @@ const initialSchema = {
 const pageKey = 'reasonForAppointment';
 
 export default function ReasonForAppointmentPage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
   const pageTitle = useSelector(state => getPageTitle(state, pageKey));
 
   const dispatch = useDispatch();
@@ -138,9 +132,7 @@ export default function ReasonForAppointmentPage({ changeCrumb }) {
           useV2,
         ),
       );
-      if (featureBreadcrumbUrlUpdate) {
-        changeCrumb(pageTitle);
-      }
+      changeCrumb(pageTitle);
     },
     [dispatch],
   );

--- a/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.jsx
@@ -7,7 +7,6 @@ import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-sys
 import FormButtons from '../../components/FormButtons';
 import { getFormPageInfo } from '../redux/selectors';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
 import {
   openFormPage,
   routeToNextAppointmentPage,
@@ -59,10 +58,6 @@ const uiSchema = {
 };
 
 export default function TypeOfAudiologyCarePage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
-
   const dispatch = useDispatch();
   const { schema, data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
@@ -72,9 +67,7 @@ export default function TypeOfAudiologyCarePage({ changeCrumb }) {
   useEffect(() => {
     dispatch(openFormPage(pageKey, uiSchema, initialSchema));
     document.title = `${pageTitle} | Veterans Affairs`;
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
+    changeCrumb(pageTitle);
   }, []);
   useEffect(
     () => {

--- a/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
@@ -8,7 +8,6 @@ import FormButtons from '../../components/FormButtons';
 import { getFormPageInfo } from '../redux/selectors';
 import { TYPES_OF_EYE_CARE } from '../../utils/constants';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
 
 import {
   openFormPage,
@@ -59,9 +58,6 @@ const uiSchema = {
 };
 
 export default function TypeOfEyeCarePage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
   const dispatch = useDispatch();
   const { schema, data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
@@ -71,9 +67,7 @@ export default function TypeOfEyeCarePage({ changeCrumb }) {
   useEffect(() => {
     dispatch(openFormPage(pageKey, uiSchema, initialSchema));
     document.title = `${pageTitle} | Veterans Affairs`;
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
+    changeCrumb(pageTitle);
   }, []);
   useEffect(
     () => {

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
@@ -8,7 +8,6 @@ import FormButtons from '../../components/FormButtons';
 import { FACILITY_TYPES } from '../../utils/constants';
 import { getFormPageInfo } from '../redux/selectors';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
 import {
   openFormPage,
   routeToNextAppointmentPage,
@@ -32,10 +31,6 @@ const initialSchema = {
 const pageKey = 'typeOfFacility';
 
 export default function TypeOfFacilityPage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
-
   const pageTitle = useSelector(state => getPageTitle(state, pageKey));
 
   const uiSchema = {
@@ -64,9 +59,7 @@ export default function TypeOfFacilityPage({ changeCrumb }) {
   useEffect(() => {
     dispatch(openFormPage(pageKey, uiSchema, initialSchema));
     document.title = `${pageTitle} | Veterans Affairs`;
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
+    changeCrumb(pageTitle);
 
     dispatch(startDirectScheduleFlow({ isRecordEvent: false }));
   }, []);

--- a/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
@@ -14,7 +14,6 @@ import {
 import { getFormPageInfo } from '../redux/selectors';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
 import { TYPES_OF_SLEEP_CARE } from '../../utils/constants';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
 
 const pageKey = 'typeOfSleepCare';
 const pageTitle = 'Which type of sleep care do you need?';
@@ -58,10 +57,6 @@ const uiSchema = {
 };
 
 export default function TypeOfSleepCarePage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
-
   const history = useHistory();
   const dispatch = useDispatch();
   const { schema, data, pageChangeInProgress } = useSelector(
@@ -71,9 +66,7 @@ export default function TypeOfSleepCarePage({ changeCrumb }) {
   useEffect(() => {
     dispatch(openFormPage(pageKey, uiSchema, initialSchema));
     document.title = `${pageTitle} | Veterans Affairs`;
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
+    changeCrumb(pageTitle);
   }, []);
   useEffect(
     () => {

--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -8,10 +8,7 @@ import {
   Redirect,
 } from 'react-router-dom';
 import { selectIsCernerOnlyPatient } from 'platform/user/cerner-dsot/selectors';
-import {
-  selectFeatureBreadcrumbUrlUpdate,
-  selectFeatureUseVaDate,
-} from '../redux/selectors';
+import { selectFeatureUseVaDate } from '../redux/selectors';
 import { selectIsNewAppointmentStarted } from './redux/selectors';
 import newAppointmentReducer from './redux/reducer';
 import FormLayout from './components/FormLayout';
@@ -23,7 +20,6 @@ import TypeOfEyeCarePage from './components/TypeOfEyeCarePage';
 import TypeOfAudiologyCarePage from './components/TypeOfAudiologyCarePage';
 import PreferredDatePage from './components/PreferredDatePage';
 import PreferredDatePageVaDate from './components/PreferredDatePageVaDate';
-import DateTimeRequestPage from './components/DateTimeRequestPage';
 import VARequest from './components/DateTimeRequestPage/VA';
 import CCRequest from './components/DateTimeRequestPage/CommunityCare';
 import DateTimeSelectPage from './components/DateTimeSelectPage';
@@ -45,9 +41,6 @@ import ScheduleCernerPage from './components/ScheduleCernerPage';
 export function NewAppointment() {
   const isCernerOnlyPatient = useSelector(selectIsCernerOnlyPatient);
   const isNewAppointmentStarted = useSelector(selectIsNewAppointmentStarted);
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
   const featureUseVaDate = useSelector(state => selectFeatureUseVaDate(state));
   const match = useRouteMatch();
   const location = useLocation();
@@ -73,200 +66,126 @@ export function NewAppointment() {
     return <Redirect to="/" />;
   }
 
-  if (featureBreadcrumbUrlUpdate) {
-    return (
-      <FormLayout pageTitle={crumb}>
-        <Switch>
-          <Route
-            path={[
-              `${match.url}/va-request/contact-information`,
-              `${match.url}/community-request/contact-information`,
-              `${match.url}/contact-information`,
-            ]}
-          >
-            <ContactInfoPage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route path={`${match.url}/facility-type`}>
-            <TypeOfFacilityPage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route
-            path={[
-              `${match.url}/va-request/preferred-method`,
-              `${match.url}/choose-visit-type`,
-            ]}
-          >
-            <TypeOfVisitPage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route path={`${match.url}/sleep-care`}>
-            <TypeOfSleepCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route path={`${match.url}/eye-care`}>
-            <TypeOfEyeCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route path={`${match.url}/audiology-care`}>
-            <TypeOfAudiologyCarePage
-              changeCrumb={newTitle => setCrumb(newTitle)}
-            />
-          </Route>
-          <Route path={`${match.url}/preferred-date`}>
-            {featureUseVaDate ? (
-              <PreferredDatePageVaDate
-                changeCrumb={newTitle => setCrumb(newTitle)}
-              />
-            ) : (
-              <PreferredDatePage changeCrumb={newTitle => setCrumb(newTitle)} />
-            )}
-          </Route>
-          <Route path={`${match.url}/date-time`}>
-            <DateTimeSelectPage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route exact path={`${match.url}/va-request/`}>
-            <VARequest changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route exact path={`${match.url}/community-request/`}>
-            <CCRequest changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route path={`${match.url}/location`}>
-            <VAFacilityPageV2 changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route path={`${match.url}/provider`}>
-            <ProviderSelectPage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route
-            path={`${match.url}/how-to-schedule`}
-            component={ScheduleCernerPage}
-          />
-          <Route
-            path={[
-              `${match.url}/va-request/community-care-preferences`,
-              `${match.url}/community-request/preferred-provider`,
-            ]}
-          >
-            <CommunityCareProviderSelectionPage
-              changeCrumb={newTitle => setCrumb(newTitle)}
-            />
-          </Route>
-          <Route
-            path={[
-              `${match.url}/va-request/community-care-language`,
-              `${match.url}/community-request/preferred-language`,
-            ]}
-          >
-            <CommunityCareLanguagePage
-              changeCrumb={newTitle => setCrumb(newTitle)}
-            />
-          </Route>
-          <Route
-            path={[
-              `${match.url}/va-request/choose-closest-city`,
-              `${match.url}/community-request/closest-city`,
-            ]}
-          >
-            <ClosestCityStatePage
-              changeCrumb={newTitle => setCrumb(newTitle)}
-            />
-          </Route>
-          <Route path={`${match.url}/clinic`}>
-            <ClinicChoicePage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route
-            path={[
-              `${match.url}/va-request/reason`,
-              `${match.url}/community-request/reason`,
-              `${match.url}/reason`,
-            ]}
-          >
-            <ReasonForAppointmentPage
-              changeCrumb={newTitle => setCrumb(newTitle)}
-            />
-          </Route>
-          <Route
-            path={[
-              `${match.url}/va-request/review`,
-              `${match.url}/community-request/review`,
-              `${match.url}/review`,
-            ]}
-          >
-            <ReviewPage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-          <Route
-            path={`${match.url}/confirmation`}
-            component={ConfirmationPage}
-          />
-          <Route path={match.url}>
-            <TypeOfCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
-          </Route>
-        </Switch>
-      </FormLayout>
-    );
-  }
   return (
     <FormLayout pageTitle={crumb}>
       <Switch>
-        <Route path={`${match.url}/contact-info`} component={ContactInfoPage} />
         <Route
-          path={`${match.url}/choose-facility-type`}
-          component={TypeOfFacilityPage}
-        />
+          path={[
+            `${match.url}/va-request/contact-information`,
+            `${match.url}/community-request/contact-information`,
+            `${match.url}/contact-information`,
+          ]}
+        >
+          <ContactInfoPage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route path={`${match.url}/facility-type`}>
+          <TypeOfFacilityPage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
         <Route
-          path={`${match.url}/choose-visit-type`}
-          component={TypeOfVisitPage}
-        />
-        <Route
-          path={`${match.url}/choose-sleep-care`}
-          component={TypeOfSleepCarePage}
-        />
-        <Route
-          path={`${match.url}/choose-eye-care`}
-          component={TypeOfEyeCarePage}
-        />
-        <Route
-          path={`${match.url}/audiology`}
-          component={TypeOfAudiologyCarePage}
-        />
-        <Route
-          path={`${match.url}/preferred-date`}
-          component={PreferredDatePage}
-        />
-        <Route
-          path={`${match.url}/request-date`}
-          component={DateTimeRequestPage}
-        />
-        <Route
-          path={`${match.url}/select-date`}
-          component={DateTimeSelectPage}
-        />
-        <Route
-          path={`${match.url}/va-facility-2`}
-          component={VAFacilityPageV2}
-        />
+          path={[
+            `${match.url}/va-request/preferred-method`,
+            `${match.url}/choose-visit-type`,
+          ]}
+        >
+          <TypeOfVisitPage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route path={`${match.url}/sleep-care`}>
+          <TypeOfSleepCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route path={`${match.url}/eye-care`}>
+          <TypeOfEyeCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route path={`${match.url}/audiology-care`}>
+          <TypeOfAudiologyCarePage
+            changeCrumb={newTitle => setCrumb(newTitle)}
+          />
+        </Route>
+        <Route path={`${match.url}/preferred-date`}>
+          {featureUseVaDate ? (
+            <PreferredDatePageVaDate
+              changeCrumb={newTitle => setCrumb(newTitle)}
+            />
+          ) : (
+            <PreferredDatePage changeCrumb={newTitle => setCrumb(newTitle)} />
+          )}
+        </Route>
+        <Route path={`${match.url}/date-time`}>
+          <DateTimeSelectPage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route exact path={`${match.url}/va-request/`}>
+          <VARequest changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route exact path={`${match.url}/community-request/`}>
+          <CCRequest changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route path={`${match.url}/location`}>
+          <VAFacilityPageV2 changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route path={`${match.url}/provider`}>
+          <ProviderSelectPage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
         <Route
           path={`${match.url}/how-to-schedule`}
           component={ScheduleCernerPage}
         />
         <Route
-          path={`${match.url}/community-care-preferences`}
-          component={CommunityCareProviderSelectionPage}
-        />
+          path={[
+            `${match.url}/va-request/community-care-preferences`,
+            `${match.url}/community-request/preferred-provider`,
+          ]}
+        >
+          <CommunityCareProviderSelectionPage
+            changeCrumb={newTitle => setCrumb(newTitle)}
+          />
+        </Route>
         <Route
-          path={`${match.url}/community-care-language`}
-          component={CommunityCareLanguagePage}
-        />
+          path={[
+            `${match.url}/va-request/community-care-language`,
+            `${match.url}/community-request/preferred-language`,
+          ]}
+        >
+          <CommunityCareLanguagePage
+            changeCrumb={newTitle => setCrumb(newTitle)}
+          />
+        </Route>
         <Route
-          path={`${match.url}/choose-closest-city`}
-          component={ClosestCityStatePage}
-        />
-        <Route path={`${match.url}/clinics`} component={ClinicChoicePage} />
+          path={[
+            `${match.url}/va-request/choose-closest-city`,
+            `${match.url}/community-request/closest-city`,
+          ]}
+        >
+          <ClosestCityStatePage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
+        <Route path={`${match.url}/clinic`}>
+          <ClinicChoicePage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
         <Route
-          path={`${match.url}/reason-appointment`}
-          component={ReasonForAppointmentPage}
-        />
-        <Route path={`${match.url}/review`} component={ReviewPage} />
+          path={[
+            `${match.url}/va-request/reason`,
+            `${match.url}/community-request/reason`,
+            `${match.url}/reason`,
+          ]}
+        >
+          <ReasonForAppointmentPage
+            changeCrumb={newTitle => setCrumb(newTitle)}
+          />
+        </Route>
+        <Route
+          path={[
+            `${match.url}/va-request/review`,
+            `${match.url}/community-request/review`,
+            `${match.url}/review`,
+          ]}
+        >
+          <ReviewPage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
         <Route
           path={`${match.url}/confirmation`}
           component={ConfirmationPage}
         />
-        <Route path="/" component={TypeOfCarePage} />
+        <Route path={match.url}>
+          <TypeOfCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
+        </Route>
       </Switch>
     </FormLayout>
   );

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -1,6 +1,5 @@
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import {
-  selectFeatureBreadcrumbUrlUpdate,
   selectFeatureOHDirectSchedule,
   selectFeatureOHRequest,
   selectRegisteredCernerFacilityIds,
@@ -358,82 +357,59 @@ const flow = {
  * @returns {object} Appointment workflow object
  */
 export default function getNewAppointmentFlow(state) {
-  const featureBreadcrumbUrlUpdate = selectFeatureBreadcrumbUrlUpdate(state);
   const flowType = getFlowType(state);
   const isSingleVaFacility = selectSingleSupportedVALocation(state);
 
   return {
-    ...flow,
+    home: {
+      url: '/',
+    },
     appointmentTime: {
       ...flow.appointmentTime,
-      url: featureBreadcrumbUrlUpdate
-        ? 'appointment-time'
-        : '/new-appointment/appointment-time',
+      url: 'appointment-time',
     },
     audiologyCareType: {
       ...flow.audiologyCareType,
-      url: featureBreadcrumbUrlUpdate
-        ? 'audiology-care'
-        : '/new-appointment/audiology',
+      url: 'audiology-care',
     },
     ccClosestCity: {
       ...flow.ccClosestCity,
-      url: featureBreadcrumbUrlUpdate
-        ? 'closest-city'
-        : '/new-appointment/choose-closest-city',
+      url: 'closest-city',
     },
     ccLanguage: {
       ...flow.ccLanguage,
-      url: featureBreadcrumbUrlUpdate
-        ? 'preferred-language'
-        : '/new-appointment/community-care-language',
+      url: 'preferred-language',
     },
     ccPreferences: {
       ...flow.ccPreferences,
-      url: featureBreadcrumbUrlUpdate
-        ? 'preferred-provider'
-        : '/new-appointment/community-care-preferences',
+      url: 'preferred-provider',
     },
     clinicChoice: {
       ...flow.clinicChoice,
-      url: featureBreadcrumbUrlUpdate
-        ? '/schedule/clinic'
-        : '/new-appointment/clinics',
+      url: '/schedule/clinic',
     },
     contactInfo: {
       ...flow.contactInfo,
-      url: featureBreadcrumbUrlUpdate
-        ? 'contact-information'
-        : '/new-appointment/contact-info',
+      url: 'contact-information',
     },
     preferredDate: {
       ...flow.preferredDate,
-      url: featureBreadcrumbUrlUpdate
-        ? 'preferred-date'
-        : '/new-appointment/preferred-date',
+      url: 'preferred-date',
     },
     reasonForAppointment: {
       ...flow.reasonForAppointment,
-      url: featureBreadcrumbUrlUpdate
-        ? 'reason'
-        : '/new-appointment/reason-appointment',
+      url: 'reason',
     },
     requestDateTime: {
       ...flow.requestDateTime,
-      url: featureBreadcrumbUrlUpdate
-        ? 'va-request/'
-        : '/new-appointment/request-date',
+      url: 'va-request/',
     },
     ccRequestDateTime: {
       ...flow.requestDateTime,
-      url: featureBreadcrumbUrlUpdate
-        ? 'community-request/'
-        : '/new-appointment/request-date',
+      url: 'community-request/',
     },
     root: {
-      url: featureBreadcrumbUrlUpdate
-        ? '/my-health/appointments'
-        : '/health-care/schedule-view-va-appointments/appointments/',
+      url: '/my-health/appointments',
     },
     review: {
       ...flow.review,
@@ -441,63 +417,48 @@ export default function getNewAppointmentFlow(state) {
         FLOW_TYPES.DIRECT === flowType
           ? 'Review and confirm your appointment details'
           : 'Review and submit your request',
-      url: featureBreadcrumbUrlUpdate ? 'review' : '/new-appointment/review',
+      url: 'review',
     },
     scheduleCerner: {
       ...flow.scheduleCerner,
-      url: featureBreadcrumbUrlUpdate
-        ? 'how-to-schedule'
-        : '/new-appointment/how-to-schedule',
+      url: 'how-to-schedule',
     },
     selectDateTime: {
       ...flow.selectDateTime,
-      url: featureBreadcrumbUrlUpdate
-        ? 'date-time'
-        : '/new-appointment/select-date',
+      url: 'date-time',
     },
     typeOfCare: {
       ...flow.typeOfCare,
-      url: featureBreadcrumbUrlUpdate
-        ? '/schedule/type-of-care'
-        : '/new-appointment',
+      url: '/schedule/type-of-care',
     },
     typeOfEyeCare: {
       ...flow.typeOfEyeCare,
-      url: featureBreadcrumbUrlUpdate
-        ? 'eye-care'
-        : '/new-appointment/choose-eye-care',
+      url: 'eye-care',
     },
     typeOfFacility: {
       ...flow.typeOfFacility,
-      url: featureBreadcrumbUrlUpdate
-        ? 'facility-type'
-        : '/new-appointment/choose-facility-type',
+      url: 'facility-type',
     },
     typeOfSleepCare: {
       ...flow.typeOfSleepCare,
-      url: featureBreadcrumbUrlUpdate
-        ? 'sleep-care'
-        : '/new-appointment/choose-sleep-care',
+      url: 'sleep-care',
     },
     vaccineFlow: {
       ...flow.vaccineFlow,
-      url: featureBreadcrumbUrlUpdate
-        ? // IMPORTANT!!!
-          // The trailing slash is needed for going back to the previous page to work properly.
-          // The training slash indicates that 'new-covid-19-vaccine-appointment' is a parent path
-          // with children.
-          //
-          // Ex. /schedule/new-covid-19-vaccine-appointment/
-          //
-          // Leaving the '/' off makes '/schedule' the parent.
-          'covid-vaccine/'
-        : '/new-covid-19-vaccine-appointment',
+      // IMPORTANT!!!
+      url:
+        // The trailing slash is needed for going back to the previous page to work properly.
+        // The training slash indicates that 'new-covid-19-vaccine-appointment' is a parent path
+        // with children.
+        //
+        // Ex. /schedule/new-covid-19-vaccine-appointment/
+        //
+        // Leaving the '/' off makes '/schedule' the parent.
+        'covid-vaccine/',
     },
     vaFacility: {
       ...flow.vaFacility,
-      url: featureBreadcrumbUrlUpdate
-        ? 'va-facility'
-        : '/new-appointment/va-facility',
+      url: 'va-facility',
     },
     vaFacilityV2: {
       ...flow.vaFacilityV2,
@@ -505,15 +466,11 @@ export default function getNewAppointmentFlow(state) {
         ? 'Your appointment location'
         : 'Which VA location would you like to go to?',
 
-      url: featureBreadcrumbUrlUpdate
-        ? 'location'
-        : '/new-appointment/va-facility-2',
+      url: 'location',
     },
     visitType: {
       ...flow.visitType,
-      url: featureBreadcrumbUrlUpdate
-        ? 'preferred-method'
-        : '/new-appointment/choose-visit-type',
+      url: 'preferred-method',
     },
   };
 }

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-shadow */
+
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import {
   selectFeatureOHDirectSchedule,
@@ -138,215 +140,6 @@ async function vaFacilityNext(state, dispatch) {
   return VA_FACILITY_V2_KEY;
 }
 
-const flow = {
-  home: {
-    url: '/',
-  },
-  typeOfAppointment: {
-    url: '/new-appointment',
-    // Temporary stub for typeOfAppointment which will eventually be first step
-    // Next will direct to type of care or provider once both flows are complete
-    next: 'typeOfFacility',
-  },
-  vaccineFlow: {
-    url: '/new-covid-19-vaccine-appointment',
-    label: 'COVID-19 vaccine appointment',
-  },
-  typeOfCare: {
-    url: '/new-appointment',
-    label: 'What type of care do you need?',
-    async next(state, dispatch) {
-      if (isCovidVaccine(state)) {
-        recordEvent({
-          event: `${GA_PREFIX}-schedule-covid19-button-clicked`,
-        });
-        dispatch(startNewVaccineFlow());
-        return 'vaccineFlow';
-      }
-      if (isSleepCare(state)) {
-        dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-        return 'typeOfSleepCare';
-      }
-      if (isEyeCare(state)) {
-        return 'typeOfEyeCare';
-      }
-      if (isCommunityCare(state)) {
-        const isEligible = await dispatch(checkCommunityCareEligibility());
-
-        if (isEligible && isPodiatry(state)) {
-          // If CC enabled systems and toc is podiatry, skip typeOfFacility
-          dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
-          dispatch(startRequestAppointmentFlow(true));
-          return 'ccRequestDateTime';
-        }
-        if (isEligible) {
-          return 'typeOfFacility';
-        }
-        if (isPodiatry(state)) {
-          // If no CC enabled systems and toc is podiatry, show modal
-          dispatch(showPodiatryAppointmentUnavailableModal());
-          return 'typeOfCare';
-        }
-      }
-
-      dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-      return VA_FACILITY_V2_KEY;
-    },
-  },
-  typeOfFacility: {
-    url: '/new-appointment/choose-facility-type',
-    label: 'Where do you prefer to receive care?',
-    next(state, dispatch) {
-      if (isCCAudiology(state)) {
-        return 'audiologyCareType';
-      }
-
-      if (isCCFacility(state)) {
-        dispatch(startRequestAppointmentFlow(true));
-        return 'ccRequestDateTime';
-      }
-
-      return VA_FACILITY_V2_KEY;
-    },
-  },
-  typeOfSleepCare: {
-    url: '/new-appointment/choose-sleep-care',
-    label: 'Choose the type of sleep care you need',
-    next: VA_FACILITY_V2_KEY,
-  },
-  typeOfEyeCare: {
-    url: '/new-appointment/choose-eye-care',
-    label: 'Choose the type of eye care you need',
-    async next(state, dispatch) {
-      const data = getFormData(state);
-
-      // check that the result does have a ccId
-      if (getTypeOfCare(data)?.ccId) {
-        const isEligible = await dispatch(checkCommunityCareEligibility());
-
-        if (isEligible) {
-          return 'typeOfFacility';
-        }
-      }
-
-      dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-      return VA_FACILITY_V2_KEY;
-    },
-  },
-  audiologyCareType: {
-    url: '/new-appointment/audiology',
-    label: 'Choose the type of audiology care you need',
-    next(state, dispatch) {
-      dispatch(startRequestAppointmentFlow(true));
-      return 'ccRequestDateTime';
-    },
-  },
-  ccPreferences: {
-    url: '/new-appointment/community-care-preferences',
-    label: 'Which provider do you prefer?',
-    next: 'ccLanguage',
-  },
-  ccLanguage: {
-    url: '/new-appointment/community-care-language',
-    label: 'What language do you prefer?',
-    next: 'reasonForAppointment',
-  },
-  ccClosestCity: {
-    url: '/new-appointment/choose-closest-city',
-    label: 'What’s the nearest city to you?',
-    next: 'ccPreferences',
-  },
-  vaFacility: {
-    url: '/new-appointment/va-facility',
-    next: vaFacilityNext,
-  },
-  vaFacilityV2: {
-    url: '/new-appointment/va-facility-2',
-    label: 'Which VA location would you like to go to?',
-    next: vaFacilityNext,
-  },
-  scheduleCerner: {
-    url: '/new-appointment/how-to-schedule',
-    label: 'How to schedule',
-  },
-  clinicChoice: {
-    url: '/new-appointment/clinics',
-    label: 'Which VA clinic would you like to go to?',
-    next(state, dispatch) {
-      if (getFormData(state).clinicId === 'NONE') {
-        dispatch(startRequestAppointmentFlow());
-        return 'requestDateTime';
-      }
-
-      // fetch appointment slots
-      dispatch(startDirectScheduleFlow());
-      return 'preferredDate';
-    },
-  },
-  selectProvider: {
-    url: '/new-appointment/provider',
-    label: 'Which provider do you want to schedule with?',
-    next: 'preferredDate',
-  },
-  preferredDate: {
-    url: '/new-appointment/preferred-date',
-    label: 'When are you available for this appointment?',
-    next: 'selectDateTime',
-  },
-  selectDateTime: {
-    url: '/new-appointment/select-date',
-    label: 'What date and time do you want for this appointment?',
-    next: 'reasonForAppointment',
-  },
-  requestDateTime: {
-    url: '/new-appointment/request-date',
-    label: 'When would you like an appointment?',
-    next(state) {
-      const supportedSites = selectCommunityCareSupportedSites(state);
-      if (isCCFacility(state) && supportedSites.length > 1) {
-        return 'ccClosestCity';
-      }
-      if (isCCFacility(state)) {
-        return 'ccPreferences';
-      }
-
-      return 'reasonForAppointment';
-    },
-  },
-  reasonForAppointment: {
-    url: '/new-appointment/reason-appointment',
-    label: 'What’s the reason for this appointment?',
-    next(state) {
-      if (
-        isCCFacility(state) ||
-        getNewAppointment(state).flowType === FLOW_TYPES.DIRECT
-      ) {
-        return 'contactInfo';
-      }
-
-      return 'visitType';
-    },
-  },
-  visitType: {
-    url: '/new-appointment/choose-visit-type',
-    label: 'How do you want to attend this appointment?',
-    next: 'contactInfo',
-  },
-  appointmentTime: {
-    url: '/new-appointment/appointment-time',
-    next: 'contactInfo',
-  },
-  contactInfo: {
-    url: '/new-appointment/contact-info',
-    label: 'How should we contact you?',
-    next: 'review',
-  },
-  review: {
-    url: '/new-appointment/review',
-    label: 'Review and confirm your appointment details',
-  },
-};
-
 /**
  * Function to get new appointment workflow.
  * The URL displayed in the browser address bar is changed when the feature flag
@@ -364,55 +157,96 @@ export default function getNewAppointmentFlow(state) {
     home: {
       url: '/',
     },
+    typeOfAppointment: {
+      url: '/new-appointment',
+      // Temporary stub for typeOfAppointment which will eventually be first step
+      // Next will direct to type of care or provider once both flows are complete
+      next: 'typeOfFacility',
+    },
     appointmentTime: {
-      ...flow.appointmentTime,
       url: 'appointment-time',
+      next: 'contactInfo',
     },
     audiologyCareType: {
-      ...flow.audiologyCareType,
+      label: 'Choose the type of audiology care you need',
       url: 'audiology-care',
+      next(state, dispatch) {
+        dispatch(startRequestAppointmentFlow(true));
+        return 'ccRequestDateTime';
+      },
     },
     ccClosestCity: {
-      ...flow.ccClosestCity,
+      label: 'What’s the nearest city to you?',
       url: 'closest-city',
+      next: 'ccPreferences',
     },
     ccLanguage: {
-      ...flow.ccLanguage,
+      label: 'What language do you prefer?',
       url: 'preferred-language',
+      next: 'reasonForAppointment',
     },
     ccPreferences: {
-      ...flow.ccPreferences,
+      label: 'Which provider do you prefer?',
       url: 'preferred-provider',
+      next: 'ccLanguage',
     },
     clinicChoice: {
-      ...flow.clinicChoice,
+      label: 'Which VA clinic would you like to go to?',
       url: '/schedule/clinic',
+      next(state, dispatch) {
+        if (getFormData(state).clinicId === 'NONE') {
+          dispatch(startRequestAppointmentFlow());
+          return 'requestDateTime';
+        }
+
+        // fetch appointment slots
+        dispatch(startDirectScheduleFlow());
+        return 'preferredDate';
+      },
     },
     contactInfo: {
-      ...flow.contactInfo,
+      label: 'How should we contact you?',
       url: 'contact-information',
+      next: 'review',
     },
     preferredDate: {
-      ...flow.preferredDate,
+      label: 'When are you available for this appointment?',
       url: 'preferred-date',
+      next: 'selectDateTime',
     },
     reasonForAppointment: {
-      ...flow.reasonForAppointment,
+      label: 'What’s the reason for this appointment?',
       url: 'reason',
+      next(state) {
+        if (
+          isCCFacility(state) ||
+          getNewAppointment(state).flowType === FLOW_TYPES.DIRECT
+        ) {
+          return 'contactInfo';
+        }
+
+        return 'visitType';
+      },
     },
     requestDateTime: {
-      ...flow.requestDateTime,
+      label: 'When would you like an appointment?',
       url: 'va-request/',
-    },
-    ccRequestDateTime: {
-      ...flow.requestDateTime,
-      url: 'community-request/',
+      next(state) {
+        const supportedSites = selectCommunityCareSupportedSites(state);
+        if (isCCFacility(state) && supportedSites.length > 1) {
+          return 'ccClosestCity';
+        }
+        if (isCCFacility(state)) {
+          return 'ccPreferences';
+        }
+
+        return 'reasonForAppointment';
+      },
     },
     root: {
       url: '/my-health/appointments',
     },
     review: {
-      ...flow.review,
       label:
         FLOW_TYPES.DIRECT === flowType
           ? 'Review and confirm your appointment details'
@@ -420,31 +254,102 @@ export default function getNewAppointmentFlow(state) {
       url: 'review',
     },
     scheduleCerner: {
-      ...flow.scheduleCerner,
+      label: 'How to schedule',
       url: 'how-to-schedule',
     },
     selectDateTime: {
-      ...flow.selectDateTime,
+      label: 'What date and time do you want for this appointment?',
       url: 'date-time',
+      next: 'reasonForAppointment',
     },
     typeOfCare: {
-      ...flow.typeOfCare,
+      label: 'What type of care do you need?',
       url: '/schedule/type-of-care',
+      async next(state, dispatch) {
+        if (isCovidVaccine(state)) {
+          recordEvent({
+            event: `${GA_PREFIX}-schedule-covid19-button-clicked`,
+          });
+          dispatch(startNewVaccineFlow());
+          return 'vaccineFlow';
+        }
+        if (isSleepCare(state)) {
+          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+          return 'typeOfSleepCare';
+        }
+        if (isEyeCare(state)) {
+          return 'typeOfEyeCare';
+        }
+        if (isCommunityCare(state)) {
+          const isEligible = await dispatch(checkCommunityCareEligibility());
+
+          if (isEligible && isPodiatry(state)) {
+            // If CC enabled systems and toc is podiatry, skip typeOfFacility
+            dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
+            dispatch(startRequestAppointmentFlow(true));
+            return 'ccRequestDateTime';
+          }
+          if (isEligible) {
+            return 'typeOfFacility';
+          }
+          if (isPodiatry(state)) {
+            // If no CC enabled systems and toc is podiatry, show modal
+            dispatch(showPodiatryAppointmentUnavailableModal());
+            return 'typeOfCare';
+          }
+        }
+
+        dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+        return VA_FACILITY_V2_KEY;
+      },
     },
     typeOfEyeCare: {
-      ...flow.typeOfEyeCare,
+      label: 'Choose the type of eye care you need',
       url: 'eye-care',
+      async next(state, dispatch) {
+        const data = getFormData(state);
+
+        // check that the result does have a ccId
+        if (getTypeOfCare(data)?.ccId) {
+          const isEligible = await dispatch(checkCommunityCareEligibility());
+
+          if (isEligible) {
+            return 'typeOfFacility';
+          }
+        }
+
+        dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+        return VA_FACILITY_V2_KEY;
+      },
     },
     typeOfFacility: {
-      ...flow.typeOfFacility,
+      label: 'Where do you prefer to receive care?',
       url: 'facility-type',
+      next(state, dispatch) {
+        if (isCCAudiology(state)) {
+          return 'audiologyCareType';
+        }
+
+        if (isCCFacility(state)) {
+          dispatch(startRequestAppointmentFlow(true));
+          return 'ccRequestDateTime';
+        }
+
+        return VA_FACILITY_V2_KEY;
+      },
     },
     typeOfSleepCare: {
-      ...flow.typeOfSleepCare,
+      label: 'Choose the type of sleep care you need',
       url: 'sleep-care',
+      next: VA_FACILITY_V2_KEY,
+    },
+    selectProvider: {
+      url: '/new-appointment/provider',
+      label: 'Which provider do you want to schedule with?',
+      next: 'preferredDate',
     },
     vaccineFlow: {
-      ...flow.vaccineFlow,
+      label: 'COVID-19 vaccine appointment',
       // IMPORTANT!!!
       url:
         // The trailing slash is needed for going back to the previous page to work properly.
@@ -456,21 +361,18 @@ export default function getNewAppointmentFlow(state) {
         // Leaving the '/' off makes '/schedule' the parent.
         'covid-vaccine/',
     },
-    vaFacility: {
-      ...flow.vaFacility,
-      url: 'va-facility',
-    },
     vaFacilityV2: {
-      ...flow.vaFacilityV2,
       label: isSingleVaFacility
         ? 'Your appointment location'
         : 'Which VA location would you like to go to?',
 
       url: 'location',
+      next: vaFacilityNext,
     },
     visitType: {
-      ...flow.visitType,
+      label: 'How do you want to attend this appointment?',
       url: 'preferred-method',
+      next: 'contactInfo',
     },
   };
 }

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -14,7 +14,6 @@ import {
   selectRegisteredCernerFacilityIds,
   selectFeatureVAOSServiceVAAppointments,
   selectFeatureClinicFilter,
-  selectFeatureBreadcrumbUrlUpdate,
   selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthVA,
@@ -922,7 +921,6 @@ export function submitAppointmentOrRequest(history) {
     const featureVAOSServiceVAAppointments = selectFeatureVAOSServiceVAAppointments(
       state,
     );
-    const featureBreadcrumbUrlUpdate = selectFeatureBreadcrumbUrlUpdate(state);
     const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
@@ -968,11 +966,7 @@ export function submitAppointmentOrRequest(history) {
         resetDataLayer();
 
         if (featureVAOSServiceVAAppointments) {
-          if (featureBreadcrumbUrlUpdate) {
-            history.push(`/${appointment.id}?confirmMsg=true`);
-          } else {
-            history.push(`/va/${appointment.id}?confirmMsg=true`);
-          }
+          history.push(`/${appointment.id}?confirmMsg=true`);
         } else {
           history.push('/new-appointment/confirmation');
         }
@@ -1063,11 +1057,7 @@ export function submitAppointmentOrRequest(history) {
           ...additionalEventData,
         });
         resetDataLayer();
-        history.push(
-          `${featureBreadcrumbUrlUpdate ? '/pending' : '/requests'}/${
-            requestData.id
-          }?confirmMsg=true`,
-        );
+        history.push(`/pending/${requestData.id}?confirmMsg=true`);
       } catch (error) {
         let extraData = null;
         if (requestBody) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR is part of a group of PR's that remove conditional code related to the `va_online_scheduling_breadcrumb_url_update` feature flag in the VAOS application. This feature flag has been set to `true` for all users for some time in all environments, this PR removes unused code.

This particular PR addresses code in the `src/applications/vaos/new-appointment/` directory.

The work on https://github.com/department-of-veterans-affairs/va.gov-team/issues/95922 will be split between several PR's to allow for more straightforward reviews.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/95922

## Testing done

- Unit tests
- e2e tests
- Manual local testing

## What areas of the site does it impact?
Code in `src/applications/vaos/new-appointment/`

## Acceptance criteria

### Quality Assurance & Testing

- [X] I updated unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
