### PR TITLE
[105297] Update Secondary Nav default active state

### DIFF
--- a/src/platform/mhv/secondary-nav/components/MhvSecondaryNavMenu.jsx
+++ b/src/platform/mhv/secondary-nav/components/MhvSecondaryNavMenu.jsx
@@ -22,25 +22,25 @@ const MhvSecondaryNavMenu = ({ items, loading }) => {
   const stripTrailingSlash = path => path?.replace(/\/$/, '');
 
   /**
-   * Find which navigation item needs to be set to active, if any. An item should be active
-   * when the URL pathname starts with the app's root URL, or the href matches the current
-   * URL pathname.
+   * Find which navigation item, if any, should be set as active based on the current URL.
+   * This method compares the first two segments of the current URL pathname with each item's
+   * `appRootUrl` or `href`. It returns the first matching item or undefined if no match is found.
+   *
    * @param secNavItems the list of navigation items
-   * @returns the item to be set as active, or null if none found
+   * @returns the item to be set as active, or undefined if none found
    */
   const findActiveItem = (secNavItems = items) => {
-    // Perform a reverse find to match which nav link we are on, so we match on the home page last
     return [...secNavItems] // Clone the array, so the original stays the same
-      .reverse()
       .find(item => {
+        // Normalizes paths by removing trailing slashes to ensure consistent comparisons
         const appRootUrl = stripTrailingSlash(item.appRootUrl || item.href);
-        // Remove the trailing slash as they are optional.
-        const linkNoTrailing = stripTrailingSlash(item.href);
-        const urlNoTrailing = stripTrailingSlash(window?.location?.pathname);
-        return (
-          window?.location?.pathname?.startsWith(appRootUrl) ||
-          linkNoTrailing === urlNoTrailing
-        );
+        const currentPath = stripTrailingSlash(window?.location?.pathname);
+        // Extracts the first two segment of the current URL for root path comparison
+        const currentAppRootPath = currentPath
+          .split('/')
+          .slice(0, 3)
+          .join('/');
+        return appRootUrl === currentAppRootPath;
       });
   };
 

--- a/src/platform/mhv/secondary-nav/components/MhvSecondaryNavMenu.jsx
+++ b/src/platform/mhv/secondary-nav/components/MhvSecondaryNavMenu.jsx
@@ -34,7 +34,8 @@ const MhvSecondaryNavMenu = ({ items, loading }) => {
       .find(item => {
         // Normalizes paths by removing trailing slashes to ensure consistent comparisons
         const appRootUrl = stripTrailingSlash(item.appRootUrl || item.href);
-        const currentPath = stripTrailingSlash(window?.location?.pathname);
+        const currentPath =
+          stripTrailingSlash(window?.location?.pathname) || '';
         // Extracts the first two segment of the current URL for root path comparison
         const currentAppRootPath = currentPath
           .split('/')

--- a/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavMenu.unit.spec.jsx
+++ b/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavMenu.unit.spec.jsx
@@ -34,6 +34,12 @@ const testSecNavItems = [
   },
 ];
 
+const noneActiveItems = [
+  '/my-health/travel-pay/claims/',
+  '/my-health/order-medical-supplies',
+  '/my-health/update-benefits-information-form-10-10ezr',
+];
+
 /**
  * Set the current window's URL.
  * @param {String} pathname the pathname of the URL
@@ -128,6 +134,23 @@ describe('MHV Secondary Navigation Menu Component', () => {
       expect(getOneLink(medNavItem).className).to.not.include(
         activeClassString,
       );
+    });
+  });
+
+  describe('no active item', () => {
+    it('does not set any active item for none of the 5-options', () => {
+      noneActiveItems.forEach(item => {
+        setWindowUrl(item);
+        const { getAllByTestId } = render(
+          <MhvSecondaryNavMenu items={testSecNavItems} />,
+        );
+        const links = getAllByTestId('mhv-sec-nav-item');
+        links.forEach(link => {
+          // This tests that there are no selected item is active item
+          expect(link.className).to.not.include(activeClassString);
+        });
+        cleanup(); // must be done after the render
+      });
     });
   });
 });

--- a/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavMenu.unit.spec.jsx
+++ b/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavMenu.unit.spec.jsx
@@ -117,8 +117,10 @@ describe('MHV Secondary Navigation Menu Component', () => {
 
   describe('renders', () => {
     it('when window location pathname is not set', () => {
-      delete window.location;
-      expect(getOneLink(medNavItem)).to.exist;
+      setWindowUrl('');
+      expect(getOneLink(medNavItem).className).to.not.include(
+        activeClassString,
+      );
     });
   });
 });

--- a/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavMenu.unit.spec.jsx
+++ b/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavMenu.unit.spec.jsx
@@ -116,8 +116,15 @@ describe('MHV Secondary Navigation Menu Component', () => {
   });
 
   describe('renders', () => {
-    it('when window location pathname is not set', () => {
+    it('when window location pathname is empty', () => {
       setWindowUrl('');
+      expect(getOneLink(medNavItem).className).to.not.include(
+        activeClassString,
+      );
+    });
+
+    it('when window location pathname is not set', () => {
+      delete window.location;
       expect(getOneLink(medNavItem).className).to.not.include(
         activeClassString,
       );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#105297

## Testing done
- Local testing:
  - go to /my-health pages for 10-10EZR, travel pay (/my-health/travel-pay), and medical supply re-ordering (/my-health/order-medical-supplies), the secondary nav will show that nothing is selected (no active state)
  - go to our landing page (or any of the 5 mhv apps), the secondary nav will show the active state for MHV home (MHV home option is selected)
- Update test specs.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    <img width="489" alt="Screenshot 2025-04-22 at 8 08 43 AM" src="https://github.com/user-attachments/assets/c4409f4c-77a6-4e74-a0a1-bd9074b9daa5" />    |   <img width="489" alt="Screenshot 2025-04-22 at 8 08 34 AM" src="https://github.com/user-attachments/assets/750115eb-961c-4523-86a8-291dea35acc2" />    |
| Desktop |   <img width="722" alt="Screenshot 2025-04-22 at 8 06 33 AM" src="https://github.com/user-attachments/assets/75c5a198-4eb2-4438-923b-c3afa7ff949b" />     |    <img width="722" alt="Screenshot 2025-04-22 at 8 06 16 AM" src="https://github.com/user-attachments/assets/d9929577-5a40-4aff-b587-fdfe34f580bf" />   |

## What areas of the site does it impact?

MHV Secondary Navigation

## Acceptance criteria
- When MHV users go to /my-health pages for 10-10EZR, travel pay, and medical supply re-ordering, the secondary nav will show that nothing is selected (no active state)
- When MHV users go to our landing page, the secondary nav will show the active state for MHV home (MHV home option is selected)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback


