### PR TITLE
NOD 109138: Adjust BasicLink href

### DIFF
--- a/src/applications/appeals/shared/components/web-component-wrappers/BasicLink.jsx
+++ b/src/applications/appeals/shared/components/web-component-wrappers/BasicLink.jsx
@@ -8,12 +8,16 @@ import { VaLink } from '@department-of-veterans-affairs/component-library/dist/r
 // https://design.va.gov/storybook/?path=/docs/components-va-link--docs
 const BasicLink = ({ path, search, router, ...props }) => {
   const ariaLabel = props?.['aria-label'] ?? {};
+  const href = path.charAt(0) === '/' ? path : `/${path}`;
 
   return (
     <VaLink
-      label={ariaLabel}
       {...props}
-      onClick={() => {
+      href={href}
+      label={ariaLabel}
+      onClick={event => {
+        event.preventDefault();
+
         if (search && path) {
           router.push(`${path}${search}`);
         } else if (path) {


### PR DESCRIPTION
## Summary
Adjust the new `BasicLink` component to specify the `href` attribute.

Because this component uses an `onClick` for the functionality, the `href` isn't necessary for the link to behave as expected to a sighted user. This change fully fleshes out the attributes in case any screen readers need it to work properly and also for the analytics reason specified below.

Without the `href` property set, the `link-destination` below is undefined as shown below:

<img width="600" alt="Screenshot 2025-06-02 at 2 27 08 PM" src="https://github.com/user-attachments/assets/ddba4461-15fc-4bac-b1a4-793e6e60e463" />

To see what the Google Analytics event looks like when interacting with elements set up for analytics, download the Chrome extension titled `Adswerve - dataLayer Inspector+`, enable it in your extensions, and reload the page. Then you can see the events logging in the console as you click around.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/109138

## Testing done

Tested the "Go back to add more issues" link in the NOD flow, as it is the only one that is currently consuming this component.

### UI
<img width="522" alt="Screenshot 2025-06-02 at 2 23 59 PM" src="https://github.com/user-attachments/assets/fa43f309-2383-4949-bda3-651e2f5175aa" />

### DOM
<img width="326" alt="Screenshot 2025-06-02 at 2 24 06 PM" src="https://github.com/user-attachments/assets/d4177604-ee56-40bc-a1e8-bd06d82aec4c" />

### New analytics event

<img width="600" alt="Screenshot 2025-06-02 at 2 26 31 PM" src="https://github.com/user-attachments/assets/d0e17540-89e3-462b-8e44-149f0f6f7383" />

**URL that the link goes to**: `http://localhost:3001/decision-reviews/board-appeal/request-board-appeal-form-10182/contestable-issues?redirect`