### PR TITLE
1095-B - Label improvement

### DIFF
--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -179,7 +179,7 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
                 `${environment.API_URL}/v0/form1095_bs/download_pdf/${year}`,
               )}
               id="pdf-download-link"
-              label="Download PDF (best for printing)"
+              label={`Download ${year} 10 95-B PDF (best for printing)`}
               text="Download PDF (best for printing)"
               onClick={e => {
                 e.preventDefault();
@@ -195,7 +195,7 @@ export const App = ({ displayToggle, toggleLoginModal }) => {
                 `${environment.API_URL}/v0/form1095_bs/download_txt/${year}`,
               )}
               id="txt-download-link"
-              label="Download Text file (best for screen readers, enlargers, and refreshable Braille displays)"
+              label={`Download ${year} 10 95-B Text file (best for screen readers, enlargers, and refreshable Braille displays)`}
               text="Download Text file (best for screen readers, enlargers, and refreshable Braille displays)"
               onClick={e => {
                 e.preventDefault();


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Using a screen reader and the keyboard to navigate the page by moving from one actionable element to the next, you arrive at the download links without the context that they are for a given form and year. So this update adds the relevant information to the `aria-label`s.

I work for VA IIR and we own this application.

## Related issue(s)

[VA IIR ticket 1604](https://github.com/department-of-veterans-affairs/va-iir/issues/1604)

## Testing done

Previously a screen reader would not announce the form type and date when focused on either of the download links.

To verify this is working run the site with a screen reader such as VoiceOver for Mac. Ensure when each download link is focused the correct year and name of the form is announced as a part of describing the link.

Run the mock server:
```
yarn mock-api --responses src/applications/static-pages/download-1095b/mocks/server.js
```
Run the site:
```
yarn watch --env entry=static-pages
```
Visit the site here: http://localhost:3001/health-care/download-1095b/

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
