### PR TITLE
Adds deletion alert for form upload

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781/manualUploadPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/manualUploadPage.jsx
@@ -13,6 +13,9 @@ export const manualUploadPageDescription = (
   </>
 );
 
+export const manualUploadAlertText =
+  'We’ve deleted files about your mental health statement.';
+
 export const howToScanFileInfo = (
   <va-additional-info trigger="How to scan a file">
     <div>

--- a/src/applications/disability-benefits/all-claims/content/form0781/manualUploadPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/manualUploadPage.jsx
@@ -14,7 +14,7 @@ export const manualUploadPageDescription = (
 );
 
 export const manualUploadAlertText =
-  'We’ve deleted files about your mental health statement.';
+  'We’ve deleted this file about your mental health statement.';
 
 export const howToScanFileInfo = (
   <va-additional-info trigger="How to scan a file">

--- a/src/applications/disability-benefits/all-claims/pages/form0781/manualUploadPage.js
+++ b/src/applications/disability-benefits/all-claims/pages/form0781/manualUploadPage.js
@@ -5,6 +5,7 @@ import {
   manualUploadPageTitle,
   manualUploadRequirementsText,
   manualUploadRequirementsTextTitle,
+  manualUploadAlertText,
 } from '../../content/form0781/manualUploadPage';
 import {
   ancillaryFormUploadUi,
@@ -28,6 +29,7 @@ export const uiSchema = {
         customClasses: 'upload-completed-form',
         isDisabled: true,
         attachmentName: true,
+        deleteAlertText: manualUploadAlertText,
       },
     ),
     'ui:description': manualUploadRequirementsText,

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -276,26 +276,24 @@ export const ancillaryFormUploadUi = (
     isDisabled = false,
     buttonText = '',
     addAnotherLabel = 'Add Another',
+    deleteAlertText,
   } = {},
 ) => {
-  // a11y focus management. Move focus to select after upload
-  // see va.gov-team/issues/19688
   const findAndFocusLastSelect = () => {
-    // focus on last document type select since all new uploads are appended
     const lastSelect = [...document.querySelectorAll('select')].slice(-1);
     if (lastSelect.length) {
       focusElement(lastSelect[0]);
     }
   };
+
   return fileUploadUI(label, {
     itemDescription,
     hideLabelText: !label,
     fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
     buttonText,
     addAnotherLabel,
+    deleteAlertText,
     fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'],
-    // not sure what to do here... we need to differentiate pdf vs everything
-    // else; the check is in the actions.js > uploadFile function
     maxSize: MAX_FILE_SIZE_BYTES,
     maxPdfSize: MAX_PDF_FILE_SIZE_BYTES,
     minSize: 1,

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -419,6 +419,13 @@ const FileField = props => {
             const newData = props.formData || [];
             newData[idx] = { ...file, isEncrypted: !!password };
             onChange(newData);
+            if (file.uploading) {
+              $('.schemaform-file-uploading .cancel-upload')?.focus();
+            }
+            // Focus on the file card after the file has finished uploading
+            if (!file.uploading) {
+              $(getFileListId(idx))?.focus();
+            }
             setUploadRequest(null);
           },
           () => setUploadRequest(null),

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -4,7 +4,10 @@ import React, { useEffect, useState, useRef } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { isLoggedIn } from 'platform/user/selectors';
 import classNames from 'classnames';
-import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaModal,
+  VaAlert,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { toggleValues } from '../../../../site-wide/feature-toggles/selectors';
 import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
@@ -224,6 +227,7 @@ const FileField = props => {
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [removeIndex, setRemoveIndex] = useState(null);
   const [initialized, setInitialized] = useState(false);
+  const [deletedFileAlerts, setDeletedFileAlerts] = useState(false);
 
   const previousValue = usePreviousValue(formData);
   const fileInputRef = useRef(null);
@@ -359,28 +363,23 @@ const FileField = props => {
    */
   const onAddFile = async (event, index = null, password) => {
     if (event.target?.files?.length) {
+      setDeletedFileAlerts(false);
       const currentFile = event.target.files[0];
       const allFiles = props.formData || [];
       const addUiOptions = props.uiSchema['ui:options'];
-      // needed for FileField unit tests
       const { mockReadAndCheckFile } = uiOptions;
 
-      let idx = index;
-      if (idx === null) {
-        idx = allFiles.length === 0 ? 0 : allFiles.length;
-      }
+      const idx = index ?? (allFiles.length === 0 ? 0 : allFiles.length);
 
       let checkResults;
       const checks = { checkTypeAndExtensionMatches, checkIsEncryptedPdf };
 
       if (currentFile.type === 'testing') {
-        // Skip read file for Cypress testing
         checkResults = {
           checkTypeAndExtensionMatches: true,
           checkIsEncryptedPdf: false,
         };
       } else {
-        // read file mock for unit testing
         checkResults =
           typeof mockReadAndCheckFile === 'function'
             ? mockReadAndCheckFile()
@@ -397,7 +396,6 @@ const FileField = props => {
         return;
       }
 
-      // Check if the file is an encrypted PDF
       if (
         currentFile.name?.endsWith('pdf') &&
         !password &&
@@ -408,9 +406,7 @@ const FileField = props => {
           name: currentFile.name,
           isEncrypted: true,
         };
-
         props.onChange(allFiles);
-        // wait for user to enter a password before uploading
         return;
       }
 
@@ -420,23 +416,12 @@ const FileField = props => {
           addUiOptions,
           updateProgress,
           file => {
-            // formData is undefined initially
             const newData = props.formData || [];
             newData[idx] = { ...file, isEncrypted: !!password };
             onChange(newData);
-            // Focus on the 'Cancel' button when a file is being uploaded
-            if (file.uploading) {
-              $('.schemaform-file-uploading .cancel-upload')?.focus();
-            }
-            // Focus on the file card after the file has finished uploading
-            if (!file.uploading) {
-              $(getFileListId(idx))?.focus();
-            }
             setUploadRequest(null);
           },
-          () => {
-            setUploadRequest(null);
-          },
+          () => setUploadRequest(null),
           formContext.trackingPrefix,
           password,
           props.enableShortWorkflow,
@@ -498,6 +483,9 @@ const FileField = props => {
     setShowRemoveModal(false);
     if (remove) {
       removeFile(idx);
+      if (uiOptions?.deleteAlertText) {
+        setDeletedFileAlerts(true);
+      }
     } else {
       setTimeout(() => {
         focusElement(
@@ -819,6 +807,22 @@ const FileField = props => {
           })}
         </ul>
       )}
+      {deletedFileAlerts &&
+        uiOptions?.deleteAlertText && (
+          <div className="vads-u-margin-top--2">
+            <VaAlert
+              id="success-alert"
+              status="success"
+              closeable
+              visible
+              class="vads-u-margin-bottom--4"
+              uswds
+              onCloseEvent={() => setDeletedFileAlerts(false)}
+            >
+              {uiOptions?.deleteAlertText}
+            </VaAlert>
+          </div>
+        )}
       {// Don't render an upload button on review & submit page while in
       // review mode
       showButtons && (

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -492,6 +492,9 @@ const FileField = props => {
       removeFile(idx);
       if (uiOptions?.deleteAlertText) {
         setDeletedFileAlerts(true);
+        setTimeout(() => {
+          focusElement('#success-alert');
+        }, 110);
       }
     } else {
       setTimeout(() => {


### PR DESCRIPTION
This ticket expands the functionality of the FileField to allow a user to pass through an optional deleteAlertText message. When this prop is provided, a VAAlert will appear once a file has been deleted. 

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds deleteAlertText to ancillaryFormUploadUi
- When deleteAlertText is provided a VAAlert will show with the provided message when a file is deleted

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107724

## Testing done

- Previously if you deleted a file you just received a VAModal asking you to confirm deletion
- Now, after the confirmation of the file deletion a user gets a VAAlert to confirm the data was deleted.
- This can be tested on http://localhost:3001/disability/file-disability-claim-form-21-526ez/mental-health-form-0781/upload

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<img width="610" alt="Screenshot 2025-04-28 at 4 12 56 PM" src="https://github.com/user-attachments/assets/52593634-a4ca-440a-bd2d-ef73d7fe9e7c" />


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
