### PR TITLE
[DBEX] Add page title, update content and render auth validation error

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -43,21 +43,9 @@ export const privateRecordsPageTitle = (
   </h3>
 );
 
-export const patientAcknowledgmentTitle = (
-  <h3 className="vads-u-margin-top--0">Request a disclosure</h3>
-);
+export const patientAcknowledgmentTitle = 'Request a disclosure';
 
-export const patientAcknowledgmentError = (
-  <div>
-    <p className="vads-u-margin-top--0">
-      We need your permission to ask your doctor for your medical records.
-    </p>
-    <p className="vads-u-margin-bottom--0">
-      To continue, select "I acknowledge and authorize this release of
-      information."
-    </p>
-  </div>
-);
+export const patientAcknowledgmentError = 'You must accept the acknowledgment';
 
 export const patientAcknowledgmentText = (
   <div className="patient-acknowldegment-help">

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -43,8 +43,9 @@ export const privateRecordsPageTitle = (
   </h3>
 );
 
-export const patientAcknowledgmentTitle = 'Request a disclosure';
-
+export const patientAcknowledgmentTitle = (
+  <h3 className="vads-u-margin-top--0">Request a disclosure</h3>
+);
 export const patientAcknowledgmentError = 'You must accept the acknowledgment';
 
 export const patientAcknowledgmentText = (

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -44,9 +44,14 @@ export const privateRecordsPageTitle = (
 );
 
 export const patientAcknowledgmentTitle = (
-  <h3 className="vads-u-margin-top--0">Request a disclosure</h3>
+  <h3 className="vads-u-margin-top--0">Authorize us to get your records</h3>
 );
-export const patientAcknowledgmentError = 'You must accept the acknowledgment';
+export const patientAcknowledgmentError = (
+  <p>
+    You must select I acknowledge and authorize this release of information for
+    us to get your records from your provider.
+  </p>
+);
 
 export const patientAcknowledgmentText = (
   <div className="patient-acknowldegment-help">

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -37,8 +37,24 @@ export const privateRecordsChoiceHelp = (
   </div>
 );
 
+export const privateRecordsPageTitle = (
+  <h3 className="vads-u-font-size--h3 vads-u-color--base vads-u-margin--0">
+    Private medical records
+  </h3>
+);
+
 export const patientAcknowledgmentTitle = (
   <h3 className="vads-u-margin-top--0">Request a disclosure</h3>
+);
+
+export const patientAcknowledgmentError = (
+  <div>
+    <p>We need your permission to ask your doctor for your medical records.</p>
+    <p>
+      To continue, select "I acknowledge and authorize this release of
+      information."
+    </p>
+  </div>
 );
 
 export const patientAcknowledgmentText = (

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -49,8 +49,10 @@ export const patientAcknowledgmentTitle = (
 
 export const patientAcknowledgmentError = (
   <div>
-    <p>We need your permission to ask your doctor for your medical records.</p>
-    <p>
+    <p className="vads-u-margin-top--0">
+      We need your permission to ask your doctor for your medical records.
+    </p>
+    <p className="vads-u-margin-bottom--0">
       To continue, select "I acknowledge and authorize this release of
       information."
     </p>

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -51,6 +51,7 @@ export const uiSchema = {
       'ui:webComponentField': VaCheckboxField,
       'ui:options': {
         useDlWrap: true,
+        classNames: 'vads-u-margin-y--neg3',
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -1,15 +1,19 @@
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
+import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 import {
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import {
+  privateRecordsPageTitle,
   privateRecordsChoiceHelp,
   patientAcknowledgmentTitle,
   patientAcknowledgmentText,
+  patientAcknowledgmentError,
 } from '../content/privateMedicalRecords';
 
 export const uiSchema = {
+  'ui:title': privateRecordsPageTitle,
   'ui:description':
     'Now we’ll ask you about your private medical records for your condition.',
   'view:aboutPrivateMedicalRecords': {
@@ -36,8 +40,11 @@ export const uiSchema = {
       expandUnder: 'view:uploadPrivateRecordsQualifier',
       expandUnderCondition: data =>
         data?.['view:hasPrivateRecordsToUpload'] === false,
-      showFieldLabel: false,
-      // forceDivWrapper: true,
+      showFieldLabel: true,
+    },
+    'ui:validations': [validateBooleanGroup],
+    'ui:errorMessages': {
+      atLeastOne: patientAcknowledgmentError,
     },
     'view:acknowledgement': {
       'ui:title': 'I acknowledge and authorize this release of information',
@@ -46,20 +53,15 @@ export const uiSchema = {
         useDlWrap: true,
       },
     },
-    'view:helpText': {
-      'ui:title': ' ',
-      'ui:description': patientAcknowledgmentText,
-      'ui:options': {
-        forceDivWrapper: true,
-      },
+  },
+  'view:patientAcknowledgmentHelp': {
+    'ui:description': patientAcknowledgmentText,
+    'ui:options': {
+      expandUnder: 'view:uploadPrivateRecordsQualifier',
+      expandUnderCondition: data =>
+        data?.['view:hasPrivateRecordsToUpload'] === false,
+      forceDivWrapper: true,
     },
-    'ui:validations': [
-      (errors, item) => {
-        if (!item['view:acknowledgement']) {
-          errors.addError('You must accept the acknowledgment');
-        }
-      },
-    ],
   },
 };
 
@@ -92,11 +94,11 @@ export const schema = {
           type: 'boolean',
           default: true,
         },
-        'view:helpText': {
-          type: 'object',
-          properties: {},
-        },
       },
+    },
+    'view:patientAcknowledgmentHelp': {
+      type: 'object',
+      properties: {},
     },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -23,7 +23,7 @@ export const uiSchema = {
       title: 'Do you want to upload your private medical records?',
       labels: {
         Y: 'Yes',
-        N: 'No, please get my records from my doctor.',
+        N: 'No, please get my records from my provider.',
       },
     }),
     'view:privateRecordsChoiceHelp': {

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -11,6 +11,9 @@ import {
   patientAcknowledgmentError,
 } from '../content/privateMedicalRecords';
 
+const isNotUploadingPrivateRecords = data =>
+  data?.['view:hasPrivateRecordsToUpload'] === false;
+
 export const uiSchema = {
   'ui:title': privateRecordsPageTitle,
   'ui:description':
@@ -31,8 +34,7 @@ export const uiSchema = {
     'ui:title': patientAcknowledgmentTitle,
     'ui:options': {
       expandUnder: 'view:uploadPrivateRecordsQualifier',
-      expandUnderCondition: data =>
-        data?.['view:hasPrivateRecordsToUpload'] === false,
+      expandUnderCondition: isNotUploadingPrivateRecords,
       showFieldLabel: true,
     },
     'ui:validations': [
@@ -62,8 +64,7 @@ export const uiSchema = {
     'ui:description': patientAcknowledgmentText,
     'ui:options': {
       expandUnder: 'view:uploadPrivateRecordsQualifier',
-      expandUnderCondition: data =>
-        data?.['view:hasPrivateRecordsToUpload'] === false,
+      expandUnderCondition: isNotUploadingPrivateRecords,
       forceDivWrapper: true,
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -1,4 +1,3 @@
-import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 import {
   yesNoUI,
@@ -16,12 +15,6 @@ export const uiSchema = {
   'ui:title': privateRecordsPageTitle,
   'ui:description':
     'Now we’ll ask you about your private medical records for your condition.',
-  'view:aboutPrivateMedicalRecords': {
-    'ui:title': 'About private medical records',
-    'ui:description': `If you have your private medical records, you can upload them to your
-      application. If you want us to get them for you, you’ll need to
-      authorize their release.`,
-  },
   'view:uploadPrivateRecordsQualifier': {
     'view:hasPrivateRecordsToUpload': yesNoUI({
       title: 'Do you want to upload your private medical records?',
@@ -36,22 +29,36 @@ export const uiSchema = {
   },
   'view:patientAcknowledgement': {
     'ui:title': patientAcknowledgmentTitle,
+    'ui:required': formData =>
+      formData?.['view:uploadPrivateRecordsQualifier']?.[
+        'view:hasPrivateRecordsToUpload'
+      ] === false,
     'ui:options': {
       expandUnder: 'view:uploadPrivateRecordsQualifier',
       expandUnderCondition: data =>
         data?.['view:hasPrivateRecordsToUpload'] === false,
       showFieldLabel: true,
     },
-    'ui:validations': [validateBooleanGroup],
-    'ui:errorMessages': {
-      atLeastOne: patientAcknowledgmentError,
-    },
+    'ui:validations': [
+      (errors, fieldData, formData) => {
+        const shouldValidate =
+          formData?.['view:uploadPrivateRecordsQualifier']?.[
+            'view:hasPrivateRecordsToUpload'
+          ] === false;
+
+        if (shouldValidate) {
+          return validateBooleanGroup(errors, fieldData, null, null, {
+            atLeastOne: patientAcknowledgmentError,
+          });
+        }
+
+        return errors;
+      },
+    ],
     'view:acknowledgement': {
       'ui:title': 'I acknowledge and authorize this release of information',
-      'ui:webComponentField': VaCheckboxField,
       'ui:options': {
         useDlWrap: true,
-        classNames: 'vads-u-margin-y--neg3',
       },
     },
   },
@@ -93,7 +100,7 @@ export const schema = {
       properties: {
         'view:acknowledgement': {
           type: 'boolean',
-          default: true,
+          default: false,
         },
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -29,10 +29,6 @@ export const uiSchema = {
   },
   'view:patientAcknowledgement': {
     'ui:title': patientAcknowledgmentTitle,
-    'ui:required': formData =>
-      formData?.['view:uploadPrivateRecordsQualifier']?.[
-        'view:hasPrivateRecordsToUpload'
-      ] === false,
     'ui:options': {
       expandUnder: 'view:uploadPrivateRecordsQualifier',
       expandUnderCondition: data =>

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
@@ -25,7 +25,6 @@ describe('526 All Claims Private medical records', () => {
         formData={{}}
       />,
     );
-
     expect($$('va-radio-option').length).to.equal(2);
   });
 
@@ -69,10 +68,11 @@ describe('526 All Claims Private medical records', () => {
     userEvent.click(submitButton);
     expect(onSubmit.calledOnce).to.be.true;
     expect($('va-radio').error).to.be.null;
+    expect($$('va-checkbox').length).to.equal(0); // Expect the acknowledgment to NOT be on screen
   });
 
   // TODO: This will change once 4142 is integrated
-  it('should submit when user selects "no" to upload', () => {
+  it('should not submit when user selects "no" to upload and does NOT check the acknowledgment', () => {
     const onSubmit = sinon.spy();
     const { getByText } = render(
       <DefinitionTester
@@ -83,12 +83,40 @@ describe('526 All Claims Private medical records', () => {
           'view:uploadPrivateRecordsQualifier': {
             'view:hasPrivateRecordsToUpload': false,
           },
+          'view:patientAcknowledgement': {
+            'view:acknowledgement': false, // The user has NOT checked the acknowledgment
+          },
         }}
         formData={{}}
         onSubmit={onSubmit}
       />,
     );
+    const submitButton = getByText('Submit');
+    userEvent.click(submitButton);
+    expect(onSubmit.calledOnce).to.be.false;
+    expect($('va-radio').error).to.be.null;
+  });
 
+  // User selected 'No' in the radio button and checked 'yes' in the acknowledgment which allows user to submit
+  it('should submit when user selects "no" to upload and checks "yes" for the acknowledgment', () => {
+    const onSubmit = sinon.spy();
+    const { getByText } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:uploadPrivateRecordsQualifier': {
+            'view:hasPrivateRecordsToUpload': false,
+          },
+          'view:patientAcknowledgement': {
+            'view:acknowledgement': true,
+          },
+        }}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
     const submitButton = getByText('Submit');
     userEvent.click(submitButton);
     expect(onSubmit.calledOnce).to.be.true;

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
@@ -97,7 +97,7 @@ describe('526 All Claims Private medical records', () => {
     expect($('va-radio').error).to.be.null;
   });
 
-  // User selected 'No' in the radio button and checked 'yes' in the acknowledgment which allows user to submit
+  // 'No' radio button selected and acknowledgment checked allows user to submit
   it('should submit when user selects "no" to upload and checks "yes" for the acknowledgment', () => {
     const onSubmit = sinon.spy();
     const { getByText } = render(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - to Private medical records page (/disability/file-disability-claim-form-21-526ez/supporting-evidence/private-medical-records):
    - added stylized page title
    - updates to choice selection descriptions, the authorization section heading, and the error message
    - enabled error message rendering on failed validation (unselected checkbox) 
- _(If bug, how to reproduce)_
  - no page title previously
  - currently, no error message is rendered when user attempts to continue with checkbox unselected
- _(What is the solution, why is this the solution)_
  - with addition of page title, brings page into conformance with other pages in form
  - alerts user that checkbox must be selected to continue
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Disability Benefits
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - n/a

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108842

## Testing done

- _Describe what the old behavior was prior to the change_
  - no error message is rendered when user attempts to continue with checkbox unselected
- _Describe the steps required to verify your changes are working as expected_
  1. in Supporting evidence chapter, on Evidence types page (/disability/file-disability-claim-form-21-526ez/supporting-evidence/evidence-types), select the 'Yes' radio button and 'Private medical records' checkbox, then click 'Continue'
  2. on the subsequent (Private medical records) page, select the 'No' radio button and deselect the single 'acknowledgment' checkbox (if pre-selected), then click 'Continue'
  3. an error message renders explaining that the release of information must be authorized 
  4. navigation to the next page is prevented until the error is resolved ('acknowledgment' checkbox is selected) or the 'Yes' radio button is selected
- _Describe the tests completed and the results_
  - Enhanced existing test for:
     - Additionally asking user to acknowledge their choice of 'not' uploading private medical records, they must acknowledge and authorize the release of those records to continue to the next page. If the user refuses to acknowledge and authorize, the user is not able to get to the next page.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| valid selection | ![Screenshot 2025-05-16 at 1 18 54 PM](https://github.com/user-attachments/assets/5edcfc9a-afed-46f3-a417-dd93004a823f) |![Screenshot 2025-05-27 at 10 49 45 AM](https://github.com/user-attachments/assets/a9da80b9-ceb0-4c30-9183-82dd2b88f72d)|
| invalid selection by submitting before checking the acknowledgment |  ![Screenshot 2025-05-16 at 1 19 23 PM](https://github.com/user-attachments/assets/0d3346b0-2d6f-40da-aae6-b02d7a8d3864) |![Screenshot 2025-05-27 at 10 48 07 AM](https://github.com/user-attachments/assets/4a0308ed-b95b-41c4-82ca-84d4cde75371) |

## What areas of the site does it impact?

Form 526EZ, Supporting evidence chapter, Private medical records page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
