### PR TITLE
[Secure Messaging] Replaces PageNotFound with MhvPageNotFound component

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/AuthorizedRoutes.jsx
+++ b/src/applications/mhv-secure-messaging/containers/AuthorizedRoutes.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Switch, Route, useLocation } from 'react-router-dom';
-import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
+import { MhvPageNotFound } from '@department-of-veterans-affairs/mhv/exports';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
@@ -18,7 +18,7 @@ import manifest from '../manifest.json';
 import SmBreadcrumbs from '../components/shared/SmBreadcrumbs';
 import EditContactList from './EditContactList';
 
-// Prepend SmBreadcrumbs to each route, except for PageNotFound
+// Prepend SmBreadcrumbs to each route, except for MhvPageNotFound
 const AppRoute = ({ children, ...rest }) => {
   return (
     <Route {...rest}>
@@ -110,7 +110,7 @@ const AuthorizedRoutes = () => {
           <EditContactList />
         </AppRoute>
         <Route>
-          <PageNotFound />
+          <MhvPageNotFound />
         </Route>
       </Switch>
     </div>

--- a/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
@@ -423,7 +423,7 @@ describe('App', () => {
       path: `/sdfsdf`,
     });
     await waitFor(() => {
-      expect(screen.getByTestId('mhv-page-not-found')).to.exist;
+      expect(screen.findByTestId('mhv-page-not-found')).to.exist;
     });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/App.unit.spec.jsx
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
-import { pageNotFoundHeading } from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 import sinon from 'sinon';
 import { addDays, subDays, format } from 'date-fns';
 import { waitFor } from '@testing-library/dom';
@@ -424,12 +423,7 @@ describe('App', () => {
       path: `/sdfsdf`,
     });
     await waitFor(() => {
-      expect(
-        screen.getByText(pageNotFoundHeading, {
-          selector: 'h1',
-          exact: true,
-        }),
-      ).to.exist;
+      expect(screen.getByTestId('mhv-page-not-found')).to.exist;
     });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderLoadPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderLoadPage.js
@@ -126,20 +126,10 @@ class FolderLoadPage {
 
   verifyUrlError = () => {
     cy.visit(`${Paths.UI_MAIN}/dummy`);
+    cy.findByTestId('mhv-page-not-found').should('exist');
     cy.get('[data-testid="secure-messaging"]')
       .find('h1')
       .should('have.text', Alerts.PAGE_NOT_FOUND);
-    // // Testing for more than the testId or heading of the PageNotFound
-    // //   component is "diving into the details" of the implementation of the
-    // //   PageNotFound component. Lean on the component unit specs to handle
-    // //   testing these specifics.
-    // cy.get('[data-testid="secure-messaging"]')
-    //   .find('p')
-    //   .should('have.text', Alerts.TRY_SEARCH);
-    // cy.get('#mobile-query').should('be.visible');
-    // cy.get('input[type="submit"]').should('be.visible');
-    // cy.get('#common-questions').should('be.visible');
-    // cy.get('#popular-on-vagov').should('be.visible');
   };
 }
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderLoadPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderLoadPage.js
@@ -125,7 +125,6 @@ class FolderLoadPage {
   };
 
   verifyUrlError = () => {
-    cy.visit(`${Paths.UI_MAIN}/dummy`);
     cy.findByTestId('mhv-page-not-found').should('exist');
     cy.get('[data-testid="secure-messaging"]')
       .find('h1')

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-url-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-url-errors.cypress.spec.js
@@ -7,12 +7,6 @@ describe('Verify alert for invalid url', () => {
     SecureMessagingSite.login();
   });
 
-  it('Invalid landing page url', () => {
-    FolderLoadPage.verifyUrlError();
-    cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT);
-  });
-
   it('Invalid Inbox page url', () => {
     cy.visit(`${Paths.UI_MAIN}/inbox1`);
     FolderLoadPage.verifyUrlError();

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -1,5 +1,3 @@
-import { pageNotFoundHeading } from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
-
 export const AXE_CONTEXT = '.secure-messaging-container';
 
 export const Paths = {
@@ -320,7 +318,7 @@ export const Alerts = {
   OLD_MSG_HEAD: 'This conversation is too old for new replies',
   OLD_MSG_SUBHEAD:
     "The last message in this conversation is more than 45 days old. If you want to continue this conversation, you'll need to start a new message.",
-  PAGE_NOT_FOUND: pageNotFoundHeading,
+  PAGE_NOT_FOUND: 'Page not found',
   TRY_SEARCH: 'Try the search box or one of the common questions below.',
   SAVE_ATTCH: `We can't save attachments in a draft message`,
   EL_SIGN: `Messages to this team require a signature. We added a signature box to this page.`,


### PR DESCRIPTION
## Summary

- Replaces PageNotFound with MhvPageNotFound component

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#106740

## Testing done

- unit, e2e, localhost

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img src="https://github.com/user-attachments/assets/f42f3d66-0c7f-46ab-9fc6-e1be2f447e48" width="320" />     |    <img src="https://github.com/user-attachments/assets/9095199c-782d-43fb-bf2d-202e4215688e" width="320" />   |
| Desktop |    ![Screenshot 2025-04-29 at 10-06-01 Page not found Veterans Affairs](https://github.com/user-attachments/assets/0fc92488-f828-43c2-926a-10df301b4e5d)    |    ![Screenshot 2025-04-29 at 10-01-36 Page not found Veterans Affairs](https://github.com/user-attachments/assets/9192dc0d-1743-43b9-a510-66aefc5e50bb)   |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario
