### PR TITLE
remove window.location deletions

### DIFF
--- a/src/applications/mhv-medical-records/tests/actions/download.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/actions/download.unit.spec.jsx
@@ -26,7 +26,6 @@ describe('Download Actions', () => {
     });
     afterEach(() => {
       delete window.URL;
-      delete window.location;
       HTMLAnchorElement.prototype.click = clickToRestore;
     });
     it('should dispatch an error on failed API calls', async () => {

--- a/src/applications/mhv-medical-records/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/App.unit.spec.jsx
@@ -26,7 +26,6 @@ describe('App', () => {
   beforeEach(() => {
     mockFetch();
     oldLocation = global.window.location;
-    delete global.window.location;
     global.window.location = {
       replace: sinon.spy(),
     };


### PR DESCRIPTION
Small PR to update unit tests for forwards compatibility with node 22. ([ref](https://depo-platform-documentation.scrollhelp.site/developer-docs/guide-for-vfs-teams-to-update-tests-for-node-22#GuideforVFSteamstoupdatetestsforNode22-window.location))