### PR TITLE
style: Adding Quotes In Authorization Error

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -42,8 +42,8 @@ export const patientAcknowledgmentTitle = (
 );
 export const patientAcknowledgmentError = (
   <p>
-    You must select I acknowledge and authorize this release of information for
-    us to get your records from your provider.
+    You must select "I acknowledge and authorize this release of information"
+    for us to get your records from your provider.
   </p>
 );
 

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -42,7 +42,7 @@ export const patientAcknowledgmentTitle = (
 );
 export const patientAcknowledgmentError = (
   <p>
-    You must select "I acknowledge and authorize this release of information"
+    You must select “I acknowledge and authorize this release of information”
     for us to get your records from your provider.
   </p>
 );


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Quotes were added around the authorization error acknowledgement text, guiding users on how to proceed to the next page.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/108842

## Testing done
Old Behavior - Authorization text did not have quotation marks around the text that requires the user to check off to continue to the next page if the user decides to allow VA to get their records from their provider.

New Behavior - Has quotation marks around the text for the user to check off to continue to the next page.

Test - Ensure the quotation marks are around the phrase "I acknowledge and authorize this release of information" in the authorization error message in section 4/6 in form 526 where user selects `Private Medical Records`
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="524" alt="Screenshot 2025-05-30 at 11 58 28 AM" src="https://github.com/user-attachments/assets/59836999-f57e-43f3-a387-5bcba107c1c4" />|<img width="524" alt="Screenshot 2025-06-02 at 10 01 11 AM" src="https://github.com/user-attachments/assets/1ad0bce9-ce9e-4883-8238-b42212259229" />|

## What areas of the site does it impact?
It affects chapter 4 of 6 in VA Form 21-526EZ when user opts for providing evidence where user selects private medical records. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

