### PR TITLE
Ask VA - Inquiry not found alert

### DIFF
--- a/src/applications/ask-va/containers/ResponseInboxPage.jsx
+++ b/src/applications/ask-va/containers/ResponseInboxPage.jsx
@@ -22,7 +22,6 @@ import {
   formatDate,
   getFiles,
   getVAStatusFromCRM,
-  ServerErrorAlert,
 } from '../config/helpers';
 import {
   envUrl,
@@ -194,10 +193,6 @@ const ResponseInboxPage = ({ router }) => {
       });
   };
 
-  const handleRetry = () => {
-    if (inquiryId) getApiData(`${envUrl}${URL.GET_INQUIRIES}/${inquiryId}`);
-  };
-
   useEffect(
     () => {
       if (inquiryId) getApiData(`${envUrl}${URL.GET_INQUIRIES}/${inquiryId}`);
@@ -214,10 +209,23 @@ const ResponseInboxPage = ({ router }) => {
 
   if (error) {
     return (
-      <VaAlert status="error" className="vads-u-margin-y--4">
-        <ServerErrorAlert />
-        <VaButton onClick={handleRetry} text="Retry" />
-      </VaAlert>
+      <>
+        <VaAlert status="error" className="vads-u-margin-y--4">
+          <h2
+            slot="headline"
+            className="vads-u-font-size--h3 vads-u-margin-y--0 vads-u-font-size--lg"
+          >
+            You can’t access this page
+          </h2>
+          <p className="vads-u-font-size--base vads-u-margin-bottom--0p5">
+            You can only access questions you asked on{' '}
+            <VaLink href="/" text="VA.gov" />.
+          </p>
+          <p className="vads-u-font-size--base vads-u-margin-top--0p5">
+            Please confirm your reference number is correct, and try again.
+          </p>
+        </VaAlert>
+      </>
     );
   }
 

--- a/src/applications/ask-va/containers/ResponseInboxPage.jsx
+++ b/src/applications/ask-va/containers/ResponseInboxPage.jsx
@@ -4,6 +4,7 @@ import {
   VaIcon,
   VaTextarea,
   VaLink,
+  VaTelephone,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
@@ -215,14 +216,13 @@ const ResponseInboxPage = ({ router }) => {
             slot="headline"
             className="vads-u-font-size--h3 vads-u-margin-y--0 vads-u-font-size--lg"
           >
-            You can’t access this page
+            We’ve run into a problem
           </h2>
-          <p className="vads-u-font-size--base vads-u-margin-bottom--0p5">
-            You can only access questions you asked on{' '}
-            <VaLink href="/" text="VA.gov" />.
-          </p>
-          <p className="vads-u-font-size--base vads-u-margin-top--0p5">
-            Please confirm your reference number is correct, and try again.
+          <p className="vads-u-font-size--base">
+            We’re sorry. Something went wrong on our end. Please try again later
+            or call us at <VaTelephone contact="800-698-2411" /> (
+            <VaTelephone contact="711" tty />
+            ). We’re here 24/7.
           </p>
         </VaAlert>
       </>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updating the alert on the Inquiry response page when an error occurs 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- Ticket: [1750](git push --set-upstream origin ASK-VA/1750-ResponseInbox-Alert)


## Testing done

- Manual testing done
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

<img width="856" alt="Screenshot 2025-04-22 at 9 53 40 AM" src="https://github.com/user-attachments/assets/3e5346e4-3000-4e99-8f5d-f157d8336c1d" />


## What areas of the site does it impact?

Only impacts the Ask VA form.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

