### PR TITLE
MHV-71075: PHR refresh no records bug fixed

### DIFF
--- a/src/applications/mhv-medical-records/components/shared/RecordListSection.jsx
+++ b/src/applications/mhv-medical-records/components/shared/RecordListSection.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import AccessTroubleAlertBox from './AccessTroubleAlertBox';
-import NoRecordsMessage from './NoRecordsMessage';
 import TrackedSpinner from './TrackedSpinner';
 import useInitialFhirLoadTimeout from '../../hooks/useInitialFhirLoadTimeout';
 
@@ -10,7 +9,6 @@ const RecordListSection = ({
   accessAlert,
   accessAlertType,
   recordCount,
-  recordType,
   listCurrentAsOf,
   initialFhirLoad,
 }) => {
@@ -37,10 +35,7 @@ const RecordListSection = ({
       </div>
     );
   }
-  if (recordCount === 0) {
-    return <NoRecordsMessage type={recordType} />;
-  }
-  if (recordCount) {
+  if (recordCount || recordCount === 0) {
     return children;
   }
   return (

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -38,9 +38,9 @@ import {
 } from '../util/pdfHelpers/allergies';
 import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
-
 import useAcceleratedData from '../hooks/useAcceleratedData';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
+import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 
 const Allergies = props => {
   const { runningUnitTest } = props;
@@ -227,13 +227,17 @@ ${allergies.map(entry => generateAllergyListItemTxt(entry)).join('')}`;
           allowTxtDownloads={allowTxtDownloads}
           description="Allergies"
         />
-        <RecordList
-          records={allergies?.map(allergy => ({
-            ...allergy,
-            isOracleHealthData: isAcceleratingAllergies,
-          }))}
-          type={recordType.ALLERGIES}
-        />
+        {allergies?.length ? (
+          <RecordList
+            records={allergies?.map(allergy => ({
+              ...allergy,
+              isOracleHealthData: isAcceleratingAllergies,
+            }))}
+            type={recordType.ALLERGIES}
+          />
+        ) : (
+          <NoRecordsMessage type={recordType.ALLERGIES} />
+        )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -216,25 +216,27 @@ ${allergies.map(entry => generateAllergyListItemTxt(entry)).join('')}`;
           />
         )}
 
-        <PrintDownload
-          description="Allergies - List"
-          list
-          downloadPdf={generateAllergiesPdf}
-          allowTxtDownloads={allowTxtDownloads}
-          downloadTxt={generateAllergiesTxt}
-        />
-        <DownloadingRecordsInfo
-          allowTxtDownloads={allowTxtDownloads}
-          description="Allergies"
-        />
         {allergies?.length ? (
-          <RecordList
-            records={allergies?.map(allergy => ({
-              ...allergy,
-              isOracleHealthData: isAcceleratingAllergies,
-            }))}
-            type={recordType.ALLERGIES}
-          />
+          <>
+            <PrintDownload
+              description="Allergies - List"
+              list
+              downloadPdf={generateAllergiesPdf}
+              allowTxtDownloads={allowTxtDownloads}
+              downloadTxt={generateAllergiesTxt}
+            />
+            <DownloadingRecordsInfo
+              allowTxtDownloads={allowTxtDownloads}
+              description="Allergies"
+            />
+            <RecordList
+              records={allergies?.map(allergy => ({
+                ...allergy,
+                isOracleHealthData: isAcceleratingAllergies,
+              }))}
+              type={recordType.ALLERGIES}
+            />
+          </>
         ) : (
           <NoRecordsMessage type={recordType.ALLERGIES} />
         )}

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -20,6 +20,7 @@ import useAlerts from '../hooks/use-alerts';
 import RecordListSection from '../components/shared/RecordListSection';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
+import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 
 const CareSummariesAndNotes = () => {
   const dispatch = useDispatch();
@@ -99,12 +100,15 @@ const CareSummariesAndNotes = () => {
             dispatch(reloadRecords());
           }}
         />
-
-        <RecordList
-          records={careSummariesAndNotes}
-          type="care summaries and notes"
-          hideRecordsLabel
-        />
+        {careSummariesAndNotes?.length ? (
+          <RecordList
+            records={careSummariesAndNotes}
+            type="care summaries and notes"
+            hideRecordsLabel
+          />
+        ) : (
+          <NoRecordsMessage type={recordType.CARE_SUMMARIES_AND_NOTES} />
+        )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -17,6 +17,7 @@ import useAlerts from '../hooks/use-alerts';
 import useListRefresh from '../hooks/useListRefresh';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
+import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 
 const HealthConditions = () => {
   const ABOUT_THE_CODES_LABEL = 'About the codes in some condition names';
@@ -105,7 +106,14 @@ const HealthConditions = () => {
             condition, ask your provider at your next appointment.
           </p>
         </va-additional-info>
-        <RecordList records={conditions} type={recordType.HEALTH_CONDITIONS} />
+        {conditions?.length ? (
+          <RecordList
+            records={conditions}
+            type={recordType.HEALTH_CONDITIONS}
+          />
+        ) : (
+          <NoRecordsMessage type={recordType.HEALTH_CONDITIONS} />
+        )}
       </RecordListSection>
     </>
   );

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -17,6 +17,7 @@ import useAlerts from '../hooks/use-alerts';
 import useListRefresh from '../hooks/useListRefresh';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
+import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 
 const LabsAndTests = () => {
   const dispatch = useDispatch();
@@ -98,8 +99,11 @@ const LabsAndTests = () => {
             dispatch(reloadRecords());
           }}
         />
-
-        <RecordList records={labsAndTests} type={recordType.LABS_AND_TESTS} />
+        {labsAndTests?.length ? (
+          <RecordList records={labsAndTests} type={recordType.LABS_AND_TESTS} />
+        ) : (
+          <NoRecordsMessage type={recordType.LABS_AND_TESTS} />
+        )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -201,19 +201,21 @@ ${vaccines.map(entry => generateVaccineListItemTxt(entry)).join('')}`;
           }}
         />
 
-        <PrintDownload
-          description="Vaccines - List"
-          list
-          downloadPdf={generateVaccinesPdf}
-          allowTxtDownloads={allowTxtDownloads}
-          downloadTxt={generateVaccinesTxt}
-        />
-        <DownloadingRecordsInfo
-          allowTxtDownloads={allowTxtDownloads}
-          description="Vaccines"
-        />
         {vaccines?.length ? (
-          <RecordList records={vaccines} type={recordType.VACCINES} />
+          <>
+            <PrintDownload
+              description="Vaccines - List"
+              list
+              downloadPdf={generateVaccinesPdf}
+              allowTxtDownloads={allowTxtDownloads}
+              downloadTxt={generateVaccinesTxt}
+            />
+            <DownloadingRecordsInfo
+              allowTxtDownloads={allowTxtDownloads}
+              description="Vaccines"
+            />
+            <RecordList records={vaccines} type={recordType.VACCINES} />
+          </>
         ) : (
           <NoRecordsMessage type={recordType.VACCINES} />
         )}

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -45,6 +45,7 @@ import {
 import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
+import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 
 const Vaccines = props => {
   const { runningUnitTest } = props;
@@ -211,7 +212,11 @@ ${vaccines.map(entry => generateVaccineListItemTxt(entry)).join('')}`;
           allowTxtDownloads={allowTxtDownloads}
           description="Vaccines"
         />
-        <RecordList records={vaccines} type={recordType.VACCINES} />
+        {vaccines?.length ? (
+          <RecordList records={vaccines} type={recordType.VACCINES} />
+        ) : (
+          <NoRecordsMessage type={recordType.VACCINES} />
+        )}
       </RecordListSection>
     </div>
   );

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -28,6 +28,7 @@ import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import useAcceleratedData from '../hooks/useAcceleratedData';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
 import RecordListSection from '../components/shared/RecordListSection';
+import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 
 const Vitals = () => {
   const dispatch = useDispatch();
@@ -197,17 +198,20 @@ const Vitals = () => {
             <hr className="vads-u-margin-y--1 vads-u-padding-0" />
           </div>
         )}
-
-        <RecordList
-          records={cards}
-          type={recordType.VITALS}
-          perPage={PER_PAGE}
-          hidePagination
-          domainOptions={{
-            isAccelerating: isAcceleratingVitals,
-            timeFrame: acceleratedVitalsDate,
-          }}
-        />
+        {cards?.length ? (
+          <RecordList
+            records={cards}
+            type={recordType.VITALS}
+            perPage={PER_PAGE}
+            hidePagination
+            domainOptions={{
+              isAccelerating: isAcceleratingVitals,
+              timeFrame: acceleratedVitalsDate,
+            }}
+          />
+        ) : (
+          <NoRecordsMessage type={recordType.VITALS} />
+        )}
       </RecordListSection>
     );
   };

--- a/src/applications/mhv-medical-records/tests/components/shared/RecordListSection.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/shared/RecordListSection.unit.spec.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import RecordListSection from '../../../components/shared/RecordListSection';
+import reducer from '../../../reducers';
+
+describe('RecordListSection component', () => {
+  const mockChildren = <div data-testid="mock-children">Child Content</div>;
+  const testDate = new Date();
+  let screen;
+
+  it('renders access alert when accessAlert is true', () => {
+    screen = renderWithStoreAndRouter(
+      <RecordListSection
+        accessAlert
+        accessAlertType="error"
+        initialFhirLoad={testDate}
+      />,
+      {
+        initialState: {},
+        reducers: reducer,
+        path: '/',
+      },
+    );
+
+    expect(screen.queryByTestId('expired-alert-message')).to.exist;
+  });
+
+  it('renders access alert when initialFhirLoadTimedOut is true', () => {
+    screen = renderWithStoreAndRouter(
+      <RecordListSection
+        accessAlert={false}
+        accessAlertType="warning"
+        initialFhirLoad={testDate}
+      />,
+      {
+        initialState: {},
+        reducers: reducer,
+        path: '/',
+      },
+    );
+
+    screen.debug();
+    expect(screen.queryByTestId('initial-fhir-loading-indicator')).to.exist;
+  });
+
+  it('renders initial FHIR loading spinner when listCurrentAsOf is undefined', () => {
+    screen = renderWithStoreAndRouter(
+      <RecordListSection
+        accessAlert={false}
+        initialFhirLoad={testDate}
+        listCurrentAsOf={undefined}
+      />,
+      {
+        initialState: {},
+        reducers: reducer,
+        path: '/',
+      },
+    );
+
+    expect(screen.queryByTestId('initial-fhir-loading-indicator')).to.exist;
+  });
+
+  it('renders children when recordCount is 0', () => {
+    screen = renderWithStoreAndRouter(
+      <RecordListSection
+        recordCount={0}
+        accessAlert={false}
+        initialFhirLoad={testDate}
+        listCurrentAsOf={testDate}
+      >
+        {mockChildren}
+      </RecordListSection>,
+      {
+        initialState: {},
+        reducers: reducer,
+        path: '/',
+      },
+    );
+
+    expect(screen.getByTestId('mock-children')).to.exist;
+  });
+
+  it('renders loading spinner when no recordCount and not initial FHIR load', () => {
+    screen = renderWithStoreAndRouter(
+      <RecordListSection
+        accessAlert={false}
+        initialFhirLoad={null}
+        listCurrentAsOf={null}
+      />,
+      {
+        initialState: {},
+        reducers: reducer,
+        path: '/',
+      },
+    );
+
+    expect(screen.queryByTestId('loading-indicator')).to.exist;
+  });
+});

--- a/src/applications/mhv-medical-records/tests/components/shared/RecordListSection.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/shared/RecordListSection.unit.spec.jsx
@@ -40,7 +40,6 @@ describe('RecordListSection component', () => {
       },
     );
 
-    screen.debug();
     expect(screen.queryByTestId('initial-fhir-loading-indicator')).to.exist;
   });
 

--- a/src/applications/mhv-medical-records/util/constants.js
+++ b/src/applications/mhv-medical-records/util/constants.js
@@ -1,5 +1,5 @@
 export const recordType = {
-  ALLERGIES: 'allergies',
+  ALLERGIES: 'allergies or reactions',
   VACCINES: 'vaccines',
   CARE_SUMMARIES_AND_NOTES: 'care summaries and notes',
   LABS_AND_TESTS: 'lab and test results',

--- a/src/applications/mhv-medical-records/util/testHelper.js
+++ b/src/applications/mhv-medical-records/util/testHelper.js
@@ -1,26 +1,45 @@
+/**
+ * This module provides mock helper functions for simulating PHR (Personal Health Record)
+ * refresh scenarios in tests for the MHV Medical Records application.
+ * It emulates backend status and data responses to facilitate frontend testing of different
+ * refresh states and behaviors.
+ */
 import { refreshExtractTypes } from './constants';
 
+// Controls which mock scenario is returned by `mockGetRefreshStatus` and `mockGetData`
+// Change this value to simulate different test cases.
 const scenario = 4;
 const extractType = refreshExtractTypes.VPR;
-// 1 = Refresh times out with stale data (FAILED)
-// 2 = Refresh already happened (GRAY BAR)
-// 3 = Refresh in progress, no new records (GREEN BAR)
-// 4 = Refresh in progress, new records found (BLUE BAR)
-// 5 = Refresh in progress, failed from Vista (FAILED)
-// 6 = Refresh has stale data, but the refresh happened > 2 minutes ago (GRAY BAR)
+
+// Scenario descriptions:
+// 1 = Simulates a refresh timeout with stale data (FAILED)
+// 2 = Simulates a refresh that has already completed successfully (GRAY BAR)
+// 3 = Simulates a refresh currently in progress with no new records (GREEN BAR)
+// 4 = Simulates a refresh currently in progress with new records found (BLUE BAR)
+// 5 = Simulates a refresh in progress that ultimately fails (failure from Vista) (FAILED)
+// 6 = Simulates a stale refresh where the last successful completion was over 2 minutes ago (GRAY BAR)
 
 const beginDate = new Date();
 
+// Returns a timestamp representing the given number of minutes before the provided date.
 const minutesAgo = (date, minutes) => {
   return new Date(date.getTime() - minutes * 60 * 1000).getTime();
 };
 
+// Returns true if the elapsed time since `beginDate` exceeds the given number of seconds.
 const trueElapsed = seconds => {
   const currentTime = new Date().getTime();
   const givenTime = beginDate.getTime();
   return currentTime - givenTime > seconds * 1000;
 };
 
+/**
+ * Generates a mock facility status response object with provided time offsets.
+ * @param {number} retrieved - Minutes ago that the data was retrieved.
+ * @param {number} requested - Minutes ago that the refresh was requested.
+ * @param {number} completed - Minutes ago that the refresh was completed.
+ * @param {number} successful - Minutes ago that the refresh successfully completed.
+ */
 const mockStatusResponse = (retrieved, requested, completed, successful) => {
   const now = new Date();
   return {
@@ -41,12 +60,16 @@ const mockStatusResponse = (retrieved, requested, completed, successful) => {
 // IN_PROGRESS = requested > completed
 // FAILED = completed != successful
 // CURRENT = none of the above hold
+// params: retrieved, requested, completed, successful
 const STALE = mockStatusResponse(0, 1, 70, 70);
 const IN_PROGRESS = mockStatusResponse(0, 1, 20, 20);
 const FAILED = mockStatusResponse(0, 10, 5, 80);
 const CURRENT = mockStatusResponse(0, 10, 5, 5);
 const STALE_AND_TIMED_OUT = mockStatusResponse(0, 3, 70, 70);
 
+/**
+ * Returns a mock status object simulating different backend states based on the selected scenario.
+ */
 export const mockGetRefreshStatus = () => {
   switch (scenario) {
     case 1: {
@@ -81,6 +104,12 @@ export const mockGetRefreshStatus = () => {
   }
 };
 
+/**
+ * Returns a mock response representing the data returned from the API,
+ * based on the current scenario and elapsed time.
+ * @param {Object} response - The full mock response object.
+ * @param {boolean} isMhvData - Indicates if the response is for data from MHV.
+ */
 export const mockGetData = (response, isMhvData) => {
   let oneRecord;
   if (isMhvData) oneRecord = [response[0]];


### PR DESCRIPTION
## Summary
The PHR refresh indicator now shows when records are loaded but a user has no records. This is important because a user may show as having no records on their initial visit when the PHR refresh is running for the first time. They should see the notification that we are checking for records, even if they currently have none. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-71075
### Investigate Medallia survey issues
Description
Here is a [session replay](https://vagov.ddog-gov.com/rum/sessions?query=%40type%3Aaction%20%40application.id%3A04496177-4c70-4caf-9d1e-de7087d1d296%20%22click%20on%20Feedback%22&agg_m=count&agg_m_source=base&agg_t=count&cols=has_replay%2Cstatus%2Ctimestamp%2C%40action.type%2C%40action.name%2C%40action.frustration.type%2C%40view.name%2C%40device.type%2C%40browser.name%2C%40session.id&event=AwAAAZZY7sNRhIOfmgAAABhBWlpZN3NOUkFBQ1YtbmxlTzlMRExWN1UAAAAkMDE5NjU5MTMtZWI5Ny00YzY5LWI4NTgtMzkwMDE4YzkzOTkwAAEWyQ&fromUser=false&p_tab=performance&sort_by=timestamp&sort_order=asc&track=rum&viz=stream&from_ts=1745245800000&to_ts=1745249400000&live=false) that exhibited one of the issues. User data was being loaded for the first time and came back “There are no Care Summaries…”. The user later came back and the notes were there.

Other issues include users seeing old data but not recent data. Here is a [list in Excel](https://bylightcorporate.sharepoint.com/:x:/r/sdc/hcd/_layouts/15/doc2.aspx?sourcedoc=%7B49C7D76F-6C9A-4783-B287-2A8AC1F164D8%7D&file=2504_MHV%20on%20VA.gov%20Medallia%20feedback.xlsx&action=default&mobileredirect=true&DefaultItemOpen=1). Here's a [Mural Board](https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1741373701114/077318691a06e53780a76e418042a335792b3456).

Work with [Melissa Stern](https://jira.devops.va.gov/secure/ViewProfile.jspa?name=Melissa.Stern%40va.gov) for latest updates. As part of this work, record videos of the various scenarios for PHR refresh of records while viewing the list.

## Testing done
I wrote several unit tests for the record list section component and fixed one that was failing undetected before this fix. 

## Screenshots
Before the fix, the list pages showed no records and no PHR refresh in progress:
<img width="939" alt="Screenshot 2025-05-22 at 9 45 59 AM" src="https://github.com/user-attachments/assets/f31a0468-7b24-4965-adea-3825e6467480" />
Now the flow is:
<img width="909" alt="Screenshot 2025-05-22 at 11 47 29 AM" src="https://github.com/user-attachments/assets/75896425-4ce7-44f1-9988-609a65aba457" />
<img width="893" alt="Screenshot 2025-05-22 at 11 47 49 AM" src="https://github.com/user-attachments/assets/c60efccc-a4bc-4e5d-8854-85eb938a4795" />
<img width="898" alt="Screenshot 2025-05-22 at 12 16 28 PM" src="https://github.com/user-attachments/assets/1f9d7376-67b2-4e70-8301-acf0f2b0d31b" />
<img width="921" alt="Screenshot 2025-05-23 at 8 45 23 AM" src="https://github.com/user-attachments/assets/8f84c28c-b8b3-4a27-b425-d4227f22ecf7" />


## What areas of the site does it impact?
MHV medical records - all list pages

## Acceptance criteria
Users are shown the PHR refresh notification even if they have no records at present. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
