### PR TITLE
VEBT-1573: 22-1995 - Remove school section based on Rudisill answer

### DIFF
--- a/src/applications/edu-benefits/1995/config/chapters.js
+++ b/src/applications/edu-benefits/1995/config/chapters.js
@@ -214,6 +214,7 @@ export const chapters = {
         },
         uiSchema: newSchoolUiSchema(),
         schema: newSchoolSchema(),
+        depends: formData => formData?.rudisillReview !== 'Yes',
       },
     },
   },

--- a/src/applications/edu-benefits/1995/tests/config/form.unit.spec.jsx
+++ b/src/applications/edu-benefits/1995/tests/config/form.unit.spec.jsx
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import formConfig from '../../config/form';
+
+describe('Form 22-1995', () => {
+  describe('Chapter 4: School selection', () => {
+    const { chapters } = formConfig;
+    const { schoolSelection } = chapters;
+    const newSchoolPage = schoolSelection.pages.newSchool;
+
+    describe('depends function for rudisillReview', () => {
+      it('should return false if rudisillReview is "Yes"', () => {
+        const formData = { rudisillReview: 'Yes' };
+        expect(newSchoolPage.depends(formData)).to.be.false;
+      });
+
+      it('should return true if rudisillReview is "No"', () => {
+        const formData = { rudisillReview: 'No' };
+        expect(newSchoolPage.depends(formData)).to.be.true;
+      });
+
+      it('should return true if rudisillReview is not select (Rudisill feature toggle off)', () => {
+        const formData = { rudisillReview: undefined };
+        expect(newSchoolPage.depends(formData)).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- During chapter 2: `Education benefit` of the 22-1995 form, if the question `Do you wish to request a Rudisill review?` is answered as `Yes`, chapter 4: `School/training facility selection` should be skipped
- This will change the total number of steps on the form from 6 to 5, if applicable

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-1573

**As a...**

VEBT Developer

**I want…**

To remove school section based on Rudisill answer

**So that…**

1995 can reflect the latest updates

**Acceptance Criteria**

If Do you wish to request a Rudisill review? is answered YES, remove only STEP 4: School/training facility selection entirely. 

## Testing done

- Manual testing of form done for both Rudisill review choices as well as when the Rudisill feature toggle is turned off
- Verified form is able to be submitted with School/training facility section being hidden
- Unit tests were added for the `depends` for each case

![Unit Test Coverage](https://github.com/user-attachments/assets/035186e7-f464-4f72-8e79-cf5c404db4c3)

## Screenshots

**Before:**

![Rudisill Question (Before)](https://github.com/user-attachments/assets/66d78025-3cdb-4361-844e-6391b24a1c48)
![Step 4 (Before)](https://github.com/user-attachments/assets/cfc444ad-c028-4941-bce8-3dc533762e42)

**After:**

![Rudisill Question (After)](https://github.com/user-attachments/assets/f9e4926e-982c-4248-b2de-328fb7d25a7b)
![Step 4 (After)](https://github.com/user-attachments/assets/823f4b1a-4e2b-4416-addf-7a447ff35aa8)

## What areas of the site does it impact?

- 22-1995 Chapter 4: School/training facility selection

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
