### PR TITLE
Testing | setup e2e testing to start & stop of specific pages

### DIFF
--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -183,8 +183,12 @@ const performPageActions = (pathname, _13647Exception = false) => {
  * Top level loop that invokes all of the processing for a form page and
  * asserts that it proceeds to the next page until it gets to the confirmation.
  */
-const processPage = ({ _13647Exception }) => {
+const processPage = ({ _13647Exception, stopTestAfterPath }) => {
   cy.location('pathname', NO_LOG_OPTION).then(pathname => {
+    if (pathname.endsWith(stopTestAfterPath)) {
+      return;
+    }
+
     performPageActions(pathname, _13647Exception);
 
     if (!pathname.endsWith('/confirmation')) {
@@ -194,7 +198,7 @@ const processPage = ({ _13647Exception }) => {
             throw new Error(`Expected to navigate away from ${pathname}`);
           }
         })
-        .then(() => processPage({ _13647Exception }));
+        .then(() => processPage({ _13647Exception, stopTestAfterPath }));
     }
   });
 };
@@ -545,6 +549,9 @@ Cypress.Commands.add('fillPage', () => {
  * @property {(boolean|string[])} [skip] - Skips specific tests if it's an array
  *     that contains the test names as strings. Skips the whole suite
  *     if it's otherwise truthy.
+ * @property {string} [stopTestAfterPath] - The pathname of the page to stop the
+ *     e2e test on. Useful for testing a set range of pages within a form. See
+ *     setupInProgressReturnUrl in the utilities folder to set a start page.
  * ---
  * @param {TestConfig} testConfig
  */
@@ -561,6 +568,8 @@ const testForm = testConfig => {
     setup = () => {},
     setupPerTest = () => {},
     skip,
+    // null prevents endsWith string comparison returning true
+    stopTestAfterPath = null,
     _13647Exception = false,
     // whether or not to auto fill web component fields
     // (using RJSF naming convention #root_field_subField)
@@ -633,7 +642,7 @@ const testForm = testConfig => {
 
           cy.get(LOADING_SELECTOR)
             .should('not.exist')
-            .then(() => processPage({ _13647Exception }));
+            .then(() => processPage({ stopTestAfterPath, _13647Exception }));
         });
       });
     };

