### PR TITLE
BMT-108007 | Fix heading levels for Cypress test violations for claims status & letters

### DIFF
--- a/src/applications/claims-status/components/NoClaims.jsx
+++ b/src/applications/claims-status/components/NoClaims.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 export default function NoClaims() {
   return (
     <div className="usa-alert usa-alert-info claims-alert background-color-only claims-alert-status">
-      <h4 className="claims-alert-header usa-alert-heading">
+      <h3 className="claims-alert-header usa-alert-heading">
         You do not have any submitted claims
-      </h4>
+      </h3>
       <p>This page shows only completed claim applications.</p>
     </div>
   );

--- a/src/applications/claims-status/components/appeals-v2/PastEvent.jsx
+++ b/src/applications/claims-status/components/appeals-v2/PastEvent.jsx
@@ -7,7 +7,7 @@ const PastEvent = ({ title, date, description, hideSeparator }) => {
 
   return (
     <li className="process-step section-complete">
-      <h3>{title}</h3>
+      <h2 className="vads-u-font-size--h3">{title}</h2>
       <div className="appeal-event-date">on {date}</div>
       <p>{description}</p>
       {separator}

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -157,7 +157,7 @@ class YourClaimsPageV2 extends React.Component {
     }
 
     if (canAccessClaims && claimsAvailable !== claimsAvailability.AVAILABLE) {
-      return <ClaimsUnavailable />;
+      return <ClaimsUnavailable headerLevel={3} />;
     }
 
     if (

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -519,7 +519,7 @@ h1:focus {
     }
 
     // Move up the headers to align with the bullet point better
-    h3 {
+    h2 {
       padding-top: 0.4em;
     }
 

--- a/src/applications/letters/containers/DownloadLetters.jsx
+++ b/src/applications/letters/containers/DownloadLetters.jsx
@@ -23,7 +23,11 @@ export function DownloadLetters() {
         To receive some benefits, Veterans need a letter proving their status.
         You can download some of these benefit letters and documents online.
       </p>
-      <va-segmented-progress-bar total={total} current={currentStep} />
+      <va-segmented-progress-bar
+        total={total}
+        current={currentStep}
+        header-level={2}
+      />
       <div className="section-content">
         <h2 id="nav-form-header" className="vads-u-font-size--h4">
           {headerText}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- The addition of new accessibility rules to the Cypress tests flagged a few issues for the Claims Status tool & letters.
- Adjusted the headings so that headings appear in the correct order, but styling stays the same.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108007

## Testing done

- To test this run the 5 Cypress tests listed below under "Screenshots".
- Add the following rule below to the Cypress rules in `src/platform/testing/e2e/cypress/support/commands/axeCheck.js` on line 56.

```jsx
      'empty-heading': {
        enabled: true,
      },
      'heading-order': {
        enabled: true,
      },
      'page-has-heading-one': {
        enabled: true,
      },
```

- Run vets-website with`yarn watch`
- In another tab on vets-website Run the mock api responses with:
    `yarn mock-api --responses src/applications/claims-status/tests/e2e/fixtures/mocks/mock-api/index.js`
- In a third terminal tab open vets-website again. Run the Cypress tests with `yarn cy:open`
- In the browser Cypress UI select the tests to run them. On the main branch they will fail, on this branch they will pass.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
|src/applications/claims-status/tests/e2e/00.claims-list-empty.cypress.spec.js|<img width="2558" alt="00_before_fontSize20" src="https://github.com/user-attachments/assets/a0eddeea-a037-4d5f-b56a-cc11d3931fed" />|<img width="1287" alt="00_after" src="https://github.com/user-attachments/assets/59d43395-583d-44a1-b8cc-eee66a09c5ed" />|
src/applications/claims-status/tests/e2e/07.appeal-status.cypress.spec.js |<img width="2212" alt="07_before" src="https://github.com/user-attachments/assets/1d859c32-a3fb-4caa-9892-1986d08a2721" />|<img width="2206" alt="07_after" src="https://github.com/user-attachments/assets/73c2ebc6-dbc6-442b-b7ea-54f543ca74ab" />|<img width="2206" alt="07_after" src="https://github.com/user-attachments/assets/6fda4625-35d3-40dc-838b-fccd3482bbe1" />|
|src/applications/letters/tests/01-authed.lighthouse.cypress.spec.js|<img width="1289" alt="01_before_23 236px" src="https://github.com/user-attachments/assets/7cff9341-17ab-4bb9-9425-b3b23d1afde5" />|<img width="2551" alt="01_after" src="https://github.com/user-attachments/assets/9921cdf9-ae68-49c4-a280-d565eb44fcb5" />|
|src/applications/letters/tests/01-authed.cypress.spec.js|<img width="2557" alt="01_authed_before" src="https://github.com/user-attachments/assets/7080fdf8-c334-4f10-b36f-371cb005529e" />|<img width="1281" alt="01_authed_after" src="https://github.com/user-attachments/assets/5c547031-30d2-448c-aa1d-c6e4f6c4811c" />|
|src/applications/letters/tests/02-keyboard-only.cypress.spec.js|<img width="1290" alt="02_before" src="https://github.com/user-attachments/assets/fd90742a-a58b-4ce9-addf-27aa6af43c6f" />|<img width="2551" alt="Screenshot 2025-04-25 at 1 49 39 PM" src="https://github.com/user-attachments/assets/e0bfeac8-7895-4ab3-8b04-969e18c72e58" />|


## What areas of the site does it impact?

Claims status tool & letters
