### PR TITLE
106647 - Update default address in MissingFileOverview to use constant - IVC CHAMPVA forms

### DIFF
--- a/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
+++ b/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
@@ -58,11 +58,18 @@ const mailInfo = (address, officeName, faxNum, preamble, appType) => {
           <p>Mail your {appType} and supporting document copies to:</p>
         </>
       )}
-      <address className="vads-u-border-color--primary vads-u-border-left--4px vads-u-margin-left--3">
-        <p className="vads-u-padding-x--10px vads-u-margin-left--1">
-          {address ?? { CHAMPVA_ELIGIBILITY_ADDRESS }}
-        </p>
-      </address>
+      {address ? (
+        <address className="vads-u-border-color--primary vads-u-border-left--4px vads-u-margin-left--3">
+          <p className="vads-u-padding-x--10px vads-u-margin-left--1">
+            {address}
+          </p>
+        </address>
+      ) : (
+        <>
+          {CHAMPVA_ELIGIBILITY_ADDRESS}
+          <br />
+        </>
+      )}
       Or fax it to:
       {officeName ? (
         <>

--- a/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
+++ b/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
@@ -36,6 +36,7 @@ import PropTypes from 'prop-types';
 import { getConditionalPages } from '../../utilities';
 import SupportingDocsVerification from './supportingDocsVerification';
 import MissingFileList from './MissingFileList';
+import { CHAMPVA_ELIGIBILITY_ADDRESS } from '../../constants';
 
 const mailInfo = (address, officeName, faxNum, preamble, appType) => {
   const faxNumMarkup = (
@@ -59,17 +60,7 @@ const mailInfo = (address, officeName, faxNum, preamble, appType) => {
       )}
       <address className="vads-u-border-color--primary vads-u-border-left--4px vads-u-margin-left--3">
         <p className="vads-u-padding-x--10px vads-u-margin-left--1">
-          {address ?? (
-            <>
-              VHA Office of Integrated Veteran Care
-              <br />
-              CHAMPVA Eligibility
-              <br />
-              PO Box 137
-              <br />
-              Spring City. PA 19475
-            </>
-          )}
+          {address ?? { CHAMPVA_ELIGIBILITY_ADDRESS }}
         </p>
       </address>
       Or fax it to:


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updated the address in the `MissingFileOverview` component used by form 10-10d to display the address from shared constant rather than being hardcoded.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106647

## Testing done

- Manual

## Screenshots

|before|after|
|-|-|
|![before](https://github.com/user-attachments/assets/a8df8935-4b32-4829-920c-43ffa1c9872d)|![after](https://github.com/user-attachments/assets/7ecd3723-3602-40ee-ab53-b0df470e9909)|

## What areas of the site does it impact?

IVC CHAMPVA forms 10-10d and 10-7959c (both use this shared component)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA