### PR TITLE
Remove usage of friendlyName

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
@@ -30,12 +30,12 @@ describe('VAOS vaccine flow: ClinicChoicePage', () => {
   const clinic1 = createMockClinic({
     id: '308',
     stationId: '983',
-    friendlyName: 'Green team clinic',
+    name: 'Green team clinic',
   });
   const clinic2 = createMockClinic({
     id: '309',
     stationId: '983',
-    friendlyName: 'Red team clinic',
+    name: 'Red team clinic',
   });
   const clinics = [clinic1, clinic2];
 

--- a/src/applications/vaos/covid-19-vaccine/components/SelectDate1Page.unit.spec.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/SelectDate1Page.unit.spec.jsx
@@ -35,13 +35,13 @@ describe('VAOS vaccine flow: SelectDate1Page', () => {
   const clinic1 = createMockClinic({
     id: '308',
     stationId: '983',
-    friendlyName: 'Green team clinic',
+    name: 'Green team clinic',
   });
 
   const clinic2 = createMockClinic({
     id: '309',
     stationId: '983',
-    friendlyName: 'Red team clinic',
+    name: 'Red team clinic',
   });
   const clinics = [clinic1, clinic2];
 

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -60,12 +60,12 @@ function setDateTimeSelectMockFetchesBase({
   const clinic1 = createMockClinic({
     id: '308',
     stationId: '983',
-    friendlyName: 'Green team clinic',
+    name: 'Green team clinic',
   });
   const clinic2 = createMockClinic({
     id: '309',
     stationId: '983',
-    friendlyName: 'Red team clinic',
+    name: 'Red team clinic',
   });
   const clinics = [clinic1, clinic2];
 

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.jsx
@@ -119,12 +119,12 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
           createMockClinic({
             id: '308',
             stationId: '983',
-            friendlyName: 'Green team clinic',
+            name: 'Green team clinic',
           }),
           createMockClinic({
             id: '309',
             stationId: '983',
-            friendlyName: 'Red team clinic',
+            name: 'Red team clinic',
           }),
         ],
         requestPastVisits: false,
@@ -161,7 +161,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
           createMockClinic({
             id: '308',
             stationId: '983',
-            friendlyName: 'Green team clinic',
+            name: 'Green team clinic',
           }),
         ],
         limit: false,

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -291,7 +291,7 @@ export function transformVAOSAppointment(
       vistaId: appt.locationId?.substr(0, 3) || null,
       clinicId: appt.clinic,
       stationId: appt.locationId,
-      clinicName: appt.friendlyName || appt.serviceName || null,
+      clinicName: appt.serviceName || null,
       clinicPhysicalLocation: appt.physicalLocation || null,
       clinicPhone: appt.extension?.clinic?.phoneNumber || null,
       clinicPhoneExtension:

--- a/src/applications/vaos/services/appointment/types.js
+++ b/src/applications/vaos/services/appointment/types.js
@@ -64,7 +64,7 @@
  * @property {string} clinicId The VistA clinic id for the appointment. Only applies to in person VA appointments
  * - Mapped from vaAppointment.clinicId
  * @property {string} clinicName The VistA clinic name for the appointment. Only applies to in person VA appointments
- * - Mapped from vaAppointment.clinicFriendlyName, with fallback to vaAppointment.vdsAppointments[0].clinic.name
+ * - Mapped from vaAppointment.serviceName
  */
 
 /**
@@ -189,7 +189,7 @@
  * @property {string} actor.reference Mapped to HealthcareService/${appointment.facilityId}_${appointment.clinicId}
  *
  * Clinics are uniquely identified by a combination of the VistA site/instance id and the clinic id
- * @property {string} actor.display Clinic name, mapped from appointment.clinicFriendlyName or appointment.vdsAppointments[0].clinic.name
+ * @property {string} actor.display Clinic name, mapped from appointment.serviceName
  */
 
 /**

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -98,7 +98,6 @@
         "localStartTime": "2023-10-13T09:00:00.000-06:00",
         "avsPath": "Error retrieving AVS link",
         "serviceName": "CHY MENTAL HEALTH ONE",
-        "friendlyName": "CHY MENTAL HEALTH ONE",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -215,7 +214,6 @@
         "localStartTime": "2023-10-13T09:00:00.000-06:00",
         "avsPath": null,
         "serviceName": "CHY MENTAL HEALTH ONE",
-        "friendlyName": "CHY MENTAL HEALTH ONE",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -331,7 +329,6 @@
         },
         "localStartTime": "2023-10-13T09:00:00.000-06:00",
         "serviceName": "CHY MENTAL HEALTH ONE",
-        "friendlyName": "CHY MENTAL HEALTH ONE",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -460,7 +457,6 @@
         "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988639578151",
         "serviceName": "CHY PC CASSIDY",
         "physicalLocation": "ARROWHEAD WING, 2ND FLOOR",
-        "friendlyName": "CHY PC CASSIDY",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -909,7 +905,7 @@
         "requestedPeriods": null,
         "cancellable": false,
         "clinic": "some string",
-        "friendlyName": "clinic friendly name",
+        "serviceName": "clinic friendly name",
         "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
         "extension": {
           "ccLocation": {
@@ -1066,7 +1062,6 @@
         "ien": "5658",
         "avsPath": null,
         "serviceName": "MID-V10 CRH MH PSY MD PT",
-        "friendlyName": "MID-V10 CRH MH PSY MD PT",
         "location": {
           "id": "984GA",
           "type": "appointments",
@@ -1451,7 +1446,6 @@
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
-        "friendlyName": "C&P BEV AUDIO FTC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -1544,7 +1538,6 @@
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
-        "friendlyName": "C&P BEV AUDIO FTC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -1637,7 +1630,6 @@
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
-        "friendlyName": "C&P BEV AUDIO FTC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -1730,7 +1722,6 @@
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
-        "friendlyName": "C&P BEV AUDIO FTC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -2338,7 +2329,6 @@
         },
         "localStartTime": "2024-12-01T08:00:00.000-06:00",
         "serviceName": "COVID VACCINE CLIN1",
-        "friendlyName": "COVID VACCINE CLIN1",
         "physicalLocation": "MHC",
         "location": {
           "id": "983",
@@ -2609,7 +2599,6 @@
         },
         "localStartTime": "2024-12-01T09:00:00.000-06:00",
         "serviceName": "COVID VACCINE CLIN1",
-        "friendlyName": "COVID VACCINE CLIN1",
         "physicalLocation": "MHC",
         "location": {
           "id": "983",
@@ -2749,7 +2738,6 @@
         },
         "localStartTime": "2025-12-05T13:00:00.000-05:00",
         "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
         "physicalLocation": "DAYTSHR PHONE Provider",
         "location": {
           "id": "984",
@@ -2872,7 +2860,6 @@
         },
         "localStartTime": "2025-12-05T14:00:00.000-05:00",
         "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
         "physicalLocation": "DAYTSHR PHONE Provider",
         "location": {
           "id": "984",
@@ -3101,7 +3088,6 @@
         },
         "localStartTime": "2024-12-19T08:40:00.000-07:00",
         "serviceName": "C&P BEV AUDIO FTC",
-        "friendlyName": "C&P BEV AUDIO FTC",
         "physicalLocation": "FORT COLLINS AUDIO",
         "location": {
           "id": "983GC",
@@ -3982,7 +3968,6 @@
         "station": "984",
         "ien": "9700",
         "serviceName": "DAY NUTRITION",
-        "friendlyName": "DAY NUTRITION",
         "physicalLocation": "B330, 1E-151",
         "location": {
           "id": "984",
@@ -4280,7 +4265,6 @@
         "localStartTime": "2025-01-14T08:00:00.000-05:00",
         "avsPath": null,
         "serviceName": "MID-V10 CRH MH PSY MD PT",
-        "friendlyName": "MID-V10 CRH MH PSY MD PT",
         "location": {
           "id": "984GA",
           "type": "appointments",
@@ -4411,7 +4395,6 @@
         "localStartTime": "2025-01-14T09:00:00.000-05:00",
         "avsPath": null,
         "serviceName": "MID-V10 CRH MH PSY MD PT",
-        "friendlyName": "MID-V10 CRH MH PSY MD PT",
         "location": {
           "id": "984GA",
           "type": "appointments",
@@ -4734,7 +4717,6 @@
         },
         "localStartTime": "2025-02-25T10:25:00.000-06:00",
         "serviceName": "VISUAL FIELD",
-        "friendlyName": "VISUAL FIELD",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -4874,7 +4856,6 @@
         },
         "localStartTime": "2025-03-25T11:25:00.000-06:00",
         "serviceName": "VISUAL FIELD",
-        "friendlyName": "VISUAL FIELD",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -5014,7 +4995,6 @@
         },
         "localStartTime": "2025-03-25T10:25:00.000-06:00",
         "serviceName": "VISUAL FIELD",
-        "friendlyName": "VISUAL FIELD",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -5176,7 +5156,6 @@
         "patientComments": "123Test",
         "reasonForAppointment": "Routine/Follow-up",
         "serviceName": "",
-        "friendlyName": "",
         "physicalLocation": "NONE",
         "location": {
           "id": "983GC",

--- a/src/applications/vaos/services/mocks/v2/confirmed_null_states.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed_null_states.json
@@ -79,7 +79,6 @@
         "localStartTime": "2024-09-20T17:00:00.000-06:00",
         "serviceName": "YOUR FRIENDLY MH CLINIC",
         "physicalLocation": "PHYSICAL LOCATIION TESTING",
-        "friendlyName": "YOUR FRIENDLY MH CLINIC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -191,7 +190,6 @@
         "localStartTime": "2024-05-20T17:00:00.000-06:00",
         "serviceName": "YOUR FRIENDLY MH CLINIC",
         "physicalLocation": "PHYSICAL LOCATIION TESTING",
-        "friendlyName": "YOUR FRIENDLY MH CLINIC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -502,7 +500,6 @@
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
-        "friendlyName": "C&P BEV AUDIO FTC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -596,7 +593,6 @@
         },
         "serviceName": "FTC C&P AUDIO BEV",
         "physicalLocation": "FORT COLLINS AUDIO",
-        "friendlyName": "C&P BEV AUDIO FTC",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -876,7 +872,6 @@
         "localStartTime": "2025-02-25T12:00:00.000-07:00",
         "physicalLocation": "CHYSHR VIDEO Provider",
         "serviceName": "CHY HEALTH ONE",
-        "friendlyName": "CHY HEALTH ONE",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -993,7 +988,6 @@
         "localStartTime": "2024-06-25T12:00:00.000-07:00",
         "physicalLocation": "CHYSHR VIDEO Provider",
         "serviceName": "CHY HEALTH ONE",
-        "friendlyName": "CHY HEALTH ONE",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -1473,7 +1467,6 @@
         },
         "localStartTime": "2024-12-05T13:00:00.000-05:00",
         "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
         "physicalLocation": "DAYTSHR PHONE Provider",
         "location": {
           "id": "984",
@@ -1595,7 +1588,6 @@
         },
         "localStartTime": "2024-05-05T13:00:00.000-05:00",
         "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
         "physicalLocation": "DAYTSHR PHONE Provider",
         "location": {
           "id": "984",
@@ -2248,7 +2240,6 @@
         },
         "localStartTime": "2024-12-01T08:00:00.000-07:00",
         "serviceName": "ATLAS satellite",
-        "friendlyName": "ATLAS satellite",
         "location": {
           "id": "983",
           "type": "appointments",
@@ -2378,7 +2369,6 @@
         },
         "localStartTime": "2024-06-01T08:00:00.000-07:00",
         "serviceName": "ATLAS satellite",
-        "friendlyName": "ATLAS satellite",
         "location": {
           "id": "983",
           "type": "appointments",

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -86,23 +86,17 @@ export function createMockAppointment({
  * @param {string} params.id Clinic id
  * @param {string} params.stationId Full location id (sta6aid)
  * @param {?string} params.name Standard clinic name,
- * @param {?string} params.friendlyName Friendly clinic name,
  *
  * @returns {VAOSClinic} A mock clinic object
  */
-export function createMockClinic({
-  id = null,
-  stationId = null,
-  name = null,
-  friendlyName = null,
-}) {
+export function createMockClinic({ id = null, stationId = null, name = null }) {
   return {
     id,
     type: 'clinics',
     attributes: {
       vistaSite: stationId.substr(0, 3),
       id,
-      serviceName: friendlyName || name,
+      serviceName: name,
       physicalLocation: null,
       phoneNumber: null,
       stationId,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Vets-api will be updated to only return serviceName so this PR updates vets-website to use that field instead and remove all references to the friendlyName field.
- Appointments Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108275

## Testing done

- Tested locally
- Ensured existing unit tests pass 

## Screenshots

N/A there's no visible change for this PR

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

