### PR TITLE
Include output when tests fail

### DIFF
--- a/script/run-unit-tests-local.js
+++ b/script/run-unit-tests-local.js
@@ -80,6 +80,7 @@ async function runCommandAsync(command) {
     exec(command, (error, stdout) => {
       if (error) {
         console.error(`Runtime ${error}`);
+        console.log(stdout);
         reject(error);
       } else {
         console.log(`Output: ${stdout}`);


### PR DESCRIPTION
## Summary

Right now, the test output does not include information about which test cases are failing. This updates the local test runner to include output about which cases are passing and failing when tests fail.

## Screenshots

<table>
<tr>
<td> </td><td> Before </td> <td> After </td>
</tr>
<tr>
<td> Passing Test </td>
<td>

```
OITECHRolleA@HAC-LT3537169 vw2 % yarn test:unit src/applications/vaos/components/Breadcrumbs.unit.spec.jsx
yarn run v1.22.22
$ node ./script/run-unit-tests-local.js src/applications/vaos/components/Breadcrumbs.unit.spec.jsx
src/applications/vaos/components/Breadcrumbs.unit.spec.jsx
Executing: shopt -s extglob; LOG_LEVEL=warn BABEL_ENV=test NODE_ENV=test mocha  --max-old-space-size=8192 --config config/mocha.json 'src/applications/vaos/components/Breadcrumbs.unit.spec.jsx'
Output: 
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  2 passing (30ms)


Selected Tests Complete
✨  Done in 5.32s.
```

</td>
<td>
    
```
OITECHRolleA@HAC-LT3537169 vw2 % yarn test:unit src/applications/vaos/components/Breadcrumbs.unit.spec.jsx                                           
yarn run v1.22.22
$ node ./script/run-unit-tests-local.js src/applications/vaos/components/Breadcrumbs.unit.spec.jsx
src/applications/vaos/components/Breadcrumbs.unit.spec.jsx
Executing: shopt -s extglob; LOG_LEVEL=warn BABEL_ENV=test NODE_ENV=test mocha  --max-old-space-size=8192 --config config/mocha.json 'src/applications/vaos/components/Breadcrumbs.unit.spec.jsx'
Output: 
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  2 passing (47ms)


Selected Tests Complete
✨  Done in 30.27s.
```

</td>
</tr>
<tr>
<td> Failing test </td>
<td>

```
OITECHRolleA@HAC-LT3537169 vw2 % yarn test:unit src/applications/vaos/routes.unit.spec.jsx 
yarn run v1.22.22
$ node ./script/run-unit-tests-local.js src/applications/vaos/routes.unit.spec.jsx
src/applications/vaos/routes.unit.spec.jsx
Executing: shopt -s extglob; LOG_LEVEL=warn BABEL_ENV=test NODE_ENV=test mocha  --max-old-space-size=8192 --config config/mocha.json 'src/applications/vaos/routes.unit.spec.jsx'
Runtime Error: Command failed: shopt -s extglob; LOG_LEVEL=warn BABEL_ENV=test NODE_ENV=test mocha  --max-old-space-size=8192 --config config/mocha.json 'src/applications/vaos/routes.unit.spec.jsx'
`isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`
    at isModuleDeclaration (/Users/OITECHRolleA/src/vw2/node_modules/@babel/types/lib/validators/generated/index.js:2766:35)
    at PluginPass.Program (/Users/OITECHRolleA/src/vw2/node_modules/babel-plugin-lodash/lib/index.js:102:44)
Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
Error: vaos_lazy_loading: Reloading page error!
    at handleLoadError (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.jsx:19:18)
    at call (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:223:43)
    at tryCatch (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at Generator._invoke (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at Generator.next (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at asyncGeneratorStep (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at _next (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at /Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1
    at new Promise (<anonymous>)
    at Context.<anonymous> (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at callFn (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runnable.js:364:21)
    at Test.Runnable.run (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runnable.js:352:5)
    at Test.Runnable.run (/Users/OITECHRolleA/src/vw2/node_modules/mocha-snapshots/src/index.js:19:22)
    at Runner.runTest (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:677:10)
    at /Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:800:12
    at next (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:592:14)
    at /Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:602:7
    at next (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:485:14)
    at Immediate._onImmediate (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:570:5)
    at processImmediate (node:internal/timers:491:21)
    at process.callbackTrampoline (node:internal/async_hooks:130:17)

Continuing loop after reported runtime error.
Selected Tests Complete
✨  Done in 28.22s.
```

</td>
<td>

```
OITECHRolleA@HAC-LT3537169 vw2 % yarn test:unit src/applications/vaos/routes.unit.spec.jsx 
yarn run v1.22.22
$ node ./script/run-unit-tests-local.js src/applications/vaos/routes.unit.spec.jsx
src/applications/vaos/routes.unit.spec.jsx
Executing: shopt -s extglob; LOG_LEVEL=warn BABEL_ENV=test NODE_ENV=test mocha  --max-old-space-size=8192 --config config/mocha.json 'src/applications/vaos/routes.unit.spec.jsx'
Runtime Error: Command failed: shopt -s extglob; LOG_LEVEL=warn BABEL_ENV=test NODE_ENV=test mocha  --max-old-space-size=8192 --config config/mocha.json 'src/applications/vaos/routes.unit.spec.jsx'
`isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`
    at isModuleDeclaration (/Users/OITECHRolleA/src/vw2/node_modules/@babel/types/lib/validators/generated/index.js:2766:35)
    at PluginPass.Program (/Users/OITECHRolleA/src/vw2/node_modules/babel-plugin-lodash/lib/index.js:102:44)
Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
Error: vaos_lazy_loading: Reloading page error!
    at handleLoadError (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.jsx:19:18)
    at call (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:223:43)
    at tryCatch (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at Generator._invoke (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at Generator.next (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at asyncGeneratorStep (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at _next (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at /Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1
    at new Promise (<anonymous>)
    at Context.<anonymous> (/Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1)
    at callFn (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runnable.js:364:21)
    at Test.Runnable.run (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runnable.js:352:5)
    at Test.Runnable.run (/Users/OITECHRolleA/src/vw2/node_modules/mocha-snapshots/src/index.js:19:22)
    at Runner.runTest (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:677:10)
    at /Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:800:12
    at next (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:592:14)
    at /Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:602:7
    at next (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:485:14)
    at Immediate._onImmediate (/Users/OITECHRolleA/src/vw2/node_modules/mocha/lib/runner.js:570:5)
    at processImmediate (node:internal/timers:491:21)
    at process.callbackTrampoline (node:internal/async_hooks:130:17)


  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  6 passing (81ms)
  1 failing

  1) VAOS <handleLoadError>
       When dynamic import loading error: 1st time
         should display reloading page indicator:
     TypeError: Cannot read properties of undefined (reading 'args')
      at call (src/applications/vaos/routes.unit.spec.jsx:211:47)
      at tryCatch (src/applications/vaos/routes.unit.spec.jsx:2:1)
      at Generator._invoke (src/applications/vaos/routes.unit.spec.jsx:2:1)
      at Generator.next (src/applications/vaos/routes.unit.spec.jsx:2:1)
      at asyncGeneratorStep (src/applications/vaos/routes.unit.spec.jsx:2:1)
      at _next (src/applications/vaos/routes.unit.spec.jsx:2:1)
      at /Users/OITECHRolleA/src/vw2/src/applications/vaos/routes.unit.spec.jsx:2:1
      at new Promise (<anonymous>)
      at Context.<anonymous> (src/applications/vaos/routes.unit.spec.jsx:2:1)
      at Test.Runnable.run (node_modules/mocha-snapshots/src/index.js:19:22)
      at processImmediate (node:internal/timers:491:21)
      at process.callbackTrampoline (node:internal/async_hooks:130:17)




Continuing loop after reported runtime error.
Selected Tests Complete
✨  Done in 12.93s.
```

</td>
</tr>
</table>
