### PR TITLE
Fix feature toggle name casing

### DIFF
--- a/src/applications/vaos/components/EnrolledRoute.unit.spec.jsx
+++ b/src/applications/vaos/components/EnrolledRoute.unit.spec.jsx
@@ -16,7 +16,7 @@ const initialState = {
   featureToggles: {
     vaOnlineScheduling: true,
     vaOnlineSchedulingCancel: true,
-    vaOnlineSchedulingMhvRouteGuards: false,
+    vaOnlineSchedulingMHVRouteGuards: false,
   },
   user: {
     login: {
@@ -123,7 +123,7 @@ describe('VAOS Component: EnrolledRoute', () => {
       ...initialState,
       featureToggles: {
         ...initialState.featureToggles,
-        vaOnlineSchedulingMhvRouteGuards: true,
+        vaOnlineSchedulingMHVRouteGuards: true,
       },
       user: {
         ...initialState.user,
@@ -153,7 +153,7 @@ describe('VAOS Component: EnrolledRoute', () => {
       ...initialState,
       featureToggles: {
         ...initialState.featureToggles,
-        vaOnlineSchedulingMhvRouteGuards: true,
+        vaOnlineSchedulingMHVRouteGuards: true,
       },
       user: {
         ...initialState.user,

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -112,7 +112,7 @@ export const selectFeatureFeSourceOfTruthTelehealth = state =>
   toggleValues(state).vaOnlineSchedulingFeSourceOfTruthTelehealth;
 
 export const selectFeatureMhvRouteGuards = state =>
-  toggleValues(state).vaOnlineSchedulingMhvRouteGuards;
+  toggleValues(state).vaOnlineSchedulingMHVRouteGuards;
 
 export const selectFeatureDirectScheduleAppointmentConflict = state =>
   toggleValues(state).vaOnlineSchedulingDirectScheduleAppointmentConflict;

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -20,7 +20,7 @@ module.exports = [
   { name: 'vaOnlineSchedulingFeSourceOfTruthCC', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthModality', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthTelehealth', value: true },
-  { name: 'vaOnlineSchedulingMhvRouteGuards', value: false },
+  { name: 'vaOnlineSchedulingMHVRouteGuards', value: false },
   { name: 'vaOnlineSchedulingDirectScheduleAppointmentConflict', value: false },
   { name: 'vaOnlineSchedulingDisplayPastCancelledAppointments', value: true },
   { name: 'vaOnlineSchedulingPatientHistoryFutureAppts', value: false },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -274,7 +274,7 @@
   "vaDependentsV2": "va_dependents_v2",
   "vaDependentsV2Banner": "va_dependents_v2_banner",
   "vaOnlineScheduling": "va_online_scheduling",
-  "vaOnlineSchedulingBookingExclusion": "va_online_scheduling_booking_exclusion\t",
+  "vaOnlineSchedulingBookingExclusion": "va_online_scheduling_booking_exclusion",
   "vaOnlineSchedulingBreadcrumbUrlUpdate": "va_online_scheduling_breadcrumb_url_update",
   "vaOnlineSchedulingCancel": "va_online_scheduling_cancel",
   "vaOnlineSchedulingCCDirectScheduling": "va_online_scheduling_cc_direct_scheduling",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -293,7 +293,7 @@
   "vaOnlineSchedulingFeSourceOfTruthCC": "va_online_scheduling_fe_source_of_truth_cc",
   "vaOnlineSchedulingFeSourceOfTruthModality": "va_online_scheduling_fe_source_of_truth_modality",
   "vaOnlineSchedulingFeSourceOfTruthTelehealth": "va_online_scheduling_fe_source_of_truth_telehealth",
-  "vaOnlineSchedulingMhvRouteGuards": "va_online_scheduling_mhv_route_guards",
+  "vaOnlineSchedulingMHVRouteGuards": "va_online_scheduling_mhv_route_guards",
   "vaOnlineSchedulingDirectScheduleAppointmentConflict": "va_online_scheduling_direct_schedule_appointment_conflict",
   "vaOnlineSchedulingDisplayPastCancelledAppointments": "va_online_scheduling_display_past_cancelled_appointments",
   "vaOnlineSchedulingPatientHistoryFutureAppts": "va_online_scheduling_patient_history_future_appts",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR fixes the feature toggle name casing for `va_online_scheduling_mhv_route_guards`
- It turns out that staging and production environments capitalizes MHV so we need to update the naming so the feature toggle can be retrieved.
  <img width="402" alt="image" src="https://github.com/user-attachments/assets/10cfb749-4d7c-4d0a-bffa-d17cee001c11" />
- Appointments Team


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101532
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/101531

## Testing done

- Verified in staging

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
