### PR TITLE
Remove unused exports in VAOS files

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -47,7 +47,7 @@ function getFirstDayOfMonth(momentDate) {
  * @param {string} maxDate YYYY-DD-MM
  * @returns {string} YYYY-MM
  */
-export function getMaxMonth(maxDate, overrideMaxDays) {
+function getMaxMonth(maxDate, overrideMaxDays) {
   const defaultMaxMonth = moment()
     .add(DEFAULT_MAX_DAYS_AHEAD, 'days')
     .format('YYYY-MM');
@@ -148,7 +148,7 @@ function getCells(momentDate, showWeekend) {
  * @param {boolean} [showWeekend] Whether to show full weekend slots or not
  * @returns {Array} Array of weeks
  */
-export function getCalendarWeeks(momentDate, showWeekend) {
+function getCalendarWeeks(momentDate, showWeekend) {
   const dateCells = getCells(momentDate, showWeekend);
   const weeks = [];
   const daysToShow = showWeekend ? 7 : 5;

--- a/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
@@ -66,7 +66,7 @@ const uiSchema = {
 const pageKey = 'contactInfo';
 const pageTitle = 'Confirm your contact information';
 
-export function ContactInfoPage({
+function ContactInfoPage({
   data,
   openFormPage,
   pageChangeInProgress,

--- a/src/applications/vaos/covid-19-vaccine/flow.js
+++ b/src/applications/vaos/covid-19-vaccine/flow.js
@@ -68,7 +68,7 @@ export default function getPageFlow() {
   };
 }
 
-export function routeToPageInFlow(history, current, action, data) {
+function routeToPageInFlow(history, current, action, data) {
   return async (dispatch, getState) => {
     const pageFlow = getPageFlow();
 

--- a/src/applications/vaos/covid-19-vaccine/redux/selectors.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/selectors.js
@@ -8,7 +8,7 @@ import { getSiteIdFromFacilityId } from '../../services/location';
 import { selectCanUseVaccineFlow } from '../../appointment-list/redux/selectors';
 import { TYPE_OF_CARE_ID } from '../utils';
 
-export function selectCovid19Vaccine(state) {
+function selectCovid19Vaccine(state) {
   return state.covid19Vaccine;
 }
 
@@ -33,20 +33,20 @@ export function getCovid19VaccineFormPageInfo(state, pageKey) {
   };
 }
 
-export function getSiteIdForChosenFacility(state) {
+function getSiteIdForChosenFacility(state) {
   return getSiteIdFromFacilityId(
     selectCovid19VaccineFormData(state).vaFacility,
   );
 }
 
 export function getChosenSlot(state) {
-  const availableSlots = selectCovid19VaccineNewBooking(state).availableSlots;
+  const { availableSlots } = selectCovid19VaccineNewBooking(state);
   const selectedTime = selectCovid19VaccineFormData(state).date1?.[0];
 
   return availableSlots?.find(slot => slot.start === selectedTime);
 }
 
-export function getChosenFacilityInfo(state) {
+function getChosenFacilityInfo(state) {
   return (
     selectCovid19VaccineNewBooking(state).facilities?.find(
       facility =>
@@ -57,10 +57,10 @@ export function getChosenFacilityInfo(state) {
 
 export function getDateTimeSelect(state, pageKey) {
   const newBooking = selectCovid19VaccineNewBooking(state);
-  const appointmentSlotsStatus = newBooking.appointmentSlotsStatus;
+  const { appointmentSlotsStatus } = newBooking;
   const data = selectCovid19VaccineFormData(state);
   const formInfo = getCovid19VaccineFormPageInfo(state, pageKey);
-  const availableSlots = newBooking.availableSlots;
+  const { availableSlots } = newBooking;
 
   const timezoneDescription = getTimezoneDescByFacilityId(data.vaFacility);
   const timezone = getTimezoneByFacilityId(data.vaFacility);
@@ -119,7 +119,7 @@ export function getFacilityPageInfo(state) {
 export function getClinicPageInfo(state, pageKey) {
   const formPageInfo = getCovid19VaccineFormPageInfo(state, pageKey);
   const newBooking = selectCovid19VaccineNewBooking(state);
-  const facilities = newBooking.facilities;
+  const { facilities } = newBooking;
 
   return {
     ...formPageInfo,
@@ -131,7 +131,7 @@ export function getClinicPageInfo(state, pageKey) {
 
 export function getChosenClinicInfo(state) {
   const data = selectCovid19VaccineFormData(state);
-  const clinics = selectCovid19VaccineNewBooking(state).clinics;
+  const { clinics } = selectCovid19VaccineNewBooking(state);
 
   return (
     clinics[data.vaFacility]?.find(clinic => clinic.id === data.clinicId) ||
@@ -148,16 +148,6 @@ export function getReviewPage(state) {
     submitStatus: selectCovid19Vaccine(state).submitStatus,
     submitStatusVaos400: selectCovid19Vaccine(state).submitStatusVaos400,
     systemId: getSiteIdForChosenFacility(state),
-  };
-}
-
-export function selectConfirmationPage(state) {
-  return {
-    clinic: getChosenClinicInfo(state),
-    data: selectCovid19VaccineFormData(state),
-    facilityDetails: getChosenFacilityInfo(state),
-    slot: getChosenSlot(state),
-    submitStatus: selectCovid19Vaccine(state).submitStatus,
   };
 }
 

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
@@ -80,7 +80,7 @@ function ActionButtons(props) {
   );
 }
 
-export const WaitTimeAlert = ({
+const WaitTimeAlert = ({
   eligibleForRequests,
   facilityId,
   nextAvailableApptDate,

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -74,7 +74,7 @@ import { getTypeOfCare } from './selectors';
 import { distanceBetween } from '../../utils/address';
 import { isTypeOfCareSupported } from '../../services/location';
 
-export const REASON_ADDITIONAL_INFO_TITLES = {
+const REASON_ADDITIONAL_INFO_TITLES = {
   va: 'Add any details you’d like to share with your provider.',
   ccRequest:
     'Share any information that you think will help the provider prepare for your appointment. You don’t have to share anything if you don’t want to.',

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -40,10 +40,6 @@ export function getFlowType(state) {
   return getNewAppointment(state)?.flowType;
 }
 
-export function getAppointmentLength(state) {
-  return getNewAppointment(state).appointmentLength;
-}
-
 export function getFormPageInfo(state, pageKey) {
   return {
     schema: getNewAppointment(state).pages[pageKey],
@@ -121,7 +117,7 @@ export function getChosenCCSystemById(state) {
   );
 }
 
-export function getSiteIdForChosenFacility(state) {
+function getSiteIdForChosenFacility(state) {
   return getSiteIdFromFacilityId(getFormData(state).vaFacility);
 }
 
@@ -219,11 +215,11 @@ export function selectProviderSelectionInfo(state) {
   };
 }
 
-export function selectFacilityPageSortMethod(state) {
+function selectFacilityPageSortMethod(state) {
   return getNewAppointment(state).facilityPageSortMethod;
 }
 
-export function selectNoValidVAFacilities(state) {
+function selectNoValidVAFacilities(state) {
   const newAppointment = getNewAppointment(state);
   const formInfo = getFormPageInfo(state, 'vaFacilityV2');
   const { childFacilitiesStatus } = newAppointment;
@@ -234,7 +230,7 @@ export function selectNoValidVAFacilities(state) {
   );
 }
 
-export function selectSingleValidVALocation(state) {
+function selectSingleValidVALocation(state) {
   const formInfo = getFormPageInfo(state, 'vaFacilityV2');
   const data = getFormData(state);
   const validFacilities = formInfo.schema?.properties.vaFacility.enum;
@@ -343,7 +339,7 @@ export function selectPatientProviderRelationships(state) {
   };
 }
 
-export function getChosenVACityState(state) {
+function getChosenVACityState(state) {
   const schema =
     state.newAppointment.pages.ccPreferences?.properties.communityCareSystemId;
 
@@ -356,20 +352,6 @@ export function getChosenVACityState(state) {
   }
 
   return null;
-}
-
-export function selectConfirmationPage(state) {
-  return {
-    data: getFormData(state),
-    clinic: getChosenClinicInfo(state),
-    facilityDetails: getChosenFacilityInfo(state),
-    slot: getChosenSlot(state),
-    systemId: getSiteIdForChosenFacility(state),
-    submitStatus: getNewAppointment(state).submitStatus,
-    flowType: getFlowType(state),
-    appointmentLength: getAppointmentLength(state),
-    hasResidentialAddress: selectHasVAPResidentialAddress(state),
-  };
 }
 
 export function selectReviewPage(state) {

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -99,9 +99,6 @@ export const selectFeatureFeSourceOfTruthModality = state =>
 export const selectFeatureFeSourceOfTruthTelehealth = state =>
   toggleValues(state).vaOnlineSchedulingFeSourceOfTruthTelehealth;
 
-export const selectFeatureMhvRouteGuards = state =>
-  toggleValues(state).vaOnlineSchedulingMHVRouteGuards;
-
 export const selectFeatureDirectScheduleAppointmentConflict = state =>
   toggleValues(state).vaOnlineSchedulingDirectScheduleAppointmentConflict;
 

--- a/src/applications/vaos/redux/sitewide.js
+++ b/src/applications/vaos/redux/sitewide.js
@@ -3,11 +3,7 @@
  * reducers, importing across those boundaries may pull in code we don't want.
  */
 export const STARTED_NEW_APPOINTMENT_FLOW = 'vaos/STARTED_NEW_APPOINTMENT_FLOW';
-export const STARTED_NEW_EXPRESS_CARE_FLOW =
-  'vaos/STARTED_NEW_EXPRESS_CARE_FLOW';
 export const STARTED_NEW_VACCINE_FLOW = 'vaos/STARTED_NEW_VACCINE_FLOW';
 export const FORM_SUBMIT_SUCCEEDED = 'vaos/FORM_SUBMIT_SUCCEEDED';
-export const EXPRESS_CARE_FORM_SUBMIT_SUCCEEDED =
-  'expressCare/FORM_SUBMIT_SUCCEEDED';
 export const VACCINE_FORM_SUBMIT_SUCCEEDED =
   'covid19Vaccine/FORM_SUBMIT_SUCCEEDED';

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -85,7 +85,7 @@ function getMomentConfirmedDate(appt) {
  *  +60 min or +240 min in the case of video
  * @param {*} appt VAOS Service appointment object
  */
-export function isPastAppointment(appt) {
+function isPastAppointment(appt) {
   const isVideo = appt.kind === 'telehealth';
   const threshold = isVideo ? 240 : 60;
   const apptDateTime = moment(getMomentConfirmedDate(appt));
@@ -97,7 +97,7 @@ export function isPastAppointment(appt) {
  * @param {*} appt VAOS Service appointment object
  * @param {*} isRequest is appointment a request
  */
-export function isFutureAppointment(appt, isRequest) {
+function isFutureAppointment(appt, isRequest) {
   const apptDateTime = moment(appt.start);
   return (
     !isRequest &&

--- a/src/applications/vaos/services/healthcare-service/index.js
+++ b/src/applications/vaos/services/healthcare-service/index.js
@@ -74,13 +74,3 @@ export async function fetchHealthcareServiceById({ locationId, id }) {
 export function getClinicId(clinic) {
   return clinic.id.split('_')[1];
 }
-
-/**
- * Method to get the site code.
- *
- * @param {Object} clinic
- * @returns {String} The clinic site code or empty string.
- */
-export function getSiteCode(clinic) {
-  return clinic.id.split('_')[0];
-}

--- a/src/applications/vaos/services/healthcare-service/transformers.js
+++ b/src/applications/vaos/services/healthcare-service/transformers.js
@@ -9,7 +9,7 @@
  *
  * @returns {HealthCareService} A HealthCareService resource
  */
-export function transformClinicV2(clinic) {
+function transformClinicV2(clinic) {
   return {
     // ID: VA facility site code and clinic id
     id: `${clinic.vistaSite}_${clinic.id}`,

--- a/src/applications/vaos/services/location/transformers.js
+++ b/src/applications/vaos/services/location/transformers.js
@@ -99,12 +99,11 @@ export function setSupportedSchedulingMethods({ location, settings } = {}) {
  * Transforms a single vets-api PPMS provider format into a Location
  * resource
  *
- * @export
  * @param {Object<PPMSProvider>} provider A PPMS provider
  * @returns {Array<Location>} A Location resource
  */
 
-export function transformCommunityProvider(provider) {
+function transformCommunityProvider(provider) {
   return {
     id: provider.id,
     identifier: [{ system: 'PPMS', value: provider.uniqueId }],

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -38,7 +38,6 @@ const VAOS_SERVICE_REQUEST_LIMIT = 'facility-request-limit-exceeded';
 /**
  * Returns patient based eligibility checks for specified request or direct types
  *
- * @export
  * @param {Object} params
  * @param {TypeOfCare} params.typeOfCare Type of care object,
  * @param {Location} params.location Location of where patient should have eligibility checked,
@@ -47,11 +46,7 @@ const VAOS_SERVICE_REQUEST_LIMIT = 'facility-request-limit-exceeded';
  * }
  * @returns {PatientEligibility} Patient eligibility data
  */
-export async function fetchPatientEligibility({
-  typeOfCare,
-  location,
-  type = null,
-}) {
+async function fetchPatientEligibility({ typeOfCare, location, type = null }) {
   const checks = {};
   if (type !== 'request') {
     checks.direct = getPatientEligibility(

--- a/src/applications/vaos/tests/e2e/page-objects/AppointmentList/AppointmentDetailPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/AppointmentList/AppointmentDetailPageObject.js
@@ -76,7 +76,7 @@ function assertSummary(type, tokens) {
   }
 }
 
-export class AppointmentDetailPageObject extends PageObject {
+class AppointmentDetailPageObject extends PageObject {
   assertAddToCalendar() {
     this.assertShadow({
       element: '[data-testid="add-to-calendar-button"]',

--- a/src/applications/vaos/tests/e2e/page-objects/AppointmentList/PastAppointmentListPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/AppointmentList/PastAppointmentListPageObject.js
@@ -1,6 +1,6 @@
 import { AppointmentListPageObject } from './AppointmentListPageObject';
 
-export class PastAppointmentListPageObject extends AppointmentListPageObject {
+class PastAppointmentListPageObject extends AppointmentListPageObject {
   assertAppointmentList({ numberOfAppointments = 0 } = {}) {
     super.assertAppointmentList({ numberOfAppointments });
 

--- a/src/applications/vaos/tests/e2e/page-objects/AppointmentList/PendingAppointmentListPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/AppointmentList/PendingAppointmentListPageObject.js
@@ -1,6 +1,6 @@
 import { AppointmentListPageObject } from './AppointmentListPageObject';
 
-export class PendingAppointmentListPageObject extends AppointmentListPageObject {
+class PendingAppointmentListPageObject extends AppointmentListPageObject {
   assertAppointmentList({ numberOfAppointments = 0 } = {}) {
     super.assertAppointmentList({ numberOfAppointments });
 

--- a/src/applications/vaos/tests/e2e/page-objects/AudiologyPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/AudiologyPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class AudiologyPageObject extends PageObject {
+class AudiologyPageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', 'audiology-care');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/ClinicChoicePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ClinicChoicePageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ClinicChoicePageObject extends PageObject {
+class ClinicChoicePageObject extends PageObject {
   assertSingleClinic() {
     cy.get('va-radio').contains('Would you like to make an appointment at');
     return this;

--- a/src/applications/vaos/tests/e2e/page-objects/ClosestCityStatePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ClosestCityStatePageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ClosestCityStatePageObject extends PageObject {
+class ClosestCityStatePageObject extends PageObject {
   assertHeading({ name }) {
     return this.assertShadow({
       element: 'va-radio',

--- a/src/applications/vaos/tests/e2e/page-objects/CommunityCarePreferencesPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/CommunityCarePreferencesPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class CommunityCarePreferencesPageObject extends PageObject {
+class CommunityCarePreferencesPageObject extends PageObject {
   assertHomeAddress({ exist = true } = {}) {
     cy.findByTestId('providersSelect')
       .as('providersSelect')

--- a/src/applications/vaos/tests/e2e/page-objects/ConfirmationPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ConfirmationPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ConfirmationPageObject extends PageObject {
+class ConfirmationPageObject extends PageObject {
   assertUrl({ isDirect = true } = {}) {
     cy.url().should('include', isDirect ? '/mock1' : '/pending');
     cy.get('va-loading-indicator.hydrated', { timeout: 240000 }).should(

--- a/src/applications/vaos/tests/e2e/page-objects/ContactFacilityPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ContactFacilityPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ContactFacilityPageObject extends PageObject {
+class ContactFacilityPageObject extends PageObject {
   assertText(value, exist = true) {
     if (exist) {
       cy.findByText(value);

--- a/src/applications/vaos/tests/e2e/page-objects/ContactInfoPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ContactInfoPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ContactInfoPageObject extends PageObject {
+class ContactInfoPageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', '/contact-information');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/DateTimeRequestPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/DateTimeRequestPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class DateTimeRequestPageObject extends PageObject {
+class DateTimeRequestPageObject extends PageObject {
   assertUrl({ isVARequest = true } = {}) {
     if (isVARequest) cy.url().should('include', '/va-request');
     else cy.url().should('include', '/community-request');

--- a/src/applications/vaos/tests/e2e/page-objects/DateTimeSelectPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/DateTimeSelectPageObject.js
@@ -3,7 +3,7 @@ import { formatInTimeZone, zonedTimeToUtc } from 'date-fns-tz';
 import { getTimezoneByFacilityId } from '../../../utils/timezone';
 import PageObject from './PageObject';
 
-export class DateTimeSelectPageObject extends PageObject {
+class DateTimeSelectPageObject extends PageObject {
   assertDateSelected(date, facilityId = 983) {
     const timezone = getTimezoneByFacilityId(facilityId);
     const d = zonedTimeToUtc(date, timezone);

--- a/src/applications/vaos/tests/e2e/page-objects/DosesReceivedPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/DosesReceivedPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class DosesReceivedPageObject extends PageObject {
+class DosesReceivedPageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', 'doses-received');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/PlanAheadPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PlanAheadPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class PlanAheadPageObject extends PageObject {
+class PlanAheadPageObject extends PageObject {
   assertUrl() {
     return super.assertUrl({
       url: 'covid-vaccine',

--- a/src/applications/vaos/tests/e2e/page-objects/PreferredDatePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PreferredDatePageObject.js
@@ -1,7 +1,7 @@
 import { addDays, addMonths, format, startOfMonth } from 'date-fns';
 import PageObject from './PageObject';
 
-export class PreferredDatePageObject extends PageObject {
+class PreferredDatePageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', '/preferred-date');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/PreferredLanguagePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PreferredLanguagePageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class PreferredLanguagePageObject extends PageObject {
+class PreferredLanguagePageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', 'preferred-language');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/ReasonForAppointmentPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ReasonForAppointmentPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ReasonForAppointmentPageObject extends PageObject {
+class ReasonForAppointmentPageObject extends PageObject {
   assertHeading({ name }) {
     return this.assertShadow({
       element: 'va-radio',

--- a/src/applications/vaos/tests/e2e/page-objects/ReviewPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ReviewPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ReviewPageObject extends PageObject {
+class ReviewPageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', '/review');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/ScheduleCernerPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ScheduleCernerPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class ScheduleCernerPageObject extends PageObject {
+class ScheduleCernerPageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', '/how-to-schedule');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/SecondDosePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/SecondDosePageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class SecondDosePageObject extends PageObject {
+class SecondDosePageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', '/second-dose');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfCarePageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class TypeOfCarePageObject extends PageObject {
+class TypeOfCarePageObject extends PageObject {
   assertAddressAlert({ exist = true } = {}) {
     if (exist) {
       cy.get('va-alert[status=warning]')

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfEyeCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfEyeCarePageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class TypeOfEyeCarePageObject extends PageObject {
+class TypeOfEyeCarePageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', '/eye-care');
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfFacilityPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfFacilityPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class TypeOfFacilityPageObject extends PageObject {
+class TypeOfFacilityPageObject extends PageObject {
   assertUrl() {
     cy.url().should('include', '/facility-type', { timeout: 5000 });
     cy.axeCheckBestPractice();

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfVisitPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfVisitPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class TypeOfVisitPageObject extends PageObject {
+class TypeOfVisitPageObject extends PageObject {
   assertHeading({ name }) {
     return this.assertShadow({
       element: 'va-radio',

--- a/src/applications/vaos/tests/e2e/page-objects/VAFacilityPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/VAFacilityPageObject.js
@@ -1,6 +1,6 @@
 import PageObject from './PageObject';
 
-export class VAFacilityPageObject extends PageObject {
+class VAFacilityPageObject extends PageObject {
   /**
    * Method to assert exisitence of home address.
    *

--- a/src/applications/vaos/utils/address.js
+++ b/src/applications/vaos/utils/address.js
@@ -24,10 +24,10 @@ export function distanceBetween(lat1, lng1, lat2, lng2) {
 
 /*
  * Adapted from node-geopoint: https://github.com/davidwood/node-geopoint
- * 
+ *
  * This will end up creating a 2 * radius by 2 * radius box around the lat
- * long passed in. 
- * 
+ * long passed in.
+ *
  * This is different than the FL bounding box calc, which adds a fixed amount
  * of lat/long degrees to create a box
  */
@@ -63,26 +63,4 @@ export function getPreciseLocation() {
       },
     );
   });
-}
-
-export function vapAddressToString({
-  addressLine1,
-  addressLine2,
-  addressLine3,
-  city,
-  stateCode,
-  zipCode,
-  country,
-}) {
-  return [
-    addressLine1,
-    addressLine2,
-    addressLine3,
-    city,
-    stateCode,
-    zipCode,
-    country,
-  ]
-    .filter(item => !!item)
-    .join(',');
 }

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -5,7 +5,7 @@
  */
 
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import { format, addDays, differenceInDays, parseISO } from 'date-fns';
+import { addDays, differenceInDays, parseISO } from 'date-fns';
 import {
   TYPES_OF_EYE_CARE,
   TYPES_OF_SLEEP_CARE,
@@ -13,33 +13,6 @@ import {
   TYPES_OF_CARE,
   SERVICE_CATEGORY,
 } from './constants';
-
-export const CANCELLED_APPOINTMENT_SET = new Set([
-  'CANCELLED BY CLINIC & AUTO RE-BOOK',
-  'CANCELLED BY CLINIC',
-  'CANCELLED BY PATIENT & AUTO-REBOOK',
-  'CANCELLED BY PATIENT',
-]);
-
-// Appointments in these "HIDE_STATUS_SET"s should show in list, but their status should be hidden
-export const FUTURE_APPOINTMENTS_HIDE_STATUS_SET = new Set([
-  'ACT REQ/CHECKED IN',
-  'ACT REQ/CHECKED OUT',
-]);
-
-export const PAST_APPOINTMENTS_HIDE_STATUS_SET = new Set([
-  'ACTION REQUIRED',
-  'INPATIENT APPOINTMENT',
-  'INPATIENT/ACT REQ',
-  'INPATIENT/CHECKED IN',
-  'INPATIENT/CHECKED OUT',
-  'INPATIENT/FUTURE',
-  'INPATIENT/NO ACT TAKN',
-  'NO ACTION TAKEN',
-  'NO-SHOW & AUTO RE-BOOK',
-  'NO-SHOW',
-  'NON-COUNT',
-]);
 
 /**
  * Replaces a mock facility id with a real facility id in non production environments
@@ -86,22 +59,6 @@ export function getTypeOfCareById(inputId) {
 }
 
 /**
- * Method to get patient video instruction
- * @param {Appointment} appointment A FHIR appointment resource
- * @return {string} Returns patient video instruction title and exclude remaining data
- */
-
-export function getPatientInstruction(appointment) {
-  if (appointment?.patientInstruction.includes('Medication Review')) {
-    return 'Medication Review';
-  }
-  if (appointment?.patientInstruction.includes('Video Visit Preparation')) {
-    return 'Video Visit Preparation';
-  }
-  return null;
-}
-
-/**
  * Get the provider name based on api version
  *
  *
@@ -126,35 +83,6 @@ export function getProviderName(appointment) {
   }
   return null;
 }
-
-/**
- * Function to generate appointment REST API URL
- *
- * @param {*} startDate - Appointment start date
- * @param {*} endDate - Appointment end date
- * @param {*} [statuses=[]] - Appointment statusesm i.e. ['booked', 'arrived', 'fulfilled', 'cancelled']
- * @param {number} [version=2] - API version number
- * @returns URL string
- */
-export function generateAppointmentUrl(
-  startDate,
-  endDate,
-  statuses = [],
-  version = 2,
-) {
-  const start = format(parseISO(startDate), 'yyyy-MM-dd');
-  const end = format(parseISO(endDate), 'yyyy-MM-dd');
-
-  return `/vaos/v${version}/appointments?_include=facilities,clinics&start=${start}&end=${end}&${statuses
-    .map(status => `statuses[]=${status}`)
-    .join('&')}`;
-}
-
-export const TIME_TEXT = {
-  AM: 'in the morning',
-  PM: 'in the afternoon',
-  'No Time Selected': '',
-};
 
 /**
  * Function to get the time remaining to file a travel claim

--- a/src/applications/vaos/utils/calendar.js
+++ b/src/applications/vaos/utils/calendar.js
@@ -4,12 +4,12 @@ import { DATE_FORMATS } from './constants';
 
 /*
  * ICS files have a 75 character line limit. Longer fields need to be broken
- * into 75 character chunks with a CRLF in between. They also apparenly need to have a tab
+ * into 75 character chunks with a CRLF in between. They also apparently need to have a tab
  * character at the start of each new line, which is why I set the limit to 74
  *
  * Additionally, any actual line breaks in the text need to be escaped
  */
-export const ICS_LINE_LIMIT = 74;
+const ICS_LINE_LIMIT = 74;
 
 /**
  * @summary Function that returns a collection of ICS key/value pairs.
@@ -118,7 +118,7 @@ export function getICSTokens(buffer) {
   return map;
 }
 
-export function formatDescription(description, location = '') {
+function formatDescription(description, location = '') {
   if (!description || !description.text) {
     return 'DESCRIPTION:';
   }

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -20,17 +20,6 @@ export function arrayToObject(items, idProp = 'id') {
 }
 
 /**
- * Returns an array with any duplicate values removed
- *
- * @export
- * @param {Array} items
- * @returns {Array} items array with duplicates removed
- */
-export function dedupeArray(items) {
-  return Array.from(new Set(items)).filter(i => !!i);
-}
-
-/**
  * Returns an array with any duplicate id objects removed
  *
  * @export

--- a/src/applications/vaos/utils/formatters.js
+++ b/src/applications/vaos/utils/formatters.js
@@ -38,12 +38,6 @@ export function lowerCase(str = '') {
     .join(' ');
 }
 
-export function joinWithAnd(items) {
-  const start = items.slice(0, items.length - 1);
-
-  return `${start.join(', ')} and ${items[items.length - 1]}`;
-}
-
 export function aOrAn(noun) {
   if (['a', 'e', 'i', 'o', 'u'].includes(noun[0].toLowerCase())) {
     return 'an';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove unused exports in VAOS codebase.
- Appointments FE Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110515

## Testing done

- Ensures current unit tests and cypress tests suites pass.
- Checked that export is not used in the application
- Double checked that these files are not anticipated to be used in the future

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

