### PR TITLE
MBMS-86661 Changed pre need int service period date range error

### DIFF
--- a/src/applications/pre-need-integration/config/pages/servicePeriodsPages.jsx
+++ b/src/applications/pre-need-integration/config/pages/servicePeriodsPages.jsx
@@ -252,6 +252,7 @@ export function servicePeriodInformationPage(isVet, isPrep) {
           'Sponsor’s service end date',
           'Applicant’s service end date',
         ),
+        'The service end date must be after the service start date.', // Range error message
       ),
       dischargeType: {
         'ui:title': handleTitle(


### PR DESCRIPTION
## Summary

- Validation error messaging for when the inputted end date is before the inputted start date is wrong in Pre-Need integration and pre-integration

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-86661

## Testing done

- [x] POR/UI/UX Review
- [x] Unit Tests Passing
- [ ] Internal Review
- [x] External Review
- [x] QA

## Screenshots

https://github.com/user-attachments/assets/70375b18-66ae-4053-bbfb-288410ec245e

## What areas of the site does it impact?

_**Pre-need-integration service period date range**_

## Acceptance criteria
![image](https://github.com/user-attachments/assets/74a29d5e-3639-4e4f-b90d-1cad52b9b659)