### PR TITLE
Remove DS Logon references from Mock Data in Education Letters App

### DIFF
--- a/src/applications/education-letters/tests/fixtures/userResponse.js
+++ b/src/applications/education-letters/tests/fixtures/userResponse.js
@@ -10,7 +10,7 @@ export const mebUser = {
       },
       profile: {
         signIn: {
-          serviceName: CSP_IDS.DS_LOGON,
+          serviceName: CSP_IDS.ID_ME,
           accountType: '2',
           ssoe: false,
         },
@@ -23,7 +23,7 @@ export const mebUser = {
         birthDate: '1985-01-01',
         // dateOfBirth: '1990-01-01',
         verified: true,
-        authnContext: 'dslogon',
+        authnContext: 'idme',
         multifactor: true,
         zip: '21076',
         lastSignedIn: '2022-05-18T22:02:02.188Z',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated the mock data in the Education Letters App so that it no longer references DS Logon (which is soon to be deprecated).

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/300)

## Testing done
- Ran tests locally and ensured no breaking changes.
- Can be replicated by running `yarn cy:run --spec "src/applications/education-letters/tests/e2e/00-letters-all-fields.cypress.spec.js"`

## What areas of the site does it impact?
This primarily impacts `src/applications/education-letters/tests/fixtures/userResponse.js` and the related tests.

## Acceptance criteria
- [x] Update mocks to replace DS Logon with a different CSP.
- [x] Update tests if needed.