### PR TITLE
Fix Nametag aria-label to address voice command software accessibility issue

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -53,7 +53,7 @@ const DisabilityRatingContent = ({ rating }) => {
           <strong>
             {rating
               ? `${rating}% service connected`
-              : 'Review your disability rating '}
+              : 'Review your disability rating'}
           </strong>
           <va-icon
             icon="chevron_right"

--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -44,8 +44,8 @@ const DisabilityRatingContent = ({ rating }) => {
           href="/disability/view-disability-rating/rating"
           aria-label={
             rating
-              ? `View your ${rating}% service connected disability rating`
-              : 'view your disability rating'
+              ? `${rating} percent service connected disability rating`
+              : 'Review your disability rating'
           }
           className="vads-u-color--white medium-screen:vads-u-margin-top--neg0p25 medium-screen:vads-u-margin-left--0 vads-u-margin-left--2"
           style={{ whiteSpace: 'nowrap' }}
@@ -53,7 +53,7 @@ const DisabilityRatingContent = ({ rating }) => {
           <strong>
             {rating
               ? `${rating}% service connected`
-              : 'View disability rating '}
+              : 'Review your disability rating '}
           </strong>
           <va-icon
             icon="chevron_right"

--- a/src/applications/personalization/components/NameTag.unit.spec.jsx
+++ b/src/applications/personalization/components/NameTag.unit.spec.jsx
@@ -78,7 +78,7 @@ describe('<NameTag>', () => {
       });
       view.getByText(/your disability rating:/i);
       view.getByRole('link', {
-        name: /View your 70% service connected disability rating/i,
+        name: /70 percent service connected disability rating/i,
         text: /70% service connected/i,
         href: /disability\/view-disability-rating\/rating/i,
       });
@@ -95,7 +95,7 @@ describe('<NameTag>', () => {
         expect(view.queryByText(/your disability rating:/i)).to.not.exist;
         expect(
           view.queryByRole('link', {
-            name: /view your disability rating/i,
+            name: /review your disability rating/i,
             href: /disability\/view-disability-rating\/rating/i,
           }),
         ).to.not.exist;
@@ -116,8 +116,8 @@ describe('<NameTag>', () => {
         );
         expect(view.queryByText(/your disability rating:/i)).to.not.exist;
         view.getByRole('link', {
-          name: /view your disability rating/i,
-          text: /view disability rating/i,
+          name: /review your disability rating/i,
+          text: /review disability rating/i,
           href: /disability\/view-disability-rating\/rating/i,
         });
       });

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -78,20 +78,20 @@ export function nameTagRendersWithDisabilityRating() {
   nameTagRenders();
   cy.findByText('Your disability rating:').should('exist');
   cy.findByText('90% service connected').should('exist');
-  cy.findByText(/View disability rating/i).should('not.exist');
+  cy.findByText(/Review your disability rating/i).should('not.exist');
 }
 
 export function nameTagRendersWithFallbackLink() {
   nameTagRenders();
   cy.findByText('Your disability rating:').should('not.exist');
-  cy.findByText(/View disability rating/i).should('exist');
+  cy.findByText(/Review your disability rating/i).should('exist');
   cy.findByText(/service connected/i).should('not.exist');
 }
 
 export function nameTagRendersWithoutDisabilityRating() {
   nameTagRenders();
   cy.findByText('Your disability rating:').should('not.exist');
-  cy.findByText(/View disability rating/i).should('not.exist');
+  cy.findByText(/Review your disability rating/i).should('not.exist');
   cy.findByText(/service connected/i).should('not.exist');
 }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

There is a bug where voice command software does not recognize the disability rating link in the nametag. This is likely due to the disconnect between the symbol, %, and the spoken/written word, "percent".
- To reproduce this bug:
  - Sign into VA.gov with a test user on a web browser
  - Using voice command software (such as Voice Control on Mac), say "Click [percentage]% service connected"
  - Verify that the link is not clicked and the user is not redirected to the disability settings page
- Solution:
  - This change updates the disability rating aria-label to use the word "percent" (rather than the symbol, %) so that the voice command software recognizes the word "percent" when spoken.

This fix also updates the word "view" to "review" in the link text and aria-label to be more inclusive for non-sighted users.

The Authenticated Experience team owns the nametag component.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/54881

## Testing done

- Old behavior: "clicking" the disability rating link via voice command software did not successfully click the link and navigate to the disability rating page
- To verify this change:
  - Sign into VA.gov/profile with a test user (e.g., user 226) on a web browser
  - Inspect the disability rating link element to verify the aria-label is "[percentage] percent service connected disability rating" (e.g., "70 percent service connected disability rating" for user 226)
  - Using voice command software (such as Voice Control on Mac), say "Click [percentage]% service connected"
  - Verify that the link is clicked and the user is redirected to the disability settings page (e.g., "Click 70% service connected" for user 226)

- Tests completed:
  - Performed the above verification steps in local development with a mocked user on MacOS using Voice Control
    - Manually set `showFallbackLink` to `true` to force "Review your disability rating" link text to show, and performed these steps again with the voice command "Click review your disability rating"
    - Results: successfully clicked the link text in both states (with and without rating) in Chrome, Edge, and Firefox; the local environment did not work with the voice command software in Safari
  - Ran full page scan with axe devtools in Chrome, Firefox, and Edge - 0 issues reported
  - Ran accessibility audit in Safari - found no issues with nametag component

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Rating | <img width="464" alt="Screenshot 2025-04-25 at 12 50 00 PM" src="https://github.com/user-attachments/assets/c5d5eb6e-edd5-47b5-b35d-241c2f79b22f" /> | <img width="464" alt="Screenshot 2025-04-25 at 12 50 00 PM" src="https://github.com/user-attachments/assets/98a094e3-3e7f-4c02-939d-8b0fd49b8b95" /> |
| No rating | <img width="368" alt="Screenshot 2025-04-25 at 12 49 22 PM" src="https://github.com/user-attachments/assets/4f3201a5-02f9-406b-8bca-d6e5d50b1a9b" /> | <img width="372" alt="Screenshot 2025-04-25 at 12 48 07 PM" src="https://github.com/user-attachments/assets/95ed93d8-12eb-4260-b80a-58cee4681a3f" /> |

## What areas of the site does it impact?

VA.gov Profile, Nametag

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
