### PR TITLE
MHV-71158 Fixed date handling for Blue Button appointments

### DIFF
--- a/src/applications/mhv-medical-records/tests/actions/blueButtonReport.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/blueButtonReport.unit.spec.jsx
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { mockApiRequest } from '@department-of-veterans-affairs/platform-testing/helpers';
 import sinon from 'sinon';
-import { formatISO, subYears, addMonths } from 'date-fns';
 import {
   getBlueButtonReportData,
   clearFailedList,
@@ -173,90 +172,36 @@ describe('Blue Button Actions', () => {
           );
           await action(dispatch);
 
+          const [fromDateArg, toDateArg] = getAppointmentsStub.firstCall.args;
+          expect(fromDateArg).to.not.be.null;
+          expect(toDateArg).to.not.be.null;
           expect(getAppointmentsStub.calledOnce).to.be.true;
 
-          // The 'any' option should calculate fromDate as 2 years ago and toDate as 13 months in the future
-          const currentDate = new Date();
-          const dateTwoYearsAgo = subYears(currentDate, 2);
-          const dateThirteenMonthsAhead = addMonths(currentDate, 13);
+          expect(dispatch.calledOnce).to.be.true;
+          const dispatchedAction = dispatch.firstCall.args[0];
+          expect(dispatchedAction.type).to.equal(Actions.BlueButtonReport.GET);
+          expect(dispatchedAction.appointmentsResponse).to.deep.equal(mockData);
 
-          const expectedFromDate = formatISO(dateTwoYearsAgo);
-          const expectedToDate = formatISO(dateThirteenMonthsAhead);
+          getAppointmentsStub.restore();
+        });
+
+        it('should fetch appointments with the provided custom dateFilter range', async () => {
+          const mockData = { mockData: 'appointmentsMockData' };
+          const getAppointmentsStub = sinon
+            .stub(MrApi, 'getAppointments')
+            .resolves(mockData);
+
+          const dispatch = sinon.spy();
+          const action = getBlueButtonReportData(
+            { appointments: true },
+            { fromDate: '2021-06-01', toDate: '2021-12-31' },
+          );
+          await action(dispatch);
 
           const [fromDateArg, toDateArg] = getAppointmentsStub.firstCall.args;
-          expect(fromDateArg).to.equal(expectedFromDate);
-          expect(toDateArg).to.equal(expectedToDate);
-
-          expect(dispatch.calledOnce).to.be.true;
-          const dispatchedAction = dispatch.firstCall.args[0];
-          expect(dispatchedAction.type).to.equal(Actions.BlueButtonReport.GET);
-          expect(dispatchedAction.appointmentsResponse).to.deep.equal(mockData);
-
-          getAppointmentsStub.restore();
-        });
-
-        it('should fetch appointments with the provided custom dateFilter range (in range)', async () => {
-          const mockData = { mockData: 'appointmentsMockData' };
-          const getAppointmentsStub = sinon
-            .stub(MrApi, 'getAppointments')
-            .resolves(mockData);
-
-          const fromDateCustom = '2021-06-01';
-          const toDateCustom = '2021-12-31';
-          const dispatch = sinon.spy();
-          const action = getBlueButtonReportData(
-            { appointments: true },
-            { fromDate: fromDateCustom, toDate: toDateCustom },
-          );
-          await action(dispatch);
-
+          expect(fromDateArg).to.not.be.null;
+          expect(toDateArg).to.not.be.null;
           expect(getAppointmentsStub.calledOnce).to.be.true;
-          expect(getAppointmentsStub.firstCall.args[0]).to.equal(
-            formatISO(new Date(fromDateCustom)),
-          );
-          expect(getAppointmentsStub.firstCall.args[1]).to.equal(
-            formatISO(new Date(toDateCustom)),
-          );
-
-          expect(dispatch.calledOnce).to.be.true;
-          const dispatchedAction = dispatch.firstCall.args[0];
-          expect(dispatchedAction.type).to.equal(Actions.BlueButtonReport.GET);
-          expect(dispatchedAction.appointmentsResponse).to.deep.equal(mockData);
-
-          getAppointmentsStub.restore();
-        });
-
-        it('should clamp provided custom dateFilter range if dates are out of allowed boundaries', async () => {
-          const mockData = { mockData: 'appointmentsMockData' };
-          const getAppointmentsStub = sinon
-            .stub(MrApi, 'getAppointments')
-            .resolves(mockData);
-
-          // Provide custom dates that are out-of-bounds
-          const fromDateCustom = '2018-01-01';
-          const toDateCustom = '2025-01-01';
-          const dispatch = sinon.spy();
-          const action = getBlueButtonReportData(
-            { appointments: true },
-            { fromDate: fromDateCustom, toDate: toDateCustom },
-          );
-          await action(dispatch);
-
-          // With the fake current date of Jan 1, 2022,
-          // allowed range is from 2 years ago (Jan 1, 2020) to 13 months ahead (Feb 1, 2023)
-          const currentDate = new Date();
-          const earliestAllowedFromDate = subYears(currentDate, 2);
-          const latestAllowedToDate = addMonths(currentDate, 13);
-
-          const expectedFromDate = formatISO(earliestAllowedFromDate);
-          const expectedToDate = formatISO(latestAllowedToDate);
-
-          expect(getAppointmentsStub.firstCall.args[0]).to.equal(
-            expectedFromDate,
-          );
-          expect(getAppointmentsStub.firstCall.args[1]).to.equal(
-            expectedToDate,
-          );
 
           expect(dispatch.calledOnce).to.be.true;
           const dispatchedAction = dispatch.firstCall.args[0];

--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
@@ -764,8 +764,8 @@ describe('removeTrailingSlash', () => {
 
 describe('getAppointmentsDateRange', () => {
   let clock;
-  // Freeze "now" at Jan 1, 2022 UTC
-  const fakeNow = new Date('2022-01-01T00:00:00Z');
+  // Freeze "now" at Jan 1, 2022 local time
+  const fakeNow = new Date(2022, 0, 1, 0, 0, 0);
   const earliestFormatted = formatISO(startOfDay(subYears(fakeNow, 2)));
   const latestFormatted = formatISO(endOfDay(addMonths(fakeNow, 13)));
 
@@ -779,6 +779,24 @@ describe('getAppointmentsDateRange', () => {
   afterEach(() => {
     clock.restore();
   });
+
+  function assertDateComponents(
+    isoString,
+    year,
+    month,
+    day,
+    hours,
+    minutes,
+    seconds,
+  ) {
+    const d = parseISO(isoString);
+    expect(d.getFullYear()).to.equal(year);
+    expect(d.getMonth()).to.equal(month);
+    expect(d.getDate()).to.equal(day);
+    expect(d.getHours()).to.equal(hours);
+    expect(d.getMinutes()).to.equal(minutes);
+    expect(d.getSeconds()).to.equal(seconds);
+  }
 
   it('returns the full allowed window when both inputs are null', () => {
     const { startDate, endDate } = getAppointmentsDateRange(null, null);
@@ -874,5 +892,23 @@ describe('getAppointmentsDateRange', () => {
 
     expect(startDate).to.equal(formatISO(startOfDay(parseISO(date))));
     expect(endDate).to.equal(formatISO(endOfDay(parseISO(date))));
+  });
+
+  it('uses the correct start and end dates', () => {
+    const from = '2021-06-01';
+    const to = '2022-06-01';
+    const { startDate, endDate } = getAppointmentsDateRange(from, to);
+
+    assertDateComponents(startDate, 2021, 5, 1, 0, 0, 0); // 2021-06-01T00:00:00 local time
+    assertDateComponents(endDate, 2022, 5, 1, 23, 59, 59); // 2022-06-01T23:59:59 local time
+  });
+
+  it('uses the correct start and end dates for maximum window', () => {
+    const from = '2018-01-01';
+    const to = '2025-01-01';
+    const { startDate, endDate } = getAppointmentsDateRange(from, to);
+
+    assertDateComponents(startDate, 2020, 0, 1, 0, 0, 0); // 2020-01-01T00:00:00 local time
+    assertDateComponents(endDate, 2023, 1, 1, 23, 59, 59); // 2023-02-01T23:59:59 local time
   });
 });

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -4,7 +4,16 @@ import { datadogRum } from '@datadog/browser-rum';
 import { snakeCase } from 'lodash';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
-import { format as dateFnsFormat, parseISO, isValid } from 'date-fns';
+import {
+  format as dateFnsFormat,
+  formatISO,
+  subYears,
+  addMonths,
+  startOfDay,
+  endOfDay,
+  parseISO,
+  isValid,
+} from 'date-fns';
 import {
   EMPTY_FIELD,
   interpretationMap,
@@ -733,4 +742,35 @@ export const formatUserDob = userProfile => {
 export const removeTrailingSlash = path => {
   if (!path) return path;
   return path.replace(/\/$/, '');
+};
+
+export const getAppointmentsDateRange = (fromDate, toDate) => {
+  function clamp(d, min, max) {
+    if (d < min) return min;
+    if (d > max) return max;
+    return d;
+  }
+
+  const now = new Date();
+  const earliest = startOfDay(subYears(now, 2));
+  const latest = endOfDay(addMonths(now, 13));
+
+  // parse or default
+  const rawFrom = fromDate ? startOfDay(parseISO(fromDate)) : earliest;
+  const rawTo = toDate ? endOfDay(parseISO(toDate)) : latest;
+
+  // clamp both ends
+  let clampedFrom = clamp(rawFrom, earliest, latest);
+  let clampedTo = clamp(rawTo, earliest, latest);
+
+  // ensure from <= to
+  if (clampedFrom > clampedTo) {
+    clampedFrom = earliest;
+    clampedTo = latest;
+  }
+
+  return {
+    startDate: formatISO(clampedFrom),
+    endDate: formatISO(clampedTo),
+  };
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Our old function to handle dates was not properly handling all cases
- Pulled the functionality out into a util function and re-wrote it
- Wrote extensive unit tests to test edge cases

## Related issue(s)

### [MHV-71158](https://jira.devops.va.gov/browse/MHV-71158) - BB report may be messing up search dates for appointments ###

> See [this Datadog link](https://vagov.ddog-gov.com/apm/traces?query=%40_top_level%3A1%20env%3Aeks-prod%20service%3Amhv-appointments%20resource_name%3A%22VAOS%3A%3AV2%3A%3AAppointmentsController%23index%22%20status%3Aerror%20%40http.status_code%3A400&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2Chost%2C%40http.url%2C%40_duration.by_service&fromUser=false&graphType=span_list&historicalData=true&messageDisplay=inline&shouldShowLegend=true&sort=desc&spanType=service-entry&spanViewType=errors&storage=hot&traceQuery=&view=spans&viz=stream&start=1746479308151&end=1746565708151&paused=false) for offending traces.
> 
> All the entries seem to have a start date two years in the past (correct assuming a wide open search), and a random end date that is earlier than the start date.
> 
> Verify our date handling.

## Testing done

- Extensive new unit tests to catch all edge cases.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
