### PR TITLE
MHV-71086 Pass param for military service AAL

### DIFF
--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -292,9 +292,10 @@ export const getDemographicInfo = async () => {
  */
 export const getMilitaryService = async () => {
   try {
-    return await apiRequest(`${apiBasePath}/medical_records/military_service`, {
-      textHeaders,
-    });
+    return await apiRequest(
+      `${apiBasePath}/medical_records/military_service?bb=true`,
+      { textHeaders },
+    );
   } catch (error) {
     // Handle special case of missing EDIPI
     if (error?.error === 'No EDIPI found for the current user') {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added a `bb` param to military service when generating a BB report, thereby bypassing creation of an AAL
- Corresponding BE PR: https://github.com/department-of-veterans-affairs/vets-api/pull/22212

## Related issue(s)

### [MHV-71086](https://jira.devops.va.gov/browse/MHV-71086) - Implement DOD report AAL entry ###

> Implement DOD report AAL entry-pass a parameter to the BackEnd that indicates AAL needed 
> 
> This is a new report being implemented.  Once the report functionality is complete, this AAL will need to be added.
> 
> AAL work to be done spreadsheet link below (See Medical Records tab-line 42, red highlighted line item)
> 
> https://dvagov.sharepoint.com/:x:/r/sites/HealthApartment/_layouts/15/Doc.aspx?sourcedoc=%7B80534FA8-97C2-4726-9E08-20166C9609DF%7D&file=AAL%20work%20to%20be%20done-VHA%20Privacy%20Office%20additions.xlsx&action=default&mobileredirect=true 
> 
> Approved content for all MR domains on va.gov is as follows:
> 
> Date/Time = Completion_Time
> 
> Activity Details = Detail_Value
> 
> Activity = Activity_Type
> 
> Action = Action
> 
> Performer Type = Performer_Type
> 
> Results = Status
> 
> 
> 
> 
> User Story: As a Medical Records User, I want to see my MR usage by looking at my AAL entries, so that I can have a list of my MR usage.
> 
> GIVEN:
> WHEN:
> THEN:
> 
> Feature Flag Y/N ? N
> Manual Testing Y/N ? Y-Maruf
> Automated Testing Y/N ? N
> Accessibility Testing Y/N ? N
> 
> Acceptance Criteria:
> AC1 DoD AAL has been added (See Medical Records tab-line 42, red highlighted line items)
> AC2 Content will follow the approved content outlined above
> AC3 
> AC4
> AC5
> 
>  ** 

## Testing done

- Unit testing for this ticket is being done on the backend.
- Manual testing was performed to validate the flow.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
