### PR TITLE
106722 - Fix GA tracking for direct_deposits endpoint

### DIFF
--- a/src/applications/personalization/profile/tests/util/direct-deposit.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/direct-deposit.unit.spec.jsx
@@ -112,7 +112,7 @@ describe('DirectDepositClient', () => {
       });
     });
 
-    it('records lighthouse analytics event with supplied endpoint and veteranStatus', () => {
+    it('records lighthouse analytics event with veteranStatus and a supplied endpoint', () => {
       client.recordDirectDepositEvent({
         endpoint: '/profile/direct_deposits',
         status: API_STATUS.SUCCESSFUL,

--- a/src/applications/personalization/profile/tests/util/direct-deposit.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/direct-deposit.unit.spec.jsx
@@ -112,8 +112,9 @@ describe('DirectDepositClient', () => {
       });
     });
 
-    it('records lighthouse GET analytics event without error', () => {
+    it('records lighthouse analytics event with supplied endpoint and veteranStatus', () => {
       client.recordDirectDepositEvent({
+        endpoint: '/profile/direct_deposits',
         status: API_STATUS.SUCCESSFUL,
         method: 'GET',
         extraProperties: {
@@ -123,7 +124,7 @@ describe('DirectDepositClient', () => {
 
       expect(recordEventSpy.firstCall.args[0]).to.deep.equal({
         event: 'api_call',
-        'api-name': 'GET /profile/direct_deposits/disability_compensations',
+        'api-name': 'GET /profile/direct_deposits',
         'api-status': API_STATUS.SUCCESSFUL,
         'veteran-status': 'DEPENDENT',
       });

--- a/src/applications/personalization/profile/util/direct-deposit.js
+++ b/src/applications/personalization/profile/util/direct-deposit.js
@@ -51,10 +51,16 @@ export class DirectDepositClient {
     };
   }
 
-  recordDirectDepositEvent({ status, method = 'GET', extraProperties = {} }) {
+  recordDirectDepositEvent({
+    endpoint,
+    status,
+    method = 'GET',
+    extraProperties = {},
+  }) {
+    const apiEndpoint = endpoint || this.endpoint;
     const payload = {
       event: 'api_call',
-      'api-name': `${method} ${this.endpoint}`,
+      'api-name': `${method} ${apiEndpoint}`,
       'api-status': status,
     };
 

--- a/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('<AutoSSO>', () => {
     wrapper.unmount();
   });
 
-  it.skip('should call removeLoginAttempted if user is logged in', () => {
+  it('should call removeLoginAttempted if user is logged in', () => {
     const stub = sinon.stub(loginAttempted, 'removeLoginAttempted');
     props = generateProps({ loggedIn: true });
     const wrapper = shallow(<AutoSSO {...props} />);


### PR DESCRIPTION
This resolves a regression in GA tracking that was added in #36243.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Previously, API calls to `/profile/direct_deposits` used the `recordDirectDepositEvent` method in the direct-deposit.js file but that was changed to using the method with the same name in directDeposit.js which did not support receiving the `endpoint` property and forced all tracking events to register as if they were made against the `/profile/direct_deposits/disability_compensations` API endpoint.
- Observe the API request to `/profile/direct_deposits` complete when viewing the profile page and then note that the `api_call` GA event will list `/profile/direct_deposits/disability_compensations` as the completed `api_call`
- Allow the `recordDirectDepositEvent` to optionally accept an `endpoint` property but fallback to the original endpoint when no endpoint is supplied to maintain backwards compatibility.
- Authenticated Experience Team Authentiknights

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106722
- https://github.com/department-of-veterans-affairs/vets-website/pull/36243

## Testing done

- Updated the unit test and ran it both with an expected successful run and an expected failed run. 
- Check load up the profile page on the website and note that any calls to `/profile/direct_deposits` (and others under `/profile/direct_deposits*` are matching the API call that triggered that GA event.

## Screenshots

N/A

## What areas of the site does it impact?

Just the Profile page and Direct Deposit sub pages of the profile.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
