### PR TITLE
Global | Fix currency validation issue

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/CurrencyField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/CurrencyField.jsx
@@ -27,12 +27,6 @@ export default function CurrencyField(fieldProps) {
   const handleInput = event => {
     const { value } = event.target;
     setDisplayVal(value);
-    props.onChange(value);
-  };
-
-  const handleBlur = event => {
-    const { value } = event.target;
-    setDisplayVal(value);
 
     // Not using props.onInput because in the vaTextInputFieldMapping onInput
     // callback, it uses `value || event.target.value;` and sets the value to
@@ -48,16 +42,30 @@ export default function CurrencyField(fieldProps) {
       // Needs to parse as a number
       const parsedValue = parseNumber(value);
       if (!isNaN(parsedValue)) {
-        const roundedValue = Math.round(parsedValue * 100) / 100;
-        const roundedString = roundedValue.toFixed(2);
-        setDisplayVal(roundedString);
-        props.onChange(schemaType === 'number' ? roundedValue : roundedString);
+        setDisplayVal(value);
+        props.onChange(schemaType === 'number' ? parsedValue : value);
       } else {
         props.onChange(value);
       }
     }
 
+    // props.onChange(value);
+  };
+
+  const handleBlur = event => {
+    const { value } = event.target;
+    setDisplayVal(value);
     props.onBlur(props.name);
+    // Needs to parse as a number
+    const parsedValue = parseNumber(value);
+    if (!isNaN(parsedValue)) {
+      const roundedValue = Math.round(parsedValue * 100) / 100;
+      const roundedString = roundedValue.toFixed(2);
+      setDisplayVal(roundedString);
+      props.onChange(schemaType === 'number' ? roundedValue : roundedString);
+    } else {
+      props.onChange(value);
+    }
   };
 
   const handleFocus = () => {

--- a/src/platform/forms-system/src/js/web-component-fields/CurrencyField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/CurrencyField.jsx
@@ -48,8 +48,6 @@ export default function CurrencyField(fieldProps) {
         props.onChange(value);
       }
     }
-
-    // props.onChange(value);
   };
 
   const handleBlur = event => {

--- a/src/platform/forms-system/src/js/web-component-patterns/currencyPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/currencyPattern.jsx
@@ -49,15 +49,13 @@ export const currencyUI = options => {
     min = 0,
     // large numbers converted to scientific notation; so add limit
     max = 999999999,
+    validations = [],
     ...uiOptions
   } = typeof options === 'object' ? options : { title: options };
 
-  let validations = {};
-
-  if (typeof min !== 'undefined' || typeof max !== 'undefined') {
-    validations = {
-      'ui:validations': [minMaxValidation(min, max)],
-    };
+  // if the title is a string, set it to the title property
+  if (min !== null || max !== null) {
+    validations.push(minMaxValidation(min, max));
   }
 
   return {
@@ -75,13 +73,12 @@ export const currencyUI = options => {
       pattern: 'Enter a valid dollar amount',
       // error shows when CurrencyField is expecting a number & gets a string
       type: 'Enter a valid dollar amount',
-      min:
-        typeof min !== 'undefined' ? `Enter a number greater than ${min}` : '',
-      max: typeof max !== 'undefined' ? `Enter a number less than ${max}` : '',
+      min: min !== null ? `Enter a number greater than or equal to ${min}` : '',
+      max: max !== null ? `Enter a number less than or equal to ${max}` : '',
       ...errorMessages,
     },
     'ui:reviewWidget': CurrencyWidget,
-    ...validations,
+    'ui:validations': validations,
   };
 };
 

--- a/src/platform/forms-system/test/js/web-component-fields/CurrencyField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-fields/CurrencyField.unit.spec.jsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { $ } from '../../../src/js/utilities/ui';
+
+import CurrencyField from '../../../src/js/web-component-fields/CurrencyField';
+import {
+  currencySchema,
+  currencyStringSchema,
+} from '../../../src/js/web-component-patterns';
+
+describe('CurrencyField', () => {
+  const getProps = ({
+    onChange = () => {},
+    onBlur = () => {},
+    options = {},
+    value = '',
+    schema = currencySchema,
+  } = {}) => ({
+    label: 'test',
+    childrenProps: {
+      name: 'test',
+      value,
+      onChange,
+      onBlur,
+      schema,
+      uiSchema: {},
+      idSchema: { $id: 'test' },
+    },
+    uiOptions: options,
+  });
+
+  it('should render with default props', () => {
+    const { container } = render(<CurrencyField {...getProps()} />);
+    expect($('va-text-input', container)).to.exist;
+  });
+
+  it('should render with custom props', () => {
+    const props = {
+      ...getProps({
+        options: {
+          currencySymbol: 'USD',
+          classNames: 'test-class',
+          width: '2xs',
+        },
+      }),
+    };
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    expect(input.getAttribute('class')).to.contain('test-class');
+    expect(input.getAttribute('input-prefix')).to.equal('USD');
+    expect(input.getAttribute('width')).to.equal('2xs');
+  });
+
+  it('should render value with 2 decimal places on focus', () => {
+    const props = getProps({ value: 1234 });
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+
+    fireEvent.focus(input);
+    waitFor(() => {
+      expect(input.value).to.equal('1234.00');
+    });
+  });
+
+  it('should handle input blur and return a parsed numeric value', async () => {
+    const onBlur = sinon.spy();
+    const onChange = sinon.spy(); // onChange is also called on blur
+    const props = getProps({ onBlur, onChange });
+
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    input.value = '1,234.56';
+    await fireEvent.blur(input, { target: { name: '1,234.56' } });
+
+    expect(onBlur.calledOnce).to.be.true;
+    expect(onBlur.args[0][0]).to.equal('test'); // field name
+    expect(onChange.args[0][0]).to.equal(1234.56);
+  });
+
+  it('should handle input blur and return a string value', async () => {
+    const onBlur = sinon.spy();
+    const onChange = sinon.spy(); // onChange is also called on blur
+    const props = getProps({ onBlur, onChange, schema: currencyStringSchema });
+
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    input.value = '123,456';
+    await fireEvent.blur(input, { target: { name: '123,456' } });
+
+    expect(onBlur.calledOnce).to.be.true;
+    expect(onBlur.args[0][0]).to.equal('test'); // field name
+    expect(onChange.args[0][0]).to.equal('123456.00'); // comma removed on blur
+  });
+
+  it('should handle input change (submit without blur) and return a parsed numeric value', async () => {
+    const onChange = sinon.spy();
+    const props = getProps({ onChange });
+
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    input.value = '1,234.56';
+    await fireEvent.input(input, { target: { name: '1,234.56' } });
+
+    expect(onChange.calledOnce).to.be.true;
+    expect(onChange.args[0][0]).to.equal(1234.56);
+  });
+
+  it('should handle input change (submit without blur) and return a string value', async () => {
+    const onChange = sinon.spy();
+    const props = getProps({ onChange, schema: currencyStringSchema });
+
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    input.value = '123,456';
+    await fireEvent.input(input, { target: { name: '123,456' } });
+
+    expect(onChange.calledOnce).to.be.true;
+    expect(onChange.args[0][0]).to.equal('123,456'); // comma removed on blur
+  });
+
+  it('should round values to 2 decimal places', async () => {
+    const onBlur = sinon.spy();
+    const onChange = sinon.spy(); // onChange is also called on blur
+    const props = getProps({ onBlur, onChange });
+
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    input.value = '234.567890';
+    await fireEvent.blur(input, { target: { name: '234.567890' } });
+
+    expect(onBlur.calledOnce).to.be.true;
+    expect(onBlur.args[0][0]).to.equal('test'); // field name
+    expect(onChange.args[0][0]).to.equal(234.57); // rounded up
+  });
+
+  it('should ignore dollar sign, commas and other non-digits (expect decimal)', async () => {
+    const onBlur = sinon.spy();
+    const onChange = sinon.spy(); // onChange is also called on blur
+    const props = getProps({ onBlur, onChange });
+
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    input.value = '$987.654 USD';
+    await fireEvent.blur(input, { target: { name: '$987.654 USD' } });
+
+    expect(onBlur.calledOnce).to.be.true;
+    expect(onBlur.args[0][0]).to.equal('test'); // field name
+    expect(onChange.args[0][0]).to.equal(987.65);
+  });
+
+  it('should handle an invalid value', async () => {
+    // error message is not shown at this level, RJSF handles it from the
+    // onChange event and depends on the schema
+    const onBlur = sinon.spy();
+    const onChange = sinon.spy(); // onChange is also called on blur
+    const props = getProps({ onBlur, onChange });
+
+    const { container } = render(<CurrencyField {...props} />);
+    const input = $('va-text-input', container);
+    input.value = 'abcdefg';
+    await fireEvent.blur(input, { target: { name: 'abcdefg' } });
+
+    expect(onBlur.calledOnce).to.be.true;
+    expect(onBlur.args[0][0]).to.equal('test'); // field name
+    expect(onChange.args[0][0]).to.equal('abcdefg');
+  });
+});

--- a/src/platform/forms-system/test/js/web-component-patterns/currencyPattern.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/web-component-patterns/currencyPattern.unit.spec.jsx
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+
+import { currencyUI } from '../../../src/js/web-component-patterns';
+
+describe('currencyUI', () => {
+  it('should return a uiSchema with default properties', () => {
+    const uiSchema = currencyUI('Test Title');
+    const uiErrors = uiSchema['ui:errorMessages'];
+
+    expect(uiSchema['ui:title']).to.equal('Test Title');
+    expect(uiSchema['ui:description']).to.be.undefined;
+    expect(uiSchema['ui:hint']).to.be.undefined;
+    expect(uiSchema['ui:validations'].length).to.equal(1);
+    expect(uiErrors.pattern).to.equal('Enter a valid dollar amount');
+    expect(uiErrors.type).to.equal('Enter a valid dollar amount');
+    expect(uiErrors.min).to.equal('Enter a number greater than or equal to 0');
+    expect(uiErrors.max).to.equal(
+      'Enter a number less than or equal to 999999999',
+    );
+  });
+
+  it('should return a uiSchema with the correct properties', () => {
+    const options = {
+      title: 'Test Title',
+      description: 'Test Description',
+      hint: 'Test Hint',
+      width: 'lg',
+      currencySymbol: '$',
+      min: 12,
+      max: 34,
+    };
+    const uiSchema = currencyUI(options);
+    const uiOptions = uiSchema['ui:options'];
+    const uiErrors = uiSchema['ui:errorMessages'];
+
+    expect(uiSchema['ui:title']).to.equal('Test Title');
+    expect(uiSchema['ui:description']).to.equal('Test Description');
+    expect(uiOptions.hint).to.equal('Test Hint');
+    expect(uiOptions.width).to.equal('lg');
+    expect(uiOptions.currencySymbol).to.equal('$');
+    expect(uiOptions.min).to.equal(12);
+    expect(uiOptions.max).to.equal(34);
+    expect(uiErrors.required).to.equal('Enter an amount');
+    expect(uiErrors.pattern).to.equal('Enter a valid dollar amount');
+    expect(uiErrors.type).to.equal('Enter a valid dollar amount');
+    expect(uiErrors.min).to.equal('Enter a number greater than or equal to 12');
+    expect(uiErrors.max).to.equal('Enter a number less than or equal to 34');
+  });
+
+  it('should return a uiSchema with no min or max', () => {
+    const uiSchema = currencyUI({
+      title: 'Test Title',
+      min: null,
+      max: null,
+    });
+
+    const uiErrors = uiSchema['ui:errorMessages'];
+
+    expect(uiSchema['ui:validations'].length).to.equal(0);
+    expect(uiErrors.pattern).to.equal('Enter a valid dollar amount');
+    expect(uiErrors.type).to.equal('Enter a valid dollar amount');
+    expect(uiErrors.min).to.equal('');
+    expect(uiErrors.max).to.equal('');
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Currently when a currency value is entered into the CurrencyField (Currency UI pattern for web components), the value isn't saved until the field is blurred. When the submit (continue) button is used immediately, the currency input shows an error that won't clear until you focus, then blur the input. This PR fixes this behavior by switching the saving of the value to form data to the `onInput` callback, but the `onBlur` callback still does the final rounding and processing.
  >
  > Additionally, unit tests have been added to monitor this behavior
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestyle team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/108980

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Pension form  | ![before behavior where after adding a currency value, and not blurring the input, the continue button is clicked and the input shows an invalid value error. After focusing and blurring the input, the error clears](https://github.com/user-attachments/assets/81dd8f59-63c0-496d-9555-c245c3aa36b4) | ![after behavior shows that the currency value is accepted on submit without blurring the input](https://github.com/user-attachments/assets/1d7f554e-8430-4cf4-bad2-04b61b71b331) |

## What areas of the site does it impact?

Pensions, income & asset statement, and 686C-674

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
