### PR TITLE
Global | Fix CurrencyField to parse scientific notation 

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/CurrencyField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/CurrencyField.jsx
@@ -3,21 +3,10 @@ import PropTypes from 'prop-types';
 
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import vaTextInputFieldMapping from './vaTextInputFieldMapping';
+import { parseNumber } from '../web-component-patterns/numberPattern';
 
-export function coerceStringValue(possibleString) {
-  return typeof possibleString !== 'string'
-    ? possibleString.toString()
-    : possibleString;
-}
-
-export function parseCurrencyString(currencyString = '') {
-  const stringValue = coerceStringValue(currencyString);
-  const value = parseFloat(stringValue.replace(/[^\d.-]/g, ''));
-  if (isNaN(value)) {
-    return undefined;
-  }
-  return Math.round(value * 100) / 100;
-}
+export const CURRENCY_REGEXP = /^[0-9,]*(\.\d*)?$/;
+export const CURRENCY_PATTERN = '^\\d*(\\.\\d{1,2})?$'; // for schemas
 
 /**
  * Use a currencyPattern instead of this.
@@ -32,32 +21,49 @@ export default function CurrencyField(fieldProps) {
   const { uiOptions } = fieldProps;
   const schemaType = fieldProps.childrenProps?.schema.type || 'number';
 
-  const [val, setVal] = useState(parseCurrencyString(props.value));
   const [displayVal, setDisplayVal] = useState(props.value);
   const className = `${props.class || ''} currency-field`;
 
-  const handleChange = event => {
+  const handleInput = event => {
     const { value } = event.target;
-    const parsedValue = parseCurrencyString(value);
-    setVal(parsedValue);
     setDisplayVal(value);
-    const dataValue = schemaType === 'number' ? parsedValue : value;
+    props.onChange(value);
+  };
+
+  const handleBlur = event => {
+    const { value } = event.target;
+    setDisplayVal(value);
 
     // Not using props.onInput because in the vaTextInputFieldMapping onInput
     // callback, it uses `value || event.target.value;` and sets the value to
     // undefined. I found that if you enter "--" in the input, the input will
     // highlight like there's an error, but no error message will show.
     // Returning null will show the error message
-    props.onChange(typeof parsedValue === 'undefined' ? null : dataValue);
-  };
+    if (value === '' || typeof value === 'undefined') {
+      props.onChange();
+      // Needs to look like a currency
+    } else if (!CURRENCY_REGEXP.test(value)) {
+      props.onChange(value);
+    } else {
+      // Needs to parse as a number
+      const parsedValue = parseNumber(value);
+      if (!isNaN(parsedValue)) {
+        const roundedValue = Math.round(parsedValue * 100) / 100;
+        const roundedString = roundedValue.toFixed(2);
+        setDisplayVal(roundedString);
+        props.onChange(schemaType === 'number' ? roundedValue : roundedString);
+      } else {
+        props.onChange(value);
+      }
+    }
 
-  const handleBlur = () => {
-    setDisplayVal(val);
     props.onBlur(props.name);
   };
 
   const handleFocus = () => {
-    setDisplayVal(val);
+    setDisplayVal(
+      typeof props.value === 'number' ? props.value.toFixed(2) : props.value,
+    );
   };
 
   // Not using currency property because inside the web component, it switches
@@ -74,7 +80,7 @@ export default function CurrencyField(fieldProps) {
       class={className}
       value={displayVal}
       showInputError
-      onInput={handleChange}
+      onInput={handleInput}
       onBlur={handleBlur}
       onFocus={handleFocus}
     />

--- a/src/platform/forms-system/src/js/web-component-patterns/currencyPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/currencyPattern.jsx
@@ -1,4 +1,6 @@
-import CurrencyField from '../web-component-fields/CurrencyField';
+import CurrencyField, {
+  CURRENCY_PATTERN,
+} from '../web-component-fields/CurrencyField';
 import CurrencyWidget from '../review/CurrencyWidget';
 
 import { minMaxValidation } from './numberPattern';
@@ -40,12 +42,19 @@ import { minMaxValidation } from './numberPattern';
  * @returns {UISchemaOptions}
  */
 export const currencyUI = options => {
-  const { title, description, errorMessages, min, max, ...uiOptions } =
-    typeof options === 'object' ? options : { title: options };
+  const {
+    title,
+    description,
+    errorMessages,
+    min = 0,
+    // large numbers converted to scientific notation; so add limit
+    max = 999999999,
+    ...uiOptions
+  } = typeof options === 'object' ? options : { title: options };
 
   let validations = {};
 
-  if (min !== undefined || max !== undefined) {
+  if (typeof min !== 'undefined' || typeof max !== 'undefined') {
     validations = {
       'ui:validations': [minMaxValidation(min, max)],
     };
@@ -60,10 +69,15 @@ export const currencyUI = options => {
     // the input for a11y reasons, one of which is that its easy to accidentally
     // scroll on
     'ui:webComponentField': CurrencyField,
-    'ui:options': uiOptions,
+    'ui:options': { ...uiOptions, min, max },
     'ui:errorMessages': {
       required: 'Enter an amount',
       pattern: 'Enter a valid dollar amount',
+      // error shows when CurrencyField is expecting a number & gets a string
+      type: 'Enter a valid dollar amount',
+      min:
+        typeof min !== 'undefined' ? `Enter a number greater than ${min}` : '',
+      max: typeof max !== 'undefined' ? `Enter a number less than ${max}` : '',
       ...errorMessages,
     },
     'ui:reviewWidget': CurrencyWidget,
@@ -80,10 +94,10 @@ export const currencyUI = options => {
  */
 export const currencySchema = {
   type: 'number',
-  pattern: '^\\d+(\\.\\d{1,2})?$',
+  pattern: CURRENCY_PATTERN,
 };
 
 export const currencyStringSchema = {
   type: 'string',
-  pattern: '^\\d+(\\.\\d{1,2})?$',
+  pattern: CURRENCY_PATTERN,
 };

--- a/src/platform/forms-system/src/js/web-component-patterns/numberPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/numberPattern.jsx
@@ -1,15 +1,23 @@
 import VaTextInputField from '../web-component-fields/VaTextInputField';
 
+// Suppor negative numbers and scientific notation
+export const NUMBER_PARSE_REGEXP = /[^0-9.e+-]/g;
+
+export const parseNumber = value =>
+  parseFloat((value || '').toString().replace(NUMBER_PARSE_REGEXP, ''));
+
 export function minMaxValidation(min, max) {
   return (errors, formData, uiSchema, schema, errorMessages) => {
-    const value = parseInt(formData, 10);
+    // formData could be a number or string, make sure not to strip out
+    // scientific notation before parsing & comparing to min and max
+    const value = parseNumber(formData);
 
     let defaultErrorMessage = `Enter a number between ${min} and ${max}`;
-    if (min !== undefined && max === undefined) {
+    if (typeof min !== 'undefined' && typeof max === 'undefined') {
       defaultErrorMessage = `Enter a number larger than ${
         min - 1 > 0 ? min - 1 : 0
       }`;
-    } else if (min === undefined && max !== undefined) {
+    } else if (typeof min === 'undefined' && typeof max !== 'undefined') {
       defaultErrorMessage = `Enter a number smaller than ${max + 1}`;
     }
 

--- a/src/platform/forms-system/src/js/web-component-tests/validations.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/web-component-tests/validations.unit.spec.jsx
@@ -1,11 +1,34 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { minMaxValidation } from '../web-component-patterns/numberPattern';
+import {
+  parseNumber,
+  minMaxValidation,
+} from '../web-component-patterns/numberPattern';
 import {
   symbolsValidation,
   emailValidation,
 } from '../web-component-patterns/emailPattern';
 import { validateNameSymbols } from '../web-component-patterns/fullNamePattern';
+
+describe('parseNumber', () => {
+  it('should parse a number string', () => {
+    expect(parseNumber('123.45')).to.equal(123.45);
+  });
+
+  it('should return same number (not a string)', () => {
+    expect(parseNumber(345.67)).to.equal(345.67);
+    expect(parseNumber(1.2345e2)).to.equal(123.45);
+  });
+
+  it('should parse a scientific notation string', () => {
+    expect(parseNumber('1.23e+2')).to.equal(123);
+  });
+
+  it('should return NaN for an invalid number or empty string', () => {
+    expect(parseNumber('abc')).to.be.NaN;
+    expect(parseNumber('')).to.be.NaN;
+  });
+});
 
 describe('minMaxValidation', () => {
   it('should add an error if the number is less than the minimum range', () => {
@@ -22,9 +45,33 @@ describe('minMaxValidation', () => {
     expect(errors.addError.calledWith(errorMessages.min)).to.be.true;
   });
 
+  it('should add an error if the number is in scientific notation and less than the minimum range', () => {
+    const errors = { addError: sinon.stub() };
+    const formData = '-2.34e+10';
+    const min = 1;
+    const max = 10;
+    const errorMessages = { min: `Enter a number greater than ${min}` };
+
+    const validation = minMaxValidation(min, max);
+    validation(errors, formData, null, null, errorMessages);
+    expect(errors.addError.calledWith(errorMessages.min)).to.be.true;
+  });
+
   it('should add an error if the number is greater than the maximum range', () => {
     const errors = { addError: sinon.stub() };
     const formData = '11';
+    const min = 3;
+    const max = 10;
+    const errorMessages = { max: `Enter a number between ${min} and ${max}` };
+
+    const validation = minMaxValidation(min, max);
+    validation(errors, formData, null, null, errorMessages);
+    expect(errors.addError.calledWith(errorMessages.max)).to.be.true;
+  });
+
+  it('should add an error if the number is in scientific notation and greater than the maximum range', () => {
+    const errors = { addError: sinon.stub() };
+    const formData = '4.5e+10';
     const min = 3;
     const max = 10;
     const errorMessages = { max: `Enter a number between ${min} and ${max}` };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Update Currency UI web component to
  > - properly parse scientific notation
  > - Include the 2 digits after the decimal (when saving numeric strings)
  > - Add unit tests
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/107683

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Currency behavior | ![before change scientific notation exponentiation would be ignored so 1.2e2 would become 1.2](https://github.com/user-attachments/assets/9269d0af-ee38-4dd1-a09e-4e986b8c461b) | ![after scientific notation is now properly parsed and shows an error message for large numbers](https://github.com/user-attachments/assets/8f9ea4ac-8ceb-4a94-b58b-32f7efebe3df) |

## What areas of the site does it impact?

Any apps using the new CurrencyUI

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
