### PR TITLE
DR 110075: Separate batched components (part 5)

### DIFF
--- a/src/applications/appeals/shared/components/ConfirmationPersonalInfo.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationPersonalInfo.jsx
@@ -1,168 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { getPhoneString } from '~/platform/forms-system/src/js/utilities/data/profile';
-
-import { renderFullName, maskVafn } from '../utils/data';
-import { getReadableDate } from '../utils/dates';
 import { showValueOrNotSelected } from '../utils/confirmation';
-
 import { chapterHeaderClass } from './ConfirmationSummary';
-
-export const VeteranInfo = ({ dob, userFullName = {}, vaFileLastFour }) => (
-  <>
-    <li>
-      <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-        Name
-      </div>
-      {renderFullName(userFullName)}
-    </li>
-    {vaFileLastFour && (
-      <li>
-        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-          VA File Number
-        </div>
-        <div
-          className="vads-u-margin-bottom--2 dd-privacy-hidden"
-          data-dd-action-name="VA file number"
-        >
-          {maskVafn(vaFileLastFour || '')}
-        </div>
-      </li>
-    )}
-    <li>
-      <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-        Date of birth
-      </div>
-      <div
-        className="vads-u-margin-bottom--2 dd-privacy-hidden"
-        data-dd-action-name="date of birth"
-      >
-        {getReadableDate(dob)}
-      </div>
-    </li>
-  </>
-);
-
-VeteranInfo.propTypes = {
-  dob: PropTypes.string,
-  userFullName: PropTypes.shape({}),
-  vaFileLastFour: PropTypes.string,
-};
-
-export const VeteranContactInfo = ({ veteran, hasHomeAndMobilePhone }) => {
-  const {
-    address = {},
-    email = '',
-    homePhone = {},
-    mobilePhone = {},
-  } = veteran;
-  // Only 995 has both home & mobile phone (currently)
-  const phone = hasHomeAndMobilePhone ? mobilePhone : veteran.phone;
-  return (
-    <>
-      {hasHomeAndMobilePhone && (
-        <li>
-          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-            Home phone number
-          </div>
-          <div
-            className="vads-u-margin-bottom--2 dd-privacy-hidden"
-            data-dd-action-name="home phone number"
-          >
-            <va-telephone
-              contact={getPhoneString(homePhone)}
-              extension={homePhone?.extension}
-              not-clickable
-            />
-          </div>
-        </li>
-      )}
-      <li>
-        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-          Mobile phone number
-        </div>
-        <div
-          className="vads-u-margin-bottom--2 dd-privacy-hidden"
-          data-dd-action-name="mobile phone number"
-        >
-          <va-telephone
-            contact={getPhoneString(phone)}
-            extension={phone?.extension}
-            not-clickable
-          />
-        </div>
-      </li>
-      <li>
-        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-          Email address
-        </div>
-        <div
-          className="vads-u-margin-bottom--2 dd-privacy-hidden"
-          data-dd-action-name="email address"
-        >
-          {email}
-        </div>
-      </li>
-      <li>
-        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
-          Mailing address
-        </div>
-        <div
-          className="vads-u-margin-bottom--2 dd-privacy-hidden"
-          data-dd-action-name="mailing address"
-        >
-          <div>{address.addressLine1}</div>
-          <div>
-            {address.city}, {address.stateCode || address.province || ''}
-            {address.addressType === 'INTERNATIONAL'
-              ? `, ${address.countryName} `
-              : ' '}
-            {address.zipCode || address.internationalPostalCode || ''}
-          </div>
-        </div>
-      </li>
-    </>
-  );
-};
-
-VeteranContactInfo.propTypes = {
-  hasHomeAndMobilePhone: PropTypes.bool,
-  veteran: PropTypes.shape({
-    vaFileLastFour: PropTypes.string,
-    address: PropTypes.shape({
-      addressLine1: PropTypes.string,
-      addressLine2: PropTypes.string,
-      addressLine3: PropTypes.string,
-      addressType: PropTypes.string,
-      city: PropTypes.string,
-      countryName: PropTypes.string,
-      internationalPostalCode: PropTypes.string,
-      province: PropTypes.string,
-      stateCode: PropTypes.string,
-      zipCode: PropTypes.string,
-    }),
-    email: PropTypes.string,
-    phone: PropTypes.shape({
-      countryCode: PropTypes.string,
-      areaCode: PropTypes.string,
-      phoneNumber: PropTypes.string,
-      phoneNumberExt: PropTypes.string,
-    }),
-    homePhone: PropTypes.shape({
-      countryCode: PropTypes.string,
-      areaCode: PropTypes.string,
-      phoneNumber: PropTypes.string,
-      phoneNumberExt: PropTypes.string,
-    }),
-    mobilePhone: PropTypes.shape({
-      countryCode: PropTypes.string,
-      areaCode: PropTypes.string,
-      phoneNumber: PropTypes.string,
-      phoneNumberExt: PropTypes.string,
-    }),
-  }),
-};
+import { ConfirmationVeteranID } from './ConfirmationVeteranID';
+import { ConfirmationVeteranContact } from './ConfirmationVeteranContact';
 
 const ConfirmationPersonalInfo = data => {
   const {
@@ -182,7 +23,7 @@ const ConfirmationPersonalInfo = data => {
           a problem with Safari not treating the `ul` as a list. */}
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ul className="remove-bullets" role="list">
-        <VeteranInfo
+        <ConfirmationVeteranID
           dob={dob}
           userFullName={userFullName}
           vaFileLastFour={vaFileLastFour}
@@ -202,7 +43,7 @@ const ConfirmationPersonalInfo = data => {
           </li>
         )}
 
-        <VeteranContactInfo
+        <ConfirmationVeteranContact
           veteran={veteran}
           hasHomeAndMobilePhone={hasHomeAndMobilePhone}
         />

--- a/src/applications/appeals/shared/components/ConfirmationVeteranContact.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationVeteranContact.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getPhoneString } from '~/platform/forms-system/src/js/utilities/data/profile';
+
+export const ConfirmationVeteranContact = ({
+  veteran,
+  hasHomeAndMobilePhone,
+}) => {
+  const {
+    address = {},
+    email = '',
+    homePhone = {},
+    mobilePhone = {},
+  } = veteran;
+  // Only 995 has both home & mobile phone (currently)
+  const phone = hasHomeAndMobilePhone ? mobilePhone : veteran.phone;
+  return (
+    <>
+      {hasHomeAndMobilePhone && (
+        <li>
+          <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+            Home phone number
+          </div>
+          <div
+            className="vads-u-margin-bottom--2 dd-privacy-hidden"
+            data-dd-action-name="home phone number"
+          >
+            <va-telephone
+              contact={getPhoneString(homePhone)}
+              extension={homePhone?.extension}
+              not-clickable
+            />
+          </div>
+        </li>
+      )}
+      <li>
+        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+          Mobile phone number
+        </div>
+        <div
+          className="vads-u-margin-bottom--2 dd-privacy-hidden"
+          data-dd-action-name="mobile phone number"
+        >
+          <va-telephone
+            contact={getPhoneString(phone)}
+            extension={phone?.extension}
+            not-clickable
+          />
+        </div>
+      </li>
+      <li>
+        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+          Email address
+        </div>
+        <div
+          className="vads-u-margin-bottom--2 dd-privacy-hidden"
+          data-dd-action-name="email address"
+        >
+          {email}
+        </div>
+      </li>
+      <li>
+        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+          Mailing address
+        </div>
+        <div
+          className="vads-u-margin-bottom--2 dd-privacy-hidden"
+          data-dd-action-name="mailing address"
+        >
+          <div>{address.addressLine1}</div>
+          <div>
+            {address.city}, {address.stateCode || address.province || ''}
+            {address.addressType === 'INTERNATIONAL'
+              ? `, ${address.countryName} `
+              : ' '}
+            {address.zipCode || address.internationalPostalCode || ''}
+          </div>
+        </div>
+      </li>
+    </>
+  );
+};
+
+ConfirmationVeteranContact.propTypes = {
+  hasHomeAndMobilePhone: PropTypes.bool,
+  veteran: PropTypes.shape({
+    vaFileLastFour: PropTypes.string,
+    address: PropTypes.shape({
+      addressLine1: PropTypes.string,
+      addressLine2: PropTypes.string,
+      addressLine3: PropTypes.string,
+      addressType: PropTypes.string,
+      city: PropTypes.string,
+      countryName: PropTypes.string,
+      internationalPostalCode: PropTypes.string,
+      province: PropTypes.string,
+      stateCode: PropTypes.string,
+      zipCode: PropTypes.string,
+    }),
+    email: PropTypes.string,
+    phone: PropTypes.shape({
+      countryCode: PropTypes.string,
+      areaCode: PropTypes.string,
+      phoneNumber: PropTypes.string,
+      phoneNumberExt: PropTypes.string,
+    }),
+    homePhone: PropTypes.shape({
+      countryCode: PropTypes.string,
+      areaCode: PropTypes.string,
+      phoneNumber: PropTypes.string,
+      phoneNumberExt: PropTypes.string,
+    }),
+    mobilePhone: PropTypes.shape({
+      countryCode: PropTypes.string,
+      areaCode: PropTypes.string,
+      phoneNumber: PropTypes.string,
+      phoneNumberExt: PropTypes.string,
+    }),
+  }),
+};

