### PR TITLE
style: Add Comma In Page C&P Exam Instructions

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
@@ -26,7 +26,7 @@ export const claimExamsDescription = (
       </p>
     </va-alert>
 
-    <p>At this time we partner with 3 vendors:</p>
+    <p>At this time, we partner with 3 vendors:</p>
     <ul>
       <li>QTC Medical Services (QTC)</li>
       <li>Veterans Evaluation Services (VES)</li>

--- a/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
@@ -15,22 +15,22 @@ export const defaultOtherEvidence = (
 
 export const evidenceTypeHelp = (
   <va-additional-info trigger="Which evidence type should I choose?">
-    <h4>Types of evidence</h4>
-    <h5 className="vads-u-padding-top--1p5">
+    <h3>Types of evidence</h3>
+    <h4 className="vads-u-padding-top--1p5">
       Required Separation Health Assessment - Part A Self-Assessment
-    </h5>
+    </h4>
     <p>
       You’ll need to submit your completed Separation Health Assessment - Part A
       Self-Assessment so we can request your VA exams.
     </p>
-    <h5 className="vads-u-padding-top--1p5">Private medical records</h5>
+    <h4 className="vads-u-padding-top--1p5">Private medical records</h4>
     <p>
       If you were treated by a private doctor, including a Veteran’s Choice
       doctor, you’ll have private medical records. We’ll need to see those
       records to make a decision on your claim. A Disability Benefits
       Questionnaire is an example of a private medical record.
     </p>
-    <h5 className="vads-u-padding-top--1">Lay statements or other evidence</h5>
+    <h4 className="vads-u-padding-top--1">Lay statements or other evidence</h4>
     <p>
       A lay statement is a written statement from family, friends, or coworkers
       to help support your claim. Lay statements are also called “buddy


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Styling C&P Exam Instruction page in VA Form 21-526EZ to add comma in listing the current vendors. This is addressing a design defect

closes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/110952
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110952

## Testing done

- Old Behavior: Paragraph tag describing the vendors did not have a comma
- New behavior: Paragraph tag includes a comma to describe the current list of vendors
- Tests:
   - Unit Tests for this particular page
   - Review UI page for this page to confirm changes
   
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="543" alt="Screenshot 2025-06-03 at 12 32 37 PM" src="https://github.com/user-attachments/assets/2feaf300-bf52-44f0-a032-a47ec01b0e24" />|<img width="543" alt="Screenshot 2025-06-03 at 12 31 41 PM" src="https://github.com/user-attachments/assets/a329033f-0a3e-412e-ada1-fde76d5347cb" />|

## What areas of the site does it impact?

Impacted Chapter 4 of 6 Supporting Evidence 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

