### PR TITLE
Implement redesigned VAOS null state diagnostics

### DIFF
--- a/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/CCLayout.unit.spec.jsx
@@ -53,6 +53,8 @@ describe('VAOS Component: CCLayout', () => {
         type: 'COMMUNITY_CARE_APPOINTMENT',
         modality: 'communityCare',
         isCerner: false,
+        'fields-load-success': '',
+        'fields-load-fail': 'type-of-care,provider',
       };
 
       // Act
@@ -79,26 +81,8 @@ describe('VAOS Component: CCLayout', () => {
           );
         }),
       );
-
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-any',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-provider',
+        event: 'vaos-null-states',
         ...nullAttributes,
       });
     });
@@ -109,6 +93,8 @@ describe('VAOS Component: CCLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'COMMUNITY_CARE_APPOINTMENT',
+        modality: 'communityCare',
         patientComments: 'This is a test:Additional information',
         communityCareProvider: {
           address: {
@@ -140,11 +126,19 @@ describe('VAOS Component: CCLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: false,
           isUpcomingAppointment: true,
+          isCerner: false,
           apiData: {
             serviceType: 'primaryCare',
           },
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'COMMUNITY_CARE_APPOINTMENT',
+        modality: 'communityCare',
+        isCerner: false,
+        'fields-load-success': 'type-of-care,provider',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -225,22 +219,8 @@ describe('VAOS Component: CCLayout', () => {
       ).not.to.exist;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-provider',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
   });

--- a/src/applications/vaos/components/layouts/CCRequestLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/CCRequestLayout.unit.spec.jsx
@@ -34,6 +34,8 @@ describe('VAOS Component: CCRequestLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'COMMUNITY_CARE_REQUEST',
+        modality: 'communityCare',
         patientComments: 'This is a test:Additional information',
         created: new Date().toISOString(),
         contact: {
@@ -62,11 +64,19 @@ describe('VAOS Component: CCRequestLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: true,
           isUpcomingAppointment: false,
+          isCerner: false,
           apiData: {
             serviceType: 'primaryCare',
           },
         },
         status: 'proposed',
+      };
+      const nullAttributes = {
+        type: 'COMMUNITY_CARE_REQUEST',
+        modality: 'communityCare',
+        isCerner: false,
+        'fields-load-success': 'type-of-care,provider',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -167,22 +177,8 @@ describe('VAOS Component: CCRequestLayout', () => {
         .to.be.ok;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-provider',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
   });

--- a/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/ClaimExamLayout.unit.spec.jsx
@@ -173,6 +173,9 @@ describe('VAOS Component: ClaimExamLayout', () => {
         type: 'VA',
         modality: 'claimExamAppointment',
         isCerner: false,
+        'fields-load-success': '',
+        'fields-load-fail':
+          'type-of-care,clinic-phone,facility-id,facility-details,facility-phone',
       };
 
       // Act
@@ -195,47 +198,8 @@ describe('VAOS Component: ClaimExamLayout', () => {
           );
         }),
       );
-
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-any',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-id',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-id',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
         ...nullAttributes,
       });
     });
@@ -312,6 +276,8 @@ describe('VAOS Component: ClaimExamLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'claimExamAppointment',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -336,6 +302,7 @@ describe('VAOS Component: ClaimExamLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: false,
           isUpcomingAppointment: true,
+          isCerner: false,
           apiData: {
             serviceCategory: [
               {
@@ -345,6 +312,14 @@ describe('VAOS Component: ClaimExamLayout', () => {
           },
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'claimExamAppointment',
+        isCerner: false,
+        'fields-load-success':
+          'type-of-care,clinic-phone,facility-id,facility-details,facility-phone',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -439,40 +414,8 @@ describe('VAOS Component: ClaimExamLayout', () => {
       ).to.not.exist;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-id',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-id',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
   });

--- a/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.unit.spec.jsx
@@ -160,6 +160,9 @@ describe('VAOS Component: InPersonLayout', () => {
         type: 'VA',
         modality: 'vaInPerson',
         isCerner: false,
+        'fields-load-success': '',
+        'fields-load-fail':
+          'type-of-care,provider,clinic-phone,facility-id,facility-details,facility-phone',
       };
 
       // Act
@@ -199,54 +202,8 @@ describe('VAOS Component: InPersonLayout', () => {
           );
         }),
       );
-
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-any',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-id',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-id',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
         ...nullAttributes,
       });
     });
@@ -322,6 +279,8 @@ describe('VAOS Component: InPersonLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'vaInPerson',
         reasonForAppointment: 'This is a test',
         patientComments: 'Additional information:colon',
         practitioners: [
@@ -349,11 +308,20 @@ describe('VAOS Component: InPersonLayout', () => {
           isPendingAppointment: false,
           isUpcomingAppointment: true,
           isCancellable: true,
+          isCerner: false,
           apiData: {
             serviceType: 'primaryCare',
           },
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'vaInPerson',
+        isCerner: false,
+        'fields-load-success':
+          'type-of-care,provider,clinic-phone,facility-id,facility-details,facility-phone',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -445,46 +413,8 @@ describe('VAOS Component: InPersonLayout', () => {
       ).to.be.ok;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-id',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-id',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
 

--- a/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.unit.spec.jsx
@@ -73,6 +73,9 @@ describe('VAOS Component: PhoneLayout', () => {
         type: 'VA',
         modality: 'phone',
         isCerner: false,
+        'fields-load-success': '',
+        'fields-load-fail':
+          'type-of-care,provider,clinic-phone,facility-details,facility-phone',
       };
 
       // Act
@@ -116,45 +119,7 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(screen.getByText(/Other details: Not available/i));
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-any',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
         ...nullAttributes,
       });
     });
@@ -235,6 +200,8 @@ describe('VAOS Component: PhoneLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'phone',
         reasonForAppointment: 'This is a test',
         patientComments: 'Additional information:colon',
         location: {
@@ -263,11 +230,20 @@ describe('VAOS Component: PhoneLayout', () => {
           isUpcomingAppointment: true,
           isPhoneAppointment: true,
           isCancellable: true,
+          isCerner: false,
           apiData: {
             serviceType: 'primaryCare',
           },
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'phone',
+        isCerner: false,
+        'fields-load-success':
+          'type-of-care,provider,clinic-phone,facility-details,facility-phone',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -359,40 +335,8 @@ describe('VAOS Component: PhoneLayout', () => {
       ).to.be.ok;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
     it('should display phone layout without cancel button', async () => {

--- a/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
@@ -36,6 +36,8 @@ describe('VAOS Component: VARequestLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'REQUEST',
+        modality: 'vaInPerson',
         reasonForAppointment: 'This is a test',
         patientComments: 'Additional information:colon',
         created: new Date().toISOString(),
@@ -64,11 +66,20 @@ describe('VAOS Component: VARequestLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: true,
           isUpcomingAppointment: false,
+          isCerner: false,
           apiData: {
             serviceType: 'primaryCare',
           },
         },
         status: 'proposed',
+      };
+      const nullAttributes = {
+        type: 'REQUEST',
+        modality: 'vaInPerson',
+        isCerner: false,
+        'fields-load-success':
+          'type-of-care,facility-id,facility-details,facility-phone',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -170,34 +181,8 @@ describe('VAOS Component: VARequestLayout', () => {
       ).to.be.null;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-id',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-id',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
   });

--- a/src/applications/vaos/components/layouts/VideoLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.unit.spec.jsx
@@ -73,6 +73,9 @@ describe('VAOS Component: VideoLayout', () => {
         type: 'VA',
         modality: 'vaVideoCareAtHome',
         isCerner: false,
+        'fields-load-success': '',
+        'fields-load-fail':
+          'type-of-care,provider,clinic-phone,facility-details,facility-phone',
       };
 
       // Act
@@ -109,45 +112,7 @@ describe('VAOS Component: VideoLayout', () => {
       expect(screen.getByText(/Facility not available/i));
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-any',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
         ...nullAttributes,
       });
     });
@@ -242,6 +207,8 @@ describe('VAOS Component: VideoLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'vaVideoCareAtHome',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -275,11 +242,20 @@ describe('VAOS Component: VideoLayout', () => {
           isPendingAppointment: false,
           isUpcomingAppointment: true,
           isVideo: true,
+          isCerner: false,
           apiData: {
             serviceType: 'primaryCare',
           },
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'vaVideoCareAtHome',
+        isCerner: false,
+        'fields-load-success':
+          'type-of-care,provider,clinic-phone,facility-details,facility-phone',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -386,40 +362,8 @@ describe('VAOS Component: VideoLayout', () => {
       ).to.be.ok;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
   });

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.unit.spec.jsx
@@ -82,6 +82,9 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
         type: 'VA',
         modality: 'vaVideoCareAtAnAtlasLocation',
         isCerner: false,
+        'fields-load-success': '',
+        'fields-load-fail':
+          'type-of-care,provider,clinic-phone,facility-details,facility-phone',
       };
 
       // Act
@@ -122,45 +125,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       expect(screen.getByText(/Facility not available/i));
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-any',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
         ...nullAttributes,
       });
     });
@@ -289,6 +254,8 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
+        type: 'VA',
+        modality: 'vaVideoCareAtAnAtlasLocation',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -332,11 +299,20 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
           isPendingAppointment: false,
           isUpcomingAppointment: true,
           isVideo: true,
+          isCerner: false,
           apiData: {
             serviceType: 'primaryCare',
           },
         },
         status: 'booked',
+      };
+      const nullAttributes = {
+        type: 'VA',
+        modality: 'vaVideoCareAtAnAtlasLocation',
+        isCerner: false,
+        'fields-load-success':
+          'type-of-care,provider,clinic-phone,facility-details,facility-phone',
+        'fields-load-fail': '',
       };
 
       // Act
@@ -463,40 +439,8 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       ).to.be.ok;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-any',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).not.to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
+        ...nullAttributes,
       });
     });
   });

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.unit.spec.jsx
@@ -187,6 +187,9 @@ describe('VAOS Component: VideoLayoutVA', () => {
         type: 'VA',
         modality: 'vaVideoCareAtAVaLocation',
         isCerner: false,
+        'fields-load-success': '',
+        'fields-load-fail':
+          'type-of-care,provider,clinic-phone,facility-id,facility-details,facility-phone',
       };
 
       // Act
@@ -220,52 +223,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
       ).not.to.exist;
 
       expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-total',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-any',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-type-of-care',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-type-of-care',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-provider',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-provider',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-clinic-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-clinic-phone',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-id',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-id',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-details',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-details',
