### PR TITLE
Update alert wording to use applicant's name - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
@@ -159,9 +159,10 @@ export const medicalClaimUploadSchema = {
         <va-alert status="warning">
           <p className="vads-u-margin-y--0">
             You’ll need to submit a copy of an <b>itemized billing statement</b>
-            , often called a superbill, for this claim. Ask your provider for an
-            itemized bill as the patient copy is often missing critical
-            information required by CHAMPVA to process claims.
+            , often called a superbill, for this claim. Ask{' '}
+            {nameWording(formData, true, false, true)} provider for an itemized
+            bill as the patient copy is often missing critical information
+            required by CHAMPVA to process claims.
           </p>
         </va-alert>
         <p>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates a static "your" to be either "your" or a dynamic first name value depending on the role of the user filling out the form.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108997

## Testing done

- Manual

## Screenshots

|         | Filling out for self | Filling out for other |
| ------- | ------ | ----- |
| Alert text |![Screenshot 2025-05-05 at 13 23 17](https://github.com/user-attachments/assets/2d74d4c4-3687-400a-8b63-087fabcc3886)|![alert](https://github.com/user-attachments/assets/b7629388-28c4-4ad7-9e0c-aafa5dabda77)|

## What areas of the site does it impact?

IVC CHAMPVA form 10-7959a 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA