### PR TITLE
108327 milestone 2 update links pt 2

### DIFF
--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -128,7 +128,7 @@ const resolveLandingPageLinks = (
         },
         {
           href: '/health-care/wellness-programs/',
-          text: 'Veteran programs for health and wellness',
+          text: 'Veterans programs for health and wellness',
         },
         {
           href: '/family-and-caregiver-benefits/',

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -42,71 +42,135 @@ const resolveLandingPageLinks = (
   if (messagesLinks.length > 0)
     messagesLinks[0].ariaLabel = unreadMessageAriaLabel;
 
-  const myVaHealthBenefitsLinks = [
-    {
-      href: '/health-care/copay-rates/',
-      text: 'Current Veteran copay rates',
-    },
-    {
-      href: '/health-care/health-needs-conditions/mental-health',
-      text: 'Mental health services',
-    },
-    {
-      href: '/health-care/about-va-health-benefits/dental-care/',
-      text: 'Dental care',
-    },
-    {
-      href: '/COMMUNITYCARE/programs/veterans/index.asp',
-      text: 'Community care',
-    },
-    registered && {
-      href: '/my-health/update-benefits-information-form-10-10ezr/introduction',
-      text: 'Update health benefits info (10-10EZR)',
-    },
-    {
-      href: '/health-care/get-health-id-card/',
-      text: 'Veteran health information card',
-    },
-    // {
-    //   href: '#FIXME-need-link',
-    //   text: 'Download my IRS 1095-B form',
-    // },
-  ].filter(isLinkData);
+  const myVaHealthBenefitsLinks = (featureToggles[
+    FEATURE_FLAG_NAMES.mhvMilestone2ChangesEnabled
+  ]
+    ? [
+        {
+          href: '/health-care/get-health-id-card/',
+          text: 'Veteran health information card',
+        },
+        registered && {
+          href:
+            '/my-health/update-benefits-information-form-10-10ezr/introduction',
+          text: 'Update health benefits info (10-10EZR)',
+        },
+        {
+          href: '/health-care/copay-rates/',
+          text: 'Current Veteran copay rates',
+        },
+        {
+          href: '/health-care/health-needs-conditions/mental-health',
+          text: 'Mental health services',
+        },
+        {
+          href: '/health-care/about-va-health-benefits/dental-care/',
+          text: 'Dental care',
+        },
+        {
+          href: '/health-care/about-va-health-benefits/vision-care/',
+          text: 'Vision care',
+        },
+        {
+          href: '/COMMUNITYCARE/programs/veterans/index.asp',
+          text: 'Community care',
+        },
+        // {
+        //   href: '#FIXME-need-link',
+        //   text: 'Download my IRS 1095-B form',
+        // },
+      ]
+    : [
+        {
+          href: '/health-care/copay-rates/',
+          text: 'Current Veteran copay rates',
+        },
+        {
+          href: '/health-care/health-needs-conditions/mental-health',
+          text: 'Mental health services',
+        },
+        {
+          href: '/health-care/about-va-health-benefits/dental-care/',
+          text: 'Dental care',
+        },
+        {
+          href: '/COMMUNITYCARE/programs/veterans/index.asp',
+          text: 'Community care',
+        },
+        registered && {
+          href:
+            '/my-health/update-benefits-information-form-10-10ezr/introduction',
+          text: 'Update health benefits info (10-10EZR)',
+        },
+        {
+          href: '/health-care/get-health-id-card/',
+          text: 'Veteran health information card',
+        },
+        // {
+        //   href: '#FIXME-need-link',
+        //   text: 'Download my IRS 1095-B form',
+        // },
+      ]
+  ).filter(isLinkData);
 
-  const moreResourcesLinks = [
-    featureToggles[FEATURE_FLAG_NAMES.mhvVaHealthChatEnabled] && {
-      href: 'https://eauth.va.gov/MAP/users/v2/landing?redirect_uri=/cirrusmd/',
-      text: 'Chat live with a health professional on VA Health Chat',
-    },
-    {
-      href: '/resources/the-pact-act-and-your-va-benefits/',
-      text: 'The PACT Act and your benefits',
-    },
-    {
-      href: mhvUrl(authdWithSSOe, 'check-your-mental-health'),
-      text: 'Check your mental health',
-    },
-    {
-      href: 'https://www.veteranshealthlibrary.va.gov/',
-      text: 'Veterans Health Library',
-    },
-    {
-      href: 'https://www.myhealth.va.gov/healthy-living-centers',
-      text: 'Healthy Living Centers',
-    },
-    {
-      href: 'https://www.myhealth.va.gov/mhv-community',
-      text: 'The My HealtheVet community',
-    },
-    {
-      href: '/wholehealth/',
-      text: 'VA’s Whole Health living',
-    },
-    {
-      href: mhvUrl(authdWithSSOe, 'ss20200320-va-video-connect'),
-      text: 'How to use VA Video Connect',
-    },
-  ].filter(isLinkData);
+  const moreResourcesLinks = (featureToggles[
+    FEATURE_FLAG_NAMES.mhvMilestone2ChangesEnabled
+  ]
+    ? [
+        {
+          href:
+            'https://eauth.va.gov/MAP/users/v2/landing?redirect_uri=/cirrusmd/',
+          text: 'Chat live with a health professional on VA Health Chat',
+        },
+        {
+          href: 'https://www.veteranshealthlibrary.va.gov/',
+          text: 'Veterans Health Library',
+        },
+        {
+          href: '/health-care/wellness-programs/',
+          text: 'Veteran programs for health and wellness',
+        },
+        {
+          href: '/family-and-caregiver-benefits/',
+          text: 'Learn about family and caregiver benefits',
+        },
+      ]
+    : [
+        {
+          href:
+            'https://eauth.va.gov/MAP/users/v2/landing?redirect_uri=/cirrusmd/',
+          text: 'Chat live with a health professional on VA Health Chat',
+        },
+        {
+          href: '/resources/the-pact-act-and-your-va-benefits/',
+          text: 'The PACT Act and your benefits',
+        },
+        {
+          href: mhvUrl(authdWithSSOe, 'check-your-mental-health'),
+          text: 'Check your mental health',
+        },
+        {
+          href: 'https://www.veteranshealthlibrary.va.gov/',
+          text: 'Veterans Health Library',
+        },
+        {
+          href: 'https://www.myhealth.va.gov/healthy-living-centers',
+          text: 'Healthy Living Centers',
+        },
+        {
+          href: 'https://www.myhealth.va.gov/mhv-community',
+          text: 'The My HealtheVet community',
+        },
+        {
+          href: '/wholehealth/',
+          text: 'VA’s Whole Health living',
+        },
+        {
+          href: mhvUrl(authdWithSSOe, 'ss20200320-va-video-connect'),
+          text: 'How to use VA Video Connect',
+        },
+      ]
+  ).filter(isLinkData);
 
   const spotlightLinks = [
     {
@@ -154,9 +218,7 @@ const resolveLandingPageLinks = (
 
   const medicalRecordsLinks = [
     HEALTH_TOOL_LINKS.MEDICAL_RECORDS[0],
-    featureToggles[
-      FEATURE_FLAG_NAMES.mhvLandingPageShowShareMyHealthDataLink
-    ] && {
+    {
       href: resolveSHMDLink,
       text:
         'Share your personal health data on the Share My Health Data website',
@@ -184,12 +246,10 @@ const resolveLandingPageLinks = (
     {
       title: HEALTH_TOOL_HEADINGS.MEDICAL_RECORDS,
       icon: 'note_add',
-      ...(!featureToggles[
-        FEATURE_FLAG_NAMES.mhvLandingPageShowShareMyHealthDataLink
-      ] && {
+      ...{
         introduction:
           'Get quick, easy access to your medical records. Now you can print or download what you need, when you need it.',
-      }),
+      },
       links: medicalRecordsLinks,
     },
     {
@@ -205,20 +265,35 @@ const resolveLandingPageLinks = (
     },
   ];
 
-  const hubs = [
-    {
-      title: registered ? 'My VA health benefits' : 'VA health benefits',
-      links: myVaHealthBenefitsLinks,
-    },
-    {
-      title: 'More resources and support',
-      links: moreResourcesLinks,
-    },
-    {
-      title: 'In the spotlight',
-      links: spotlightLinks,
-    },
-  ];
+  const hubs = featureToggles[FEATURE_FLAG_NAMES.mhvMilestone2ChangesEnabled]
+    ? [
+        {
+          title: 'VA health benefits',
+          links: myVaHealthBenefitsLinks,
+        },
+        {
+          title: 'More health resources',
+          links: moreResourcesLinks,
+        },
+        {
+          title: 'In the spotlight',
+          links: spotlightLinks,
+        },
+      ]
+    : [
+        {
+          title: registered ? 'My VA health benefits' : 'VA health benefits',
+          links: myVaHealthBenefitsLinks,
+        },
+        {
+          title: 'More resources and support',
+          links: moreResourcesLinks,
+        },
+        {
+          title: 'In the spotlight',
+          links: spotlightLinks,
+        },
+      ];
 
   return { cards, hubs };
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This change is in response to QA of [this previous change](https://github.com/department-of-veterans-affairs/vets-website/pull/36483)

## Related issue(s)
[108327](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108327)

## Testing done
specs green

## What areas of the site does it impact?
One *single* link one the MHV landing page

## Acceptance criteria
The link says 'Veterans programs for health and wellness' instead of 'Veteran programs for health and wellness'