### PR TITLE
Use local timezone in static pages instead of modifying globally

### DIFF
--- a/src/applications/static-pages/events/helpers/event-generator.js
+++ b/src/applications/static-pages/events/helpers/event-generator.js
@@ -1,8 +1,9 @@
 import moment from 'moment-timezone';
 import { fleshOutRecurringEvents, removeDuplicateEvents } from '.';
 
-moment.tz.setDefault('America/New_York');
-const now = moment().clone();
+const now = moment()
+  .clone()
+  .tz('America/New_York');
 let lastEntityId = 0;
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
## Summary

This file was calling [moment.tz.setDefault('America/New_York')](https://momentjs.com/timezone/docs/#/using-timezones/default-timezone/), which changes the global state for moment. Under certain circumstances, that was causing other unit tests to fail. This PR changes to only set the timezone on the local moment object.
