### PR TITLE
MHV-71125 Make-DateFormatWithout-Timezone-More

### DIFF
--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -3,7 +3,6 @@ import { Actions } from '../util/actionTypes';
 import {
   concatObservationInterpretations,
   dateFormatWithoutTimezone,
-  formatDate,
   extractContainedByRecourceType,
   extractContainedResource,
   getObservationValueWithUnits,
@@ -216,7 +215,7 @@ export const convertMicrobiologyRecord = record => {
     labType: title ? 'Microbiology' : null,
     orderedBy: extractOrderedBy(record) || EMPTY_FIELD,
     dateCompleted: record.effectiveDateTime
-      ? formatDate(record.effectiveDateTime)
+      ? dateFormatWithoutTimezone(record.effectiveDateTime)
       : EMPTY_FIELD,
     date: specimen?.collection?.collectedDateTime
       ? dateFormatWithoutTimezone(specimen.collection.collectedDateTime)

--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -3,6 +3,7 @@ import { Actions } from '../util/actionTypes';
 import {
   concatObservationInterpretations,
   dateFormatWithoutTimezone,
+  formatDateInLocalTimezone,
   extractContainedByRecourceType,
   extractContainedResource,
   getObservationValueWithUnits,
@@ -358,7 +359,7 @@ export const convertMhvRadiologyRecord = record => {
     clinicalHistory: record?.clinicalHistory?.trim() || EMPTY_FIELD,
     imagingLocation: record.performingLocation,
     date: record.eventDate
-      ? dateFormatWithoutTimezone(record.eventDate)
+      ? formatDateInLocalTimezone(record.eventDate, true)
       : EMPTY_FIELD,
     sortDate: record.eventDate,
     imagingProvider: imagingProvider || EMPTY_FIELD,
@@ -377,7 +378,7 @@ export const convertCvixRadiologyRecord = record => {
     clinicalHistory: parsedReport['Clinical History'] || EMPTY_FIELD,
     imagingLocation: record.facilityInfo?.name || EMPTY_FIELD,
     date: record.performedDatePrecise
-      ? dateFormatWithoutTimezone(record.performedDatePrecise)
+      ? formatDateInLocalTimezone(record.performedDatePrecise, true)
       : EMPTY_FIELD,
     sortDate: record.performedDatePrecise
       ? `${new Date(record.performedDatePrecise).toISOString().split('.')[0]}Z`

--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -2,6 +2,7 @@ import { parseISO } from 'date-fns';
 import { Actions } from '../util/actionTypes';
 import {
   concatObservationInterpretations,
+  formatDate,
   dateFormatWithoutTimezone,
   formatDateInLocalTimezone,
   extractContainedByRecourceType,
@@ -216,7 +217,7 @@ export const convertMicrobiologyRecord = record => {
     labType: title ? 'Microbiology' : null,
     orderedBy: extractOrderedBy(record) || EMPTY_FIELD,
     dateCompleted: record.effectiveDateTime
-      ? dateFormatWithoutTimezone(record.effectiveDateTime)
+      ? formatDate(record.effectiveDateTime)
       : EMPTY_FIELD,
     date: specimen?.collection?.collectedDateTime
       ? dateFormatWithoutTimezone(specimen.collection.collectedDateTime)

--- a/src/applications/mhv-medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
@@ -255,7 +255,7 @@ describe('LabsAndTestsListItem component with radiology record', () => {
 
   // This test will give different results when run in different time zones.
   it('should display the date of the record', () => {
-    const date = screen.getByText('January 6, 2004, 7:27 p.m.', {
+    const date = screen.getByText('January 6, 2004 7:27 p.m.', {
       selector: 'div',
       exact: true,
     });

--- a/src/applications/mhv-medical-records/tests/components/RadiologyDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/RadiologyDetails.unit.spec.jsx
@@ -17,405 +17,409 @@ import {
   convertMhvRadiologyRecord,
 } from '../../reducers/labsAndTests';
 
-describe('Radiology details component - images', () => {
-  const radiologyRecord = convertCvixRadiologyRecord(radiologyMhvWithImages);
-  const initialState = {
-    mr: {
-      labsAndTests: {
-        labsAndTestsDetails: radiologyRecord,
+describe('RadiologyDetails component', () => {
+  describe('images', () => {
+    const radiologyRecord = convertCvixRadiologyRecord(radiologyMhvWithImages);
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: radiologyRecord,
+        },
+        images,
       },
-      images,
-    },
-    featureToggles: {
-      // eslint-disable-next-line camelcase
-      mhv_medical_records_allow_txt_downloads: true,
-    },
-  };
-
-  let screen;
-  beforeEach(() => {
-    screen = renderWithStoreAndRouter(
-      <RadiologyDetails
-        record={radiologyRecord}
-        fullState={initialState}
-        runningUnitTest
-      />,
-      {
-        initialState,
-        reducers: reducer,
-        path: '/labs-and-tests/r5621490',
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medical_records_allow_txt_downloads: true,
       },
-    );
-  });
+    };
 
-  it('renders without errors', () => {
-    expect(screen).to.exist;
-  });
-
-  it('should display the test name', () => {
-    const header = screen.getByText('KNEE 4 OR MORE VIEWS (LEFT)', {
-      exact: true,
-      selector: 'h1',
+    let screen;
+    beforeEach(() => {
+      screen = renderWithStoreAndRouter(
+        <RadiologyDetails
+          record={radiologyRecord}
+          fullState={initialState}
+          runningUnitTest
+        />,
+        {
+          initialState,
+          reducers: reducer,
+          path: '/labs-and-tests/r5621490',
+        },
+      );
     });
-    expect(header).to.exist;
-  });
 
-  // This test will give different results when run in different time zones.
-  it('should display the formatted date', () => {
-    const formattedDate = screen.getByText('April 4, 2024, 9:03 p.m.', {
-      exact: true,
-      selector: 'span',
+    it('renders without errors', () => {
+      expect(screen).to.exist;
     });
-    expect(formattedDate).to.exist;
-  });
 
-  it('should display the reason for the test', () => {
-    expect(screen.getByTestId('radiology-reason')).to.contain.text(
-      'Test data number2 Todd',
-    );
-  });
-
-  it('should display the clinical history', () => {
-    expect(screen.getByTestId('radiology-clinical-history')).to.contain.text(
-      'None recorded',
-    );
-  });
-
-  it('should display who the test was ordered by', () => {
-    const orderedBy = screen.getByText('RODRIGUEZ,CARLOS', {
-      exact: true,
-      selector: 'p',
-    });
-    expect(orderedBy).to.exist;
-  });
-
-  it('should display the performing lab location', () => {
-    const performingLocation = screen.getByText('IPO TEST 2', {
-      exact: true,
-      selector: 'p',
-    });
-    expect(performingLocation).to.exist;
-  });
-
-  it('should display the imaging provider', () => {
-    expect(screen.getByTestId('radiology-imaging-provider')).to.contain.text(
-      'None recorded',
-    );
-  });
-
-  it('should display the lab results', () => {
-    const results = screen.getByText(
-      'Degenerative arthritis of left knee which has shown',
-      {
-        exact: false,
-        selector: 'p',
-      },
-    );
-    expect(results).to.exist;
-  });
-
-  it('should display a download started message when the download pdf button is clicked', () => {
-    fireEvent.click(screen.getByTestId('printButton-1'));
-    expect(screen.getByTestId('download-success-alert-message')).to.exist;
-  });
-
-  it('should display a download started message when the download txt file button is clicked', () => {
-    fireEvent.click(screen.getByTestId('printButton-2'));
-    expect(screen.getByTestId('download-success-alert-message')).to.exist;
-  });
-});
-
-describe('Radiology details component - image with error', () => {
-  const radiologyRecord = convertCvixRadiologyRecord(
-    radiologyMhvWithImageError,
-  );
-  const initialState = {
-    mr: {
-      labsAndTests: {
-        labsAndTestsDetails: radiologyRecord,
-      },
-      images: {
-        ...images,
-        notificationStatus: true,
-      },
-    },
-    featureToggles: {
-      // eslint-disable-next-line camelcase
-      mhv_medical_records_allow_txt_downloads: true,
-    },
-  };
-
-  let screen;
-  beforeEach(() => {
-    screen = renderWithStoreAndRouter(
-      <RadiologyDetails
-        record={radiologyRecord}
-        fullState={initialState}
-        runningUnitTest
-      />,
-      {
-        initialState,
-        reducers: reducer,
-        path: '/labs-and-tests/r5621490',
-      },
-    );
-  });
-
-  it('renders without errors', () => {
-    expect(screen).to.exist;
-  });
-
-  it('displays an error message', () => {
-    const error = screen.getByText(
-      'We’re sorry. There was a problem with our system. Try requesting your images again.',
-      {
+    it('should display the test name', () => {
+      const header = screen.getByText('KNEE 4 OR MORE VIEWS (LEFT)', {
         exact: true,
-        selector: 'p',
-      },
-    );
-    expect(error).to.exist;
-
-    const requestImagesButton = screen.getByTestId(
-      'radiology-request-images-button',
-    );
-    expect(requestImagesButton).to.exist;
-    // assert that the button is enabled:
-    expect(requestImagesButton.getAttribute('disabled')).to.eq('false');
-    fireEvent.click(requestImagesButton);
-  });
-});
-
-describe('Radiology details component - new image', () => {
-  const radiologyRecord = convertCvixRadiologyRecord(radiologyMhvWithImagesNew);
-  const initialState = {
-    mr: {
-      labsAndTests: {
-        labsAndTestsDetails: radiologyRecord,
-      },
-      images: {
-        ...images,
-        notificationStatus: true,
-      },
-    },
-    featureToggles: {
-      // eslint-disable-next-line camelcase
-      mhv_medical_records_allow_txt_downloads: true,
-    },
-  };
-
-  let screen;
-  beforeEach(() => {
-    screen = renderWithStoreAndRouter(
-      <RadiologyDetails
-        record={radiologyRecord}
-        fullState={initialState}
-        runningUnitTest
-      />,
-      {
-        initialState,
-        reducers: reducer,
-        path: '/labs-and-tests/r5621490',
-      },
-    );
-  });
-
-  it('renders without errors', () => {
-    expect(screen).to.exist;
-  });
-});
-
-describe('Radiology details component', () => {
-  const radiologyRecord = convertMhvRadiologyRecord(radiologyMhv);
-  const initialState = {
-    mr: {
-      labsAndTests: {
-        labsAndTestsDetails: radiologyRecord,
-      },
-    },
-    featureToggles: {
-      // eslint-disable-next-line camelcase
-      mhv_medical_records_allow_txt_downloads: true,
-    },
-  };
-
-  let screen;
-  beforeEach(() => {
-    screen = renderWithStoreAndRouter(
-      <RadiologyDetails
-        record={radiologyRecord}
-        fullState={initialState}
-        runningUnitTest
-      />,
-      {
-        initialState,
-        reducers: reducer,
-        path: '/labs-and-tests/r5621490',
-      },
-    );
-  });
-
-  it('renders without errors', () => {
-    expect(screen).to.exist;
-  });
-
-  it('should display the test name', () => {
-    const header = screen.getByText('DEXA, PERIPHERAL STUDY', {
-      exact: true,
-      selector: 'h1',
+        selector: 'h1',
+      });
+      expect(header).to.exist;
     });
-    expect(header).to.exist;
-  });
 
-  // This test will give different results when run in different time zones.
-  it('should display the formatted date', () => {
-    const formattedDate = screen.getByText('January 6, 2004, 7:27 p.m.', {
-      exact: true,
-      selector: 'span',
+    // This test will give different results when run in different time zones.
+    it('should display the formatted date', () => {
+      const formattedDate = screen.getByText('April 4, 2024 9:03 p.m.', {
+        exact: true,
+        selector: 'span',
+      });
+      expect(formattedDate).to.exist;
     });
-    expect(formattedDate).to.exist;
-  });
 
-  it('should display the reason for the test', () => {
-    const reason = screen.getByText('None recorded', {
-      exact: true,
-      selector: 'p',
+    it('should display the reason for the test', () => {
+      expect(screen.getByTestId('radiology-reason')).to.contain.text(
+        'Test data number2 Todd',
+      );
     });
-    expect(reason).to.exist;
-  });
 
-  it('should display the clinical history', () => {
-    const clinicalHistory = screen.getByText('this is 71 yr old pt', {
-      exact: false,
-      selector: 'p',
-    });
-    expect(clinicalHistory).to.exist;
-  });
-
-  it('should display who the test was ordered by', () => {
-    const orderedBy = screen.getByText('JOHN DOE', {
-      exact: true,
-      selector: 'p',
-    });
-    expect(orderedBy).to.exist;
-  });
-
-  it('should display the performing lab location', () => {
-    const performingLocation = screen.getByText('DAYT3', {
-      exact: true,
-      selector: 'p',
-    });
-    expect(performingLocation).to.exist;
-  });
-
-  it('should display the imaging provider', () => {
-    const imagingProvider = screen.getByText('JANE DOE', {
-      exact: true,
-      selector: 'p',
-    });
-    expect(imagingProvider).to.exist;
-  });
-
-  it('should display the lab results', () => {
-    const results = screen.getByText('Osteopenia of the left forearm.', {
-      exact: false,
-      selector: 'p',
-    });
-    expect(results).to.exist;
-  });
-
-  it('should display a download started message when the download pdf button is clicked', () => {
-    fireEvent.click(screen.getByTestId('printButton-1'));
-    expect(screen.getByTestId('download-success-alert-message')).to.exist;
-  });
-
-  it('should display a download started message when the download txt file button is clicked', () => {
-    fireEvent.click(screen.getByTestId('printButton-2'));
-    expect(screen.getByTestId('download-success-alert-message')).to.exist;
-  });
-});
-
-describe('Radiology details component with missing fields', () => {
-  const initialState = {
-    mr: {
-      labsAndTests: {
-        labsAndTestsDetails: convertMhvRadiologyRecord(
-          radiologyWithMissingFields,
-        ),
-      },
-    },
-  };
-
-  const screen = renderWithStoreAndRouter(
-    <RadiologyDetails
-      record={convertMhvRadiologyRecord(radiologyWithMissingFields)}
-      fullState={initialState}
-      runningUnitTest
-    />,
-    {
-      initialState,
-      reducers: reducer,
-      path: '/labs-and-tests/123',
-    },
-  );
-
-  it('should not display the date if date is missing', () => {
-    waitFor(() => {
-      expect(screen.queryByTestId('header-time').innerHTML).to.contain(
+    it('should display the clinical history', () => {
+      expect(screen.getByTestId('radiology-clinical-history')).to.contain.text(
         'None recorded',
       );
     });
+
+    it('should display who the test was ordered by', () => {
+      const orderedBy = screen.getByText('RODRIGUEZ,CARLOS', {
+        exact: true,
+        selector: 'p',
+      });
+      expect(orderedBy).to.exist;
+    });
+
+    it('should display the performing lab location', () => {
+      const performingLocation = screen.getByText('IPO TEST 2', {
+        exact: true,
+        selector: 'p',
+      });
+      expect(performingLocation).to.exist;
+    });
+
+    it('should display the imaging provider', () => {
+      expect(screen.getByTestId('radiology-imaging-provider')).to.contain.text(
+        'None recorded',
+      );
+    });
+
+    it('should display the lab results', () => {
+      const results = screen.getByText(
+        'Degenerative arthritis of left knee which has shown',
+        {
+          exact: false,
+          selector: 'p',
+        },
+      );
+      expect(results).to.exist;
+    });
+
+    it('should display a download started message when the download pdf button is clicked', () => {
+      fireEvent.click(screen.getByTestId('printButton-1'));
+      expect(screen.getByTestId('download-success-alert-message')).to.exist;
+    });
+
+    it('should display a download started message when the download txt file button is clicked', () => {
+      fireEvent.click(screen.getByTestId('printButton-2'));
+      expect(screen.getByTestId('download-success-alert-message')).to.exist;
+    });
   });
-});
 
-describe('Radiology details component - over request limit', () => {
-  const radiologyRecord = convertCvixRadiologyRecord(radiologyMhvWithImages);
-  const initialState = {
-    mr: {
-      labsAndTests: {
-        labsAndTestsDetails: radiologyRecord,
+  describe('image with error', () => {
+    const radiologyRecord = convertCvixRadiologyRecord(
+      radiologyMhvWithImageError,
+    );
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: radiologyRecord,
+        },
+        images: {
+          ...images,
+          notificationStatus: true,
+        },
       },
-      images: {
-        ...threeImageRequestInProgress,
-        studyRequestLimitReached: true, // simulating request limit reached
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medical_records_allow_txt_downloads: true,
       },
-    },
-    featureToggles: {
-      // eslint-disable-next-line camelcase
-      mhv_medical_records_allow_txt_downloads: true,
-    },
-  };
+    };
 
-  let screen;
-  beforeEach(() => {
-    screen = renderWithStoreAndRouter(
+    let screen;
+    beforeEach(() => {
+      screen = renderWithStoreAndRouter(
+        <RadiologyDetails
+          record={radiologyRecord}
+          fullState={initialState}
+          runningUnitTest
+        />,
+        {
+          initialState,
+          reducers: reducer,
+          path: '/labs-and-tests/r5621490',
+        },
+      );
+    });
+
+    it('renders without errors', () => {
+      expect(screen).to.exist;
+    });
+
+    it('displays an error message', () => {
+      const error = screen.getByText(
+        'We’re sorry. There was a problem with our system. Try requesting your images again.',
+        {
+          exact: true,
+          selector: 'p',
+        },
+      );
+      expect(error).to.exist;
+
+      const requestImagesButton = screen.getByTestId(
+        'radiology-request-images-button',
+      );
+      expect(requestImagesButton).to.exist;
+      // assert that the button is enabled:
+      expect(requestImagesButton.getAttribute('disabled')).to.eq('false');
+      fireEvent.click(requestImagesButton);
+    });
+  });
+
+  describe('Radiology details component - new image', () => {
+    const radiologyRecord = convertCvixRadiologyRecord(
+      radiologyMhvWithImagesNew,
+    );
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: radiologyRecord,
+        },
+        images: {
+          ...images,
+          notificationStatus: true,
+        },
+      },
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medical_records_allow_txt_downloads: true,
+      },
+    };
+
+    let screen;
+    beforeEach(() => {
+      screen = renderWithStoreAndRouter(
+        <RadiologyDetails
+          record={radiologyRecord}
+          fullState={initialState}
+          runningUnitTest
+        />,
+        {
+          initialState,
+          reducers: reducer,
+          path: '/labs-and-tests/r5621490',
+        },
+      );
+    });
+
+    it('renders without errors', () => {
+      expect(screen).to.exist;
+    });
+  });
+
+  describe('baseline', () => {
+    const radiologyRecord = convertMhvRadiologyRecord(radiologyMhv);
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: radiologyRecord,
+        },
+      },
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medical_records_allow_txt_downloads: true,
+      },
+    };
+
+    let screen;
+    beforeEach(() => {
+      screen = renderWithStoreAndRouter(
+        <RadiologyDetails
+          record={radiologyRecord}
+          fullState={initialState}
+          runningUnitTest
+        />,
+        {
+          initialState,
+          reducers: reducer,
+          path: '/labs-and-tests/r5621490',
+        },
+      );
+    });
+
+    it('renders without errors', () => {
+      expect(screen).to.exist;
+    });
+
+    it('should display the test name', () => {
+      const header = screen.getByText('DEXA, PERIPHERAL STUDY', {
+        exact: true,
+        selector: 'h1',
+      });
+      expect(header).to.exist;
+    });
+
+    // This test will give different results when run in different time zones.
+    it('should display the formatted date', () => {
+      const formattedDate = screen.getByText('January 6, 2004 7:27 p.m.', {
+        exact: true,
+        selector: 'span',
+      });
+      expect(formattedDate).to.exist;
+    });
+
+    it('should display the reason for the test', () => {
+      const reason = screen.getByText('None recorded', {
+        exact: true,
+        selector: 'p',
+      });
+      expect(reason).to.exist;
+    });
+
+    it('should display the clinical history', () => {
+      const clinicalHistory = screen.getByText('this is 71 yr old pt', {
+        exact: false,
+        selector: 'p',
+      });
+      expect(clinicalHistory).to.exist;
+    });
+
+    it('should display who the test was ordered by', () => {
+      const orderedBy = screen.getByText('JOHN DOE', {
+        exact: true,
+        selector: 'p',
+      });
+      expect(orderedBy).to.exist;
+    });
+
+    it('should display the performing lab location', () => {
+      const performingLocation = screen.getByText('DAYT3', {
+        exact: true,
+        selector: 'p',
+      });
+      expect(performingLocation).to.exist;
+    });
+
+    it('should display the imaging provider', () => {
+      const imagingProvider = screen.getByText('JANE DOE', {
+        exact: true,
+        selector: 'p',
+      });
+      expect(imagingProvider).to.exist;
+    });
+
+    it('should display the lab results', () => {
+      const results = screen.getByText('Osteopenia of the left forearm.', {
+        exact: false,
+        selector: 'p',
+      });
+      expect(results).to.exist;
+    });
+
+    it('should display a download started message when the download pdf button is clicked', () => {
+      fireEvent.click(screen.getByTestId('printButton-1'));
+      expect(screen.getByTestId('download-success-alert-message')).to.exist;
+    });
+
+    it('should display a download started message when the download txt file button is clicked', () => {
+      fireEvent.click(screen.getByTestId('printButton-2'));
+      expect(screen.getByTestId('download-success-alert-message')).to.exist;
+    });
+  });
+
+  describe('with missing fields', () => {
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: convertMhvRadiologyRecord(
+            radiologyWithMissingFields,
+          ),
+        },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(
       <RadiologyDetails
-        record={radiologyRecord}
+        record={convertMhvRadiologyRecord(radiologyWithMissingFields)}
         fullState={initialState}
         runningUnitTest
       />,
       {
         initialState,
         reducers: reducer,
-        path: '/labs-and-tests/r5621490',
+        path: '/labs-and-tests/123',
       },
     );
+
+    it('should not display the date if date is missing', () => {
+      waitFor(() => {
+        expect(screen.queryByTestId('header-time').innerHTML).to.contain(
+          'None recorded',
+        );
+      });
+    });
   });
 
-  it('should display the over-request limit message', () => {
-    const limitMessage = screen.getByText(
-      'You can’t request images for this report right now. You can only have 3 image requests at a time.',
-      {
-        exact: false,
-        selector: 'p',
+  describe('over request limit', () => {
+    const radiologyRecord = convertCvixRadiologyRecord(radiologyMhvWithImages);
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: radiologyRecord,
+        },
+        images: {
+          ...threeImageRequestInProgress,
+          studyRequestLimitReached: true, // simulating request limit reached
+        },
       },
-    );
-    expect(limitMessage).to.exist;
-  });
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medical_records_allow_txt_downloads: true,
+      },
+    };
 
-  it('should not display the request images button', () => {
-    const requestButton = screen.queryByTestId(
-      'radiology-request-images-button',
-    );
-    expect(requestButton).to.be.null;
+    let screen;
+    beforeEach(() => {
+      screen = renderWithStoreAndRouter(
+        <RadiologyDetails
+          record={radiologyRecord}
+          fullState={initialState}
+          runningUnitTest
+        />,
+        {
+          initialState,
+          reducers: reducer,
+          path: '/labs-and-tests/r5621490',
+        },
+      );
+    });
+
+    it('should display the over-request limit message', () => {
+      const limitMessage = screen.getByText(
+        'You can’t request images for this report right now. You can only have 3 image requests at a time.',
+        {
+          exact: false,
+          selector: 'p',
+        },
+      );
+      expect(limitMessage).to.exist;
+    });
+
+    it('should not display the request images button', () => {
+      const requestButton = screen.queryByTestId(
+        'radiology-request-images-button',
+      );
+      expect(requestButton).to.be.null;
+    });
   });
 });

--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
@@ -54,39 +54,32 @@ describe('Date formatter', () => {
 });
 
 describe('dateFormatWithoutTimezone', () => {
-  it('should format a valid ISO string correctly without time zone', () => {
-    const isoString = '2021-05-18T10:30:00+02:00';
-    const expectedFormat = 'May 18, 2021, 10:30 a.m.';
-    const result = dateFormatWithoutTimezone(isoString, 'MMMM d, yyyy, h:mm a');
-    expect(result).to.equal(expectedFormat);
+  const testFormat = (isoString, expected) => {
+    expect(dateFormatWithoutTimezone(isoString)).to.equal(expected);
+  };
+
+  it('should format a valid FHIR date string by stripping the time zone', () => {
+    testFormat('2018', '2018'); // Year only
+    testFormat('1973-06', 'June 1973'); // Year + month
+    testFormat('2000-08-09', 'August 9, 2000'); // Full date
+    testFormat('1990-06-30T23:59:60Z', 'June 30, 1990, 11:59 p.m.'); // Leap second
+    testFormat('2020-01-02T03:04:05Z', 'January 2, 2020, 3:04 a.m.'); // Zulu time
+    testFormat('2019-07-19T16:20:30.123Z', 'July 19, 2019, 4:20 p.m.'); // Fractional seconds
+    testFormat('2021-05-18T10:30:00+02:00', 'May 18, 2021, 10:30 a.m.'); // Positive offset
+    testFormat('2017-08-02T09:50:57-04:00', 'August 2, 2017, 9:50 a.m.'); // Negative offset
+    testFormat('2017-01-01T00:00:00.000Z', 'January 1, 2017, 12:00 a.m.'); // Millisecond precision
+    testFormat('2022-11-15T08:00:00+00:00', 'November 15, 2022, 8:00 a.m.'); // Zero offset required
+    testFormat('2020-12-31T23:59:59+05:30', 'December 31, 2020, 11:59 p.m.'); // Non-hour offset
   });
 
-  it('should return null for an invalid string', () => {
-    const invalidString = null;
-    const result = dateFormatWithoutTimezone(invalidString);
-    expect(result).to.equal(null);
-  });
-
-  it('should return null for a non-string input', () => {
-    const nonStringInput = 12345;
-    const result = dateFormatWithoutTimezone(nonStringInput);
-    expect(result).to.equal(null);
-  });
-
-  it('should throw an error for an invalid ISO string', () => {
-    const invalidISO = '2021-05-18T10:30:00';
-    try {
-      dateFormatWithoutTimezone(invalidISO);
-    } catch (error) {
-      expect(error.message).to.equal('Invalid time value');
-    }
-  });
-
-  it('should correctly format date without time zone using default format', () => {
-    const isoString = '2021-05-18T10:30:00+02:00';
-    const expectedFormat = 'May 18, 2021, 10:30 a.m.';
-    const result = dateFormatWithoutTimezone(isoString); // Default format used
-    expect(result).to.equal(expectedFormat);
+  it('should return null for invalid input', () => {
+    testFormat('', null); // empty string
+    testFormat('foo', null); // garbage
+    testFormat(12345, null); // non-string input
+    testFormat(undefined, null); // missing
+    testFormat('2021-13', null); // bad month in YYYY-MM
+    testFormat('2021-02-29', null); // non-leap Feb-29
+    testFormat('2021-00-01', null); // zero month
   });
 
   it('should handle different date formats', () => {

--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
@@ -693,11 +693,48 @@ describe('handleDataDogAction', () => {
 });
 
 describe('formatDateInLocalTimezone', () => {
+  let originalTZ;
+
+  // Ensure these tests run in a predictable time zone
+  before(() => {
+    originalTZ = process.env.TZ;
+    process.env.TZ = 'UTC';
+  });
+
+  // Restore the original time zone value
+  after(() => {
+    if (originalTZ === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTZ;
+    }
+  });
+
   it('should format a valid ISO8601 date string to the local timezone', () => {
     const dateString = '2023-01-05T14:48:00.000-05:00';
     const formattedDate = formatDateInLocalTimezone(dateString);
     const expectedDate = 'January 5, 2023 7:48 p.m. UTC';
     expect(formattedDate).to.equal(expectedDate);
+  });
+
+  it('should format a date when providing a UNIX timestamp as a number', () => {
+    const timestamp = 1672941680000; // Jan 5, 2023, 19:48 UTC
+    const formattedDate = formatDateInLocalTimezone(timestamp);
+    const expectedDate = 'January 5, 2023 6:01 p.m. UTC';
+    expect(formattedDate).to.equal(expectedDate);
+  });
+
+  it('should hide time zone when hideTimeZone is true', () => {
+    const dateString = '2023-01-05T14:48:00.000-05:00';
+    const formattedDate = formatDateInLocalTimezone(dateString, true);
+    const expectedDate = 'January 5, 2023 7:48 p.m.';
+    expect(formattedDate).to.equal(expectedDate);
+  });
+
+  it('should show time zone by default', () => {
+    const dateString = '2023-01-05T14:48:00.000-05:00';
+    const formattedDate = formatDateInLocalTimezone(dateString);
+    expect(formattedDate).to.include('UTC');
   });
 
   it('should handle an invalid date string gracefully', () => {

--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
@@ -11,7 +11,6 @@ import {
 import {
   concatObservationInterpretations,
   dateFormat,
-  dateFormatWithoutTime,
   dateFormatWithoutTimezone,
   dispatchDetails,
   extractContainedByRecourceType,
@@ -54,23 +53,87 @@ describe('Date formatter', () => {
   });
 });
 
-describe('Date formatter with no timezone', () => {
-  it('removes the time from a dateTime', () => {
-    const dateTime = 'October 27, 2023, 10:00 a.m.';
-    const formattedDate = dateFormatWithoutTime(dateTime);
-    expect(formattedDate).to.eq('October 27, 2023');
+describe('dateFormatWithoutTimezone – edge cases', () => {
+  // 1) Positive offset
+  it('strips a +HH:MM offset', () => {
+    const ts = '2023-09-29T11:04:31+02:00';
+    expect(dateFormatWithoutTimezone(ts)).to.eq(
+      'September 29, 2023, 11:04 a.m.',
+    );
   });
 
-  it('formats a date in the original time without a timezone', () => {
-    const timeStamp = '2023-09-29T11:04:31.316-04:00';
-    const formattedDate = dateFormatWithoutTimezone(timeStamp);
-    expect(formattedDate).to.eq('September 29, 2023, 11:04 a.m.');
+  // 2) Offset with no colon
+  it('strips a -HHMM offset', () => {
+    const ts = '2023-09-29T11:04:31-0400';
+    expect(dateFormatWithoutTimezone(ts)).to.eq(
+      'September 29, 2023, 11:04 a.m.',
+    );
   });
 
-  it('formats an epoch date in the original time without a timezone', () => {
-    const timeStamp = 1605300748000;
-    const formattedDate = dateFormatWithoutTimezone(timeStamp);
-    expect(formattedDate).to.eq('November 13, 2020, 8:52 p.m.');
+  // 3) Zulu (UTC) suffix
+  it('handles a Z suffix', () => {
+    const ts = '2023-09-29T11:04:31Z';
+    expect(dateFormatWithoutTimezone(ts)).to.eq(
+      'September 29, 2023, 11:04 a.m.',
+    );
+  });
+
+  // 4) Sub-second precision or missing seconds
+  it('handles sub-second precision', () => {
+    const ts = '2023-09-29T11:04:31.123456-04:00';
+    expect(dateFormatWithoutTimezone(ts)).to.eq(
+      'September 29, 2023, 11:04 a.m.',
+    );
+  });
+
+  it('handles timestamps without seconds', () => {
+    const ts = '2023-09-29T11:04-04:00';
+    expect(dateFormatWithoutTimezone(ts)).to.eq(
+      'September 29, 2023, 11:04 a.m.',
+    );
+  });
+
+  // 5) Date-only inputs
+  it('formats pure dates (no time)', () => {
+    const ts = '2000-08-09';
+    expect(dateFormatWithoutTimezone(ts, 'MMMM d, yyyy')).to.eq(
+      'August 9, 2000',
+    );
+  });
+
+  // 6) Epoch styles
+  it('accepts numeric epoch (0 → 1970-01-01)', () => {
+    expect(dateFormatWithoutTimezone(0)).to.eq('January 1, 1970, 12:00 a.m.');
+  });
+  it('accepts stringified epoch', () => {
+    expect(dateFormatWithoutTimezone('1605300748000')).to.eq(
+      'November 13, 2020, 8:52 p.m.',
+    );
+  });
+
+  // 7) Midday / midnight disambiguation
+  it('labels midnight as 12:00 a.m.', () => {
+    const ts = '2023-05-06T00:00:00-04:00';
+    expect(dateFormatWithoutTimezone(ts)).to.eq('May 6, 2023, 12:00 a.m.');
+  });
+  it('labels noon as 12:00 p.m.', () => {
+    const ts = '2023-05-06T12:00:00-04:00';
+    expect(dateFormatWithoutTimezone(ts)).to.eq('May 6, 2023, 12:00 p.m.');
+  });
+
+  // 8) DST‐transition "holes" (ensure it doesn't blow up)
+  it('does not throw on nonexistent local times (DST shift)', () => {
+    const ts = '2023-03-12T02:30:00-05:00'; // US spring-forward
+    expect(() => dateFormatWithoutTimezone(ts)).not.to.throw();
+  });
+
+  // 9) Totally malformed inputs
+  it('falls back gracefully for bad strings', () => {
+    expect(dateFormatWithoutTimezone('not-a-date')).to.match(/Invalid/);
+  });
+  it('handles null/undefined', () => {
+    expect(() => dateFormatWithoutTimezone(null)).to.throw();
+    expect(() => dateFormatWithoutTimezone()).to.throw();
   });
 });
 

--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
@@ -53,87 +53,48 @@ describe('Date formatter', () => {
   });
 });
 
-describe('dateFormatWithoutTimezone – edge cases', () => {
-  // 1) Positive offset
-  it('strips a +HH:MM offset', () => {
-    const ts = '2023-09-29T11:04:31+02:00';
-    expect(dateFormatWithoutTimezone(ts)).to.eq(
-      'September 29, 2023, 11:04 a.m.',
-    );
+describe('dateFormatWithoutTimezone', () => {
+  it('should format a valid ISO string correctly without time zone', () => {
+    const isoString = '2021-05-18T10:30:00+02:00';
+    const expectedFormat = 'May 18, 2021, 10:30 a.m.';
+    const result = dateFormatWithoutTimezone(isoString, 'MMMM d, yyyy, h:mm a');
+    expect(result).to.equal(expectedFormat);
   });
 
-  // 2) Offset with no colon
-  it('strips a -HHMM offset', () => {
-    const ts = '2023-09-29T11:04:31-0400';
-    expect(dateFormatWithoutTimezone(ts)).to.eq(
-      'September 29, 2023, 11:04 a.m.',
-    );
+  it('should return null for an invalid string', () => {
+    const invalidString = null;
+    const result = dateFormatWithoutTimezone(invalidString);
+    expect(result).to.equal(null);
   });
 
-  // 3) Zulu (UTC) suffix
-  it('handles a Z suffix', () => {
-    const ts = '2023-09-29T11:04:31Z';
-    expect(dateFormatWithoutTimezone(ts)).to.eq(
-      'September 29, 2023, 11:04 a.m.',
-    );
+  it('should return null for a non-string input', () => {
+    const nonStringInput = 12345;
+    const result = dateFormatWithoutTimezone(nonStringInput);
+    expect(result).to.equal(null);
   });
 
-  // 4) Sub-second precision or missing seconds
-  it('handles sub-second precision', () => {
-    const ts = '2023-09-29T11:04:31.123456-04:00';
-    expect(dateFormatWithoutTimezone(ts)).to.eq(
-      'September 29, 2023, 11:04 a.m.',
-    );
+  it('should throw an error for an invalid ISO string', () => {
+    const invalidISO = '2021-05-18T10:30:00';
+    try {
+      dateFormatWithoutTimezone(invalidISO);
+    } catch (error) {
+      expect(error.message).to.equal('Invalid time value');
+    }
   });
 
-  it('handles timestamps without seconds', () => {
-    const ts = '2023-09-29T11:04-04:00';
-    expect(dateFormatWithoutTimezone(ts)).to.eq(
-      'September 29, 2023, 11:04 a.m.',
-    );
+  it('should correctly format date without time zone using default format', () => {
+    const isoString = '2021-05-18T10:30:00+02:00';
+    const expectedFormat = 'May 18, 2021, 10:30 a.m.';
+    const result = dateFormatWithoutTimezone(isoString); // Default format used
+    expect(result).to.equal(expectedFormat);
   });
 
-  // 5) Date-only inputs
-  it('formats pure dates (no time)', () => {
-    const ts = '2000-08-09';
-    expect(dateFormatWithoutTimezone(ts, 'MMMM d, yyyy')).to.eq(
-      'August 9, 2000',
-    );
-  });
-
-  // 6) Epoch styles
-  it('accepts numeric epoch (0 → 1970-01-01)', () => {
-    expect(dateFormatWithoutTimezone(0)).to.eq('January 1, 1970, 12:00 a.m.');
-  });
-  it('accepts stringified epoch', () => {
-    expect(dateFormatWithoutTimezone('1605300748000')).to.eq(
-      'November 13, 2020, 8:52 p.m.',
-    );
-  });
-
-  // 7) Midday / midnight disambiguation
-  it('labels midnight as 12:00 a.m.', () => {
-    const ts = '2023-05-06T00:00:00-04:00';
-    expect(dateFormatWithoutTimezone(ts)).to.eq('May 6, 2023, 12:00 a.m.');
-  });
-  it('labels noon as 12:00 p.m.', () => {
-    const ts = '2023-05-06T12:00:00-04:00';
-    expect(dateFormatWithoutTimezone(ts)).to.eq('May 6, 2023, 12:00 p.m.');
-  });
-
-  // 8) DST‐transition "holes" (ensure it doesn't blow up)
-  it('does not throw on nonexistent local times (DST shift)', () => {
-    const ts = '2023-03-12T02:30:00-05:00'; // US spring-forward
-    expect(() => dateFormatWithoutTimezone(ts)).not.to.throw();
-  });
-
-  // 9) Totally malformed inputs
-  it('falls back gracefully for bad strings', () => {
-    expect(dateFormatWithoutTimezone('not-a-date')).to.match(/Invalid/);
-  });
-  it('handles null/undefined', () => {
-    expect(() => dateFormatWithoutTimezone(null)).to.throw();
-    expect(() => dateFormatWithoutTimezone()).to.throw();
+  it('should handle different date formats', () => {
+    const isoString = '2021-05-18T10:30:00+02:00';
+    const customFormat = 'yyyy-MM-dd';
+    const expectedFormat = '2021-05-18';
+    const result = dateFormatWithoutTimezone(isoString, customFormat);
+    expect(result).to.equal(expectedFormat);
   });
 });
 

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -326,8 +326,14 @@ export const getActiveLinksStyle = (linkPath, currentPath) => {
 };
 
 /**
- * Formats the date and accounts for the lack of a 'dd' in a date
- * @param {String} str str
+ * Formats a date string to a human-readable representation, handling cases where only the year or
+ * year-month portion is provided.
+ *
+ * @param {String} str The input date string to format
+ * @returns {string} A human-readable date string (see examples)
+ * @example formatDate("2025"); // "2025"
+ * @example formatDate("2025-07"); // "July, 2025"
+ * @example formatDate("2025-07-15"); // "July 15, 2025" (any other ISO 8601 date returns this format)
  */
 export const formatDate = str => {
   const yearRegex = /^\d{4}$/;
@@ -623,14 +629,29 @@ export const handleDataDogAction = ({
 };
 
 /**
- * Format a iso8601 date in the local browser timezone.
+ * Format an ISO 8601 date in the local browser timezone.
  *
- * @param {string} date the date to format, in ISO8601 format
- * @returns {String} formatted timestamp
+ * @param {string|number} date the date to format, in ISO 8601 format or as a millisecond timestamp
+ * @param {boolean} hideTimeZone hide time zone in output if true, otherwise include it (default is false)
+ * @returns {String} a formatted date and time string in the local timezone
+ * @example formatDateInLocalTimezone(1712264626910, true); // "April 4, 2024 5:03 p.m."
+ * @example formatDateInLocalTimezone('1997-05-07T19:14:00Z', true); // "May 7, 1997 3:14 p.m."
+ * @example formatDateInLocalTimezone('1997-05-07T19:14:00Z'); // "May 7, 1997 3:14 p.m. EDT"
  */
-export const formatDateInLocalTimezone = date => {
-  const dateObj = parseISO(date);
+export const formatDateInLocalTimezone = (date, hideTimeZone = false) => {
+  let dateObj;
+
+  if (typeof date === 'number') {
+    dateObj = new Date(date); // Millisecond timestamp
+  } else {
+    dateObj = parseISO(date); // ISO 8601
+  }
+
   const formattedDate = dateFnsFormat(dateObj, 'MMMM d, yyyy h:mm aaaa');
+  if (hideTimeZone) {
+    return formattedDate;
+  }
+
   const localTimeZoneName = dateObj
     .toLocaleDateString(undefined, { day: '2-digit', timeZoneName: 'short' })
     .substring(4);

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -67,8 +67,11 @@ export function dateFormatWithoutTimezone(
     throw new Error('Invalid time value');
   }
 
-  // 4) Format and return the formatted date
-  return dateFnsFormat(parsedDate, fmt);
+  // 4) Format and replace "PM" with "pm"
+  const formattedDate = dateFnsFormat(parsedDate, fmt);
+
+  // Replace "PM" with "pm" (case-insensitive replacement)
+  return formattedDate.replace(/\sPM$/, ' p.m.').replace(/\sAM$/, ' a.m.');
 }
 
 /**


### PR DESCRIPTION
## Summary
This refactor ensures that the function correctly handles positive and negative time-zone offsets, adjusts the time accordingly, and formats it correctly.

## Related issue(s)
[MHV-71125](https://jira.devops.va.gov/browse/MHV-71125)- Make dateFormatWithoutTimezone more robust

Currently our dateFormatWithoutTimezone is complex, and may not handle all date cases. For example, it does not handle positive time-zone offsets.

Revisit this function and ensure that it can handle anything thrown at it. Beef up the unit tests to handle all edge cases.

 
Figma Link: N/A

User Story:  As a MR user, I want to    so that I can


 ** 

DEV:

Feature Flag Y/N ? N

Collab Cycle Y/N ? N

Platform Approval T/N ? N


UCD:

DataDog Analytics Y/N ? N

Analytics Tagging Changes needed (Datadog or other)?  Y/N ? N

 

Testing:

Manual Testing Y/N ? TBD

Automated Testing Y/N ? N

Accessibility Testing Y/N ? N

UCD Validation Y/N ? N

 

Acceptance Criteria:

AC1  Review and changes of timezone functionality is complete

AC2 Add testing tickets if code changes are necessary

AC3

AC4

## Screen Shot
NONE



## What areas of the site does it impact?
All components that uses dateFormatWithoutTimezone in  the medical records section

## Acceptance criteria
Handles positive time-zone offsets

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


