### PR TITLE
mhv-landing-page nodejs v22.11.0, typescript tsx components

### DIFF
--- a/build.stdout
+++ b/build.stdout
@@ -1,0 +1,599 @@
+yarn run v1.22.22
+$ node ./script/watch.js --env entry=mhv-landing-page
+Found local asset at ../content-build/src/site/assets/js/record-event.js.
+Found local asset at ../content-build/src/site/assets/js/static-page-widgets.js.
+Found local asset at ../content-build/src/applications/registry.json.
+ℹ Compiling Webpack
+✔ Webpack: Compiled with some errors in 17.09s
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/HubLinks.tsx
+./src/applications/mhv-landing-page/components/HubLinks.tsx 22:12-17
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/HubLinks.tsx(22,13)
+      TS2353: Object literal may only specify known properties, and 'event' does not exist in type '{ eventCallback: Function; }'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 59:33-54
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/HubLinks.tsx
+./src/applications/mhv-landing-page/components/HubLinks.tsx 55:20-24
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/HubLinks.tsx(55,21)
+      TS18048: 'hubs' is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 59:33-54
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 6:7-52
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(6,8)
+      TS2307: Cannot find module '@department-of-veterans-affairs/mhv/exports' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 10:7-51
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(10,8)
+      TS2307: Cannot find module '~/platform/monitoring/DowntimeNotification' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 33:10-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(33,11)
+      TS2339: Property 'cards' does not exist on type '{}'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 33:22-26
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(33,23)
+      TS2339: Property 'hubs' does not exist on type '{}'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 41:4-6
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(41,5)
+      TS2322: Type '{ children: unknown[]; }' is not assignable to type '{ children?: ReactNode; }'.
+  Types of property 'children' are incompatible.
+    Type 'unknown[]' is not assignable to type 'ReactNode'.
+      Type 'unknown[]' is not assignable to type 'Iterable<ReactNode>'.
+        The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
+          Type 'IteratorResult<unknown, any>' is not assignable to type 'IteratorResult<ReactNode, any>'.
+            Type 'IteratorYieldResult<unknown>' is not assignable to type 'IteratorResult<ReactNode, any>'.
+              Type 'IteratorYieldResult<unknown>' is not assignable to type 'IteratorYieldResult<ReactNode>'.
+                Type 'unknown' is not assignable to type 'ReactNode'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 61:12-16
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(61,13)
+      TS2322: Type 'unknown' is not assignable to type 'boolean | undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 62:12-25
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(62,13)
+      TS2322: Type 'unknown' is not assignable to type 'boolean | undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 65:10-57
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(65,11)
+      TS2322: Type 'unknown' is not assignable to type 'ReactNode'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 67:8-75:10
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(67,9)
+      TS2322: Type 'unknown' is not assignable to type 'ReactNode'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 76:8-52
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(76,9)
+      TS2322: Type 'unknown' is not assignable to type 'ReactNode'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx
+./src/applications/mhv-landing-page/components/LandingPage.tsx 77:8-48
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/LandingPage.tsx(77,9)
+      TS2322: Type 'unknown' is not assignable to type 'ReactNode'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx
+./src/applications/mhv-landing-page/components/NavCard.tsx 3:24-60
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx(3,25)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/CardLayout.jsx 6:0-32 35:44-51
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 57:35-58
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx
+./src/applications/mhv-landing-page/components/NavCard.tsx 31:2-6
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx(31,3)
+      TS2322: Type 'null' is not assignable to type '"calendar_today" | "forum" | "pill" | "note_add" | "attach_money" | "medical_services"'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/CardLayout.jsx 6:0-32 35:44-51
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 57:35-58
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx
+./src/applications/mhv-landing-page/components/NavCard.tsx 39:7-16
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx(39,8)
+      TS2339: Property 'ariaLabel' does not exist on type '{ text?: string | ReactElement<any, string | JSXElementConstructor<any>> | undefined; href?: string | undefined; isExternal?: boolean | undefined; omitExternalLinkText?: boolean | undefined; }'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/CardLayout.jsx 6:0-32 35:44-51
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 57:35-58
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx
+./src/applications/mhv-landing-page/components/NavCard.tsx 60:26-67
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx(60,27)
+      TS2339: Property 'va-icon' does not exist on type 'JSX.IntrinsicElements'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/CardLayout.jsx 6:0-32 35:44-51
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 57:35-58
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx
+./src/applications/mhv-landing-page/components/NavCard.tsx 65:35-45
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx(65,36)
+      TS2550: Property 'replaceAll' does not exist on type 'string'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2021' or later.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/CardLayout.jsx 6:0-32 35:44-51
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 57:35-58
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx
+./src/applications/mhv-landing-page/components/NavCard.tsx 80:14-46
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/NavCard.tsx(80,15)
+      TS2339: Property 'va-icon' does not exist on type 'JSX.IntrinsicElements'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/CardLayout.jsx 6:0-32 35:44-51
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 57:35-58
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/Welcome.tsx
+./src/applications/mhv-landing-page/components/Welcome.tsx 3:24-60
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/Welcome.tsx(3,25)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/WelcomeContainer.jsx 4:0-44 13:42-49
+ @ ./src/applications/mhv-landing-page/components/HeaderLayout.tsx 15:41-82
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 58:37-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/Welcome.tsx
+./src/applications/mhv-landing-page/components/Welcome.tsx 43:8-50
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/Welcome.tsx(43,9)
+      TS2339: Property 'va-icon' does not exist on type 'JSX.IntrinsicElements'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/containers/WelcomeContainer.jsx 4:0-44 13:42-49
+ @ ./src/applications/mhv-landing-page/components/HeaderLayout.tsx 15:41-82
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 58:37-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx 3:41-77
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx(3,42)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 7:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx 19:2-16
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx(19,3)
+      TS2339: Property 'userActionable' does not exist on type 'AlertAccountApiAlertProps'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 7:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx 25:4-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx(25,5)
+      TS2722: Cannot invoke an object which is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 7:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx 53:12-49
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx(53,13)
+      TS2339: Property 'va-telephone' does not exist on type 'JSX.IntrinsicElements'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 7:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx 53:50-80
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx(53,51)
+      TS2339: Property 'va-telephone' does not exist on type 'JSX.IntrinsicElements'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 7:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx 75:11-20
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx(75,12)
+      TS18048: 'errorCode' is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 7:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx 3:41-77
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx(3,42)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 1:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx 4:24-66
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx(4,25)
+      TS2307: Cannot find module '~/platform/user/authentication/constants' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 1:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx 5:29-85
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx(5,30)
+      TS2307: Cannot find module '~/platform/user/authentication/components/VerifyButton' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 1:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx 21:4-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx(21,5)
+      TS2722: Cannot invoke an object which is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 1:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx 35:6-22
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx(35,7)
+      TS2322: Type '{ children: Element[]; variant: string; "data-testid": string | undefined; visible: true; disableAnalytics: true; }' is not assignable to type 'IntrinsicAttributes & VaAlertSignIn & Omit<HTMLAttributes<HTMLVaAlertSignInElement>, "style"> & StyleReactProps & RefAttributes<...>'.
+  Property 'disableAnalytics' does not exist on type 'IntrinsicAttributes & VaAlertSignIn & Omit<HTMLAttributes<HTMLVaAlertSignInElement>, "style"> & StyleReactProps & RefAttributes<...>'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 1:0-58 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx 3:41-77
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx(3,42)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 6:0-50 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx 21:4-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx(21,5)
+      TS2722: Cannot invoke an object which is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 6:0-50 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx 3:41-77
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx(3,42)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 5:0-54 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx 21:4-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx(21,5)
+      TS2722: Cannot invoke an object which is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 5:0-54 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx 3:41-77
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx(3,42)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 2:0-50 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx 4:24-78
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx(4,25)
+      TS2307: Cannot find module '~/platform/user/authorization/components/VerifyAlert' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 2:0-50 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx 8:7-49
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx(8,8)
+      TS2307: Cannot find module '~/platform/user/authentication/constants' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 2:0-50 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx 23:4-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx(23,5)
+      TS2722: Cannot invoke an object which is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 2:0-50 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx 2:23-59
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx(2,24)
+      TS2307: Cannot find module '~/platform/site-wide/mhv/utilities' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 3:0-52 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx 4:41-77
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx(4,42)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 3:0-52 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx 28:4-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx(28,5)
+      TS2722: Cannot invoke an object which is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 3:0-52 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx 3:24-78
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx(3,25)
+      TS2307: Cannot find module '~/platform/user/authorization/components/VerifyAlert' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 4:0-62 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx 5:41-77
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx(5,42)
+      TS2307: Cannot find module '~/platform/monitoring/record-event' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 4:0-62 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx
+./src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx 20:4-15
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx(20,5)
+      TS2722: Cannot invoke an object which is possibly 'undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/components/alerts/index.js 4:0-62 8:0-153
+ @ ./src/applications/mhv-landing-page/containers/Alerts.jsx 3:0-125 16:44-64 19:44-66 24:44-61 29:44-64
+ @ ./src/applications/mhv-landing-page/components/LandingPage.tsx 62:31-62
+ @ ./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 68:36-72
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/AppConfig.tsx
+./src/applications/mhv-landing-page/containers/AppConfig.tsx 6:7-52
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/AppConfig.tsx(6,8)
+      TS2307: Cannot find module '@department-of-veterans-affairs/mhv/exports' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 4:0-47 6:46-55
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/AppConfig.tsx
+./src/applications/mhv-landing-page/containers/AppConfig.tsx 44:24-35
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/AppConfig.tsx(44,25)
+      TS2339: Property 'accountUuid' does not exist on type '{}'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 4:0-47 6:46-55
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
+./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 3:28-99
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx(3,29)
+      TS2307: Cannot find module '@department-of-veterans-affairs/platform-user/profile/backendServices' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
+./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 4:34-99
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx(4,35)
+      TS2307: Cannot find module '@department-of-veterans-affairs/platform-user/RequiredLoginView' or its corresponding type declarations.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
+./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 26:10-24
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx(26,11)
+      TS2339: Property 'featureToggles' does not exist on type 'DefaultRootState'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
+./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 26:26-30
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx(26,27)
+      TS2339: Property 'user' does not exist on type 'DefaultRootState'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
+./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 39:6-10
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx(39,7)
+      TS2345: Argument of type 'unknown' is not assignable to parameter of type 'boolean | undefined'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
+./src/applications/mhv-landing-page/containers/LandingPageContainer.tsx 47:30-37
+[tsl] ERROR in /home/rd/va/vets-website/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx(47,31)
+      TS18046: 'profile' is of type 'unknown'.
+ts-loader-default_e3b0c44298fc1c14
+ @ ./src/applications/mhv-landing-page/routes.jsx 5:0-69 8:44-64
+ @ ./src/applications/mhv-landing-page/app-entry.jsx 5:0-30 11:10-16
+
+ERROR in /home/rd/va/vets-website/node_modules/@department-of-veterans-affairs/component-library/dist/react-bindings/react-component-lib/utils/index.tsx
+40:26-36
+[tsl] ERROR in /home/rd/va/vets-website/node_modules/@department-of-veterans-affairs/component-library/dist/react-bindings/react-component-lib/utils/index.tsx(40,27)
+      TS2345: Argument of type '{ (props: StencilReactExternalProps<PropType, ElementType>, ref: StencilReactForwardedRef<ElementType>): React.JSX.Element; displayName: string; }' is not assignable to parameter of type 'ForwardRefRenderFunction<ElementType, PropsWithoutRef<StencilReactExternalProps<PropType, ElementType>>>'.
+  Types of parameters 'props' and 'props' are incompatible.
+    Type 'PropsWithoutRef<StencilReactExternalProps<PropType, ElementType>>' is not assignable to type 'StencilReactExternalProps<PropType, ElementType>'.
+      Type 'Omit<HTMLAttributes<ElementType>, "style"> & StyleReactProps' is not assignable to type 'StencilReactExternalProps<PropType, ElementType>'.
+        Type 'Omit<HTMLAttributes<ElementType>, "style"> & StyleReactProps' is not assignable to type 'PropType'.
+          'PropType' could be instantiated with an arbitrary type which could be unrelated to 'Omit<HTMLAttributes<ElementType>, "style"> & StyleReactProps'.
+ts-loader-default_e

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:webpack:dev": "yarn build:webpack --env buildtype=vagovdev",
     "build:webpack:local": "yarn build:webpack --env buildtype=localhost",
     "check-app-imports": "node script/check-cross-app-imports.js",
