### PR TITLE
478 - Veteran Status Card Alert Updates

### DIFF
--- a/src/applications/personalization/profile/components/veteran-status-card/FrequentlyAskedQuestions.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/FrequentlyAskedQuestions.jsx
@@ -69,8 +69,4 @@ FrequentlyAskedQuestions.propTypes = {
   pdfError: PropTypes.bool,
 };
 
-FrequentlyAskedQuestions.propTypes = {
-  createPdf: PropTypes.func,
-};
-
 export default FrequentlyAskedQuestions;

--- a/src/applications/personalization/profile/components/veteran-status-card/FrequentlyAskedQuestions.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/FrequentlyAskedQuestions.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { PDFErrorAlert } from './VeteranStatusAlerts';
 
-const FrequentlyAskedQuestions = ({ createPdf }) => (
+const FrequentlyAskedQuestions = ({ createPdf, pdfError = false }) => (
   <>
     <h2 className="vads-u-margin-top--2">Frequently asked questions</h2>
     <va-accordion>
@@ -38,6 +39,11 @@ const FrequentlyAskedQuestions = ({ createPdf }) => (
             />
           </>
         )}
+        {pdfError && (
+          <div className="vads-u-margin-top--4">
+            <PDFErrorAlert />
+          </div>
+        )}
         <p />
         Note: The Veteran Status Card is for identification only and does not
         guarantee benefits. Additional documentation may be required. You may be
@@ -57,6 +63,11 @@ const FrequentlyAskedQuestions = ({ createPdf }) => (
     </va-accordion>
   </>
 );
+
+FrequentlyAskedQuestions.propTypes = {
+  createPdf: PropTypes.func,
+  pdfError: PropTypes.bool,
+};
 
 FrequentlyAskedQuestions.propTypes = {
   createPdf: PropTypes.func,

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatus.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatus.jsx
@@ -14,8 +14,8 @@ import Headline from '../ProfileSectionHeadline';
 import VeteranStatusCard from './VeteranStatusCard';
 import FrequentlyAskedQuestions from './FrequentlyAskedQuestions';
 import {
-  ApiMessageAlert,
-  NoServiceHistoryWarningAlert,
+  NotConfirmedAlert,
+  NoServiceHistoryAlert,
   SystemErrorAlert,
 } from './VeteranStatusAlerts';
 import LoadFail from '../alerts/LoadFail';
@@ -185,41 +185,65 @@ const VeteranStatus = ({
     }
     if (isServiceHistory403Error || !isServiceHistoryValid) {
       // Service history 403 error or no service history
-      return <NoServiceHistoryWarningAlert />;
+      return <NoServiceHistoryAlert />;
     }
-    if (!isCardDataValid) {
-      if (formattedFullName) {
-        if (
-          data?.attributes?.veteranStatus === 'not confirmed' &&
-          data?.message?.length > 0
-        ) {
-          // Vet verification status warning
-          return (
-            <ApiMessageAlert
-              headline={data.title}
-              message={data.message}
-              status={data.status}
-            />
-          );
-        }
-        if (
-          vetStatusEligibility?.confirmed === false &&
-          vetStatusEligibility?.message?.length > 0
-        ) {
-          // Vet status eligibility warning
-          return (
-            <ApiMessageAlert
-              headline={vetStatusEligibility.title}
-              message={vetStatusEligibility.message}
-              status={vetStatusEligibility.status}
-            />
-          );
-        }
+    if (formattedFullName) {
+      if (
+        data?.attributes?.veteranStatus === 'not confirmed' &&
+        data?.message?.length > 0
+      ) {
+        // Vet verification status warning
+        return (
+          <NotConfirmedAlert
+            headline={data.title}
+            message={data.message}
+            status={data.status}
+          />
+        );
       }
-      // System error
-      return <SystemErrorAlert />;
+      if (
+        vetStatusEligibility?.confirmed === false &&
+        vetStatusEligibility?.message?.length > 0
+      ) {
+        // Vet status eligibility warning
+        return (
+          <NotConfirmedAlert
+            headline={vetStatusEligibility.title}
+            message={vetStatusEligibility.message}
+            status={vetStatusEligibility.status}
+          />
+        );
+      }
     }
-    return null;
+    // System error
+    return <SystemErrorAlert />;
+  };
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <va-loading-indicator
+          set-focus
+          message="Checking your eligibility..."
+          data-testid="veteran-status-loading-indicator"
+        />
+      );
+    }
+    if (isCardDataValid) {
+      return (
+        <div className="vads-l-grid-container--full">
+          <div className="vads-l-row">
+            <VeteranStatusCard
+              edipi={edipi}
+              formattedFullName={formattedFullName}
+              latestService={latestService}
+              totalDisabilityRating={totalDisabilityRating}
+            />
+          </div>
+        </div>
+      );
+    }
+    return renderAlert();
   };
 
   return (
@@ -233,31 +257,7 @@ const VeteranStatus = ({
         appTitle="Veteran Status Card page"
         dependencies={[externalServices.VAPRO_MILITARY_INFO]}
       >
-        <div id="veteran-status">
-          {isLoading ? (
-            <va-loading-indicator
-              set-focus
-              message="Checking your eligibility..."
-              data-testid="veteran-status-loading-indicator"
-            />
-          ) : (
-            <>
-              {renderAlert()}
-              {isCardDataValid && (
-                <div className="vads-l-grid-container--full">
-                  <div className="vads-l-row">
-                    <VeteranStatusCard
-                      edipi={edipi}
-                      formattedFullName={formattedFullName}
-                      latestService={latestService}
-                      totalDisabilityRating={totalDisabilityRating}
-                    />
-                  </div>
-                </div>
-              )}
-            </>
-          )}
-        </div>
+        <div id="veteran-status">{renderContent()}</div>
         <FrequentlyAskedQuestions
           createPdf={isCardDataValid ? createPdf : null}
           pdfError={pdfError}

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatus.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatus.jsx
@@ -83,7 +83,7 @@ const VeteranStatus = ({
   useEffect(
     () => {
       let isMounted = true;
-      if (isServiceHistoryValid) {
+      if (formattedFullName && isServiceHistoryValid) {
         const fetchVerificationStatus = async () => {
           setIsLoading(true);
 
@@ -112,7 +112,7 @@ const VeteranStatus = ({
         isMounted = false;
       };
     },
-    [isServiceHistoryValid],
+    [formattedFullName, isServiceHistoryValid],
   );
 
   const getLatestService = () => {
@@ -215,8 +215,11 @@ const VeteranStatus = ({
         );
       }
     }
-    // System error
-    return <SystemErrorAlert />;
+    if (!isCardDataValid) {
+      // System error
+      return <SystemErrorAlert />;
+    }
+    return null;
   };
 
   const renderContent = () => {

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatus.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatus.jsx
@@ -155,7 +155,10 @@ const VeteranStatus = ({
     }
   };
 
+  const hasConfirmationData = !!(data && data.attributes);
+
   const userHasRequiredCardData = !!(
+    hasConfirmationData &&
     data?.attributes?.veteranStatus === 'confirmed' &&
     serviceHistory.length &&
     formattedFullName
@@ -178,7 +181,12 @@ const VeteranStatus = ({
         </va-alert>
       );
     }
-    if (!formattedFullName || systemError || notConfirmedReason === 'ERROR') {
+    if (
+      !formattedFullName ||
+      !hasConfirmationData ||
+      systemError ||
+      notConfirmedReason === 'ERROR'
+    ) {
       return (
         <va-alert
           close-btn-aria-label="Close notification"

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
@@ -59,28 +59,7 @@ VeteranStatusAlert.propTypes = {
   status: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
 };
 
-export const ApiMessageAlert = ({
-  headline = '',
-  message = [],
-  status = 'warning',
-}) => {
-  const messages = message.map(item => buildContactElements(item));
-  return (
-    <VeteranStatusAlert
-      headline={headline}
-      messages={messages}
-      status={status}
-    />
-  );
-};
-
-ApiMessageAlert.propTypes = {
-  headline: PropTypes.string,
-  message: PropTypes.arrayOf(PropTypes.string),
-  status: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
-};
-
-export const NoServiceHistoryWarningAlert = () => {
+export const NoServiceHistoryAlert = () => {
   return (
     <va-alert status="warning" uswds class="vads-u-margin-bottom--4">
       <h2 slot="headline">
@@ -115,6 +94,27 @@ export const NoServiceHistoryWarningAlert = () => {
       </div>
     </va-alert>
   );
+};
+
+export const NotConfirmedAlert = ({
+  headline = '',
+  message = [],
+  status = 'warning',
+}) => {
+  const messages = message.map(item => buildContactElements(item));
+  return (
+    <VeteranStatusAlert
+      headline={headline}
+      messages={messages}
+      status={status}
+    />
+  );
+};
+
+NotConfirmedAlert.propTypes = {
+  headline: PropTypes.string,
+  message: PropTypes.arrayOf(PropTypes.string),
+  status: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
 };
 
 export const PDFErrorAlert = () => {

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+const buildContactElements = item => {
+  const contactNumber = `${CONTACTS.DS_LOGON.slice(
+    0,
+    3,
+  )}-${CONTACTS.DS_LOGON.slice(3, 6)}-${CONTACTS.DS_LOGON.slice(6)}`;
+  const startIndex = item.indexOf(contactNumber);
+
+  if (startIndex === -1) {
+    return item;
+  }
+
+  const before = item.slice(0, startIndex);
+  const telephone = item.slice(
+    startIndex,
+    startIndex + contactNumber.length + 11,
+  );
+  const after = item.slice(startIndex + telephone.length);
+
+  return (
+    <>
+      {before}
+      <va-telephone contact={contactNumber} /> (
+      <va-telephone contact={CONTACTS[711]} tty />){after}
+    </>
+  );
+};
+
+const VeteranStatusAlert = ({ headline, messages, status = 'error' }) => {
+  return (
+    <va-alert
+      class="vads-u-margin-bottom--4"
+      close-btn-aria-label="Close notification"
+      status={status}
+      uswds
+      visible
+    >
+      {headline && <h2 slot="headline">{headline}</h2>}
+      {messages?.map((message, i) => (
+        <p
+          key={i}
+          className={`${i === 0 ? 'vads-u-margin-top--0' : ''} ${
+            i === messages.length - 1 ? 'vads-u-margin-bottom--0' : ''
+          }`}
+        >
+          {message}
+        </p>
+      ))}
+    </va-alert>
+  );
+};
+
+VeteranStatusAlert.propTypes = {
+  headline: PropTypes.string,
+  messages: PropTypes.arrayOf(PropTypes.string),
+  status: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
+};
+
+export const ApiMessageAlert = ({
+  headline = '',
+  message = [],
+  status = 'warning',
+}) => {
+  const messages = message.map(item => buildContactElements(item));
+  return (
+    <VeteranStatusAlert
+      headline={headline}
+      messages={messages}
+      status={status}
+    />
+  );
+};
+
+ApiMessageAlert.propTypes = {
+  headline: PropTypes.string,
+  message: PropTypes.arrayOf(PropTypes.string),
+  status: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
+};
+
+export const NoServiceHistoryWarningAlert = () => {
+  return (
+    <va-alert status="warning" uswds class="vads-u-margin-bottom--4">
+      <h2 slot="headline">
+        We can’t match your information to any military service records
+      </h2>
+      <div>
+        <p>We’re sorry for this issue.</p>
+        <p>
+          <b>
+            If you want to learn what military service records may be on file
+            for you
+          </b>
+          , call the Defense Manpower Data Center (DMDC) at{' '}
+          <va-telephone contact={CONTACTS.DS_LOGON} />
+          &nbsp;(
+          <va-telephone contact={CONTACTS['711']} tty />
+          ). The DMDC office is open Monday through Friday (except federal
+          holidays), 8:00 a.m. to 8:00 p.m. ET.
+        </p>
+        <p>
+          <b>
+            If you think there might be a problem with your military service
+            records
+          </b>
+          , you can apply for a correction.
+        </p>
+        <va-link
+          href="https://www.archives.gov/veterans/military-service-records/correct-service-records.html"
+          text="Learn how to correct your military service records on the National Archives website"
+        />
+        .
+      </div>
+    </va-alert>
+  );
+};
+
+export const PDFErrorAlert = () => {
+  return (
+    <VeteranStatusAlert
+      headline="Something went wrong"
+      messages={[
+        'We’re sorry. Try to download your Veteran Status Card later.',
+      ]}
+    />
+  );
+};
+
+export const SystemErrorAlert = () => {
+  return (
+    <VeteranStatusAlert
+      headline="Something went wrong"
+      messages={['We’re sorry. Try to view your Veteran Status Card later.']}
+    />
+  );
+};

--- a/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
+++ b/src/applications/personalization/profile/components/veteran-status-card/VeteranStatusAlerts.jsx
@@ -121,9 +121,7 @@ export const PDFErrorAlert = () => {
   return (
     <VeteranStatusAlert
       headline="Something went wrong"
-      messages={[
-        'We’re sorry. Try to download your Veteran Status Card later.',
-      ]}
+      messages={['We’re sorry. Try to print your Veteran Status Card later.']}
     />
   );
 };

--- a/src/applications/personalization/profile/mocks/endpoints/service-history/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/service-history/index.js
@@ -6,10 +6,11 @@ const none = {
       serviceHistory: [],
       vetStatusEligibility: {
         confirmed: false,
+        title: 'There’s a problem with your discharge status records',
         message: [
-          'We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now.',
-          'To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
+          'We’re sorry. To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
         ],
+        status: 'warning',
       },
     },
   },

--- a/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
@@ -37,6 +37,7 @@ const notConfirmedIneligible = {
       'To get a Veteran status card, you must have received an honorable discharge for at least one period of service.',
       'If you think your discharge status is incorrect, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
     ],
+    status: 'warning',
   },
 };
 

--- a/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/vet-verification-status/index.js
@@ -16,10 +16,11 @@ const notConfirmedProblem = {
       veteranStatus: 'not confirmed',
       notConfirmedReason: 'PERSON_NOT_FOUND',
     },
+    title: 'There’s a problem with your discharge status records',
     message: [
-      'We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now.',
-      'To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
+      'We’re sorry. To fix the problem with your records, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
     ],
+    status: 'warning',
   },
 };
 
@@ -31,8 +32,9 @@ const notConfirmedIneligible = {
       veteranStatus: 'not confirmed',
       notConfirmedReason: 'NOT_TITLE_38',
     },
+    title: 'You’re not eligible for a Veteran Status Card',
     message: [
-      'Our records show that you’re not eligible for a Veteran status card. To get a Veteran status card, you must have received an honorable discharge for at least one period of service.',
+      'To get a Veteran status card, you must have received an honorable discharge for at least one period of service.',
       'If you think your discharge status is incorrect, call the Defense Manpower Data Center at 800-538-9552 (TTY: 711). They’re open Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.',
     ],
   },

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -242,17 +242,27 @@ const responses = {
     return res.status(200).json(bankAccounts.saved.success);
   },
   'GET /v0/profile/service_history': (_req, res) => {
-    // user doesnt have any service history or is not authorized
-    // return res.status(403).json(genericErrors.error403);
-
+    // Succcess
     return res.status(200).json(serviceHistory.airForce);
-    // return res.status(200).json(serviceHistory.error);
+
+    // No service history
     // return res.status(200).json(serviceHistory.none);
-    // return res.status(200).json(serviceHistory.dishonorableDischarge);
-    // return res.status(200).json(serviceHistory.unknownDischarge);
+
+    // 403 error (no service found)
     // return res
     //   .status(200)
     //   .json(serviceHistory.generateServiceHistoryError('403'));
+
+    // Non-403 error
+    // return res
+    //   .status(200)
+    //   .json(serviceHistory.generateServiceHistoryError('500'));
+
+    // Dishonorable discharge
+    // return res.status(200).json(serviceHistory.dishonorableDischarge);
+
+    // Unknown discharge
+    // return res.status(200).json(serviceHistory.unknownDischarge);
   },
   'GET /v0/profile/vet_verification_status': (_req, res) => {
     return res.status(200).json(vetVerificationStatus.confirmed);

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -110,6 +110,7 @@ const responses = {
             profileShowPrivacyPolicy: true,
             veteranStatusCardUseLighthouse: true,
             veteranStatusCardUseLighthouseFrontend: true,
+            vetStatusStage1: true,
           }),
         ),
       secondsOfDelay,

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -246,6 +246,10 @@ const responses = {
     // return res.status(403).json(genericErrors.error403);
 
     return res.status(200).json(serviceHistory.airForce);
+    // return res.status(200).json(serviceHistory.error);
+    // return res.status(200).json(serviceHistory.none);
+    // return res.status(200).json(serviceHistory.dishonorableDischarge);
+    // return res.status(200).json(serviceHistory.unknownDischarge);
     // return res
     //   .status(200)
     //   .json(serviceHistory.generateServiceHistoryError('403'));

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/FrequentlyAskedQuestions.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/FrequentlyAskedQuestions.unit.spec.jsx
@@ -63,7 +63,7 @@ describe('<FrequentlyAskedQuestions />', () => {
 
     // Check that the link is not rendered
     expect(
-      getByText('We’re sorry. Try to download your Veteran Status Card later.'),
+      getByText('We’re sorry. Try to print your Veteran Status Card later.'),
     ).to.exist;
   });
 
@@ -72,10 +72,10 @@ describe('<FrequentlyAskedQuestions />', () => {
     render(<FrequentlyAskedQuestions createPdf={mockCreatePdf} />);
 
     // Click the link
-    const printLink = document.querySelector(
+    const pdfLink = document.querySelector(
       'va-link[text="Print your Veteran Status Card (PDF)"]',
     );
-    fireEvent.click(printLink);
+    fireEvent.click(pdfLink);
 
     // Check that createPdf was called
     expect(mockCreatePdf.calledOnce).to.be.true;

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/FrequentlyAskedQuestions.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/FrequentlyAskedQuestions.unit.spec.jsx
@@ -58,6 +58,15 @@ describe('<FrequentlyAskedQuestions />', () => {
     ).to.not.exist;
   });
 
+  it('renders PDF error alert when pdfError is true', () => {
+    const { getByText } = render(<FrequentlyAskedQuestions pdfError />);
+
+    // Check that the link is not rendered
+    expect(
+      getByText('We’re sorry. Try to download your Veteran Status Card later.'),
+    ).to.exist;
+  });
+
   it('calls createPdf when "Print your Veteran Status Card" link is clicked', () => {
     const mockCreatePdf = sinon.spy();
     render(<FrequentlyAskedQuestions createPdf={mockCreatePdf} />);

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
@@ -206,7 +206,7 @@ describe('VeteranStatus', () => {
       await waitFor(() => {
         expect(
           view.queryByText(
-            /There’s a problem with your discharge status records/,
+            /We’re sorry. There’s a problem with your discharge status records./,
           ),
         ).to.exist;
         expect(
@@ -381,7 +381,7 @@ describe('VeteranStatus', () => {
       await waitFor(() => {
         expect(
           view.queryByText(
-            /There’s a problem with your discharge status records/,
+            /We’re sorry. There’s a problem with your discharge status records./,
           ),
         ).to.exist;
         expect(
@@ -403,7 +403,7 @@ describe('VeteranStatus', () => {
       await waitFor(() => {
         expect(
           view.queryByText(
-            /There’s a problem with your discharge status records/,
+            /We’re sorry. There’s a problem with your discharge status records./,
           ),
         ).to.exist;
         expect(
@@ -465,7 +465,9 @@ describe('VeteranStatus', () => {
 
       await waitFor(() => {
         expect(
-          view.queryByText(/You’re not eligible for a Veteran Status Card/),
+          view.queryByText(
+            /Our records show that you’re not eligible for a Veteran status card./,
+          ),
         ).to.exist;
       });
       expect(

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
@@ -161,24 +161,22 @@ function createBasicInitialState(serviceHistory) {
   };
 }
 
+// Function to find the PDF link in the view
+function pdfLinkElement(view) {
+  return Array.from(view.container.querySelectorAll('va-link')).find(
+    link =>
+      link.getAttribute('text') === 'Print your Veteran Status Card (PDF)',
+  );
+}
+
 // Function to check if the PDF link is rendered
 function expecPDFLinkToBeRendered(view) {
-  expect(
-    Array.from(view.container.querySelectorAll('va-link')).some(
-      link =>
-        link.getAttribute('text') === 'Print your Veteran Status Card (PDF)',
-    ),
-  ).to.be.true; // PDF link should be available
+  expect(pdfLinkElement(view)).to.exist;
 }
 
 // Function to check if the PDF link is not rendered
 function expectPDFLinkToNoBeRendered(view) {
-  expect(
-    Array.from(view.container.querySelectorAll('va-link')).some(
-      link =>
-        link.getAttribute('text') === 'Print your Veteran Status Card (PDF)',
-    ),
-  ).to.be.not.true; // PDF link should NOT be available
+  expect(pdfLinkElement(view)).to.not.exist;
 }
 
 describe('VeteranStatus', () => {

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
@@ -48,9 +48,18 @@ const notEligibleData = {
 const serviceEpisodes = [
   {
     branchOfService: 'Air Force',
-    beginDate: '2020-01-01',
-    endDate: '2021-01-01',
-    personnelCategoryTypeCode: 'V',
+    beginDate: '2009-04-12',
+    endDate: '2013-04-11',
+    periodOfServiceTypeCode: 'V',
+    periodOfServiceTypeText: 'Reserve member',
+    characterOfDischargeCode: 'A',
+  },
+  {
+    branchOfService: 'Air Force',
+    beginDate: '2005-04-12',
+    endDate: '2009-04-11',
+    periodOfServiceTypeCode: 'A',
+    periodOfServiceTypeText: 'Active duty member',
     characterOfDischargeCode: 'A',
   },
 ];
@@ -228,14 +237,25 @@ describe('VeteranStatus', () => {
             }`,
           ),
         ).to.exist;
+      });
 
-        // Check that the PDF download link is rendered
-        expect(pdfLink(view)).to.exist;
-
-        // Check that the PDF download link can be clicked
-        generatePdfStub.resolves();
-        fireEvent.click(pdfLink(view));
+      // Check that the PDF download link exists and can be clicked
+      generatePdfStub.resolves();
+      expect(pdfLink(view)).to.exist;
+      fireEvent.click(pdfLink(view));
+      await waitFor(() => {
         expect(generatePdfStub.calledOnce).to.be.true;
+      });
+
+      // Check that the PDF download link shows the correct error alert
+      generatePdfStub.rejects(new Error('PDF Error'));
+      fireEvent.click(pdfLink(view));
+      await waitFor(() => {
+        expect(
+          view.getByText(
+            'We’re sorry. Try to print your Veteran Status Card later.',
+          ),
+        ).to.exist;
       });
     });
   });

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import * as api from '~/platform/utilities/api';
-import { waitFor } from '@testing-library/react';
+import * as pdf from '~/platform/pdf';
+import { fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import { addDays, subDays, format } from 'date-fns';
 import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
@@ -163,21 +164,23 @@ function createBasicInitialState(serviceHistory) {
 
 // Function to find the PDF link in the view
 function pdfLink(view) {
-  return Array.from(view.container.querySelectorAll('va-link')).find(
-    link =>
-      link.getAttribute('text') === 'Print your Veteran Status Card (PDF)',
+  return view.container.querySelector(
+    'va-link[text="Print your Veteran Status Card (PDF)"]',
   );
 }
 
 describe('VeteranStatus', () => {
   let apiRequestStub;
+  let generatePdfStub;
 
   beforeEach(() => {
     apiRequestStub = sinon.stub(api, 'apiRequest');
+    generatePdfStub = sinon.stub(pdf, 'generatePdf');
   });
 
   afterEach(() => {
     apiRequestStub.restore();
+    generatePdfStub.restore();
   });
 
   // Test case for when the user is eligible for a Veteran Status Card
@@ -228,6 +231,11 @@ describe('VeteranStatus', () => {
 
         // Check that the PDF download link is rendered
         expect(pdfLink(view)).to.exist;
+
+        // Check that the PDF download link can be clicked
+        generatePdfStub.resolves();
+        fireEvent.click(pdfLink(view));
+        expect(generatePdfStub.calledOnce).to.be.true;
       });
     });
   });

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
@@ -162,21 +162,11 @@ function createBasicInitialState(serviceHistory) {
 }
 
 // Function to find the PDF link in the view
-function pdfLinkElement(view) {
+function pdfLink(view) {
   return Array.from(view.container.querySelectorAll('va-link')).find(
     link =>
       link.getAttribute('text') === 'Print your Veteran Status Card (PDF)',
   );
-}
-
-// Function to check if the PDF link is rendered
-function expecPDFLinkToBeRendered(view) {
-  expect(pdfLinkElement(view)).to.exist;
-}
-
-// Function to check if the PDF link is not rendered
-function expectPDFLinkToNoBeRendered(view) {
-  expect(pdfLinkElement(view)).to.not.exist;
 }
 
 describe('VeteranStatus', () => {
@@ -237,7 +227,7 @@ describe('VeteranStatus', () => {
         ).to.exist;
 
         // Check that the PDF download link is rendered
-        expecPDFLinkToBeRendered(view);
+        expect(pdfLink(view)).to.exist;
       });
     });
   });
@@ -252,7 +242,7 @@ describe('VeteranStatus', () => {
       expect(view.getByText(`This page isn't available right now.`)).to.exist;
 
       // Check that the PDF download link is not rendered
-      expectPDFLinkToNoBeRendered(view);
+      expect(pdfLink(view)).to.not.exist;
     });
 
     it('should render the NoServiceHistoryAlert alert for 403 service history errors', () => {
@@ -267,7 +257,7 @@ describe('VeteranStatus', () => {
       ).to.exist;
 
       // Check that the PDF download link is not rendered
-      expectPDFLinkToNoBeRendered(view);
+      expect(pdfLink(view)).to.not.exist;
     });
 
     it('should render the NoServiceHistoryAlert alert when there is no service history', () => {
@@ -282,7 +272,7 @@ describe('VeteranStatus', () => {
       ).to.exist;
 
       // Check that the PDF download link is not rendered
-      expectPDFLinkToNoBeRendered(view);
+      expect(pdfLink(view)).to.not.exist;
     });
 
     it('should render the SystemErrorAlert alert when an API error occurs', async () => {
@@ -304,7 +294,7 @@ describe('VeteranStatus', () => {
         ).to.exist;
 
         // Check that the PDF download link is not rendered
-        expectPDFLinkToNoBeRendered(view);
+        expect(pdfLink(view)).to.not.exist;
       });
     });
 
@@ -324,7 +314,7 @@ describe('VeteranStatus', () => {
       ).to.exist;
 
       // Check that the PDF download link is not rendered
-      expectPDFLinkToNoBeRendered(view);
+      expect(pdfLink(view)).to.not.exist;
     });
 
     it('should render the NotConfirmedAlert alert when vet status returns a discharge problem', async () => {
@@ -342,7 +332,7 @@ describe('VeteranStatus', () => {
         expect(view.getByText(dischargeProblemData.title)).to.exist;
 
         // Check that the PDF download link is not rendered
-        expectPDFLinkToNoBeRendered(view);
+        expect(pdfLink(view)).to.not.exist;
       });
     });
 
@@ -361,7 +351,7 @@ describe('VeteranStatus', () => {
         expect(view.getByText(notEligibleData.title)).to.exist;
 
         // Check that the PDF download link is not rendered
-        expectPDFLinkToNoBeRendered(view);
+        expect(pdfLink(view)).to.not.exist;
       });
     });
 
@@ -382,7 +372,7 @@ describe('VeteranStatus', () => {
         expect(view.getByText(dischargeProblemData.title)).to.exist;
 
         // Check that the PDF download link is not rendered
-        expectPDFLinkToNoBeRendered(view);
+        expect(pdfLink(view)).to.not.exist;
       });
     });
 
@@ -401,7 +391,7 @@ describe('VeteranStatus', () => {
         expect(view.getByText(notEligibleData.title)).to.exist;
 
         // Check that the PDF download link is not rendered
-        expectPDFLinkToNoBeRendered(view);
+        expect(pdfLink(view)).to.not.exist;
       });
     });
   });

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
@@ -185,11 +185,8 @@ describe('VeteranStatus', () => {
       );
 
       await waitFor(() => {
-        expect(
-          view.queryByText(
-            /We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now./,
-          ),
-        ).to.not.exist;
+        // No alerts should be displayed
+        expect(view.container.querySelectorAll('va-alert').length).to.equal(0);
         expect(
           Array.from(view.container.querySelectorAll('va-link')).some(
             link =>
@@ -209,7 +206,7 @@ describe('VeteranStatus', () => {
       await waitFor(() => {
         expect(
           view.queryByText(
-            /We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now./,
+            /There’s a problem with your discharge status records/,
           ),
         ).to.exist;
         expect(
@@ -232,11 +229,7 @@ describe('VeteranStatus', () => {
       });
 
       await waitFor(() => {
-        expect(
-          view.queryByText(
-            'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later.',
-          ),
-        ).to.exist;
+        expect(view.queryByText('Something went wrong')).to.exist;
         expect(
           Array.from(view.container.querySelectorAll('va-link')).some(
             link =>
@@ -254,11 +247,7 @@ describe('VeteranStatus', () => {
       });
 
       await waitFor(() => {
-        expect(
-          view.getByText(
-            'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later.',
-          ),
-        ).to.exist;
+        expect(view.queryByText('Something went wrong')).to.exist;
         expect(
           Array.from(view.container.querySelectorAll('va-link')).some(
             link =>
@@ -286,11 +275,7 @@ describe('VeteranStatus', () => {
       });
 
       await waitFor(() => {
-        expect(
-          view.queryByText(
-            'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later.',
-          ),
-        ).to.exist;
+        expect(view.queryByText('Something went wrong')).to.exist;
         expect(
           Array.from(view.container.querySelectorAll('va-link')).some(
             link =>
@@ -318,11 +303,7 @@ describe('VeteranStatus', () => {
       });
 
       await waitFor(() => {
-        expect(
-          view.queryByText(
-            'We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later.',
-          ),
-        ).to.exist;
+        expect(view.queryByText('Something went wrong')).to.exist;
         expect(
           Array.from(view.container.querySelectorAll('va-link')).some(
             link =>
@@ -400,7 +381,7 @@ describe('VeteranStatus', () => {
       await waitFor(() => {
         expect(
           view.queryByText(
-            /We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now./,
+            /There’s a problem with your discharge status records/,
           ),
         ).to.exist;
         expect(
@@ -422,7 +403,7 @@ describe('VeteranStatus', () => {
       await waitFor(() => {
         expect(
           view.queryByText(
-            /We’re sorry. There’s a problem with your discharge status records. We can’t provide a Veteran status card for you right now./,
+            /There’s a problem with your discharge status records/,
           ),
         ).to.exist;
         expect(
@@ -459,16 +440,7 @@ describe('VeteranStatus', () => {
       });
 
       await waitFor(() => {
-        expect(
-          view.queryByText(
-            /We’re sorry. There’s a problem with our system. We can’t show your Veteran status card right now. Try again later./,
-          ),
-        ).to.exist;
-        expect(
-          view.queryByText(
-            /We’re sorry. There’s a problem with your discharge status records./,
-          ),
-        ).to.not.exist;
+        expect(view.queryByText(/Something went wrong/)).to.exist;
         expect(
           Array.from(view.container.querySelectorAll('va-link')).some(
             link =>
@@ -493,9 +465,7 @@ describe('VeteranStatus', () => {
 
       await waitFor(() => {
         expect(
-          view.queryByText(
-            /Our records show that you’re not eligible for a Veteran status card./,
-          ),
+          view.queryByText(/You’re not eligible for a Veteran Status Card/),
         ).to.exist;
       });
       expect(

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatus.unit.spec.jsx
@@ -91,6 +91,18 @@ const vetStatusNotEligible = {
 
 function createBasicInitialState(serviceHistory, eligibility) {
   return {
+    featureToggles: {
+      loading: false,
+    },
+    scheduledDowntime: {
+      globalDowntime: null,
+      isReady: true,
+      isPending: false,
+      serviceMap: {
+        get() {},
+      },
+      dismissedDowntimeWarnings: [],
+    },
     user: {
       profile: {
         veteranStatus: {

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
@@ -88,9 +88,7 @@ describe('VeteranStatusAlerts', () => {
       const { getByText } = render(<PDFErrorAlert />);
       expect(getByText('Something went wrong')).to.exist;
       expect(
-        getByText(
-          'We’re sorry. Try to download your Veteran Status Card later.',
-        ),
+        getByText('We’re sorry. Try to print your Veteran Status Card later.'),
       ).to.exist;
     });
   });

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import {
+  ApiMessageAlert,
+  NoServiceHistoryWarningAlert,
+  PDFErrorAlert,
+  SystemErrorAlert,
+} from '../../../components/veteran-status-card/VeteranStatusAlerts';
+
+describe('VeteranStatusAlerts', () => {
+  describe('ApiMessageAlert', () => {
+    it('renders headline and messages', () => {
+      const { getByText } = render(
+        <ApiMessageAlert
+          headline="Test Headline"
+          message={['Test message 1', 'Test message 2']}
+        />,
+      );
+      expect(getByText('Test Headline')).to.exist;
+      expect(getByText('Test message 1')).to.exist;
+      expect(getByText('Test message 2')).to.exist;
+    });
+
+    it('renders contact numbers as va-telephone links', () => {
+      const message = 'Call us at 800-538-9552 (TTY: 711) for help.';
+      const { getByText } = render(<ApiMessageAlert message={[message]} />);
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '800-538-9552'
+          );
+        }),
+      ).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '711'
+          );
+        }),
+      ).to.exist;
+    });
+  });
+
+  describe('NoServiceHistoryWarningAlert', () => {
+    it('renders no service history warning alert with correct headline and content', () => {
+      const { getByText } = render(<NoServiceHistoryWarningAlert />);
+      expect(
+        getByText(
+          'We can’t match your information to any military service records',
+        ),
+      ).to.exist;
+      expect(getByText('We’re sorry for this issue.')).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '8005389552'
+          );
+        }),
+      ).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '711'
+          );
+        }),
+      ).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-link' &&
+            element.getAttribute('href') ===
+              'https://www.archives.gov/veterans/military-service-records/correct-service-records.html' &&
+            element.getAttribute('text') ===
+              'Learn how to correct your military service records on the National Archives website'
+          );
+        }),
+      ).to.exist;
+    });
+  });
+
+  describe('PDFErrorAlert', () => {
+    it('renders the PDF error alert', () => {
+      const { getByText } = render(<PDFErrorAlert />);
+      expect(getByText('Something went wrong')).to.exist;
+      expect(
+        getByText(
+          'We’re sorry. Try to download your Veteran Status Card later.',
+        ),
+      ).to.exist;
+    });
+  });
+
+  describe('SystemErrorAlert', () => {
+    it('renders the system error alert', () => {
+      const { getByText } = render(<SystemErrorAlert />);
+      expect(getByText('Something went wrong')).to.exist;
+      expect(
+        getByText('We’re sorry. Try to view your Veteran Status Card later.'),
+      ).to.exist;
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/veteran-status-card/VeteranStatusAlerts.unit.spec.jsx
@@ -2,51 +2,16 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import {
-  ApiMessageAlert,
-  NoServiceHistoryWarningAlert,
+  NoServiceHistoryAlert,
+  NotConfirmedAlert,
   PDFErrorAlert,
   SystemErrorAlert,
 } from '../../../components/veteran-status-card/VeteranStatusAlerts';
 
 describe('VeteranStatusAlerts', () => {
-  describe('ApiMessageAlert', () => {
-    it('renders headline and messages', () => {
-      const { getByText } = render(
-        <ApiMessageAlert
-          headline="Test Headline"
-          message={['Test message 1', 'Test message 2']}
-        />,
-      );
-      expect(getByText('Test Headline')).to.exist;
-      expect(getByText('Test message 1')).to.exist;
-      expect(getByText('Test message 2')).to.exist;
-    });
-
-    it('renders contact numbers as va-telephone links', () => {
-      const message = 'Call us at 800-538-9552 (TTY: 711) for help.';
-      const { getByText } = render(<ApiMessageAlert message={[message]} />);
-      expect(
-        getByText((content, element) => {
-          return (
-            element.tagName.toLowerCase() === 'va-telephone' &&
-            element.getAttribute('contact') === '800-538-9552'
-          );
-        }),
-      ).to.exist;
-      expect(
-        getByText((content, element) => {
-          return (
-            element.tagName.toLowerCase() === 'va-telephone' &&
-            element.getAttribute('contact') === '711'
-          );
-        }),
-      ).to.exist;
-    });
-  });
-
-  describe('NoServiceHistoryWarningAlert', () => {
-    it('renders no service history warning alert with correct headline and content', () => {
-      const { getByText } = render(<NoServiceHistoryWarningAlert />);
+  describe('NoServiceHistoryAlert', () => {
+    it('renders no service history alert with correct headline and content', () => {
+      const { getByText } = render(<NoServiceHistoryAlert />);
       expect(
         getByText(
           'We can’t match your information to any military service records',
@@ -77,6 +42,41 @@ describe('VeteranStatusAlerts', () => {
               'https://www.archives.gov/veterans/military-service-records/correct-service-records.html' &&
             element.getAttribute('text') ===
               'Learn how to correct your military service records on the National Archives website'
+          );
+        }),
+      ).to.exist;
+    });
+  });
+
+  describe('NotConfirmedAlert', () => {
+    it('renders headline and messages', () => {
+      const { getByText } = render(
+        <NotConfirmedAlert
+          headline="Test Headline"
+          message={['Test message 1', 'Test message 2']}
+        />,
+      );
+      expect(getByText('Test Headline')).to.exist;
+      expect(getByText('Test message 1')).to.exist;
+      expect(getByText('Test message 2')).to.exist;
+    });
+
+    it('renders contact numbers as va-telephone links', () => {
+      const message = 'Call us at 800-538-9552 (TTY: 711) for help.';
+      const { getByText } = render(<NotConfirmedAlert message={[message]} />);
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '800-538-9552'
+          );
+        }),
+      ).to.exist;
+      expect(
+        getByText((content, element) => {
+          return (
+            element.tagName.toLowerCase() === 'va-telephone' &&
+            element.getAttribute('contact') === '711'
           );
         }),
       ).to.exist;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated the alerts that can show on the new Veteran Status Card page per this [Figma](https://www.figma.com/design/AobGKkBvIiDuYXR2QqkytC/IIR-Veteran-Status?node-id=3230-30325&p=f&t=9gfcya96magGx9dZ-0) design. Also updated the unit tests to verify that these alerts are shown under various conditions. Note that the new Veteran Status Card page is enabled with the `vetStatusStage1` feature flag.

## Related issue(s)
- Link to parent ticket in IIR repo
https://github.com/department-of-veterans-affairs/va-iir/issues/1067
- Link to BE ticket in MFS repo
https://github.com/department-of-veterans-affairs/va-mobile-feature-support/issues/457
- Link to FE ticket in MFS repo
https://github.com/department-of-veterans-affairs/va-mobile-feature-support/issues/478

## Testing done
- The majority of the manual testing was performed using mock API's, uncommenting responses for `GET /v0/profile/service_history` and `GET /v0/profile/vet_verification_status` in `vets-website/src/applications/personalization/profile/mocks/server.js`.
- To force an error with downloading/printing the PDF of the Veteran Status Card, the `createPdf` function in `VeteranStatus.jsx` was modified to throw an exception.
- More testing was performed by running the updated unit tests located in `vets-website/src/applications/personalization/profile/tests/components/veteran-status-card`.

## Screenshots
### When the card displays successfully
<img width="538" alt="Success" src="https://github.com/user-attachments/assets/ccb6dc7f-b58f-4888-9cb1-e2700f92708f" />

### When the user is LOA 1
<img width="532" alt="LOA 1 User" src="https://github.com/user-attachments/assets/620e1011-eeeb-4db4-850e-1093a84dce85" />

### When the page is down for maintenance
<img width="538" alt="Maintenance" src="https://github.com/user-attachments/assets/9af63074-d079-4671-89f5-d249c11cdf07" />

### When the service history endpoint returns a non-403 error
<img width="538" alt="Non-403 Error" src="https://github.com/user-attachments/assets/3f287564-b1b6-4088-88f2-999fae9da738" />

### When the service history endpoint returns a 403 error
<img width="538" alt="403 Error" src="https://github.com/user-attachments/assets/1d41e5d8-15fa-46a1-a9ef-b0584698a774" />

### When the service history endpoint returns no service history
<img width="538" alt="No Service History" src="https://github.com/user-attachments/assets/af0f411b-31b0-4006-acf2-15c414e80936" />

### When the vet verification status endpoint returns an API error
<img width="538" alt="API Error" src="https://github.com/user-attachments/assets/cb29a5d2-b23e-4744-9102-788a02be57af" />

### When an endpoint returns a discharge problem warning
<img width="538" alt="Discharge Problem" src="https://github.com/user-attachments/assets/9e1d1b7b-aaab-4a9e-8478-5fa7f06631e0" />

### When an endpoint returns a not eligible warning
<img width="538" alt="Not Eligible" src="https://github.com/user-attachments/assets/9d04aa29-76ca-4fe9-9004-ebe5c58253d4" />

### When there's a problem generating the PDF
<img width="538" alt="Print Error" src="https://github.com/user-attachments/assets/cc909f96-4dc5-438e-9ce0-f3f712749c7b" />


## What areas of the site does it impact?
The new Veteran Status Card page was the only area of the site impacted.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
Please do an extensive review on `VeteranStatus.jsx`. The logic in this module was leveraged from `MilitaryInformation.jsx` and `ProofOfVeteranStatus.jsx` where the old implementation lived. The tricky thing going on here is that the card makes use of two endpoints to decide whether it can be successfully displayed.
