### PR TITLE
refresh_access_token

### DIFF
--- a/src/applications/representative-form-upload/pages/upload.jsx
+++ b/src/applications/representative-form-upload/pages/upload.jsx
@@ -6,6 +6,8 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import PropTypes from 'prop-types';
+import { fetchAndUpdateSessionExpiration } from 'platform/utilities/api';
+import merge from 'lodash/merge';
 import {
   UPLOAD_TITLE,
   UPLOAD_DESCRIPTION,
@@ -14,12 +16,55 @@ import {
 } from '../config/constants';
 import { getFormContent, getPdfDownloadUrl, onCloseAlert } from '../helpers';
 import { CustomAlertPage } from './helpers';
+import { getSignInUrl } from '../utilities/constants';
+import manifest from '../manifest.json';
 
 const { formNumber, title } = getFormContent();
-const fileUploadUrl = `${
-  environment.API_URL
-}/accredited_representative_portal/v0/representative_form_upload`;
+const baseURL = `${environment.API_URL}/accredited_representative_portal/v0`;
+const fileUploadUrl = `${baseURL}/representative_form_upload`;
 const warningsPresent = formData => formData.uploadedFile?.warnings?.length > 0;
+
+const fetchNewAccessToken = async () => {
+  window.appName = manifest.entryName;
+  const csrfTokenStored = localStorage.getItem('csrfToken');
+
+  const defaultSettings = {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'X-Key-Inflection': 'camel',
+      'Source-App-Name': window.appName,
+      'X-CSRF-Token': csrfTokenStored,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  const settings = merge(defaultSettings, {}, {});
+  const response = await fetchAndUpdateSessionExpiration(
+    `${baseURL}/user`,
+    settings,
+  );
+  if (response.ok || response.status === 304) {
+    return response;
+  }
+
+  if (
+    response.status === 401 &&
+    // Don't redirect to login for our app's root / landing page experience.
+    // People are allowed to be unauthenticated there.
+    // TODO: probably need a more sound & principled solution here.
+    ![manifest.rootUrl, `${manifest.rootUrl}/`].includes(
+      window.location.pathname,
+    )
+  ) {
+    window.location = getSignInUrl({
+      returnUrl: window.location.href,
+    });
+    return null;
+  }
+
+  throw response;
+};
 
 export const uploadPage = {
   uiSchema: {
@@ -58,6 +103,7 @@ export const uploadPage = {
 /** @type {CustomPageType} */
 export function UploadPage(props) {
   const warnings = props.data?.uploadedFile?.warnings;
+  fetchNewAccessToken();
   const alert =
     warnings?.length > 0
       ? FORM_UPLOAD_OCR_ALERT(


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No


## Summary

- If our access token expired after 5 mins, the user would get an unauthorized error but it would fail silently so the user wouldn't know what was wrong

## Related issue(s)

- Other half of this ticket - https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/1?sliceBy%5Bvalue%5D=patrick-brown-oddball&pane=issue&itemId=107497883&issue=department-of-veterans-affairs%7Cva.gov-team%7C108186


## Testing done

- Walked through it locally
- Borrow the way it is used from other parts of the app

## Screenshots

N/A

## What areas of the site does it impact?

/representative/representative-form-upload/21-686c/upload

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

