### PR TITLE
SA-113646: Fix app tag in 22-5490 entry file

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/app-entry.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/app-entry.jsx
@@ -11,4 +11,5 @@ startApp({
   url: manifest.rootUrl,
   reducer,
   routes,
+  entryName: manifest.appName,
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
 Fix app tag in 22-5490 entry file
 
 Added entryName: manifest.appName to the 22-5490 form's startApp Config to properly register the 22-5490 form in our metrics tracking.
  
## Related issue(s)
<img width="795" alt="Screenshot 2025-06-02 at 3 15 18 PM" src="https://github.com/user-attachments/assets/f7182743-1f78-4b75-af92-874e4b74c7bc" />


## Testing done

## Screenshots


## What areas of the site does it impact?
Form 22-5490

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

