### PR TITLE
Array Builder: Add key delete for validation

### DIFF
--- a/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
+++ b/src/applications/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
@@ -21,13 +21,6 @@ import {
   customLocationSchema,
 } from '../../helpers';
 
-/* NOTE:
- * In "Add mode" of the array builder, formData represents the entire formData object.
- * In "Edit mode," formData represents the specific array item being edited.
- * As a result, the index param may sometimes come back null depending on which mode the user is in.
- * To handle both modes, ensure that you check both via RJSF like these pages do.
- */
-
 /** @type {ArrayBuilderOptions} */
 export const spouseMarriageHistoryOptions = {
   arrayPath: 'spouseMarriageHistory',
@@ -64,25 +57,27 @@ export const spouseMarriageHistoryOptions = {
 /** @returns {PageSchema} */
 export const spouseMarriageHistorySummaryPage = {
   uiSchema: {
-    'view:completedSpouseFormerMarriage': arrayBuilderYesNoUI(
-      spouseMarriageHistoryOptions,
-      {
-        title: 'Does your spouse have any former marriages to add?',
-        hint:
-          'If yes, you’ll need to add at least one former marriage. You can add up to 20.',
-        labels: {
-          Y: 'Yes',
-          N: 'No',
+    'view:completedSpouseFormerMarriage': {
+      ...arrayBuilderYesNoUI(
+        spouseMarriageHistoryOptions,
+        {
+          title: 'Does your spouse have any former marriages to add?',
+          hint:
+            'If yes, you’ll need to add at least one former marriage. You can add up to 20.',
+          labels: {
+            Y: 'Yes',
+            N: 'No',
+          },
         },
-      },
-      {
-        title: 'Does your spouse have any other marriages to add?',
-        labels: {
-          Y: 'Yes',
-          N: 'No',
+        {
+          title: 'Does your spouse have any other marriages to add?',
+          labels: {
+            Y: 'Yes',
+            N: 'No',
+          },
         },
-      },
-    ),
+      ),
+    },
   },
   schema: {
     type: 'object',

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
@@ -127,6 +127,9 @@ const ArrayBuilderCards = ({
       (_, index) => index !== currentIndex,
     );
     const newData = set(arrayPath, arrayWithRemovedItem, formData);
+    if (!required(newData) && !arrayWithRemovedItem?.length) {
+      delete newData[arrayPath];
+    }
     setFormData(newData);
     hideRemoveConfirmationModal({
       focusRemoveButton: false,

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderCards.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderCards.unit.spec.jsx
@@ -136,7 +136,8 @@ describe('ArrayBuilderCards', () => {
     expect($modal.getAttribute('visible')).to.eq('true');
     $modal.__events.primaryButtonClick();
     expect(setFormData.called).to.be.true;
-    expect(setFormData.args[0][0].employers).to.eql([]);
+    expect(setFormData.args[0][0].employers).to.be.undefined;
+    expect(setFormData.args[0][0]).to.contains({ otherData: 'test' });
     expect(onRemoveAll.called).to.be.true;
   });
 

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -482,7 +482,7 @@ describe('ArrayBuilderSummaryPage', () => {
     await waitFor(() => {
       const alert = container.querySelector('va-alert');
       expect(alert).to.include.text('has been deleted');
-      expect(setFormData.args[0][0].employers).to.have.lengthOf(0);
+      expect(setFormData.args[0][0]).to.eql({});
     });
   });
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds additional check + delete for empty optional array keys
- Optional arrays were triggering submission validation errors after item removal

## Related issue(s)


## Testing done

- Manual / Unit / E2E

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
