### PR TITLE
Dependents | Update array summary card titles

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/674/addStudentsArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/674/addStudentsArrayPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { capitalize } from 'lodash';
+
 import {
   titleUI,
   textUI,
@@ -30,6 +30,7 @@ import {
 import VaMemorableDateField from 'platform/forms-system/src/js/web-component-fields/VaMemorableDateField';
 import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import { validateCurrentOrFutureDate } from 'platform/forms-system/src/js/validation';
+
 import {
   AccreditedSchool,
   AddStudentsIntro,
@@ -39,6 +40,7 @@ import {
   TermDateHint,
 } from './helpers';
 import { CancelButton, generateHelpText } from '../../helpers';
+import { getFullName } from '../../../../shared/utils';
 
 /** @type {ArrayBuilderOptions} */
 export const addStudentsOptions = {
@@ -80,14 +82,7 @@ export const addStudentsOptions = {
   maxItems: 20,
   text: {
     summaryTitle: 'Review your students',
-    getItemName: () => 'Student',
-    cardDescription: item => (
-      <span className="dd-privacy" data-dd-privacy="mask">
-        {`${capitalize(item?.fullName?.first) || ''} ${capitalize(
-          item?.fullName?.last,
-        ) || ''}`.trim()}
-      </span>
-    ),
+    getItemName: item => getFullName(item.fullName),
   },
 };
 

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { capitalize } from 'lodash';
 import {
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderYesNoSchema,
@@ -20,6 +19,7 @@ import {
   spouseFormerMarriageLabels,
   customLocationSchema,
 } from '../../helpers';
+import { getFullName } from '../../../../shared/utils';
 
 /** @type {ArrayBuilderOptions} */
 export const spouseMarriageHistoryOptions = {
@@ -48,14 +48,7 @@ export const spouseMarriageHistoryOptions = {
   maxItems: 20,
   text: {
     summaryTitle: 'Review your spouse’s marital history',
-    getItemName: () => 'Spouse’s former marriage',
-    cardDescription: item => (
-      <span className="dd-privacy" data-dd-privacy="mask">
-        {`${capitalize(item?.fullName?.first) || ''} ${capitalize(
-          item?.fullName?.last,
-        ) || ''}`.trim()}
-      </span>
-    ),
+    getItemName: item => getFullName(item.fullName),
   },
 };
 

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import { capitalize } from 'lodash';
 import {
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderYesNoSchema,
@@ -15,12 +13,14 @@ import {
 import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import VaSelectField from 'platform/forms-system/src/js/web-component-fields/VaSelectField';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
+
 import {
   marriageEnums,
   veteranFormerMarriageLabels,
   customLocationSchema,
   generateHelpText,
 } from '../../helpers';
+import { getFullName } from '../../../../shared/utils';
 
 /* NOTE:
  * In "Add mode" of the array builder, formData represents the entire formData object.
@@ -56,14 +56,7 @@ export const veteranMarriageHistoryOptions = {
   maxItems: 20,
   text: {
     summaryTitle: 'Review your marital history',
-    getItemName: () => 'Your former marriage',
-    cardDescription: item => (
-      <span className="dd-privacy" data-dd-privacy="mask">
-        {`${capitalize(item?.fullName?.first || '')} ${capitalize(
-          item?.fullName?.last || '',
-        )}`.trim()}
-      </span>
-    ),
+    getItemName: item => getFullName(item.fullName),
   },
 };
 

--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/config.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/config.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { getFullName } from '../../../../shared/utils';
 
 function isFieldMissing(value) {
   return value === undefined || value === null || value === '';
@@ -128,12 +128,6 @@ export const arrayBuilderOptions = {
   isItemIncomplete,
   maxItems: 20,
   text: {
-    getItemName: () => 'Child',
-    cardDescription: item => (
-      <span className="dd-privacy" data-dd-privacy="mask">
-        {`${item?.fullName?.first ?? ''} ${item?.fullName?.last ??
-          ''}`.trim() || ' '}
-      </span>
-    ),
+    getItemName: item => getFullName(item.fullName),
   },
 };

--- a/src/applications/dependents/686c-674/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { capitalize } from 'lodash';
+
 import {
   titleUI,
   arrayBuilderItemFirstPageTitleUI,
@@ -15,7 +15,9 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+
 import { CancelButton } from '../../helpers';
+import { getFullName } from '../../../../shared/utils';
 
 /** @type {ArrayBuilderOptions} */
 export const removeChildStoppedAttendingSchoolOptions = {
@@ -32,14 +34,7 @@ export const removeChildStoppedAttendingSchoolOptions = {
   maxItems: 20,
   text: {
     summaryTitle: 'Review your children between ages 18 and 23 who left school',
-    getItemName: () => 'Child',
-    cardDescription: item => (
-      <span className="dd-privacy" data-dd-privacy="mask">
-        {`${capitalize(item?.fullName?.first) || ''} ${capitalize(
-          item?.fullName?.last,
-        ) || ''}`.trim()}
-      </span>
-    ),
+    getItemName: item => getFullName(item.fullName),
     cancelAddButtonText: 'Cancel removing this child',
   },
 };

--- a/src/applications/dependents/686c-674/config/chapters/report-dependent-death/deceasedDependentArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-dependent-death/deceasedDependentArrayPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { capitalize } from 'lodash';
+
 import {
   titleUI,
   arrayBuilderItemFirstPageTitleUI,
@@ -22,6 +22,7 @@ import {
 import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import VaSelectField from 'platform/forms-system/src/js/web-component-fields/VaSelectField';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
+
 import {
   relationshipEnums,
   relationshipLabels,
@@ -33,6 +34,7 @@ import {
   generateHelpText,
   CancelButton,
 } from '../../helpers';
+import { getFullName } from '../../../../shared/utils';
 
 /** @type {ArrayBuilderOptions} */
 export const deceasedDependentOptions = {
@@ -54,7 +56,8 @@ export const deceasedDependentOptions = {
       !item?.dependentDeathLocation?.location?.country),
   maxItems: 20,
   text: {
-    getItemName: item => {
+    getItemName: item => getFullName(item.fullName),
+    cardDescription: item => {
       const dependentType = item?.dependentType;
 
       if (!dependentType) {
@@ -68,15 +71,6 @@ export const deceasedDependentOptions = {
       }
 
       return 'Dependent';
-    },
-    cardDescription: item => {
-      const firstName = capitalize(item?.fullName?.first || '');
-      const lastName = capitalize(item?.fullName?.last || '');
-      return (
-        <span className="dd-privacy" data-dd-privacy="mask">
-          {`${firstName} ${lastName}`.trim()}
-        </span>
-      );
     },
     summaryTitle: 'Review your dependents who have died',
     cancelAddButtonText: 'Cancel removing this dependent',

--- a/src/applications/dependents/686c-674/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { capitalize } from 'lodash';
+
 import {
   titleUI,
   arrayBuilderItemFirstPageTitleUI,
@@ -15,7 +15,9 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+
 import { CancelButton } from '../../helpers';
+import { getFullName } from '../../../../shared/utils';
 
 /** @type {ArrayBuilderOptions} */
 export const removeMarriedChildOptions = {
@@ -32,14 +34,7 @@ export const removeMarriedChildOptions = {
   maxItems: 20,
   text: {
     summaryTitle: 'Review your children under 18 who got married',
-    getItemName: () => 'Child',
-    cardDescription: item => (
-      <span className="dd-privacy" data-dd-privacy="mask">
-        {`${capitalize(item?.fullName?.first) || ''} ${capitalize(
-          item?.fullName?.last,
-        ) || ''}`.trim()}
-      </span>
-    ),
+    getItemName: item => getFullName(item.fullName),
     cancelAddButtonText: 'Cancel removing this child',
   },
 };

--- a/src/applications/dependents/686c-674/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { capitalize } from 'lodash';
+
 import {
   titleUI,
   arrayBuilderItemFirstPageTitleUI,
@@ -19,7 +19,9 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+
 import { CancelButton } from '../../helpers';
+import { getFullName } from '../../../../shared/utils';
 
 /** @type {ArrayBuilderOptions} */
 export const removeChildHouseholdOptions = {
@@ -43,14 +45,7 @@ export const removeChildHouseholdOptions = {
   maxItems: 20,
   text: {
     summaryTitle: 'Review your stepchildren who have left your household',
-    getItemName: () => 'Stepchild',
-    cardDescription: item => (
-      <span className="dd-privacy" data-dd-privacy="mask">
-        {`${capitalize(item?.fullName?.first) || ''} ${capitalize(
-          item?.fullName?.last,
-        ) || ''}`.trim()}
-      </span>
-    ),
+    getItemName: item => getFullName(item.fullName),
     cancelAddButtonText: 'Cancel removing this child',
   },
 };

--- a/src/applications/dependents/686c-674/containers/IntroductionPage.jsx
+++ b/src/applications/dependents/686c-674/containers/IntroductionPage.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+
 import { scrollTo, waitForRenderThenFocus } from 'platform/utilities/ui/';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
@@ -198,6 +200,17 @@ const IntroductionPage = props => {
       </div>
     </div>
   );
+};
+
+IntroductionPage.propTypes = {
+  route: PropTypes.shape({
+    formConfig: PropTypes.shape({
+      prefillEnabled: PropTypes.bool,
+      savedFormMessages: PropTypes.object,
+      downtime: PropTypes.object,
+    }),
+    pageList: PropTypes.array,
+  }).isRequired,
 };
 
 export default IntroductionPage;

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/spouseMarriageHistoryArrayPages.unit.spec.jsx
@@ -237,14 +237,14 @@ describe('spouseMarriageHistoryOptions', () => {
     });
   });
 
-  describe('text.getItemName + text.cardDescription', () => {
+  describe('text.getItemName', () => {
     it('should return the full name of the item', () => {
       const item = {
         fullName: { first: 'John', last: 'Doe' },
       };
 
       const { container } = render(
-        spouseMarriageHistoryOptions.text.cardDescription(item),
+        spouseMarriageHistoryOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('John Doe');
     });
@@ -254,12 +254,12 @@ describe('spouseMarriageHistoryOptions', () => {
       const missingBoth = { fullName: {} };
 
       let result = render(
-        spouseMarriageHistoryOptions.text.cardDescription(incompleteItem),
+        spouseMarriageHistoryOptions.text.getItemName(incompleteItem),
       );
       expect(result.container.textContent).to.equal('John');
 
       result = render(
-        spouseMarriageHistoryOptions.text.cardDescription(missingBoth),
+        spouseMarriageHistoryOptions.text.getItemName(missingBoth),
       );
       expect(result.container.textContent).to.equal('');
     });

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/veteranMarriageHistoryArrayPages.unit.spec.jsx
@@ -237,17 +237,13 @@ describe('veteranMarriageHistoryOptions', () => {
     });
   });
 
-  describe('veteranMarriageHistoryOptions.text.getItemName + .cardDescription', () => {
+  describe('veteranMarriageHistoryOptions.text.getItemName', () => {
     it('should return the full name of the item', () => {
       const item = {
         fullName: { first: 'John', last: 'Doe' },
       };
-      expect(veteranMarriageHistoryOptions.text.getItemName()).to.equal(
-        'Your former marriage',
-      );
-
       const { container } = render(
-        veteranMarriageHistoryOptions.text.cardDescription(item),
+        veteranMarriageHistoryOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('John Doe');
     });
@@ -255,19 +251,19 @@ describe('veteranMarriageHistoryOptions', () => {
     it('should return a trimmed name even if one part is missing', () => {
       const itemMissingLast = { fullName: { first: 'John' } };
       const { container: container1 } = render(
-        veteranMarriageHistoryOptions.text.cardDescription(itemMissingLast),
+        veteranMarriageHistoryOptions.text.getItemName(itemMissingLast),
       );
       expect(container1.textContent).to.equal('John');
 
       const itemMissingFirst = { fullName: { last: 'Doe' } };
       const { container: container2 } = render(
-        veteranMarriageHistoryOptions.text.cardDescription(itemMissingFirst),
+        veteranMarriageHistoryOptions.text.getItemName(itemMissingFirst),
       );
       expect(container2.textContent).to.equal('Doe');
 
       const itemMissingBoth = { fullName: {} };
       const { container: container3 } = render(
-        veteranMarriageHistoryOptions.text.cardDescription(itemMissingBoth),
+        veteranMarriageHistoryOptions.text.getItemName(itemMissingBoth),
       );
       expect(container3.textContent).to.equal('');
     });

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/config.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/config.unit.spec.jsx
@@ -232,26 +232,19 @@ describe('arrayBuilderOptions', () => {
   });
 
   describe('text methods', () => {
-    it('should return the correct item name from getItemName', () => {
-      const itemName = arrayBuilderOptions.text.getItemName();
-      expect(itemName).to.equal('Child');
-    });
-
-    it('should return the correct card description from cardDescription', () => {
+    it('should return the correct card title from getItemName', () => {
       const item = { fullName: { first: 'John', last: 'Doe' } };
-      const { getByText } = render(
-        arrayBuilderOptions.text.cardDescription(item),
-      );
+      const { getByText } = render(arrayBuilderOptions.text.getItemName(item));
       expect(getByText('John Doe')).to.exist;
     });
 
-    it('should return a space for cardDescription when fullName is incomplete', () => {
+    it('should return a space for getItemName when fullName is incomplete', () => {
       const incompleteItem = { fullName: {} };
       const { container } = render(
-        arrayBuilderOptions.text.cardDescription(incompleteItem),
+        arrayBuilderOptions.text.getItemName(incompleteItem),
       );
       const text = container.textContent;
-      expect(text).to.equal(' ');
+      expect(text).to.equal('');
     });
   });
 });

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.unit.spec.jsx
@@ -112,25 +112,25 @@ describe('removeChildStoppedAttendingSchoolOptions', () => {
     });
   });
 
-  describe('getItemName + cardDescription', () => {
-    it('should return the correctly capitalized full name', () => {
+  describe('getItemName', () => {
+    it('should return the correctly full name', () => {
       const item = {
         fullName: { first: 'john', last: 'doe' },
       };
       const { container } = render(
-        removeChildStoppedAttendingSchoolOptions.text.cardDescription(item),
+        removeChildStoppedAttendingSchoolOptions.text.getItemName(item),
       );
-      expect(container.textContent).to.equal('John Doe');
+      expect(container.textContent).to.equal('john doe');
     });
 
-    it('should return the correctly capitalized full name with mixed case', () => {
+    it('should return the correctly full name with mixed case', () => {
       const item = {
         fullName: { first: 'jOhN', last: 'dOe' },
       };
       const { container } = render(
-        removeChildStoppedAttendingSchoolOptions.text.cardDescription(item),
+        removeChildStoppedAttendingSchoolOptions.text.getItemName(item),
       );
-      expect(container.textContent).to.equal('John Doe');
+      expect(container.textContent).to.equal('jOhN dOe');
     });
 
     it('should handle the case when both names are empty', () => {
@@ -138,7 +138,7 @@ describe('removeChildStoppedAttendingSchoolOptions', () => {
         fullName: { first: '', last: '' },
       };
       const { container } = render(
-        removeChildStoppedAttendingSchoolOptions.text.cardDescription(item),
+        removeChildStoppedAttendingSchoolOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('');
     });

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-dependent-death/deceasedDependentsArray.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-dependent-death/deceasedDependentsArray.unit.spec.jsx
@@ -94,7 +94,7 @@ describe('deceasedDependentOptions', () => {
         fullName: { first: 'John', last: 'Doe' },
       };
       const { container } = render(
-        deceasedDependentOptions.text.cardDescription(item),
+        deceasedDependentOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('John Doe');
     });
@@ -105,36 +105,36 @@ describe('deceasedDependentOptions', () => {
         fullName: { first: 'John' },
       };
       const { container } = render(
-        deceasedDependentOptions.text.cardDescription(item),
+        deceasedDependentOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('John');
     });
 
     it('should return "Dependent" if dependentType is missing', () => {
       const item = {};
-      expect(deceasedDependentOptions.text.getItemName(item)).to.equal(
+      expect(deceasedDependentOptions.text.cardDescription(item)).to.equal(
         'Dependent',
       );
     });
 
     it('should return "Dependent" if dependentType is invalid', () => {
       const item = { dependentType: 'invalidType' };
-      expect(deceasedDependentOptions.text.getItemName(item)).to.equal(
+      expect(deceasedDependentOptions.text.cardDescription(item)).to.equal(
         'Dependent',
       );
     });
   });
 
-  describe('text.cardDescription', () => {
-    it('should return a formatted full name with capitalized first and last names', () => {
+  describe('text.getItemName', () => {
+    it('should return a formatted full name', () => {
       const item = {
         dependentType: 'CHILD',
         fullName: { first: 'jOhN', last: 'dOe' },
       };
       const { container } = render(
-        deceasedDependentOptions.text.cardDescription(item),
+        deceasedDependentOptions.text.getItemName(item),
       );
-      expect(container.textContent).to.equal('John Doe');
+      expect(container.textContent).to.equal('jOhN dOe');
     });
 
     it('should handle missing first or last name gracefully', () => {
@@ -143,7 +143,7 @@ describe('deceasedDependentOptions', () => {
         fullName: { first: 'John', last: '' },
       };
       const { container } = render(
-        deceasedDependentOptions.text.cardDescription(item),
+        deceasedDependentOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('John');
     });

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.unit.spec.jsx
@@ -47,13 +47,13 @@ describe('removeMarriedChildOptions', () => {
     });
   });
 
-  describe('getItemName + cardDescription', () => {
+  describe('getItemName', () => {
     it('should return a correctly formatted name for a child', () => {
       const item = {
         fullName: { first: 'Jane', last: 'Doe' },
       };
       const { container } = render(
-        removeMarriedChildOptions.text.cardDescription(item),
+        removeMarriedChildOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('Jane Doe');
     });
@@ -63,7 +63,7 @@ describe('removeMarriedChildOptions', () => {
         fullName: { last: 'Smith' },
       };
       const { container } = render(
-        removeMarriedChildOptions.text.cardDescription(item),
+        removeMarriedChildOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('Smith');
     });
@@ -73,7 +73,7 @@ describe('removeMarriedChildOptions', () => {
         fullName: { first: 'John' },
       };
       const { container } = render(
-        removeMarriedChildOptions.text.cardDescription(item),
+        removeMarriedChildOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('John');
     });

--- a/src/applications/dependents/686c-674/tests/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.unit.spec.jsx
@@ -83,19 +83,19 @@ describe('686 Remove child no longer in household array options', () => {
     });
   });
 
-  describe('text.getItemName + cardDescription', () => {
-    it('should return a full name with capitalized first and last name', () => {
+  describe('text.getItemName', () => {
+    it('should return a full name with first and last name', () => {
       const item = { fullName: { first: 'john', last: 'doe' } };
       const { container } = render(
-        removeChildHouseholdOptions.text.cardDescription(item),
+        removeChildHouseholdOptions.text.getItemName(item),
       );
-      expect(container.textContent).to.equal('John Doe');
+      expect(container.textContent).to.equal('john doe');
     });
 
     it('should return only the first name if the last name is missing', () => {
       const item = { fullName: { first: 'John' } };
       const { container } = render(
-        removeChildHouseholdOptions.text.cardDescription(item),
+        removeChildHouseholdOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('John');
     });
@@ -103,7 +103,7 @@ describe('686 Remove child no longer in household array options', () => {
     it('should return only the last name if the first name is missing', () => {
       const item = { fullName: { last: 'Doe' } };
       const { container } = render(
-        removeChildHouseholdOptions.text.cardDescription(item),
+        removeChildHouseholdOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('Doe');
     });
@@ -111,7 +111,7 @@ describe('686 Remove child no longer in household array options', () => {
     it('should return an empty string if both first and last names are missing', () => {
       const item = { fullName: { first: '', last: '' } };
       const { container } = render(
-        removeChildHouseholdOptions.text.cardDescription(item),
+        removeChildHouseholdOptions.text.getItemName(item),
       );
       expect(container.textContent).to.equal('');
     });

--- a/src/applications/dependents/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $$ } from 'platform/forms-system/src/js/utilities/ui';
-// import { capitalize } from 'lodash';
+
 import formConfig from '../../../../config/form';
 import { addStudentsOptions } from '../../../../config/chapters/674/addStudentsArrayPages';
 
@@ -143,44 +143,34 @@ describe('addStudentsOptions', () => {
       );
     });
   });
-  describe('getItemName + cardDescription', () => {
+  describe('getItemName', () => {
     it('should return a full name when both first and last names are provided', () => {
       const item = { fullName: { first: 'John', last: 'Doe' } };
-      const { container } = render(
-        addStudentsOptions.text.cardDescription(item),
-      );
+      const { container } = render(addStudentsOptions.text.getItemName(item));
       expect(container.textContent).to.equal('John Doe');
     });
 
     it('should return only the first name when the last name is missing', () => {
       const item = { fullName: { first: 'John' } };
-      const { container } = render(
-        addStudentsOptions.text.cardDescription(item),
-      );
+      const { container } = render(addStudentsOptions.text.getItemName(item));
       expect(container.textContent).to.equal('John');
     });
 
     it('should return only the last name when the first name is missing', () => {
       const item = { fullName: { last: 'Doe' } };
-      const { container } = render(
-        addStudentsOptions.text.cardDescription(item),
-      );
+      const { container } = render(addStudentsOptions.text.getItemName(item));
       expect(container.textContent).to.equal('Doe');
     });
 
     it('should return an empty string when both first and last names are missing', () => {
       const item = { fullName: { first: '', last: '' } };
-      const { container } = render(
-        addStudentsOptions.text.cardDescription(item),
-      );
+      const { container } = render(addStudentsOptions.text.getItemName(item));
       expect(container.textContent).to.equal('');
     });
 
     it('should return an empty string when fullName is not provided', () => {
       const item = {};
-      const { container } = render(
-        addStudentsOptions.text.cardDescription(item),
-      );
+      const { container } = render(addStudentsOptions.text.getItemName(item));
       expect(container.textContent).to.equal('');
     });
   });

--- a/src/applications/dependents/shared/utils/index.js
+++ b/src/applications/dependents/shared/utils/index.js
@@ -1,0 +1,2 @@
+export const getFullName = ({ first, middle, last } = {}) =>
+  [first || '', middle || '', last || ''].filter(Boolean).join(' ');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Currently, the array build summary cards are not using a unique card title making it difficult for screen reader users to navigate the page headers. This PR changes the title to use the person's name, assuming they are unique.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/110128

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Spouse former marriage | <img width="500" alt="before-former-spouse-summary" src="https://github.com/user-attachments/assets/5ed92a18-6780-4d53-8a80-0f48342d3de7" /> | <img width="500" alt="after-former-spouse-summary" src="https://github.com/user-attachments/assets/244cd4a6-4807-4981-906d-60e704281abe" /> |
| Veteran former marriage | <img width="500" alt="before-vet-marriage-summary" src="https://github.com/user-attachments/assets/93fd8d5e-a459-4f11-a9bd-24387a19be6c" /> | <img width="500" alt="after-vet-marriage-summary" src="https://github.com/user-attachments/assets/36ece000-5241-4580-8be2-3f2f133757bd" /> |
| Add child | <img width="560" alt="before-child-summary" src="https://github.com/user-attachments/assets/536bb535-2647-4715-85ca-519a48bea8ae" /> | <img width="567" alt="after-child-summary" src="https://github.com/user-attachments/assets/5d30c9c5-af02-4c45-8fd7-6aa12e56d966" /> |
| Child left school | <img width="500" alt="before-left-school-summary" src="https://github.com/user-attachments/assets/c2ab6399-7584-471c-a6c6-6d0e979e86d8" /> | <img width="500" alt="after-left-school-summary" src="https://github.com/user-attachments/assets/d2ad3bc5-2402-4140-b071-c18506e1b0a4" /> |
| Married child | <img width="500" alt="before-child-married-summary" src="https://github.com/user-attachments/assets/672cd907-4af4-4cca-9df4-ee9ffb8d9bd1" /> | <img width="500" alt="after-child-married-summary" src="https://github.com/user-attachments/assets/58fb865f-61b9-492d-86c1-b459fb29419e" /> |
| Student | <img width="500" alt="before-student-summary" src="https://github.com/user-attachments/assets/9194f9b4-34c9-4fd4-9261-917dba9e5ca1" /> | <img width="500" alt="after-student-summary" src="https://github.com/user-attachments/assets/9d866b22-53b6-485c-84f8-b8113b809773" /> |
| Dependent died | <img width="500" alt="before-dependent-died-summary" src="https://github.com/user-attachments/assets/53f28d9a-26cd-4889-9fcf-1ee1f9a3f564" /> | <img width="500" alt="after-dependent-died-summary" src="https://github.com/user-attachments/assets/36d9ea36-a606-4bc6-ae64-ce0dd468b893" /> |
| Stepchild | <img width="500" alt="before-stepchild-summary" src="https://github.com/user-attachments/assets/ef5f6a63-1212-4e19-9ef1-2fa2cf4402b2" /> | <img width="500" alt="after-stepchild-summary" src="https://github.com/user-attachments/assets/d0c61bbf-953a-49ae-8ba2-680ed3b2f5eb" /> |

## What areas of the site does it impact?

Dependents Management (686c-674)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
