### PR TITLE
Cc/108651/fix mocks for eps appointment details

### DIFF
--- a/src/applications/vaos/README.md
+++ b/src/applications/vaos/README.md
@@ -1,6 +1,6 @@
 # VA Online Scheduling
 
-This is the front end source for the VAOS application. Veterans can schedule, request, and view appointments through this application.
+This is the front end source for the Appointments application. Veterans can schedule, request, and view appointments through this application.
 
 It is a React/Redux application that makes heavy use of MomentJS. Tests are written with React Testing Library and Cypress.
 
@@ -50,6 +50,8 @@ The application has three major sections
   - The code for the new appointment and request flows
 - /covid-19-vaccine
   - In progress vaccine appointment scheduling MVP
+- /referral-appointments
+  - The code for the referrals and requests and scheduling a Commnunity Care referral appointment
 
 Application sections are generally organized into three folders:
 
@@ -86,3 +88,8 @@ Local development of the application requires use of the [mock API](https://gith
 ```
 yarn mock-api --responses src/applications/vaos/services/mocks/index.js
 ```
+### Mock scenarios for Referrals and Requests
+
+- http://localhost:3001/my-health/appointments/schedule-referral?id=error
+  - Should show a generic referral error indicating that vets-api returned any error status code when fetching that referral.
+

--- a/src/applications/vaos/referral-appointments/CompleteReferral.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { format } from 'date-fns';
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 
 import ReferralLayout from './components/ReferralLayout';
+import { routeToNextReferralPage } from './flow';
 import {
   pollFetchAppointmentInfo,
   setFormCurrentPage,
@@ -15,6 +16,7 @@ import getNewAppointmentFlow from '../new-appointment/newAppointmentFlow';
 import {
   getAppointmentCreateStatus,
   getReferralAppointmentInfo,
+  selectCurrentPage,
 } from './redux/selectors';
 import { FETCH_STATUS, GA_PREFIX } from '../utils/constants';
 
@@ -30,8 +32,10 @@ function handleScheduleClick(dispatch) {
 export default function CompleteReferral() {
   const { pathname } = useLocation();
   const dispatch = useDispatch();
-  const [, appointmentId] = pathname.split('/schedule-referral/complete/');
+  const history = useHistory();
   const appointmentCreateStatus = useSelector(getAppointmentCreateStatus);
+  const currentPage = useSelector(selectCurrentPage);
+  const [, appointmentId] = pathname.split('/schedule-referral/complete/');
   const { root, typeOfCare } = useSelector(getNewAppointmentFlow);
   const {
     appointmentInfoError,
@@ -39,6 +43,14 @@ export default function CompleteReferral() {
     appointmentInfoLoading,
     referralAppointmentInfo,
   } = useSelector(getReferralAppointmentInfo);
+
+  function goToDetailsView(e) {
+    e.preventDefault();
+    recordEvent({
+      event: `${GA_PREFIX}-view-eps-appointment-details-button-clicked`,
+    });
+    routeToNextReferralPage(history, currentPage, null, appointmentId);
+  }
 
   useEffect(
     () => {
@@ -170,9 +182,10 @@ export default function CompleteReferral() {
             </p>
             <p>
               <va-link
-                href={`/my-health/appointments/${attributes.id}?eps=true`}
+                href={`${root.url}/${attributes.id}?eps=true`}
                 data-testid="cc-details-link"
                 text="Details"
+                onClick={e => goToDetailsView(e)}
               />
             </p>
           </div>

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
@@ -5,10 +5,7 @@ import { format } from 'date-fns';
 
 import { fetchAppointmentInfo, setFormCurrentPage } from './redux/actions';
 // eslint-disable-next-line import/no-restricted-paths
-import {
-  getAppointmentCreateStatus,
-  getReferralAppointmentInfo,
-} from './redux/selectors';
+import { getReferralAppointmentInfo } from './redux/selectors';
 
 // eslint-disable-next-line import/no-restricted-paths
 import PageLayout from '../appointment-list/components/PageLayout';
@@ -22,10 +19,10 @@ import FacilityPhone from '../components/FacilityPhone';
 
 export default function EpsAppointmentDetailsPage() {
   const { pathname } = useLocation();
+  // get the id from the url my-health/appointments/1234
   const [, appointmentId] = pathname.split('/');
   const dispatch = useDispatch();
-  // get the id from the url my-health/appointments/1234
-  const appointmentCreateStatus = useSelector(getAppointmentCreateStatus);
+
   const {
     appointmentInfoError,
     appointmentInfoTimeout,
@@ -45,7 +42,7 @@ export default function EpsAppointmentDetailsPage() {
         !appointmentInfoError &&
         !appointmentInfoTimeout &&
         !appointmentInfoLoading &&
-        referralAppointmentInfo?.attributes?.status !== 'booked'
+        !referralAppointmentInfo?.attributes
       ) {
         dispatch(fetchAppointmentInfo(appointmentId));
       }
@@ -55,9 +52,8 @@ export default function EpsAppointmentDetailsPage() {
       appointmentId,
       appointmentInfoError,
       appointmentInfoTimeout,
-      appointmentCreateStatus,
       appointmentInfoLoading,
-      referralAppointmentInfo?.attributes?.status,
+      referralAppointmentInfo,
     ],
   );
   if (appointmentInfoError || appointmentInfoTimeout) {
@@ -69,6 +65,7 @@ export default function EpsAppointmentDetailsPage() {
             status="error"
             level={1}
             headline="We’re sorry, we can’t find your appointment"
+            data-testid="error-alert"
           >
             Try searching this appointment on your appointment list or call your
             facility.
@@ -85,15 +82,13 @@ export default function EpsAppointmentDetailsPage() {
     );
   }
 
-  if (appointmentInfoLoading || !referralAppointmentInfo.attributes) {
+  if (appointmentInfoLoading || !referralAppointmentInfo?.attributes) {
     return (
       <FullWidthLayout>
         <va-loading-indicator set-focus message="Loading your appointment..." />
       </FullWidthLayout>
     );
   }
-
-  const appointmentLoaded = !!referralAppointmentInfo?.attributes?.id;
 
   const { attributes: appointment } = referralAppointmentInfo;
 
@@ -104,83 +99,81 @@ export default function EpsAppointmentDetailsPage() {
 
   return (
     <PageLayout>
-      {!!appointmentLoaded && (
-        <div
-          className="vaos-appts__appointment-details--container vads-u-margin-top--4 vads-u-border--2px vads-u-border-color--gray-medium vads-u-padding-x--2p5 vads-u-padding-top--5 vads-u-padding-bottom--3"
-          data-testid="appointment-card"
-        >
-          <div className="vaos-appts__appointment-details--icon">
-            <va-icon
-              icon="calendar_today"
-              aria-hidden="true"
-              data-testid="appointment-icon"
-              size={3}
-            />
-          </div>
-          <h1 className="vaos__dynamic-font-size--h2">
-            Community Care Appointment
-          </h1>
-          <Section heading="When">
-            {appointmentDate}
-            <br />
-            <AppointmentTime appointment={appointment} />
-          </Section>
-          <Section heading="What">
-            <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-              {appointment.typeOfCare}
-            </p>
-          </Section>
-          <Section heading="Provider">
-            <span>
-              {`${appointment.provider.name ||
-                'Provider information not available'}`}
-            </span>
-            <br />
-            {appointment.provider.location && (
-              <>
-                <>
-                  {/* removes falsy values from address array */}
-                  <span>{appointment.provider.location.address}</span>
-                </>
-                <div className="vads-u-margin-top--1 vads-u-color--link-default">
-                  <a
-                    href={`https://maps.google.com?saddr=Current+Location&daddr=${
-                      appointment.provider.location.address
-                    }`}
-                  >
-                    <va-icon icon="directions" size="3" />
-                    Directions
-                  </a>
-                </div>
-              </>
-            )}
-            {!!appointment.provider.phoneNumber && (
-              <>
-                <br />
-                <FacilityPhone contact={appointment.provider.phoneNumber} />
-              </>
-            )}
-          </Section>
-          <Section heading="Prepare for your appointment">
-            <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-              Bring your insurance cards. And bring a list of your medications
-              and other information to share with your provider.
-            </p>
-            <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-              <va-link
-                text="Find a full list of things to bring to your appointment"
-                href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"
-              />
-            </p>
-          </Section>
-          <Section heading="Need to make changes?">
-            <span>
-              Contact this provider if you need to reschedule or cancel your
-              appointment.
-            </span>
-          </Section>
+      <div
+        className="vaos-appts__appointment-details--container vads-u-margin-top--4 vads-u-border--2px vads-u-border-color--gray-medium vads-u-padding-x--2p5 vads-u-padding-top--5 vads-u-padding-bottom--3"
+        data-testid="appointment-card"
+      >
+        <div className="vaos-appts__appointment-details--icon">
+          <va-icon
+            icon="calendar_today"
+            aria-hidden="true"
+            data-testid="appointment-icon"
+            size={3}
+          />
         </div>
-      )}
+        <h1 className="vaos__dynamic-font-size--h2">
+          Community Care Appointment
+        </h1>
+        <Section heading="When">
+          {appointmentDate}
+          <br />
+          <AppointmentTime appointment={appointment} />
+        </Section>
+        <Section heading="What">
+          <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+            {appointment.typeOfCare}
+          </p>
+        </Section>
+        <Section heading="Provider">
+          <span>
+            {`${appointment.provider.name ||
+              'Provider information not available'}`}
+          </span>
+          <br />
+          {appointment.provider.location && (
+            <>
+              <>
+                {/* removes falsy values from address array */}
+                <span>{appointment.provider.location.address}</span>
+              </>
+              <div className="vads-u-margin-top--1 vads-u-color--link-default">
+                <a
+                  href={`https://maps.google.com?saddr=Current+Location&daddr=${
+                    appointment.provider.location.address
+                  }`}
+                >
+                  <va-icon icon="directions" size="3" />
+                  Directions
+                </a>
+              </div>
+            </>
+          )}
+          {appointment.provider.phoneNumber && (
+            <>
+              <br />
+              <FacilityPhone contact={appointment.provider.phoneNumber} />
+            </>
+          )}
+        </Section>
+        <Section heading="Prepare for your appointment">
+          <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+            Bring your insurance cards. And bring a list of your medications
+            other information to share with your provider.
+          </p>
+          <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+            <va-link
+              text="Find a full list of things to bring to your appointment"
+              href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"
+            />
+          </p>
+        </Section>
+        <Section heading="Need to make changes?">
+          <span>
+            Contact this provider if you need to reschedule or cancel your
+            appointment.
+          </span>
+        </Section>
+      </div>
     </PageLayout>
   );
 }

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
@@ -25,11 +25,9 @@ export default function EpsAppointmentDetailsPage() {
 
   const {
     appointmentInfoError,
-    appointmentInfoTimeout,
     appointmentInfoLoading,
     referralAppointmentInfo,
   } = useSelector(getReferralAppointmentInfo);
-
   useEffect(
     () => {
       dispatch(setFormCurrentPage('details'));
@@ -40,7 +38,6 @@ export default function EpsAppointmentDetailsPage() {
     () => {
       if (
         !appointmentInfoError &&
-        !appointmentInfoTimeout &&
         !appointmentInfoLoading &&
         !referralAppointmentInfo?.attributes
       ) {
@@ -51,12 +48,11 @@ export default function EpsAppointmentDetailsPage() {
       dispatch,
       appointmentId,
       appointmentInfoError,
-      appointmentInfoTimeout,
       appointmentInfoLoading,
       referralAppointmentInfo,
     ],
   );
-  if (appointmentInfoError || appointmentInfoTimeout) {
+  if (appointmentInfoError) {
     return (
       <PageLayout showNeedHelp>
         <br />

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
@@ -1,0 +1,257 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import EpsAppointmentDetailsPage from './EpsAppointmentDetailsPage';
+import * as actionsModule from './redux/actions';
+import {
+  createTestStore,
+  renderWithStoreAndRouter,
+} from '../tests/mocks/setup';
+import { createMockEpsAppointment } from './utils/appointment';
+import * as epsAppointmentUtils from './utils/appointment';
+
+describe('EpsAppointmentDetailsPage', () => {
+  const appointmentId = 'test-appointment-id';
+  const referralAppointmentInfo = createMockEpsAppointment(
+    appointmentId,
+    'booked',
+    epsAppointmentUtils.appointmentData,
+  );
+
+  const sandbox = sinon.createSandbox();
+
+  const initialState = {
+    referral: {
+      appointmentInfoError: false,
+      appointmentInfoLoading: false,
+      referralAppointmentInfo,
+    },
+  };
+
+  const noAppointmentInfoState = {
+    referral: {
+      appointmentInfoError: false,
+      appointmentInfoLoading: false,
+      referralAppointmentInfo: null,
+    },
+  };
+
+  const loadingState = {
+    referral: {
+      appointmentInfoError: false,
+      appointmentInfoLoading: true,
+      referralAppointmentInfo: null,
+    },
+  };
+
+  const errorState = {
+    referral: {
+      appointmentInfoError: true,
+      appointmentInfoLoading: false,
+      referralAppointmentInfo: null,
+    },
+  };
+
+  const emptyAppointmentState = {
+    referral: {
+      appointmentInfoError: false,
+      appointmentInfoLoading: false,
+      referralAppointmentInfo: {},
+    },
+  };
+
+  beforeEach(() => {
+    sandbox
+      .stub(actionsModule, 'setFormCurrentPage')
+      .returns({ type: 'SET_FORM_CURRENT_PAGE' });
+    sandbox
+      .stub(actionsModule, 'fetchAppointmentInfo')
+      .returns({ type: 'FETCH_APPOINTMENT_INFO' });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should set form current page to details on mount', () => {
+    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(initialState),
+      path: `/${appointmentId}`,
+    });
+
+    expect(actionsModule.setFormCurrentPage.calledWith('details')).to.be.true;
+  });
+
+  it('should fetch appointment info when referralAppointmentInfo is null', () => {
+    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(noAppointmentInfoState),
+      path: `/${appointmentId}`,
+    });
+
+    expect(actionsModule.fetchAppointmentInfo.calledWith(appointmentId)).to.be
+      .true;
+  });
+
+  it('should fetch appointment info when referralAppointmentInfo exists but is empty', () => {
+    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(emptyAppointmentState),
+      path: `/${appointmentId}`,
+    });
+
+    expect(actionsModule.fetchAppointmentInfo.called).to.be.true;
+  });
+
+  it('should not fetch appointment info when there is existing appointment data', () => {
+    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(initialState),
+      path: `/${appointmentId}`,
+    });
+
+    expect(actionsModule.fetchAppointmentInfo.called).to.be.false;
+  });
+
+  it('should not fetch when appointment info is loading', () => {
+    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(loadingState),
+      path: `/${appointmentId}`,
+    });
+
+    expect(actionsModule.fetchAppointmentInfo.called).to.be.false;
+  });
+
+  it('should render loading indicator when appointment is loading', () => {
+    const { container } = renderWithStoreAndRouter(
+      <EpsAppointmentDetailsPage />,
+      {
+        store: createTestStore(loadingState),
+        path: `/${appointmentId}`,
+      },
+    );
+
+    expect(container.querySelector('va-loading-indicator')).to.exist;
+  });
+
+  it('should not fetch when there is an error', () => {
+    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(errorState),
+      path: `/${appointmentId}`,
+    });
+
+    expect(actionsModule.fetchAppointmentInfo.called).to.be.false;
+  });
+
+  it('should render error alert when there is an error', () => {
+    const container = renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(errorState),
+      path: `/${appointmentId}`,
+    });
+
+    expect(container.getByTestId('error-alert')).to.exist;
+  });
+
+  it('should render appointment details when appointment is loaded', () => {
+    const { container, getByText, getByTestId } = renderWithStoreAndRouter(
+      <EpsAppointmentDetailsPage />,
+      {
+        store: createTestStore(initialState),
+        path: `/${appointmentId}`,
+      },
+    );
+
+    // Check that main container exists
+    expect(getByTestId('appointment-card')).to.exist;
+
+    // Check that calendar icon exists
+    expect(getByTestId('appointment-icon')).to.exist;
+
+    // Check heading
+    expect(getByText('Community Care Appointment')).to.exist;
+
+    // Check sections exist
+    expect(getByText('When')).to.exist;
+    expect(getByText('What')).to.exist;
+    expect(getByText('Provider')).to.exist;
+    expect(getByText('Prepare for your appointment')).to.exist;
+    expect(getByText('Need to make changes?')).to.exist;
+
+    // Check specific content from appointment data
+    const { attributes } = referralAppointmentInfo;
+    expect(getByText(attributes.typeOfCare)).to.exist;
+    expect(getByText(attributes.provider.name)).to.exist;
+
+    // Check preparation instructions
+    expect(getByText(/Bring your insurance cards/)).to.exist;
+    expect(
+      container.querySelector(
+        'va-link[text="Find a full list of things to bring to your appointment"]',
+      ),
+    ).to.exist;
+
+    // Check change appointment text
+    expect(
+      getByText(/Contact this provider if you need to reschedule or cancel/),
+    ).to.exist;
+  });
+
+  it('should render provider address and directions link when location is available', () => {
+    const appointmentWithLocation = {
+      ...referralAppointmentInfo,
+      attributes: {
+        ...referralAppointmentInfo.attributes,
+        provider: {
+          ...referralAppointmentInfo.attributes.provider,
+          location: {
+            address: '123 Main St, Anytown, USA',
+          },
+        },
+      },
+    };
+
+    const stateWithLocation = {
+      referral: {
+        ...initialState.referral,
+        referralAppointmentInfo: appointmentWithLocation,
+      },
+    };
+
+    const { getByText } = renderWithStoreAndRouter(
+      <EpsAppointmentDetailsPage />,
+      {
+        store: createTestStore(stateWithLocation),
+        path: `/${appointmentId}`,
+      },
+    );
+
+    expect(getByText('123 Main St, Anytown, USA')).to.exist;
+    expect(getByText('Directions')).to.exist;
+  });
+
+  it('should render provider phone number when available', () => {
+    const appointmentWithPhone = {
+      ...referralAppointmentInfo,
+      attributes: {
+        ...referralAppointmentInfo.attributes,
+        provider: {
+          ...referralAppointmentInfo.attributes.provider,
+          phoneNumber: '555-123-4567',
+        },
+      },
+    };
+
+    const stateWithPhone = {
+      referral: {
+        ...initialState.referral,
+        referralAppointmentInfo: appointmentWithPhone,
+      },
+    };
+
+    const container = renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store: createTestStore(stateWithPhone),
+      path: `/${appointmentId}`,
+    });
+
+    // FacilityPhone component should be rendered
+    expect(container.getByTestId('facility-telephone')).to.exist;
+  });
+});

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
@@ -67,7 +67,7 @@ describe('EpsAppointmentDetailsPage', () => {
       .returns({ type: 'SET_FORM_CURRENT_PAGE' });
     sandbox
       .stub(actionsModule, 'fetchAppointmentInfo')
-      .returns({ type: 'FETCH_APPOINTMENT_INFO' });
+      .returns(referralAppointmentInfo);
   });
 
   afterEach(() => {
@@ -79,7 +79,6 @@ describe('EpsAppointmentDetailsPage', () => {
       store: createTestStore(initialState),
       path: `/${appointmentId}`,
     });
-
     expect(actionsModule.setFormCurrentPage.calledWith('details')).to.be.true;
   });
 
@@ -142,12 +141,15 @@ describe('EpsAppointmentDetailsPage', () => {
   });
 
   it('should render error alert when there is an error', () => {
-    const container = renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(errorState),
-      path: `/${appointmentId}`,
-    });
+    const { getByTestId } = renderWithStoreAndRouter(
+      <EpsAppointmentDetailsPage />,
+      {
+        store: createTestStore(errorState),
+        path: `/${appointmentId}`,
+      },
+    );
 
-    expect(container.getByTestId('error-alert')).to.exist;
+    expect(getByTestId('error-alert')).to.exist;
   });
 
   it('should render appointment details when appointment is loaded', () => {
@@ -246,12 +248,14 @@ describe('EpsAppointmentDetailsPage', () => {
       },
     };
 
-    const container = renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(stateWithPhone),
-      path: `/${appointmentId}`,
-    });
-
+    const { getByTestId } = renderWithStoreAndRouter(
+      <EpsAppointmentDetailsPage />,
+      {
+        store: createTestStore(stateWithPhone),
+        path: `/${appointmentId}`,
+      },
+    );
     // FacilityPhone component should be rendered
-    expect(container.getByTestId('facility-telephone')).to.exist;
+    expect(getByTestId('facility-telephone')).to.exist;
   });
 });

--- a/src/applications/vaos/referral-appointments/ReferralsAndRequests.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReferralsAndRequests.unit.spec.jsx
@@ -247,6 +247,10 @@ describe('VAOS Component: Referrals and Requests', () => {
     const screen = renderWithStoreAndRouter(<ReferralsAndRequests />, {
       initialState: {
         ...initialStateVAOSService,
+        referral: {
+          referrals: [],
+          referralsFetchStatus: FETCH_STATUS.succeeded,
+        },
       },
       reducers,
     });
@@ -327,6 +331,10 @@ describe('VAOS Component: Referrals and Requests', () => {
     const screen = renderWithStoreAndRouter(<ReferralsAndRequests />, {
       initialState: {
         ...initialStateVAOSService,
+        referral: {
+          referrals: [],
+          referralsFetchStatus: FETCH_STATUS.succeeded,
+        },
       },
       reducers,
     });
@@ -344,7 +352,7 @@ describe('VAOS Component: Referrals and Requests', () => {
     expect(
       screen.queryByRole('heading', {
         level: 3,
-        name: /You don’t have any/,
+        name: 'You don’t have any appointment requests',
       }),
     ).not.to.be.ok;
   });
@@ -363,6 +371,10 @@ describe('VAOS Component: Referrals and Requests', () => {
     const screen = renderWithStoreAndRouter(<ReferralsAndRequests />, {
       initialState: {
         ...initialStateVAOSService,
+        referral: {
+          referrals: [],
+          referralsFetchStatus: FETCH_STATUS.succeeded,
+        },
       },
       reducers,
     });
@@ -371,7 +383,7 @@ describe('VAOS Component: Referrals and Requests', () => {
     expect(
       await screen.findByRole('heading', {
         level: 2,
-        name: /You don’t have any/,
+        name: 'You don’t have any appointment requests',
       }),
     ).to.be.ok;
     expect(screen.queryByTestId('schedule-appointment-link')).to.exist;
@@ -446,6 +458,10 @@ describe('VAOS Component: Referrals and Requests', () => {
     const screen = renderWithStoreAndRouter(<ReferralsAndRequests />, {
       initialState: {
         ...initialStateVAOSService,
+        referral: {
+          referrals: [],
+          referralsFetchStatus: FETCH_STATUS.succeeded,
+        },
       },
       reducers,
     });
@@ -463,7 +479,7 @@ describe('VAOS Component: Referrals and Requests', () => {
     expect(
       screen.getByRole('heading', {
         level: 2,
-        name: /You don’t have any/,
+        name: 'You don’t have any appointment requests',
       }),
     ).to.be.ok;
   });

--- a/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralTaskCardWithReferral.jsx
@@ -6,7 +6,7 @@ import { useGetReferralByIdQuery } from '../../redux/api/vaosApi';
 
 const isExpired = referral => {
   if (!referral?.attributes?.expirationDate) {
-    return false;
+    return true;
   }
   const { expirationDate } = referral.attributes;
   const now = new Date();
@@ -23,7 +23,11 @@ export default function ReferralTaskCardWithReferral() {
     skip: !id,
   });
 
-  if (id && isLoading) {
+  if (!id) {
+    return null;
+  }
+
+  if (isLoading) {
     return (
       <va-loading-indicator
         data-testid="loading-indicator"
@@ -33,7 +37,7 @@ export default function ReferralTaskCardWithReferral() {
     );
   }
 
-  if (id && error) {
+  if (error) {
     return (
       <va-alert
         data-testid="referral-error"

--- a/src/applications/vaos/referral-appointments/flow.js
+++ b/src/applications/vaos/referral-appointments/flow.js
@@ -44,11 +44,11 @@ export function getPageFlow(referralId, appointmentId) {
     complete: {
       url: `/schedule-referral/complete/${appointmentId}`,
       label: 'Your appointment is scheduled',
-      next: '',
+      next: 'details',
       previous: 'appointments',
     },
     details: {
-      url: `/${appointmentId}`,
+      url: `/${appointmentId}?eps=true`,
       label: '',
       next: '',
       previous: 'complete',

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -480,6 +480,22 @@ const responses = {
       return res.status(400).json({ error: true });
     }
 
+    // Check if the request is coming from the details page
+    // We can determine this by checking the referer header or request path
+    const refererHeader = req.headers.referer || '';
+    const isDetailsView =
+      refererHeader.includes(`/${appointmentId}`) ||
+      req.query.view === 'details';
+
+    if (isDetailsView) {
+      // For details view, immediately return appointment in booked state
+      mockAppointment.attributes.status = 'booked';
+      return res.json({
+        data: mockAppointment,
+      });
+    }
+
+    // Continue with normal polling behavior for ReviewAndConfirm component
     const count = draftAppointmentPollCount[appointmentId] || 0;
 
     // Mock polling for appointment state change


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes local mocks for eps appointment details fetch so that they don't mock the polling situation
- Adds tests for appointment details
- Adds a click handler to route to appointment details
- Updates the readme

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#108651](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108651)

## Testing done

- Navigate through the scheduling flow to the appointment details page by clicking the details link on the complete view
- It should not refresh the app
- It should fetch on refresh


## Screenshots
![Screenshot 2025-05-09 at 1 08 35 PM](https://github.com/user-attachments/assets/331f1eff-c59c-445e-97b8-0b4bb49d2cac)
![image](https://github.com/user-attachments/assets/2d941719-0a2e-4919-82ad-ac874cd497e2)

## What areas of the site does it impact?

Appointments app

## Acceptance criteria

- [ ] Doesn't mock the retries on details fetch
- [ ] Loads the view without fetching if clicking from the details link
- [ ] EpsAppointmentDetails component Unit tests pass and coverage is above 80%


### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
