### PR TITLE
[#109613] Travel Pay, Add describedBy for radio description

### DIFF
--- a/src/applications/travel-pay/components/SmocRadio.jsx
+++ b/src/applications/travel-pay/components/SmocRadio.jsx
@@ -9,6 +9,7 @@ export default function SmocRadio({
   children,
   onValueChange,
   error,
+  description,
 }) {
   const options = ['Yes', 'No'];
   return (
@@ -20,6 +21,7 @@ export default function SmocRadio({
       error={error ? 'You must make a selection to continue.' : null}
       label={label}
       label-header-level="1"
+      messageAriaDescribedby={description}
     >
       {children}
       {options.map(opt => (
@@ -37,6 +39,7 @@ export default function SmocRadio({
 
 SmocRadio.propTypes = {
   children: PropTypes.node,
+  description: PropTypes.string,
   error: PropTypes.bool,
   label: PropTypes.string,
   name: PropTypes.string,

--- a/src/applications/travel-pay/components/submit-flow/pages/AddressPage.jsx
+++ b/src/applications/travel-pay/components/submit-flow/pages/AddressPage.jsx
@@ -100,6 +100,11 @@ const AddressPage = ({
         value={yesNo.address}
         error={requiredAlert}
         label={title}
+        description={`Answer “yes” if you traveled from the address listed here and you confirm that it’s not a Post Office box. Home address. ${
+          address.addressLine1
+        } ${address.addressLine2 ?? ''} ${address.addressLine3 ?? ''} ${
+          address.city
+        }, ${address.stateCode} ${address.zipCode}`}
         onValueChange={e => {
           setYesNo({ ...yesNo, address: e.detail.value });
         }}

--- a/src/applications/travel-pay/components/submit-flow/pages/MileagePage.jsx
+++ b/src/applications/travel-pay/components/submit-flow/pages/MileagePage.jsx
@@ -62,6 +62,11 @@ const MileagePage = ({
         value={yesNo.mileage}
         label={title}
         error={requiredAlert}
+        description={`For your appointment on ${formattedDate} at ${formattedTime} ${
+          data.location?.attributes?.name
+            ? `at ${data.location.attributes.name}`
+            : ''
+        }, ${data.reasonForAppointment ?? ''}`}
         onValueChange={e => {
           setYesNo({ ...yesNo, mileage: e.detail.value });
         }}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Passing a string version of the content current provided as `children` to the `VaRadio` components used for the SMOC flow in order for the content to be picked up by screenreaders.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/109613

## Testing done

Tested with VoiceOver locally. Prior to the changes, it would not read out the content now provided to `messageAriaDescribedby`

## Screenshots

### Before 
https://github.com/user-attachments/assets/929c652f-81a2-4b2c-a8f5-6ca64a351dc8 

### After
https://github.com/user-attachments/assets/cd0f88ff-6f6d-4f61-8923-9f51d6e04ea7

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user