### PR TITLE
[CHORE]: Enable letters and docs e2e tests after DS accordion bug fix.

### DIFF
--- a/src/applications/letters/tests/01-authed-lighthouse.cypress.spec.js
+++ b/src/applications/letters/tests/01-authed-lighthouse.cypress.spec.js
@@ -91,14 +91,12 @@ describe('Authed Letter Test', () => {
       });
     });
 
-    // TODO: Restore test when Design System fix is ready
-    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/110212
     // collapse the bsl accordion
-    // cy.get('.step-content va-accordion-item:nth-of-type(4)')
-    //   .shadow()
-    //   .find('button[aria-expanded=true]')
-    //   .click();
-    // cy.get('label[name="militaryService-label"]').should('not.be.visible');
+    cy.get('.step-content va-accordion-item:nth-of-type(4)')
+      .shadow()
+      .find('button[aria-expanded=true]')
+      .click();
+    cy.get('label[name="militaryService-label"]').should('not.be.visible');
 
     // poke the back button
     cy.get('.step-content p:nth-of-type(4) a').click();

--- a/src/applications/letters/tests/01-authed.cypress.spec.js
+++ b/src/applications/letters/tests/01-authed.cypress.spec.js
@@ -94,14 +94,12 @@ describe('Authed Letter Test', () => {
       });
     });
 
-    // TODO: Restore test when Design System fix is ready
-    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/110212
     // collapse the bsl accordion
-    // cy.get('.step-content va-accordion-item:nth-of-type(4)')
-    //   .shadow()
-    //   .find('button[aria-expanded=true]')
-    //   .click();
-    // cy.get('label[name="militaryService-label"]').should('not.be.visible');
+    cy.get('.step-content va-accordion-item:nth-of-type(4)')
+      .shadow()
+      .find('button[aria-expanded=true]')
+      .click();
+    cy.get('label[name="militaryService-label"]').should('not.be.visible');
 
     // poke the back button
     cy.get('.step-content p:nth-of-type(4) a').click();


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
Restored two skipped e2e tests in the Your VA letters and documents application after Design System team [merged a fix](https://github.com/department-of-veterans-affairs/component-library/pull/1603) for the `va-accordion` component.

## Related issue(s)

- PR closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/110212

## Testing done

- Re-enabled two e2e test
- Ran tests locally to verify they pass in a Chrome environment

## What areas of the site does it impact?

- Your VA letters and documents tests only

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [x] Browser console contains no warnings or errors.