--- a/src/applications/appeals/shared/components/ConfirmationVeteranID.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationVeteranID.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { renderFullName, maskVafn } from '../utils/data';
+import { getReadableDate } from '../utils/dates';
+
+export const ConfirmationVeteranID = ({
+  dob,
+  userFullName = {},
+  vaFileLastFour,
+}) => (
+  <>
+    <li>
+      <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+        Name
+      </div>
+      {renderFullName(userFullName)}
+    </li>
+    {vaFileLastFour && (
+      <li>
+        <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+          VA File Number
+        </div>
+        <div
+          className="vads-u-margin-bottom--2 dd-privacy-hidden"
+          data-dd-action-name="VA file number"
+        >
+          {maskVafn(vaFileLastFour || '')}
+        </div>
+      </li>
+    )}
+    <li>
+      <div className="vads-u-margin-bottom--0p5 vads-u-color--gray vads-u-font-size--sm">
+        Date of birth
+      </div>
+      <div
+        className="vads-u-margin-bottom--2 dd-privacy-hidden"
+        data-dd-action-name="date of birth"
+      >
+        {getReadableDate(dob)}
+      </div>
+    </li>
+  </>
+);
+
+ConfirmationVeteranID.propTypes = {
+  dob: PropTypes.string,
+  userFullName: PropTypes.shape({}),
+  vaFileLastFour: PropTypes.string,
+};

