### PR TITLE
Update past appointment list to focus on count on fetch succeeded

### DIFF
--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.jsx
@@ -62,7 +62,7 @@ export default function PastAppointmentsPage() {
   }, []);
   useEffect(
     () => {
-      if (pastStatus === FETCH_STATUS.succeeded) {
+      if (pastStatus === FETCH_STATUS.succeeded && !isInitialMount) {
         scrollAndFocus('#appointment-count');
       } else if (pastStatus === FETCH_STATUS.failed) {
         scrollAndFocus('h3');

--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.jsx
@@ -45,7 +45,6 @@ export default function PastAppointmentsPage() {
     pastAppointmentsByMonth,
     pastStatus,
     pastSelectedIndex,
-    hasTypeChanged,
   } = useSelector(state => getPastAppointmentListInfo(state), shallowEqual);
   const pastAppointments = useSelector(state => selectPastAppointments(state));
 
@@ -63,15 +62,13 @@ export default function PastAppointmentsPage() {
   }, []);
   useEffect(
     () => {
-      if (pastStatus === FETCH_STATUS.succeeded && !isInitialMount) {
-        scrollAndFocus('h3');
-      } else if (hasTypeChanged && pastStatus === FETCH_STATUS.succeeded) {
-        scrollAndFocus('#type-dropdown');
-      } else if (hasTypeChanged && pastStatus === FETCH_STATUS.failed) {
+      if (pastStatus === FETCH_STATUS.succeeded) {
+        scrollAndFocus('#appointment-count');
+      } else if (pastStatus === FETCH_STATUS.failed) {
         scrollAndFocus('h3');
       }
     },
-    [isInitialMount, pastStatus, hasTypeChanged],
+    [isInitialMount, pastStatus],
   );
 
   const onDateRangeChange = index => {
@@ -102,7 +99,7 @@ export default function PastAppointmentsPage() {
       <>
         <div className="vads-u-margin-y--8">
           <va-loading-indicator
-            set-focus={hasTypeChanged || !isInitialMount}
+            set-focus={!isInitialMount}
             message="Loading your past appointments..."
           />
         </div>
@@ -148,7 +145,10 @@ export default function PastAppointmentsPage() {
         {dateRangeOptions[pastSelectedIndex]?.label}
       </div>
 
-      <div className="vads-u-margin-bottom--2 vads-u-font-style--italic">
+      <div
+        id="appointment-count"
+        className="vads-u-margin-bottom--2 vads-u-font-style--italic"
+      >
         Showing {pastAppointments.length} appointments between today and{' '}
         {format(
           dateRangeOptions[pastSelectedIndex].startDateRaw,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR updates the past appointment list page to focus on the text below the dropdown after successful fetches, as per UX feedback.
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107531

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Initial loads  |   <img width="478" alt="image" src="https://github.com/user-attachments/assets/0840297c-e114-4346-a434-1c4ae55058c4" />    |   <img width="493" alt="image" src="https://github.com/user-attachments/assets/4faff4ff-6e12-4574-a97a-efe7e9633741" />  |
| Subsequent load  |   <img width="494" alt="image" src="https://github.com/user-attachments/assets/fc712ff8-a2d6-4f55-b945-d25e6d3af1bf" />    |   <img width="492" alt="image" src="https://github.com/user-attachments/assets/fb2b100a-617e-491e-808c-bef166ea8fa3" />   |

## What areas of the site does it impact?

Appointments 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
