### PR TITLE
Modify form: Submit full country name

### DIFF
--- a/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
+++ b/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
 import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
+import updateAddressUiSchema from '../../../utils/updateAddressSchema';
 
 const { newAddress, isMoving, yearsOfEducation } = fullSchema.properties;
 
 const checkboxTitle =
   'I will live on a United States military base outside of the U.S.';
 
-const newAddressUi = addressUiSchema(
+const addressUi = addressUiSchema(
   'newAddress',
   checkboxTitle,
   formData => formData?.isMoving,
 );
+const newAddressUi = updateAddressUiSchema(addressUi);
 
 export const schema = {
   type: 'object',

--- a/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
+++ b/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
@@ -1,15 +1,9 @@
 import fullSchema from 'vets-json-schema/dist/28-1900_V2-schema.json';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
-import get from 'platform/utilities/data/get';
-import addressUiSchema, {
-  COUNTRY_NAMES,
-  STATE_NAMES,
-  STATE_VALUES,
-  MILITARY_STATE_NAMES,
-  MILITARY_STATE_VALUES,
-} from 'platform/forms-system/src/js/definitions/profileAddress';
+import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
 
 import { VeteranAddressDescription } from '../../../../components/VeteranAddressDescription';
+import updateAddressUiSchema from '../../../../utils/updateAddressSchema';
 
 const { veteranAddress, mainPhone, cellPhone, email } = fullSchema.properties;
 
@@ -33,62 +27,14 @@ export const schema = {
   },
   required: ['email'],
 };
-const veteranAddressUiSchema = addressUiSchema(
+const originalVeteranAddressUiSchema = addressUiSchema(
   'veteranAddress',
   checkboxTitle,
   () => true,
 );
-
-veteranAddressUiSchema.country['ui:options'].updateSchema = (
-  _,
-  _schema,
-  uiSchema,
-  __,
-) => {
-  const countryUI = uiSchema;
-  countryUI['ui:disabled'] = false;
-  return {
-    type: 'string',
-    enum: COUNTRY_NAMES,
-    enumNames: COUNTRY_NAMES,
-  };
-};
-
-veteranAddressUiSchema.state['ui:options'].replaceSchema = (
-  formData,
-  _schema,
-  _,
-  index,
-) => {
-  const insertArrayIndex = (key, idx) => key.replace('[INDEX]', `[${idx}]`);
-  const getPath = (pathToData, idx) =>
-    typeof idx === 'number' ? insertArrayIndex(pathToData, idx) : pathToData;
-
-  const formDataPath = getPath('veteranAddress', index);
-  const data = get(formDataPath, formData) ?? {};
-  const { country } = data;
-  const { isMilitary } = data;
-  if (isMilitary) {
-    return {
-      type: 'string',
-      title: 'State',
-      enum: MILITARY_STATE_VALUES,
-      enumNames: MILITARY_STATE_NAMES,
-    };
-  }
-  if (!isMilitary && country === 'United States') {
-    return {
-      type: 'string',
-      title: 'State',
-      enum: STATE_VALUES,
-      enumNames: STATE_NAMES,
-    };
-  }
-  return {
-    type: 'string',
-    title: 'State/Province/Region',
-  };
-};
+const veteranAddressUiSchema = updateAddressUiSchema(
+  originalVeteranAddressUiSchema,
+);
 
 export const uiSchema = {
   'view:addressDescription': {

--- a/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
+++ b/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
@@ -1,6 +1,13 @@
-import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
+import fullSchema from 'vets-json-schema/dist/28-1900_V2-schema.json';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
-import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
+import get from 'platform/utilities/data/get';
+import addressUiSchema, {
+  COUNTRY_NAMES,
+  STATE_NAMES,
+  STATE_VALUES,
+  MILITARY_STATE_NAMES,
+  MILITARY_STATE_VALUES,
+} from 'platform/forms-system/src/js/definitions/profileAddress';
 
 import { VeteranAddressDescription } from '../../../../components/VeteranAddressDescription';
 
@@ -26,12 +33,68 @@ export const schema = {
   },
   required: ['email'],
 };
+const veteranAddressUiSchema = addressUiSchema(
+  'veteranAddress',
+  checkboxTitle,
+  () => true,
+);
+
+veteranAddressUiSchema.country['ui:options'].updateSchema = (
+  _,
+  _schema,
+  uiSchema,
+  __,
+) => {
+  const countryUI = uiSchema;
+  countryUI['ui:disabled'] = false;
+  return {
+    type: 'string',
+    enum: COUNTRY_NAMES,
+    enumNames: COUNTRY_NAMES,
+  };
+};
+
+veteranAddressUiSchema.state['ui:options'].replaceSchema = (
+  formData,
+  _schema,
+  _,
+  index,
+) => {
+  const insertArrayIndex = (key, idx) => key.replace('[INDEX]', `[${idx}]`);
+  const getPath = (pathToData, idx) =>
+    typeof idx === 'number' ? insertArrayIndex(pathToData, idx) : pathToData;
+
+  const formDataPath = getPath('veteranAddress', index);
+  const data = get(formDataPath, formData) ?? {};
+  const { country } = data;
+  const { isMilitary } = data;
+  if (isMilitary) {
+    return {
+      type: 'string',
+      title: 'State',
+      enum: MILITARY_STATE_VALUES,
+      enumNames: MILITARY_STATE_NAMES,
+    };
+  }
+  if (!isMilitary && country === 'United States') {
+    return {
+      type: 'string',
+      title: 'State',
+      enum: STATE_VALUES,
+      enumNames: STATE_NAMES,
+    };
+  }
+  return {
+    type: 'string',
+    title: 'State/Province/Region',
+  };
+};
 
 export const uiSchema = {
   'view:addressDescription': {
     'ui:description': VeteranAddressDescription,
   },
-  veteranAddress: addressUiSchema('veteranAddress', checkboxTitle, () => true),
+  veteranAddress: veteranAddressUiSchema,
   mainPhone: {
     'ui:required': () => true,
     'ui:options': {

--- a/src/applications/vre/28-1900/config/form.js
+++ b/src/applications/vre/28-1900/config/form.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
+import fullSchema from 'vets-json-schema/dist/28-1900_V2-schema.json';
 import environment from 'platform/utilities/environment';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import PreSubmitInfo from 'applications/vre/28-1900/components/PreSubmitInfo';

--- a/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.jsx
@@ -52,7 +52,7 @@ describe('Chapter 31 veteran contact information', () => {
         onSubmit={onSubmit}
       />,
     );
-    fillData(form, 'select#root_veteranAddress_country', 'USA');
+    fillData(form, 'select#root_veteranAddress_country', 'United States');
     fillData(form, 'input#root_veteranAddress_street', 'Some road');
     fillData(form, 'input#root_veteranAddress_city', 'Some city');
     changeDropdown(form, 'select#root_veteranAddress_state', 'DC');
@@ -79,7 +79,7 @@ describe('Chapter 31 veteran contact information', () => {
         onSubmit={onSubmit}
       />,
     );
-    fillData(form, 'select#root_veteranAddress_country', 'USA');
+    fillData(form, 'select#root_veteranAddress_country', 'United States');
     fillData(form, 'input#root_veteranAddress_street', 'Some road');
     fillData(form, 'input#root_veteranAddress_city', 'Some city');
     changeDropdown(form, 'select#root_veteranAddress_state', 'DC');

--- a/src/applications/vre/28-1900/tests/e2e/formDataSets/chapter31-maximal.json
+++ b/src/applications/vre/28-1900/tests/e2e/formDataSets/chapter31-maximal.json
@@ -13,7 +13,7 @@
   "isMoving": true,
   "newAddress": {
     "view:militaryBaseDescription": {},
-    "country": "USA",
+    "country": "United States",
     "street": "124 Someplace Lane",
     "street2": "Apartment 98",
     "city": "Yet Another Place",
@@ -22,7 +22,7 @@
   },
   "veteranAddress": {
     "view:militaryBaseDescription": {},
-    "country": "USA",
+    "country": "United States",
     "street": "123 Someplace Lane",
     "street2": "Apartment 4",
     "city": "Another Place",

--- a/src/applications/vre/28-1900/utils/updateAddressSchema.js
+++ b/src/applications/vre/28-1900/utils/updateAddressSchema.js
@@ -1,0 +1,63 @@
+import get from 'platform/utilities/data/get';
+import {
+  COUNTRY_NAMES,
+  STATE_NAMES,
+  STATE_VALUES,
+} from 'platform/forms-system/src/js/definitions/profileAddress';
+
+export default function updateAddressUiSchema(uiSchema) {
+  return {
+    ...uiSchema,
+    country: {
+      ...uiSchema.country,
+      'ui:options': {
+        ...uiSchema.country['ui:options'],
+        updateSchema: (formData, schema, existingSchema, index) => {
+          const originalResult = uiSchema.country['ui:options'].updateSchema(
+            formData,
+            schema,
+            existingSchema,
+            index,
+          );
+
+          return {
+            ...originalResult,
+            type: 'string',
+            enum: COUNTRY_NAMES,
+            enumNames: COUNTRY_NAMES,
+          };
+        },
+      },
+      state: {
+        ...uiSchema.state,
+        'ui:options': {
+          ...uiSchema.state['ui:options'],
+          replaceSchema: (formData, _schema, _, index) => {
+            const insertArrayIndex = (key, idx) =>
+              key.replace('[INDEX]', `[${idx}]`);
+            const getPath = (pathToData, idx) =>
+              typeof idx === 'number'
+                ? insertArrayIndex(pathToData, idx)
+                : pathToData;
+
+            const formDataPath = getPath('veteranAddress', index);
+            const data = get(formDataPath, formData) ?? {};
+            const { country } = data;
+            if (country === 'United States') {
+              return {
+                type: 'string',
+                title: 'State',
+                enum: STATE_VALUES,
+                enumNames: STATE_NAMES,
+              };
+            }
+            return {
+              type: 'string',
+              title: 'State/Province/Region',
+            };
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
This PR modifies the Ch31 (AKA 28-1900, VR&E) form's address field, and instead of displaying a full text country name and submitting an abbreviation ("United States" -> "USA"), it submits the full name.

A [PR](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/998) was made to update the vets-json-schema repository, and this change pulls in the new schema.  Additional changes had to be made in a somewhat awkward way because the uiSchema that is imported from the platform directory follows the new practice of forms defining their own schema instead of relying on vets-json-schema.  Changes to the uiSchema for the form elements imported from platform were made in the "local" veteranAddress scope.

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
