### PR TITLE
cleans up mhv feature toggle

### DIFF
--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -64,7 +64,7 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
                 >
                   DS Logon sign-in option
                   <span className="vads-u-display--block vads-u-font-size--md vads-u-font-family--sans">
-                    'Available through September 30, 2025'
+                    Available through September 30, 2025
                   </span>
                 </h3>
                 <p>

--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -1,14 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { externalApplicationsConfig } from '../usip-config';
 import { reduceAllowedProviders, getQueryParams } from '../utilities';
 import LoginButton from './LoginButton';
 
 export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
-  const mhvButtonDeprecated = useSelector(
-    state => state?.featureToggles?.mhvCredentialButtonDisabled,
-  );
   const [useOAuth, setOAuth] = useState();
   const { OAuth, clientId, codeChallenge, state } = getQueryParams();
   const {
@@ -28,7 +24,6 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
 
   const actionLocation = isUnifiedSignIn ? 'usip' : 'modal';
   const isValid = mhv || dslogon;
-  const mhvButtonShouldDisplay = mhvButtonDeprecated;
 
   return (
     <div className="row">
@@ -47,47 +42,20 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
         </a>
         {isValid && (
           <div>
+            {/* Remove this hardcoded message for MHV */}
             <h2>Other sign-in options</h2>
-            {!mhvButtonShouldDisplay && (
-              <>
-                <h3 id="mhvH3">
-                  My HealtheVet sign-in option
-                  <span className="vads-u-display--block vads-u-font-size--md vads-u-font-family--sans">
-                    Available through March 4, 2025
-                  </span>
-                </h3>
-                <p>
-                  You’ll still be able to use the <strong>My HealtheVet</strong>{' '}
-                  website after this date. You’ll just need to start signing in
-                  with a <strong>Login.gov</strong> or <strong>ID.me</strong>{' '}
-                  account.
-                </p>
-                <LoginButton
-                  csp="mhv"
-                  useOAuth={useOAuth}
-                  ariaDescribedBy="mhvH3"
-                  actionLocation={actionLocation}
-                />
-                <va-link
-                  text="Learn how to access your benefits and set up your new account"
-                  href="/resources/what-to-do-if-you-havent-switched-to-logingov-or-idme-yet"
-                />
-              </>
-            )}
-            {mhvButtonDeprecated && (
-              <div>
-                <h3 id="mhvH3" className="vads-u-margin-top--3">
-                  My HealtheVet sign-in option
-                  <span className="vads-u-display--block vads-u-font-size--md vads-u-font-family--sans">
-                    This option is no longer available
-                  </span>
-                </h3>
-                <va-link
-                  text="Learn how to access your benefits and set up your new account"
-                  href="/resources/what-to-do-if-you-havent-switched-to-logingov-or-idme-yet"
-                />
-              </div>
-            )}
+            <div>
+              <h3 id="mhvH3" className="vads-u-margin-top--3">
+                My HealtheVet sign-in option
+                <span className="vads-u-display--block vads-u-font-size--md vads-u-font-family--sans">
+                  This option is no longer available
+                </span>
+              </h3>
+              <va-link
+                text="Learn how to access your benefits and set up your new account"
+                href="/resources/what-to-do-if-you-havent-switched-to-logingov-or-idme-yet"
+              />
+            </div>
             {dslogon && (
               <>
                 <h3
@@ -96,9 +64,7 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
                 >
                   DS Logon sign-in option
                   <span className="vads-u-display--block vads-u-font-size--md vads-u-font-family--sans">
-                    {mhvButtonDeprecated
-                      ? 'We’ll remove this option after September 30, 2025'
-                      : 'Available through September 30, 2025'}
+                    'Available through September 30, 2025'
                   </span>
                 </h3>
                 <p>

--- a/src/platform/user/tests/authentication/components/loginActions.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/loginActions.unit.spec.jsx
@@ -10,10 +10,10 @@ import { CSP_IDS } from '../../../authentication/constants';
 
 describe('login DOM ', () => {
   const sandbox = sinon.createSandbox();
-  const generateStore = ({ featureToggles = {} } = {}) => ({
+  const generateStore = () => ({
     dispatch: sinon.spy(),
     subscribe: sinon.spy(),
-    getState: () => ({ featureToggles }),
+    getState: () => ({}),
   });
   const mockStore = generateStore();
 
@@ -39,7 +39,6 @@ describe('login DOM ', () => {
         idme: { policy: CSP_IDS.ID_ME },
         logingov: { policy: CSP_IDS.LOGIN_GOV },
         dslogon: { policy: CSP_IDS.DS_LOGON },
-        mhv: { policy: CSP_IDS.MHV },
       };
 
       button.simulate('click');
@@ -55,50 +54,36 @@ describe('login DOM ', () => {
     loginButtons.find('button').forEach(testButton);
     loginButtons.unmount();
   });
+  it('sets actionLocation to "usip" when isUnifiedSignIn is true and "modal" otherwise', () => {
+    const testActionLocation = (isUnifiedSignIn, expectedLocation) => {
+      const store = {
+        dispatch: sinon.spy(),
+        subscribe: sinon.spy(),
+        getState: () => ({}),
+      };
 
-  it(`should render 3 buttons when flipper is enabled`, () => {
-    global.window.location = new URL(
-      'https://dev.va.gov/sign-in/?application=vaoccmobile',
-    );
-    const store = generateStore({
-      featureToggles: { mhvCredentialButtonDisabled: true },
-    });
-    const loginButtons = mount(
-      <Provider store={store}>
-        <LoginActions externalApplication="vaoccmobile" isUnifiedSignIn />
-      </Provider>,
-    );
-    expect(loginButtons.find('button').length).to.eql(3);
-    loginButtons.unmount();
-  });
+      global.window.location = new URL(
+        'https://dev.va.gov/sign-in/?application=vaoccmobile&OAuth=true',
+      );
 
-  it(`should render 4 buttons when flipper is false`, () => {
-    global.window.location = new URL(
-      'https://dev.va.gov/sign-in/?application=mhv',
-    );
-    const store = generateStore({
-      featureToggles: { mhvCredentialButtonDisabled: false },
-    });
-    const loginButtons = mount(
-      <Provider store={store}>
-        <LoginActions externalApplication="mhv" />
-      </Provider>,
-    );
-    expect(loginButtons.find('button').length).to.eql(4);
-    loginButtons.unmount();
-  });
+      const wrapper = mount(
+        <Provider store={store}>
+          <LoginActions
+            externalApplication="vaoccmobile"
+            isUnifiedSignIn={isUnifiedSignIn}
+          />
+        </Provider>,
+      );
 
-  it(`should use fallback when featureToggles not found`, () => {
-    global.window.location = new URL(
-      'https://dev.va.gov/sign-in/?application=mhv',
-    );
-    const store = generateStore({ featureToggles: {} });
-    const loginButtons = mount(
-      <Provider store={store}>
-        <LoginActions externalApplication="mhv" />
-      </Provider>,
-    );
-    expect(loginButtons.find('button').length).to.eql(4);
-    loginButtons.unmount();
+      wrapper.find('LoginButton').forEach(button => {
+        expect(button.prop('actionLocation')).to.equal(expectedLocation);
+      });
+
+      wrapper.unmount();
+    };
+
+    testActionLocation(true, 'usip');
+    testActionLocation(false, 'modal');
+    testActionLocation(undefined, 'modal'); // also test default
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Clean up ```LoginActions``` component to remove MHV feature toggle from MHV deprecation. The deprecation is complete so it is no longer needed.

## Related issue(s)

[GitHub Projects ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/24)

## Testing done

- Unit tests were updated and passing at 100%

## Screenshots

![Screenshot 2025-04-24 at 7 38 05 AM](https://github.com/user-attachments/assets/19a9d274-7f79-437e-b92d-1d9e8a895553)

## What areas of the site does it impact?

- Login Modal
- Unified sign-in page

## Acceptance criteria

- remove ```mhvButtonDeprecated``` feature toggle and related code
- update unit tests

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