--- a/src/applications/appeals/shared/tests/components/ConfirmationPersonalInfo.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationPersonalInfo.unit.spec.jsx
@@ -1,53 +1,12 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-
 import {
   $,
   $$,
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
-
-import ConfirmationPersonalInfo, {
-  VeteranInfo,
-  VeteranContactInfo,
-} from '../../components/ConfirmationPersonalInfo';
-
-const dob = '2001-10-28';
-const userFullName = {
-  first: 'Mike',
-  middle: '',
-  last: 'Wazowski',
-  suffix: '',
-};
-const veteran = (US = true, phone = 'phone') => ({
-  vaFileLastFour: '8765',
-  address: {
-    addressType: US ? 'DOMESTIC' : 'INTERNATIONAL',
-    addressLine1: '123 Main St',
-    addressLine2: 'Suite #1200',
-    addressLine3: 'Box 4567890',
-    city: US ? 'New York' : 'Paris',
-    countryName: US ? 'United States' : 'France',
-    countryCodeIso2: US ? 'US' : 'FR',
-    stateCode: US ? 'NY' : null,
-    province: US ? null : 'Ile-de-France',
-    zipCode: US ? '30012' : null,
-    internationalPostalCode: US ? null : '75000',
-  },
-  [phone]: {
-    countryCode: '6',
-    areaCode: '555',
-    phoneNumber: '8001111',
-    extension: '2345',
-  },
-  homePhone: {
-    countryCode: '7',
-    areaCode: '555',
-    phoneNumber: '8002222',
-    extension: '5678',
-  },
-  email: 'user@example.com',
-});
+import ConfirmationPersonalInfo from '../../components/ConfirmationPersonalInfo';
+import { dob, userFullName, veteran } from '../data/veteran';
 
 describe('ConfirmationPersonalInfo', () => {
   it('should render all fields for HLR & NOD', () => {
@@ -163,81 +122,5 @@ describe('ConfirmationPersonalInfo', () => {
         (item, index) => item[index === 3 ? 'innerHTML' : 'textContent'],
       ),
     ).to.deep.equal(['', 'Not selected', '', '', ',  ']);
-  });
-});
-
-describe('VeteranInfo', () => {
-  it('should render all fields', () => {
-    const { container } = render(
-      <VeteranInfo
-        dob={dob}
-        userFullName={userFullName}
-        vaFileLastFour={veteran().vaFileLastFour}
-      />,
-    );
-
-    expect(
-      $$('.dd-privacy-hidden[data-dd-action-name]', container).length,
-    ).to.eq(3);
-    const items = $$('li', container);
-    expect(items.map(item => item.textContent)).to.deep.equal([
-      'NameMike Wazowski',
-      'VA File Number●●●–●●–8765V A file number ending with 8 7 6 5',
-      'Date of birthOctober 28, 2001',
-    ]);
-  });
-
-  it('should render without any data', () => {
-    const { container } = render(<VeteranInfo />);
-
-    expect(
-      $$('.dd-privacy-hidden[data-dd-action-name]', container).length,
-    ).to.eq(1);
-    const items = $$('li', container);
-    expect(items.length).to.eq(2);
-    expect(items.map(item => item.textContent)).to.deep.equal([
-      'Name',
-      'Date of birth',
-    ]);
-  });
-});
-
-describe('VeteranContactInfo', () => {
-  it('should render one phone field', () => {
-    const { container } = render(<VeteranContactInfo veteran={veteran()} />);
-
-    const items = $$('.dd-privacy-hidden[data-dd-action-name]', container);
-    expect(items.length).to.eq(3);
-    expect(
-      items.map(
-        (item, index) => item[index === 0 ? 'innerHTML' : 'textContent'],
-      ),
-    ).to.deep.equal([
-      '<va-telephone contact="5558001111" extension="2345" not-clickable="true"></va-telephone>',
-      'user@example.com',
-      '123 Main StNew York, NY 30012',
-    ]);
-  });
-  it('should render two phone fields (SC)', () => {
-    const { container } = render(
-      <VeteranContactInfo
-        veteran={veteran(true, 'mobilePhone')}
-        hasHomeAndMobilePhone
-      />,
-    );
-
-    const items = $$('.dd-privacy-hidden[data-dd-action-name]', container);
-    expect(items.length).to.eq(4);
-    expect(
-      items.map(
-        (item, index) =>
-          item[[0, 1].includes(index) ? 'innerHTML' : 'textContent'],
-      ),
-    ).to.deep.equal([
-      '<va-telephone contact="5558002222" extension="5678" not-clickable="true"></va-telephone>',
-      '<va-telephone contact="5558001111" extension="2345" not-clickable="true"></va-telephone>',
-      'user@example.com',
-      '123 Main StNew York, NY 30012',
-    ]);
   });
 });

--- a/src/applications/appeals/shared/tests/components/ConfirmationVeteranContact.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationVeteranContact.unit.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { $$ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { ConfirmationVeteranContact } from '../../components/ConfirmationVeteranContact';
+import { veteran } from '../data/veteran';
+
+describe('ConfirmationVeteranContact', () => {
+  it('should render one phone field', () => {
+    const { container } = render(
+      <ConfirmationVeteranContact veteran={veteran()} />,
+    );
+
+    const items = $$('.dd-privacy-hidden[data-dd-action-name]', container);
+    expect(items.length).to.eq(3);
+    expect(
+      items.map(
+        (item, index) => item[index === 0 ? 'innerHTML' : 'textContent'],
+      ),
+    ).to.deep.equal([
+      '<va-telephone contact="5558001111" extension="2345" not-clickable="true"></va-telephone>',
+      'user@example.com',
+      '123 Main StNew York, NY 30012',
+    ]);
+  });
+
+  it('should render two phone fields (SC)', () => {
+    const { container } = render(
+      <ConfirmationVeteranContact
+        veteran={veteran(true, 'mobilePhone')}
+        hasHomeAndMobilePhone
+      />,
+    );
+
+    const items = $$('.dd-privacy-hidden[data-dd-action-name]', container);
+    expect(items.length).to.eq(4);
+    expect(
+      items.map(
+        (item, index) =>
+          item[[0, 1].includes(index) ? 'innerHTML' : 'textContent'],
+      ),
+    ).to.deep.equal([
+      '<va-telephone contact="5558002222" extension="5678" not-clickable="true"></va-telephone>',
+      '<va-telephone contact="5558001111" extension="2345" not-clickable="true"></va-telephone>',
+      'user@example.com',
+      '123 Main StNew York, NY 30012',
+    ]);
+  });
+});

--- a/src/applications/appeals/shared/tests/components/ConfirmationVeteranID.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationVeteranID.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { $$ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { ConfirmationVeteranID } from '../../components/ConfirmationVeteranID';
+import { dob, userFullName, veteran } from '../data/veteran';
+
+describe('ConfirmationVeteranID', () => {
+  it('should render all fields', () => {
+    const { container } = render(
+      <ConfirmationVeteranID
+        dob={dob}
+        userFullName={userFullName}
+        vaFileLastFour={veteran().vaFileLastFour}
+      />,
+    );
+
+    expect(
+      $$('.dd-privacy-hidden[data-dd-action-name]', container).length,
+    ).to.eq(3);
+    const items = $$('li', container);
+    expect(items.map(item => item.textContent)).to.deep.equal([
+      'NameMike Wazowski',
+      'VA File Number●●●–●●–8765V A file number ending with 8 7 6 5',
+      'Date of birthOctober 28, 2001',
+    ]);
+  });
+
+  it('should render without any data', () => {
+    const { container } = render(<ConfirmationVeteranID />);
+
+    expect(
+      $$('.dd-privacy-hidden[data-dd-action-name]', container).length,
+    ).to.eq(1);
+    const items = $$('li', container);
+    expect(items.length).to.eq(2);
+    expect(items.map(item => item.textContent)).to.deep.equal([
+      'Name',
+      'Date of birth',
+    ]);
+  });
+});

--- a/src/applications/appeals/shared/tests/data/veteran.js
+++ b/src/applications/appeals/shared/tests/data/veteran.js
@@ -1,0 +1,37 @@
+export const dob = '2001-10-28';
+export const userFullName = {
+  first: 'Mike',
+  middle: '',
+  last: 'Wazowski',
+  suffix: '',
+};
+
+export const veteran = (US = true, phone = 'phone') => ({
+  vaFileLastFour: '8765',
+  address: {
+    addressType: US ? 'DOMESTIC' : 'INTERNATIONAL',
+    addressLine1: '123 Main St',
+    addressLine2: 'Suite #1200',
+    addressLine3: 'Box 4567890',
+    city: US ? 'New York' : 'Paris',
+    countryName: US ? 'United States' : 'France',
+    countryCodeIso2: US ? 'US' : 'FR',
+    stateCode: US ? 'NY' : null,
+    province: US ? null : 'Ile-de-France',
+    zipCode: US ? '30012' : null,
+    internationalPostalCode: US ? null : '75000',
+  },
+  [phone]: {
+    countryCode: '6',
+    areaCode: '555',
+    phoneNumber: '8001111',
+    extension: '2345',
+  },
+  homePhone: {
+    countryCode: '7',
+    areaCode: '555',
+    phoneNumber: '8002222',
+    extension: '5678',
+  },
+  email: 'user@example.com',
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In the Decision Reviews shared code ([src/applications/appeals/shared in vets-website](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/appeals/shared)), there are some files that house multiple individual components (multiple `export const`s). These components should live in separate files. This reduces the cognitive load of code changes on the author and reviewers as well as reduces dependency/risk when making changes in a single file.

No UI or functionality changes are expected.

Details about the code changes are in comments in the diffs.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/110075

## Testing done

Cypress & unit tests pass. Also did manual runthroughs of the flows at:

- Supplemental Claims: http://localhost:3001/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start
- Higher Level Review: http://localhost:3001/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/start
- Notice of Disagreement: http://localhost:3001/decision-reviews/board-appeal/request-board-appeal-form-10182/introduction

## What areas of the site does it impact?

All 3 DR flows' confirmation pages.

Screenshots of the components in-context in the apps:

### SC
<img width="500" alt="Screenshot 2025-05-23 at 9 27 18 AM" src="https://github.com/user-attachments/assets/e694ec5a-140e-4462-b04d-f8a1168729cd" />

### HLR

<img width="500" alt="Screenshot 2025-05-23 at 9 29 29 AM" src="https://github.com/user-attachments/assets/2ac19eef-4429-41fa-b7d9-548da47ba3d7" />


### NOD

<img width="500" alt="Screenshot 2025-05-23 at 9 31 19 AM" src="https://github.com/user-attachments/assets/8e985ef4-f7a2-457b-947b-6749a3b6f269" />


## Acceptance Criteria

- [x] [ConfirmationPersonalInfo](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/appeals/shared/components/ConfirmationPersonalInfo.jsx) is separated into individual files per exported component