+    "codemod": "codemod",
     "cy:count": "node ./script/count-cy-specs",
     "cy:my-testrail-helper": "node ./script/cypress-testrail-helper",
     "cy:my-testrail-run": "cypress run --config-file config/my-cypress-testrail.config.js",

--- a/src/applications/mhv-landing-page/components/ErrorNavCard.tsx
+++ b/src/applications/mhv-landing-page/components/ErrorNavCard.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { VaIcon, VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+interface ErrorNavCardProps {
+  title: string;
+  code?: string;
+  iconClasses?: string;
+  userActionable?: boolean;
+}
 
 /**
  * A navigation card only displayed when an error occurs.
@@ -14,9 +21,9 @@ const ErrorNavCard = ({
   iconClasses = 'vads-u-margin-right--1p5',
   title,
   code,
-  userActionable = false,
-}) => {
-  const slug = `mhv-c-card-${title.replaceAll(/\W+/g, '-').toLowerCase()}`;
+  userActionable = false
+}: ErrorNavCardProps) => {
+  const slug = `mhv-c-card-${title.replace(/\W+/g, '-').toLowerCase()}`;
   return (
     <div
       className={classnames(
@@ -30,7 +37,7 @@ const ErrorNavCard = ({
       <div className="vads-l-row vads-u-margin-right--neg1">
         <div className="vads-u-display--flex vads-u-align-items--center">
           <div className={`vads-u-flex--auto ${iconClasses}`}>
-            <va-icon icon="error" size={4} />
+            <VaIcon icon="error" size={4} />
           </div>
 
           <div className="vads-u-flex--fill vads-u-margin-right--1p5">
@@ -62,8 +69,8 @@ const ErrorNavCard = ({
               'vada-u-font-size--md',
             )}
           >
-            Call us at <va-telephone contact="8773270022" />({' '}
-            <va-telephone contact={CONTACTS[711]} tty /> ). We’re here Monday
+            Call us at <VaTelephone contact="8773270022" />({' '}
+            <VaTelephone contact={CONTACTS[711]} tty /> ). We’re here Monday
             through Friday, 8:00 a.m. to 8:00 p.m. ET.
           </p>
         </div>
@@ -86,9 +93,4 @@ const ErrorNavCard = ({
   );
 };
 
-ErrorNavCard.propTypes = {
-  title: PropTypes.string.isRequired,
-  code: PropTypes.string,
-  iconClasses: PropTypes.string,
-};
 export default ErrorNavCard;

--- a/src/applications/mhv-landing-page/components/HeaderLayout.tsx
+++ b/src/applications/mhv-landing-page/components/HeaderLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
+import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/mhv/utilities';
 import { datadogRum } from '@datadog/browser-rum';
 import WelcomeContainer from '../containers/WelcomeContainer';
 

--- a/src/applications/mhv-landing-page/components/HeaderLayout.tsx
+++ b/src/applications/mhv-landing-page/components/HeaderLayout.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { datadogRum } from '@datadog/browser-rum';
 import WelcomeContainer from '../containers/WelcomeContainer';
 
 const goBackLinkText = 'Go back to the previous version of My HealtheVet';
 
+interface HeaderLayoutProps {
+  showMhvGoBack?: boolean;
+  showWelcomeMessage?: boolean;
+  ssoe?: boolean;
+}
+
 const HeaderLayout = ({
   showWelcomeMessage = false,
   showMhvGoBack = false,
-  ssoe = false,
-}) => {
+  ssoe = false
+}: HeaderLayoutProps) => {
   const mhvHomeUrl = mhvUrl(ssoe, 'home');
 
   return (
@@ -91,12 +96,6 @@ const HeaderLayout = ({
       )}
     </>
   );
-};
-
-HeaderLayout.propTypes = {
-  showMhvGoBack: PropTypes.bool,
-  showWelcomeMessage: PropTypes.bool,
-  ssoe: PropTypes.bool,
 };
 
 export default HeaderLayout;

--- a/src/applications/mhv-landing-page/components/HubLinks.tsx
+++ b/src/applications/mhv-landing-page/components/HubLinks.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import recordEvent from '~/platform/monitoring/record-event';
 
-const HubSection = ({ title, links }) => {
+interface HubSectionProps {
+  links?: {
+    text?: string;
+    href?: string;
+  }[];
+  title?: string;
+}
+
+const HubSection = ({
+  title,
+  links
+}: HubSectionProps) => {
   const listItems = links.map(({ href, text }, index) => (
     <li key={`${href}--${index}`}>
       <a
@@ -29,7 +39,19 @@ const HubSection = ({ title, links }) => {
   );
 };
 
-const HubLinks = ({ hubs }) => {
+interface HubLinksProps {
+  hubs?: {
+    title?: string;
+    links?: {
+      text?: string;
+      href?: string;
+    }[];
+  }[];
+}
+
+const HubLinks = ({
+  hubs
+}: HubLinksProps) => {
   const hubLayout = hubs.map((h, index) => (
     <div
       key={h.title}
@@ -46,21 +68,4 @@ const HubLinks = ({ hubs }) => {
   );
 };
 
-HubSection.propTypes = {
-  links: PropTypes.arrayOf(
-    PropTypes.shape({ text: PropTypes.string, href: PropTypes.string }),
-  ),
-  title: PropTypes.string,
-};
-
-HubLinks.propTypes = {
-  hubs: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string,
-      links: PropTypes.arrayOf(
-        PropTypes.shape({ text: PropTypes.string, href: PropTypes.string }),
-      ),
-    }),
-  ),
-};
 export default HubLinks;

--- a/src/applications/mhv-landing-page/components/HubLinks.tsx
+++ b/src/applications/mhv-landing-page/components/HubLinks.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import recordEvent from '~/platform/monitoring/record-event';
+import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
 
 interface HubSectionProps {
   links?: {
@@ -11,7 +11,7 @@ interface HubSectionProps {
 
 const HubSection = ({
   title,
-  links
+  links = []
 }: HubSectionProps) => {
   const listItems = links.map(({ href, text }, index) => (
     <li key={`${href}--${index}`}>

--- a/src/applications/mhv-landing-page/components/LandingPage.tsx
+++ b/src/applications/mhv-landing-page/components/LandingPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 import {
   renderMHVDowntime,
   MhvSecondaryNav,
@@ -24,7 +23,13 @@ import {
 } from '../selectors';
 import manifest from '../manifest.json';
 
-const LandingPage = ({ data = {} }) => {
+interface LandingPageProps {
+  data?: object;
+}
+
+const LandingPage = ({
+  data = {}
+}: LandingPageProps) => {
   const { cards = [], hubs = [] } = data;
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const userVerified = useSelector(isLOA3);
@@ -73,10 +78,6 @@ const LandingPage = ({ data = {} }) => {
       </div>
     </>
   );
-};
-
-LandingPage.propTypes = {
-  data: PropTypes.object,
 };
 
 export default LandingPage;

--- a/src/applications/mhv-landing-page/components/NavCard.tsx
+++ b/src/applications/mhv-landing-page/components/NavCard.tsx
@@ -1,9 +1,22 @@
 import React from 'react';
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 import recordEvent from '~/platform/monitoring/record-event';
 
 export const externalLinkText = '(opens in new tab)';
+
+interface NavCardProps {
+  title: string;
+  icon?: "attach_money" | "calendar_today" | "forum" | "medical_services" | "note_add" | "pill";
+  iconClasses?: string;
+  introduction?: string;
+  links?: {
+    text?: string | React.ReactElement;
+    href?: string;
+    isExternal?: boolean;
+    omitExternalLinkText?: boolean;
+  }[];
+  tag?: string;
+}
 
 /**
  * A navigation card.
@@ -20,8 +33,8 @@ const NavCard = ({
   introduction,
   title,
   links,
-  tag,
-}) => {
+  tag
+}: NavCardProps) => {
   const listItems = links?.map(
     ({ ariaLabel, href, text, isExternal, omitExternalLinkText }) => (
       <li className="mhv-c-navlistitem" key={href}>
@@ -133,26 +146,4 @@ const NavCard = ({
   );
 };
 
-NavCard.propTypes = {
-  title: PropTypes.string.isRequired,
-  icon: PropTypes.oneOf([
-    'attach_money',
-    'calendar_today',
-    'forum',
-    'medical_services',
-    'note_add',
-    'pill',
-  ]),
-  iconClasses: PropTypes.string,
-  introduction: PropTypes.string,
-  links: PropTypes.arrayOf(
-    PropTypes.shape({
-      text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-      href: PropTypes.string,
-      isExternal: PropTypes.bool,
-      omitExternalLinkText: PropTypes.bool,
-    }),
-  ),
-  tag: PropTypes.string,
-};
 export default NavCard;

--- a/src/applications/mhv-landing-page/components/Welcome.tsx
+++ b/src/applications/mhv-landing-page/components/Welcome.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 import recordEvent from '~/platform/monitoring/record-event';
 import { datadogRum } from '@datadog/browser-rum';
 
-const Welcome = ({ name }) => (
+interface WelcomeProps {
+  name?: string;
+}
+
+const Welcome = ({
+  name
+}: WelcomeProps) => (
   <div
     className={classnames(
       'vads-u-display--flex',
@@ -56,9 +61,5 @@ const Welcome = ({ name }) => (
     </div>
   </div>
 );
-
-Welcome.propTypes = {
-  name: PropTypes.string,
-};
 
 export default Welcome;

--- a/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertAccountApiAlert.tsx
@@ -1,16 +1,23 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { datadogRum } from '@datadog/browser-rum';
 
+interface AlertAccountApiAlertProps {
+  errorCode?: number;
+  headline?: string;
+  recordEvent?(...args: unknown[]): unknown;
+  testId?: string;
+  title?: string;
+}
+
 const AlertAccountApiAlert = ({
   errorCode,
   testId,
   recordEvent,
-  userActionable = false,
-}) => {
+  userActionable = false
+}: AlertAccountApiAlertProps) => {
   const headline = userActionable
     ? `Error code ${errorCode}: Contact the My HealtheVet help desk`
     : `You can't access messages, medications, or medical records right now`;
@@ -98,14 +105,6 @@ AlertAccountApiAlert.defaultProps = {
   errorCode: 0,
   recordEvent: recordEventFn,
   testId: 'mhv-alert--mhv-registration',
-};
-
-AlertAccountApiAlert.propTypes = {
-  errorCode: PropTypes.number,
-  headline: PropTypes.string,
-  recordEvent: PropTypes.func,
-  testId: PropTypes.string,
-  title: PropTypes.string,
 };
 
 export default AlertAccountApiAlert;

--- a/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertMhvBasicAccount.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import { CSP_IDS } from '~/platform/user/authentication/constants';
@@ -7,7 +6,17 @@ import { VerifyButton } from '~/platform/user/authentication/components/VerifyBu
 import { VaAlertSignIn } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { datadogRum } from '@datadog/browser-rum';
 
-const AlertMhvBasicAccount = ({ headline, recordEvent, testId }) => {
+interface AlertMhvBasicAccountProps {
+  headline?: string;
+  recordEvent?(...args: unknown[]): unknown;
+  testId?: string;
+}
+
+const AlertMhvBasicAccount = ({
+  headline,
+  recordEvent,
+  testId
+}: AlertMhvBasicAccountProps) => {
   useEffect(() => {
     recordEvent({
       event: 'nav-alert-box-load',
@@ -39,12 +48,6 @@ AlertMhvBasicAccount.defaultProps = {
   headline: 'You need to sign in with a different account',
   recordEvent: recordEventFn,
   testId: 'mhv-alert--mhv-basic-account',
-};
-
-AlertMhvBasicAccount.propTypes = {
-  headline: PropTypes.string,
-  recordEvent: PropTypes.func,
-  testId: PropTypes.string,
 };
 
 export default AlertMhvBasicAccount;

--- a/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertMhvNoAction.tsx
@@ -1,10 +1,21 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-const AlertMhvNoAction = ({ errorCode, testId, recordEvent }) => {
+interface AlertMhvNoActionProps {
+  errorCode?: string;
+  headline?: string;
+  recordEvent?(...args: unknown[]): unknown;
+  testId?: string;
+  title?: string;
+}
+
+const AlertMhvNoAction = ({
+  errorCode,
+  testId,
+  recordEvent
+}: AlertMhvNoActionProps) => {
   const headline = `You can't access messages, medications, or medical records right now`;
   useEffect(() => {
     recordEvent({
@@ -56,14 +67,6 @@ AlertMhvNoAction.defaultProps = {
   errorCode: 'unknown',
   recordEvent: recordEventFn,
   testId: 'mhv-alert--mhv-registration',
-};
-
-AlertMhvNoAction.propTypes = {
-  errorCode: PropTypes.string,
-  headline: PropTypes.string,
-  recordEvent: PropTypes.func,
-  testId: PropTypes.string,
-  title: PropTypes.string,
 };
 
 export default AlertMhvNoAction;

--- a/src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertMhvUserAction.tsx
@@ -1,10 +1,21 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-const AlertMhvUserAction = ({ errorCode, testId, recordEvent }) => {
+interface AlertMhvUserActionProps {
+  errorCode?: string;
+  headline?: string;
+  recordEvent?(...args: unknown[]): unknown;
+  testId?: string;
+  title?: string;
+}
+
+const AlertMhvUserAction = ({
+  errorCode,
+  testId,
+  recordEvent
+}: AlertMhvUserActionProps) => {
   const headline = `Error code ${errorCode}: Contact the My HealtheVet help desk`;
   useEffect(() => {
     recordEvent({
@@ -56,14 +67,6 @@ AlertMhvUserAction.defaultProps = {
   errorCode: 'unknown',
   recordEvent: recordEventFn,
   testId: 'mhv-alert--mhv-registration',
-};
-
-AlertMhvUserAction.propTypes = {
-  errorCode: PropTypes.string,
-  headline: PropTypes.string,
-  recordEvent: PropTypes.func,
-  testId: PropTypes.string,
-  title: PropTypes.string,
 };
 
 export default AlertMhvUserAction;

--- a/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertNotVerified.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import VerifyAlert from '~/platform/user/authorization/components/VerifyAlert';
@@ -8,7 +7,15 @@ import {
   SERVICE_PROVIDERS,
 } from '~/platform/user/authentication/constants';
 
-const AlertNotVerified = ({ cspId, recordEvent }) => {
+interface AlertNotVerifiedProps {
+  cspId?: unknown[];
+  recordEvent?(...args: unknown[]): unknown;
+}
+
+const AlertNotVerified = ({
+  cspId,
+  recordEvent
+}: AlertNotVerifiedProps) => {
   const serviceLabel = SERVICE_PROVIDERS[cspId].label;
   const headline = `Verify your identity to use your ${serviceLabel} account on My HealtheVet`;
 
@@ -29,11 +36,6 @@ const AlertNotVerified = ({ cspId, recordEvent }) => {
 AlertNotVerified.defaultProps = {
   cspId: CSP_IDS.DS_LOGON,
   recordEvent: recordEventFn,
-};
-
-AlertNotVerified.propTypes = {
-  cspId: PropTypes.oneOf(Object.keys(SERVICE_PROVIDERS)),
-  recordEvent: PropTypes.func,
 };
 
 export default AlertNotVerified;

--- a/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertUnregistered.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
@@ -10,7 +9,19 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { datadogRum } from '@datadog/browser-rum';
 
-const AlertUnregistered = ({ headline, recordEvent, ssoe, testId }) => {
+interface AlertUnregisteredProps {
+  headline?: string;
+  recordEvent?(...args: unknown[]): unknown;
+  ssoe?: boolean;
+  testId?: string;
+}
+
+const AlertUnregistered = ({
+  headline,
+  recordEvent,
+  ssoe,
+  testId
+}: AlertUnregisteredProps) => {
   const mhvHomeUrl = mhvUrl(ssoe, 'home');
 
   useEffect(() => {
@@ -69,13 +80,6 @@ AlertUnregistered.defaultProps = {
   recordEvent: recordEventFn,
   ssoe: false,
   testId: 'mhv-alert--unregistered',
-};
-
-AlertUnregistered.propTypes = {
-  headline: PropTypes.string,
-  recordEvent: PropTypes.func,
-  ssoe: PropTypes.bool,
-  testId: PropTypes.string,
 };
 
 export default AlertUnregistered;

--- a/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx
+++ b/src/applications/mhv-landing-page/components/alerts/AlertVerifyAndRegister.tsx
@@ -1,12 +1,19 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 
 import VerifyAlert from '~/platform/user/authorization/components/VerifyAlert';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
 import { datadogRum } from '@datadog/browser-rum';
 
-const AlertVerifyAndRegister = ({ recordEvent, testId }) => {
+interface AlertVerifyAndRegisterProps {
+  recordEvent?(...args: unknown[]): unknown;
+  testId?: string;
+}
+
+const AlertVerifyAndRegister = ({
+  recordEvent,
+  testId
+}: AlertVerifyAndRegisterProps) => {
   const headline = 'Verify your identity';
 
   useEffect(() => {
@@ -25,11 +32,6 @@ const AlertVerifyAndRegister = ({ recordEvent, testId }) => {
 AlertVerifyAndRegister.defaultProps = {
   recordEvent: recordEventFn,
   testId: 'mhv-alert--verify-and-register',
-};
-
-AlertVerifyAndRegister.propTypes = {
-  recordEvent: PropTypes.func,
-  testId: PropTypes.string,
 };
 
 export default AlertVerifyAndRegister;

--- a/src/applications/mhv-landing-page/containers/AppConfig.tsx
+++ b/src/applications/mhv-landing-page/containers/AppConfig.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import {
   setDatadogRumUser,
@@ -14,11 +13,17 @@ import {
   selectVaPatient,
 } from '../selectors';
 
+interface AppConfigProps {
+  children?: React.ReactNode;
+  setDatadogRumUserFn?(...args: unknown[]): unknown;
+  useDatadogRumFn?(...args: unknown[]): unknown;
+}
+
 const AppConfig = ({
   children,
   setDatadogRumUserFn = setDatadogRumUser,
-  useDatadogRumFn = useDatadogRum,
-}) => {
+  useDatadogRumFn = useDatadogRum
+}: AppConfigProps) => {
   const profile = useSelector(selectProfile);
 
   useDatadogRumFn({
@@ -51,12 +56,6 @@ const AppConfig = ({
   }, [profile, setDatadogRumUserFn]);
 
   return <>{children}</>;
-};
-
-AppConfig.propTypes = {
-  children: PropTypes.node,
-  setDatadogRumUserFn: PropTypes.func,
-  useDatadogRumFn: PropTypes.func,
 };
 
 export default AppConfig;

--- a/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
+++ b/src/applications/mhv-landing-page/containers/LandingPageContainer.tsx
@@ -19,6 +19,7 @@ import {
   hasMessagingAccess,
   mhvAccountStatusLoading,
 } from '../selectors';
+import { VaLoadingIndicator } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const LandingPageContainer = () => {
   const mhvAccountStatusIsLoading = useSelector(mhvAccountStatusLoading);
@@ -56,17 +57,14 @@ const LandingPageContainer = () => {
     }
   }, [userHasMessagingAccess, loading]);
 
-  useEffect(() => {
-    // For accessibility purposes.
-    focusElement('h1');
-  }, [loading]);
+  useEffect(() => focusElement('h1'), [loading]);
 
   useAccountCreationApi();
 
   if (loading)
     return (
       <div className="vads-u-margin--5">
-        <va-loading-indicator
+        <VaLoadingIndicator
           data-testid="mhv-landing-page-loading"
           message="Please wait..."
         />

--- a/src/applications/mhv-landing-page/containers/WelcomeContainer.jsx
+++ b/src/applications/mhv-landing-page/containers/WelcomeContainer.jsx
@@ -9,9 +9,7 @@ const WelcomeContainer = () => {
   const loa3 = useSelector(isLOA3);
   const name = useSelector(selectGreetingName);
 
-  useEffect(() => {
-    return inMPI && loa3;
-  }, [dispatch, inMPI, loa3]);
+  useEffect(() => inMPI && loa3, [dispatch, inMPI, loa3]);
 
   return <Welcome name={name} />;
 };

--- a/src/applications/mhv-landing-page/index.d.ts
+++ b/src/applications/mhv-landing-page/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@department-of-veterans-affairs/component-library/contacts';

--- a/src/applications/mhv-landing-page/tsconfig.json
+++ b/src/applications/mhv-landing-page/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../config/base-tsconfig.json",
+  "include": ["**/*"],
+  "exclude": ["./tests", "./mocks"]
+}


### PR DESCRIPTION
## Summary

- **Migrates mhv-landing-page to ts, tsx files**
- **Addresses TypeScript syntax errors, adds build output**
- and much more todo...

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108558

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario
