### PR TITLE
MHV-70927 Update Health Conditions intro text

### DIFF
--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -68,6 +68,11 @@ const HealthConditions = () => {
         Health conditions
       </h1>
 
+      <p className="page-description">
+        This list includes the same information as your "VA problem list" in the
+        previous My HealtheVet experience.
+      </p>
+
       <AcceleratedCernerFacilityAlert
         {...CernerAlertContent.HEALTH_CONDITIONS}
       />

--- a/src/applications/mhv-medical-records/tests/containers/HealthConditions.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/HealthConditions.unit.spec.jsx
@@ -38,6 +38,15 @@ describe('Health conditions list container', () => {
     expect(screen.getAllByText('None recorded', { exact: false })).to.exist;
   });
 
+  it('displays intro text for conditions', () => {
+    expect(
+      screen.getAllByText(
+        'This list includes the same information as your "VA problem list"',
+        { exact: false },
+      ),
+    ).to.exist;
+  });
+
   it('displays about codes info', () => {
     expect(
       screen.getByText(

--- a/src/applications/mhv-medical-records/util/pdfHelpers/blueButton.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/blueButton.js
@@ -135,6 +135,7 @@ export const generateBlueButtonData = (
   data.push({
     title: 'Health conditions',
     subtitles: [
+      'This list includes the same information as your "VA problem list" in the previous My HealtheVet experience.',
       'About the codes in some condition names: Some of your health conditions may have diagnosis codes in the name that start with SCT or ICD. Providers use these codes to track your health conditions and to communicate with other providers about your care. If you have a question about these codes or a health condition, ask your provider at your next appointment.',
       `Showing ${conditions?.length} records from newest to oldest`,
     ],

--- a/src/applications/mhv-medical-records/util/txtHelpers/conditions.js
+++ b/src/applications/mhv-medical-records/util/txtHelpers/conditions.js
@@ -4,7 +4,8 @@ export const parseHealthConditions = (records, index = 5) => {
   return `
 ${index}) Health conditions
 
-Health conditions are available 36 hours after your providers enter them.
+This list includes the same information as your "VA problem list" in the 
+previous My HealtheVet experience.
 
 About the codes in some condition names: Some of your health conditions may have diagnosis
 codes in the name that start with SCT or ICD. Providers use these codes to track your health


### PR DESCRIPTION
## Summary

- I updated content that existed already. 
  - Removed 36 hour message for UCD from .txt function (wasn't in the ticket but it didn't take much to do).
  - Created a function to the tests to check for the text on the Health Conditions List page.
  - Added text to .txt function.
  - Added text to bluebutton.js PDF.
  - Added content to Health conditions JSX.
- This is not a bug.
- Mostly just updated already existing methods. 
 
- MHV Medical Records.

## Related issue(s)
### [MHV-70927](https://jira.devops.va.gov/browse/MHV-70927) Update Health Conditions intro text.
![Screenshot 2025-05-29 at 1 25 51 PM](https://github.com/user-attachments/assets/b967f20a-cfb2-450e-9d85-2509916be6a7)

## Screenshot

#### List Page
![Screenshot 2025-05-29 at 1 30 42 PM](https://github.com/user-attachments/assets/eff78076-5b02-4df9-9f84-f04b50064fa7)

#### PDF
![Screenshot 2025-05-29 at 1 26 43 PM](https://github.com/user-attachments/assets/0e4e1f96-1132-41aa-9ec4-da3ad235db97)

#### TXT
![Screenshot 2025-05-29 at 1 29 12 PM](https://github.com/user-attachments/assets/eaf2a5e0-b330-422d-95dd-8f16f240698e)

## Testing done

-  Tests are passing.

## What areas of the site does it impact?
MHV Medical Records
