### PR TITLE
Update cancelation alert message and links

### DIFF
--- a/src/applications/vaos/components/StatusAlert.jsx
+++ b/src/applications/vaos/components/StatusAlert.jsx
@@ -120,15 +120,17 @@ export default function StatusAlert({ appointment, facility }) {
       <>
         <InfoAlert status="error" backgroundOnly>
           {message}
-          <br />
-          <br />
           {displayScheduleLink && (
-            <va-link
-              text="Schedule a new appointment"
-              data-testid="schedule-appointment-link"
-              onClick={handleClick(dispatch)}
-              href={`${root.url}${typeOfCare.url}`}
-            />
+            <>
+              <br />
+              <br />
+              <va-link
+                text="Schedule a new appointment"
+                data-testid="schedule-appointment-link"
+                onClick={handleClick(dispatch)}
+                href={`${root.url}${typeOfCare.url}`}
+              />
+            </>
           )}
         </InfoAlert>
       </>

--- a/src/applications/vaos/components/StatusAlert.jsx
+++ b/src/applications/vaos/components/StatusAlert.jsx
@@ -104,19 +104,32 @@ export default function StatusAlert({ appointment, facility }) {
 
   if (canceled) {
     const who = canceler.get(appointment?.cancelationReason) || 'Facility';
+    let message;
+    let displayScheduleLink = false;
+    if (appointment.type === 'COMMUNITY_CARE_APPOINTMENT') {
+      message = `${who} canceled this appointment. If you still want this appointment, call your community care provider to schedule.`;
+    } else if (appointment.vaos.isCompAndPenAppointment) {
+      message = `${who} canceled this appointment. If you still want this appointment, call your VA health facility’s compensation and pension office to schedule.`;
+    } else if (appointment.vaos.isPendingAppointment) {
+      message = `${who} canceled this request. If you still want this appointment, call your VA health facility or submit another request online.`;
+      displayScheduleLink = true;
+    } else {
+      message = `${who} canceled this appointment. If you still want this appointment, call your VA health facility to schedule.`;
+    }
     return (
       <>
         <InfoAlert status="error" backgroundOnly>
-          {who} canceled this appointment. If you want to reschedule, call us or
-          schedule a new appointment online.
+          {message}
           <br />
           <br />
-          <va-link
-            text="Schedule a new appointment"
-            data-testid="schedule-appointment-link"
-            onClick={handleClick(dispatch)}
-            href={`${root.url}${typeOfCare.url}`}
-          />
+          {displayScheduleLink && (
+            <va-link
+              text="Schedule a new appointment"
+              data-testid="schedule-appointment-link"
+              onClick={handleClick(dispatch)}
+              href={`${root.url}${typeOfCare.url}`}
+            />
+          )}
         </InfoAlert>
       </>
     );
@@ -156,10 +169,12 @@ export default function StatusAlert({ appointment, facility }) {
 StatusAlert.propTypes = {
   appointment: PropTypes.shape({
     status: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
     cancelationReason: PropTypes.string,
     created: PropTypes.string,
     avsPath: PropTypes.string,
     vaos: PropTypes.shape({
+      isCompAndPenAppointment: PropTypes.bool.isRequired,
       isPastAppointment: PropTypes.bool.isRequired,
       isPendingAppointment: PropTypes.bool.isRequired,
     }),

--- a/src/applications/vaos/components/StatusAlert.unit.spec.jsx
+++ b/src/applications/vaos/components/StatusAlert.unit.spec.jsx
@@ -102,23 +102,103 @@ describe('VAOS Component: StatusAlert', () => {
       event: 'vaos-schedule-appointment-button-clicked',
     });
   });
-  it('Should display cancellation alert message', () => {
-    const mockAppointment = new MockAppointment({ start: moment() });
-    mockAppointment.setKind('clinic');
-    mockAppointment.setStatus('cancelled');
-    mockAppointment.setCancelationReason('pat');
 
-    const screen = renderWithStoreAndRouter(
-      <StatusAlert appointment={mockAppointment} facility={facilityData} />,
-      {
-        initialState,
-        path: `/${mockAppointment.id}`,
-      },
-    );
-    expect(screen.baseElement).to.contain('.usa-alert-error');
-    expect(screen.baseElement).to.contain.text('You canceled this appointment');
+  describe('Cancellation alert', () => {
+    it('Should display for canceled VA appointments', () => {
+      const mockAppointment = new MockAppointment({ start: moment() });
+      mockAppointment.setStatus('cancelled');
+      mockAppointment.setCancelationReason('pat');
 
-    expect(screen.queryByTestId('review-appointments-link')).to.not.exist;
-    expect(screen.queryByTestId('schedule-appointment-link')).to.exist;
+      const screen = renderWithStoreAndRouter(
+        <StatusAlert appointment={mockAppointment} facility={facilityData} />,
+        {
+          initialState,
+          path: `/${mockAppointment.id}`,
+        },
+      );
+      expect(screen.baseElement).to.contain('.usa-alert-error');
+      expect(screen.baseElement).to.contain.text(
+        'You canceled this appointment',
+      );
+      expect(screen.baseElement).to.contain.text(
+        'If you still want this appointment, call your VA health facility to schedule.',
+      );
+
+      expect(screen.queryByTestId('review-appointments-link')).to.not.exist;
+      expect(screen.queryByTestId('schedule-appointment-link')).to.not.exist;
+    });
+
+    it('Should display for canceled CC appointments', () => {
+      const mockAppointment = new MockAppointment({ start: moment() });
+      mockAppointment.setType('COMMUNITY_CARE_APPOINTMENT');
+      mockAppointment.setStatus('cancelled');
+      mockAppointment.setCancelationReason('pat');
+
+      const screen = renderWithStoreAndRouter(
+        <StatusAlert appointment={mockAppointment} facility={facilityData} />,
+        {
+          initialState,
+          path: `/${mockAppointment.id}`,
+        },
+      );
+      expect(screen.baseElement).to.contain('.usa-alert-error');
+      expect(screen.baseElement).to.contain.text(
+        'You canceled this appointment',
+      );
+      expect(screen.baseElement).to.contain.text(
+        'If you still want this appointment, call your community care provider to schedule.',
+      );
+
+      expect(screen.queryByTestId('review-appointments-link')).to.not.exist;
+      expect(screen.queryByTestId('schedule-appointment-link')).to.not.exist;
+    });
+
+    it('Should display for canceled C&P appointments', () => {
+      const mockAppointment = new MockAppointment({ start: moment() });
+      mockAppointment.setIsCompAndPenAppointment(true);
+      mockAppointment.setStatus('cancelled');
+      mockAppointment.setCancelationReason('pat');
+
+      const screen = renderWithStoreAndRouter(
+        <StatusAlert appointment={mockAppointment} facility={facilityData} />,
+        {
+          initialState,
+          path: `/${mockAppointment.id}`,
+        },
+      );
+      expect(screen.baseElement).to.contain('.usa-alert-error');
+      expect(screen.baseElement).to.contain.text(
+        'You canceled this appointment',
+      );
+      expect(screen.baseElement).to.contain.text(
+        'If you still want this appointment, call your VA health facility’s compensation and pension office to schedule.',
+      );
+
+      expect(screen.queryByTestId('review-appointments-link')).to.not.exist;
+      expect(screen.queryByTestId('schedule-appointment-link')).to.not.exist;
+    });
+
+    it('Should display for canceled appointment requests', () => {
+      const mockAppointment = new MockAppointment({ start: moment() });
+      mockAppointment.setIsPendingAppointment(true);
+      mockAppointment.setStatus('cancelled');
+      mockAppointment.setCancelationReason('pat');
+
+      const screen = renderWithStoreAndRouter(
+        <StatusAlert appointment={mockAppointment} facility={facilityData} />,
+        {
+          initialState,
+          path: `/${mockAppointment.id}`,
+        },
+      );
+      expect(screen.baseElement).to.contain('.usa-alert-error');
+      expect(screen.baseElement).to.contain.text('You canceled this request');
+      expect(screen.baseElement).to.contain.text(
+        'If you still want this appointment, call your VA health facility or submit another request online.',
+      );
+
+      expect(screen.queryByTestId('review-appointments-link')).to.not.exist;
+      expect(screen.queryByTestId('schedule-appointment-link')).to.exist;
+    });
   });
 });

--- a/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
@@ -390,6 +390,7 @@ describe('VAOS Component: CCLayout', () => {
         },
         start: moment().format('YYYY-MM-DDTHH:mm:ss'),
         status: 'cancelled',
+        type: 'COMMUNITY_CARE_APPOINTMENT',
       };
 
       // Act
@@ -406,7 +407,7 @@ describe('VAOS Component: CCLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your community care provider to schedule/i,
         ),
       );
       expect(
@@ -524,6 +525,7 @@ describe('VAOS Component: CCLayout', () => {
           .subtract(2, 'day')
           .format('YYYY-MM-DDTHH:mm:ss'),
         status: 'cancelled',
+        type: 'COMMUNITY_CARE_APPOINTMENT',
       };
 
       // Act
@@ -540,7 +542,7 @@ describe('VAOS Component: CCLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your community care provider to schedule/i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.jsx
@@ -602,7 +602,7 @@ describe('VAOS Component: ClaimExamLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility’s compensation and pension office to schedule./i,
         ),
       );
       expect(
@@ -720,7 +720,7 @@ describe('VAOS Component: ClaimExamLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility’s compensation and pension office to schedule./i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
@@ -713,7 +713,7 @@ describe('VAOS Component: InPersonLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(
@@ -825,7 +825,7 @@ describe('VAOS Component: InPersonLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
@@ -630,7 +630,7 @@ describe('VAOS Component: PhoneLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(screen.queryByRole('heading', { level: 2, name: /How to join/ }))
@@ -745,7 +745,7 @@ describe('VAOS Component: PhoneLayout', () => {
       );
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(screen.queryByRole('heading', { level: 2, name: /How to join/ }))

--- a/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
@@ -261,7 +261,7 @@ describe('VAOS Component: VARequestLayout', () => {
           'va-link[text="Schedule a new appointment"]',
         ),
       ).to.be.ok;
-      expect(screen.getByText(/Facility canceled this appointment/i));
+      expect(screen.getByText(/Facility canceled this request/i));
       expect(
         screen.getByRole('heading', {
           level: 2,

--- a/src/applications/vaos/components/layouts/VideoLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.unit.spec.jsx
@@ -607,7 +607,7 @@ describe('VAOS Component: VideoLayout', () => {
 
         expect(
           screen.getByText(
-            /If you want to reschedule, call us or schedule a new appointment online/i,
+            /If you still want this appointment, call your VA health facility to schedule./i,
           ),
         );
         expect(
@@ -741,7 +741,7 @@ describe('VAOS Component: VideoLayout', () => {
 
         expect(
           screen.getByText(
-            /If you want to reschedule, call us or schedule a new appointment online/i,
+            /If you still want this appointment, call your VA health facility to schedule./i,
           ),
         );
         expect(
@@ -903,7 +903,7 @@ describe('VAOS Component: VideoLayout', () => {
 
         expect(
           screen.getByText(
-            /If you want to reschedule, call us or schedule a new appointment online/i,
+            /If you still want this appointment, call your VA health facility to schedule./i,
           ),
         );
         expect(

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.jsx
@@ -705,7 +705,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
 
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(
@@ -869,7 +869,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
 
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.jsx
@@ -866,7 +866,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
 
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(
@@ -1017,7 +1017,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
 
       expect(
         screen.getByText(
-          /If you want to reschedule, call us or schedule a new appointment online/i,
+          /If you still want this appointment, call your VA health facility to schedule./i,
         ),
       );
       expect(

--- a/src/applications/vaos/tests/mocks/unit-test-helpers.js
+++ b/src/applications/vaos/tests/mocks/unit-test-helpers.js
@@ -98,6 +98,7 @@ export class MockAppointment {
     this.practitioners = [];
     this.preferredProviderName = '';
     this.resourceType = '';
+    this.type = '';
 
     if (start && start.isValid())
       this.start = start.format('YYYY-MM-DDTHH:mm:ss');
@@ -107,6 +108,8 @@ export class MockAppointment {
     this.vaos = {
       isPastAppointment: false,
       isUpcomingAppointment: false,
+      isPendingAppointment: false,
+      isCompAndPenAppointment: false,
     };
     this.version = 2;
     this.videoData = {
@@ -137,6 +140,14 @@ export class MockAppointment {
     this.vaos.isUpcomingAppointment = value;
   }
 
+  setIsPendingAppointment(value) {
+    this.vaos.isPendingAppointment = value;
+  }
+
+  setIsCompAndPenAppointment(value) {
+    this.vaos.isCompAndPenAppointment = value;
+  }
+
   setAvsPath(value) {
     this.avsPath = value;
   }
@@ -151,5 +162,9 @@ export class MockAppointment {
 
   setModality(value) {
     this.modality = value;
+  }
+
+  setType(value) {
+    this.type = value;
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated behavior of the cancelation alerts based on feedback from design
  - Remove scheduling links for all appointment types except appointment requests
  - Update alert message for CC appointments, C&P appointments, requests and other appointments
- Appointments Team
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107877

## Testing done

- Tested locally, see screenshots
- Added/updated unit tests for the new behaviors

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| CC appointment  |   ![image](https://github.com/user-attachments/assets/37dd4d41-645b-4f6d-9596-61b2f1fd32cb)    |   ![image](https://github.com/user-attachments/assets/95723710-a75d-40de-882a-d5aadaa5015c)   |
| C&P appointments |  ![image](https://github.com/user-attachments/assets/88e0ba12-f495-4106-b71f-ef6188537199)     |   ![image](https://github.com/user-attachments/assets/8badad13-a53d-4b80-b054-59858478b6d0)   |
| Requests |    ![image](https://github.com/user-attachments/assets/7b788e1d-74ea-4b49-9165-932c6bcd4ff1)   |   ![image](https://github.com/user-attachments/assets/50467490-586b-456e-82e1-2b18952505fc)   |
| Other appointments |   ![image](https://github.com/user-attachments/assets/f69973f5-6f4e-4373-9636-5d156ecbb1ca)    |   ![image](https://github.com/user-attachments/assets/6323b213-8410-4121-90df-4e09935f7426)   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

