### PR TITLE
Add link from Profile page to Veteran Status Card

### DIFF
--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -20,6 +20,8 @@ export const Hub = () => {
     TOGGLE_NAMES.representativeStatusEnableV2Features,
   );
 
+  const showVeteranStatus = useToggleValue(TOGGLE_NAMES.vetStatusStage1);
+
   const { label, link } = useSignInServiceProvider();
   const hasBadAddress = useSelector(hasBadAddressSelector);
 
@@ -104,6 +106,21 @@ export const Hub = () => {
             />
           </>
         </HubCard>
+
+        {showVeteranStatus && (
+          <HubCard
+            heading={PROFILE_PATH_NAMES.VETERAN_STATUS_CARD}
+            content="Your Veteran Status Card makes it easy to prove your service and access Veteran discounts."
+          >
+            <>
+              <ProfileLink
+                className="vads-u-display--block vads-u-margin-bottom--2"
+                text="View your Veteran Status Card"
+                href={PROFILE_PATHS.VETERAN_STATUS_CARD}
+              />
+            </>
+          </HubCard>
+        )}
 
         <HubCard
           heading={PROFILE_PATH_NAMES.DIRECT_DEPOSIT}

--- a/src/applications/personalization/profile/tests/e2e/profile-hub-keyboard-navigation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub-keyboard-navigation.cypress.spec.js
@@ -9,6 +9,7 @@ const PROFILE_HREFS = [
   PROFILE_PATHS.CONTACTS,
   PROFILE_PATHS.MILITARY_INFORMATION,
   '/records/get-military-service-records/',
+  PROFILE_PATHS.VETERAN_STATUS_CARD,
   PROFILE_PATHS.DIRECT_DEPOSIT,
   '/va-payment-history/payments/',
   PROFILE_PATHS.NOTIFICATION_SETTINGS,
@@ -21,7 +22,7 @@ describe('Profile - Hub page, Keyboard navigation', () => {
   it('should allow tabbing through all links on the page, in order', () => {
     cy.login(mockUser);
 
-    mockProfileLOA3(generateFeatureToggles());
+    mockProfileLOA3(generateFeatureToggles({ vetStatusStage1: true }));
 
     cy.visit(PROFILE_PATHS.PROFILE_ROOT);
 

--- a/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
@@ -8,7 +8,7 @@ import user from '../../mocks/endpoints/user';
 describe('Profile - Hub page', () => {
   beforeEach(() => {
     cy.login(mockUser);
-    mockProfileLOA3(generateFeatureToggles());
+    mockProfileLOA3(generateFeatureToggles({ vetStatusStage1: true }));
   });
 
   it('should render the correct content', () => {
@@ -21,6 +21,7 @@ describe('Profile - Hub page', () => {
       'exist',
     );
     cy.findByText('Military information', { selector: 'h2' }).should('exist');
+    cy.findByText('Veteran Status Card', { selector: 'h2' }).should('exist');
     cy.findByText('Direct deposit information', { selector: 'h2' }).should(
       'exist',
     );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added link on the profile page to get access to the Veteran Status Card page. This is behind a feature flag

## Related issue(s)
- Link to parent ticket in IIR repo
https://github.com/department-of-veterans-affairs/va-iir/issues/1067
- Link to ticket in MFS repo
https://github.com/department-of-veterans-affairs/va-iir/issues/1577

## Testing done

- Verified that when the `vetStatusStage1` feature flag is on, the profile page includes the Veteran Status Card option
- Verified that when the `vetStatusStage1` feature flag is off, the profile page does not include the option

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  ![Screenshot 2025-05-06 at 3 23 22 PM](https://github.com/user-attachments/assets/04860a83-5a6a-4b31-80bb-2d89014ce7d7) | ![Screenshot 2025-05-06 at 3 22 39 PM](https://github.com/user-attachments/assets/8c05ecc3-b805-4bff-8a23-1e03728c3a60)
 |

## What areas of the site does it impact?

User Profile page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
