### PR TITLE
refactor(ezr): migrate from react-scroll

### DIFF
--- a/src/applications/ezr/components/ConfirmationPage/ConfirmationScreenView.jsx
+++ b/src/applications/ezr/components/ConfirmationPage/ConfirmationScreenView.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import { focusElement } from 'platform/utilities/ui';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { scrollToTop } from 'platform/utilities/scroll';
 import content from '../../locales/en/content.json';
 
 const ConfirmationScreenView = ({ name, timestamp }) => {

--- a/src/applications/ezr/components/FormFields/DependentDeclarationField.jsx
+++ b/src/applications/ezr/components/FormFields/DependentDeclarationField.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { scrollAndFocus } from 'platform/utilities/ui';
+import { scrollAndFocus } from 'platform/utilities/scroll';
 import YesNoWidget from 'platform/forms-system/src/js/widgets/YesNoWidget';
 import { DEPENDENT_VIEW_FIELDS } from '../../utils/constants';
 import content from '../../locales/en/content.json';

--- a/src/applications/ezr/components/FormFields/InsuranceCoverageField.jsx
+++ b/src/applications/ezr/components/FormFields/InsuranceCoverageField.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { scrollAndFocus } from 'platform/utilities/ui';
+import { scrollAndFocus } from 'platform/utilities/scroll';
 import YesNoWidget from 'platform/forms-system/src/js/widgets/YesNoWidget';
 import { INSURANCE_VIEW_FIELDS } from '../../utils/constants';
 import content from '../../locales/en/content.json';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR removes all usages of the react-scroll library for this app, in favor of the platform scroll utilities. This has been slated to be deprecated for some time, and is blocking the node version upgrade. This has been split out from #36799 since there are issues when running the full test suite.