### PR TITLE
Fix heading level error in SaveInProgressIntro alert

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -168,7 +168,7 @@ class SaveInProgressIntro extends React.Component {
           <div>
             <va-alert status="info" visible>
               <Header slot="headline">
-                We've prefilled some of your information
+                We’ve prefilled some of your information
               </Header>
               Since you’re signed in, we can prefill part of your {appType}{' '}
               based on your profile details. You can also save your {appType} in

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -87,6 +87,8 @@ class SaveInProgressIntro extends React.Component {
     // You can continue applying now for planning and career guidance, or...
     const appContinuing = formConfig?.customText?.appContinuing || '';
 
+    const Header = `h${this.props.headingLevel}`;
+
     if (login.currentlyLoggedIn) {
       if (savedForm) {
         /**
@@ -111,7 +113,6 @@ class SaveInProgressIntro extends React.Component {
         const isExpired = isBefore(expiresAt, new Date());
         const inProgressMessage = getInProgressMessage(formConfig);
 
-        const Header = `h${this.props.headingLevel}`;
         if (!isExpired) {
           const lastSavedDateTime =
             savedAt && format(savedAt, "MMMM d, yyyy', at' h:mm aaaa z");
@@ -166,7 +167,9 @@ class SaveInProgressIntro extends React.Component {
         alert = (
           <div>
             <va-alert status="info" visible>
-              <h3>We've prefilled some of your information</h3>
+              <Header slot="headline">
+                We've prefilled some of your information
+              </Header>
               Since you’re signed in, we can prefill part of your {appType}{' '}
               based on your profile details. You can also save your {appType} in
               progress and come back later to finish filling it out.

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -318,7 +318,8 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       />,
     );
 
-    expect(tree.find('va-alert h3').text()).to.equal(
+    // Default heading level is 2
+    expect(tree.find('va-alert h2').text()).to.equal(
       "We've prefilled some of your information",
     );
 

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -320,7 +320,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
 
     // Default heading level is 2
     expect(tree.find('va-alert h2').text()).to.equal(
-      "We've prefilled some of your information",
+      'We’ve prefilled some of your information',
     );
 
     const alertText = tree.find('va-alert').text();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
A conditional alert in the SaveInProgressIntro component was failing the new cypress axe heading order rule in the bdd-claims cypress spec.

- _(Summarize the changes that have been made to the platform)_
This PR updates a conditional alert to use the headingLevel props, instead of a hard-coded h3.
Another small fix was to replace a straight quote with a curly quote, per the [VA style guide](https://design.va.gov/content-style-guide/punctuation#apostrophes)

- _(If bug, how to reproduce)_
With the hard-coded h3, this was the the error message using the new axe rules in src/applications/disability-benefits/all-claims/tests/bdd-claims.cypress.spec.js. (Results have been flakey, so you may have to run it many times.)
```
| html           │ <h3>We've prefilled some of your information</h3>  
| failure summary │ Fix any of the following:     Heading order invalid  
```

- _(What is the solution, why is this the solution)_
The pattern of using the headingLevel props is already used within the component, which allows flexibility on the heading level based on where this alert will appear. 

- _(Which team do you work for, does your team own the maintenance of this component?)_
Disability benefits

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/109736
https://github.com/department-of-veterans-affairs/va.gov-team/issues/106879

## Testing done

- _Describe what the old behavior was prior to the change_
The alert heading was hard-coded as an h3
- _Describe the steps required to verify your changes are working as expected_
Run the maximal bdd spec in cypress using the new axe rules: `src/applications/disability-benefits/all-claims/tests/bdd-claims.cypress.spec.js`  Instructions for using the new rules are in the ticket.
- _Describe the tests completed and the results_
Cypress tests pass with new axe rule
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

BEFORE (h3 + straight quote)
![Screenshot 2025-05-23 at 3 10 38 PM](https://github.com/user-attachments/assets/8a80107c-163c-4256-a9e1-5fc1cdbc3cca)

AFTER (h2 + curly quote)
![Screenshot 2025-05-27 at 11 21 39 AM](https://github.com/user-attachments/assets/aeaee3d4-7b42-4972-bf20-2b8186b0bb57)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
