### PR TITLE
Task/make rtk middleware configurable

### DIFF
--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -109,7 +109,7 @@ export function renderWithStoreAndRouter(
     store,
     path,
     history,
-    middlewares: [vaosApi.middleware],
+    additionalMiddlewares: [vaosApi.middleware],
   });
 }
 

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -109,6 +109,7 @@ export function renderWithStoreAndRouter(
     store,
     path,
     history,
+    middlewares: [vaosApi.middleware],
   });
 }
 

--- a/src/applications/vaos/vaos-entry.jsx
+++ b/src/applications/vaos/vaos-entry.jsx
@@ -6,10 +6,12 @@ import startApp from 'platform/startup/router';
 import createRoutesWithStore from './routes';
 import manifest from './manifest.json';
 import reducer from './redux/reducer';
+import { vaosApi } from './redux/api/vaosApi';
 
 startApp({
   url: manifest.rootUrl,
   createRoutesWithStore,
   reducer,
   entryName: manifest.entryName,
+  additionalMiddlewares: [vaosApi.middleware],
 });

--- a/src/platform/startup/index.js
+++ b/src/platform/startup/index.js
@@ -29,6 +29,7 @@ import setUpCommonFunctionality from './setup';
  * to true, the maintenance_windows API request is made without having to wait for the
  * DowntimeNotification component to mount. This can improve startup time for applications
  * that use the DowntimeNotification component.
