### PR TITLE
SC 110072: Separate batched components (part 1)

### DIFF
--- a/src/applications/appeals/995/components/ConfirmationPageV2.jsx
+++ b/src/applications/appeals/995/components/ConfirmationPageV2.jsx
@@ -1,27 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-
 import { selectProfile } from 'platform/user/selectors';
 
+// Content
 import { title995 } from '../content/title';
-
-import {
-  housingRiskTitle,
-  livingSituationTitle,
-  livingSituationList,
-  otherHousingRisksLabel,
-  pointOfContactNameLabel,
-  pointOfContactPhoneLabel,
-} from '../content/livingSituation';
 import {
   VaContent,
   PrivateContent,
   UploadContent,
 } from './EvidenceSummaryLists';
-
 import { content as notice5103Content } from '../content/notice5103';
 import { facilityTypeTitle, facilityTypeList } from '../content/facilityTypes';
 import { content as evidenceContent } from '../content/evidenceSummary';
@@ -30,12 +19,17 @@ import {
   optionIndicatorLabel,
   optionIndicatorChoices,
 } from '../content/optionIndicator';
+
+// Utils
 import {
   getVAEvidence,
   getPrivateEvidence,
   getOtherEvidence,
 } from '../utils/evidence';
+import { SC_NEW_FORM_DATA, EVIDENCE_LIMIT } from '../constants';
+import { getReadableDate } from '../../shared/utils/dates';
 
+// Components
 import {
   chapterHeaderClass,
   ConfirmationTitle,
@@ -45,97 +39,9 @@ import {
 } from '../../shared/components/ConfirmationCommon';
 import ConfirmationPersonalInfo from '../../shared/components/ConfirmationPersonalInfo';
 import ConfirmationIssues from '../../shared/components/ConfirmationIssues';
-import { showValueOrNotSelected } from '../../shared/utils/confirmation';
-import { SC_NEW_FORM_DATA, EVIDENCE_LIMIT } from '../constants';
+import { LivingSituation } from './LivingSituation';
 
 // import maxData from '../tests/fixtures/data/maximal-test-v2.json';
-
-import { getReadableDate } from '../../shared/utils/dates';
-
-export const LivingSituationQuestions = ({ data } = {}) => (
-  <>
-    <li>
-      <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-        {housingRiskTitle}
-      </div>
-      <div
-        className="vads-u-margin-bottom--2 dd-privacy-hidden"
-        data-dd-action-name="has housing risk"
-      >
-        {showValueOrNotSelected(data.housingRisk)}
-      </div>
-    </li>
-    {data.housingRisk && (
-      <>
-        <li>
-          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-            {livingSituationTitle}
-          </div>
-          <div
-            className="vads-u-margin-bottom--2 dd-privacy-hidden"
-            data-dd-action-name="living situation"
-          >
-            {livingSituationList(data?.livingSituation) || 'None selected'}
-          </div>
-        </li>
-        {data.livingSituation?.other && (
-          <li>
-            <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-              {otherHousingRisksLabel}
-            </div>
-            <div
-              className="vads-u-margin-bottom--2 dd-privacy-hidden"
-              data-dd-action-name="other housing risks"
-            >
-              {data.otherHousingRisks || 'Nothing entered'}
-            </div>
-          </li>
-        )}
-        <li>
-          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-            {pointOfContactNameLabel}
-          </div>
-          <div
-            className="vads-u-margin-bottom--2 dd-privacy-hidden"
-            data-dd-action-name="point of contact full name"
-          >
-            {data.pointOfContactName || 'Nothing entered'}
-          </div>
-        </li>
-        <li>
-          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-            {pointOfContactPhoneLabel}
-          </div>
-          <div
-            className="vads-u-margin-bottom--2 dd-privacy-hidden"
-            data-dd-action-name="point of contact phone number"
-          >
-            {data.pointOfContactPhone ? (
-              <va-telephone
-                contact={data.pointOfContactPhone}
-                international={data.pointOfContactHasInternationalPhone}
-                not-clickable
-              />
-            ) : (
-              'Nothing entered'
-            )}
-          </div>
-        </li>
-      </>
-    )}
-  </>
-);
-
-LivingSituationQuestions.propTypes = {
-  data: PropTypes.shape({
-    housingRisk: PropTypes.bool,
-    livingSituation: PropTypes.arrayOf(PropTypes.string),
-    otherHousingRisks: PropTypes.string,
-    pointOfContactName: PropTypes.string,
-    pointOfContactPhone: PropTypes.string,
-    pointOfContactHasInternationalPhone: PropTypes.bool,
-  }),
-};
 
 export const ConfirmationPageV2 = () => {
   const form = useSelector(state => state.form || {});
@@ -163,7 +69,7 @@ export const ConfirmationPageV2 = () => {
   );
 
   const livingSituation = showScNewForm ? (
-    <LivingSituationQuestions data={data} />
+    <LivingSituation data={data} />
   ) : null;
 
   return (

--- a/src/applications/appeals/995/components/LivingSituation.jsx
+++ b/src/applications/appeals/995/components/LivingSituation.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  housingRiskTitle,
+  livingSituationTitle,
+  livingSituationList,
+  otherHousingRisksLabel,
+  pointOfContactNameLabel,
+  pointOfContactPhoneLabel,
+} from '../content/livingSituation';
+import { showValueOrNotSelected } from '../../shared/utils/confirmation';
+
+export const LivingSituation = ({ data } = {}) => (
+  <>
+    <li>
+      <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+        {housingRiskTitle}
+      </div>
+      <div
+        className="vads-u-margin-bottom--2 dd-privacy-hidden"
+        data-dd-action-name="has housing risk"
+      >
+        {showValueOrNotSelected(data.housingRisk)}
+      </div>
+    </li>
+    {data.housingRisk && (
+      <>
+        <li>
+          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+            {livingSituationTitle}
+          </div>
+          <div
+            className="vads-u-margin-bottom--2 dd-privacy-hidden"
+            data-dd-action-name="living situation"
+          >
+            {livingSituationList(data?.livingSituation) || 'None selected'}
+          </div>
+        </li>
+        {data.livingSituation?.other && (
+          <li>
+            <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+              {otherHousingRisksLabel}
+            </div>
+            <div
+              className="vads-u-margin-bottom--2 dd-privacy-hidden"
+              data-dd-action-name="other housing risks"
+            >
+              {data.otherHousingRisks || 'Nothing entered'}
+            </div>
+          </li>
+        )}
+        <li>
+          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+            {pointOfContactNameLabel}
+          </div>
+          <div
+            className="vads-u-margin-bottom--2 dd-privacy-hidden"
+            data-dd-action-name="point of contact full name"
+          >
+            {data.pointOfContactName || 'Nothing entered'}
+          </div>
+        </li>
+        <li>
+          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+            {pointOfContactPhoneLabel}
+          </div>
+          <div
+            className="vads-u-margin-bottom--2 dd-privacy-hidden"
+            data-dd-action-name="point of contact phone number"
+          >
+            {data.pointOfContactPhone ? (
+              <va-telephone
+                contact={data.pointOfContactPhone}
+                international={data.pointOfContactHasInternationalPhone}
+                not-clickable
+              />
+            ) : (
+              'Nothing entered'
+            )}
+          </div>
+        </li>
+      </>
+    )}
+  </>
+);
+
+LivingSituation.propTypes = {
+  data: PropTypes.shape({
+    housingRisk: PropTypes.bool,
+    livingSituation: PropTypes.arrayOf(PropTypes.string),
+    otherHousingRisks: PropTypes.string,
+    pointOfContactName: PropTypes.string,
+    pointOfContactPhone: PropTypes.string,
+    pointOfContactHasInternationalPhone: PropTypes.bool,
+  }),
+};

--- a/src/applications/appeals/995/tests/components/ConfirmationPagev2.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/ConfirmationPagev2.unit.spec.jsx
@@ -4,15 +4,11 @@ import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { expect } from 'chai';
-
 import {
   $,
   $$,
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
-
-import ConfirmationPageV2, {
-  LivingSituationQuestions,
-} from '../../components/ConfirmationPageV2';
+import ConfirmationPageV2 from '../../components/ConfirmationPageV2';
 import maxData from '../fixtures/data/maximal-test.json';
 import maxDataV2 from '../fixtures/data/maximal-test-v2.json';
 import { EVIDENCE_VA, EVIDENCE_PRIVATE, EVIDENCE_OTHER } from '../../constants';
@@ -511,58 +507,5 @@ describe('ConfirmationPageV2', () => {
       'None selected',
     ]);
     expect($$('.vads-c-action-link--green', container).length).to.eq(1);
-  });
-});
-
-describe('LivingSituationQuestions', () => {
-  it('should render the living situation questions', () => {
-    const data = { housingRisk: true };
-    const { container } = render(<LivingSituationQuestions data={data} />);
-    expect($$('li', container).length).to.eq(4);
-  });
-
-  it('should prevent submission & show error if none & any other option selected', () => {
-    const data = { housingRisk: false };
-    const { container } = render(<LivingSituationQuestions data={data} />);
-    expect($$('li', container).length).to.eq(1);
-  });
-
-  it('should render the other living situation question with nothing entered', () => {
-    const data = { housingRisk: true, livingSituation: { other: true } };
-    const { container } = render(<LivingSituationQuestions data={data} />);
-
-    const list = $$('li', container);
-    expect(list.length).to.eq(5);
-    expect(list.map(el => el.textContent)).to.deep.equal([
-      'Are you experiencing homelessness or at risk of becoming homeless?Yes',
-      'Which of these statements best describes your living situation?I have another housing risk not listed here.',
-      'Tell us about other housing risks you’re experiencing.Nothing entered',
-      'Name of your point of contactNothing entered',
-      'Telephone number of your point of contactNothing entered',
-    ]);
-  });
-
-  it('should render the other living situation question', () => {
-    const data = {
-      housingRisk: true,
-      livingSituation: {
-        other: true,
-        friendOrFamily: true,
-      },
-      otherHousingRisks: 'Lorem ipsum',
-      pointOfContactName: 'John Doe',
-      pointOfContactPhone: '8005551212',
-    };
-    const { container } = render(<LivingSituationQuestions data={data} />);
-
-    const list = $$('li', container);
-    expect(list.length).to.eq(5);
-    expect(list.map(el => el.textContent)).to.deep.equal([
-      'Are you experiencing homelessness or at risk of becoming homeless?Yes',
-      'Which of these statements best describes your living situation?I have another housing risk not listed here and I’m staying with a friend or family member',
-      'Tell us about other housing risks you’re experiencing.Lorem ipsum',
-      'Name of your point of contactJohn Doe',
-      'Telephone number of your point of contact', // number inside va-telephone
-    ]);
   });
 });

--- a/src/applications/appeals/995/tests/components/LivingSituation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/LivingSituation.unit.spec.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { $$ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { LivingSituation } from '../../components/LivingSituation';
+
+describe('LivingSituation', () => {
+  it('should render the living situation questions', () => {
+    const data = { housingRisk: true };
+    const { container } = render(<LivingSituation data={data} />);
+    expect($$('li', container).length).to.eq(4);
+  });
+
+  it('should prevent submission & show error if none & any other option selected', () => {
+    const data = { housingRisk: false };
+    const { container } = render(<LivingSituation data={data} />);
+    expect($$('li', container).length).to.eq(1);
+  });
+
+  it('should render the other living situation question with nothing entered', () => {
+    const data = { housingRisk: true, livingSituation: { other: true } };
+    const { container } = render(<LivingSituation data={data} />);
+
+    const list = $$('li', container);
+    expect(list.length).to.eq(5);
+    expect(list.map(el => el.textContent)).to.deep.equal([
+      'Are you experiencing homelessness or at risk of becoming homeless?Yes',
+      'Which of these statements best describes your living situation?I have another housing risk not listed here.',
+      'Tell us about other housing risks you’re experiencing.Nothing entered',
+      'Name of your point of contactNothing entered',
+      'Telephone number of your point of contactNothing entered',
+    ]);
+  });
+
+  it('should render the other living situation question', () => {
+    const data = {
+      housingRisk: true,
+      livingSituation: {
+        other: true,
+        friendOrFamily: true,
+      },
+      otherHousingRisks: 'Lorem ipsum',
+      pointOfContactName: 'John Doe',
+      pointOfContactPhone: '8005551212',
+    };
+    const { container } = render(<LivingSituation data={data} />);
+
+    const list = $$('li', container);
+    expect(list.length).to.eq(5);
+    expect(list.map(el => el.textContent)).to.deep.equal([
+      'Are you experiencing homelessness or at risk of becoming homeless?Yes',
+      'Which of these statements best describes your living situation?I have another housing risk not listed here and I’m staying with a friend or family member',
+      'Tell us about other housing risks you’re experiencing.Lorem ipsum',
+      'Name of your point of contactJohn Doe',
+      'Telephone number of your point of contact', // number inside va-telephone
+    ]);
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In the Supplemental Claims code ([src/applications/appeals/995 in vets-website](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/appeals/995)), there are some files that house multiple individual components (multiple `export const`s). These components should live in separate files. This reduces the cognitive load of code changes on the author and reviewers as well as reduces dependency/risk when making changes in a single file.

No UI or functionality changes are expected.

### Screenshot of the `LivingSituation` questions on the confirmation page (shown in local env)

<img width="693" alt="Screenshot 2025-05-21 at 11 11 57 AM" src="https://github.com/user-attachments/assets/62e2fe06-8378-4a61-9e97-60da2e32ee96" />


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/110072

## Testing done

Cypress & unit tests pass. Also did manual runthroughs of the flow at http://localhost:3001/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start.

## What areas of the site does it impact?

Supplemental Claims only.

## Acceptance criteria

- [x] [ConfirmationPageV2](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/appeals/995/components/ConfirmationPageV2.jsx) is separated into individual files per exported component