### PR TITLE
MHV-68579: Allergies API error alert not showing when user clicks pri…

### DIFF
--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -549,10 +549,7 @@ const Prescriptions = () => {
   };
 
   const isShowingErrorNotification = Boolean(
-    (((prescriptionsFullList?.length &&
-      pdfTxtGenerateStatus.format !== PRINT_FORMAT.PRINT) ||
-      paginatedPrescriptionsList) &&
-      pdfTxtGenerateStatus.status === PDF_TXT_GENERATE_STATUS.InProgress &&
+    (pdfTxtGenerateStatus.status === PDF_TXT_GENERATE_STATUS.InProgress &&
       allergiesError) ||
       hasFullListDownloadError,
   );

--- a/src/applications/mhv-medications/tests/e2e/medications-print-medications-allergies-error-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-print-medications-allergies-error-list-page.cypress.spec.js
@@ -1,18 +1,14 @@
 import MedicationsSite from './med_site/MedicationsSite';
-import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
 
-describe.skip('Medications List Page Print Error No Allergies Network Call', () => {
+describe('Medications List Page Print Error No Allergies Network Call', () => {
   it('visits Print Medications List Error Message When No Allergies API Call', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
-    const landingPage = new MedicationsLandingPage();
-    // cy.visit('my-health/about-medications/');
     site.login();
-    landingPage.visitLandingPageURL();
+    listPage.visitMedicationsLinkWhenNoAllergiesAPICallFails();
     cy.injectAxe();
     cy.axeCheck('main');
-    listPage.clickGoToMedicationsLinkWhenNoAllergiesAPICallFails();
     listPage.clickPrintOrDownloadThisListDropDown();
     listPage.clickPrintThisPageOfTheListButtonOnListPage();
     listPage.verifyPrintErrorMessageForAllergiesAPICallFail();


### PR DESCRIPTION
## Summary

- Updated logic to when the API error alert should be display on Medications page 

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-68579

## Testing done

- Manual testing
- e2e testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Fix "Print this page of the list" option on List page to include the allergies error when necessary.

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

