### PR TITLE
New workflow: Add Team Reviewer CoP Checker

### DIFF
--- a/.github/workflows/add_team_reviewer_cop_checker.yml
+++ b/.github/workflows/add_team_reviewer_cop_checker.yml
@@ -1,0 +1,55 @@
+name: Add Team Reviewer CoP Checker
+
+on:
+  pull_request_review:
+    types: [submitted]
+    
+jobs:
+  add-team-reviewer:
+    # Only run this job when changes are requested
+    if: github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Check if reviewer is team member and add team
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const reviewer = context.payload.review.user.login;
+            const teamSlug = 'va-platform-cop-frontend';
+            const teamToAdd = 'department-of-veterans-affairs/va-platform-cop-frontend';
+            
+            console.log(`Changes requested by: ${reviewer}`);
+            
+            try {
+              // Check if the reviewer is a member of the specified team
+              const { data: teamMembers } = await github.rest.teams.listMembersInOrg({
+                org: context.repo.owner,
+                team_slug: teamSlug
+              });
+              
+              const isTeamMember = teamMembers.some(member => member.login === reviewer);
+              
+              if (isTeamMember) {
+                console.log(`${reviewer} is a member of ${teamSlug}. Adding team as reviewer.`);
+                
+                // Add the team as a reviewer
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  team_reviewers: [teamSlug]
+                });
+                
+                console.log(`Added ${teamSlug} as reviewer`);
+              } else {
+                console.log(`${reviewer} is not a member of ${teamSlug}. No action taken.`);
+              }
+            } catch (error) {
+              console.error('Error:', error);
+              core.setFailed(`Action failed with error: ${error}`);
+            }


### PR DESCRIPTION
This work will add a new workflow to vets-website Pull Requests. 

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

When a PR has changes requested by the CoP engineer, the CoP is removed as a reviewer from the Pull Request. This will workflow is designed to fix the issue.

The workflow will trigger on a submitted pull request with changes requested. It will take the reviewers GitHub username and reference the CoP GitHub team. If the reviewer is a member of the va-platform-cop-frontend, the CoP will be added back to the PR as a reviewer. 

More detailed information on this can be found within this GitHub ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/107277

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/107277

## Testing done

Testing this is only possible once this PR is merged and the workflow is active

## What areas of the site does it impact?

Not Applicable

*(Describe what parts of the site are impacted **if** code touched other areas)*

Not Applicable
