### PR TITLE
removed ebenefits from logout

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -16,7 +16,6 @@ import {
   POLICY_TYPES,
   SIGNUP_TYPES,
   API_SESSION_URL,
-  EBENEFITS_DEFAULT_PATH,
   AUTH_PARAMS,
   IDME_TYPES,
 } from './constants';
@@ -135,12 +134,6 @@ export const createExternalApplicationUrl = () => {
       break;
     case EXTERNAL_APPS.VA_OCC_MOBILE:
       URL = sanitizeUrl(`${externalRedirectUrl}${window.location.search}`);
-      break;
-    case EXTERNAL_APPS.EBENEFITS:
-      URL = sanitizeUrl(
-        `${externalRedirectUrl}`,
-        `${!to ? EBENEFITS_DEFAULT_PATH : sanitizePath(to)}`,
-      );
       break;
     case EXTERNAL_APPS.MHV:
       URL = sanitizeUrl(

--- a/src/platform/user/tests/authentication/utilities.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.jsx
@@ -18,7 +18,6 @@ import {
   API_SESSION_URL,
   SIGNUP_TYPES,
   GA,
-  EBENEFITS_DEFAULT_PATH,
   POLICY_TYPES,
   AUTH_EVENTS,
 } from '../../authentication/constants';
@@ -341,28 +340,28 @@ describe('Authentication Utilities', () => {
   describe('createExternalApplicationUrl', () => {
     afterEach(() => cleanup());
     it('should return correct url or null for the parsed application param', () => {
-      Object.values(EXTERNAL_APPS).forEach(application => {
-        setup({ path: `${usipPath}?application=${application}` });
+      Object.values(EXTERNAL_APPS)
+        .filter(application => application !== EXTERNAL_APPS.EBENEFITS)
+        .forEach(application => {
+          setup({ path: `${usipPath}?application=${application}` });
 
-        const pathAppend = () => {
-          switch (application) {
-            case EXTERNAL_APPS.EBENEFITS:
-              return EBENEFITS_DEFAULT_PATH;
-            case EXTERNAL_APPS.VA_OCC_MOBILE:
-              return `${global.window.location.search}`;
-            case EXTERNAL_APPS.MY_VA_HEALTH:
-              return `/?authenticated=true`;
-            default:
-              return '';
-          }
-        };
+          const pathAppend = () => {
+            switch (application) {
+              case EXTERNAL_APPS.VA_OCC_MOBILE:
+                return `${global.window.location.search}`;
+              case EXTERNAL_APPS.MY_VA_HEALTH:
+                return `/?authenticated=true`;
+              default:
+                return '';
+            }
+          };
 
-        expect(authUtilities.createExternalApplicationUrl()).to.eq(
-          `${EXTERNAL_REDIRECTS[application]}${pathAppend()}`,
-        );
+          expect(authUtilities.createExternalApplicationUrl()).to.eq(
+            `${EXTERNAL_REDIRECTS[application]}${pathAppend()}`,
+          );
 
-        setup({});
-      });
+          setup({});
+        });
 
       expect(authUtilities.createExternalApplicationUrl()).to.eq(null);
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed ebenefits from the logout process and fixed related tests.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/107907)

## Testing done
- Updated tests in `utilities.unit.spec.jsx` and ran them locally.
- Can be replicated by running `yarn test:unit src/platform/user/tests/authentication/utilities.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `src/platform/user/authentication/utilities.js` and its related tests.

## Acceptance criteria
- [x] Remove ebenefits from the logout component
- [x] Update tests as needed
