### PR TITLE
Added VerifyAccountLink Hook

### DIFF
--- a/src/platform/user/authentication/components/VerifyAccountLink.jsx
+++ b/src/platform/user/authentication/components/VerifyAccountLink.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
-import * as authUtilities from 'platform/user/authentication/utilities';
+import { useIdentityVerificationURL } from '../hooks';
 import { SERVICE_PROVIDERS, AUTH_EVENTS } from '../constants';
 
 export default function VerifyAccountLink({
@@ -9,22 +9,7 @@ export default function VerifyAccountLink({
   useOAuth = false,
   children,
 }) {
-  const [href, setHref] = useState('');
-  useEffect(() => {
-    async function generateURL() {
-      const url = await authUtilities.signupOrVerify({
-        policy,
-        allowVerification: true,
-        isSignup: false,
-        isLink: true,
-        useOAuth,
-      });
-      setHref(url);
-    }
-
-    generateURL();
-  }, []);
-
+  const { href } = useIdentityVerificationURL({ policy, useOAuth });
   return (
     <a
       href={href}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed `useEffect` in VerifyAccountLink and replaced with a hook from `src/platform/user/authentication/hooks/index.js`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/312)

## Testing done
- Ran tests locally and ensured no breaking changes or updates needed.
- Can be replicated by running `yarn test:unit src/platform/user/tests/authentication/components/VerifyAccountLink.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `src/platform/user/authentication/components/VerifyAccountLink.jsx`

## Acceptance criteria
- [x] Ensure hook exists in `src/platform/user/authentication/hooks/index.js`
- [x] Replace `useEffect` with hook
- [x] Ensure tests run correctly and update them (if necessary)