### PR TITLE
10-10CG | Filter 3rd party fetch errors from DD Logs

### DIFF
--- a/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
+++ b/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
@@ -36,7 +36,7 @@ const initializeRealUserMonitoring = () => {
       beforeSend: ({ type, resource }) => {
         return !(
           type === 'resource' &&
-          EXCLUDED_DOMAINS.some(d => resource.url.includes(d))
+          EXCLUDED_DOMAINS.some(domain => resource.url.includes(domain))
         );
       },
     });
@@ -53,7 +53,10 @@ const initializeBrowserLogging = () => {
       ...DEFAULT_CONFIG,
       forwardErrorsToLogs: true,
       beforeSend: ({ http }) => {
-        return !(http?.url && EXCLUDED_DOMAINS.some(d => http.url.includes(d)));
+        return !(
+          http?.url &&
+          EXCLUDED_DOMAINS.some(domain => http.url.includes(domain))
+        );
       },
     });
   }

--- a/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
+++ b/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
@@ -46,7 +46,7 @@ const initializeRealUserMonitoring = () => {
   }
 };
 
-const intitalizeBrowserLogging = () => {
+const initializeBrowserLogging = () => {
   // prevent LOGS from re-initializing the SDK
   if (!window.DD_LOGS?.getInitConfiguration()) {
     datadogLogs.init({
@@ -69,7 +69,7 @@ const useBrowserMonitoring = () => {
       if (!environment.BASE_URL.includes('localhost')) return;
 
       // enable browser logging
-      intitalizeBrowserLogging();
+      initializeBrowserLogging();
 
       // enable RUM if feature flag value is `true`
       if (isBrowserMonitoringEnabled) {

--- a/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
+++ b/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
@@ -14,6 +14,13 @@ const DEFAULT_CONFIG = {
   sessionSampleRate: 100,
 };
 
+// declare 3rd party domains to exclude from logs
+const EXCLUDED_DOMAINS = [
+  'google-analytics.com',
+  'browser-intake-ddog-gov.com',
+  'eauth.va.gov',
+];
+
 const initializeRealUserMonitoring = () => {
   // prevent RUM from re-initializing the SDK
   if (!window.DD_RUM?.getInitConfiguration()) {
@@ -26,6 +33,12 @@ const initializeRealUserMonitoring = () => {
       trackResources: true,
       trackLongTasks: true,
       defaultPrivacyLevel: 'mask-user-input',
+      beforeSend: ({ type, resource }) => {
+        return !(
+          type === 'resource' &&
+          EXCLUDED_DOMAINS.some(d => resource.url.includes(d))
+        );
+      },
     });
 
     // if sessionReplaySampleRate > 0, we need to manually start the recording
@@ -39,6 +52,9 @@ const intitalizeBrowserLogging = () => {
     datadogLogs.init({
       ...DEFAULT_CONFIG,
       forwardErrorsToLogs: true,
+      beforeSend: ({ http }) => {
+        return !(http?.url && EXCLUDED_DOMAINS.some(d => http.url.includes(d)));
+      },
     });
   }
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Since implementing Datadog RUM and Logs, the primary logs are fetch errors related to 3rd party apps (like Google Analytics). In an effort to clean up the noise, we need to filter out these fetch errors. This PR filters out the declared list of 3rd party URLs that are unnecessary for our logs.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#108801

## Acceptance criteria

- Logs are meaningful and can have action taken upon them

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution