### PR TITLE
MBMS-64711 Fixed Review Page Read mode headers

### DIFF
--- a/src/applications/pre-need-integration/config/form.jsx
+++ b/src/applications/pre-need-integration/config/form.jsx
@@ -100,6 +100,8 @@ import {
   nonVeteranApplicantDetailsDescription,
   nonVeteranApplicantDetailsDescriptionPreparer,
   isApplicantTheSponsor,
+  militaryDetailsReviewHeader,
+  previousNameReviewHeader,
 } from '../utils/helpers';
 import SupportingFilesDescription from '../components/SupportingFilesDescription';
 import {
@@ -562,7 +564,7 @@ const formConfig = {
       pages: {
         militaryDetailsSelf: {
           path: 'military-details-self',
-          title: 'Military details',
+          title: formData => militaryDetailsReviewHeader(formData),
           depends: formData =>
             isVeteran(formData) && !isAuthorizedAgent(formData),
           uiSchema: militaryDetailsSelf.uiSchema,
@@ -570,7 +572,7 @@ const formConfig = {
         },
         militaryDetailsPreparer: {
           path: 'military-details-preparer',
-          title: 'Military details',
+          title: formData => militaryDetailsReviewHeader(formData),
           depends: formData =>
             isVeteran(formData) && isAuthorizedAgent(formData),
           uiSchema: militaryDetailsPreparer.uiSchema,
@@ -613,7 +615,7 @@ const formConfig = {
           schema: applicantMilitaryName.schema,
         },
         applicantMilitaryNameInformation: {
-          title: 'Previous name',
+          title: formData => previousNameReviewHeader(formData),
           path: 'applicant-military-name-information',
           depends: formData =>
             isVeteranAndHasServiceName(formData) &&
@@ -622,7 +624,7 @@ const formConfig = {
           schema: applicantMilitaryNameInformation.schema,
         },
         applicantMilitaryNameInformationPreparer: {
-          title: 'Previous name',
+          title: formData => previousNameReviewHeader(formData),
           path: 'applicant-military-name-information-preparer',
           depends: formData =>
             isVeteranAndHasServiceName(formData) && isAuthorizedAgent(formData),

--- a/src/applications/pre-need-integration/utils/helpers.js
+++ b/src/applications/pre-need-integration/utils/helpers.js
@@ -208,6 +208,24 @@ export function militaryDetailsSubHeader(formData) {
   );
 }
 
+export function militaryDetailsReviewHeader(formData) {
+  return get(
+    'application.applicant.applicantRelationshipToClaimant',
+    formData,
+  ) === 'Authorized Agent/Rep'
+    ? `Applicant’s military details`
+    : `Your military details`;
+}
+
+export function previousNameReviewHeader(formData) {
+  return get(
+    'application.applicant.applicantRelationshipToClaimant',
+    formData,
+  ) === 'Authorized Agent/Rep'
+    ? `Applicant’s previous name`
+    : `Your previous name`;
+}
+
 export const createPayload = (file, formId, password) => {
   const payload = new FormData();
   payload.set('form_id', formId);


### PR DESCRIPTION
## Summary

- The sub headers on the Review screen in "READ" mode are incorrect. It should reflect what it states in "EDIT" mode for both the Self and Preparer Veteran flows, in the Military History section.

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-64711

## Testing done

- [x] Internal Review
- [x] External Review
- [x] QA
- [x] POR/UI/UX Review
- [x] Unit Tests Passing

## Screenshots

https://github.com/user-attachments/assets/739ba751-dae2-46e5-bc2c-c151bdfd4cd5

## What areas of the site does it impact?

_**Pre-need-integration military history review page in read mode**_
## Acceptance criteria
![image](https://github.com/user-attachments/assets/14de7146-db3b-4a6c-ba34-d2f1b6b7f8a1)