### PR TITLE
MHV-69535: Radiology details component refactor and request image button fix

### DIFF
--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -369,7 +369,7 @@ ${record.results}`;
     return (
       imageStudyJob &&
       (imageStudyJob.status === studyJobStatus.NEW ||
-        studyJob?.status !== studyJobStatus.QUEUED ||
+        imageStudyJob.status === studyJobStatus.QUEUED ||
         imageStudyJob.status === studyJobStatus.PROCESSING) &&
       imageStudyJob.percentComplete < 100
     );

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -363,6 +363,19 @@ ${record.results}`;
     studyJob?.status !== studyJobStatus.COMPLETE;
 
   /**
+   * Determines whether image requests should be disabled for a given study job.
+   */
+  const disableRequestImages = imageStudyJob => {
+    return (
+      imageStudyJob &&
+      (imageStudyJob.status === studyJobStatus.NEW ||
+        studyJob?.status !== studyJobStatus.QUEUED ||
+        imageStudyJob.status === studyJobStatus.PROCESSING) &&
+      imageStudyJob.percentComplete < 100
+    );
+  };
+
+  /**
    * Either renders the “limit reached” paragraph or the Request Images button.
    */
   const renderRequestImagesControl = imageRequest => {
@@ -379,7 +392,7 @@ ${record.results}`;
     return (
       <va-button
         onClick={makeImageRequest}
-        disabled={imageRequest?.percentComplete < 100}
+        disabled={disableRequestImages(imageRequest)}
         ref={elementRef}
         text="Request Images"
         data-testid="radiology-request-images-button"

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -140,11 +140,15 @@ const RadiologyDetails = props => {
 
   useEffect(
     () => {
-      if (imageRequestApiFailed || studyRequestLimitReached) {
+      if (
+        imageRequestApiFailed ||
+        studyRequestLimitReached ||
+        studyJob?.status === studyJobStatus.ERROR
+      ) {
         setProcessingRequest(false);
       }
     },
-    [imageRequestApiFailed, studyRequestLimitReached],
+    [imageRequestApiFailed, studyJob, studyRequestLimitReached],
   );
 
   useEffect(

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -23,6 +23,7 @@ import {
   pageTitles,
   studyJobStatus,
   ALERT_TYPE_IMAGE_STATUS_ERROR,
+  radiologyErrors,
 } from '../../util/constants';
 import {
   formatNameFirstLast,
@@ -85,11 +86,6 @@ const RadiologyDetails = props => {
 
   const activeAlert = useAlerts(dispatch);
 
-  const ERROR_REQUEST_AGAIN =
-    'We’re sorry. There was a problem with our system. Try requesting your images again.';
-  const ERROR_TRY_LATER =
-    'We’re sorry. There was a problem with our system. Try again later.';
-
   useEffect(
     () => {
       dispatch(fetchImageRequestStatus());
@@ -103,8 +99,9 @@ const RadiologyDetails = props => {
       if (studyJobs?.length) {
         const jobsInProcess = studyJobs.filter(
           job =>
-            job.status === studyJobStatus.PROCESSING ||
-            job.status === studyJobStatus.NEW,
+            job.status === studyJobStatus.NEW ||
+            job.status === studyJobStatus.QUEUED ||
+            job.status === studyJobStatus.PROCESSING,
         );
         if (jobsInProcess.length >= 3) {
           dispatch(setStudyRequestLimitReached(true));
@@ -113,7 +110,7 @@ const RadiologyDetails = props => {
         }
       }
     },
-    [studyJobs],
+    [dispatch, studyJobs, studyRequestLimitReached],
   );
 
   useEffect(
@@ -155,6 +152,7 @@ const RadiologyDetails = props => {
       let timeoutId;
       if (
         studyJob?.status === studyJobStatus.NEW ||
+        studyJob?.status === studyJobStatus.QUEUED ||
         studyJob?.status === studyJobStatus.PROCESSING
       ) {
         setProcessingRequest(false);
@@ -190,7 +188,7 @@ const RadiologyDetails = props => {
     GenerateRadiologyPdf(record, user, runningUnitTest);
   };
 
-  const generateRadioloyTxt = async () => {
+  const generateRadiologyTxt = async () => {
     setDownloadStarted(true);
     const content = `\n
 ${crisisLineHeader}\n\n
@@ -279,20 +277,7 @@ ${record.results}`;
     </p>
   );
 
-  const imagesNotRequested = imageRequest => (
-    <>
-      {requestNote()}
-      <va-button
-        onClick={() => makeImageRequest()}
-        disabled={imageRequest?.percentComplete < 100}
-        ref={elementRef}
-        text="Request Images"
-        uswds
-      />
-    </>
-  );
-
-  const imageAlertProcessing = imageRequest => {
+  const jobProcessingAlert = imageRequest => {
     const percent =
       imageRequest.status === studyJobStatus.NEW
         ? 0
@@ -322,7 +307,7 @@ ${record.results}`;
     );
   };
 
-  const imageAlertComplete = () => {
+  const jobCompleteAlert = () => {
     const endDateParts = formatDateAndTime(
       new Date(studyJob.endDate + 3 * 24 * 60 * 60 * 1000), // Add 3 days
     );
@@ -351,6 +336,7 @@ ${record.results}`;
 
   const imageAlert = message => (
     <va-alert
+      class="vads-u-margin-bottom--2"
       status="error"
       visible
       aria-live="polite"
@@ -369,28 +355,52 @@ ${record.results}`;
     </va-alert>
   );
 
-  const imageAlertError = imageRequest => (
-    <>
-      <p>To review and download your images, you’ll need to request them.</p>
-      {imageAlert(ERROR_REQUEST_AGAIN)}
+  const isLimitReachedPertinent =
+    studyRequestLimitReached &&
+    studyJob?.status !== studyJobStatus.NEW &&
+    studyJob?.status !== studyJobStatus.QUEUED &&
+    studyJob?.status !== studyJobStatus.PROCESSING &&
+    studyJob?.status !== studyJobStatus.COMPLETE;
+
+  /**
+   * Either renders the “limit reached” paragraph or the Request Images button.
+   */
+  const renderRequestImagesControl = imageRequest => {
+    if (isLimitReachedPertinent) {
+      return (
+        <p>
+          You can’t request images for this report right now. You can only have
+          3 image requests at a time. Once a report is done processing you can
+          request images for this report here.
+        </p>
+      );
+    }
+
+    return (
       <va-button
-        class="vads-u-margin-top--2"
-        onClick={() => makeImageRequest()}
-        data-testid="radiology-request-images-button"
+        onClick={makeImageRequest}
         disabled={imageRequest?.percentComplete < 100}
         ref={elementRef}
         text="Request Images"
+        data-testid="radiology-request-images-button"
         uswds
       />
+    );
+  };
+
+  const imagesNotRequested = imageRequest => (
+    <>
+      {!isLimitReachedPertinent && requestNote()}
+      {renderRequestImagesControl(imageRequest)}
     </>
   );
 
-  const requestLimitReachedAlert = () => (
-    <p>
-      You can’t request images for this report right now. You can only have 3
-      image requests at a time. Once a report is done processing you can request
-      images for this report here.
-    </p>
+  const imageAlertError = imageRequest => (
+    <>
+      <p>To review and download your images, you’ll need to request them.</p>
+      {imageAlert(radiologyErrors.ERROR_REQUEST_AGAIN)}
+      {renderRequestImagesControl(imageRequest)}
+    </>
   );
 
   const imageStatusContent = () => {
@@ -406,26 +416,25 @@ ${record.results}`;
       }
 
       if (activeAlert && activeAlert.type === ALERT_TYPE_IMAGE_STATUS_ERROR) {
-        return imageAlert(ERROR_TRY_LATER);
+        return imageAlert(radiologyErrors.ERROR_TRY_LATER);
       }
+
+      const newOrProcessing =
+        studyJob?.status === studyJobStatus.NEW ||
+        studyJob?.status === studyJobStatus.QUEUED ||
+        studyJob?.status === studyJobStatus.PROCESSING;
+      const jobComplete = studyJob?.status === studyJobStatus.COMPLETE;
+      const requestFailedOrError =
+        imageRequestApiFailed || studyJob?.status === studyJobStatus.ERROR;
+      const nillOrLimitReached =
+        (!studyJob || studyRequestLimitReached) && !requestFailedOrError;
 
       return (
         <>
-          {(!studyJob || studyJob.status === studyJobStatus.NONE) &&
-            !studyRequestLimitReached &&
-            imagesNotRequested(studyJob)}
-          {(studyJob?.status === studyJobStatus.NEW ||
-            studyJob?.status === studyJobStatus.PROCESSING) &&
-            imageAlertProcessing(studyJob)}
-          {studyJob?.status === studyJobStatus.COMPLETE && imageAlertComplete()}
-          {studyRequestLimitReached &&
-            studyJob.status !== studyJobStatus.PROCESSING &&
-            studyJob.status !== studyJobStatus.NEW &&
-            studyJob.status !== studyJobStatus.COMPLETE &&
-            requestLimitReachedAlert()}
-          {(imageRequestApiFailed ||
-            studyJob?.status === studyJobStatus.ERROR) &&
-            imageAlertError(studyJob)}
+          {nillOrLimitReached && imagesNotRequested(studyJob)}
+          {newOrProcessing && jobProcessingAlert(studyJob)}
+          {jobComplete && jobCompleteAlert()}
+          {requestFailedOrError && imageAlertError(studyJob)}
           {notificationContent()}
         </>
       );
@@ -461,14 +470,14 @@ ${record.results}`;
             <h3 className="vads-u-font-size--lg vads-u-font-family--sans no-print">
               Images ready
             </h3>
-            {imageAlertComplete()}
+            {jobCompleteAlert()}
           </VaAlert>
         )}
         {downloadStarted && <DownloadSuccessAlert />}
         <PrintDownload
           description="L&TR Detail"
           downloadPdf={downloadPdf}
-          downloadTxt={generateRadioloyTxt}
+          downloadTxt={generateRadiologyTxt}
           allowTxtDownloads={allowTxtDownloads}
         />
         <DownloadingRecordsInfo

--- a/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -143,7 +143,7 @@ const RadiologyDetails = props => {
       if (
         imageRequestApiFailed ||
         studyRequestLimitReached ||
-        studyJob?.status === studyJobStatus.ERROR
+        studyJob?.status
       ) {
         setProcessingRequest(false);
       }

--- a/src/applications/mhv-medical-records/tests/components/RadiologyDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/RadiologyDetails.unit.spec.jsx
@@ -179,6 +179,8 @@ describe('Radiology details component - image with error', () => {
       'radiology-request-images-button',
     );
     expect(requestImagesButton).to.exist;
+    // assert that the button is enabled:
+    expect(requestImagesButton.getAttribute('disabled')).to.eq('false');
     fireEvent.click(requestImagesButton);
   });
 });

--- a/src/applications/mhv-medical-records/util/constants.js
+++ b/src/applications/mhv-medical-records/util/constants.js
@@ -334,8 +334,8 @@ export const allergyTypes = {
 };
 
 export const studyJobStatus = {
-  NONE: 'NONE', // has not been requested
   NEW: 'NEW', // has been requested but not yet processing (very short-lived)
+  QUEUED: 'QUEUED', // has been requested but not yet processing (also very short-lived)
   PROCESSING: 'PROCESSING', // has been requested
   COMPLETE: 'COMPLETE', // request complete
   ERROR: 'ERROR', // error
@@ -520,4 +520,11 @@ export const CernerAlertContent = {
     linkPath: '/pages/health_record/results',
     pageName: 'vitals',
   },
+};
+
+export const radiologyErrors = {
+  ERROR_REQUEST_AGAIN:
+    'We’re sorry. There was a problem with our system. Try requesting your images again.',
+  ERROR_TRY_LATER:
+    'We’re sorry. There was a problem with our system. Try again later.',
 };


### PR DESCRIPTION
## Summary
- I refactored the radiology details component to make it easier to understand
- I created a single instance of the request images button within it
- I made it so that the request images button is enabled after an image (study) request fails

## Related issue(s)
MHV-69535
![image (4)](https://github.com/user-attachments/assets/16494b50-e156-4640-9f4b-d629688e9eba)

## Testing done
I added a test to validate that the request images button remains enabled when an image request errors out. 

## Screenshots
Images not requested
<img width="918" alt="Screenshot 2025-04-28 at 1 43 57 PM" src="https://github.com/user-attachments/assets/b4afaa14-10de-47e0-87d7-82cd9fb10438" />

Study request limit reached
<img width="823" alt="Screenshot 2025-04-28 at 2 40 19 PM" src="https://github.com/user-attachments/assets/8ca4e51b-ebc6-493d-a28d-210f5aba8d1b" />

Image request complete
<img width="797" alt="Screenshot 2025-04-28 at 2 02 31 PM" src="https://github.com/user-attachments/assets/4ee3997b-ef70-4f82-92dd-8ae8c348d643" />

Image request error
<img width="830" alt="Screenshot 2025-04-28 at 1 04 07 PM" src="https://github.com/user-attachments/assets/111e1a19-cb12-4e4f-af10-b7e67685f6ff" />

Image request error and over the study limit reached
<img width="839" alt="Screenshot 2025-04-28 at 1 02 37 PM" src="https://github.com/user-attachments/assets/5ec7b5dd-5fe1-4e09-b7f7-b54b1a194f9e" />

## What areas of the site does it impact?
MHV medical records - radiology details

## Acceptance criteria
Request images button on radiology details page is enabled after a study/images request fails

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
