### PR TITLE
Removed styling class one-liner

### DIFF
--- a/src/platform/user/widgets/representative-status/containers/ProfileTabContainer.jsx
+++ b/src/platform/user/widgets/representative-status/containers/ProfileTabContainer.jsx
@@ -48,7 +48,7 @@ export const ProfileTabContainer = ({
           concatAddress={concatAddress}
           vcfUrl={vcfUrl}
         />
-        <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
+        <h2 className="vads-u-font-size--h3">
           How to replace your current accredited representative
         </h2>{' '}
         <p>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Removed y-margin class in rep status tool header

## Related issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108220
