### PR TITLE
Add forms system AI prompts and tasks to vets-website

### DIFF
--- a/.agent/tasks/open_app_in_browser.js
+++ b/.agent/tasks/open_app_in_browser.js
@@ -1,0 +1,39 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const open = require("open");
+
+const appFolderPath = ".agent/tmp/context/input.txt";
+
+if (!fs.existsSync(appFolderPath)) {
+  console.error("❌ No app folder file found. Run agent first.");
+  process.exit(1);
+}
+
+const appFolder = fs.readFileSync(appFolderPath, "utf-8").trim();
+if (!appFolder) {
+  console.error("❌ App folder is empty.");
+  process.exit(1);
+}
+
+console.log(`✅ Opening ${appFolder} in browser`);
+const manifestPath = `src/applications/${appFolder}/manifest.json`;
+
+if (!fs.existsSync(manifestPath)) {
+  console.error("❌ Manifest file not found. Ensure the app folder is correct.");
+  process.exit(1);
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+const rootUrl = manifest.rootUrl;
+
+if (!rootUrl) {
+  console.error("❌ rootUrl not found in manifest file.");
+  process.exit(1);
+}
+
+try {
+  open(`http://localhost:3001${rootUrl}`);
+} catch (error) {
+  console.error("❌ Failed to open the URL:", error);
+  process.exit(1);
+}

--- a/.agent/tasks/run_app_unit_tests.js
+++ b/.agent/tasks/run_app_unit_tests.js
@@ -1,0 +1,19 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+
+const appFolderPath = ".agent/tmp/context/input.txt";
+
+if (!fs.existsSync(appFolderPath)) {
+  console.error("❌ No app folder file found. Run agent first.");
+  process.exit(1);
+}
+
+const appFolder = fs.readFileSync(appFolderPath, "utf-8").trim();
+if (!appFolder) {
+  console.error("❌ App folder is empty.");
+  process.exit(1);
+}
+
+console.log(`✅ Running tests for ${appFolder}`);
+const outPath = ".agent/tmp/output.txt";
+execSync(`yarn test:unit --app-folder ${appFolder} > ${outPath}`, { stdio: "inherit" });

--- a/.agent/tasks/yarn_watch.js
+++ b/.agent/tasks/yarn_watch.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+
+const entryName = ".agent/tmp/context/input.txt";
+
+if (!fs.existsSync(entryName)) {
+  console.error("❌ No context file found. Run agent first.");
+  process.exit(1);
+}
+
+console.log(`✅ Running yarn watch for ${entryName}`);
+execSync(`yarn watch --env entry=${entryName}`, { stdio: "inherit" });

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -162,5 +162,14 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['**/*.prompt.md'],
+      rules: {
+        'no-unused-expressions': 'off',
+        'no-undef': 'off',
+        'import/no-unresolved': 'off',
+        'no-restricted-syntax': 'off',
+      },
+    },
   ],
 };

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,11 @@
+# Copilot Instructions
 This is a monorepo for VA.gov, with shared code in `src/platform` and individual React applications under `src/applications`.
 
-We write javascript following the Prettier conventions with 2 spaces for indentation, single quotes and trailing commas, so when your responses include JavaScript code, please follow those conventions.
-
-All code written must conform to WCAG 2.2 AA and Section 508 accessibility guidelines.
+## General Instructions
+- vets-website uses yarn, Javascript, React, RJSF, Redux, React router, platform/forms-system, platform/forms, and the va.gov design system.
+- Use prettier conventions with 2 spaces for indentation, single quotes, and trailing commas.
+- When using React, prefer web components such as va-button, va-text-input instead of HTML elements.
+- When using RJSF, prefer web component patterns from `platform/forms-system/src/js/web-component-patterns` for individual fields for both uiSchema and schema such as textUI and textSchema.
+- For unit tests, use mocha, chai, sinon, and prefer RTL over Enzyme.
+- Prefer functional components and hooks for new components.
+- All code should conform to WCAG 2.2 AA and Section 508 accessibility guidelines.

--- a/.github/prompts/fs-app-locate-folder.prompt.md
+++ b/.github/prompts/fs-app-locate-folder.prompt.md
@@ -1,0 +1,11 @@
+# Forms app locate folder
+
+Your goal is to locate the application folder relevant to the context, likely a form app.
+
+If the user provides a form number or name, then search using glob pattern `src/applications/**/*<form number or name>*/manifest.json` in the codebase to find the folder. For example if the user provides `4142`, then search for `src/applications/**/*4142*/manifest.json`. The actual application name may have additional characters such as 21-4142, or 4142-v2.
+
+If context is not provided, then search context around the current file to the nearest parent with a `manifest.json` file, otherwise search the codebase for best guess.
+
+Apps are located in the `src/applications/` but they might be in a subfolder. You will know if you are in the right folder if it contains a manifest.json file.
+
+Validate that the folder contains a manifest.json, a pages folder, and a config folder. And now use this folder for additional context.

--- a/.github/prompts/fs-app-open-url.prompt.md
+++ b/.github/prompts/fs-app-open-url.prompt.md
@@ -1,0 +1,22 @@
+# Forms app open URL
+
+1. Determine the {app_folder} we are in [instructions](fs-app-locate-folder.prompt.md). The {app_folder} should be the remaining path after `src/applications`
+2. In the folder must contain a manifest.json file, extract the value for the "rootUrl" key.
+Open this URL in the browser:
+http://localhost:3001/{rootUrl}
+
+Example 1:
+User requests: open 4142
+
+Tasks:
+- You find `src/applications/simple-forms/21-4142/manifest.json`
+- You find key "rootUrl" with value "21-4142-medical-release" in the manifest.json file.
+- You open `http://localhost:3001/21-4142-medical-release` in the browser automatically.
+
+Example 2:
+User requests: open 686c
+
+Tasks:
+- You find `src/applications/686c-674/manifest.json` and `src/applications/686c-674-v1/manifest.json` so you ask the user to choose one.
+- You find key "rootUrl" with value "686C-674" in the manifest.json file.
+- You open `http://localhost:3001/686C-674` in the browser automatically.

--- a/.github/prompts/fs-app-run-unit-tests.prompt.md
+++ b/.github/prompts/fs-app-run-unit-tests.prompt.md
@@ -1,0 +1,8 @@
+# Forms app run unit tests (yarn test)
+
+Steps:
+1. Determine the {app_folder} we are in [instructions](fs-app-locate-folder.prompt.md). The {app_folder} should be the remaining path after `src/applications`
+2. Write the output to `.agent/tmp/input.txt`. Overrite if it exists. Only a single line.
+3. Run task `agent-run-tests-current-app`
+4. Check results in `.agent/tmp/output.txt`
+5. Check if there are any failures, if there are any failures, try to correct and start at step 3 again, Otherwise, report success.

--- a/.github/prompts/fs-app-yarn-watch.prompt.md
+++ b/.github/prompts/fs-app-yarn-watch.prompt.md
@@ -1,0 +1,7 @@
+# Forms app yarn watch
+
+Steps:
+1. Determine the {app_folder} we are in [instructions](fs-app-locate-folder.prompt.md). The {app_folder} should be the remaining path after `src/applications`
+2. Look at the manifest.json file in the {app_folder} folder and extract the value for the "entryName" key
+3. Write the value to `.agent/tmp/context/input.txt`. Overrite if it exists. Only a single line. Do not use the terminal or echo commands. Just edit directly in the IDE.
+4. Run task `agent-yarn-watch-current-app`

--- a/.github/prompts/fs-page-add-or-update-array-builder.prompt.md
+++ b/.github/prompts/fs-page-add-or-update-array-builder.prompt.md
@@ -1,0 +1,6 @@
+# Add or update array builder pages
+
+Follow guidance for adding or updating pages, but array builder instructions should take precedence.
+
+Form instructions: [fs-page-add-or-update](fs-page-add-or-update.prompt.md)
+Array builder instructions: [fs-patterns-array-builder](fs-patterns-array-builder.prompt.md).

--- a/.github/prompts/fs-page-add-or-update.prompt.md
+++ b/.github/prompts/fs-page-add-or-update.prompt.md
@@ -1,0 +1,66 @@
+# Forms adding or updating pages
+
+1. Determine the {app_folder} we are in [instructions](fs-app-locate-folder.prompt.md). The {app_folder} should be the remaining path after `src/applications`
+
+Continue to search until you find it.
+
+## App structure
+Manifest file = {app_folder}/manifest.json
+Form config = {app_folder}/config/form.js
+Pages = {app_folder}/pages
+Tests = {app_folder}/tests/unit
+
+## Creating or updating a page
+
+You must make 3 changes for each page.
+
+1. Create or update the page in the `{app_folder}/pages/{page-name}.js` file.
+2. Update the `{app_folder}/config/form.js` file to add or update the new page to the form.
+3. Use [forms-web-component-patterns](fs-patterns-web-component-schema-patterns.prompt.md) for code format patterns and validation.
+4. Validate the new page uses the patterns correctly, and correct if necessary.
+
+All pages should define the uiSchema and schema, and use web component patterns.
+
+Follow instructions for code format patterns:
+
+### Titles
+
+Page titles must be updated in both the page and the form.
+
+```js
+// {FORM_ROOT}/pages/{page-name}.js
+export default {
+  uiSchema: {
+    ...titleUI('Page title'),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      ...
+    },
+  },
+};
+```
+
+### Form config
+
+```js
+// {FORM_ROOT}/config/form.js
+const formConfig = {
+  ...
+  chapters: {
+    ...
+    chapterName: {
+      title: 'Chapter title',
+      pages: {
+        pageName: {
+          path: 'page-path',
+          title: 'Page title',
+          uiSchema: pageName.uiSchema,
+          schema: pageName.schema,
+        },
+      },
+    },
+  },
+};
+```

