### PR TITLE
109862 - Add shared address selector to sponsor info section of 10-10d/10-7959c merged form - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   addressUI,
   addressSchema,
@@ -16,6 +17,8 @@ import {
   yesNoSchema,
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import CustomPrefillMessage from '../components/CustomPrefillAlert';
+import { sponsorWording } from '../../10-10D/helpers/utilities';
 import { sponsorAddressCleanValidation } from '../../shared/validations';
 
 export const sponsorNameDobSchema = {
@@ -106,8 +109,17 @@ export const sponsorStatusDetails = {
 export const sponsorAddress = {
   uiSchema: {
     ...titleUI(
-      `Sponsor's mailing address`,
-      `We'll send any important information about this application to your address.`,
+      ({ formData }) => `${sponsorWording(formData)} mailing address`,
+      ({ formData }) => (
+        // Prefill message conditionally displays based on `certifierRole`
+        <>
+          <p>
+            We’ll send any important information about this application to this
+            address.
+          </p>
+          {CustomPrefillMessage(formData, 'sponsor')}
+        </>
+      ),
     ),
     sponsorAddress: {
       ...addressUI({

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -2,12 +2,15 @@ import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { minimalHeaderFormConfigOptions } from 'platform/forms-system/src/js/patterns/minimal-header';
 import { VA_FORM_IDS } from 'platform/forms/constants';
+import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
 import { TITLE, SUBTITLE } from '../constants';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import SubmissionError from '../../shared/components/SubmissionError';
 import GetFormHelp from '../../shared/components/GetFormHelp';
+import { ApplicantAddressCopyPage } from '../../shared/components/applicantLists/ApplicantAddressPage';
+import { sponsorWording } from '../../10-10D/helpers/utilities';
 
 import {
   certifierRoleSchema,
@@ -141,6 +144,35 @@ const formConfig = {
             get('certifierRole', formData) !== 'sponsor' &&
             get('sponsorIsDeceased', formData),
           ...sponsorStatusDetails,
+        },
+        page10b0: {
+          path: 'sponsor-mailing-same',
+          title: formData => `${sponsorWording(formData)} address selection`,
+          // Only show if we have addresses to pull from:
+          depends: formData =>
+            !get('sponsorIsDeceased', formData) &&
+            get('certifierRole', formData) !== 'sponsor' &&
+            get('street', formData?.certifierAddress),
+          CustomPage: props => {
+            const extraProps = {
+              ...props,
+              customAddressKey: 'sponsorAddress',
+              customTitle: `${sponsorWording(props.data)} address selection`,
+              customDescription:
+                'We’ll send any important information about this form to this address.',
+              customSelectText: `Does ${sponsorWording(
+                props.data,
+                false,
+                false,
+              )} live at a previously entered address?`,
+              positivePrefix: 'Yes, their address is',
+              negativePrefix: 'No, they have a different address',
+            };
+            return ApplicantAddressCopyPage(extraProps);
+          },
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: blankSchema,
         },
         page10: {
           path: 'sponsor-mailing-address',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds the shared address select page to the sponsor information section of the 10-10d/10-7959c merged form application (unreleased).

This functionality has been directly pulled over from the standalone 10-10d form which has been using it in production for some months now.

- Allows users to select a previously entered address to populate the sponsor address fields
- If applicant specifies they are the sponsor, the address from the certifier information section is automatically copied to the sponsor address page and an alert is shown

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109862

## Testing done

- Manual
- Pre-existing specs for the ApplicantAddressCopyPage component are located [here](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/ivc-champva/10-10D/tests/unit/pages/applicantAddressCopyPage.unit.spec.jsx).

## Screenshots

|         | Img |
| ------- | ------ |
| Select |![Screenshot 2025-05-29 at 15 42 56](https://github.com/user-attachments/assets/3f94ad5c-0fb0-410f-a18a-8ea847dfdab3)|
| Copy alert |![Screenshot 2025-05-29 at 15 48 56](https://github.com/user-attachments/assets/95894e3f-12a1-42ca-a873-cdaaf0478379)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA