### PR TITLE
10-10CG | Properly assert Mapbox geocode fetch

### DIFF
--- a/src/applications/caregivers/tests/unit/actions/fetchMapBoxGeocoding.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/actions/fetchMapBoxGeocoding.unit.spec.jsx
@@ -72,7 +72,12 @@ describe('CG fetchMapBoxGeocoding action', () => {
       clientStub.returns({ send: sinon.stub().rejects(error) });
 
       await fetchMapBoxGeocoding(query, mockClient);
-      expect(mockLogger.error.calledWith(loggerMessage, {}, error)).to.be.true;
+      sinon.assert.calledOnceWithExactly(
+        mockLogger.error,
+        loggerMessage,
+        {},
+        error,
+      );
     });
 
     it('should render the error message string when error origin is not `mapbox.com`', async () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates an assertion that was missed during recent unit tests updates to utilize Sinon's assert functionality.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#107402

## Acceptance criteria

 - Assertions are consistent across all spec files.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution