### PR TITLE
fix(526): Update upload PDF destructive modal styling

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -8,6 +8,11 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { scrollToFirstError, scrollTo } from 'platform/utilities/ui';
 import { form0781HeadingTag, titleWithTag } from '../form0781';
+/**
+ * TODO: tech-debt(import/no-cycle): Fix upstream import cycle
+ * @see https://github.com/department-of-veterans-affairs/va.gov-team/issues/110538
+ */
+// eslint-disable-next-line import/no-cycle
 import { checkValidations } from '../../utils/submit';
 
 export const workflowChoicePageTitle =
@@ -269,15 +274,13 @@ const confirmationCompleteOnline = {
 const modalDescriptionUpload = (
   <>
     <p>
-      <strong>What to know:</strong> If you choose to upload a PDF statement,
-      we’ll delete this information from your claim:
+      If you choose to upload a PDF statement, we’ll delete this information
+      from your claim:
     </p>
     <p>
       <ul>
         {sectionsOfMentalHealthStatement.map((section, i) => (
-          <li key={i}>
-            <b>{section}</b>
-          </li>
+          <li key={i}>{section}</li>
         ))}
       </ul>
     </p>
@@ -415,6 +418,12 @@ const WorkflowChoicePage = props => {
         goForward(data);
       }
     },
+
+    /**
+     * TODO: tech-debt(react-hooks/exhaustive-deps): Validate this rule exception is needed and why
+     * @see https://github.com/department-of-veterans-affairs/va.gov-team/issues/110539
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [data?.mentalHealthWorkflowChoice, shouldGoForward],
   );
 
@@ -656,13 +665,11 @@ const WorkflowChoicePage = props => {
         </VaModal>
       </fieldset>
       {onReviewPage ? (
-        <button
-          className="usa-button-primary"
-          type="button"
+        <va-button
+          class="usa-button-primary"
+          text="Update page"
           onClick={event => handlers.onUpdatePage(event)}
-        >
-          Update page
-        </button>
+        />
       ) : (
         <>
           {contentBeforeButtons}

--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -665,11 +665,18 @@ const WorkflowChoicePage = props => {
         </VaModal>
       </fieldset>
       {onReviewPage ? (
-        <va-button
-          class="usa-button-primary"
-          text="Update page"
+        /**
+         * Does not use web component for design consistency on all pages.
+         * @see https://github.com/department-of-veterans-affairs/vets-website/pull/35911
+         */
+        // eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component
+        <button
+          className="usa-button-primary"
+          type="button"
           onClick={event => handlers.onUpdatePage(event)}
-        />
+        >
+          Update page
+        </button>
       ) : (
         <>
           {contentBeforeButtons}

--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -290,8 +290,8 @@ const modalDescriptionUpload = (
 const modalDescriptionSkip = (
   <>
     <p>
-      <strong>What to know:</strong> If you choose to delete this statement,
-      we’ll delete this information from your claim:
+      If you choose to delete this statement, we’ll delete this information from
+      your claim:
     </p>
     <ul>
       {sectionsOfMentalHealthStatement.map((section, i) => (
@@ -307,8 +307,8 @@ const modalDescriptionOnline = formData => {
   return (
     <>
       <p>
-        <strong>What to know:</strong> If you choose to answer questions online,
-        we’ll delete this PDF you uploaded:
+        If you choose to answer questions online, we’ll delete this PDF you
+        uploaded:
       </p>
       <p>
         <ul>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR updates the destructive action alerts across the 0781 form experience to align with VA.gov standards and design feedback.
- In staging review, inconsistencies in alert styling were identified: bullets were bolded and lead-in text such as "What to know:" was unnecessarily applied.
- This PR:
  - Removes bold styling from bullet points
  - Removes the lead-in "What to know:"
  - Adds a link to the paper 0781 form
  - Updates alert language to reflect how uploads are handled  
- These changes are based on feedback from the staging review and the latest Figma designs.
- Team: Disability Benefits 
- No flipper is used in this PR

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108799
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108128 (staging review feedback)
- Figma design: https://www.figma.com/design/r3Aj9FtLFS989mlVeBsgJg/0781-Redesign?node-id=20094-97962&t=46QVMXQgg6SHWPsX-11

## Testing done

- [ ] Verified destructive alert content changes render across the following pages:
  - [3.2] 0781 Opt-In / Choice Page
  - Review and Submit
  - [3.3] 0781 Upload
  - [3.6] Types of Traumatic Events
  - [3.11b] Behavior intro (COMBAT ONLY)
  - [3.12] Behavior list
- [x] Confirmed styling updates removed bold bullet text
- [x] Confirmed "What to know:" lead-in was removed
- [ ] Verified link to paper 0781 form is present and functional
- [ ] Ran keyboard and screen reader checks on alerts to ensure accessibility

## Screenshots

> Note: This field is mandatory for UI changes (non-component work should NOT have screenshots).

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![before-mobile](https://github.com/user-attachments/assets/d09db44b-833b-4389-831a-fa8e5ac6d573) | ![after-mobile](https://github.com/user-attachments/assets/e0582bb1-5e18-4ade-ab3a-a54b1d9c7493) |
| Desktop | ![before-desktop](https://github.com/user-attachments/assets/b027c852-d2a9-4110-87ed-615f373cc55a) | ![after-desktop](https://github.com/user-attachments/assets/e6719c27-e4c9-4954-af4f-e01cb6f7e57e) |

## What areas of the site does it impact?

- Form 0781 user flow (destructive alerts)  
- Veteran-facing content and usability within the disability claims experience

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please confirm whether the alert copy matches the latest platform tone and guidance. Let me know if any additional content or accessibility adjustments are needed before merging to production.
