### PR TITLE
Allow default content before and after buttons on personal info page

### DIFF
--- a/src/platform/forms-system/src/js/components/PersonalInformation/index.js
+++ b/src/platform/forms-system/src/js/components/PersonalInformation/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   defaultConfig,
@@ -66,6 +67,38 @@ const personalInformationPage = ({
     ...defaultPageConfig.personalInfoConfig,
     ...personalInfoConfig,
   };
+
+  // Create a CustomPage component with proper PropTypes
+  const CustomPage = props => (
+    <PersonalInformation
+      {...props}
+      config={config}
+      dataAdapter={dataAdapter}
+      errorMessage={errorMessage}
+      contentBeforeButtons={contentBeforeButtons || props.contentBeforeButtons}
+      contentAfterButtons={contentAfterButtons || props.contentAfterButtons}
+    >
+      {header && (
+        <PersonalInformationHeader>{header}</PersonalInformationHeader>
+      )}
+      {cardHeader && (
+        <PersonalInformationCardHeader>
+          {cardHeader}
+        </PersonalInformationCardHeader>
+      )}
+      {note && <PersonalInformationNote>{note}</PersonalInformationNote>}
+      {footer && (
+        <PersonalInformationFooter>{footer}</PersonalInformationFooter>
+      )}
+    </PersonalInformation>
+  );
+
+  // Add PropTypes to the CustomPage component
+  CustomPage.propTypes = {
+    contentAfterButtons: PropTypes.node,
+    contentBeforeButtons: PropTypes.node,
+  };
+
   return {
     [key]: {
       title,
@@ -75,29 +108,7 @@ const personalInformationPage = ({
         type: 'object',
         properties: {},
       },
-      CustomPage: props => (
-        <PersonalInformation
-          {...props}
-          config={config}
-          dataAdapter={dataAdapter}
-          errorMessage={errorMessage}
-          contentBeforeButtons={contentBeforeButtons}
-          contentAfterButtons={contentAfterButtons}
-        >
-          {header && (
-            <PersonalInformationHeader>{header}</PersonalInformationHeader>
-          )}
-          {cardHeader && (
-            <PersonalInformationCardHeader>
-              {cardHeader}
-            </PersonalInformationCardHeader>
-          )}
-          {note && <PersonalInformationNote>{note}</PersonalInformationNote>}
-          {footer && (
-            <PersonalInformationFooter>{footer}</PersonalInformationFooter>
-          )}
-        </PersonalInformation>
-      ),
+      CustomPage,
       CustomPageReview: hideOnReview
         ? null
         : props => (


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

Changes are exclusive to one section of forms-system pattern
Personal information page does not affect injected header or any related code in that regard

## Summary


- uses the fallback of the standard beforeButtonContent and afterButtonContent for the personal information page
- no breaking changes added, and custom content can still be passed as needed into personalInfo factory function


## Related issue(s)

- hotfix
- support request: https://dsva.slack.com/archives/CBU0KDSB1/p1745954992081569

## Testing done

- Tested to verify backwards compat
- Passed custom and no content into function to verify what is displayed

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2025-05-01 at 5 51 06 AM](https://github.com/user-attachments/assets/febeb24a-d419-4287-82b2-ca3901171a04) | ![Screenshot 2025-05-01 at 5 50 43 AM](https://github.com/user-attachments/assets/ef443da4-5ed0-40ec-b203-44f1985974ef) |

## What areas of the site does it impact?

Personal Info Page

## Acceptance criteria

- Content shown

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
