### PR TITLE
Update continuous-integration to add new axe rules for cypress tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -700,11 +700,11 @@ jobs:
 
       - name: Checkout axe-headings branch
         if: needs.tests-prep.outputs.cypress-tests != '[]'
-        run: git fetch origin axe-heading --depth=1
+        run: git fetch origin axe-check-new-heading-rules --depth=1
 
       - name: Merge axe-headings checks
         if: needs.tests-prep.outputs.cypress-tests != '[]'
-        run: git merge origin/axe-heading
+        run: git merge origin/axe-check-new-heading-rules
 
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests != '[]'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -702,11 +702,15 @@ jobs:
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         run: git fetch origin axe-check-new-heading-rules --depth=1
 
+      - name: Get va-vsp-bot token
+        uses: ./.github/workflows/inject-secrets
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
       - name: Merge axe-check-new-heading-rules checks
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         run: git merge origin/axe-check-new-heading-rules --allow-unrelated-histories
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests != '[]'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -704,7 +704,7 @@ jobs:
 
       - name: Merge axe-check-new-heading-rules checks
         if: needs.tests-prep.outputs.cypress-tests != '[]'
-        run: git merge origin/axe-check-new-heading-rules
+        run: git merge origin/axe-check-new-heading-rules --allow-unrelated-histories
 
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests != '[]'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -698,11 +698,11 @@ jobs:
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
-      - name: Checkout axe-headings branch
+      - name: Checkout axe-check-new-heading-rules branch
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         run: git fetch origin axe-check-new-heading-rules --depth=1
 
-      - name: Merge axe-headings checks
+      - name: Merge axe-check-new-heading-rules checks
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         run: git merge origin/axe-check-new-heading-rules
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -702,6 +702,13 @@ jobs:
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         run: git fetch origin axe-check-new-heading-rules --depth=1
 
+      - name: Configure AWS credentials
+        uses: ./.github/workflows/configure-aws-credentials
+        with:
+          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-gov-west-1
+
       - name: Get va-vsp-bot token
         uses: ./.github/workflows/inject-secrets
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -698,6 +698,14 @@ jobs:
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
+      - name: Checkout axe-headings branch
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: git fetch origin axe-heading --depth=1
+
+      - name: Merge axe-headings checks
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        run: git merge origin/axe-heading
+
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         uses: ./.github/workflows/configure-aws-credentials

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -705,6 +705,8 @@ jobs:
       - name: Merge axe-check-new-heading-rules checks
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         run: git merge origin/axe-check-new-heading-rules --allow-unrelated-histories
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests != '[]'


### PR DESCRIPTION
## Summary

This pull request updates the continuous integration workflow to enforce new axe check rules for headings.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#103613

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user