### PR TITLE
MHV-69208: Download alert changes

### DIFF
--- a/src/applications/mhv-medications/components/shared/ApiErrorNotification.jsx
+++ b/src/applications/mhv-medications/components/shared/ApiErrorNotification.jsx
@@ -12,6 +12,7 @@ const ApiErrorNotification = ({ errorType, content, children }) => {
   return (
     <va-alert
       status="error"
+      data-testid="api-error-notification"
       setFocus
       aria-live="polite"
       role="alert"

--- a/src/applications/mhv-medications/components/shared/ApiErrorNotification.jsx
+++ b/src/applications/mhv-medications/components/shared/ApiErrorNotification.jsx
@@ -1,9 +1,23 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const ApiErrorNotification = ({ errorType, content, children }) => {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    focusElement(ref.current);
+  }, []);
+
   return (
-    <va-alert status="error" setFocus aria-live="polite" role="alert" uswds>
+    <va-alert
+      status="error"
+      setFocus
+      aria-live="polite"
+      role="alert"
+      ref={ref}
+      uswds
+    >
       <h2
         className="vads-u-margin--0 vads-u-font-size--h3"
         data-testid="no-medications-list"

--- a/src/applications/mhv-medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv-medications/components/shared/PrintDownload.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { DOWNLOAD_FORMAT, PRINT_FORMAT } from '../../util/constants';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 
@@ -11,6 +12,8 @@ const PrintDownload = props => {
   const [printIndex, setPrintIndex] = useState(0);
   const containerEl = useRef(null);
   const toggleButton = useRef(null);
+  const successAlert = useRef(null);
+  const errorAlert = useRef(null);
   let toggleMenuButtonClasses =
     'toggle-menu-button vads-u-justify-content--space-between';
   let menuOptionsClasses = 'menu-options';
@@ -19,6 +22,20 @@ const PrintDownload = props => {
       ' toggle-menu-button-open vads-u-justify-content--space-between';
     menuOptionsClasses += ' menu-options-open';
   }
+
+  useEffect(
+    () => {
+      if (isError) {
+        focusElement(errorAlert.current);
+        return;
+      }
+
+      if (isSuccess) {
+        focusElement(successAlert.current);
+      }
+    },
+    [isSuccess, isError],
+  );
 
   const handleDownload = async format => {
     setMenuOpen(!menuOpen);
@@ -82,21 +99,31 @@ const PrintDownload = props => {
   return (
     <>
       {isLoading && (
-        <va-loading-indicator
-          message="Loading..."
-          data-testid="print-download-loading-indicator"
-        />
+        <div className="vads-u-margin-y--3">
+          <va-loading-indicator
+            message="Loading..."
+            data-testid="print-download-loading-indicator"
+          />
+        </div>
       )}
       {isSuccess &&
         !isError && (
           <div
-            className="vads-u-margin-bottom--3"
+            className="vads-u-margin-y--3"
             data-testid="download-success-banner"
           >
-            <va-alert role="alert" status="success" background-only uswds>
+            <va-alert
+              role="alert"
+              status="success"
+              ref={successAlert}
+              background-only
+              uswds
+            >
               <h2 slot="headline">Download started</h2>
               <p className="vads-u-margin--0">
-                Check your device’s downloads location for your file.
+                Your file should download automatically. If it doesn’t, try
+                again. If you can’t find it, check your browser settings to find
+                where your browser saves downloaded files.
               </p>
             </va-alert>
           </div>
@@ -106,8 +133,8 @@ const PrintDownload = props => {
         <va-telephone />
       </va-alert>
       {isError && (
-        <div className="vads-u-margin-bottom--3">
-          <va-alert role="alert" status="error" uswds>
+        <div className="vads-u-margin-y--3">
+          <va-alert role="alert" status="error" ref={errorAlert} uswds>
             <h2 slot="headline">We can’t download your records right now</h2>
             <p>
               We’re sorry. There’s a problem with our system. Check back later.

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -722,6 +722,7 @@ const Prescriptions = () => {
                       )}
                       {!isLoading && (
                         <>
+                          <BeforeYouDownloadDropdown page={pageType.LIST} />
                           <PrintDownload
                             onDownload={handleFullListDownload}
                             isSuccess={
@@ -735,7 +736,6 @@ const Prescriptions = () => {
                             }
                             list
                           />
-                          <BeforeYouDownloadDropdown page={pageType.LIST} />
                         </>
                       )}
                     </>

--- a/src/applications/mhv-medications/tests/e2e/medications-download-no-alert-after-navigating-away-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-no-alert-after-navigating-away-list-page.cypress.spec.js
@@ -4,6 +4,7 @@ import rxList from './fixtures/listOfPrescriptions.json';
 import MedicationsListPage from './pages/MedicationsListPage';
 import mockPrescriptionDetails from './fixtures/prescription-details.json';
 import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+import { Data } from './utils/constants';
 
 describe('Medications Download PDF no alert after navigating away from Med List Page', () => {
   const site = new MedicationsSite();
@@ -17,8 +18,11 @@ describe('Medications Download PDF no alert after navigating away from Med List 
   });
   it('visits download pdf no alert after navigating away from list page', () => {
     listPage.clickDownloadListAsPDFButtonOnListPage();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
+
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',
       moment(),
@@ -34,7 +38,9 @@ describe('Medications Download PDF no alert after navigating away from Med List 
     listPage.clickDownloadListAsTxtButtonOnListPage();
     // listPage.verifyLoadingSpinnerForDownloadOnListPage();
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
     detailsPage.clickMedicationHistoryAndDetailsLink(mockPrescriptionDetails);
     listPage.verifyDownloadSuccessMessageBannerNotVisibleAfterReload();

--- a/src/applications/mhv-medications/tests/e2e/medications-download-no-alert-after-navigating-away-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-no-alert-after-navigating-away-list-page.cypress.spec.js
@@ -1,0 +1,44 @@
+import moment from 'moment-timezone';
+import MedicationsSite from './med_site/MedicationsSite';
+import rxList from './fixtures/listOfPrescriptions.json';
+import MedicationsListPage from './pages/MedicationsListPage';
+import mockPrescriptionDetails from './fixtures/prescription-details.json';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+
+describe('Medications Download PDF no alert after navigating away from Med List Page', () => {
+  const site = new MedicationsSite();
+  const listPage = new MedicationsListPage();
+  const detailsPage = new MedicationsDetailsPage();
+  beforeEach(() => {
+    site.login();
+    listPage.visitMedicationsListPageURL(rxList);
+    listPage.clickPrintOrDownloadThisListDropDown();
+    listPage.verifyFocusOnPrintDownloadDropDownButton();
+  });
+  it('visits download pdf no alert after navigating away from list page', () => {
+    listPage.clickDownloadListAsPDFButtonOnListPage();
+    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyFocusOnDownloadAlertSuccessBanner();
+    site.verifyDownloadedPdfFile(
+      'VA-medications-list-Safari-Mhvtp',
+      moment(),
+      '',
+    );
+    detailsPage.clickMedicationHistoryAndDetailsLink(mockPrescriptionDetails);
+    listPage.verifyDownloadSuccessMessageBannerNotVisibleAfterReload();
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+
+  it('visits download txt no alert after navigating away from list page', () => {
+    listPage.clickDownloadListAsTxtButtonOnListPage();
+    // listPage.verifyLoadingSpinnerForDownloadOnListPage();
+    listPage.verifyFocusOnDownloadAlertSuccessBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
+    detailsPage.clickMedicationHistoryAndDetailsLink(mockPrescriptionDetails);
+    listPage.verifyDownloadSuccessMessageBannerNotVisibleAfterReload();
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-details-page.cypress.spec.js
@@ -4,6 +4,7 @@ import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 import MedicationsListPage from './pages/MedicationsListPage';
 import mockPrescriptionDetails from './fixtures/prescription-details.json';
 import rxList from './fixtures/listOfPrescriptions.json';
+import { Data } from './utils/constants';
 
 describe('Medications Details Page Download', () => {
   it('visits Medications Details Page Download PDF Dropdown', () => {
@@ -18,8 +19,10 @@ describe('Medications Details Page Download', () => {
     detailsPage.verifyDownloadMedicationsDetailsAsPDFButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationDetailsAsPdfOnDetailsPage();
     detailsPage.verifyLoadingSpinnerForDownloadOnDetailsPage();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
-    detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
+    listPage.verifyFocusOnDownloadAlertSuccessBanner();
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',
       moment(),

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-list-page.cypress.spec.js
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 import MedicationsSite from './med_site/MedicationsSite';
 import rxList from './fixtures/listOfPrescriptions.json';
 import MedicationsListPage from './pages/MedicationsListPage';
+import { Data } from './utils/constants';
 
 describe('Medications Download PDF on Medications List Page', () => {
   it('visits download pdf on list page', () => {
@@ -14,7 +15,9 @@ describe('Medications Download PDF on Medications List Page', () => {
     listPage.clickPrintOrDownloadThisListDropDown();
     listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.clickDownloadListAsPDFButtonOnListPage();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-no-alert-after-reloading-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-no-alert-after-reloading-list-page.cypress.spec.js
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 import MedicationsSite from './med_site/MedicationsSite';
 import rxList from './fixtures/listOfPrescriptions.json';
 import MedicationsListPage from './pages/MedicationsListPage';
+import { Data } from './utils/constants';
 
 describe('Medications Download PDF no alert after reloading on Med List Page', () => {
   it('visits download pdf no alert after reload on list page', () => {
@@ -14,7 +15,9 @@ describe('Medications Download PDF no alert after reloading on Med List Page', (
     listPage.clickPrintOrDownloadThisListDropDown();
     listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.clickDownloadListAsPDFButtonOnListPage();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-no-alert-after-reloading-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-no-alert-after-reloading-list-page.cypress.spec.js
@@ -1,0 +1,27 @@
+import moment from 'moment-timezone';
+import MedicationsSite from './med_site/MedicationsSite';
+import rxList from './fixtures/listOfPrescriptions.json';
+import MedicationsListPage from './pages/MedicationsListPage';
+
+describe('Medications Download PDF no alert after reloading on Med List Page', () => {
+  it('visits download pdf no alert after reload on list page', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    site.login();
+    listPage.visitMedicationsListPageURL(rxList);
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.clickPrintOrDownloadThisListDropDown();
+    listPage.verifyFocusOnPrintDownloadDropDownButton();
+    listPage.clickDownloadListAsPDFButtonOnListPage();
+    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyFocusOnDownloadAlertSuccessBanner();
+    site.verifyDownloadedPdfFile(
+      'VA-medications-list-Safari-Mhvtp',
+      moment(),
+      '',
+    );
+    cy.reload();
+    listPage.verifyDownloadSuccessMessageBannerNotVisibleAfterReload();
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-allergies-error-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-allergies-error-details-page.cypress.spec.js
@@ -13,6 +13,7 @@ describe('Medications Details Page Download Txt Error when Allergies API call Fa
     detailsPage.clickMedicationHistoryAndDetailsLink(mockPrescriptionDetails);
     listPage.clickPrintOrDownloadThisListDropDown();
     detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
+    listPage.verifyFocusOnDownloadFailureAlertBanner();
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-allergies-error-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-allergies-error-list-page.cypress.spec.js
@@ -10,6 +10,7 @@ describe('Medications Download Txt Error when API Call Fails on List Page', () =
     listPage.clickPrintOrDownloadThisListDropDown();
     listPage.clickDownloadListAsTxtButtonOnListPage();
     listPage.verifyDownloadErrorMessageForAllergiesAPICallFail();
+    listPage.verifyFocusOnDownloadFailureAlertBanner();
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
@@ -16,7 +16,7 @@ describe('Medications Details Page Download', () => {
     detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
-    detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
+    listPage.verifyFocusOnDownloadAlertSuccessBanner();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
     cy.injectAxe();
     cy.axeCheck('main');

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
@@ -3,6 +3,7 @@ import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 import MedicationsListPage from './pages/MedicationsListPage';
 import mockPrescriptionDetails from './fixtures/prescription-details.json';
 import rxList from './fixtures/listOfPrescriptions.json';
+import { Data } from './utils/constants';
 
 describe('Medications Details Page Download', () => {
   it('visits Medications Details Page Download Txt Dropdown', () => {
@@ -15,7 +16,9 @@ describe('Medications Details Page Download', () => {
     listPage.clickPrintOrDownloadThisListDropDown();
     detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
     cy.injectAxe();

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
@@ -1,6 +1,7 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import rxList from './fixtures/listOfPrescriptions.json';
 import MedicationsListPage from './pages/MedicationsListPage';
+import { Data } from './utils/constants';
 
 describe('Medications Download Txt on List Page', () => {
   it('visits download txt on list page', () => {
@@ -15,7 +16,9 @@ describe('Medications Download Txt on List Page', () => {
     listPage.clickDownloadListAsTxtButtonOnListPage();
     // listPage.verifyLoadingSpinnerForDownloadOnListPage();
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
@@ -14,8 +14,8 @@ describe('Medications Download Txt on List Page', () => {
     listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.clickDownloadListAsTxtButtonOnListPage();
     // listPage.verifyLoadingSpinnerForDownloadOnListPage();
+    listPage.verifyFocusOnDownloadAlertSuccessBanner();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
-    listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-no-alert-after-reloading-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-no-alert-after-reloading-list-page.cypress.spec.js
@@ -1,10 +1,9 @@
-import moment from 'moment-timezone';
 import MedicationsSite from './med_site/MedicationsSite';
 import rxList from './fixtures/listOfPrescriptions.json';
 import MedicationsListPage from './pages/MedicationsListPage';
 
-describe('Medications Download PDF on Medications List Page', () => {
-  it('visits download pdf on list page', () => {
+describe('Medications Download Alert Not Visible after Reload List Page', () => {
+  it('visits no download txt alert after reload on list page', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
     site.login();
@@ -13,13 +12,12 @@ describe('Medications Download PDF on Medications List Page', () => {
     cy.axeCheck('main');
     listPage.clickPrintOrDownloadThisListDropDown();
     listPage.verifyFocusOnPrintDownloadDropDownButton();
-    listPage.clickDownloadListAsPDFButtonOnListPage();
+    listPage.clickDownloadListAsTxtButtonOnListPage();
+    // listPage.verifyLoadingSpinnerForDownloadOnListPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
-    site.verifyDownloadedPdfFile(
-      'VA-medications-list-Safari-Mhvtp',
-      moment(),
-      '',
-    );
+    listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
+    cy.reload();
+    listPage.verifyDownloadSuccessMessageBannerNotVisibleAfterReload();
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-no-alert-after-reloading-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-no-alert-after-reloading-list-page.cypress.spec.js
@@ -1,6 +1,7 @@
 import MedicationsSite from './med_site/MedicationsSite';
 import rxList from './fixtures/listOfPrescriptions.json';
 import MedicationsListPage from './pages/MedicationsListPage';
+import { Data } from './utils/constants';
 
 describe('Medications Download Alert Not Visible after Reload List Page', () => {
   it('visits no download txt alert after reload on list page', () => {
@@ -14,7 +15,9 @@ describe('Medications Download Alert Not Visible after Reload List Page', () => 
     listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.clickDownloadListAsTxtButtonOnListPage();
     // listPage.verifyLoadingSpinnerForDownloadOnListPage();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
     cy.reload();

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-refill-history-med-description-field.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-refill-history-med-description-field.cypress.spec.js
@@ -16,7 +16,9 @@ describe('Medications Details Page Download TXT Refill History field', () => {
     listPage.clickPrintOrDownloadThisListDropDown();
     detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
-    listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyDownloadCompleteSuccessMessageBanner(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyFocusOnDownloadAlertSuccessBanner();
     detailsPage.verifyMedicationDescriptionInTxtDownload(
       Data.DOWNLOAD_TXT_REFILL_HISTORY,

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-refill-history-med-description-field.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-refill-history-med-description-field.cypress.spec.js
@@ -3,6 +3,7 @@ import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 import MedicationsListPage from './pages/MedicationsListPage';
 import mockPrescriptionDetails from './fixtures/older-prescription-details.json';
 import rxList from './fixtures/grouped-prescriptions-list.json';
+import { Data } from './utils/constants';
 
 describe('Medications Details Page Download TXT Refill History field', () => {
   it('visits Details Page Download Txt Refill History Med Description', () => {
@@ -16,10 +17,10 @@ describe('Medications Details Page Download TXT Refill History field', () => {
     detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
-    detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
-    // detailsPage.verifyMedicationDescriptionInTxtDownload(
-    //   Data.DOWNLOAD_TXT_REFILL_HISTORY,
-    // );
+    listPage.verifyFocusOnDownloadAlertSuccessBanner();
+    detailsPage.verifyMedicationDescriptionInTxtDownload(
+      Data.DOWNLOAD_TXT_REFILL_HISTORY,
+    );
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-patient-information-download-pdf.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-patient-information-download-pdf.cypress.spec.js
@@ -27,6 +27,9 @@ describe('Medications Details Page Medication Information pdf download', () => {
     medInfoPage.verifyDownloadSuccessConfirmationMessageOnMedInfoPage(
       Data.DOWNLOAD_SUCCESS_CONFIRMATION_MESSAGE,
     );
+    medInfoPage.verifyDownloadSuccessAlertContentOnMedInfoPage(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     medInfoPage.verifyMedicationDescriptionInDownload(
       rxTrackingDetails.data.attributes.prescriptionName,
       'pdf',

--- a/src/applications/mhv-medications/tests/e2e/medications-patient-information-download-txt.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-patient-information-download-txt.cypress.spec.js
@@ -24,6 +24,9 @@ describe('Medications Details Page Medication Information txt download', () => {
     medInfoPage.verifyDownloadSuccessConfirmationMessageOnMedInfoPage(
       Data.DOWNLOAD_SUCCESS_CONFIRMATION_MESSAGE,
     );
+    medInfoPage.verifyDownloadSuccessAlertContentOnMedInfoPage(
+      Data.DOWNLOAD_SUCCESS_ALERT_CONTENT,
+    );
     listPage.verifyDownloadTextFileHeadless(
       'Safari',
       'Mhvtp',

--- a/src/applications/mhv-medications/tests/e2e/medications-patient-medication-information-error-message.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-patient-medication-information-error-message.cypress.spec.js
@@ -17,6 +17,7 @@ describe('Medication Information Error Message', () => {
     detailsPage.clickMedicationDetailsLink(rxTrackingDetails, cardNumber);
     detailsPage.clickLearnMoreAboutMedicationLinkOnDetailsPageError();
     informationPage.verifyApiErrorText();
+    informationPage.verifyFocusOnAPIErrorAlertTextOnPatientInformationPage();
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
@@ -27,7 +27,9 @@ class MedicationsInformationPage {
   };
 
   verifyFocusOnAPIErrorAlertTextOnPatientInformationPage = () => {
-    cy.get('[data-testid="no-medications-list"]').should('be.focused');
+    cy.get('[data-testid="api-error-notification"]', {
+      includeShadowDom: true,
+    }).should('be.focused');
   };
 
   verifyNoInformationWarningText = () => {
@@ -57,6 +59,13 @@ class MedicationsInformationPage {
     cy.get('[data-testid="download-success-banner"]')
       .should('be.visible')
       .and('contain', text);
+  };
+
+  verifyDownloadSuccessAlertContentOnMedInfoPage = text => {
+    cy.get('[data-testid="download-success-banner"] > .hydrated').should(
+      'contain',
+      text,
+    );
   };
 
   verifyMedicationDescriptionInDownload = (text, downloadFormat) => {

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsInformationPage.js
@@ -26,6 +26,10 @@ class MedicationsInformationPage {
       .and('contain', 'We can’t access your medication information right now');
   };
 
+  verifyFocusOnAPIErrorAlertTextOnPatientInformationPage = () => {
+    cy.get('[data-testid="no-medications-list"]').should('be.focused');
+  };
+
   verifyNoInformationWarningText = () => {
     cy.get('[data-testid="medication-information-no-info"]')
       .should('be.visible')

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -166,7 +166,7 @@ class MedicationsListPage {
   };
 
   verifyFocusOnDownloadFailureAlertBanner = () => {
-    cy.get('[data-testid="no-medications-list"]').should('be.focused');
+    cy.get('[data-testid="api-error-notification"]').should('be.focused');
   };
 
   verifyTextInsideDropDownOnListPage = () => {
@@ -272,12 +272,11 @@ class MedicationsListPage {
     });
   };
 
-  verifyDownloadCompleteSuccessMessageBanner = () => {
+  verifyDownloadCompleteSuccessMessageBanner = text => {
     cy.intercept('GET', Paths.MED_LIST, prescriptions).as('medicationsList');
-    cy.get('[data-testid="download-success-banner"]').should(
-      'contain',
-      'Download started',
-    );
+    cy.get('[data-testid="download-success-banner"]')
+      .should('contain', 'Download started')
+      .and('contain', text);
   };
 
   verifyFocusOnDownloadAlertSuccessBanner = () => {

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -165,6 +165,10 @@ class MedicationsListPage {
     );
   };
 
+  verifyFocusOnDownloadFailureAlertBanner = () => {
+    cy.get('[data-testid="no-medications-list"]').should('be.focused');
+  };
+
   verifyTextInsideDropDownOnListPage = () => {
     cy.get('[data-testid="dropdown-info"]').should(
       'contain',

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -276,6 +276,16 @@ class MedicationsListPage {
     );
   };
 
+  verifyFocusOnDownloadAlertSuccessBanner = () => {
+    cy.get('[data-testid="download-success-banner"] > .hydrated').should(
+      'be.focused',
+    );
+  };
+
+  verifyDownloadSuccessMessageBannerNotVisibleAfterReload = () => {
+    cy.get('[data-testid="download-success-banner"]').should('not.exist');
+  };
+
   verifyDownloadTextFileHeadless = (
     userFirstName = 'Safari',
     userLastName = 'Mhvtp',

--- a/src/applications/mhv-medications/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-medications/tests/e2e/utils/constants.js
@@ -90,6 +90,8 @@ export const Data = {
   PRESCRIPTION_INFO_TRACKING: 'Prescriptions in this package',
   FILLED_ON_DATE: 'February 11, 2025',
   DOWNLOAD_SUCCESS_CONFIRMATION_MESSAGE: 'Download started',
+  DOWNLOAD_SUCCESS_ALERT_CONTENT:
+    'Your file should download automatically. If it doesn’t, try again. If you can’t find it, check your browser settings to find where your browser saves downloaded files.',
 };
 export const Paths = {
   LANDING_LIST:


### PR DESCRIPTION
## Summary

- Updated `PrintDownload` button component to handle its success/error alerts focusing
- Updated its layout and verbiage
- Updated `Prescriptions` container component to place `BeforeYouDownloadDropdown` component above `PrintDownload`
- Fixed `ApiErrorNotification` so that it autofocuses properly

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-69208

## Testing done

- Manual testing
- e2e testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Change: “What to know before...” additional info dropdown is above the “Print or download” button
AC2: Change: Change content of description for “Download started” alert on Med list and Med details page
AC3: Design specifications (these apply to both success and error alerts):
- Focus lands on the alert after the download starts
- Alert appears below the “What to know before...” additional info dropdown and above the “Print or download” button. 
- Alert should go away if the user navigates to a different page, or if they refresh the page.
- This should work the same for both the success and error messages

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

