### PR TITLE
Update aria label logic in review pages to use `itemAriaLabel` optionally

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -207,10 +207,16 @@ class ReviewCollapsibleChapter extends React.Component {
       // Remove bottom margin when the div content is empty
       'vads-u-margin-bottom--0': !pageSchema && arrayFields.length === 0,
     });
+
+    const uiOptions = pageUiSchema['ui:options'] || {};
+    let ariaLabel = uiOptions.itemAriaLabel;
+    const itemName =
+      (typeof ariaLabel === 'function' && ariaLabel(pageData || {})) ||
+      pageData[uiOptions.itemName] ||
+      uiOptions.itemName;
+
     const title = page.reviewTitle || page.title || '';
-    const ariaLabel = `Update ${(typeof title === 'function'
-      ? title(pageData)
-      : title) || 'page'}`;
+    ariaLabel = (itemName && `Update ${itemName}`) || `Update ${title}`;
 
     const visibleFields =
       pageSchema &&

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -208,15 +208,11 @@ class ReviewCollapsibleChapter extends React.Component {
       'vads-u-margin-bottom--0': !pageSchema && arrayFields.length === 0,
     });
 
-    const uiOptions = pageUiSchema['ui:options'] || {};
-    let ariaLabel = uiOptions.itemAriaLabel;
-    const itemName =
-      (typeof ariaLabel === 'function' && ariaLabel(pageData || {})) ||
-      pageData[uiOptions.itemName] ||
-      uiOptions.itemName;
-
     const title = page.reviewTitle || page.title || '';
-    ariaLabel = (itemName && `Update ${itemName}`) || `Update ${title}`;
+    let ariaLabel = pageUiSchema['ui:options']?.itemAriaLabel || title;
+    ariaLabel = `Update ${(typeof ariaLabel === 'function'
+      ? ariaLabel({ formData: pageData })
+      : ariaLabel) || 'page'}`;
 
     const visibleFields =
       pageSchema &&

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -209,10 +209,10 @@ class ReviewCollapsibleChapter extends React.Component {
     });
 
     const title = page.reviewTitle || page.title || '';
-    let ariaLabel = pageUiSchema['ui:options']?.itemAriaLabel || title;
-    ariaLabel = `Update ${(typeof ariaLabel === 'function'
-      ? ariaLabel({ formData: pageData })
-      : ariaLabel) || 'page'}`;
+    const labelTitle = pageUiSchema['ui:options']?.itemAriaLabel || title;
+    const ariaText =
+      typeof labelTitle === 'function' ? labelTitle(pageData) : labelTitle;
+    const ariaLabel = `Update ${ariaText || 'page'}`;
 
     const visibleFields =
       pageSchema &&


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the logic that sets the aria label on the review page "Update" button so that custom values set in `ui:options` get picked up (`'ui:options'.itemAriaLabel` was ignored).

The logic works similarly to what was already being done for "Edit" buttons on the review page ([seen here](https://github.com/department-of-veterans-affairs/vets-website/blob/f4000445ae2bd261be868a5979e651f8a1ecda50/src/platform/forms-system/src/js/review/ObjectField.jsx#L151)).

Previously, setting `itemAriaLabel` in the `ui:options` would not impact the aria labels of the 'Update' button when editing an entry on the review page. With this change, the aria labels will behave the same as before, but now if the user chooses to enter `itemAriaLabel`  in the ui Options, it will be respected.

This is specifically useful when using DataDog Real User Monitoring (RUM) and needing to wrap dynamic headers in JSX with the `'dd-privacy-hidden'` class as described here. Since aria labels don't evaluate JSX into plain text, those titles would always result in an aria label on the update button of `Update [object Object]`.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109014

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Title function only, returns a string (behavior unchanged)|![before_title_func_str](https://github.com/user-attachments/assets/cf004e84-8caa-4c0c-9b34-85fb4396030d)|![after_title_func_str](https://github.com/user-attachments/assets/7ff6227b-1aa7-4eb7-a637-df77e73d876f)|
| Title function only, returns JSX (behavior unchanged)|![before_title_func_jsx](https://github.com/user-attachments/assets/88270b19-fcaf-4b67-94d5-fc79bc8fb133)|![after_title_func_jsx](https://github.com/user-attachments/assets/d0bf51e4-51cd-47d2-9529-0b34b53de26f)|
|`itemAriaLabel` set as a string (before, ignored completely. After, `itemAriaLabel` overrides title). Title function set. |![before_itemarialabel_str](https://github.com/user-attachments/assets/b096ef0a-1b34-4043-bfbc-1971a1b0f602)|![after_itemarialabel_str](https://github.com/user-attachments/assets/7d09214c-3fd5-4e80-b89c-06f914b5c85e)|
|`itemAriaLabel` set as a function (before, ignored completely. After, `itemAriaLabel` overrides title). Title function set.|![before_itemarialabel_func](https://github.com/user-attachments/assets/1cb620cb-40d1-4707-b381-414ed180ff21)|![after_itemarialabel_func](https://github.com/user-attachments/assets/61907062-2c71-444e-9793-a723d9c6ccf5)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