--- a/.github/prompts/fs-patterns-array-builder.prompt.md
+++ b/.github/prompts/fs-patterns-array-builder.prompt.md
@@ -1,0 +1,293 @@
+# Array Builder Pattern (Multiple responses list & loop)
+
+Follow these steps when adding or updating array builder pages in the form.
+1. Update `config/form.js` based on Step 1 below.
+2. Update or create `pages/{nounPluralReplaceMe}.js`. For example if working with "employers", the file would be `pages/employers.js`. The content of `pages/{nounPluralReplaceMe}.js` should be similar to the one of the examples below, which contains all sub pages and exports. Use best judgement whether you think the page should be required or optional, which uses different templates below.
+3. Ensure any text that says noun or noun plural or replace me is replaced with the correct noun or noun plural based on the type of data.
+4. Validate pages uses `arrayBuilderItemFirstPageTitleUI` or `arrayBuilderItemSubsequentPageTitleUI` instead of `titleUI`, and `arrayBuilderYesNoUI` for is used for summary page instead of `yesNoUI`.
+5. Validate the exports are used correctly by the form config.
+6. Validate the web component patterns are used correctly, and correct if necessary.
+
+## Example code
+### Step 1. `config/form.js`
+```js
+import { nounPluralReplaceMePages } from '../pages/nounPluralReplaceMe';
+
+const formConfig = {
+  ...
+  chapters: {
+    nounPluralReplaceMeChapter: {
+      title: 'Noun Plural',
+      pages: nounPluralReplaceMePages
+    },
+  }
+}
+```
+
+### Step 2. Create either "required" pages flow or "optional" pages flow
+
+### Example Pages "Required" Flow
+You can copy this to a new file `pages/nounPluralReplaceMe.js` as a starting point, and then import to `config/form.js`
+```js
+import {
+  arrayBuilderItemFirstPageTitleUI,
+  arrayBuilderItemSubsequentPageTitleUI,
+  arrayBuilderYesNoSchema,
+  arrayBuilderYesNoUI,
+  currentOrPastDateSchema,
+  currentOrPastDateUI,
+  textUI,
+  textSchema,
+  titleUI,
+} from '~/platform/forms-system/src/js/web-component-patterns';
+import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { formatReviewDate } from 'platform/forms-system/src/js/helpers';
+
+/** @type {ArrayBuilderOptions} */
+const options = {
+  arrayPath: 'nounPluralReplaceMe',
+  nounSingular: '[noun singular]',
+  nounPlural: '[noun plural]',
+  required: true,
+  isItemIncomplete: item => !item?.name, // include all required fields here
+  maxItems: 5,
+  text: {
+    getItemName: (item, index) => item.name,
+    cardDescription: item => `${formatReviewDate(item?.date)}`,
+  },
+};
+
+/** @returns {PageSchema} */
+const introPage = {
+  uiSchema: {
+    ...titleUI(
+      `Your ${options.nounPlural}`,
+      `In the next few questions, we’ll ask you about your ${
+        options.nounPlural
+      }. You must add at least one ${options.nounSingular}. You may add up to 5 ${
+        options.nounPlural
+      }.`,
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+/**
+ * This page is skipped on the first loop for required flow
+ * Cards are populated on this page above the uiSchema if items are present
+ *
+ * @returns {PageSchema}
+ */
+const summaryPage = {
+  uiSchema: {
+    'view:hasNounPluralReplaceMe': arrayBuilderYesNoUI(options),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      'view:hasNounPluralReplaceMe': arrayBuilderYesNoSchema,
+    },
+    required: ['view:hasNounPluralReplaceMe'],
+  },
+};
+
+/** @returns {PageSchema} */
+const namePage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Name',
+      nounSingular: options.nounSingular,
+    }),
+    name: textUI('Name'),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      name: textSchema,
+    },
+    required: ['name'],
+  },
+};
+
+/** @returns {PageSchema} */
+const datePage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) => (formData?.name ? `Date at ${formData.name}` : 'Date'),
+    ),
+    date: currentOrPastDateUI(),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      date: currentOrPastDateSchema,
+    },
+    required: ['date'],
+  },
+};
+
+export const nounPluralReplaceMePages = arrayBuilderPages(
+  options,
+  pageBuilder => ({
+    nounPluralReplaceMe: pageBuilder.introPage({
+      title: '[noun plural]',
+      path: 'noun-plural-replace-me',
+      uiSchema: introPage.uiSchema,
+      schema: introPage.schema,
+    }),
+    nounPluralReplaceMeSummary: pageBuilder.summaryPage({
+      title: 'Review your [noun plural]',
+      path: 'noun-plural-replace-me-summary',
+      uiSchema: summaryPage.uiSchema,
+      schema: summaryPage.schema,
+    }),
+    nounSingularReplaceMeNamePage: pageBuilder.itemPage({
+      title: 'Name',
+      path: 'noun-plural-replace-me/:index/name',
+      uiSchema: namePage.uiSchema,
+      schema: namePage.schema,
+    }),
+    nounSingularReplaceMeDatePage: pageBuilder.itemPage({
+      title: 'Date',
+      path: 'noun-plural-replace-me/:index/date',
+      uiSchema: datePage.uiSchema,
+      schema: datePage.schema,
+    }),
+  }),
+);
+```
+
+### Example Pages "Optional" Flow
+You can copy this to a new file `pages/nounPluralReplaceMe.js` as a starting point, and then import to `config/form.js`
+```js
+import {
+  arrayBuilderItemFirstPageTitleUI,
+  arrayBuilderItemSubsequentPageTitleUI,
+  arrayBuilderYesNoSchema,
+  arrayBuilderYesNoUI,
+  currentOrPastDateSchema,
+  currentOrPastDateUI,
+  textUI,
+  textSchema,
+} from '~/platform/forms-system/src/js/web-component-patterns';
+import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { formatReviewDate } from 'platform/forms-system/src/js/helpers';
+
+/** @type {ArrayBuilderOptions} */
+const options = {
+  arrayPath: 'nounPluralReplaceMe',
+  nounSingular: '[noun singular]',
+  nounPlural: '[noun plural]',
+  required: false,
+  isItemIncomplete: item => !item?.name, // include all required fields here
+  maxItems: 5,
+  text: {
+    getItemName: (item, index) => item.name,
+    cardDescription: item => `${formatReviewDate(item?.date)}`,
+    summaryDescription: 'You can add up to 5 items',
+  },
+};
+
+/**
+ * Cards are populated on this page above the uiSchema if items are present
+ *
+ * @returns {PageSchema}
+ */
+const summaryPage = {
+  uiSchema: {
+    'view:hasNounPluralReplaceMe': arrayBuilderYesNoUI(options),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      'view:hasNounPluralReplaceMe': arrayBuilderYesNoSchema,
+    },
+    required: ['view:hasNounPluralReplaceMe'],
+  },
+};
+
+/** @returns {PageSchema} */
+const namePage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Name',
+      nounSingular: options.nounSingular,
+    }),
+    name: textUI('Name'),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      name: textSchema,
+    },
+    required: ['name'],
+  },
+};
+
+/** @returns {PageSchema} */
+const datePage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) => (formData?.name ? `Date at ${formData.name}` : 'Date'),
+    ),
+    date: currentOrPastDateUI(),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      date: currentOrPastDateSchema,
+    },
+    required: ['date'],
+  },
+};
+
+export const nounPluralReplaceMePages = arrayBuilderPages( options,
+  pageBuilder => ({
+    nounPluralReplaceMeSummary: pageBuilder.summaryPage({
+      title: 'Review your [noun plural]',
+      path: 'noun-plural-replace-me-summary',
+      uiSchema: summaryPage.uiSchema,
+      schema: summaryPage.schema,
+    }),
+    nounSingularReplaceMeNamePage: pageBuilder.itemPage({
+      title: 'Name',
+      path: 'noun-plural-replace-me/:index/name',
+      uiSchema: namePage.uiSchema,
+      schema: namePage.schema,
+    }),
+    nounSingularReplaceMeDatePage: pageBuilder.itemPage({
+      title: 'Date',
+      path: 'noun-plural-replace-me/:index/date',
+      uiSchema: datePage.uiSchema,
+      schema: datePage.schema,
+    }),
+  }),
+);
+```
+
+### Example `arrayBuilderYesNoUI` Text Overrides:
+```js
+'view:hasEmployment': arrayBuilderYesNoUI(
+  options,
+  {
+    title:
+      'Do you have any employment, including self-employment for the last 5 years to report?',
+    hint: (props) =>
+      `Include self-employment and military duty (including inactive duty for training). ${maxItemsHint(props)}`,
+    labels: {
+      Y: 'Yes, I have employment to report',
+      N: 'No, I don’t have employment to report',
+    },
+  },
+  {
+    title: 'Do you have another employer to report?',
+    labels: {
+      Y: 'Yes, I have another employer to report',
+      N: 'No, I don’t have another employer to report',
+    },
+  },
+),
+```

--- a/.github/prompts/fs-patterns-unit-tests-web-components-schema-patterns.prompt.md
+++ b/.github/prompts/fs-patterns-unit-tests-web-components-schema-patterns.prompt.md
@@ -1,0 +1,58 @@
+# Unit tests
+
+- Use chai, mocha, sinon, and react-testing-library (RTL) for unit tests.
+- Use DefinitionTester if working with RJSF (React JSON Schema Form).
+- Use Provider to wrap all DefinitionTester tests, and any component using Redux.
+
+If we are testing RJSF, use DefinitionTester
+```js
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+```
+
+Example:
+```js
+const getProps = () => {
+  return {
+    mockStore: {
+      getState: () => ({
+        form: { data: {} },
+      }),
+      subscribe: () => {},
+      dispatch: () => ({
+        setFormData: () => {},
+      }),
+    },
+  };
+};
+
+const expectedFieldTypesWebComponents =
+  'va-text-input, va-select, va-textarea, va-radio, va-checkbox, va-memorable-date';
+const wrapperWebComponents = 'va-checkbox-group, va-memorable-date';
+
+it('should show the correct number of errors on submit for web components', () => {
+    const { mockStore } = getProps();
+
+    const { container, getByRole } = render(
+    <Provider store={mockStore}>
+        <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        formData={{}}
+        />
+    </Provider>,
+    );
+
+    getByRole('button', { name: /submit/i }).click();
+    const nodes = Array.from(
+    container.querySelectorAll(
+        `${expectedFieldTypesWebComponents}, ${wrapperWebComponents}`,
+    ),
+    );
+    const errors = nodes.filter(node => node.error);
+    expect(errors).to.have.lengthOf(expectedNumberOfErrors);
+});
+```

--- a/.github/prompts/fs-patterns-web-component-schema-patterns.prompt.md
+++ b/.github/prompts/fs-patterns-web-component-schema-patterns.prompt.md
@@ -1,0 +1,109 @@
+# Forms web component patterns for RJSF (React JSON Schema Form)
+
+Look at [README](../../src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.md) for all available web component patterns.
+
+## Example of Usage:
+
+```js
+import {
+  addressSchema,
+  addressUI,
+  emailToSendNotificationsSchema,
+  emailToSendNotificationsUI,
+  phoneSchema,
+  phoneUI,
+  ssnUI,
+  ssnSchema,
+  dateOfBirthSchema,
+  dateOfBirthUI,
+  currentOrPastDateRangeUI,
+  currentOrPastDateRangeSchema,
+  radioSchema,
+  radioUI,
+  yesNoUI,
+  yesNoSchema,
+  checkboxGroupSchema,
+  checkboxGroupUI,
+  titleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    ...titleUI(
+      'Mailing address',
+      'We’ll send any important information about your application to this address.',
+    ),
+    veteranMailingAddress: addressUI(),
+    veteranPhone: phoneUI(),
+    veteranEmail: emailToSendNotificationsUI(),
+    wcV3CheckSsn: ssnUI(),
+    dateWCV3: currentOrPastDateUI('Web component - Generic'),
+    dateOfBirthWCV3: dateOfBirthUI('Web component - Date of birth'),
+    wcv3VaTileCompensationType: radioUI({
+      title: 'Do you receive VA disability compensation?',
+      tile: true,
+      labels: {
+        lowDisability:
+          'Yes, for a service-connected disability rating of up to 40%',
+        highDisability:
+          'Yes, for a service-connected disability rating of 50% or higher',
+        none: 'No',
+      },
+    }),
+    wcv3IsCurrentlyActiveDuty: yesNoUI({
+      title: 'Are you on active duty now?',
+      description: 'This is a description',
+      labels: {
+        Y: 'Yes, the Veteran is on active duty now',
+        N: 'No, the Veteran is not on active duty now',
+      },
+    }),
+    checkboxGroupAtLeastOneRequired: checkboxGroupUI({
+      title: 'Checkbox group - At least one required',
+      required: true,
+      description: (
+        <va-additional-info trigger="JSX description">
+          We need the Veteran’s Social Security number or tax identification
+          number to process the application when it’s submitted online, but it’s
+          not a requirement to apply for the program.
+        </va-additional-info>
+      ),
+      hint: 'This is hint text',
+      labels: {
+        hasA: 'Option A',
+        hasB: 'Option B',
+      },
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['veteranMailingAddress'],
+    properties: {
+      veteranMailingAddress: addressSchema(),
+      veteranPhone: phoneSchema,
+      veteranEmail: emailToSendNotificationsSchema,
+      wcV3CheckSsn: ssnSchema,
+      dateWCV3: currentOrPastDateSchema,
+      dateOfBirthWCV3: dateOfBirthSchema,
+      wcv3VaTileCompensationType: radioSchema([
+        'lowDisability',
+        'highDisability',
+        'none',
+      ]),
+      wcv3IsCurrentlyActiveDuty: yesNoSchema,
+      checkboxGroupAtLeastOneRequired: checkboxGroupSchema(['hasA', 'hasB']),
+    },
+  },
+};
+```
+
+## Exceptions
+
+titleUI does not have a schema, and is used like:
+
+```js
+uiSchema: {
+  ...titleUI('Name and date of birth'),
+},
+```

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ src/site/tests/html/
 .env
 npm-debug.log
 *.log
