### PR TITLE
Update 686c breadcrumbs position

### DIFF
--- a/src/applications/686c-674/containers/App.jsx
+++ b/src/applications/686c-674/containers/App.jsx
@@ -64,8 +64,12 @@ function App({
 
   const content = (
     <article id="form-686c" data-location={`${location?.pathname?.slice(1)}`}>
+      <div className="row">
+        <div className="columns">
+          <va-breadcrumbs breadcrumb-list={rawBreadcrumbs} wrapping />
+        </div>
+      </div>
       <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-        <va-breadcrumbs breadcrumb-list={rawBreadcrumbs} wrapping />
         {children}
       </RoutedSavableApp>
     </article>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- move breadcrumbs out of application definition and apply independent padding

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108174

## Testing done

- run 686c on both intro page and in application
- verify breadcrumbs look correct on mobile & desktop

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/2d236242-b739-4558-92fd-2627360a813e" />

## What areas of the site does it impact?

686c v2

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
