### PR TITLE
MHV-71095: Shipped on date is not getting displayed in refill history

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -782,8 +782,8 @@ const VaPrescription = prescription => {
                                       data-testid="shipped-on"
                                     >
                                       {dateFormat(
-                                        entry?.trackingList
-                                          ? entry.trackingList[0]
+                                        prescription?.trackingList
+                                          ? prescription.trackingList[0]
                                               ?.completeDateTime
                                           : null,
                                         'MMMM D, YYYY',

--- a/src/applications/mhv-medications/tests/e2e/medications-refill-history-shipped-on-date-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-refill-history-shipped-on-date-details-page.cypress.spec.js
@@ -1,0 +1,51 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+import rxList from './fixtures/listOfPrescriptions.json';
+import MedicationsListPage from './pages/MedicationsListPage';
+import refillHistoryDetails from './fixtures/prescription-tracking-details.json';
+import olderRxDetails from './fixtures/older-prescription-details.json';
+import medicationsList from './fixtures/grouped-prescriptions-list.json';
+import { Data } from './utils/constants';
+
+describe('Medications Refill History Shipped On Latest Refill', () => {
+  it('visits prescription refill history Shipped on date', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const detailsPage = new MedicationsDetailsPage();
+    const cardNumber = 16;
+    const shippedDate = 'Sun, 24 Sept 2023 04:39:11 EDT';
+    site.login();
+    listPage.visitMedicationsListPageURL(rxList);
+    cy.injectAxe();
+    cy.axeCheck('main');
+    detailsPage.clickMedicationDetailsLink(refillHistoryDetails, cardNumber);
+    detailsPage.verifyRefillHistoryHeaderOnDetailsPage();
+    detailsPage.verifyFirstRefillHeaderTextOnDetailsPage();
+    detailsPage.clickRefillHistoryAccordionOnDetailsPage();
+    detailsPage.verifyShippedOnDateFieldOnDetailsPage();
+    cy.get('@Medications')
+      .its('response')
+      .then(res => {
+        expect(res.body.data[15].attributes.trackingList[0]).to.include({
+          completeDateTime: shippedDate,
+        });
+      });
+  });
+
+  it('visits prescription refill history no shipping date available ', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const detailsPage = new MedicationsDetailsPage();
+    const cardNumber = 3;
+    site.login();
+    listPage.visitMedicationsListPageURL(medicationsList);
+    cy.injectAxe();
+    cy.axeCheck('main');
+    detailsPage.clickMedicationDetailsLink(olderRxDetails, cardNumber);
+    detailsPage.clickRefillHistoryAccordionOnDetailsPage();
+    detailsPage.verifyShippedOnDateFieldOnDetailsPage();
+    detailsPage.verifyShippedOnDateNotAvailableTextInRefillAccordion(
+      Data.DATE_EMPTY,
+    );
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -749,6 +749,10 @@ class MedicationsDetailsPage {
       .find('[class="va-accordion__subheader"]', { force: true })
       .should('contain', text);
   };
+
+  verifyShippedOnDateNotAvailableTextInRefillAccordion = text => {
+    cy.get('[data-testid="shipped-on"]').should('contain', text);
+  };
 }
 
 export default MedicationsDetailsPage;


### PR DESCRIPTION
## Summary

- A follow up to https://dsva.slack.com/archives/C059Q28DV99/p1746111305730669
- Fixed `trackingList` being pulled from main object instead of a `rxRfRecords` entry for Refill History

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-71095

## Testing done

- Manual testing
- e2e testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Shipped on date appears correctly in the refill history

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

