### PR TITLE
Dependents | Fix focus after upload

### DIFF
--- a/src/applications/dependents/686c-674/config/upload.js
+++ b/src/applications/dependents/686c-674/config/upload.js
@@ -1,7 +1,8 @@
 import environment from 'platform/utilities/environment';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
-import { focusElement } from 'platform/utilities/ui';
+import { scrollAndFocus } from 'platform/utilities/ui';
 import VaSelectField from 'platform/forms-system/src/js/web-component-fields/VaSelectField';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 // Modified version of the file upload from applications/appeals/995
 
@@ -20,11 +21,13 @@ export function createPayload(file, _formId, password) {
 }
 
 export const dependentsUploadUI = (content, options = {}) => {
-  const findAndFocusLastSelect = () => {
-    const lastSelect = [...document.querySelectorAll('select')].slice(-1);
-    if (lastSelect.length) {
-      focusElement(lastSelect[0]);
-    }
+  const findAndFocusLastCard = name => {
+    const target = $$('.schemaform-file-list li').find(entry =>
+      $('strong', entry)
+        .textContent?.trim()
+        .includes(name),
+    );
+    scrollAndFocus(target);
   };
 
   const addAnotherLabel = 'Upload another file';
@@ -40,12 +43,13 @@ export const dependentsUploadUI = (content, options = {}) => {
     confirmRemove: true,
     classNames: 'vads-u-font-size--md',
     createPayload,
-    parseResponse: (response, file) => {
+    parseResponse: (response, { name, size }) => {
       setTimeout(() => {
-        findAndFocusLastSelect();
+        findAndFocusLastCard(name);
       });
       return {
-        name: file?.name,
+        name,
+        size,
         confirmationCode: response?.data?.attributes?.confirmationCode,
         attachmentId: '',
       };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Currently, after an upload, focus is set on the "Here's how you know" additional info button is the top banner. This PR set focus to the file card after upload. It also includes the file size so that is shown on the file card
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/110411

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Upload  | ![focus-before](https://github.com/user-attachments/assets/8c843602-1da1-4d8c-8eb0-46c526e0182f) | ![focus](https://github.com/user-attachments/assets/4f1e3960-e446-4366-ad62-fa398ea328bf) |

## What areas of the site does it impact?

Spouse & child uploads in Dependents Management (686c-674)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
