### PR TITLE
Revert "SA-113646: Fix app tag in 22-5490 entry file"

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/app-entry.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/app-entry.jsx
@@ -11,5 +11,4 @@ startApp({
   url: manifest.rootUrl,
   reducer,
   routes,
-  entryName: manifest.appName,
 });


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#36868

This [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/36868/files) was pushed 5 hours ago causing issues in prod. Monitor [here](https://vagov.ddog-gov.com/monitors/200229?eval_ts=1748894529000&event_id=8130766596175995431&link_source=monitor_notif&from_ts=1748893329000&to_ts=1748894529000). The app name is currently in Vets-API. I dug around and the PR contains , entryName: manifest.appName, NOT entryName: manifest.entryName.