### PR TITLE
convert pages to cy.fillAddressWebComponentPattern

### DIFF
--- a/src/applications/burials-ez/tests/e2e/burials.cypress.spec.js
+++ b/src/applications/burials-ez/tests/e2e/burials.cypress.spec.js
@@ -12,11 +12,7 @@ import mockUser from '../fixtures/mocks/user.json';
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 
-import {
-  fillAddressWebComponentPattern,
-  selectCheckboxWebComponent,
-  selectRadioWebComponent,
-} from './helpers';
+import { selectCheckboxWebComponent, selectRadioWebComponent } from './helpers';
 
 import pagePaths from './pagePaths';
 
@@ -94,7 +90,10 @@ export const pageHooks = cy => ({
   },
   [pagePaths.mailingAddress]: () => {
     cy.get('@testData').then(data => {
-      fillAddressWebComponentPattern('claimantAddress', data.claimantAddress);
+      cy.fillAddressWebComponentPattern(
+        'claimantAddress',
+        data.claimantAddress,
+      );
     });
   },
   [pagePaths.separationDocuments]: () => {

--- a/src/applications/burials-ez/tests/e2e/helpers/index.js
+++ b/src/applications/burials-ez/tests/e2e/helpers/index.js
@@ -40,25 +40,3 @@ export const selectRadioWebComponent = (fieldName, value) => {
     cy.get(`va-radio-option[name="${fieldName}"][value="${value}"]`).click();
   }
 };
-
-// pattern fill helpers
-export const fillAddressWebComponentPattern = (fieldName, addressObject) => {
-  selectCheckboxWebComponent(
-    `${fieldName}_isMilitary`,
-    addressObject.isMilitary,
-  );
-  if (addressObject.city) {
-    if (addressObject.isMilitary) {
-      // there is a select dropdown instead when military is checked
-      selectDropdownWebComponent(`${fieldName}_city`, addressObject.city);
-    } else {
-      fillTextWebComponent(`${fieldName}_city`, addressObject.city);
-    }
-  }
-  selectDropdownWebComponent(`${fieldName}_country`, addressObject.country);
-  fillTextWebComponent(`${fieldName}_street`, addressObject.street);
-  fillTextWebComponent(`${fieldName}_street2`, addressObject.street2);
-  fillTextWebComponent(`${fieldName}_street3`, addressObject.street3);
-  selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
-  fillTextWebComponent(`${fieldName}_postalCode`, addressObject.postalCode);
-};

--- a/src/applications/ezr/tests/e2e/ezr.cypress.spec.js
+++ b/src/applications/ezr/tests/e2e/ezr.cypress.spec.js
@@ -171,7 +171,7 @@ const testConfig = createTestConfig(
             const fieldName = 'spouseAddress';
             const fieldData =
               data['view:spouseContactInformation'].spouseAddress;
-            fillAddressWebComponentPattern(fieldName, fieldData);
+            cy.fillAddressWebComponentPattern(fieldName, fieldData);
             cy.injectAxeThenAxeCheck();
             goToNextPage();
           });

--- a/src/applications/ezr/tests/e2e/ezr.cypress.spec.js
+++ b/src/applications/ezr/tests/e2e/ezr.cypress.spec.js
@@ -8,11 +8,7 @@ import mockUser from './fixtures/mocks/mock-user';
 import mockPrefill from './fixtures/mocks/mock-prefill.json';
 import featureToggles from './fixtures/mocks/mock-features.json';
 import { MOCK_ENROLLMENT_RESPONSE } from '../../utils/constants';
-import {
-  fillAddressWebComponentPattern,
-  selectYesNoWebComponent,
-  goToNextPage,
-} from './helpers';
+import { selectYesNoWebComponent, goToNextPage } from './helpers';
 import {
   fillContactPersonalInfo,
   fillContactAddress,
@@ -48,7 +44,7 @@ const testConfig = createTestConfig(
           cy.get('@testData').then(data => {
             const fieldName = 'veteranHomeAddress';
             const fieldData = data.veteranHomeAddress;
-            fillAddressWebComponentPattern(fieldName, fieldData);
+            cy.fillAddressWebComponentPattern(fieldName, fieldData);
             cy.injectAxeThenAxeCheck();
             goToNextPage();
           });

--- a/src/applications/ezr/tests/e2e/helpers/index.js
+++ b/src/applications/ezr/tests/e2e/helpers/index.js
@@ -62,28 +62,6 @@ export const selectYesNoWebComponent = (fieldName, value) => {
   selectRadioWebComponent(fieldName, selection);
 };
 
-// pattern fill helpers
-export const fillAddressWebComponentPattern = (fieldName, addressObject) => {
-  selectCheckboxWebComponent(
-    `${fieldName}_isMilitary`,
-    addressObject.isMilitary,
-  );
-  if (addressObject.city) {
-    if (addressObject.isMilitary) {
-      // there is a select dropdown instead when military is checked
-      selectDropdownWebComponent(`${fieldName}_city`, addressObject.city);
-    } else {
-      fillTextWebComponent(`${fieldName}_city`, addressObject.city);
-    }
-  }
-  selectDropdownWebComponent(`${fieldName}_country`, addressObject.country);
-  fillTextWebComponent(`${fieldName}_street`, addressObject.street);
-  fillTextWebComponent(`${fieldName}_street2`, addressObject.street2);
-  fillTextWebComponent(`${fieldName}_street3`, addressObject.street3);
-  selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
-  fillTextWebComponent(`${fieldName}_postalCode`, addressObject.postalCode);
-};
-
 export const fillDateWebComponentPattern = (fieldName, value) => {
   if (typeof value !== 'undefined') {
     const [year, month, day] = value.split('-');

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -14,7 +14,6 @@ import {
   fillFullNameWebComponentPattern,
   reviewAndSubmitPageFlow,
   fillDateWebComponentPattern,
-  fillAddressWebComponentPattern,
   getAllPages,
   verifyAllDataWasSubmitted,
 } from '../../shared/tests/helpers';
@@ -61,7 +60,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'certifierAddress',
               data.certifierAddress,
             );
@@ -98,7 +97,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'sponsorAddress',
               data.sponsorAddress,
             );
@@ -187,7 +186,7 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.get('@testData').then(data => {
             cy.url().then(url => {
-              fillAddressWebComponentPattern(
+              cy.fillAddressWebComponentPattern(
                 'applicantAddress',
                 data.applicants[getIdx(url)].applicantAddress,
               );

--- a/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
@@ -7,7 +7,6 @@ import formConfig from '../config/form';
 import manifest from '../manifest.json';
 
 import {
-  fillAddressWebComponentPattern,
   selectRadioWebComponent,
   getAllPages,
   verifyAllDataWasSubmitted,
@@ -25,10 +24,10 @@ const testConfig = createTestConfig(
     dataDir: path.join(__dirname, 'e2e', 'fixtures', 'data'),
 
     // Rename and modify the test data as needed.
-    /* 
+    /*
     1. test-data: standard run-through of the form
     The rest of the tests are described by their filenames and are just
-    variations designed to trigger the conditionals in the form/follow different paths. 
+    variations designed to trigger the conditionals in the form/follow different paths.
     */
     dataSets: [
       'not-enrolled-champva.json',
@@ -71,7 +70,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'applicantAddress',
               data.applicantAddress,
             );

--- a/src/applications/ivc-champva/10-7959C/tests/10-7959C_uploads.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/10-7959C_uploads.cypress.spec.js
@@ -22,7 +22,6 @@ import formConfig from '../config/form';
 import manifest from '../manifest.json';
 
 import {
-  fillAddressWebComponentPattern,
   selectRadioWebComponent,
   getAllPages,
   verifyAllDataWasSubmitted,
@@ -59,7 +58,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'applicantAddress',
               data.applicantAddress,
             );

--- a/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
@@ -11,7 +11,6 @@ import manifest from '../manifest.json';
 import {
   verifyAllDataWasSubmitted,
   reviewAndSubmitPageFlow,
-  fillAddressWebComponentPattern,
   selectRadioWebComponent,
   getAllPages,
 } from '../../shared/tests/helpers';
@@ -83,7 +82,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'certifierAddress',
               data.certifierAddress,
             );
@@ -96,7 +95,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'applicantAddress',
               data.applicantAddress,
             );

--- a/src/applications/ivc-champva/10-7959f-1/tests/e2e/10-7959f-1-FMP-statement-of-truth.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959f-1/tests/e2e/10-7959f-1-FMP-statement-of-truth.cypress.spec.js
@@ -6,7 +6,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 import {
-  fillAddressWebComponentPattern,
   verifyAllDataWasSubmitted,
   getAllPages,
 } from '../../../shared/tests/helpers';
@@ -47,7 +46,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranAddress',
               data.veteranAddress,
             );
@@ -60,7 +59,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'physicalAddress',
               data.physicalAddress,
             );

--- a/src/applications/ivc-champva/10-7959f-1/tests/e2e/10-7959f-1-FMP.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959f-1/tests/e2e/10-7959f-1-FMP.cypress.spec.js
@@ -6,7 +6,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 import {
-  fillAddressWebComponentPattern,
   reviewAndSubmitPageFlow,
   verifyAllDataWasSubmitted,
   getAllPages,
@@ -34,7 +33,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranAddress',
               data.veteranAddress,
             );
@@ -47,7 +46,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'physicalAddress',
               data.physicalAddress,
             );

--- a/src/applications/ivc-champva/10-7959f-2/tests/fmp-cover-sheet.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959f-2/tests/fmp-cover-sheet.cypress.spec.js
@@ -7,7 +7,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import {
-  fillAddressWebComponentPattern,
   reviewAndSubmitPageFlow,
   verifyAllDataWasSubmitted,
   getAllPages,
@@ -40,7 +39,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranAddress',
               data.veteranAddress,
             );
@@ -53,7 +52,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'physicalAddress',
               data.physicalAddress,
             );

--- a/src/applications/ivc-champva/10-7959f-2/tests/fmp-cover-sheet_uploads.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959f-2/tests/fmp-cover-sheet_uploads.cypress.spec.js
@@ -7,7 +7,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import {
-  fillAddressWebComponentPattern,
   reviewAndSubmitPageFlow,
   verifyAllDataWasSubmitted,
   getAllPages,
@@ -95,7 +94,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'veteranAddress',
               data.veteranAddress,
             );
@@ -108,7 +107,7 @@ const testConfig = createTestConfig(
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'physicalAddress',
               data.physicalAddress,
             );

--- a/src/applications/ivc-champva/shared/tests/helpers.js
+++ b/src/applications/ivc-champva/shared/tests/helpers.js
@@ -25,35 +25,6 @@ export const selectDropdownWebComponent = (fieldName, value) => {
   cy.selectVaSelect(`root_${fieldName}`, value);
 };
 
-export const fillAddressWebComponentPattern = (fieldName, addressObject) => {
-  selectCheckboxWebComponent(
-    `${fieldName}_isMilitary`,
-    addressObject.isMilitary,
-  );
-  if (addressObject.city) {
-    if (addressObject.isMilitary) {
-      // there is a select dropdown instead when military is checked
-      selectDropdownWebComponent(`${fieldName}_city`, addressObject.city);
-    } else {
-      fillTextWebComponent(`${fieldName}_city`, addressObject.city);
-    }
-  }
-  selectDropdownWebComponent(`${fieldName}_country`, addressObject.country);
-  fillTextWebComponent(`${fieldName}_street`, addressObject.street);
-  fillTextWebComponent(`${fieldName}_street2`, addressObject.street2);
-  fillTextWebComponent(`${fieldName}_street3`, addressObject.street3);
-  // List loop fields sometimes fail on this because the state <select> renders as a text input
-  // TODO: look into that bug. For now, set the test to check which field type we have
-  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/83806
-  cy.get('body').then(body => {
-    if (body.find(`va-select[name="root_${fieldName}_state"]`).length > 0)
-      selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
-    if (body.find(`va-text-input[name="root_${fieldName}_state"]`).length > 0)
-      fillTextWebComponent(`${fieldName}_state`, addressObject.state);
-  });
-  fillTextWebComponent(`${fieldName}_postalCode`, addressObject.postalCode);
-};
-
 export const fillDateWebComponentPattern = (fieldName, value) => {
   if (typeof value !== 'undefined') {
     const [year, month, day] = value.split('-');

--- a/src/applications/new-28-1900/tests/e2e/28-1900.cypress.spec.jsx
+++ b/src/applications/new-28-1900/tests/e2e/28-1900.cypress.spec.jsx
@@ -9,10 +9,7 @@ import featureToggles from '../fixtures/mocks/featureToggles.json';
 import minimalFlow from '../fixtures/data/minimalFlow.json';
 import maximalFlow from '../fixtures/data/maximalFlow.json';
 import militaryAddressFlow from '../fixtures/data/militaryAddressFlow.json';
-import {
-  fillAddressWebComponentPattern,
-  selectCheckboxWebComponent,
-} from './utilities';
+import { selectCheckboxWebComponent } from './utilities';
 
 const testConfig = createTestConfig(
   {
@@ -39,7 +36,7 @@ const testConfig = createTestConfig(
                 data.checkBoxGroup.checkForMailingAddress,
               );
             } else {
-              fillAddressWebComponentPattern(
+              cy.fillAddressWebComponentPattern(
                 'mainMailingAddress',
                 data.mainMailingAddress,
               );
@@ -51,7 +48,7 @@ const testConfig = createTestConfig(
       'new-mailing-address': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillAddressWebComponentPattern(
+            cy.fillAddressWebComponentPattern(
               'newMailingAddress',
               data.newMailingAddress,
             );

--- a/src/applications/new-28-1900/tests/e2e/utilities.js
+++ b/src/applications/new-28-1900/tests/e2e/utilities.js
@@ -9,24 +9,3 @@ export const selectDropdownWebComponent = (fieldName, value) => {
 export const selectCheckboxWebComponent = (fieldName, condition) => {
   cy.selectVaCheckbox(`root_${fieldName}`, condition);
 };
-
-export const fillAddressWebComponentPattern = (fieldName, addressObject) => {
-  selectCheckboxWebComponent(
-    `${fieldName}_isMilitary`,
-    addressObject.isMilitary,
-  );
-  if (addressObject.city) {
-    if (addressObject.isMilitary) {
-      // there is a select dropdown instead when military is checked
-      selectDropdownWebComponent(`${fieldName}_city`, addressObject.city);
-    } else {
-      fillTextWebComponent(`${fieldName}_city`, addressObject.city);
-    }
-  }
-  selectDropdownWebComponent(`${fieldName}_country`, addressObject.country);
-  fillTextWebComponent(`${fieldName}_street`, addressObject.street);
-  fillTextWebComponent(`${fieldName}_street2`, addressObject.street2);
-  fillTextWebComponent(`${fieldName}_street3`, addressObject.street3);
-  selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
-  fillTextWebComponent(`${fieldName}_postalCode`, addressObject.postalCode);
-};


### PR DESCRIPTION
## Summary

- Migrate form cypress tests to use `cy.fillAddressWebComponentPattern`, so it will keep up to date with new address changes.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
- https://github.com/department-of-veterans-affairs/vets-website/pull/36694
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4204
- https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2136

## Testing done

- unit and cypress

## Screenshots

n/a

## What areas of the site does it impact?

cypress tests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
