### PR TITLE
109014a hide pii in 10 7959a rum dashboard

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
@@ -199,11 +199,11 @@ export const medicalClaimUploadSchema = {
             </ul>
           </li>
           <li>
-            <b>A list of charges</b> for
+            <b>A list of charges</b> for{' '}
             {privWrapper(nameWording(formData, true, false, true))} care
           </li>
           <li>
-            <b>The date of service</b> when
+            <b>The date of service</b> when{' '}
             {privWrapper(nameWording(formData, false, false, true))} got the
             care
           </li>

--- a/src/applications/ivc-champva/10-7959a/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/ConfirmationPage.jsx
@@ -44,14 +44,14 @@ export class ConfirmationPage extends React.Component {
           </h2>
           {data.applicantName && (
             <>
-              <span className="veterans-full-name">
+              <span className="veterans-full-name dd-privacy-hidden">
                 <strong>Applicant’s name</strong>
                 <br />
                 {applicantWording(form.data, false, false, false)}
               </span>
               <br />
               <br />
-              <span className="signer-name">
+              <span className="signer-name dd-privacy-hidden">
                 <strong>Who submitted this form</strong>
                 <br />
                 {data.statementOfTruthSignature || data.signature}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR hides some more PII on the confirmation page of form 10-7959a when viewed in DataDog Real User Monitoring sessions.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109014

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![un](https://github.com/user-attachments/assets/13d45fda-20ef-40a3-9d22-85d0a21546aa)|![Screenshot 2025-05-27 at 11 04 26](https://github.com/user-attachments/assets/0b26cff2-ebe1-4874-9e9a-20ad5359470f)|

## What areas of the site does it impact?

IVC CHAMPVA form 10-7959a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA