### PR TITLE
Remove leave feedback link in Need help section

### DIFF
--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -35,11 +35,6 @@ export default function NeedHelp() {
         (<VaTelephone contact="711" tty />
         ). We’re here 24/7.
       </p>
-      <p className="vads-u-margin-top--0">
-        <a href="https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE">
-          Leave feedback about this application
-        </a>
-      </p>
     </div>
   );
 }

--- a/src/applications/vaos/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/vaos/components/NeedHelp.unit.spec.jsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import NeedHelp from './NeedHelp';
 
 describe('VAOS Component: NeedHelp', () => {
-  it('should show contact information and feedback link', () => {
+  it('should show contact information', () => {
     const screen = render(<NeedHelp />);
 
     expect(screen.getByRole('heading', { level: 2, name: /need help/i })).to
@@ -16,12 +16,5 @@ describe('VAOS Component: NeedHelp', () => {
     expect(
       screen.getByRole('link', { name: /find your health facility/i }),
     ).to.have.attribute('href', '/find-locations');
-    expect(
-      screen.getByRole('link', { name: /leave feedback/i }),
-    ).to.have.attribute(
-      'href',
-      'https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE',
-    );
-    expect(screen.getByText(/We’re here 24\/7/i)).to.exist;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removing leave feedback link as user should use the sitewide feedback button instead.
- Appointments Team
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108032

## Testing done

- Tested locally, see screenshots
- Updated unit test

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    ![image](https://github.com/user-attachments/assets/b8b474aa-d8b7-4679-a02a-3045196a5f6c)   |   ![image](https://github.com/user-attachments/assets/80d3a338-5a24-4ca1-b599-fa04cbbef028)   |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

