### PR TITLE
107614 - Track profile sidenav clicks

### DIFF
--- a/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
@@ -14,7 +14,7 @@ function ProfileSubNavItems({ routes, isLOA3, isInMVI, clickHandler = null }) {
   // or having isBlocked state selector return true
   const filteredRoutes = routes.filter(route => {
     // loa3 check and isBlocked check
-    if ((route.requiresLOA3 && !isLOA3) || (route.requiresLOA3 && isBlocked)) {
+    if (route.requiresLOA3 && (!isLOA3 || isBlocked)) {
       return false;
     }
 

--- a/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNavItems.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import { NavLink } from 'react-router-dom';
+import recordEvent from 'platform/monitoring/record-event';
 import { selectIsBlocked } from '../selectors';
 
 function ProfileSubNavItems({ routes, isLOA3, isInMVI, clickHandler = null }) {
@@ -20,6 +21,16 @@ function ProfileSubNavItems({ routes, isLOA3, isInMVI, clickHandler = null }) {
     // mvi check
     return !(route.requiresMVI && !isInMVI);
   });
+  const recordNavUserEvent = routePath => () => {
+    recordEvent({
+      event: 'navigation',
+      'link-location': 'sidebar',
+      'page-path': routePath,
+    });
+    if (clickHandler) {
+      clickHandler();
+    }
+  };
   return (
     <ul>
       {filteredRoutes.map(route => {
@@ -29,7 +40,7 @@ function ProfileSubNavItems({ routes, isLOA3, isInMVI, clickHandler = null }) {
               activeClassName="is-active"
               exact
               to={route.path}
-              onClick={clickHandler}
+              onClick={recordNavUserEvent(route.path)}
             >
               {route.name}
             </NavLink>

--- a/src/applications/personalization/profile/components/ProfileSubNavItems.unit.spec.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNavItems.unit.spec.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import * as ReactRedux from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import sinon from 'sinon';
+
+import ProfileSubNavItems from './ProfileSubNavItems';
+
+const defaultRoutes = [
+  { path: '/profile/personal-information', name: 'Personal Info' },
+  {
+    path: '/profile/contact-information',
+    name: 'Contact Info',
+    requiresLOA3: true,
+  },
+  {
+    path: '/profile/direct-deposit',
+    name: 'Direct Deposit',
+    requiresMVI: true,
+  },
+];
+
+function renderSubNav(ui, { store }) {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('ProfileSubNavItems', () => {
+  let store;
+  let useSelectorStub;
+  beforeEach(() => {
+    useSelectorStub = sinon.stub(ReactRedux, 'useSelector');
+    store = {
+      getState: () => ({}),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+  });
+
+  afterEach(() => {
+    useSelectorStub.restore();
+  });
+
+  it('renders all routes when requirements are met', () => {
+    useSelectorStub.returns(false);
+    const container = renderSubNav(
+      <ProfileSubNavItems routes={defaultRoutes} isLOA3 isInMVI />,
+      {
+        store,
+      },
+    );
+    expect(container.getByText('Personal Info')).to.exist;
+    expect(container.getByText('Contact Info')).to.exist;
+    expect(container.getByText('Direct Deposit')).to.exist;
+  });
+
+  it('filters out LOA3 routes if not LOA3', () => {
+    useSelectorStub.returns(false);
+    const container = renderSubNav(
+      <ProfileSubNavItems routes={defaultRoutes} isLOA3={false} isInMVI />,
+      {
+        store,
+      },
+    );
+    expect(container.getByText('Personal Info')).to.exist;
+    expect(container.queryByText('Contact Info')).to.be.null;
+    expect(container.getByText('Direct Deposit')).to.exist;
+  });
+
+  it('filters out LOA3 routes if user is blocked', () => {
+    useSelectorStub.returns(true);
+    const container = renderSubNav(
+      <ProfileSubNavItems routes={defaultRoutes} isLOA3={false} isInMVI />,
+      {
+        store,
+      },
+    );
+    expect(container.getByText('Personal Info')).to.exist;
+    expect(container.queryByText('Contact Info')).to.be.null;
+    expect(container.getByText('Direct Deposit')).to.exist;
+  });
+
+  it('filters out MVI routes if not in MVI', () => {
+    useSelectorStub.returns(false);
+    const container = renderSubNav(
+      <ProfileSubNavItems routes={defaultRoutes} isLOA3 isInMVI={false} />,
+      {
+        store,
+      },
+    );
+    expect(container.getByText('Personal Info')).to.exist;
+    expect(container.getByText('Contact Info')).to.exist;
+    expect(container.queryByText('Direct Deposit')).to.be.null;
+  });
+
+  it('calls clickHandler and records event on click', () => {
+    useSelectorStub.returns(false);
+    const clickHandler = sinon.spy();
+    const container = renderSubNav(
+      <ProfileSubNavItems
+        routes={defaultRoutes}
+        isLOA3
+        isInMVI
+        clickHandler={clickHandler}
+      />,
+      {
+        store,
+      },
+    );
+    const link = container.getByText('Personal Info');
+    fireEvent.click(link);
+    expect(clickHandler.calledOnce).to.be.true;
+  });
+});


### PR DESCRIPTION
Adds GA tracking to sidenav links in the Profile.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This updates the sidebar nav links to track clicks to Google Analytics
- Just added the `recordEvent` method to the onClick handler and maintained the existing calls to the clickHandler method if present.
- Authenticated Experience Team Authentiknights

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107614

## Testing done

- Added unit tests to cover the ProfileSubNavItems file where it didn't previously exist
- Load the Profile page and see that Google Analytics calls are being made when left nav page links are clicked

## Screenshots

N/A

## What areas of the site does it impact?

Profile pages with a side nav

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
