### PR TITLE
[#106316] Travel Pay, auth widget content fix

### DIFF
--- a/src/applications/static-pages/BTSSS-login/App/index.jsx
+++ b/src/applications/static-pages/BTSSS-login/App/index.jsx
@@ -16,12 +16,7 @@ export const App = () => {
 
   return (
     <>
-      {smocEnabled ? (
-        <p>
-          <strong>If you’re claiming mileage only</strong>, you can file a
-          travel claim for eligible past appointments here on VA.gov.
-        </p>
-      ) : (
+      {!smocEnabled && (
         <p>
           You can file a claim online through the Beneficiary Travel Self
           Service System (BTSSS).

--- a/src/applications/static-pages/BTSSS-login/App/index.unit.spec.jsx
+++ b/src/applications/static-pages/BTSSS-login/App/index.unit.spec.jsx
@@ -36,4 +36,22 @@ describe('BTSSS Widget', () => {
     });
     expect(container.querySelector('va-alert-sign-in')).to.not.exist;
   });
+
+  it('does not render BTSSS info with SMOC flag on', () => {
+    const screen = renderInReduxProvider(<BTSSSApp />, {
+      initialState: {
+        user: { login: { currentlyLoggedIn: true } },
+        featureToggles: {
+          loading: false,
+          /* eslint-disable-next-line camelcase */
+          travel_pay_submit_mileage_expense: true,
+        },
+      },
+    });
+    expect(
+      screen.queryByText(
+        'You can file a claim online through the Beneficiary Travel Self Service System (BTSSS).',
+      ),
+    ).to.not.exist;
+  });
 });

--- a/src/applications/static-pages/BTSSS-login/AuthContext/index.jsx
+++ b/src/applications/static-pages/BTSSS-login/AuthContext/index.jsx
@@ -30,6 +30,10 @@ const AuthContext = () => {
     <>
       {smocEnabled ? (
         <>
+          <p>
+            <strong>If you’re claiming mileage only</strong>, you can file a
+            travel claim for eligible past appointments here on VA.gov.
+          </p>
           <va-link-action
             data-testid="vagov-smoc-link"
             href="/my-health/appointments/past"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- A line of content should not be displayed in the unauthenticated view for this widget. Leveraging the SMOC feature flag, as before

## Related issue(s)

github.com/department-of-veterans-affairs/va.gov-team/issues/106316

## Testing done

Local testing done with short circuit for auth/unauth states to ensure correct content was present for each.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Auth  | <img width="1050" alt="before_auth" src="https://github.com/user-attachments/assets/88078dc5-339c-4765-a06f-8e897b4b5386" /> | <img width="1065" alt="after_auth" src="https://github.com/user-attachments/assets/bc33525a-b16e-4063-87cf-b18ed2cb56c9" /> |
| Unauth | <img width="1042" alt="before_unauth" src="https://github.com/user-attachments/assets/87fe16ba-f0aa-419f-aabb-e94fea5fc1d5" /> | <img width="1031" alt="after_unauth" src="https://github.com/user-attachments/assets/ab5dbbdd-99b4-45fc-a5ee-3a383180222f" /> |

## What areas of the site does it impact?

Auth widget on `/health-care/file-travel-pay-reimbursement/`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user