### PR TITLE
[Medical Records] Replaces PageNotFound with MhvPageNotFound component

### DIFF
--- a/src/applications/mhv-medical-records/routes.jsx
+++ b/src/applications/mhv-medical-records/routes.jsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
-import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
+import { MhvPageNotFound } from '@department-of-veterans-affairs/mhv/exports';
 import { useMyHealthAccessGuard } from '~/platform/mhv/hooks/useMyHealthAccessGuard';
 import FeatureFlagRoute from './components/shared/FeatureFlagRoute';
 import AppRoute from './components/shared/AppRoute';
@@ -191,7 +191,7 @@ const routes = (
           <DownloadFileType />
         </AppRoute>
         <Route>
-          <PageNotFound />
+          <MhvPageNotFound />
         </Route>
       </Switch>
     </Suspense>

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-page-not-found.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-page-not-found.cypress.spec.js
@@ -1,7 +1,11 @@
 import { rootUrl } from '../../manifest.json';
+import MedicalRecordsSite from './mr_site/MedicalRecordsSite';
 
 describe('Page Not Found', () => {
   it('Visit an unsupported URL and get a page not found', () => {
+    const site = new MedicalRecordsSite();
+    site.login();
+
     cy.visit(`${rootUrl}/path1`);
     cy.injectAxeThenAxeCheck();
     cy.get('[data-testid="mhv-page-not-found"]').should('exist');

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-page-not-found.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-page-not-found.cypress.spec.js
@@ -1,15 +1,14 @@
-import { pageNotFoundHeading } from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 import { rootUrl } from '../../manifest.json';
 
 describe('Page Not Found', () => {
   it('Visit an unsupported URL and get a page not found', () => {
     cy.visit(`${rootUrl}/path1`);
     cy.injectAxeThenAxeCheck();
-    cy.findByRole('heading', { name: pageNotFoundHeading }).should.exist;
+    cy.get('[data-testid="mhv-page-not-found"]').should('exist');
     cy.get('[data-testid="mhv-mr-navigation"]').should('not.exist');
 
     cy.visit(`${rootUrl}/path1/path2`);
-    cy.findByRole('heading', { name: pageNotFoundHeading }).should.exist;
+    cy.get('[data-testid="mhv-page-not-found"]').should('exist');
     cy.get('[data-testid="mhv-mr-navigation"]').should('not.exist');
   });
 });


### PR DESCRIPTION
## Summary

- Replaces PageNotFound with MhvPageNotFound component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#106740

## Testing done

- e2e, localhost

## Screenshots




|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    <img src="https://github.com/user-attachments/assets/a5efa24e-b5bc-4503-b03a-b8f36e0b8c22" width="320" />    |   ![Screen Shot 2025-04-29 at 12 16 53](https://github.com/user-attachments/assets/7c85b41d-2b54-4257-bf16-891bd4c93176)    |
| Desktop |   ![Screenshot 2025-04-29 at 09-57-49 Page not found Veterans Affairs](https://github.com/user-attachments/assets/77b7f5a1-9654-466a-af5a-06a2faacfdbd)     |   ![Screenshot from 2025-04-29 12-07-48](https://github.com/user-attachments/assets/c3b29cd9-865a-41e7-90f4-3c646b0d3fe9)    |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