-        ...nullAttributes,
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-expected-facility-phone',
-      });
-      expect(window.dataLayer).to.deep.include({
-        event: 'vaos-null-states-missing-facility-phone',
+        event: 'vaos-null-states',
         ...nullAttributes,
       });
     });
@@ -358,6 +316,8 @@ describe('VAOS Component: VideoLayoutVA', () => {
         // Arrange
         const store = createTestStore(initialState);
         const appointment = {
+          type: 'VA',
+          modality: 'vaVideoCareAtAVaLocation',
           location: {
             stationId: '983',
             clinicName: 'Clinic 1',
@@ -391,11 +351,20 @@ describe('VAOS Component: VideoLayoutVA', () => {
             isPendingAppointment: false,
             isUpcomingAppointment: true,
             isVideo: true,
+            isCerner: false,
             apiData: {
               serviceType: 'primaryCare',
             },
           },
           status: 'booked',
+        };
+        const nullAttributes = {
+          type: 'VA',
+          modality: 'vaVideoCareAtAVaLocation',
+          isCerner: false,
+          'fields-load-success':
+            'type-of-care,provider,clinic-phone,facility-id,facility-details,facility-phone',
+          'fields-load-fail': '',
         };
 
         // Act
@@ -503,46 +472,8 @@ describe('VAOS Component: VideoLayoutVA', () => {
         ).to.be.ok;
 
         expect(window.dataLayer).to.deep.include({
-          event: 'vaos-null-states-expected-total',
-        });
-        expect(window.dataLayer).not.to.deep.include({
-          event: 'vaos-null-states-missing-any',
-        });
-        expect(window.dataLayer).to.deep.include({
-          event: 'vaos-null-states-expected-type-of-care',
-        });
-        expect(window.dataLayer).not.to.deep.include({
-          event: 'vaos-null-states-missing-type-of-care',
-        });
-        expect(window.dataLayer).to.deep.include({
-          event: 'vaos-null-states-expected-provider',
-        });
-        expect(window.dataLayer).not.to.deep.include({
-          event: 'vaos-null-states-missing-provider',
-        });
-        expect(window.dataLayer).to.deep.include({
-          event: 'vaos-null-states-expected-clinic-phone',
-        });
-        expect(window.dataLayer).not.to.deep.include({
-          event: 'vaos-null-states-missing-clinic-phone',
-        });
-        expect(window.dataLayer).to.deep.include({
-          event: 'vaos-null-states-expected-facility-id',
-        });
-        expect(window.dataLayer).not.to.deep.include({
-          event: 'vaos-null-states-missing-facility-id',
-        });
-        expect(window.dataLayer).to.deep.include({
-          event: 'vaos-null-states-expected-facility-details',
-        });
-        expect(window.dataLayer).not.to.deep.include({
-          event: 'vaos-null-states-missing-facility-details',
-        });
-        expect(window.dataLayer).to.deep.include({
-          event: 'vaos-null-states-expected-facility-phone',
-        });
-        expect(window.dataLayer).not.to.deep.include({
-          event: 'vaos-null-states-missing-facility-phone',
+          event: 'vaos-null-states',
+          ...nullAttributes,
         });
       });
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Implement redesigned VAOS null state diagnostics as per [recommendation from A&I team](https://github.com/department-of-veterans-affairs/va.gov-team/issues/104463#issuecomment-2923298932)
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/103077

## Testing done

- Tested locally
- Updated unit tests

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

