### PR TITLE
109647 meet the standards of upcoming A11y tests

### DIFF
--- a/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
+++ b/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
@@ -98,9 +98,9 @@ const ConfirmationPage = ({
               status="info"
             >
               <section>
-                <h4 className="vads-u-margin-top--0">
+                <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
                   Request for {supplyDescription}
-                </h4>
+                </h3>
                 <p className="vads-u-margin--0 dd-privacy-mask">
                   for {fullName?.first} {fullName?.last}
                 </p>

--- a/src/applications/health-care-supply-reordering/tests/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/health-care-supply-reordering/tests/ConfirmationPage.unit.spec.jsx
@@ -480,7 +480,7 @@ describe('ConfirmationPage', () => {
   it('should render the order summary alert', () => {
     const confirmationPage = mount(<ConfirmationPage store={fakeStore} />);
     const vaAlert = confirmationPage.find('va-alert').last();
-    expect(vaAlert.find('h4').text()).to.equal(
+    expect(vaAlert.find('h3').text()).to.equal(
       'Request for hearing aid or CPAP supplies',
     );
     expect(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Upcoming A11y changes will cause some of our tests to fail. This work preempts those changes so that our tests stay green.
## Related issue(s)
[109647](https://github.com/department-of-veterans-affairs/va.gov-team/issues/109647)

## Testing done
Specs green

## What areas of the site does it impact?
`src/applications/health-care-supply-reordering/tests/e2e`

## Acceptance criteria
After running `git checkout origin/new-axe-checks src/platform/testing/e2e/cypress/support/commands/axeCheck.js` to pull down updated axe checks, all specs under `src/applications/health-care-supply-reordering/tests/e2e` should remain passing.