-*.swp 
+*.swp
 
 config/config.proxy.js
 
@@ -58,3 +58,7 @@ script/cypress-testrail-helper/my-config.json
 
 # Ignore mochawesome report directory
 mochawesome-report/
+
+# Agents
+.agent/tmp/context/*
+.github/prompts/local*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,10 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# Regenerate web component catalog if web component pattern changes are detected
+if git diff --cached --name-only | grep -q '^src/platform/forms-system/src/js/web-component-patterns/'; then
+  echo "Changes detected in web-component-patterns. Regenerating web component documentation..."
+  NODE_VERSION=18 ./script/with-node.sh node ./script/generate-web-component-patterns-catalog.js
+fi
+
 ./node_modules/.bin/lint-staged

--- a/script/generate-web-component-patterns-catalog.js
+++ b/script/generate-web-component-patterns-catalog.js
@@ -1,0 +1,137 @@
+/* eslint-disable no-shadow */
+/* eslint-disable no-console */
+// *****************************************************************
+// This file generates
+// src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.md
+// by using AST to read all the files in the web-component-patterns directory
+// *****************************************************************
+const fs = require('fs');
+const path = require('path');
+const parser = require('@babel/parser');
+const traverse = require('@babel/traverse').default;
+
+const patternsDir = path.join(
+  __dirname,
+  '../src/platform/forms-system/src/js/web-component-patterns',
+);
+const readmePath = path.join(patternsDir, 'web-component-patterns-catalog.md');
+
+// Get all files in the directory except web-component-patterns-catalog.md and index.js
+const files = fs
+  .readdirSync(patternsDir)
+  .filter(
+    file =>
+      file !== 'web-component-patterns-catalog.md' &&
+      file !== 'index.js' &&
+      (file.endsWith('.js') || file.endsWith('.jsx')),
+  );
+
+let readmeContent =
+  '<!-- This file is auto-generated. Do not edit directly. -->\n';
+readmeContent += '# Web component patterns catalog\n\n';
+readmeContent += `All patterns are imported from 'platform/forms-system/src/js/web-component-patterns'.\n\n`;
+
+files.forEach(file => {
+  const filePath = path.join(patternsDir, file);
+  const fileContent = fs.readFileSync(filePath, 'utf-8');
+
+  // Format the title to exclude "patterns.js" or "pattern.jsx" and use sentence case
+  const formattedTitle = file
+    .replace(/patterns?\.jsx?$/i, '')
+    .replace(/[-_]/g, ' ')
+    .replace(
+      /\b\w/g,
+      (char, index) => (index === 0 ? char.toUpperCase() : char.toLowerCase()),
+    )
+    .trim();
+
+  readmeContent += `## ${formattedTitle}\n\n`;
+
+  try {
+    const ast = parser.parse(fileContent, {
+      sourceType: 'module',
+      plugins: ['jsx'],
+    });
+
+    const exports = [];
+
+    traverse(ast, {
+      ExportNamedDeclaration(path) {
+        const { declaration, specifiers } = path.node;
+        if (declaration) {
+          if (declaration.type === 'FunctionDeclaration') {
+            exports.push(`${declaration.id.name} (function)`);
+          } else if (declaration.type === 'VariableDeclaration') {
+            declaration.declarations.forEach(decl => {
+              const isFunction =
+                decl.init && decl.init.type === 'ArrowFunctionExpression';
+              if (isFunction) {
+                exports.push(`${decl.id.name} (function)`);
+              } else {
+                exports.push(`${decl.id.name} (object)`);
+              }
+            });
+          } else if (declaration.type === 'ClassDeclaration') {
+            exports.push(`${declaration.id.name} (class)`);
+          }
+        } else if (specifiers && specifiers.length > 0) {
+          specifiers.forEach(specifier => {
+            const exportedName = specifier.exported.name;
+            const localName = specifier.local.name;
+
+            // Check if the local name is a function, class, or variable
+            const binding = path.scope.getBinding(localName);
+            if (binding) {
+              const bindingNode = binding.path.node;
+              if (
+                bindingNode.type === 'FunctionDeclaration' ||
+                (bindingNode.type === 'VariableDeclarator' &&
+                  bindingNode.init &&
+                  bindingNode.init.type === 'ArrowFunctionExpression')
+              ) {
+                exports.push(`${exportedName} (function)`);
+              } else if (bindingNode.type === 'ClassDeclaration') {
+                exports.push(`${exportedName} (class)`);
+              } else {
+                exports.push(`${exportedName} (object)`);
+              }
+            } else {
+              exports.push(`${exportedName} (unknown)`);
+            }
+          });
+        }
+      },
+      ExportDefaultDeclaration(path) {
+        const { declaration } = path.node;
+        if (declaration.type === 'Identifier') {
+          exports.push(`${declaration.name} (object)`);
+        } else if (declaration.type === 'FunctionDeclaration') {
+          exports.push(`default export (function)`);
+        } else {
+          exports.push('default export (object)');
+        }
+      },
+    });
+
+    // Filter exports to only include those ending in 'UI' or 'Schema'
+    const filteredExports = exports.filter(exp => exp.match(/(UI|Schema)\b/));
+
+    if (filteredExports.length > 0) {
+      filteredExports.forEach(exp => {
+        readmeContent += `- ${exp}\n`;
+      });
+    } else {
+      readmeContent += '- No matching exports found\n';
+    }
+  } catch (error) {
+    readmeContent += `- Error parsing file: ${error.message}\n`;
+  }
+
+  readmeContent += '\n';
+});
+
+fs.writeFileSync(readmePath, readmeContent);
+
+console.log(
+  'web-component-patterns-catalog.md has been generated successfully.',
+);

--- a/script/with-node.sh
+++ b/script/with-node.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Try to use nvm to use a specific node version for a given script.
+# Fail silently if nvm is not installed.
+#
+# Usage:
+# NODE_VERSION=18 ./script/with-node.sh node ./script/my-node-script.js
+
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck disable=SC1090
+  . "$NVM_DIR/nvm.sh"
+
+  if [ -n "$NODE_VERSION" ]; then
+    nvm use "$NODE_VERSION" > /dev/null 2>&1 || true
+  fi
+fi
+
+exec "$@"

--- a/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.md
+++ b/src/platform/forms-system/src/js/web-component-patterns/web-component-patterns-catalog.md
@@ -1,0 +1,148 @@
+<!-- This file is auto-generated. Do not edit directly. -->
+# Web component patterns catalog
+
+All patterns are imported from 'platform/forms-system/src/js/web-component-patterns'.
+
+## Address
+
+- addressUI (function)
+- addressSchema (function)
+- addressNoMilitaryUI (function)
+- addressNoMilitarySchema (function)
+
+## Arn
+
+- arnUI (function)
+- arnSchema (object)
+- arnOrVaFileNumberUI (function)
+- arnOrVaFileNumberSchema (object)
+
+## ArrayBuilder
+
+- arrayBuilderItemFirstPageTitleUI (function)
+- arrayBuilderItemSubsequentPageTitleUI (function)
+- arrayBuilderYesNoUI (function)
+- arrayBuilderYesNoSchema (object)
+
+## Bank
+
+- bankAccountUI (function)
+- bankAccountSchema (function)
+
+## CheckboxGroup
+
+- checkboxGroupUI (function)
+- checkboxGroupSchema (function)
+
+## Currency
+
+- currencyUI (function)
+- currencySchema (object)
+- currencyStringSchema (object)
+
+## Date
+
+- currentOrPastDateUI (function)
+- currentOrPastDateDigitsUI (function)
+- currentOrPastDateRangeUI (function)
+- currentOrPastMonthYearDateUI (function)
+- currentOrPastMonthYearDateRangeUI (function)
+- dateOfBirthUI (function)
+- dateOfDeathUI (function)
+- currentOrPastDateRangeSchema (object)
+- currentOrPastDateSchema (object)
+- currentOrPastDateDigitsSchema (object)
+- currentOrPastMonthYearDateSchema (object)
+- currentOrPastMonthYearDateRangeSchema (object)
+- dateOfBirthSchema (object)
+- dateOfDeathSchema (object)
+
+## Email
+
+- emailUI (function)
+- emailToSendNotificationsUI (function)
+- emailSchema (object)
+- emailToSendNotificationsSchema (object)
+
+## FileInput
+
+- fileInputUI (function)
+- fileInputSchema (object)
+
+## FullName
+
+- fullNameNoSuffixUI (function)
+- firstNameLastNameNoSuffixUI (function)
+- fullNameWithMaidenNameUI (function)
+- fullNameUI (function)
+- firstNameLastNameUI (function)
+- fullNameSchema (object)
+- firstNameLastNameSchema (object)
+- fullNameNoSuffixSchema (object)
+- firstNameLastNameNoSuffixSchema (object)
+- fullNameWithMaidenNameSchema (object)
+
+## Number
+
+- numberUI (function)
+- numberSchema (object)
+
+## Phone
+
+- phoneUI (function)
+- internationalPhoneUI (function)
+- phoneSchema (object)
+- internationalPhoneSchema (object)
+
+## Radio
+
+- radioUI (function)
+- radioSchema (function)
+
+## RelationshipToVeteran
+
+- relationshipToVeteranUI (function)
+- relationshipToVeteranSpouseOrChildUI (function)
+- claimantRelationshipToVeteranSpouseOrChildUI (function)
+- relationshipToVeteranSchema (object)
+- relationshipToVeteranSpouseOrChildSchema (object)
+
+## Select
+
+- selectUI (function)
+- selectSchema (function)
+
+## Ssn
+
+- ssnUI (function)
+- ssnSchema (object)
+- vaFileNumberUI (function)
+- vaFileNumberSchema (object)
+- serviceNumberUI (function)
+- serviceNumberSchema (object)
+- ssnOrVaFileNumberUI (function)
+- ssnOrVaFileNumberSchema (object)
+- ssnOrVaFileNumberNoHintUI (function)
+- ssnOrVaFileNumberNoHintSchema (object)
+
+## Text
+
+- textUI (function)
+- textSchema (object)
+- textareaUI (function)
+- textareaSchema (object)
+
+## Title
+
+- titleUI (function)
+- descriptionUI (function)
+- inlineTitleUI (function)
+- titleSchema (object)
+- inlineTitleSchema (object)
+- descriptionSchema (object)
+
+## YesNo
+
+- yesNoUI (function)
+- yesNoSchema (object)
+


### PR DESCRIPTION
Add forms system AI prompts and tasks to vets-website

## Related issues
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4055
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4033

## Proposal for `.agent` and tasks
```
.agent/tasks/open_app_in_browser.js
.agent/tasks/run_app_unit_tests.js
.agent/tasks/yarn_watch.js
.agent/tmp/context  -  for context input and output
```

## Proposal for prompts
- Add `fs-` prompts which are forms-system or forms
- Use composable prompts which reference each other
- Prefix by topic if possible
```
.github/prompts/fs-app-locate-folder.prompt.md
.github/prompts/fs-app-open-url.prompt.md
.github/prompts/fs-app-run-unit-tests.prompt.md
.github/prompts/fs-app-yarn-watch.prompt.md
.github/prompts/fs-page-add-or-update-array-builder.prompt.md
.github/prompts/fs-page-add-or-update.prompt.md
.github/prompts/fs-patterns-array-builder.prompt.md
.github/prompts/fs-patterns-unit-tests-web-components-schema-patterns.prompt.md
.github/prompts/fs-patterns-web-component-schema-patterns.prompt.md
```

## How to test
First cherry pick this commit
```
git cherry-pick a1a649453075ecd3fcf9d1e7a3e4201f3cf6cbb4
```

In your agent sidebar in VSCode/Cursor/Windsurf, attach a prompt to whatever you are doing.
For example if you want to add a page for a particular form, attach prompt `fs-page-add-or-update.prompt.md`. 
In VSCode the hotkey for attaching prompt is `ctrl+alt+/`

Example:
Add prompt `fs-page-add-or-update.prompt.md`
Say: Add a page to form 4142 that asks for the users full name and date of birth, title should be ....