### PR TITLE
Remove duplicate 'Need help' section from education benefits form

### DIFF
--- a/src/applications/my-education-benefits/containers/IntroductionPage.jsx
+++ b/src/applications/my-education-benefits/containers/IntroductionPage.jsx
@@ -29,28 +29,6 @@ export const IntroductionPage = ({ featureTogglesLoaded, route }) => {
         omb-number="2900-0154"
         exp-date="03/31/2026"
       />
-
-      <div className="vads-u-padding--0 vads-u-margin-top--4 vads-u-margin-bottom--2">
-        <h2>Need help?</h2>
-        <p>
-          If you need help with your application or have questions about
-          enrollment or eligibility, submit a request with{' '}
-          <a
-            href="https://ask.va.gov/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Ask VA
-          </a>
-          .
-        </p>
-        <p>
-          If you have technical difficulties using this online application,
-          MyVA411 main information line at{' '}
-          <va-telephone contact="8006982411" extension="711" />. We’re here
-          24/7.
-        </p>
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
The 'Need help' section was appearing twice because it was included both in the FormFooter component and as a separate getHelp property in the form configuration. Removed the redundant getHelp property since FormFooter already includes the GetFormHelp component.

## Related issue(s)
<img width="892" alt="Screenshot 2025-05-22 at 4 09 14 PM" src="https://github.com/user-attachments/assets/76a62c7d-3fa7-44eb-b039-a753fddf342b" />


## Testing done
Manual testing

## Screenshots
### Before
<img width="779" alt="Screenshot 2025-05-22 at 4 06 18 PM" src="https://github.com/user-attachments/assets/4acefe9b-6195-4710-a061-c63b6b0fe740" />

### After
<img width="397" alt="Screenshot 2025-05-22 at 4 06 30 PM" src="https://github.com/user-attachments/assets/213cbaf8-eb03-431b-b1ff-861e684d916c" />

## What areas of the site does it impact?
22-1990


## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

