### PR TITLE
Removed css style from shame.css and added to class in vet-toolbar

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-vet-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-vet-nav.scss
@@ -393,6 +393,7 @@ body.va-pos-fixed {
   > div {
     align-items: center;
     display: flex;
+    white-space: nowrap;
   }
 
   @include media($medium-screen) {

--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -234,7 +234,6 @@ $medium-phone-screen: 375px;
       .profile-nav-container {
         align-items: baseline;
         display: inherit;
-        white-space: nowrap;
       }
 
       .sign-in-nav {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   4. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Discovered the css style update in this PR #35836 was added to wrong CSS class. This PR fixes that by updating the style to correct class. 

Updates in this PR - 
1. Removed css style from shame.css in profile-nav-container.
2. Added `white-space: nowrap` style to _m-vet-nav.scss.

Will resolve this bug - [Header] On Desktop, when a user has a long first name, the Contact us link gets wraps on to two lines [#3173](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3173)

This change prevents the text for the contact us from shifting to two lines. I tested this with a very long name to verify it would work and also on mobile and desktop devices. 

I work on the Design System Team as a Designer. Yes, our team does maintenance on this component. 

## Related issue(s)

- Original issue files for bug - [#3173](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3173)
- Original PR to fix this issue - Fixed bug where the contact us link in header wraps to two lines [#35836](https://github.com/department-of-veterans-affairs/vets-website/pull/35836)

## Testing done

Refer to the testing done in the original PR for testing completed. All results were duplicated and screenshots and testing is the same. 

Testing completed in #35836  https://github.com/department-of-veterans-affairs/vets-website/pull/35836

## What areas of the site does it impact?

This would impact the links within the profile header. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
