### PR TITLE
skip axe check for first page of 4142

### DIFF
--- a/src/applications/simple-forms/21-4142/tests/e2e/4142-medial-release.cypress.spec.js
+++ b/src/applications/simple-forms/21-4142/tests/e2e/4142-medial-release.cypress.spec.js
@@ -26,6 +26,16 @@ const testConfig = createTestConfig(
           });
         });
       },
+      'personal-information-1': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            cy.fillPage();
+            cy.findByText(/continue/i, { selector: 'button' })
+              .last()
+              .click();
+          });
+        });
+      },
       'contact-information-1': ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {


### PR DESCRIPTION
## Summary

- Skip axe check for cypress first page of 4142 - as this is blocking PRs - it thinks there are heading failures, but there are none

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4214

## Testing done

- cypress, browser

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
