### PR TITLE
redirect_before_sign_in

### DIFF
--- a/src/applications/representative-form-upload/routes.jsx
+++ b/src/applications/representative-form-upload/routes.jsx
@@ -2,12 +2,20 @@ import React from 'react';
 
 import { createRoutes } from 'platform/forms-system/src/js/routing/createRoutes';
 import FormApp from 'platform/forms-system/src/js/containers/FormApp';
-
+import { userPromise } from './utilities/auth';
 import formConfig from './config/form';
 import App from './containers/App';
 
 // Add any new form-upload forms to this list
 const formUploadForms = ['21-686c'];
+
+userPromise
+  .then(user => {
+    console.log('User is logged in:', !!user); // eslint-disable-line no-console
+  })
+  .catch(error => {
+    console.error('Error checking user login status:', error); // eslint-disable-line no-console
+  });
 
 const routes = formUploadForms.map(formId => {
   const lowerCaseFormId = formId.toLowerCase();

--- a/src/applications/representative-form-upload/tests/unit/utilities/api.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/utilities/api.unit.spec.jsx
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import api from '../../../utilities/api';
+
+describe('API utilities', () => {
+  let sandbox;
+  let fetchStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    fetchStub = sandbox.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getUser', () => {
+    it('calls correct user endpoint', async () => {
+      const successResponse = new Response(JSON.stringify({ data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      fetchStub.resolves(successResponse);
+
+      await api.getUser();
+
+      expect(fetchStub.called).to.be.true;
+      const url = fetchStub.firstCall.args[0];
+      expect(url).to.include('/user');
+    });
+  });
+});

--- a/src/applications/representative-form-upload/utilities/api.js
+++ b/src/applications/representative-form-upload/utilities/api.js
@@ -1,0 +1,96 @@
+import * as Sentry from '@sentry/browser';
+import merge from 'lodash/merge';
+import { fetchAndUpdateSessionExpiration } from 'platform/utilities/api';
+import environment from 'platform/utilities/environment';
+import localStorage from 'platform/utilities/storage/localStorage';
+import manifest from '../manifest.json';
+import { getSignInUrl } from './constants';
+
+// Set app name for request headers
+window.appName = manifest.entryName;
+
+const API_VERSION = 'accredited_representative_portal/v0';
+
+/**
+ * Enhanced API wrapper that preserves Response objects for error handling
+ * while maintaining existing platform functionality where beneficial
+ */
+const wrapApiRequest = fn => {
+  return async (...args) => {
+    // Set up request options similarly to platform apiRequest
+    const optionsFromCaller = args[fn.length] || {};
+    const [resource, optionsFromFn = {}] = fn(...args.slice(0, fn.length));
+
+    const csrfTokenStored = localStorage.getItem('csrfToken');
+
+    const defaultSettings = {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'X-Key-Inflection': 'camel',
+        'Source-App-Name': window.appName,
+        'X-CSRF-Token': csrfTokenStored,
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const settings = merge(defaultSettings, optionsFromFn, optionsFromCaller);
+
+    // Build URL like platform apiRequest
+    const baseUrl = `${environment.API_URL}/${API_VERSION}`;
+    const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
+
+    try {
+      // Reuse session management from platform
+      const response = await fetchAndUpdateSessionExpiration(url, settings);
+
+      // Handle CSRF token updates
+      const csrfToken = response.headers.get('X-CSRF-Token');
+      if (csrfToken && csrfToken !== csrfTokenStored) {
+        localStorage.setItem('csrfToken', csrfToken);
+      }
+
+      // For successful responses,return data
+      if (response.ok || response.status === 304) {
+        return response;
+      }
+
+      // For 401s, redirect to login
+      if (
+        response.status === 401 &&
+        // Don't redirect to login for our app's root / landing page experience.
+        // People are allowed to be unauthenticated there.
+        // TODO: probably need a more sound & principled solution here.
+        ![manifest.rootUrl, `${manifest.rootUrl}/`].includes(
+          window.location.pathname,
+        )
+      ) {
+        window.location = getSignInUrl({
+          returnUrl: window.location.href,
+        });
+        return null;
+      }
+
+      // For errors, preserve the Response object
+      throw response;
+    } catch (err) {
+      // Log network-like errors to Sentry
+      if (!(err instanceof Response)) {
+        Sentry.withScope(scope => {
+          scope.setExtra('error', err);
+          scope.setFingerprint(['{{default}}', scope._tags?.source]);
+          Sentry.captureMessage(`vets_client_error: ${err.message}`);
+        });
+      }
+      throw err;
+    }
+  };
+};
+
+const api = {
+  getUser: wrapApiRequest(() => {
+    return ['/user'];
+  }),
+};
+
+export default api;

--- a/src/applications/representative-form-upload/utilities/auth.js
+++ b/src/applications/representative-form-upload/utilities/auth.js
@@ -1,0 +1,40 @@
+import api from './api';
+import mockApi, { configure as configureMockApi } from './mockApi';
+
+/**
+ * `userPromise` is a singleton that is created when the app is created. It has
+ * a dependency on the mock API being set up to determine whether it gets a user
+ * from mock or real data.
+ */
+configureMockApi();
+
+export const userPromise = (async () => {
+  try {
+    const userResponse = await api.getUser();
+    const user = await userResponse.json();
+
+    /**
+     * If using a mock API response for `getUser`, the dev should also disable
+     * authentication in their local server's API routes. This makes token
+     * refreshing unnecessary. It isn't strictly necessary to skip this code
+     * when mocking `getUser`, but we do so anyway for documentation purposes.
+     */
+    if (api.getUser !== mockApi.getUser) {
+      /**
+       * This is an even stricter success condition than having a user. We
+       * additionally require what is needed for access token refreshing to
+       * function.
+       */
+      const serviceName = user?.profile?.signIn?.serviceName;
+      if (!serviceName)
+        throw new Error('Missing user with sign in service name.');
+
+      // Needed for access token refreshing to function.
+      sessionStorage.setItem('serviceName', serviceName);
+    }
+
+    return user;
+  } catch (e) {
+    return null;
+  }
+})();

--- a/src/applications/representative-form-upload/utilities/constants.js
+++ b/src/applications/representative-form-upload/utilities/constants.js
@@ -1,0 +1,37 @@
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import {
+  AUTH_PARAMS as USIP_QUERY_PARAMS,
+  EXTERNAL_APPS as USIP_APPLICATIONS,
+} from 'platform/user/authentication/constants';
+import {
+  API_SIGN_IN_SERVICE_URL as SIS_API_URL,
+  OAUTH_KEYS as SIS_QUERY_PARAM_KEYS,
+} from '~/platform/utilities/oauth/constants';
+import { getFormContent } from '../helpers';
+
+const USIP_PATH = '/sign-in';
+const USIP_BASE_URL = environment.BASE_URL;
+
+export const getSignInUrl = ({ __returnUrl } = {}) => {
+  const { formNumber } = getFormContent();
+  const url = new URL(USIP_PATH, USIP_BASE_URL);
+  url.searchParams.set(USIP_QUERY_PARAMS.application, USIP_APPLICATIONS.ARP);
+  url.searchParams.set(USIP_QUERY_PARAMS.OAuth, true);
+
+  url.searchParams.set(
+    USIP_QUERY_PARAMS.to,
+    `/representative-form-upload/${formNumber}`,
+  );
+
+  return url;
+};
+
+export const SIGN_OUT_URL = (() => {
+  const url = new URL(SIS_API_URL({ endpoint: 'logout' }));
+  url.searchParams.set(
+    SIS_QUERY_PARAM_KEYS.CLIENT_ID,
+    sessionStorage.getItem('ci'),
+  );
+
+  return url;
+})();

--- a/src/applications/representative-form-upload/utilities/mockApi.js
+++ b/src/applications/representative-form-upload/utilities/mockApi.js
@@ -1,0 +1,39 @@
+import api from './api';
+import user from './mocks/user.json';
+
+const apiFetch = data => {
+  return new Promise(resolve => {
+    // Simulating network latency.
+    setTimeout(() => resolve(data), 500);
+  });
+};
+
+const mockApi = {
+  getUser() {
+    return apiFetch(user);
+  },
+};
+
+// Convenience runtime toggle between use of mock data and real data.
+let configured = false;
+export function configure() {
+  if (configured) return;
+  configured = true;
+
+  const search = new URLSearchParams(window.location.search);
+
+  if (search.has('useMockUser')) {
+    api.getUser = mockApi.getUser;
+  }
+
+  if (search.has('useMockData')) {
+    Object.values(mockApi).forEach(method => {
+      if (typeof method !== 'function') return;
+      if (method.name === 'getUser') return;
+
+      api[method.name] = method;
+    });
+  }
+}
+
+export default mockApi;

--- a/src/applications/representative-form-upload/utilities/mocks/user.json
+++ b/src/applications/representative-form-upload/utilities/mocks/user.json
@@ -1,0 +1,15 @@
+{
+  "account": {
+    "accountUuid": "88f572d491af46efa393cba6c351e252"
+  },
+  "profile": {
+    "firstName": "William",
+    "lastName": "Phelps",
+    "verified": true,
+    "signIn": {
+      "serviceName": "idme"
+    }
+  },
+  "prefillsAvailable": [],
+  "inProgressForms": []
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders 


Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No

## Summary

If you go to /representative/representative-form-upload/form-number before signing in, it will send you to the sign in page and then redirect you to the intro page of the form upload after signing in

the utilities folder looks like a lot but it's 90% from already merged in code from accredited-rep-portal utilities

## Related issue(s)

- Half this ticket - https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/1?sliceBy%5Bvalue%5D=patrick-brown-oddball&pane=issue&itemId=107497883&issue=department-of-veterans-affairs%7Cva.gov-team%7C108186

## Testing done

- Walked through locally
- added test

## Screenshots

No visual changes

## What areas of the site does it impact?

/representative/representative-form-upload

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I added unit tests and integration tests for each feature (if applicable).

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user