### PR TITLE
MHV-71252: Tracking alert + MHV-71245: Empty medications list

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -63,9 +63,10 @@ const VaPrescription = prescription => {
     prescription?.dispensedDate ||
     prescription?.rxRfRecords.find(record => record.dispensedDate);
   const latestTrackingStatus = prescription?.trackingList?.[0];
+  const fourteenDaysAgoDate = new Date().setDate(new Date().getDate() - 14);
   const showTrackingAlert =
-    prescription?.trackingList?.[0] &&
-    prescription?.dispStatus === 'Active: Submitted';
+    latestTrackingStatus?.completeDateTime &&
+    Date.parse(latestTrackingStatus?.completeDateTime) > fourteenDaysAgoDate;
   const isRefillRunningLate = isRefillTakingLongerThanExpected(prescription);
 
   const determineStatus = () => {

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -693,8 +693,9 @@ const Prescriptions = () => {
                     />
                     {showIPEContent && <InProductionEducationFiltering />}
                   </>
-                  {(paginatedPrescriptionsList?.length ||
-                    filteredList?.length) && (
+                  {!!(
+                    paginatedPrescriptionsList?.length || filteredList?.length
+                  ) && (
                     <>
                       {!isLoading && (
                         <MedicationsListSort

--- a/src/applications/mhv-medications/tests/e2e/fixtures/active-refill-in-process-details.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/active-refill-in-process-details.json
@@ -40,7 +40,22 @@
             "indicationForUse": null,
             "indicationForUseFlag": null,
             "category": "Rx Medication",
-            "trackingList": [],
+            "trackingList": [
+                {
+                    "id": 49049,
+                    "stationNumber": "989",
+                    "rxNumber": "2720542",
+                    "carrier": "FEDEX",
+                    "trackingNumber": "77298036368890000006962",
+                    "completeDateTime": "Sun, 24 Sept 2023 04:39:11 EDT",
+                    "divisionPhone": "(410)636-6899",
+                    "ndc": "00113002239",
+                    "dateLoaded": "Tue, 26 Sep 2023 16:20:00 EDT",
+                    "isLocalTracking": false,
+                    "othersInSamePackage": false,
+                    "viewImageDisplayed": true
+                }
+            ],
             "rxRfRecords": [
                 {
                     "refillStatus": "suspended",
@@ -86,7 +101,7 @@
                     "tracking": false
                 }
             ],
-            "tracking": false,
+            "tracking": true,
             "sortedDispensedDate": "2025-03-15T04:00:00.000Z"
         },
         "links": {

--- a/src/applications/mhv-medications/tests/e2e/fixtures/active-submitted-prescription-details.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/active-submitted-prescription-details.json
@@ -40,9 +40,24 @@
             "indicationForUse": null,
             "indicationForUseFlag": null,
             "category": "Rx Medication",
-            "trackingList": [],
+            "trackingList": [
+                {
+                    "id": 49049,
+                    "stationNumber": "979",
+                    "rxNumber": "2720604",
+                    "carrier": "FEDEX",
+                    "trackingNumber": "77298036368890000006962",
+                    "completeDateTime": "Wed, 30 Apr 2025 04:39:11 EDT",
+                    "divisionPhone": "(410)636-6899",
+                    "ndc": "00113002239",
+                    "dateLoaded": "Tue, 26 Sep 2023 16:20:00 EDT",
+                    "isLocalTracking": false,
+                    "othersInSamePackage": false,
+                    "viewImageDisplayed": true
+                }
+            ],
             "rxRfRecords": [],
-            "tracking": false
+            "tracking": true
         },
         "links": {
             "self": "http://127.0.0.1:3000/my_health/v1/prescriptions/22377955"

--- a/src/applications/mhv-medications/tests/e2e/fixtures/listOfPrescriptions.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/listOfPrescriptions.json
@@ -180,7 +180,7 @@
                 "dispensedDate": null,
                 "stationNumber": "989",
                 "isRefillable": true,
-                "isTrackable": false,
+                "isTrackable": true,
                 "cmopNdcNumber": null,
                 "inCernerTransition": false,
                 "notRefillableDisplayMessage": "A refill request cannot be submitted at this time. Please review the prescription status and fill date. If you need more of this medication, please call the pharmacy phone number on your prescription label.",
@@ -210,7 +210,7 @@
                         "rxNumber": "2720604",
                         "carrier": "FEDEX",
                         "trackingNumber": "77298036368890000006962",
-                        "completeDateTime": "Feb, 24 Sep 2024 04:39:11 EDT",
+                        "completeDateTime": "Wed, 30 Sep 2024 04:39:11 EDT",
                         "divisionPhone": "(410)636-6899",
                         "ndc": "00113002239",
                         "dateLoaded": "Tue, 26 Sep 2023 16:20:00 EDT",
@@ -220,7 +220,7 @@
                     }
                 ],
                 "rxRfRecords": [],
-                "tracking": false
+                "tracking": true
             },
             "links": {
                 "self": "http://127.0.0.1:3000/my_health/v1/prescriptions/22377955"

--- a/src/applications/mhv-medications/tests/e2e/fixtures/listOfPrescriptions.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/listOfPrescriptions.json
@@ -774,7 +774,22 @@
                 "indicationForUse": null,
                 "indicationForUseFlag": null,
                 "category": "Rx Medication",
-                "trackingList": [],
+                "trackingList": [
+                    {
+                        "id": 49049,
+                        "stationNumber": "989",
+                        "rxNumber": "2720542",
+                        "carrier": "FEDEX",
+                        "trackingNumber": "77298036368890000006962",
+                        "completeDateTime": "Sun, 24 Sept 2023 04:39:11 EDT",
+                        "divisionPhone": "(410)636-6899",
+                        "ndc": "00113002239",
+                        "dateLoaded": "Tue, 26 Sep 2023 16:20:00 EDT",
+                        "isLocalTracking": false,
+                        "othersInSamePackage": false,
+                        "viewImageDisplayed": true
+                    }
+                ],
                 "rxRfRecords": [
                     {
                         "refillStatus": "suspended",
@@ -820,7 +835,7 @@
                         "tracking": false
                     }
                 ],
-                "tracking": false,
+                "tracking": true,
                 "sortedDispensedDate": "2025-03-15T04:00:00.000Z"
             },
             "links": {

--- a/src/applications/mhv-medications/tests/e2e/medications-alert-refill-tracking-and-delay-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-alert-refill-tracking-and-delay-details-page.cypress.spec.js
@@ -20,7 +20,7 @@ describe('Medications Details Page Delay Alert and Tracking', () => {
     detailsPage.verifyRefillDelayAlertBannerOnDetailsPage(
       Data.DELAY_ALERT_DETAILS_BANNER,
     );
-    detailsPage.verifyTrackingForSubmittedRefillOnDetailsPage();
+    // detailsPage.verifyTrackingForSubmittedRefillOnDetailsPage();
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-alert-refill-tracking-and-delay-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-alert-refill-tracking-and-delay-details-page.cypress.spec.js
@@ -20,7 +20,7 @@ describe('Medications Details Page Delay Alert and Tracking', () => {
     detailsPage.verifyRefillDelayAlertBannerOnDetailsPage(
       Data.DELAY_ALERT_DETAILS_BANNER,
     );
-    // detailsPage.verifyTrackingForSubmittedRefillOnDetailsPage();
+    detailsPage.verifyTrackingForSubmittedRefillOnDetailsPage();
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-prescription-tracking-available-for-fourteen-days-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-prescription-tracking-available-for-fourteen-days-details-page.cypress.spec.js
@@ -1,0 +1,44 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsListPage from './pages/MedicationsListPage';
+import prescriptionList from './fixtures/listOfPrescriptions.json';
+import { Data } from './utils/constants';
+import rxDetails from './fixtures/active-submitted-prescription-details.json';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+
+describe('Medications Details Page Tracking Alert Available For fourteen days', () => {
+  it('visits Medications Details Page Tracking Alert for fourteen days', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const detailsPage = new MedicationsDetailsPage();
+    const cardNumber = 4;
+
+    const updatedData = detailsPage.updateCompleteDateTime(
+      prescriptionList,
+      rxDetails.data.attributes.prescriptionName,
+    );
+    cy.intercept(
+      'GET',
+      `/my_health/v1/prescriptions/${
+        rxDetails.data.attributes.prescriptionNumber
+      }`,
+      updatedData,
+    ).as('updatedPrescriptions');
+    site.login();
+    listPage.visitMedicationsListPageURL(updatedData);
+    detailsPage.clickMedicationDetailsLink(rxDetails, cardNumber);
+
+    detailsPage.verifyRefillDelayAlertBannerOnDetailsPage(
+      Data.DELAY_ALERT_DETAILS_BANNER,
+    );
+    detailsPage.verifyTrackingAlertHeaderOnDetailsPage(Data.TRACKING_HEADING);
+    detailsPage.verifyTrackingNumberForShippedPrescriptionOnDetailsPage(
+      rxDetails.data.attributes.trackingList[0].trackingNumber,
+    );
+    detailsPage.verifyPrescriptionInformationInTrackingAlertOnDetailsPage(
+      Data.PRESCRIPTION_INFO_TRACKING,
+      rxDetails.data.attributes.prescriptionName,
+    );
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-prescription-tracking-available-for-fourteen-days-refill-in-process-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-prescription-tracking-available-for-fourteen-days-refill-in-process-details-page.cypress.spec.js
@@ -1,0 +1,73 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
+import rxList from './fixtures/listOfPrescriptions.json';
+import MedicationsListPage from './pages/MedicationsListPage';
+import refillProcessed from './fixtures/active-refill-in-process-details.json';
+import { Data } from './utils/constants';
+
+describe('Medications Refill in Process and Tracking Alert', () => {
+  const site = new MedicationsSite();
+  const listPage = new MedicationsListPage();
+  const detailsPage = new MedicationsDetailsPage();
+
+  it('visits Medications Details Page Active Rx In Process Step Two Delay and Tracking Alert', () => {
+    const cardNumber = 14;
+    const updatedData = detailsPage.updateRefillAndCompleteDates(
+      rxList,
+      refillProcessed.data.attributes.prescriptionName,
+      -10,
+    );
+    cy.intercept('GET', '/my_health/v1/prescriptions', updatedData).as(
+      'updatedPrescriptions',
+    );
+    site.login();
+    listPage.visitMedicationsListPageURL(updatedData);
+    detailsPage.clickMedicationDetailsLink(refillProcessed, cardNumber);
+    detailsPage.verifyRefillDelayAlertBannerOnDetailsPage(
+      Data.DELAY_ALERT_DETAILS_BANNER,
+    );
+    detailsPage.verifyStepTwoHeaderOnDetailPageForRxInProcess(
+      Data.STEP_TWO_PROCESS,
+      Data.STEP_TWO_DELAY,
+    );
+    detailsPage.verifyTrackingAlertHeaderOnDetailsPage(Data.TRACKING_HEADING);
+    detailsPage.verifyTrackingNumberForShippedPrescriptionOnDetailsPage(
+      refillProcessed.data.attributes.trackingList[0].trackingNumber,
+    );
+    detailsPage.verifyPrescriptionInformationInTrackingAlertOnDetailsPage(
+      Data.PRESCRIPTION_INFO_TRACKING,
+      refillProcessed.data.attributes.prescriptionName,
+    );
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+  it('visits Medications Details Page Active Rx In Process Step Two and Tracking Alert', () => {
+    const cardNumber = 14;
+    const updatedData = detailsPage.updateRefillAndCompleteDates(
+      rxList,
+      refillProcessed.data.attributes.prescriptionName,
+      10,
+    );
+    cy.intercept('GET', '/my_health/v1/prescriptions', updatedData).as(
+      'updatedPrescriptions',
+    );
+    site.login();
+    listPage.visitMedicationsListPageURL(updatedData);
+    detailsPage.clickMedicationDetailsLink(refillProcessed, cardNumber);
+
+    detailsPage.verifyStepTwoHeaderOnDetailPageForRxInProcess(
+      Data.STEP_TWO_PROCESS,
+      Data.STEP_TWO_PROCESS_HEADER,
+    );
+    detailsPage.verifyTrackingAlertHeaderOnDetailsPage(Data.TRACKING_HEADING);
+    detailsPage.verifyTrackingNumberForShippedPrescriptionOnDetailsPage(
+      refillProcessed.data.attributes.trackingList[0].trackingNumber,
+    );
+    detailsPage.verifyPrescriptionInformationInTrackingAlertOnDetailsPage(
+      Data.PRESCRIPTION_INFO_TRACKING,
+      refillProcessed.data.attributes.prescriptionName,
+    );
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-prescription-tracking-available-for-fourteen-days-refill-submitted-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-prescription-tracking-available-for-fourteen-days-refill-submitted-details-page.cypress.spec.js
@@ -5,12 +5,13 @@ import { Data } from './utils/constants';
 import rxDetails from './fixtures/active-submitted-prescription-details.json';
 import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 
-describe('Medications Details Page Delay Alert and Tracking', () => {
-  it('visits Medications Details Page Delay Alert and Tracking', () => {
+describe('Medications Details Page Tracking Alert Available For fourteen days', () => {
+  it('visits Medications Details Page Tracking Alert for fourteen days', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
     const detailsPage = new MedicationsDetailsPage();
     const cardNumber = 4;
+
     const updatedData = detailsPage.updateCompleteDateTime(
       prescriptionList,
       rxDetails.data.attributes.prescriptionName,
@@ -25,13 +26,18 @@ describe('Medications Details Page Delay Alert and Tracking', () => {
     site.login();
     listPage.visitMedicationsListPageURL(updatedData);
     detailsPage.clickMedicationDetailsLink(rxDetails, cardNumber);
-    detailsPage.verifyCheckStatusHeaderTextOnDetailsPage(
-      Data.CHECK_STATUS_HEADER,
-    );
+
     detailsPage.verifyRefillDelayAlertBannerOnDetailsPage(
       Data.DELAY_ALERT_DETAILS_BANNER,
     );
-    detailsPage.verifyTrackingForSubmittedRefillOnDetailsPage();
+    detailsPage.verifyTrackingAlertHeaderOnDetailsPage(Data.TRACKING_HEADING);
+    detailsPage.verifyTrackingNumberForShippedPrescriptionOnDetailsPage(
+      rxDetails.data.attributes.trackingList[0].trackingNumber,
+    );
+    detailsPage.verifyPrescriptionInformationInTrackingAlertOnDetailsPage(
+      Data.PRESCRIPTION_INFO_TRACKING,
+      rxDetails.data.attributes.prescriptionName,
+    );
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -818,6 +818,50 @@ class MedicationsDetailsPage {
       ),
     };
   }
+
+  updateRefillAndCompleteDates = (
+    data,
+    prescriptionName,
+    refillDateOffset = 15,
+  ) => {
+    const currentDate = new Date();
+
+    // Fixed completeDateTime to 14 days ago (T-14)
+    const completeDate = new Date(currentDate);
+    completeDate.setDate(currentDate.getDate() - 13);
+
+    // Dynamic refillDate based on the provided offset
+    const refillDate = new Date(currentDate);
+    refillDate.setDate(currentDate.getDate() + refillDateOffset);
+
+    return {
+      ...data,
+      data: data.data.map(
+        item =>
+          item.attributes.prescriptionName === prescriptionName
+            ? {
+                ...item,
+                attributes: {
+                  ...item.attributes,
+                  refillDate:
+                    item.attributes.refillDate != null
+                      ? refillDate.toISOString()
+                      : null,
+                  tracking: true, // Ensure tracking is enabled
+                  trackingList: item.attributes.trackingList?.length
+                    ? [
+                        {
+                          ...item.attributes.trackingList[0],
+                          completeDateTime: completeDate.toISOString(), // Fixed completeDateTime
+                        },
+                      ]
+                    : [],
+                },
+              }
+            : item,
+      ),
+    };
+  };
 }
 
 export default MedicationsDetailsPage;

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -773,6 +773,51 @@ class MedicationsDetailsPage {
     );
     expect(formattedDate).to.equal(expectedDate);
   };
+
+  formatToEDTString(date) {
+    return `${date
+      .toLocaleString('en-US', {
+        weekday: 'short',
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZone: 'America/New_York',
+        hour12: false,
+      })
+      .replace(',', '')
+      .replace(' at', '')} EDT`;
+  }
+
+  updateCompleteDateTime(data, prescriptionName) {
+    const fourteenDaysAgo = new Date();
+    fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 13);
+    const formattedDate = this.formatToEDTString(fourteenDaysAgo);
+
+    return {
+      ...data,
+      data: data.data.map(
+        item =>
+          item.attributes.prescriptionName === prescriptionName
+            ? {
+                ...item,
+                attributes: {
+                  ...item.attributes,
+                  tracking: true,
+                  trackingList: [
+                    {
+                      ...item.attributes.trackingList[0],
+                      completeDateTime: formattedDate,
+                    },
+                  ],
+                },
+              }
+            : item,
+      ),
+    };
+  }
 }
 
 export default MedicationsDetailsPage;


### PR DESCRIPTION
## Summary

- On Rx Details page made Tracking Alert visible if `trackingList` data is available and `completeDateTime` is less than 14 days ago, regardless of status
- Fixed bug with trailing 0 if no medications on Rx List page

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-71252
https://jira.devops.va.gov/browse/MHV-71245

## Testing done

- Manual testing
- e2e testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Show the tracking alert if trackingList data is available and completeDateTime is less than 14 days ago, regardless of status
AC2: After applying a filter with no result, this "0" appears below the filter, we need to make sure that does not show up. 

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

