### PR TITLE
Fixed pathname

### DIFF
--- a/src/platform/user/widgets/representative-status/components/cards/CurrentRep.jsx
+++ b/src/platform/user/widgets/representative-status/components/cards/CurrentRep.jsx
@@ -21,8 +21,9 @@ export function CurrentRep({
   vcfUrl,
 }) {
   // "Learn more" link becomes Find-a-Rep link when place in profile (per design)
-  const containerIsProfile =
-    window.location.pathname === '/profile/accredited-representative';
+  const containerIsProfile = window.location.pathname.startsWith(
+    '/profile/accredited-representative',
+  );
 
   const isOrganization = poaType === 'organization';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed pathname check to use `startsWith` instead of exact match

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110426

