### PR TITLE
Dbex 0781ps behavior page titles bugfix

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -189,13 +189,13 @@ export function titleWithTag(title, headingTag) {
 
 export function behaviorDescriptionPagesTitleWithTag(title, headingTag) {
   return (
-    <div role="group">
-      <h3 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-margin--0">
-        {`${headingTag} `}
-      </h3>
-      <h3 className="vads-u-font-size--h3 vads-u-color--base vads-u-margin--0">
+    <h3 role="group" className="vads-u-margin--0">
+      <span className="vads-u-display--block vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+        {`${headingTag}`}
+      </span>
+      <span className="vads-u-display--block vads-u-font-size--h3 vads-u-color--base">
         {title}
-      </h3>
-    </div>
+      </span>
+    </h3>
   );
 }

--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -186,3 +186,16 @@ export function titleWithTag(title, headingTag) {
     </>
   );
 }
+
+export function behaviorDescriptionPagesTitleWithTag(title, headingTag) {
+  return (
+    <div role="group">
+      <h3 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-margin--0">
+        {`${headingTag} `}
+      </h3>
+      <h3 className="vads-u-font-size--h3 vads-u-color--base vads-u-margin--0">
+        {title}
+      </h3>
+    </div>
+  );
+}

--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -186,16 +186,3 @@ export function titleWithTag(title, headingTag) {
     </>
   );
 }
-
-export function behaviorDescriptionPagesTitleWithTag(title, headingTag) {
-  return (
-    <h3 role="group" className="vads-u-margin--0">
-      <span className="vads-u-display--block vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
-        {`${headingTag}`}
-      </span>
-      <span className="vads-u-display--block vads-u-font-size--h3 vads-u-color--base">
-        {title}
-      </span>
-    </h3>
-  );
-}

--- a/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/behaviorListPages.jsx
@@ -263,7 +263,7 @@ function getDescriptionForBehavior(selectedBehaviors, behaviorDetails) {
           ? BEHAVIOR_LIST_SECTION_SUBTITLES.other
           : allBehaviorDescriptions[behaviorType];
       newObject[behaviorDescription] =
-        behaviorDetails[behaviorType] || 'Optional description not provided.';
+        behaviorDetails?.[behaviorType] || 'Optional description not provided.';
     }
   });
   return newObject;

--- a/src/applications/disability-benefits/all-claims/pages/form0781/behaviorDescriptions.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/behaviorDescriptions.js
@@ -14,7 +14,7 @@ import {
   behaviorDescriptionPageHint,
 } from '../../content/form0781/behaviorListPages';
 import {
-  behaviorDescriptionPagesTitleWithTag,
+  titleWithTag,
   form0781HeadingTag,
   mentalHealthSupportAlert,
 } from '../../content/form0781';
