### PR TITLE
10-10CG | Exclude addt'l domains from DD Logs

### DIFF
--- a/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
+++ b/src/applications/caregivers/hooks/useBrowserMonitoring.jsx
@@ -16,9 +16,11 @@ const DEFAULT_CONFIG = {
 
 // declare 3rd party domains to exclude from logs
 const EXCLUDED_DOMAINS = [
-  'google-analytics.com',
+  'resource.digital.voice.va.gov',
   'browser-intake-ddog-gov.com',
+  'google-analytics.com',
   'eauth.va.gov',
+  'api.va.gov',
 ];
 
 const initializeRealUserMonitoring = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds some addititonal domains to the disallow list for Datadog Logs. This allows the logs to stay meaningful and relevant to the team work.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#108801

## Acceptance criteria

 - Logs contain meaningful & actionable data

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution