### PR TITLE
91025 update error boundry to display breadcrumbs and MHV header

### DIFF
--- a/src/applications/mhv-landing-page/components/ErrorBoundary.jsx
+++ b/src/applications/mhv-landing-page/components/ErrorBoundary.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from '~/platform/monitoring/record-event';
-import AlertMhvNoAction from './alerts/AlertMhvNoAction.jsx';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/web-components/react-bindings';
+import AlertErrorBoundry from './alerts/AlertErrorBoundry.jsx';
+import manifest from '../manifest.json';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -25,9 +27,36 @@ class ErrorBoundary extends React.Component {
     const { children } = this.props;
     const { hasError } = this.state;
     const ErrorMessage = () => (
-      <div className="vads-l-grid-container main-content vads-u-padding-y--1p5">
-        <AlertMhvNoAction errorCode="Landing Page Rendering Error" />
-      </div>
+      <>
+        <div className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--5">
+          <div className="vads-l-grid-container desktop-lg:vads-u-padding-x--0">
+            <VaBreadcrumbs
+              homeVeteransAffairs
+              breadcrumbList={[
+                { label: 'VA.gov home', href: '/' },
+                { label: 'My HealtheVet', href: manifest.rootUrl },
+              ]}
+            />
+            <div className="vads-l-col medium-screen:vads-l-col--8">
+              <div className="vads-l-col">
+                <div className="vads-l-row">
+                  <div className="vads-l-col-6 ">
+                    <h1 className="vads-u-margin-y--0">My HealtheVet</h1>
+                  </div>
+                  <div className="vads-l-col-2 vads-u-margin-left--2 vads-u-margin-top--2">
+                    <span className="usa-label vads-u-background-color--primary">
+                      New
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="vads-l-grid-container main-content vads-u-padding-y--1p5">
+              <AlertErrorBoundry />
+            </div>
+          </div>
+        </div>
+      </>
     );
 
     return hasError || !children ? <ErrorMessage /> : <>{children}</>;

--- a/src/applications/mhv-landing-page/components/alerts/AlertErrorBoundry.jsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertErrorBoundry.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+// eslint-disable-next-line import/no-named-default
+import { default as recordEventFn } from '~/platform/monitoring/record-event';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+const AlertErrorBoundry = ({ testId, recordEvent }) => {
+  const headline = `You can't access My HealtheVet tools right now`;
+  useEffect(
+    () => {
+      recordEvent({
+        event: 'nav-alert-box-load',
+        action: 'load',
+        'alert-box-headline': headline,
+        'alert-box-status': 'warning',
+      });
+    },
+    [headline, recordEvent],
+  );
+
+  return (
+    <VaAlert
+      className="vads-u-margin-bottom--3"
+      data-testid={testId}
+      status="error"
+      visible
+    >
+      <h2 className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+        {headline}
+      </h2>
+      <div className="mhv-u-reg-alert-body" role="presentation">
+        <p className="vads-u-margin-y--0">
+          We’re sorry. There’s a problem with our system. Try refreshing this
+          page. Or check back later.
+        </p>
+
+        <p>
+          If you need to contact your care team now, call your VA health
+          facility.
+        </p>
+
+        <a href="/find-locations/?page=1&facilityType=health">
+          Find your VA health facility
+        </a>
+      </div>
+    </VaAlert>
+  );
+};
+
+AlertErrorBoundry.defaultProps = {
+  title: "You can't access messages, medications, or medical records right now",
+  errorCode: 'unknown',
+  recordEvent: recordEventFn,
+  testId: 'mhv-alert--mhv-registration',
+};
+
+AlertErrorBoundry.propTypes = {
+  errorCode: PropTypes.string,
+  title: PropTypes.string,
+  headline: PropTypes.string,
+  recordEvent: PropTypes.func,
+  testId: PropTypes.string,
+};
+
+export default AlertErrorBoundry;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This is followon work to [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/36335) as a result of QA change requests

## Related issue(s)
[91025](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91025)

## Testing done
Specs green

## Screenshots
<img width="1104" alt="Screenshot 2025-05-22 at 10 42 02 AM" src="https://github.com/user-attachments/assets/38469fe1-4d0d-4cdf-aa36-654bf091cdc6" />

## What areas of the site does it impact?
MHV landing page

## Acceptance criteria
The MHV error boundary includes breadcrumbs and header

### Quality Assurance & Testing
This change is the direct result of QA testing