### PR TITLE
Added DS Logon Redirect

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -10,6 +10,7 @@ import {
   FORCE_NEEDED,
   EXTERNAL_APPS,
   EXTERNAL_REDIRECTS,
+  CSP_IDS,
 } from 'platform/user/authentication/constants';
 import { AUTH_LEVEL, getAuthError } from 'platform/user/authentication/errors';
 // import { useDatadogRum } from 'platform/user/authentication/hooks/useDatadogRum';
@@ -50,6 +51,9 @@ export default function AuthApp({ location }) {
   const isFeatureToggleLoading = useSelector(
     store => store?.featureToggles?.loading,
   );
+  const isInterstitialEnabled = useSelector(
+    store => store?.featureToggles?.dslogonInterstitialRedirect,
+  );
 
   const handleAuthError = (error, codeOverride) => {
     const { errorCode: detailedErrorCode } = getAuthError(
@@ -72,6 +76,11 @@ export default function AuthApp({ location }) {
   };
 
   const redirect = () => {
+    if (isInterstitialEnabled && CSP_IDS.DS_LOGON === loginType) {
+      window.location.replace('/sign-in-changes-reminder');
+      return;
+    }
+
     // remove from session storage
     sessionStorage.removeItem(AUTHN_SETTINGS.RETURN_URL);
 

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -328,7 +328,7 @@ describe('AuthApp', () => {
     });
   });
 
-  it('should not redirect to /sign-in-changes-reminder interstitial page', async () => {
+  it('should redirect to /sign-in-changes-reminder interstitial page', async () => {
     const originalLocation = window.location;
     delete window.location;
     window.location = { replace: sinon.spy() };
@@ -338,7 +338,7 @@ describe('AuthApp', () => {
       subscribe: sinon.spy(),
       getState: () => ({
         featureToggles: {
-          mhvInterstitialEnabled: true,
+          dslogonInterstitialRedirect: true,
         },
       }),
     };
@@ -351,7 +351,7 @@ describe('AuthApp', () => {
             data: {
               attributes: {
                 profile: {
-                  signIn: { serviceName: 'mhv', ssoe: true },
+                  signIn: { serviceName: 'dslogon', ssoe: true },
                 },
               },
             },
@@ -362,13 +362,12 @@ describe('AuthApp', () => {
 
     render(
       <Provider store={store}>
-        <AuthApp location={{ query: { auth: 'success', type: 'mhv' } }} />
+        <AuthApp location={{ query: { auth: 'success', type: 'dslogon' } }} />
       </Provider>,
     );
 
-    await waitFor(() => {
-      expect(window.location.replace.calledOnce).to.be.false;
-    });
+    await waitFor(() => expect(window.location.replace.calledOnce).to.be.true);
+    expect(window.location.replace.calledWith('/sign-in-changes-reminder'));
 
     window.location = originalLocation;
     sessionStorage.clear();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Added a redirect to `AuthApp.jsx` that sends DS Logon users to the interstitial page.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/156)

## Testing done
- Updated and ran tests locally.
- Can be replicated by running `yarn test:unit src/applications/auth/tests/AuthApp.unit.spec.jsx`

## What areas of the site does it impact?
This primarily impacts `AuthApp.jsx` and the related tests.

## Acceptance criteria
- [x] Add a redirect that sends DS Logon users to the interstitial page post-sign-in.
- [x] Update tests as needed.