@@ -26,7 +26,7 @@ import {
  */
 function makeUiSchema(behaviorType) {
   return {
-    'ui:title': behaviorDescriptionPagesTitleWithTag(
+    'ui:title': titleWithTag(
       ALL_BEHAVIOR_CHANGE_DESCRIPTIONS[behaviorType],
       form0781HeadingTag,
     ),
@@ -35,6 +35,10 @@ function makeUiSchema(behaviorType) {
         title: behaviorDescriptionPageDescription,
         hint: behaviorDescriptionPageHint,
       }),
+    },
+    'ui:options': {
+      // title wrapped in a <fieldset> causes screenreader bug on these pages
+      forceDivWrapper: true,
     },
     'view:mentalHealthSupportAlert': {
       'ui:description': mentalHealthSupportAlert,

--- a/src/applications/disability-benefits/all-claims/pages/form0781/behaviorDescriptions.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/behaviorDescriptions.js
@@ -14,7 +14,7 @@ import {
   behaviorDescriptionPageHint,
 } from '../../content/form0781/behaviorListPages';
 import {
-  titleWithTag,
+  behaviorDescriptionPagesTitleWithTag,
   form0781HeadingTag,
   mentalHealthSupportAlert,
 } from '../../content/form0781';
@@ -26,7 +26,7 @@ import {
  */
 function makeUiSchema(behaviorType) {
   return {
-    'ui:title': titleWithTag(
+    'ui:title': behaviorDescriptionPagesTitleWithTag(
       ALL_BEHAVIOR_CHANGE_DESCRIPTIONS[behaviorType],
       form0781HeadingTag,
     ),

--- a/src/applications/disability-benefits/all-claims/pages/form0781/unlistedBehaviorDescriptionPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/unlistedBehaviorDescriptionPage.js
@@ -8,13 +8,16 @@ import {
   behaviorDescriptionPageHint,
 } from '../../content/form0781/behaviorListPages';
 import {
-  titleWithTag,
+  behaviorDescriptionPagesTitleWithTag,
   form0781HeadingTag,
   mentalHealthSupportAlert,
 } from '../../content/form0781';
 
 export const uiSchema = {
-  'ui:title': titleWithTag(unlistedPageTitle, form0781HeadingTag),
+  'ui:title': behaviorDescriptionPagesTitleWithTag(
+    unlistedPageTitle,
+    form0781HeadingTag,
+  ),
   behaviorsDetails: {
     unlisted: textareaUI({
       title: unlistedDescriptionPageDescription,

--- a/src/applications/disability-benefits/all-claims/pages/form0781/unlistedBehaviorDescriptionPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/unlistedBehaviorDescriptionPage.js
@@ -8,21 +8,22 @@ import {
   behaviorDescriptionPageHint,
 } from '../../content/form0781/behaviorListPages';
 import {
-  behaviorDescriptionPagesTitleWithTag,
+  titleWithTag,
   form0781HeadingTag,
   mentalHealthSupportAlert,
 } from '../../content/form0781';
 
 export const uiSchema = {
-  'ui:title': behaviorDescriptionPagesTitleWithTag(
-    unlistedPageTitle,
-    form0781HeadingTag,
-  ),
+  'ui:title': titleWithTag(unlistedPageTitle, form0781HeadingTag),
   behaviorsDetails: {
     unlisted: textareaUI({
       title: unlistedDescriptionPageDescription,
       hint: behaviorDescriptionPageHint,
     }),
+  },
+  'ui:options': {
+    // title wrapped in a <fieldset> causes screenreader bug
+    forceDivWrapper: true,
   },
   'view:mentalHealthSupportAlert': {
     'ui:description': mentalHealthSupportAlert,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
This PR adds the form library option `forceDivWrapper: true` to remove the fieldset from these pages, which was causing an extra group that the screenreader announced. [Platform documentation](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-about-schema-and-uischema#VAFormsLibrary-AboutschemaanduiSchema-ui:options)

While testing this, I also uncovered a bug when the summary page tries to find an attribute on an undefined behavior and added a safety operator to handle it.

- _(If bug, how to reproduce)_
Select at least two behavior types then navigate through the behavior type description pages with a screenreader. The first page gets announced correctly, but subsequent pages repeat the initial page title.

- _(What is the solution, why is this the solution)_
Removing the fieldset removes the extra group that the screenreader incorrectly announced.

- _(Which team do you work for, does your team own the maintenance of this component?)_
DBEX Team 2 Carbs
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
`sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/108127

## Testing done

- _Describe what the old behavior was prior to the change_
The incorrect behavior description page title was being read on screenreaders. Video in ticket.
- _Describe the steps required to verify your changes are working as expected_
Within the new 0781 flow, select at least two behavior types then navigate through the behavior type description pages with a screenreader. Verify that the correct title is read on each behavior type description page

- _Describe the tests completed and the results_
Manually tested with mac voiceover tool

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

BEFORE - video of bug on main (at 0:50, the wrong title is read on the second page)

https://github.com/user-attachments/assets/f66c2002-cea9-43b8-ae74-38938ba4e9b3


AFTER - video from this PR


https://github.com/user-attachments/assets/525012fb-6039-416f-858c-7fb1b139c195


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
When I first tried debugging this, I created a separate function for the behavior page titles based on the concurrent work going on with staging review bugs. One idea that worked was adding a "role=group" to the title to override how the screenreader was grouping the page and reading the incorrect title.

I switched to use a form library `forceDivWrapper: true` option in the ui:schema instead. If we need to include a `<fieldset>` I could go back to the previous strategy of adding a role.