+ * @param {array} appInfo.additionalMiddlewares Array of additional Redux middlewares to include.
  */
 export default function startApp({
   routes,
@@ -39,6 +40,7 @@ export default function startApp({
   analyticsEvents,
   entryName = 'unknown',
   preloadScheduledDowntimes = false,
+  additionalMiddlewares = [],
 }) {
   const store = setUpCommonFunctionality({
     entryName,
@@ -46,6 +48,7 @@ export default function startApp({
     reducer,
     analyticsEvents,
     preloadScheduledDowntimes,
+    additionalMiddlewares,
   });
 
   let history = browserHistory;

--- a/src/platform/startup/router.js
+++ b/src/platform/startup/router.js
@@ -28,6 +28,7 @@ import setUpCommonFunctionality from './setup';
  * to true, the maintenance_windows API request is made without having to wait for the
  * DowntimeNotification component to mount. This can improve startup time for applications
  * that use the DowntimeNotification component.
+ * @param {array} appInfo.additionalMiddlewares Array of additional Redux middlewares to include.
  */
 export default function startApp({
   routes,
@@ -38,6 +39,7 @@ export default function startApp({
   analyticsEvents,
   entryName = 'unknown',
   preloadScheduledDowntimes = false,
+  additionalMiddlewares = [],
 }) {
   const store = setUpCommonFunctionality({
     entryName,
@@ -45,6 +47,7 @@ export default function startApp({
     reducer,
     analyticsEvents,
     preloadScheduledDowntimes,
+    additionalMiddlewares,
   });
 
   let content = component;

--- a/src/platform/startup/setup.js
+++ b/src/platform/startup/setup.js
@@ -16,6 +16,7 @@ import startSitewideComponents from '../site-wide';
  * @param {array} appInfo.analyticsEvents An array which contains analytics events to collect
  * when the respective actions are fired.
  * @param {boolean} preloadScheduledDowntimes Whether to fetch scheduled downtimes.
+ * @param {array} appInfo.additionalMiddlewares Array of additional Redux middlewares to include.
  */
 export default function setUpCommonFunctionality({
   entryName,
@@ -23,6 +24,7 @@ export default function setUpCommonFunctionality({
   analyticsEvents,
   url,
   preloadScheduledDowntimes,
+  additionalMiddlewares = [],
 }) {
   // Set further errors to have the appropriate source tag
   Sentry.setTag('source', entryName);
@@ -30,7 +32,11 @@ export default function setUpCommonFunctionality({
   // Set the app name for use in the apiRequest helper
   window.appName = entryName;
 
-  const store = createCommonStore(reducer, analyticsEvents);
+  const store = createCommonStore(
+    reducer,
+    analyticsEvents,
+    additionalMiddlewares,
+  );
   connectFeatureToggle(store.dispatch);
 
   if (preloadScheduledDowntimes) {

--- a/src/platform/startup/store.js
+++ b/src/platform/startup/store.js
@@ -9,7 +9,6 @@ import thunk from 'redux-thunk';
 import persistState from 'redux-localstorage';
 // Relative imports.
 import i18Reducer from 'applications/static-pages/i18Select/reducers';
-import { vaosApi } from 'applications/vaos/redux/api/vaosApi';
 import announcements from '../site-wide/announcements/reducers';
 import createAnalyticsMiddleware from './analytics-middleware';
 import environment from '../utilities/environment';
@@ -52,12 +51,14 @@ export const commonReducer = {
  *
  * @param {Object} [appReducer={}] An object with reducer functions as properties
  * @param {Array} analyticsEvents A list of analytics events to capture when redux actions are fired
+ * @param {Array} additionalMiddlewares Additional middlewares to add to the store
  * @returns {Store} The Redux store with a combined reducer from the commonReducer and
  * appReducer.
  */
 export default function createCommonStore(
   appReducer = {},
   analyticsEvents = [],
+  additionalMiddlewares = [],
 ) {
   const reducer = {
     ...appReducer,
@@ -66,14 +67,16 @@ export default function createCommonStore(
   const useDevTools =
     !environment.isProduction() && window.__REDUX_DEVTOOLS_EXTENSION__;
 
+  const middlewares = [
+    thunk,
+    createAnalyticsMiddleware(analyticsEvents),
+    ...additionalMiddlewares,
+  ];
+
   const store = createStore(
     combineReducers(reducer),
     compose(
-      applyMiddleware(
-        thunk,
-        createAnalyticsMiddleware(analyticsEvents),
-        vaosApi.middleware,
-      ),
+      applyMiddleware(...middlewares),
       persistState('i18State'),
       useDevTools ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f,
     ),

--- a/src/platform/startup/tests/store.unit.spec.jsx
+++ b/src/platform/startup/tests/store.unit.spec.jsx
@@ -1,5 +1,6 @@
-import createCommonStore from '../store';
 import { expect } from 'chai';
+import sinon from 'sinon';
+import createCommonStore from '../store';
 
 describe('Common Redux store', () => {
   it('should support injecting reducer', () => {
@@ -17,5 +18,59 @@ describe('Common Redux store', () => {
     store.dispatch({ type: 'test' });
 
     expect(store.getState().testSlice.testActionHappened).to.be.true;
+  });
+
+  it('should integrate additional middlewares that modify action flow', () => {
+    // Create a middleware that transforms action types by adding a prefix
+    const prefixingMiddleware = () => next => action => {
+      // Transform action types that start with 'TEST_' by adding 'PREFIXED_'
+      if (action.type && action.type.startsWith('TEST_')) {
+        return next({
+          ...action,
+          type: `PREFIXED_${action.type}`,
+        });
+      }
+      return next(action);
+    };
+
+    // Mock reducer that responds differently based on the action type
+    const mockReducer = (state = { actionSeen: null }, action) => {
+      if (action.type === 'TEST_ACTION') {
+        return { ...state, actionSeen: 'original' };
+      }
+      if (action.type === 'PREFIXED_TEST_ACTION') {
+        return { ...state, actionSeen: 'prefixed' };
+      }
+      return state;
+    };
+
+    // Create a store with our test reducer and middlewares
+    const spyInstance = { spy: sinon.spy() };
+    const spyMiddlewareWithSpy = () => next => action => {
+      spyInstance.spy(action);
+      return next(action);
+    };
+
+    const store = createCommonStore(
+      { testReducer: mockReducer },
+      [], // No analytics events
+      [prefixingMiddleware, spyMiddlewareWithSpy], // Our additional middlewares
+    );
+
+    // Dispatch an action that should be transformed by our middleware
+    store.dispatch({ type: 'TEST_ACTION' });
+
+    // Verify that the action was transformed by the middleware
+    expect(spyInstance.spy.calledWith({ type: 'PREFIXED_TEST_ACTION' })).to.be
+      .true;
+
+    // Verify that the state reflects the transformed action was processed
+    expect(store.getState().testReducer.actionSeen).to.equal('prefixed');
+
+    // Dispatch a different action that won't be transformed
+    store.dispatch({ type: 'REGULAR_ACTION' });
+
+    // Verify the spy saw the untransformed action
+    expect(spyInstance.spy.calledWith({ type: 'REGULAR_ACTION' })).to.be.true;
   });
 });

--- a/src/platform/startup/tests/withoutRouter.unit.spec.jsx
+++ b/src/platform/startup/tests/withoutRouter.unit.spec.jsx
@@ -63,4 +63,39 @@ describe('startApp', () => {
       ),
     ).to.be.true;
   });
+
+  it('should pass additional middlewares to setUpCommonFunctionality', () => {
+    const mockStore = {};
+    setUpCommonFunctionalityStub.returns(mockStore);
+
+    // Create mock middlewares
+    const mockMiddlewareOne = () => next => action =>
+      next({ ...action, modified: true });
+    const mockMiddlewareTwo = () => next => action => next(action);
+    const mockAdditionalMiddlewares = [mockMiddlewareOne, mockMiddlewareTwo];
+
+    const mockRouter = {};
+    const mockRouterProvider = <RouterProvider router={mockRouter} />;
+
+    startApp({
+      router: mockRouterProvider,
+      reducer: {},
+      additionalMiddlewares: mockAdditionalMiddlewares,
+    });
+
+    // Verify the middlewares were passed correctly
+    expect(setUpCommonFunctionalityStub.calledOnce).to.be.true;
+    expect(
+      setUpCommonFunctionalityStub.calledWith(
+        sinon.match({
+          additionalMiddlewares: mockAdditionalMiddlewares,
+        }),
+      ),
+    ).to.be.true;
+
+    // Verify that the middlewares array is exactly the same instance that was passed
+    const actualMiddlewares =
+      setUpCommonFunctionalityStub.firstCall.args[0].additionalMiddlewares;
+    expect(actualMiddlewares).to.equal(mockAdditionalMiddlewares);
+  });
 });

--- a/src/platform/startup/tests/withoutRouter.unit.spec.jsx
+++ b/src/platform/startup/tests/withoutRouter.unit.spec.jsx
@@ -50,6 +50,7 @@ describe('startApp', () => {
         reducer: mockReducer,
         analyticsEvents: mockAnalyticsEvents,
         preloadScheduledDowntimes: mockPreloadScheduledDowntimes,
+        additionalMiddlewares: [],
       }),
     ).to.be.true;
 

--- a/src/platform/startup/withoutRouter.js
+++ b/src/platform/startup/withoutRouter.js
@@ -24,6 +24,7 @@ import setUpCommonFunctionality from './setup';
  * to true, the maintenance_windows API request is made without having to wait for the
  * DowntimeNotification component to mount. This can improve startup time for applications
  * that use the DowntimeNotification component.
+ * @param {array} appInfo.additionalMiddlewares Array of additional Redux middlewares to include.
  */
 export default function startApp({
   router,
@@ -32,6 +33,7 @@ export default function startApp({
   analyticsEvents,
   entryName = 'unknown',
   preloadScheduledDowntimes = false,
+  additionalMiddlewares = [],
 }) {
   const store = setUpCommonFunctionality({
     entryName,
@@ -39,6 +41,7 @@ export default function startApp({
     reducer,
     analyticsEvents,
     preloadScheduledDowntimes,
+    additionalMiddlewares,
   });
 
   startReactApp(<Provider store={store}>{router}</Provider>);

--- a/src/platform/testing/unit/react-testing-library-helpers.js
+++ b/src/platform/testing/unit/react-testing-library-helpers.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { PropTypes } from 'prop-types';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import { isPlainObject } from 'lodash';
 import { render as rtlRender } from '@testing-library/react';
 
 import { commonReducer } from 'platform/startup/store';
-import { vaosApi } from 'applications/vaos/redux/api/vaosApi';
 import { createTestHistory } from './helpers';
 
 /**
@@ -22,7 +22,13 @@ import { createTestHistory } from './helpers';
  */
 export function renderInReduxProvider(
   ui,
-  { initialState = {}, reducers = {}, store = null, ...renderOptions } = {},
+  {
+    initialState = {},
+    reducers = {},
+    store = null,
+    middlewares = [],
+    ...renderOptions
+  } = {},
 ) {
   if (Object.keys(renderOptions).includes('reducer')) {
     /* eslint-disable no-console */
@@ -40,11 +46,15 @@ export function renderInReduxProvider(
     createStore(
       combineReducers({ ...commonReducer, ...reducers }),
       initialState,
-      applyMiddleware(thunk, vaosApi.middleware),
+      applyMiddleware(thunk, ...middlewares),
     );
   const Wrapper = ({ children }) => {
     return <Provider store={testStore}>{children}</Provider>;
   };
+  Wrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
   return rtlRender(ui, {
     wrapper: Wrapper,
     store: testStore,
@@ -71,18 +81,26 @@ export function renderInReduxProvider(
  * @param {ReduxStore} [renderParams.store=null] Redux store to use for the rendered page or section of the app
  * @param {string} [renderParams.path='/'] Url path to start from
  * @param {History} [renderParams.history=null] Custom history object to use, will create one if not passed
+ * @param {Array} [renderParams.middlewares=[]] Additional Redux middlewares to add to the store
  * @returns {Object} Return value of the React Testing Library render function, plus the history object used
  */
 export function renderWithStoreAndRouter(
   ui,
-  { initialState, reducers = {}, store = null, path = '/', history = null },
+  {
+    initialState,
+    reducers = {},
+    store = null,
+    path = '/',
+    history = null,
+    middlewares = [],
+  },
 ) {
   const testStore =
     store ||
     createStore(
       combineReducers({ ...commonReducer, ...reducers }),
       initialState,
-      applyMiddleware(thunk, vaosApi.middleware),
+      applyMiddleware(thunk, ...middlewares),
     );
 
   const historyObject = history || createTestHistory(path);
@@ -92,6 +110,7 @@ export function renderWithStoreAndRouter(
       store: testStore,
       initialState,
       reducers,
+      middlewares,
     },
   );
 

--- a/src/platform/testing/unit/react-testing-library-helpers.js
+++ b/src/platform/testing/unit/react-testing-library-helpers.js
@@ -26,7 +26,7 @@ export function renderInReduxProvider(
     initialState = {},
     reducers = {},
     store = null,
-    middlewares = [],
+    additionalMiddlewares = [],
     ...renderOptions
   } = {},
 ) {
@@ -46,7 +46,7 @@ export function renderInReduxProvider(
     createStore(
       combineReducers({ ...commonReducer, ...reducers }),
       initialState,
-      applyMiddleware(thunk, ...middlewares),
+      applyMiddleware(thunk, ...additionalMiddlewares),
     );
   const Wrapper = ({ children }) => {
     return <Provider store={testStore}>{children}</Provider>;
@@ -81,7 +81,7 @@ export function renderInReduxProvider(
  * @param {ReduxStore} [renderParams.store=null] Redux store to use for the rendered page or section of the app
  * @param {string} [renderParams.path='/'] Url path to start from
  * @param {History} [renderParams.history=null] Custom history object to use, will create one if not passed
- * @param {Array} [renderParams.middlewares=[]] Additional Redux middlewares to add to the store
+ * @param {Array} [renderParams.additionalMiddlewares=[]] Additional Redux middlewares to add to the store
  * @returns {Object} Return value of the React Testing Library render function, plus the history object used
  */
 export function renderWithStoreAndRouter(
@@ -92,7 +92,7 @@ export function renderWithStoreAndRouter(
     store = null,
     path = '/',
     history = null,
-    middlewares = [],
+    additionalMiddlewares = [],
   },
 ) {
   const testStore =
@@ -100,7 +100,7 @@ export function renderWithStoreAndRouter(
     createStore(
       combineReducers({ ...commonReducer, ...reducers }),
       initialState,
-      applyMiddleware(thunk, ...middlewares),
+      applyMiddleware(thunk, ...additionalMiddlewares),
     );
 
   const historyObject = history || createTestHistory(path);
@@ -110,7 +110,7 @@ export function renderWithStoreAndRouter(
       store: testStore,
       initialState,
       reducers,
-      middlewares,
+      additionalMiddlewares,
     },
   );
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

A VAOS middleware was added to the global store in #34803 to support RTK Query functionality. This PR instead allows apps to pass middleware in so that:

- there is not a global dependency on the VAOS app
- other apps can take advantage of RTK Query functionality
