### PR TITLE
Add cy.fillAddressWebComponentPattern+ update simple forms

### DIFF
--- a/src/applications/simple-forms/20-10207/tests/e2e/10207-pp.cypress.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/e2e/10207-pp.cypress.spec.js
@@ -4,7 +4,6 @@ import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import {
-  fillAddressWebComponentPattern,
   fillDateWebComponentPattern,
   fillTextWebComponent,
   reviewAndSubmitPageFlow,
@@ -70,7 +69,7 @@ const testConfig = createTestConfig(
       'veteran-mailing-address': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranMailingAddress',
               data.veteranMailingAddress,
             );
@@ -115,7 +114,10 @@ const testConfig = createTestConfig(
             const { facilityName, facilityAddress } = medicalTreatments[0];
 
             fillTextWebComponent('facilityName', facilityName);
-            fillAddressWebComponentPattern('facilityAddress', facilityAddress);
+            cy.fillAddressWebComponentPattern(
+              'facilityAddress',
+              facilityAddress,
+            );
 
             cy.findAllByText(/^Continue/, { selector: 'button' })
               .last()

--- a/src/applications/simple-forms/21-0845/tests/e2e/0845-auth-disclose.cypress.spec.js
+++ b/src/applications/simple-forms/21-0845/tests/e2e/0845-auth-disclose.cypress.spec.js
@@ -8,10 +8,7 @@ import manifest from '../../manifest.json';
 import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
 import user from './fixtures/mocks/user.json';
 import { AUTHORIZER_TYPES } from '../../definitions/constants';
-import {
-  fillAddressWebComponentPattern,
-  reviewAndSubmitPageFlow,
-} from '../../../shared/tests/e2e/helpers';
+import { reviewAndSubmitPageFlow } from '../../../shared/tests/e2e/helpers';
 import sipPut from './fixtures/mocks/in-progress-forms-put.json';
 import sipGet from './fixtures/mocks/in-progress-forms-get.json';
 
@@ -32,7 +29,7 @@ const testConfig = createTestConfig(
       'authorizer-address': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'authorizerAddress',
               data.authorizerAddress,
             );
@@ -53,7 +50,10 @@ const testConfig = createTestConfig(
       'disclosure-information-person-address': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern('personAddress', data.personAddress);
+            cy.fillAddressWebComponentPattern(
+              'personAddress',
+              data.personAddress,
+            );
 
             cy.axeCheck('.form-panel');
             cy.findByText(/continue/i, { selector: 'button' }).click();
@@ -63,7 +63,7 @@ const testConfig = createTestConfig(
       'disclosure-information-organization-address': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'organizationAddress',
               data.organizationAddress,
             );

--- a/src/applications/simple-forms/21-0966/tests/e2e/21-0966-intent-to-file-a-claim.cypress.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/e2e/21-0966-intent-to-file-a-claim.cypress.spec.js
@@ -4,10 +4,7 @@ import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import { statementOfTruthFullNamePath } from '../../config/helpers';
-import {
-  fillAddressWebComponentPattern,
-  reviewAndSubmitPageFlow,
-} from '../../../shared/tests/e2e/helpers';
+import { reviewAndSubmitPageFlow } from '../../../shared/tests/e2e/helpers';
 import mockUser from './fixtures/mocks/user.json';
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
 
@@ -46,7 +43,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'survivingDependentMailingAddress',
               data.survivingDependentMailingAddress,
             );
@@ -61,7 +58,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranMailingAddress',
               data.veteranMailingAddress,
             );

--- a/src/applications/simple-forms/21-0966/tests/e2e/21-0966-itf-active-compensation.cypress.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/e2e/21-0966-itf-active-compensation.cypress.spec.js
@@ -4,10 +4,7 @@ import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import { statementOfTruthFullNamePath } from '../../config/helpers';
-import {
-  fillAddressWebComponentPattern,
-  reviewAndSubmitPageFlow,
-} from '../../../shared/tests/e2e/helpers';
+import { reviewAndSubmitPageFlow } from '../../../shared/tests/e2e/helpers';
 import mockUser from './fixtures/mocks/user.json';
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
 
@@ -40,7 +37,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'survivingDependentMailingAddress',
               data.survivingDependentMailingAddress,
             );
@@ -55,7 +52,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranMailingAddress',
               data.veteranMailingAddress,
             );

--- a/src/applications/simple-forms/21-0966/tests/e2e/21-0966-itf-active-pension.cypress.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/e2e/21-0966-itf-active-pension.cypress.spec.js
@@ -4,10 +4,7 @@ import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import { statementOfTruthFullNamePath } from '../../config/helpers';
-import {
-  fillAddressWebComponentPattern,
-  reviewAndSubmitPageFlow,
-} from '../../../shared/tests/e2e/helpers';
+import { reviewAndSubmitPageFlow } from '../../../shared/tests/e2e/helpers';
 import mockUser from './fixtures/mocks/user.json';
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
 
@@ -40,7 +37,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'survivingDependentMailingAddress',
               data.survivingDependentMailingAddress,
             );
@@ -55,7 +52,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranMailingAddress',
               data.veteranMailingAddress,
             );

--- a/src/applications/simple-forms/21-0972/tests/e2e/21-0972-alternate-signer.cypress.spec.js
+++ b/src/applications/simple-forms/21-0972/tests/e2e/21-0972-alternate-signer.cypress.spec.js
@@ -7,10 +7,7 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
 import user from './fixtures/mocks/user.json';
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
-import {
-  fillAddressWebComponentPattern,
-  reviewAndSubmitPageFlow,
-} from '../../../shared/tests/e2e/helpers';
+import { reviewAndSubmitPageFlow } from '../../../shared/tests/e2e/helpers';
 
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
@@ -41,7 +38,7 @@ const testConfig = createTestConfig(
       [pagePaths.preparerAddress]: ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'preparerAddress',
               data.preparerAddress,
             );
@@ -54,7 +51,7 @@ const testConfig = createTestConfig(
       [pagePaths.claimantAddress]: ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'claimantAddress',
               data.claimantAddress,
             );

--- a/src/applications/simple-forms/21-10210/tests/e2e/10210-lay-witness-statement.cypress.spec.js
+++ b/src/applications/simple-forms/21-10210/tests/e2e/10210-lay-witness-statement.cypress.spec.js
@@ -11,7 +11,6 @@ import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-sub
 import user from './fixtures/mocks/user.json';
 import {
   getPagePaths,
-  fillAddressWebComponentPattern,
   reviewAndSubmitPageFlow,
 } from '../../../shared/tests/e2e/helpers';
 
@@ -57,7 +56,7 @@ const testConfig = createTestConfig(
       [pagePaths.veteranMailingAddressInfo1]: ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranMailingAddress',
               data.veteranMailingAddress,
             );
@@ -71,7 +70,7 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.get('@testData').then(data => {
             if (data.claimantMailingAddress) {
-              fillAddressWebComponentPattern(
+              cy.fillAddressWebComponentPattern(
                 'claimantMailingAddress',
                 data.claimantMailingAddress,
               );

--- a/src/applications/simple-forms/21-4138/tests/e2e/4138-ss.cypress.spec.js
+++ b/src/applications/simple-forms/21-4138/tests/e2e/4138-ss.cypress.spec.js
@@ -4,7 +4,6 @@ import testForm from '~/platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from '~/platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import {
-  fillAddressWebComponentPattern,
   fillDateWebComponentPattern,
   fillFullNameWebComponentPattern,
   fillTextAreaWebComponent,
@@ -90,7 +89,7 @@ const testConfig = createTestConfig(
       'mailing-address': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'mailingAddress',
               data.mailingAddress,
             );

--- a/src/applications/simple-forms/21-4142/tests/e2e/4142-medial-release.cypress.spec.js
+++ b/src/applications/simple-forms/21-4142/tests/e2e/4142-medial-release.cypress.spec.js
@@ -8,7 +8,6 @@ import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 import { fillProviderFacility } from './helpers';
 import {
-  fillAddressWebComponentPattern,
   reviewAndSubmitPageFlow,
   selectYesNoWebComponent,
 } from '../../../shared/tests/e2e/helpers';
@@ -52,7 +51,7 @@ const testConfig = createTestConfig(
                   }
                 }
               } else {
-                fillAddressWebComponentPattern(
+                cy.fillAddressWebComponentPattern(
                   'veteran_address',
                   data.veteran.address,
                 );

--- a/src/applications/simple-forms/21P-0847/tests/e2e/21P-0847-substitute-claimant.cypress.spec.js
+++ b/src/applications/simple-forms/21P-0847/tests/e2e/21P-0847-substitute-claimant.cypress.spec.js
@@ -6,7 +6,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
 import {
-  fillAddressWebComponentPattern,
   fillDateWebComponentPattern,
   fillFullNameWebComponentPattern,
   fillTextAreaWebComponent,
@@ -58,7 +57,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'preparerAddress',
               data.preparerAddress,
             );

--- a/src/applications/simple-forms/26-4555/tests/e2e/4555-adapted-housing.cypress.spec.js
+++ b/src/applications/simple-forms/26-4555/tests/e2e/4555-adapted-housing.cypress.spec.js
@@ -5,10 +5,7 @@ import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-tog
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
-import {
-  fillAddressWebComponentPattern,
-  reviewAndSubmitPageFlow,
-} from '../../../shared/tests/e2e/helpers';
+import { reviewAndSubmitPageFlow } from '../../../shared/tests/e2e/helpers';
 import user from './fixtures/mocks/user.json';
 import sipPut from './fixtures/mocks/sip-put.json';
 import sipGet from './fixtures/mocks/sip-get.json';
@@ -51,7 +48,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteran_address',
               data.veteran.address,
             );

--- a/src/applications/simple-forms/40-0247/tests/e2e/0247-pmc.cypress.spec.js
+++ b/src/applications/simple-forms/40-0247/tests/e2e/0247-pmc.cypress.spec.js
@@ -4,7 +4,6 @@ import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
 import {
-  fillAddressWebComponentPattern,
   fillTextWebComponent,
   reviewAndSubmitPageFlow,
 } from '../../../shared/tests/e2e/helpers';
@@ -92,7 +91,7 @@ const testConfig = createTestConfig(
                     // even now we must wait a bit!
                     // eslint-disable-next-line cypress/no-unnecessary-waiting
                     cy.wait(1000);
-                    fillAddressWebComponentPattern(
+                    cy.fillAddressWebComponentPattern(
                       'applicantAddress',
                       data.applicantAddress,
                     );
@@ -119,7 +118,7 @@ const testConfig = createTestConfig(
                     // even now we must wait a bit!
                     // eslint-disable-next-line cypress/no-unnecessary-waiting
                     cy.wait(1000);
-                    fillAddressWebComponentPattern(
+                    cy.fillAddressWebComponentPattern(
                       'additionalAddress',
                       additionalAddress,
                     );

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/tests/e2e/mock-simple-forms-patterns-v3.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/tests/e2e/mock-simple-forms-patterns-v3.cypress.spec.js
@@ -3,7 +3,6 @@ import path from 'path';
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
-import { fillAddressWebComponentPattern } from 'applications/simple-forms/shared/tests/e2e/helpers';
 import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
 
@@ -28,7 +27,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern('address', data.address);
+            cy.fillAddressWebComponentPattern('address', data.address);
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
@@ -39,7 +38,7 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.get('@testData').then(data => {
             cy.fillVaTextInput('root_name', data.treatmentRecords[0].name);
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'address',
               data.treatmentRecords[0].address,
             );

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-forms-patterns.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-simple-forms-patterns.cypress.spec.js
@@ -5,10 +5,7 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 
 import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
 import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
-import {
-  introductionPageFlow,
-  selectDropdownWebComponent,
-} from '../../../shared/tests/e2e/helpers';
+import { introductionPageFlow } from '../../../shared/tests/e2e/helpers';
 
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
@@ -32,13 +29,7 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.get('@testData').then(data => {
             // widgets
-            cy.fillPage();
-            // fillPage doesn't catch state select, so select state manually
-            selectDropdownWebComponent(
-              `wcv3Address_state`,
-              data.wcv3Address.state,
-            );
-
+            cy.fillAddressWebComponentPattern(`wcv3Address`, data.wcv3Address);
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });

--- a/src/applications/simple-forms/shared/tests/e2e/helpers.js
+++ b/src/applications/simple-forms/shared/tests/e2e/helpers.js
@@ -69,27 +69,6 @@ export const fillFullNameWebComponentPattern = (fieldName, fullName) => {
   fillTextWebComponent(`${fieldName}_last`, fullName.last);
 };
 
-export const fillAddressWebComponentPattern = (fieldName, addressObject) => {
-  selectCheckboxWebComponent(
-    `${fieldName}_isMilitary`,
-    addressObject.isMilitary,
-  );
-  if (addressObject.city) {
-    if (addressObject.isMilitary) {
-      // there is a select dropdown instead when military is checked
-      selectDropdownWebComponent(`${fieldName}_city`, addressObject.city);
-    } else {
-      fillTextWebComponent(`${fieldName}_city`, addressObject.city);
-    }
-  }
-  selectDropdownWebComponent(`${fieldName}_country`, addressObject.country);
-  fillTextWebComponent(`${fieldName}_street`, addressObject.street);
-  fillTextWebComponent(`${fieldName}_street2`, addressObject.street2);
-  fillTextWebComponent(`${fieldName}_street3`, addressObject.street3);
-  selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
-  fillTextWebComponent(`${fieldName}_postalCode`, addressObject.postalCode);
-};
-
 export const fillDateWebComponentPattern = (fieldName, value) => {
   if (typeof value !== 'undefined') {
     const [year, month, day] = value.split('-');

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -375,3 +375,41 @@ Cypress.Commands.add('checkWebComponent', callback => {
     callback(hasWebComponents);
   });
 });
+
+Cypress.Commands.add(
+  'fillAddressWebComponentPattern',
+  (fieldName, addressObject) => {
+    if (!addressObject) {
+      return;
+    }
+    cy.selectVaCheckbox(
+      `root_${fieldName}_isMilitary`,
+      addressObject.isMilitary,
+    );
+
+    if (addressObject.city) {
+      if (addressObject.isMilitary) {
+        cy.selectVaSelect(`root_${fieldName}_city`, addressObject.city);
+      } else {
+        cy.fillVaTextInput(`root_${fieldName}_city`, addressObject.city);
+      }
+    }
+
+    cy.selectVaSelect(`root_${fieldName}_country`, addressObject.country);
+    cy.fillVaTextInput(`root_${fieldName}_street`, addressObject.street);
+    cy.fillVaTextInput(`root_${fieldName}_street2`, addressObject.street2);
+    cy.fillVaTextInput(`root_${fieldName}_street3`, addressObject.street3);
+
+    cy.get('body').then(body => {
+      if (body.find(`va-select[name="root_${fieldName}_state"]`).length > 0)
+        cy.selectVaSelect(`root_${fieldName}_state`, addressObject.state);
+      if (body.find(`va-text-input[name="root_${fieldName}_state"]`).length > 0)
+        cy.fillVaTextInput(`root_${fieldName}_state`, addressObject.state);
+    });
+
+    cy.fillVaTextInput(
+      `root_${fieldName}_postalCode`,
+      addressObject.postalCode,
+    );
+  },
+);

--- a/src/platform/testing/e2e/cypress/support/index.d.ts
+++ b/src/platform/testing/e2e/cypress/support/index.d.ts
@@ -112,5 +112,28 @@ declare namespace Cypress {
     ): Chainable<Subject>;
 
     injectAxeThenAxeCheck(): Chainable<Subject>;
+
+    /**
+     * For `addressUI` pattern
+     * @param fieldName - The base name of the address field.
+     * @param addressObject - The address object containing the address details.
+     */
+    fillAddressWebComponentPattern(
+      fieldName: string,
+      addressObject: object,
+    ): Chainable<Subject>;
+
+    /**
+     * @param fields - The fields to fill.
+     * @param index - The index of the field.
+     * @param fillFieldsInVaCard - The callback function to fill fields in the va-card.
+     * @param numItems - The total number of items.
+     */
+    fillFieldsInVaCardIfNeeded(
+      fields: any,
+      index: number,
+      fillFieldsInVaCard: (fields: any, index: number) => void,
+      numItems: number,
+    ): Chainable<Subject>;
   }
 }


### PR DESCRIPTION
This is prerequisite work to migrate all forms to use `cy.fillAddressWebComponentPattern` instead of their local implementations