### PR TITLE
fix(dea): add 'Veteran or' to eligibility criteria text

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/IntroductionPage.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/IntroductionPage.jsx
@@ -119,9 +119,9 @@ export const IntroductionPage = ({
                 90 days, <strong>or</strong>
               </li>
               <li>
-                The service member is in the hospital or getting outpatient
-                treatment for a service-connected permanent and total disability
-                and is likely to be discharged for the disability,{' '}
+                The Veteran or service member is in the hospital or getting
+                outpatient treatment for a service-connected permanent and total
+                disability and is likely to be discharged for the disability,{' '}
                 <strong>and</strong>
               </li>
               <li>You meet other requirements</li>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Adds "Veteran or" before "service member" in the DEA eligibility criteria text to maintain consistent terminology throughout the form's eligibility requirements.


## What areas of the site does it impact?
5490 introduction page

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
