### PR TITLE
Remove `mhvInterstitialEnabled` Feature Flag

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -50,9 +50,6 @@ export default function AuthApp({ location }) {
   const isFeatureToggleLoading = useSelector(
     store => store?.featureToggles?.loading,
   );
-  const isInterstitialEnabled = useSelector(
-    store => store?.featureToggles?.mhvInterstitialEnabled,
-  );
 
   const handleAuthError = (error, codeOverride) => {
     const { errorCode: detailedErrorCode } = getAuthError(
@@ -75,11 +72,6 @@ export default function AuthApp({ location }) {
   };
 
   const redirect = () => {
-    if (isInterstitialEnabled && ['mhv', 'myhealthevet'].includes(loginType)) {
-      window.location.replace('/sign-in-changes-reminder');
-      return;
-    }
-
     // remove from session storage
     sessionStorage.removeItem(AUTHN_SETTINGS.RETURN_URL);
 

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -14,12 +14,7 @@ describe('AuthApp', () => {
   const mockStore = {
     dispatch: sinon.spy(),
     subscribe: sinon.spy(),
-    getState: () => ({
-      featureToggles: {
-        // eslint-disable-next-line camelcase
-        mhv_interstitial_enabled: false,
-      },
-    }),
+    getState: () => ({}),
   };
 
   before(() => {
@@ -333,14 +328,17 @@ describe('AuthApp', () => {
     });
   });
 
-  it('should redirect to /sign-in-changes-reminder interstitial page', () => {
+  it('should not redirect to /sign-in-changes-reminder interstitial page', async () => {
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { replace: sinon.spy() };
+
     const store = {
       dispatch: sinon.spy(),
       subscribe: sinon.spy(),
       getState: () => ({
         featureToggles: {
-          // eslint-disable-next-line camelcase
-          mhv_interstitial_enabled: true,
+          mhvInterstitialEnabled: true,
         },
       }),
     };
@@ -362,13 +360,17 @@ describe('AuthApp', () => {
       ),
     );
 
-    const { queryByTestId } = render(
+    render(
       <Provider store={store}>
         <AuthApp location={{ query: { auth: 'success', type: 'mhv' } }} />
       </Provider>,
     );
 
-    expect(queryByTestId('loading')).to.not.be.null;
+    await waitFor(() => {
+      expect(window.location.replace.calledOnce).to.be.false;
+    });
+
+    window.location = originalLocation;
     sessionStorage.clear();
   });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -125,7 +125,6 @@
   "mhvAcceleratedDeliveryAllergiesEnabled": "mhv_accelerated_delivery_allergies_enabled",
   "mhvAcceleratedDeliveryVitalSignsEnabled": "mhv_accelerated_delivery_vital_signs_enabled",
   "mhvIntegrationMedicalRecordsToPhase1": "mhv_integration_medical_records_to_phase_1",
-  "mhvInterstitialEnabled": "mhv_interstitial_enabled",
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",
   "mhvMedicalRecordsAllowTxtDownloads": "mhv_medical_records_allow_txt_downloads",
   "mhvMedicalRecordsDisplayConditions": "mhv_medical_records_display_conditions",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed the `mhvInterstitialEnabled` feature flag and references to it. Fixed tests where necessary,

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/29)

## Testing done
- Updated tests in `AuthApp.unit.spec.jsx` and ran them locally.
- Can be replicated by running `yarn test:unit src/applications/auth/tests/AuthApp.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `src/applications/auth/containers/AuthApp.jsx`, it's associated tests, and `src/platform/utilities/feature-toggles/featureFlagNames.json`.

## Acceptance criteria
- [x] The `mhvInterstitialEnabled` feature flag is fully removed from both code and config files.
- [x] No conditional logic referencing the flag remains in the codebase.
- [x] Associated tests are updated or removed.
