### PR TITLE
Use `fullData` property rather than nested data prop - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
+++ b/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
@@ -478,15 +478,6 @@ export const applicantRemarriageCertConfig = uploadWithInfoComponent(
   'remarriage certificates',
 );
 
-// When in list loop, formData is just the list element's data, but when editing
-// a list item's data on review-and-submit `formData` may be the complete form
-// data object. This provides a consistent interface via formContext.
-export function getTopLevelFormData(formContext) {
-  return formContext.contentAfterButtons === undefined
-    ? formContext.data
-    : formContext.contentAfterButtons.props.form.data;
-}
-
 // If the beneficiary remarried, collect proof of that remarriage
 // and any other marital docs they want to include
 export const applicantRemarriageCertUploadUiSchema = {
@@ -507,7 +498,7 @@ export const applicantRemarriageCertUploadUiSchema = {
           const nonPosessive = applicantWording(formData, false, false);
           // Inside list loop this lets us grab form data outside the scope of
           // current list element:
-          const vetName = getTopLevelFormData(formContext)?.veteransFullName;
+          const vetName = formContext?.fullData?.veteransFullName;
           return (
             <>
               If <span className="dd-privacy-hidden">{nonPosessive}</span>{' '}

--- a/src/applications/ivc-champva/10-10D/tests/unit/helpers/helpers.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/helpers/helpers.unit.spec.jsx
@@ -12,7 +12,6 @@ import {
   populateFirstApplicant,
   page15aDepends,
 } from '../../../helpers/utilities';
-import { getTopLevelFormData } from '../../../components/Applicant/applicantFileUpload';
 import ApplicantField from '../../../../shared/components/applicantLists/ApplicantField';
 import { testComponentRender } from '../../../../shared/tests/pages/pageTests.spec';
 import mockData from '../../e2e/fixtures/data/test-data.json';
@@ -85,33 +84,6 @@ testComponentRender(
   'ApplicantField',
   <ApplicantField formData={mockData.data.applicants[0]} />,
 );
-
-describe('getTopLevelFormData helper', () => {
-  it('should return data if `contentAfterButtons` is present in formContext', () => {
-    expect(
-      getTopLevelFormData({
-        contentAfterButtons: {
-          props: {
-            form: {
-              data: {
-                veteransFullName: { first: 'firstname', last: 'lastname' },
-              },
-            },
-          },
-        },
-      }),
-    ).to.not.be.undefined;
-  });
-  it('should return data if `contentAfterButtons` is not present in formContext', () => {
-    expect(
-      getTopLevelFormData({
-        data: {
-          veteransFullName: { first: 'firstname', last: 'lastname' },
-        },
-      }),
-    ).to.not.be.undefined;
-  });
-});
 
 describe('populateFirstApplicant', () => {
   const newAppInfo = {

--- a/src/applications/ivc-champva/shared/components/fileUploads/FileUpload.jsx
+++ b/src/applications/ivc-champva/shared/components/fileUploads/FileUpload.jsx
@@ -19,7 +19,7 @@ export function FileFieldCustom(props) {
   try {
     MissingFileOverview({
       contentAfterButtons: props.contentAfterButtons,
-      data: props.contentAfterButtons.props.form.data,
+      data: props?.fullData,
       goBack: props.goBack,
       goForward: props.goForward,
       disableLinks: true,
@@ -52,10 +52,9 @@ export function FileFieldCustom(props) {
     // Check if url is a review page
     const urlParams = new URLSearchParams(window?.location?.search);
     if (urlParams.get('fileReview') === 'true') {
-      /* Have to use contentAfterButtons' data because we might have
-      just received a single list-loop element as our props.data,
-      which would then lead us to the wrong conclusions */
-      if (uploadsMissing(props.contentAfterButtons.props.form.data)) {
+      /* Using fullData because we might have just received a single list-loop
+      element as our props.data, which would then lead us to the wrong conclusions */
+      if (uploadsMissing(props.fullData)) {
         props.goToPath('/supporting-files');
       } else {
         // Since we just uploaded the last file, bypass files overview page.
@@ -117,6 +116,7 @@ FileFieldCustom.propTypes = {
   contentBeforeButtons: PropTypes.any,
   data: PropTypes.object,
   formContext: PropTypes.object,
+  fullData: PropTypes.object,
   goBack: PropTypes.func,
   goForward: PropTypes.func,
   goToPath: PropTypes.func,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Previously, to get at the full form data inside a list loop element for certain checks, the `contentAfterButtons` prop was being examined. This was brittle and has now been replaced with a check of the semi-recently added `fullData` property.

This change was motivated due to a [change in the forms library](https://github.com/department-of-veterans-affairs/vets-website/commit/abf3b39131908c7e67f9996d1f0cf5192d45bb3d) that reduced the amount of properties nested under the `contentAfterButtons` object.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109473

## Testing done

- Manual
- E2E and Unit verified

## Screenshots

Prior to this change the E2E tests for form 10-10d were failing. Now, they are passing.

|         | Before | After |
| ------- | ------ | ----- |
| Cypress tests |![Screenshot 2025-05-09 at 15 15 20](https://github.com/user-attachments/assets/73656eec-357f-4c97-8cd4-d827873dcba6)|![Screenshot 2025-05-09 at 14 59 48](https://github.com/user-attachments/assets/e79dc411-1022-4066-8e28-196d4c4d8a97)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
