### PR TITLE
10-10CG | Upgrade Statements of Truth performance & readability

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -103,13 +103,22 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
   // keep signatures in sync with required data
   useEffect(
     () => {
-      const syncSignatureState = prev =>
-        requiredElements.reduce((acc, { label }) => {
-          acc[label] = prev[label] || DEFAULT_SIGNATURE_STATE;
-          return acc;
-        }, {});
-      setSignatures(prev => syncSignatureState(prev));
+      const requiredLabels = requiredElements.map(e => e.label);
+      const currentLabels = Object.keys(signatures);
+
+      const labelsChanged =
+        requiredLabels.length !== currentLabels.length ||
+        requiredLabels.some(label => !currentLabels.includes(label));
+
+      if (labelsChanged) {
+        const next = {};
+        requiredLabels.forEach(label => {
+          next[label] = signatures[label] || DEFAULT_SIGNATURE_STATE;
+        });
+        setSignatures(next);
+      }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [requiredElements],
   );
 

--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -136,7 +136,8 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
       );
       dispatch(setData({ ...formData, ...transformedSignatures }));
     },
-    [dispatch, formData, requiredElements, signatures, submission.status],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dispatch, signatures],
   );
 
   // validate that all signature text is valid and all checkboxes have been checked

--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -136,8 +136,7 @@ const PreSubmitCheckboxGroup = ({ formData, showError, onSectionComplete }) => {
       );
       dispatch(setData({ ...formData, ...transformedSignatures }));
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [dispatch, signatures],
+    [dispatch, formData, requiredElements, signatures, submission.status],
   );
 
   // validate that all signature text is valid and all checkboxes have been checked


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder
## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the performance and readability of the Statements of Truth component for the Caregivers application. This work preps the component for a transition from React components to `va-statement-of-truth` web components.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#99053

## Acceptance criteria

- Component is as performant and readable as possible ahead of the migration

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution