### PR TITLE
Fixes VAOS breadcrumb label

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -13,7 +13,9 @@ export default function VAOSBreadcrumbs({ children, labelOverride }) {
   const [breadcrumb, setBreadcrumb] = useState([]);
   const covidLabel = getCovidUrlLabel(location) || null;
   const label = useSelector(state => getUrlLabel(state, location));
-  const newLabel = labelOverride || label || covidLabel;
+  const isCovid = location.pathname.includes('covid-vaccine/');
+  let newLabel = labelOverride || label;
+  if (isCovid) newLabel = covidLabel;
 
   // get referrer query param
   const searchParams = new URLSearchParams(location.search);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This addresses an issue outlined in this [comment](https://github.com/department-of-veterans-affairs/vets-website/pull/36151#discussion_r2078727718) with a previous [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/36151).


## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/95922

## Testing done
- Local unit, e2e and manual testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
|![image](https://github.com/user-attachments/assets/79cdf914-9679-4ed5-bbda-fae7da47540c)|<img width="574" alt="CleanShot 2025-05-08 at 09 34 59@2x" src="https://github.com/user-attachments/assets/95744b3f-80f6-49a5-8626-c7f202e22c36" />|


## What areas of the site does it impact?
VAOS breadcrumbs

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