--- a/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
@@ -45,16 +45,20 @@ export const createTestConfig = (config, manifest = {}, formConfig = {}) => {
  * easier to run e2e tests starting from a specific page. See the
  * stopTestAfterPath property in testConfig that allows you to set the page to
  * stop at.
- * @param {Object} data - form data
+ * @param {Object} prefill - form data for pages before the returnUrl page
  * @param {string} returnUrl - URL to return to within the form flow
  * @param {string} version - form version based on the formConfig (usually the
  * migration length)
  * @returns {Object} - in-progress form response
  */
-export default function inProgressMock({ data, returnUrl, version } = {}) {
+export default function inProgressMock({
+  prefill = {},
+  returnUrl,
+  version,
+} = {}) {
   const date = Date.now();
   return {
-    formData: data,
+    formData: prefill,
     metadata: {
       version,
       returnUrl,
@@ -82,14 +86,14 @@ export default function inProgressMock({ data, returnUrl, version } = {}) {
  * @param {*} formConfig - The form config object, we really only need the
  *  formId and version from it
  * @param {string} returnUrl - The URL to return to to continue the form flow
- * @param {Object} data - The form data to use in the in-progress form, but only
- *  include fields before the returnUrl page
+ * @param {Object} prefill - The form data to use in the in-progress form, but
+ *  only include fields before the returnUrl page
  * @param {Object} user - The user object to use in the mock user response
  */
 export const setupInProgressReturnUrl = ({
   formConfig = {},
   returnUrl = '',
-  data = {}, // all previous page form data
+  prefill = {}, // all previous page form data
   user = {},
 }) => {
   const { formId, version } = formConfig;
@@ -115,7 +119,7 @@ export const setupInProgressReturnUrl = ({
   cy.intercept(
     'GET',
     `/v0/in_progress_forms/${formId}`,
-    inProgressMock({ data, returnUrl, version }),
+    inProgressMock({ prefill, returnUrl, version }),
   );
 
   cy.login(userData);

--- a/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
@@ -1,3 +1,6 @@
+import { add, getUnixTime } from 'date-fns';
+import set from 'platform/utilities/data/set';
+
 /**
  * Builds an array of array page objects to be used for matching against
  * page URLs in order to determine whether a page is an array page, and if so,
@@ -35,4 +38,84 @@ export const createTestConfig = (config, manifest = {}, formConfig = {}) => {
   const { appName, rootUrl } = manifest;
   const arrayPages = createArrayPageObjects(formConfig);
   return { appName, arrayPages, rootUrl, ...config };
+};
+
+/**
+ * Builds an in-progress form response. It'll include the return URL to make it
+ * easier to run e2e tests starting from a specific page. See the
+ * stopTestAfterPath property in testConfig that allows you to set the page to
+ * stop at.
+ * @param {Object} data - form data
+ * @param {string} returnUrl - URL to return to within the form flow
+ * @param {string} version - form version based on the formConfig (usually the
+ * migration length)
+ * @returns {Object} - in-progress form response
+ */
+export default function inProgressMock({ data, returnUrl, version } = {}) {
+  const date = Date.now();
+  return {
+    formData: data,
+    metadata: {
+      version,
+      returnUrl,
+      savedAt: date,
+      submission: {
+        status: false,
+        errorMessage: false,
+        id: false,
+        timestamp: null,
+        hasAttemptedSubmit: false,
+      },
+      createdAt: date,
+      expiresAt: getUnixTime(add(new Date(), { days: 30 })),
+      lastUpdated: date,
+      inProgressFormId: 460,
+    },
+  };
+}
+
+/**
+ * Set up a Cypress E2E test to mock an in-progress form. This function sets up
+ * the API intercepts for the `/user` and `/in_progress_forms` endpoints, and
+ * then logs in the mock user because the in progress form array needs to
+ * include the form ID to work
+ * @param {*} formConfig - The form config object, we really only need the
+ *  formId and version from it
+ * @param {string} returnUrl - The URL to return to to continue the form flow
+ * @param {Object} data - The form data to use in the in-progress form
+ * @param {Object} user - The user object to use in the mock user response
+ */
+export const setupInProgressReturnUrl = ({
+  formConfig = {},
+  returnUrl = '',
+  data = {},
+  user = {},
+}) => {
+  const { formId, version } = formConfig;
+
+  if (!formId) {
+    throw new Error('formId is required to set up in-progress return URL');
+  }
+
+  const userData = set(
+    'data.attributes.inProgressForms',
+    [
+      {
+        form: formId,
+        metadata: inProgressMock({ version }).metadata,
+        lastUpdated: 1715357232,
+      },
+    ],
+    user,
+  );
+
+  cy.intercept('GET', '/v0/user', userData).as('mockUser');
+
+  cy.intercept(
+    'GET',
+    `/v0/in_progress_forms/${formId}`,
+    inProgressMock({ data, returnUrl, version }),
+  );
+
+  cy.login(userData);
 };

--- a/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
@@ -82,13 +82,14 @@ export default function inProgressMock({ data, returnUrl, version } = {}) {
  * @param {*} formConfig - The form config object, we really only need the
  *  formId and version from it
  * @param {string} returnUrl - The URL to return to to continue the form flow
- * @param {Object} data - The form data to use in the in-progress form
+ * @param {Object} data - The form data to use in the in-progress form, but only
+ *  include fields before the returnUrl page
  * @param {Object} user - The user object to use in the mock user response
  */
 export const setupInProgressReturnUrl = ({
   formConfig = {},
   returnUrl = '',
-  data = {},
+  data = {}, // all previous page form data
   user = {},
 }) => {
   const { formId, version } = formConfig;

--- a/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/utilities.js
@@ -102,7 +102,7 @@ export const setupInProgressReturnUrl = ({
     [
       {
         form: formId,
-        metadata: inProgressMock({ version }).metadata,
+        metadata: inProgressMock({ returnUrl, version }).metadata,
         lastUpdated: 1715357232,
       },
     ],


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > To break up large (kitchen sink) e2e tests, we needed a simpler method to allow starting and stopping an e2e test at specific pages. This PR adds a new option, and set up function:
  > - `stopTestAfterPath` is a new property for the `createTestConfig` function. Setting it to a path within the the form will make the E2E test _stop_ at that page
  >     ```js
  >     createTestConfig(
  >       {
  >         appName: 'app',
  >         dataPrefix: 'data',
  >         dataDir: null,
  >         dataSets: [{ title: 'test chapter 2 & 3', data }],
  >         stopTestAfterPath: '/first-page-chapter-4', // Stop at chapter 3
  >         // ... other options
  >       }
  >     ```

  > - `setupInProgressReturnUrl` is a function that helps set up the in progress form to start at a specific page within the form flow. This function sets up the API intercepts for the `/user` and `/in_progress_forms` endpoints, and then logs in the mock user because the in progress form array needs to include the form ID to work
  >     ```js
  >     // setup Cypress intercepts
  >     cy.get('@testData').then(testData => {
  >       if (returnUrl) {
  >         // Set up in progress form to go to returnUrl on continuing a form
  >         // sets up GET `/v0/user` & GET `/v0/in_progress_forms/${formId}` intercepts
  >         // and logs in in the user
  >         setupInProgressReturnUrl({
  >           formConfig,
  >           returnUrl,
  >           data: testData,
  >           user: mockUser,
  >         });
  >       } else {
  >         cy.intercept('GET', `/v0/in_progress_forms/${formId}`, prefillResponse);
  >         cy.login(mockUser);
  >       }
  >       cy.intercept('PUT', `/v0/in_progress_forms/${formId}`, testData);
  >     });
  >     ```

- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > In progress forms need to include:
  > - user API data response has `inProgressForms` containing the form ID & in progress metadata
  > - in progress API data response includes form data and metadata
  > Without these specific details, you'll end up starting at the beginning of the form
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Lifestages/Pension Benefits Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/102196

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All end-to-end tests using the form tester

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
