### PR TITLE
10-10CG | Update state management for statements of truth

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -33,6 +33,10 @@ const SignatureCheckbox = props => {
   const handleCheck = event => {
     const value = event.target.checked;
     setIsChecked(value);
+    setSignatures(prev => ({
+      ...prev,
+      [label]: { ...prev[label], checked: value },
+    }));
   };
 
   useEffect(

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -45,7 +45,10 @@ const SignatureInput = props => {
   const isSignatureComplete = signatureMatches && isChecked;
 
   const handleChange = value => {
-    setSignatures(prevState => ({ ...prevState, [label]: value }));
+    setSignatures(prev => ({
+      ...prev,
+      [label]: { ...prev[label], value },
+    }));
   };
 
   const handleBlur = useCallback(

--- a/src/applications/caregivers/tests/unit/components/PreSubmitInfo/SignatureInput.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/components/PreSubmitInfo/SignatureInput.unit.spec.jsx
@@ -57,7 +57,9 @@ describe('CG <SignatureInput>', () => {
 
       await waitFor(() => {
         expect(vaTextInput).to.not.have.attr('error');
-        sinon.assert.calledWithExactly(handleChange, { [label]: 'Mary Smith' });
+        sinon.assert.calledWithExactly(handleChange, {
+          [label]: { value: 'Mary Smith' },
+        });
       });
     });
 
@@ -89,7 +91,9 @@ describe('CG <SignatureInput>', () => {
 
       await waitFor(() => {
         expect(vaTextInput).to.not.have.attr('error');
-        sinon.assert.calledWithExactly(handleChange, { [label]: fullName });
+        sinon.assert.calledWithExactly(handleChange, {
+          [label]: { value: fullName },
+        });
       });
     });
 
@@ -107,7 +111,9 @@ describe('CG <SignatureInput>', () => {
 
       await waitFor(() => {
         expect(vaTextInput).to.have.attr('error', error);
-        sinon.assert.calledWithExactly(handleChange, { [label]: '' });
+        sinon.assert.calledWithExactly(handleChange, {
+          [label]: { value: '' },
+        });
       });
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder
## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the local state management for the Statement of Truth section of the Caregivers application. This is another small step towards a refactor of the parent component as we will be migrating from custom React components to `va-statement-of-truth` web components for the Statements of Truth. The updated state management DRYs up keeping the state in sync with the form data and incorporates a structure that will be better suited for validation when the `va-statement-of-truth` web component replaces the existing React compontents.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#99053

## Acceptance criteria

- State data structure provides for validation at a root level
- State is able to better stay in sync with form data requirements

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution