### PR TITLE
108327 pt2 update link text

### DIFF
--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -128,7 +128,7 @@ const resolveLandingPageLinks = (
         },
         {
           href: '/health-care/wellness-programs/',
-          text: 'Veteran programs for health and wellness',
+          text: 'Veterans programs for health and wellness',
         },
         {
           href: '/family-and-caregiver-benefits/',
@@ -340,7 +340,7 @@ const resolveLandingPageLinks = (
     },
     {
       href: '/health-care/wellness-programs/',
-      text: 'Veteran programs for health and wellness',
+      text: 'Veterans programs for health and wellness',
     },
   ].filter(isLinkData);
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This change is in response to QA of [this previous change](https://github.com/department-of-veterans-affairs/vets-website/pull/36483)

## Related issue(s)
[108327](https://github.com/department-of-veterans-affairs/va.gov-team/issues/108327)

## Testing done
specs green

## What areas of the site does it impact?
One *single* link one the MHV landing page

## Acceptance criteria
The link says 'Veterans programs for health and wellness' instead of 'Veteran programs for health and wellness'