### PR TITLE
Fix VAOS Referral Appointment state loop bug

### DIFF
--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -122,13 +122,15 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         provider: {},
-        providerFetchStatus: FETCH_STATUS.notStarted,
         draftAppointmentInfo: {},
         draftAppointmentCreateStatus: FETCH_STATUS.notStarted,
+        appointmentCreateStatus: FETCH_STATUS.notStarted,
         appointmentInfoTimeout: false,
         appointmentInfoError: false,
         appointmentInfoLoading: false,
         referralAppointmentInfo: {},
+        referralsFetchStatus: FETCH_STATUS.notStarted,
+        referralFetchStatus: FETCH_STATUS.notStarted,
         selectedSlot: '',
       };
     default:


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixed a bug where the UI will skip the completion page if a user completed a previous booking.
- To reproduce the bug, simple run the UI locally with the local mocks and:
  1. Go to http://localhost:3001/my-health/appointments
  2. Click on the referrals link and book and appointment.
  3. On the completion page click the breadcrumb that says "Back to Appointments"
  4. Then try to book another referral appointment and get an error on the completion page.
- This bug was due to the state having old data at the start of a new booking.
- Team: UAE Check In

## Related issue(s)
[N/A](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108446)

## Testing done
- Manual testing

## Screenshots
N/A

## What areas of the site does it impact?
VAOS Referral Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
