### PR TITLE
109860 - Add logic to prepopulate sponsor section in merged 10-10d/10-7959c form - IVC CHAMVPA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
@@ -131,7 +131,7 @@ export function signerContactOnGoForward(props) {
   } else if (props?.data?.certifierRole === 'sponsor') {
     // Populate some sponsor fields with certifier info:
     formData.sponsorIsDeceased = false;
-    formData.veteransFullName = formData.certifierName;
+    formData.sponsorName = formData.certifierName;
     formData.sponsorAddress = formData.certifierAddress;
     formData.sponsorPhone = formData.certifierPhone;
   }

--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -23,11 +23,16 @@ import { sponsorAddressCleanValidation } from '../../shared/validations';
 
 export const sponsorNameDobSchema = {
   uiSchema: {
-    ...titleUI(
-      `Sponsor's name and date of birth`,
-      `Enter the personal information for the sponsor (the Veteran or service member that the applicant is connected to). 
-             We'll use the sponsor's information to confirm their eligibility for CHAMPVA benefits.`,
-    ),
+    ...titleUI(`Sponsor's name and date of birth`, ({ formData }) => (
+      <>
+        <p>
+          Enter the personal information for the sponsor (the Veteran or service
+          member that the applicant is connected to). We’ll use the sponsor’s
+          information to confirm their eligibility for CHAMPVA benefits.
+        </p>
+        {CustomPrefillMessage(formData, 'sponsor')}
+      </>
+    )),
     sponsorName: fullNameUI(),
     sponsorDob: dateOfBirthUI(),
   },
@@ -143,14 +148,18 @@ export const sponsorAddress = {
 
 export const sponsorContactInfo = {
   uiSchema: {
-    ...titleUI(`Sponsor's contact information`, ({ formData }) => {
-      return `We'll use this phone number to contact ${
-        formData.certifierRole === 'applicant' ? `you` : `the sponsor`
-      }
-             if we have any questions about ${
-               formData.certifierRole === 'applicant' ? 'your' : 'their'
-             } information.`;
-    }),
+    ...titleUI(`Sponsor's contact information`, ({ formData }) => (
+      <>
+        <p>
+          We’ll use this phone number to contact{' '}
+          {formData.certifierRole === 'applicant' ? 'you' : 'the sponsor'} if we
+          have any questions about{' '}
+          {formData.certifierRole === 'applicant' ? 'your' : 'their'}{' '}
+          information.
+        </p>
+        {CustomPrefillMessage(formData, 'sponsor')}
+      </>
+    )),
     sponsorPhone: {
       ...phoneUI(),
       'ui:required': () => true,

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -124,7 +124,7 @@ const formConfig = {
       pages: {
         page6: {
           path: 'sponsor-info',
-          title: 'Sponsor`s name and date of birth',
+          title: 'Sponsor’s name and date of birth',
           ...sponsorNameDobSchema,
         },
         page7: {

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
@@ -22,7 +22,10 @@ const minimalStore = mockStore({
 function callInnerApplicantTitleFunc(pages, pageName) {
   const { container } = render(
     <Provider store={minimalStore}>
-      {pages[pageName].uiSchema.applicants.items['ui:title']({})}
+      {pages[pageName].uiSchema.applicants.items['ui:title']({
+        formData: {},
+        formContext: {},
+      })}
     </Provider>,
   );
 

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/components/customPrefillAlert.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/components/customPrefillAlert.unit.spec.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { expect } from 'chai';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/state/helpers';
+import formConfig from '../../../config/form';
+import CustomPrefillMessage from '../../../components/CustomPrefillAlert';
+
+const mockStore = state => createStore(() => state);
+
+const initStore = ({ formData } = {}) => {
+  return mockStore({
+    form: {
+      ...createInitialState(formConfig),
+      data: formData,
+    },
+  });
+};
+
+describe('CustomPrefillMessage', () => {
+  it('should render', () => {
+    const fd = { formData: { certifierRole: 'sponsor' } };
+    const st = initStore(fd);
+
+    const { container } = render(
+      <Provider store={st}>
+        <>{CustomPrefillMessage(fd.formData, 'sponsor')}</>
+      </Provider>,
+    );
+    expect(container).to.exist;
+    expect(container.innerHTML).to.include('prefilled some details');
+  });
+  it('should attempt to use fallback view: property if certifierRole not present', () => {
+    const fd = { formData: { 'view:certifierRole': 'sponsor' } };
+    const st = initStore(fd);
+
+    const { container } = render(
+      <Provider store={st}>
+        <>{CustomPrefillMessage(fd.formData, 'sponsor')}</>
+      </Provider>,
+    );
+    expect(container).to.exist;
+    expect(container.innerHTML).to.include('prefilled some details');
+  });
+  it('should not display anything if role is unspecified', () => {
+    const st = initStore({ formData: {} });
+
+    const { container } = render(
+      <Provider store={st}>
+        <>{CustomPrefillMessage({})}</>
+      </Provider>,
+    );
+    expect(container).to.exist;
+    expect(container.innerHTML).to.eq('');
+  });
+});

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/pages/combinedPageTests.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/pages/combinedPageTests.unit.spec.jsx
@@ -48,9 +48,7 @@ describe('SignerContactOnGoForward', () => {
       },
     };
     signerContactOnGoForward(props); // operates directly on `props`
-    expect(props.data.veteransFullName.first).to.eq(
-      props.data.certifierName.first,
-    );
+    expect(props.data.sponsorName.first).to.eq(props.data.certifierName.first);
   });
   it("should copy certifier info to applicant array if certifierRole === 'applicant'", () => {
     const props = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds logic to copy name/address/contact info from the certifier/signer info section over to the sponsor info section if the person filling the form out indicated they were the sponsor. 

Similarly, this functionality was already in place for when the signer was also the applicant, but we weren't displaying the blue alerts. Those have also been added.

Also fixes some unit tests + adds new unit tests for the custom prefill alert message.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109860

## Testing done

- Unit
- Manual

## Screenshots

|         | Sponsor name | Sponsor address| Sponsor contact info|
| ------- | ------ |-|-|
| Name |![Screenshot 2025-06-03 at 12 13 16](https://github.com/user-attachments/assets/357a7b29-01d2-4bbb-bca9-94d1345a6273)| ![Screenshot 2025-06-03 at 12 13 31](https://github.com/user-attachments/assets/e40132d8-4a00-4ca0-9f89-d45ba20fc793)| ![Screenshot 2025-06-03 at 12 13 38](https://github.com/user-attachments/assets/23de426e-fb0a-439e-9f91-ca58543a9abf)|

Additionally, the applicant section of the form was already performing the same type of content copying based on role, but was not displaying the blue alerts indicating when this had happened. That has also been updated.

||Name|Address|Contact info|
|-|-|-|-|
| |![Screenshot 2025-06-03 at 15 46 36](https://github.com/user-attachments/assets/29a688c6-1d9c-46b6-82fa-2025fa8da9fc)|![Screenshot 2025-06-03 at 15 49 54](https://github.com/user-attachments/assets/394db875-fdb8-4e9f-97ed-6d5e2569840f)|![Screenshot 2025-06-03 at 15 50 01](https://github.com/user-attachments/assets/6dff59de-ebc9-4e42-b3d6-5f5edd69dcfc)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA