### PR TITLE
MHV-71149 Added AAL entries when clicking over to list pages

### DIFF
--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -13,6 +13,42 @@ const textHeaders = {
   'Content-Type': 'text/plain',
 };
 
+/**
+ * Send an Account Activity Log entry to the backend.
+ *
+ * @param {Object}   params
+ * @param {string}   params.activityType    e.g. "Allergy"
+ * @param {string}   params.action          e.g. "View"
+ * @param {string}   params.performerType   e.g. "Self"
+ * @param {string?}  params.detailValue     e.g. "..." or null
+ * @param {number}   params.status          e.g. 1
+ * @param {boolean}  [params.oncePerSession=false]  whether to dedupe per session
+ */
+export function postCreateAAL({
+  activityType,
+  action,
+  performerType,
+  detailValue = null,
+  status,
+  oncePerSession = false,
+}) {
+  return apiRequest(`${apiBasePath}/aal`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      aal: {
+        activityType,
+        action,
+        performerType,
+        detailValue,
+        status,
+      },
+      product: 'mr',
+      oncePerSession,
+    }),
+  });
+}
+
 export const createSession = () => {
   return apiRequest(`${apiBasePath}/medical_records/session`, {
     method: 'POST',

--- a/src/applications/mhv-medical-records/containers/LandingPage.jsx
+++ b/src/applications/mhv-medical-records/containers/LandingPage.jsx
@@ -21,7 +21,7 @@ import {
   downtimeNotificationParams,
   pageTitles,
 } from '../util/constants';
-import { createSession } from '../api/MrApi';
+import { createSession, postCreateAAL } from '../api/MrApi';
 import {
   selectConditionsFlag,
   selectNotesFlag,
@@ -98,6 +98,16 @@ const LandingPage = () => {
     [dispatch],
   );
 
+  const sendAalViewList = activityType => {
+    postCreateAAL({
+      activityType,
+      action: 'View',
+      performerType: 'Self',
+      status: 1,
+      oncePerSession: true,
+    });
+  };
+
   return (
     <div className="landing-page">
       <section className="vads-u-margin-bottom--2">
@@ -155,6 +165,7 @@ const LandingPage = () => {
                 className="vads-c-action-link--blue"
                 data-testid="labs-and-tests-landing-page-link"
                 onClick={() => {
+                  sendAalViewList('Lab and test results');
                   sendDataDogAction(LAB_TEST_RESULTS_LABEL);
                 }}
               >
@@ -178,6 +189,7 @@ const LandingPage = () => {
                   className="vads-c-action-link--blue"
                   data-testid="notes-landing-page-link"
                   onClick={() => {
+                    sendAalViewList('Care Summaries and Notes');
                     sendDataDogAction(CARE_SUMMARIES_AND_NOTES_LABEL);
                   }}
                 >
@@ -200,6 +212,7 @@ const LandingPage = () => {
                 className="vads-c-action-link--blue"
                 data-testid="vaccines-landing-page-link"
                 onClick={() => {
+                  sendAalViewList('Vaccines');
                   sendDataDogAction(VACCINES_LABEL);
                 }}
               >
@@ -221,6 +234,7 @@ const LandingPage = () => {
               className="vads-c-action-link--blue"
               data-testid="allergies-landing-page-link"
               onClick={() => {
+                sendAalViewList('Allergy and Reactions');
                 sendDataDogAction(ALLERGIES_AND_REACTIONS_LABEL);
               }}
             >
@@ -241,6 +255,7 @@ const LandingPage = () => {
                 className="vads-c-action-link--blue"
                 data-testid="conditions-landing-page-link"
                 onClick={() => {
+                  sendAalViewList('Health Conditions');
                   sendDataDogAction(HEALTH_CONDITIONS_LABEL);
                 }}
               >
@@ -268,6 +283,7 @@ const LandingPage = () => {
                 className="vads-c-action-link--blue"
                 data-testid="vitals-landing-page-link"
                 onClick={() => {
+                  sendAalViewList('Vitals');
                   sendDataDogAction(VITALS_LABEL);
                 }}
               >

--- a/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
@@ -1,10 +1,13 @@
 import { expect } from 'chai';
 import React from 'react';
+import sinon from 'sinon';
+import { fireEvent } from '@testing-library/react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
 import { addHours, format } from 'date-fns';
 import LandingPage from '../../containers/LandingPage';
 import reducer from '../../reducers';
+import * as MrApi from '../../api/MrApi';
 
 describe('Landing Page', () => {
   const initialState = {
@@ -84,128 +87,183 @@ describe('Landing Page', () => {
     );
   });
 
-  it('displays features when feature flags are true', () => {
+  describe('Landing Page without downtime', () => {
+    let postCreateAALStub;
+    let getByTestId;
+    let screen;
+
     const customState = {
       drupalStaticData: {
         vamcEhrData: {
           loading: false,
         },
       },
+      /* eslint-disable camelcase */
       featureToggles: {
         loading: false,
-        // eslint-disable-next-line camelcase
         mhv_medical_records_display_conditions: true,
-        // eslint-disable-next-line camelcase
         mhv_medical_records_display_labs_and_tests: true,
-        // eslint-disable-next-line camelcase
         mhv_medical_records_display_notes: true,
-        // eslint-disable-next-line camelcase
         mhv_medical_records_display_vaccines: true,
-        // eslint-disable-next-line camelcase
         mhv_medical_records_display_vitals: true,
-        // eslint-disable-next-line camelcase
         mhv_medical_records_display_settings_page: true,
-        // eslint-disable-next-line camelcase
         mhv_medical_records_update_landing_page: true,
-        // eslint-disable-next-line camelcase
         mhv_landing_page_show_share_my_health_data_link: true,
       },
+      /* eslint-enable camelcase */
       ...initialState,
     };
 
-    const screen = renderWithStoreAndRouter(<LandingPage />, {
-      initialState: customState,
-      reducers: reducer,
+    const renderPage = () => {
+      screen = renderWithStoreAndRouter(<LandingPage />, {
+        initialState: customState,
+        reducers: reducer,
+      });
+      getByTestId = screen.getByTestId;
+    };
+
+    beforeEach(() => {
+      // stub out postCreateAAL so it doesn't actually fire network requests
+      postCreateAALStub = sinon.stub(MrApi, 'postCreateAAL');
+      renderPage();
     });
 
-    // feature h2s
-    expect(
-      screen.getByText('Lab and test results', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText('Care summaries and notes', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText('Vaccines', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText('Allergies and reactions', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText('Health conditions', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText('Vitals', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText('Manage your electronic sharing settings', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
+    afterEach(() => {
+      postCreateAALStub.restore();
+    });
 
-    // links to features
-    expect(
-      screen.getByRole('link', {
-        name: 'Go to your care summaries and notes',
-      }),
-    ).to.exist;
-    expect(
-      screen.getByRole('link', {
-        name: 'Go to your vaccines',
-      }),
-    ).to.exist;
-    expect(
-      screen.getByRole('link', {
-        name: 'Go to your allergies and reactions',
-      }),
-    ).to.exist;
-    expect(
-      screen.getByRole('link', {
-        name: 'Go to your health conditions',
-      }),
-    ).to.exist;
-    expect(
-      screen.getByRole('link', {
-        name: 'Go to your vitals',
-      }),
-    ).to.exist;
-    expect(
-      screen.getByRole('link', {
-        name: 'Go to manage your electronic sharing settings',
-      }),
-    ).to.exist;
-    expect(
-      screen.getByText('Share personal health data with your care team', {
-        selector: 'h2',
-        exact: true,
-      }),
-    ).to.exist;
+    it('displays the appropriate sections', () => {
+      // feature h2s
+      expect(
+        screen.getByText('Lab and test results', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
+      expect(
+        screen.getByText('Care summaries and notes', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
+      expect(
+        screen.getByText('Vaccines', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
+      expect(
+        screen.getByText('Allergies and reactions', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
+      expect(
+        screen.getByText('Health conditions', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
+      expect(
+        screen.getByText('Vitals', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
+      expect(
+        screen.getByText('Manage your electronic sharing settings', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
 
-    // help section
-    expect(
-      screen.getByText('Need help?', {
-        selector: 'h3',
-        exact: true,
-      }),
-    ).to.exist;
+      // links to features
+      expect(
+        screen.getByRole('link', {
+          name: 'Go to your care summaries and notes',
+        }),
+      ).to.exist;
+      expect(
+        screen.getByRole('link', {
+          name: 'Go to your vaccines',
+        }),
+      ).to.exist;
+      expect(
+        screen.getByRole('link', {
+          name: 'Go to your allergies and reactions',
+        }),
+      ).to.exist;
+      expect(
+        screen.getByRole('link', {
+          name: 'Go to your health conditions',
+        }),
+      ).to.exist;
+      expect(
+        screen.getByRole('link', {
+          name: 'Go to your vitals',
+        }),
+      ).to.exist;
+      expect(
+        screen.getByRole('link', {
+          name: 'Go to manage your electronic sharing settings',
+        }),
+      ).to.exist;
+      expect(
+        screen.getByText('Share personal health data with your care team', {
+          selector: 'h2',
+          exact: true,
+        }),
+      ).to.exist;
+
+      // help section
+      expect(
+        screen.getByText('Need help?', {
+          selector: 'h3',
+          exact: true,
+        }),
+      ).to.exist;
+    });
+
+    const linkTests = [
+      {
+        testId: 'labs-and-tests-landing-page-link',
+        activityType: 'Lab and test results',
+      },
+      {
+        testId: 'notes-landing-page-link',
+        activityType: 'Care Summaries and Notes',
+      },
+      { testId: 'vaccines-landing-page-link', activityType: 'Vaccines' },
+      {
+        testId: 'allergies-landing-page-link',
+        activityType: 'Allergy and Reactions',
+      },
+      {
+        testId: 'conditions-landing-page-link',
+        activityType: 'Health Conditions',
+      },
+      { testId: 'vitals-landing-page-link', activityType: 'Vitals' },
+    ];
+
+    const clickAndAssert = (testId, activityType) => {
+      fireEvent.click(getByTestId(testId));
+      expect(postCreateAALStub.calledOnce).to.be.true;
+      expect(
+        postCreateAALStub.calledWithMatch({
+          activityType,
+          action: 'View',
+          performerType: 'Self',
+          status: 1,
+          oncePerSession: true,
+        }),
+        `postCreateAAL called with correct payload for ${activityType}`,
+      ).to.be.true;
+    };
+
+    linkTests.forEach(({ testId, activityType }) => {
+      it(`calls postCreateAAL when ${activityType} link is clicked`, () => {
+        clickAndAssert(testId, activityType);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When a user clicks on a link to go the "View List" page for a domain, log that in AAL.
- Only log once per session.

## Related issue(s)

### [MHV-71149](https://jira.devops.va.gov/browse/MHV-71149) -  Update AAL View List Page (all domains) ###

> Update AAL View List Page (all domains)

## Testing done

- Added full testing to ensure the AAL logs are always fired off with the correct information..

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
