### PR TITLE
[DBEX] Heading focus and structure

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/OfficialReport.jsx
+++ b/src/applications/disability-benefits/all-claims/components/OfficialReport.jsx
@@ -30,6 +30,7 @@ export function shouldShowPoliceDataModal(event) {
 }
 
 const OfficialReport = props => {
+  const pageTitleRef = useRef(null);
   const formDomRef = useRef(null);
   const modalRef = useRef(null);
   const alertRef = useRef(null);
@@ -150,6 +151,17 @@ const OfficialReport = props => {
 
   return (
     <div>
+      <h3 tabIndex="-1" ref={pageTitleRef} className="sr-only">
+        <span>VA FORM 21-0781</span>{' '}
+        <span>
+          {isAdd && <>{props.title}</>}
+          {isEdit && (
+            <>
+              Edit event #{index + 1} {props.title.toLowerCase()} details
+            </>
+          )}
+        </span>
+      </h3>
       <div className="vads-u-margin-bottom--1">
         <VaAlert
           ref={alertRef}

--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -33,7 +33,7 @@ export const traumaticEventsExamples = (
           You experienced offensive comments about your body or sexual
           activities
         </li>
-        <li>You experienced unwanted sexual advances</li>
+        <li>You experienced repeated unwanted sexual advances</li>
         <li>
           You experienced someone touching or grabbing you against your will,
           including during hazing

--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -165,24 +165,33 @@ export const mentalHealthSupportAlert = () => {
 };
 
 /**
- * Create a title and headingTag for a page which will be passed into ui:title so that
- * they are grouped in the same legend
- * @param {string} title - the title for the page, which displays below the stepper
- * @param {string} headingTag - the headingTag for the page, which displays above the title
- * @returns {JSX.Element} markup with title and headingTag. example below.
+ * Generates a combined heading inside a <legend> element for use in a page title.
+ * This groups a heading tag (like a form identifier) and a page-specific title
+ * into a single semantic block, styled appropriately.
  *
- * <h3 class="...">VA FORM 21-0781</h3>
- * <h3 class="...">Mental health support</h3>
+ * @param {string} title - The main title for the page, typically describing the form section
+ * @param {string} headingTag - A label or identifier that appears above the title
+ * @returns {JSX.Element} A <legend> element containing a single <h3> with two styled <span> blocks
+ *
+ * Example rendered structure:
+ * <legend>
+ *   <h3 class="vads-u-margin--0">
+ *     <span class="...">VA FORM 21-0781</span>
+ *     <span class="...">Mental health support</span>
+ *   </h3>
+ * </legend>
  */
 export function titleWithTag(title, headingTag) {
   return (
-    <>
-      <h3 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-margin--0">
-        {`${headingTag} `}
+    <legend>
+      <h3 className="vads-u-margin--0">
+        <span className="vads-u-display--block vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+          {`${headingTag}`}{' '}
+        </span>
+        <span className="vads-u-display--block vads-u-font-size--h3 vads-u-color--base">
+          {title}
+        </span>
       </h3>
-      <h3 className="vads-u-font-size--h3 vads-u-color--base vads-u-margin--0">
-        {title}
-      </h3>
-    </>
+    </legend>
   );
 }

--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -154,7 +154,7 @@ export const traumaticEventsExamples = (
           You experienced offensive comments about your body or sexual
           activities
         </li>
-        <li>You experienced unwanted sexual advances</li>
+        <li>You experienced repeated unwanted sexual advances</li>
         <li>
           You experienced someone touching or grabbing you against your will,
           including during hazing

--- a/src/applications/disability-benefits/all-claims/pages/form0781/traumaticEventsPages.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/traumaticEventsPages.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
+import { focusByOrder, scrollToTop } from 'platform/utilities/ui';
 import { isCompletingForm0781 } from '../../utils/form0781';
 import eventDetails from './traumaticEventDetails';
 import { officialReportCustom } from './officialReport';
@@ -20,6 +21,10 @@ import {
 } from '../../content/form0781';
 import { MILITARY_REPORT_TYPES, OTHER_REPORT_TYPES } from '../../constants';
 
+const scrollAndFocusToProgressBar = () => {
+  scrollToTop('topScrollElement');
+  focusByOrder([`form h2`, 'va-segmented-progress-bar']);
+};
 const isReviewAndSubmitPage = () => {
   const pathParts = window.location.pathname.split('/');
   return pathParts[pathParts.length - 1] === 'review-and-submit';
@@ -115,6 +120,7 @@ export const traumaticEventsPages = arrayBuilderPages(options, pageBuilder => ({
   eventsList: pageBuilder.summaryPage({
     title: summaryPageTitleWithTag,
     path: 'mental-health-form-0781/events-summary',
+    scrollAndFocusTarget: scrollAndFocusToProgressBar,
     depends: formData => isCompletingForm0781(formData),
     ContentBeforeButtons: (
       <div className="vads-u-margin-y--2p5">{mentalHealthSupportAlert()}</div>
@@ -123,6 +129,7 @@ export const traumaticEventsPages = arrayBuilderPages(options, pageBuilder => ({
   eventDetails: pageBuilder.itemPage({
     title: eventDetailsPageTitle,
     path: 'mental-health-form-0781/:index/event-details',
+    scrollAndFocusTarget: scrollAndFocusToProgressBar,
     depends: formData => isCompletingForm0781(formData),
     uiSchema: eventDetails.uiSchema,
     schema: eventDetails.schema,
@@ -130,6 +137,7 @@ export const traumaticEventsPages = arrayBuilderPages(options, pageBuilder => ({
   officialReport: pageBuilder.itemPage({
     title: officialReportPageTitle,
     path: `mental-health-form-0781/:index/event-report`,
+    scrollAndFocusTarget: scrollAndFocusToProgressBar,
     depends: (formData, index) => formData.events?.[index],
     CustomPage: OfficialReport,
     uiSchema: officialReportCustom.uiSchema,
@@ -138,6 +146,7 @@ export const traumaticEventsPages = arrayBuilderPages(options, pageBuilder => ({
   policeReport: pageBuilder.itemPage({
     title: policeReportLocationPageTitle,
     path: `mental-health-form-0781/:index/event-police-report`,
+    scrollAndFocusTarget: scrollAndFocusToProgressBar,
     depends: (formData, index) =>
       isCompletingForm0781(formData) &&
       formData.events?.[index]?.otherReports?.police,

--- a/src/applications/disability-benefits/all-claims/tests/components/OfficialReport.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/OfficialReport.unit.spec.jsx
@@ -134,7 +134,7 @@ function setupOfficialReport({
 
 describe('OfficialReport', () => {
   it('renders the component', () => {
-    const { getByText } = setupOfficialReport({
+    const { container } = setupOfficialReport({
       eventData: {
         agency: 'Agency 1',
         otherReports: {
@@ -143,7 +143,9 @@ describe('OfficialReport', () => {
       },
     });
 
-    expect(getByText('VA FORM 21-0781')).to.exist;
+    const visibleHeading = container.querySelector('h3.vads-u-margin--0');
+    expect(visibleHeading).to.exist;
+    expect(visibleHeading.textContent).to.include('VA FORM 21-0781');
   });
 
   it('opens the police report modal when police is deselected and a location field is filled', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - addresses a11y issues discovered during Staging review
    - group page heading within a `legend`
    - set focus to progress bar on render of Events summary and item pages
  - change content on 2 pages
- _(If bug, how to reproduce)_
  - use a screenreader to verify where focus is directed moving from `/event-details` to `/event-report`
  - when landing on `/event-police-report` focus is sent to the first H3 heading, "VA Form 21-0781" and so that text is announced to the user --- but not the subsequent text "Police report location" 
- _(What is the solution, why is this the solution)_
  - follow Staging Review recommendations linked in Related issues below 
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Disability Benefits Experience Team 2 (dBeX Carbs 🥖), which owns maintenance of all files in this PR
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - `sync_modern_0781_flow` will be utilized for specific users until (eventually) all who start a new form and claim a new disability will be routed through an alternative 0781 flow

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108126
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108125
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108201

## Testing done

- _Describe what the old behavior was prior to the change_
  - focus lost in page transition
- _Describe the steps required to verify your changes are working as expected_
  - visit the Events sub-section of the Mental Health Statement chapter
  - using a screenreader, verify where focus is directed when landing on a page
- _Describe the tests completed and the results_
  - pre-existing test updated to reflect changes 
  - used screenreader to confirm focus upon page visitation

## Screenshots

| pages | Before | After |
| ------- | ------ | ----- |
| workflow  | ![Screenshot 2025-04-24 at 4 50 55 PM](https://github.com/user-attachments/assets/4bd2a6e4-9af9-4b10-85af-6d5e6ea08693) | ![Screenshot 2025-04-24 at 4 50 40 PM](https://github.com/user-attachments/assets/920c6e5d-65e7-482d-b43d-33998dbf14df) |
| events type | ![Screenshot 2025-04-24 at 4 50 16 PM](https://github.com/user-attachments/assets/dca3cd8d-b905-45ff-808b-588bc19d134a) | ![Screenshot 2025-04-24 at 4 49 08 PM](https://github.com/user-attachments/assets/e5e57044-68f8-4941-be0e-d11295ec9176) |

| pages | screenreader snapshots |
| ------- | ------ |
| Events summary  | ![Screenshot 2025-04-24 at 3 19 56 PM](https://github.com/user-attachments/assets/7c44728d-521d-4567-a5a5-6d4dc51eafd5) |
| Event details | ![Screenshot 2025-04-24 at 3 21 33 PM](https://github.com/user-attachments/assets/8cc680bf-8c29-49ab-a460-3bb4304542fb) |
| Official report | ![Screenshot 2025-04-24 at 3 24 16 PM](https://github.com/user-attachments/assets/ee084280-4117-492d-bfee-60654b2c30cc) |
| Police report location | ![Screenshot 2025-04-24 at 3 24 33 PM](https://github.com/user-attachments/assets/e82b12c8-a5b7-4386-8895-1139d7197eab) |

## What areas of the site does it impact?

- 526 EZ claim data submission

## Acceptance criteria

### Quality Assurance & Testing

- [x] I ~fixed~|updated|~added~ unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing] has been performed – 0 issues found during axe DevTools scan

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback