### PR TITLE
NOD: 109138 Update imposter links to web components

### DIFF
--- a/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
+++ b/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
@@ -84,9 +84,10 @@ export const ConfirmationPageV2 = () => {
         status tool. It may take <strong>7 to 10 days</strong> to appear there.
       </p>
       <p>
-        <a href="/claim-or-appeal-status/">
-          Check the status of your request for a Board Appeal online
-        </a>
+        <va-link
+          href="/claim-or-appeal-status/"
+          text="Check the status of your request for a Board Appeal online"
+        />
       </p>
       <p>
         If we need more information, we’ll contact you to tell you what other
@@ -149,9 +150,10 @@ export const ConfirmationPageV2 = () => {
       </div>
 
       <p>
-        <a href="/decision-reviews/after-you-request-review/">
-          Learn more about what happens after you request a review
-        </a>
+        <va-link
+          href="/decision-reviews/after-you-request-review/"
+          text="Learn more about what happens after you request a review"
+        />
       </p>
       <p>
         If you’re worried about how long it’s taking to receive a decision, do
@@ -162,7 +164,10 @@ export const ConfirmationPageV2 = () => {
       <h2>How to contact us if you have questions</h2>
       <p>You can ask us a question online through Ask VA.</p>
       <p>
-        <a href="https://ask.va.gov/">Contact us online through Ask VA.</a>
+        <va-link
+          href="https://ask.va.gov/"
+          text="Contact us online through Ask VA."
+        />
       </p>
       <p>
         Or call us at <va-telephone contact={CONTACTS.VA_BENEFITS} /> (

--- a/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
+++ b/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
@@ -166,8 +166,9 @@ export const ConfirmationPageV2 = () => {
       <p>
         <va-link
           href="https://ask.va.gov/"
-          text="Contact us online through Ask VA."
+          text="Contact us online through Ask VA"
         />
+        .
       </p>
       <p>
         Or call us at <va-telephone contact={CONTACTS.VA_BENEFITS} /> (

--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -98,9 +98,10 @@ const IntroductionPage = props => {
                 A Veterans Law Judge at the Board of Veterans’ Appeals will
                 review your case. The amount of time it takes the Board to
                 complete its review depends on which review option you choose.{' '}
-                <a href={NOD_OPTIONS_URL}>
-                  Read about the 3 Board Appeal options
-                </a>
+                <va-link
+                  href={NOD_OPTIONS_URL}
+                  text="Read about the 3 Board Appeal options"
+                />
               </p>
             </div>
           </va-additional-info>
@@ -120,14 +121,18 @@ const IntroductionPage = props => {
         If you need help requesting a Board Appeal, you can contact a VA
         regional office near you.
       </p>
-      <a href={FACILITY_LOCATOR_URL}>Find a VA regional office near you</a>
+      <va-link
+        href={FACILITY_LOCATOR_URL}
+        text="Find a VA regional office near you"
+      />
       <p className="vads-u-margin-top--2">
         A Veteran Service Organization or VA-accredited representative or agent
         can also help you request a Board Appeal.
       </p>
-      <a href={GET_HELP_REVIEW_REQUEST_URL}>
-        Get help requesting a Board Appeal
-      </a>
+      <va-link
+        href={GET_HELP_REVIEW_REQUEST_URL}
+        text="Get help requesting a Board Appeal"
+      />
       <div className="omb-info--container vads-u-padding-left--0 vads-u-margin-top--4">
         <va-omb-info
           res-burden={30}

--- a/src/applications/appeals/10182/content/issueSummary.js
+++ b/src/applications/appeals/10182/content/issueSummary.js
@@ -27,7 +27,4 @@ export const SummaryTitle = ({ formData }) => {
 
 SummaryTitle.propTypes = {
   formData: PropTypes.shape({}),
-  router: PropTypes.shape({
-    push: PropTypes.func,
-  }),
 };

--- a/src/applications/appeals/10182/content/issueSummary.js
+++ b/src/applications/appeals/10182/content/issueSummary.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
-
+import BasicLink from '../../shared/components/web-component-wrappers/BasicLink';
 import ShowIssuesList from '../../shared/components/ShowIssuesList';
-
 import { CONTESTABLE_ISSUES_PATH } from '../../shared/constants';
 import { getSelected } from '../../shared/utils/issues';
 
@@ -17,14 +15,11 @@ export const SummaryTitle = ({ formData }) => {
       </h3>
       {ShowIssuesList({ issues })}
       <p>
-        <Link
-          to={{
-            pathname: CONTESTABLE_ISSUES_PATH,
-            search: '?redirect',
-          }}
-        >
-          Go back to add more issues
-        </Link>
+        <BasicLink
+          path={CONTESTABLE_ISSUES_PATH}
+          search="?redirect"
+          text="Go back to add more issues"
+        />
       </p>
     </>
   );
@@ -32,4 +27,7 @@ export const SummaryTitle = ({ formData }) => {
 
 SummaryTitle.propTypes = {
   formData: PropTypes.shape({}),
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
 };

--- a/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
@@ -136,7 +136,6 @@ describe('ConfirmationPageV2', () => {
       'file-2.pdf',
     ]);
     expect($('.evidence-later', container)).to.not.exist;
-    expect($$('.vads-c-action-link--green', container).length).to.eq(1);
   });
 
   it('should render the confirmation page with evidence submitted later', () => {

--- a/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
@@ -136,6 +136,7 @@ describe('ConfirmationPageV2', () => {
       'file-2.pdf',
     ]);
     expect($('.evidence-later', container)).to.not.exist;
+    expect($$('.vads-c-action-link--green', container).length).to.eq(1);
   });
 
   it('should render the confirmation page with evidence submitted later', () => {

--- a/src/applications/appeals/10182/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/IntroductionPage.unit.spec.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-
-import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import IntroductionPage from '../../containers/IntroductionPage';
 import formConfig from '../../config/form';
 
@@ -79,12 +77,17 @@ describe('IntroductionPage', () => {
 
   it('should render start action links', () => {
     const { props, mockStore } = getData();
-    const { container } = render(
+    const { getAllByRole } = render(
       <Provider store={mockStore}>
         <IntroductionPage {...props} />
       </Provider>,
     );
-    expect($$('.vads-c-action-link--green', container).length).to.equal(2);
+
+    const actionLinks = getAllByRole('link');
+    const expectedText = 'Start the Board Appeal request';
+
+    expect(actionLinks[0].textContent).to.eq(expectedText);
+    expect(actionLinks[1].textContent).to.eq(expectedText);
   });
 
   it('should render verify identity alert', () => {

--- a/src/applications/appeals/10182/tests/pages/issueSummary.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/issueSummary.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 
 import formConfig from '../../config/form';
-import { CONTESTABLE_ISSUES_PATH, SELECTED } from '../../../shared/constants';
+import { SELECTED } from '../../../shared/constants';
 
 describe('NOD selected issues summary page', () => {
   const {
@@ -32,6 +32,7 @@ describe('NOD selected issues summary page', () => {
     expect(form.find('li').length).to.equal(2);
     form.unmount();
   });
+
   it('should render a link to the eligible issues page', () => {
     const form = mount(
       <DefinitionTester
@@ -43,12 +44,10 @@ describe('NOD selected issues summary page', () => {
       />,
     );
 
-    const link = form.find('Link');
+    const link = form.find('va-link');
 
     expect(link.length).to.equal(1);
-    expect(link.text()).to.contain('Go back to add more issues');
-    expect(link.props().to.pathname).to.equal(CONTESTABLE_ISSUES_PATH);
-    expect(link.props().to.search).to.equal('?redirect');
+    expect(link.props().text).to.contain('Go back to add more issues');
     form.unmount();
   });
 

--- a/src/applications/appeals/shared/components/web-component-wrappers/BasicLink.jsx
+++ b/src/applications/appeals/shared/components/web-component-wrappers/BasicLink.jsx
@@ -15,13 +15,8 @@ const BasicLink = ({ path, search, router, ...props }) => {
       {...props}
       onClick={() => {
         if (search && path) {
-          router.push({
-            pathname: path,
-            search,
-          });
-        }
-
-        if (path) {
+          router.push(`${path}${search}`);
+        } else if (path) {
           router.push(path);
         }
       }}

--- a/src/applications/appeals/shared/components/web-component-wrappers/BasicLink.jsx
+++ b/src/applications/appeals/shared/components/web-component-wrappers/BasicLink.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import { VaLink } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+// Use this component when you need a react-router <Link> that is also a
+// va-link web component from the Design System Library
+// https://design.va.gov/storybook/?path=/docs/components-va-link--docs
+const BasicLink = ({ path, search, router, ...props }) => {
+  const ariaLabel = props?.['aria-label'] ?? {};
+
+  return (
+    <VaLink
+      label={ariaLabel}
+      {...props}
+      onClick={() => {
+        if (search && path) {
+          router.push({
+            pathname: path,
+            search,
+          });
+        }
+
+        if (path) {
+          router.push(path);
+        }
+      }}
+    />
+  );
+};
+
+BasicLink.propTypes = {
+  'aria-label': PropTypes.string,
+  path: PropTypes.string,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+  search: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+export default withRouter(BasicLink);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
We need to convert all `<a>` and `<Link>` (plain HTML link or react-router Links) to VA Design System web components. This PR is for NOD (10182) specifically.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/109138

## Testing done

Tested each affected link in the NOD (10182) flow.

## Screenshots

### Introduction page

| Link text | DOM | UI |
| --- | --- | --- |
| Read about the 3 Board Appeal options | <img width="248" alt="Screenshot 2025-05-29 at 3 08 06 PM" src="https://github.com/user-attachments/assets/bd97fd42-b578-41da-817a-69db09abb5e5" /> | <img width="687" alt="Screenshot 2025-05-29 at 3 08 11 PM" src="https://github.com/user-attachments/assets/31c1a8a9-9c50-4aa2-9551-2b701c15f453" /> |
| Find a VA Regional Office near you | <img width="304" alt="Screenshot 2025-05-29 at 3 08 22 PM" src="https://github.com/user-attachments/assets/33b85e99-d230-412b-930e-5d50dd6dbc1b" /> | <img width="682" alt="Screenshot 2025-05-29 at 3 08 15 PM" src="https://github.com/user-attachments/assets/5877b250-5c4b-4739-a0b7-5737ca7505ff" /> |
| Get help requesting a Board appeal | <img width="309" alt="Screenshot 2025-05-29 at 3 08 31 PM" src="https://github.com/user-attachments/assets/31444899-6895-41e8-8fa5-375562adfb5d" /> | <img width="682" alt="Screenshot 2025-05-29 at 3 08 15 PM" src="https://github.com/user-attachments/assets/5877b250-5c4b-4739-a0b7-5737ca7505ff" /> |

### Issues Summary

| Link text | DOM | UI |
| --- | --- | --- |
| Go back to add more issues | <img width="259" alt="Screenshot 2025-05-29 at 3 20 48 PM" src="https://github.com/user-attachments/assets/4cbd7006-daf2-40e6-82c6-626cef515d9c" /> |  <img width="531" alt="Screenshot 2025-05-29 at 3 20 42 PM" src="https://github.com/user-attachments/assets/45b08bfb-0922-4900-968e-4d37ea560c93" /> |

Note: this link was refactored from a react-router `<Link>` so I also verified that the `path` and `search` params were being properly passed.

Staging URL when this link is clicked:
<img width="600" alt="Screenshot 2025-05-29 at 3 38 29 PM" src="https://github.com/user-attachments/assets/dd3e2bbe-9692-4a33-8296-6bbf9cf1b28c" />

Local URL when this link is clicked:
<img width="600" alt="Screenshot 2025-05-29 at 3 41 15 PM" src="https://github.com/user-attachments/assets/c6af7a72-93bf-41ff-b409-51670c2077be" />

### Confirmation page

| Link text | DOM | UI |
| --- | --- | --- |
| Check the status of your request for a Board Appeal online | <img width="315" alt="Screenshot 2025-05-29 at 3 23 35 PM" src="https://github.com/user-attachments/assets/8456ac5e-e62c-4ce4-8b89-701405a31c80" /> | <img width="678" alt="Screenshot 2025-05-29 at 3 23 48 PM" src="https://github.com/user-attachments/assets/36585949-c1d5-47cb-98f6-a5309f13b213" /> |
| Learn more about what happens after you request a review | <img width="310" alt="Screenshot 2025-05-29 at 3 24 05 PM" src="https://github.com/user-attachments/assets/abe4cc5e-6fbb-4eb6-bc7b-38026aad9241" /> | <img width="682" alt="Screenshot 2025-05-29 at 3 23 59 PM" src="https://github.com/user-attachments/assets/9957dc3e-4087-40d4-9503-d9dc802f82ae" /> |
| Contact us online through Ask VA | <img width="310" alt="Screenshot 2025-05-29 at 3 48 40 PM" src="https://github.com/user-attachments/assets/04b7e876-1d00-4049-a50e-f16a45672899" /> | <img width="637" alt="Screenshot 2025-05-29 at 3 48 33 PM" src="https://github.com/user-attachments/assets/8041047a-3c41-4fa3-aa85-038712f11f28" /> |


## What areas of the site does it impact?

NOD (10182) flow only.