### PR TITLE
MBMS-87329 Subheader color

### DIFF
--- a/src/applications/pre-need-integration/sass/pre-need.scss
+++ b/src/applications/pre-need-integration/sass/pre-need.scss
@@ -258,3 +258,11 @@ fieldset.schemaform-field-template.schemaform-first-field {
 .suffixSpacing {
   padding-bottom: 1em;
 }
+
+h3, .schemaform-block-title {
+  color: var(--vads-color-base) !important;
+}
+
+article#form-4010007[data-location^="service-periods-"] .vads-u-color--gray-dark {
+  color: var(--vads-color-base) !important;
+}


### PR DESCRIPTION
## Summary
- As a UX Designer, I need to update the sub headers in the Pre-Need Integration form to align to VA.gov standards, currently the sub headers are H3 heading structure with H5 styling and need to be updated to H3. (See attachment of incorrect sub header.) The sub-headers should be #1b1b1b (Vads-color-base.) They are currently colored #3d4551 (vads-color-base-darker.) See [Color palette|https://design.va.gov/foundation/color-palette]

## Related issue(s)
- https://jira.devops.va.gov/browse/MBMS-87329
- Code changes pt. 2: https://github.com/department-of-veterans-affairs/vets-website/pull/36923

## Testing done

- [x] POR/UI/UX Review
- [x] Dev Review
- [x] QA
- [x] Unit Tests Passing

## Screenshots
https://github.com/user-attachments/assets/1242702c-d06d-499b-8046-b6a4275bba22

## What areas of the site does it impact?

_**Pre need integration forms**_

## Acceptance criteria
![image](https://github.com/user-attachments/assets/4ff02eda-e87a-4aba-b52f-c6b7109dc04a)