### PR TITLE
10-10CG | DRY up rendering of statement of truth elements

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { cloneDeep } from 'lodash';
@@ -15,46 +15,55 @@ import SubmitLoadingIndicator from './SubmitLoadingIndicator';
 import content from '../../locales/en/content.json';
 
 // organize text content for statement of truth components
-export const SIGNATURE_CERTIFICATION_STATEMENTS = {
+const LABELS = {
+  veteran: content['vet-input-label'],
+  representative: content['representative-signature-label'],
+  primary: content['primary-signature-label'],
+  secondaryOne: content['secondary-one-signature-label'],
+  secondaryTwo: content['secondary-two-signature-label'],
+};
+
+export const STATEMENTS = {
   veteran: [content['certification-statement--vet']],
-  primary: [
-    content['certification-statement--caregiver-1'],
-    replaceStrValues(
-      content['certification-statement--caregiver-2'],
-      'Primary',
-    ),
-    content['certification-statement--caregiver-3'],
-    replaceStrValues(
-      content['certification-statement--caregiver-4'],
-      'Primary',
-    ),
-    replaceStrValues(
-      content['certification-statement--caregiver-5'],
-      'Primary',
-    ),
-    content['certification-statement--caregiver-6'],
-  ],
-  secondary: [
-    content['certification-statement--caregiver-1'],
-    replaceStrValues(
-      content['certification-statement--caregiver-2'],
-      'Secondary',
-    ),
-    content['certification-statement--caregiver-3'],
-    replaceStrValues(
-      content['certification-statement--caregiver-4'],
-      'Secondary',
-    ),
-    replaceStrValues(
-      content['certification-statement--caregiver-5'],
-      'Secondary',
-    ),
-    content['certification-statement--caregiver-6'],
-  ],
   representative: [
     content['certification-statement--rep-1'],
     content['certification-statement--rep-2'],
   ],
+  caregiver: role => [
+    content['certification-statement--caregiver-1'],
+    replaceStrValues(content['certification-statement--caregiver-2'], role),
+    content['certification-statement--caregiver-3'],
+    replaceStrValues(content['certification-statement--caregiver-4'], role),
+    replaceStrValues(content['certification-statement--caregiver-5'], role),
+    content['certification-statement--caregiver-6'],
+  ],
+};
+
+// declare helpers for element rendering and validation
+const getCheckboxProps = ({ label, formData }) => {
+  const map = {
+    [LABELS.veteran]: {
+      fullName: formData.veteranFullName,
+      statementText: STATEMENTS.veteran,
+    },
+    [LABELS.representative]: {
+      fullName: formData.veteranFullName,
+      statementText: STATEMENTS.representative,
+    },
+    [LABELS.primary]: {
+      fullName: formData.primaryFullName,
+      statementText: STATEMENTS.caregiver('Primary'),
+    },
+    [LABELS.secondaryOne]: {
+      fullName: formData.secondaryOneFullName,
+      statementText: STATEMENTS.caregiver('Secondary'),
+    },
+    [LABELS.secondaryTwo]: {
+      fullName: formData.secondaryTwoFullName,
+      statementText: STATEMENTS.caregiver('Secondary'),
+    },
+  };
+  return map[label];
 };
 
 const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
@@ -65,17 +74,49 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
   const hasSecondaryOne = hasSecondaryCaregiverOne(formData);
   const hasSecondaryTwo = hasSecondaryCaregiverTwo(formData);
   const hasSubmittedForm = !!submission.status;
-  const showRepresentativeSignatureBox =
-    formData.signAsRepresentativeYesNo === 'yes';
-  const defaultSignatureKey = [
-    showRepresentativeSignatureBox
-      ? content['representative-signature-label']
-      : content['vet-input-label'],
-  ];
+  const isRep = formData.signAsRepresentativeYesNo === 'yes';
+  const defaultSignatureKey = isRep ? LABELS.representative : LABELS.veteran;
 
   const [signatures, setSignatures] = useState({
     [defaultSignatureKey]: '',
   });
+
+  const requiredLabels = useMemo(
+    () => {
+      const base = [defaultSignatureKey];
+      if (hasPrimary) base.push(LABELS.primary);
+      if (hasSecondaryOne) base.push(LABELS.secondaryOne);
+      if (hasSecondaryTwo) base.push(LABELS.secondaryTwo);
+      return base;
+    },
+    [defaultSignatureKey, hasPrimary, hasSecondaryOne, hasSecondaryTwo],
+  );
+
+  const checkboxElements = useMemo(
+    () =>
+      requiredLabels.map(label => {
+        const { fullName, statementText } = getCheckboxProps({
+          label,
+          formData,
+        });
+        return (
+          <SignatureCheckbox
+            key={label}
+            label={label}
+            fullName={fullName}
+            showError={showError}
+            submission={submission}
+            signatures={signatures}
+            setSignatures={setSignatures}
+            isRepresentative={label === LABELS.representative}
+            isRequired
+          >
+            <StatementOfTruth content={{ label, text: statementText }} />
+          </SignatureCheckbox>
+        );
+      }),
+    [formData, requiredLabels, showError, signatures, submission],
+  );
 
   const unSignedLength = Object.values(signatures).filter(
     signature => Boolean(signature) === false,
@@ -93,11 +134,11 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
     // takes in labels and renames to what schema expects
     const getKeyName = key => {
       const keyMap = {
-        [content['vet-input-label']]: 'veteran',
-        [content['representative-signature-label']]: 'veteran',
-        [content['primary-signature-label']]: 'primary',
-        [content['secondary-one-signature-label']]: 'secondaryOne',
-        [content['secondary-two-signature-label']]: 'secondaryTwo',
+        [LABELS.veteran]: 'veteran',
+        [LABELS.representative]: 'veteran',
+        [LABELS.primary]: 'primary',
+        [LABELS.secondaryOne]: 'secondaryOne',
+        [LABELS.secondaryTwo]: 'secondaryTwo',
       };
       return keyMap[key];
     };
@@ -158,30 +199,13 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
   // remove party signature box if yes/no question is answered falsy
   useEffect(
     () => {
-      removePartyIfFalsy(hasPrimary, content['primary-signature-label']);
-      removePartyIfFalsy(
-        hasSecondaryOne,
-        content['secondary-one-signature-label'],
-      );
-      removePartyIfFalsy(
-        hasSecondaryTwo,
-        content['secondary-two-signature-label'],
-      );
-      removePartyIfFalsy(
-        showRepresentativeSignatureBox,
-        content['representative-signature-label'],
-      );
-      removePartyIfFalsy(
-        !showRepresentativeSignatureBox,
-        content['vet-input-label'],
-      );
+      removePartyIfFalsy(hasPrimary, LABELS.primary);
+      removePartyIfFalsy(hasSecondaryOne, LABELS.secondaryOne);
+      removePartyIfFalsy(hasSecondaryTwo, LABELS.secondaryTwo);
+      removePartyIfFalsy(isRep, LABELS.representative);
+      removePartyIfFalsy(!isRep, LABELS.veteran);
     },
-    [
-      hasPrimary,
-      hasSecondaryOne,
-      hasSecondaryTwo,
-      showRepresentativeSignatureBox,
-    ],
+    [hasPrimary, hasSecondaryOne, hasSecondaryTwo, isRep],
   );
 
   /*
@@ -194,103 +218,11 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
     <div className="vads-u-display--flex vads-u-flex-direction--column">
       <p className="vads-u-margin-bottom--5">
         Please review information entered into this application. The{' '}
-        {showRepresentativeSignatureBox ? 'Representative' : 'Veteran'} and each
-        family caregiver applicant must sign the appropriate section.
+        {isRep ? 'representative' : 'Veteran'} and each family caregiver
+        applicant must sign the appropriate section.
       </p>
 
-      {showRepresentativeSignatureBox ? (
-        <SignatureCheckbox
-          fullName={formData.veteranFullName}
-          label={content['representative-signature-label']}
-          signatures={signatures}
-          setSignatures={setSignatures}
-          showError={showError}
-          submission={submission}
-          isRepresentative
-          isRequired
-        >
-          <StatementOfTruth
-            content={{
-              label: content['representative-signature-label'],
-              text: SIGNATURE_CERTIFICATION_STATEMENTS.representative,
-            }}
-          />
-        </SignatureCheckbox>
-      ) : (
-        <SignatureCheckbox
-          fullName={formData.veteranFullName}
-          label={content['vet-input-label']}
-          signatures={signatures}
-          setSignatures={setSignatures}
-          showError={showError}
-          submission={submission}
-          isRequired
-        >
-          <StatementOfTruth
-            content={{
-              label: content['vet-input-label'],
-              text: SIGNATURE_CERTIFICATION_STATEMENTS.veteran,
-            }}
-          />
-        </SignatureCheckbox>
-      )}
-
-      {hasPrimary && (
-        <SignatureCheckbox
-          fullName={formData.primaryFullName}
-          label={content['primary-signature-label']}
-          signatures={signatures}
-          setSignatures={setSignatures}
-          showError={showError}
-          submission={submission}
-          isRequired
-        >
-          <StatementOfTruth
-            content={{
-              label: content['primary-signature-label'],
-              text: SIGNATURE_CERTIFICATION_STATEMENTS.primary,
-            }}
-          />
-        </SignatureCheckbox>
-      )}
-
-      {hasSecondaryOne && (
-        <SignatureCheckbox
-          fullName={formData.secondaryOneFullName}
-          label={content['secondary-one-signature-label']}
-          signatures={signatures}
-          setSignatures={setSignatures}
-          showError={showError}
-          submission={submission}
-          isRequired
-        >
-          <StatementOfTruth
-            content={{
-              label: content['secondary-one-signature-label'],
-              text: SIGNATURE_CERTIFICATION_STATEMENTS.secondary,
-            }}
-          />
-        </SignatureCheckbox>
-      )}
-
-      {hasSecondaryTwo && (
-        <SignatureCheckbox
-          fullName={formData.secondaryTwoFullName}
-          label={content['secondary-two-signature-label']}
-          signatures={signatures}
-          setSignatures={setSignatures}
-          showError={showError}
-          submission={submission}
-          isRequired
-        >
-          <StatementOfTruth
-            content={{
-              label: content['secondary-two-signature-label'],
-              text: SIGNATURE_CERTIFICATION_STATEMENTS.secondary,
-            }}
-          />
-        </SignatureCheckbox>
-      )}
+      {checkboxElements}
 
       <p className="vads-u-margin-bottom--6">
         <strong>Note:</strong> {content['certification-signature-note']}

--- a/src/applications/caregivers/tests/unit/components/PreSubmitInfo/StatementOfTruth.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/components/PreSubmitInfo/StatementOfTruth.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { SIGNATURE_CERTIFICATION_STATEMENTS } from '../../../../components/PreSubmitInfo';
+import { STATEMENTS } from '../../../../components/PreSubmitInfo';
 import StatementOfTruth from '../../../../components/PreSubmitInfo/StatementOfTruth';
 
 describe('CG <StatementOfTruth>', () => {
@@ -18,7 +18,7 @@ describe('CG <StatementOfTruth>', () => {
   };
 
   it('should render the appropriate content when the props are fully provided', () => {
-    const text = SIGNATURE_CERTIFICATION_STATEMENTS.veteran;
+    const text = STATEMENTS.veteran;
     const { selectors } = subject({ label: 'Veteran\u2019s', text });
     const { legend, statements } = selectors();
     expect(legend).to.contain.text('Veteran\u2019s statement of truth');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder
## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR DRYs up rendering of the signature checkbox elements in the Statement of Truth section of the Caregivers application. This is another small step towards a refactor of the parent component as we will be migrating from custom React components to `va-statement-of-truth` web components for the Statements of Truth.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#99053

## Acceptance criteria

- Individual components can be easily swapped out as the refactor of this section continues

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution