### PR TITLE
Update cancelled request alert link text

### DIFF
--- a/src/applications/vaos/components/StatusAlert.jsx
+++ b/src/applications/vaos/components/StatusAlert.jsx
@@ -125,7 +125,7 @@ export default function StatusAlert({ appointment, facility }) {
               <br />
               <br />
               <va-link
-                text="Schedule a new appointment"
+                text="Request a new appointment"
                 data-testid="schedule-appointment-link"
                 onClick={handleClick(dispatch)}
                 href={`${root.url}${typeOfCare.url}`}

--- a/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
@@ -258,7 +258,7 @@ describe('VAOS Component: VARequestLayout', () => {
       );
       expect(
         screen.container.querySelector(
-          'va-link[text="Schedule a new appointment"]',
+          'va-link[text="Request a new appointment"]',
         ),
       ).to.be.ok;
       expect(screen.getByText(/Facility canceled this request/i));


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Follow up for https://github.com/department-of-veterans-affairs/vets-website/pull/36113 to update link text
- Appointments Team
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107877

## Testing done

- Tested locally, see screenshots
- Added/updated unit tests for the new behaviors

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Requests |  ![image](https://github.com/user-attachments/assets/50467490-586b-456e-82e1-2b18952505fc)   | ![image](https://github.com/user-attachments/assets/2d754999-848e-4c01-9788-60eff2e4d687) |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

