### PR TITLE
Remove hint text from staged changes

### DIFF
--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/medicalConditions.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/medicalConditions.js
@@ -25,8 +25,6 @@ export default {
     'ui:description': MedicalConditionDescription,
     medicalCondition: yesNoUI({
       title: 'Do you have a medical condition that prevents you from working?',
-      hint:
-        "Your answer to this question helps us determine if you're eligible for Veterans Pension benefits. We consider your age, income, and medical history in our determination.",
       classNames: 'vads-u-margin-bottom--2',
     }),
   },

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/over65.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/over65.js
@@ -20,8 +20,6 @@ export default {
     ...titleUI('Tell us your age'),
     isOver65: yesNoUI({
       title: 'Are you at least 65 years old?',
-      hint:
-        "Your answer to this question helps us determine if you're eligible for Veterans Pension benefits. We consider your age, income, and medical history in our determination. If you're under 65 years old, you may still be eligible.",
       classNames: 'vads-u-margin-bottom--2',
     }),
   },

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/socialSupplementalSecurity.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/socialSupplementalSecurity.js
@@ -23,8 +23,6 @@ export default {
     socialSecurityDisability: yesNoUI({
       title:
         'Do you receive Social Security Disability Insurance or Supplemental Security Income?',
-      hint:
-        "Your answer to this question helps us determine if you're eligible for Veterans Pension benefits. We consider your age, income, and medical history in our determination.",
       classNames: 'vads-u-margin-bottom--2',
     }),
   },


### PR DESCRIPTION
Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes

## Summary
Removed hint text from the Medical Evidence and Income and Asset pages of the Pension Benefits form (21P-527EZ) to simplify the Veteran’s form-filling experience.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110483

## Related issue(s)
- N/A

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. 3. In your local environment, set the `pension_medical_evidence_clarification ` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_medical_evidence_clarification
4. Go to `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/` in your browser

## How to verify
1. Navigate to the '/medical/history/age' page and select 'No' — confirm no hint text is displayed
2. Navigate to the /medical/history/social-security-disability' page — confirm all hint text has been removed
3. Navigate to the '/medical/history/condition' page — confirm no hint text is displayed
4. Ensure page content still renders and saves as expected

## What areas of the site does it impact?
Pension Benefits Application 

## Screenshots
### Age
| Before                 | After                  |
|------------------------|------------------------|
| Hint text is visible   | Hint text is removed   |
|![Screenshot 2025-06-04 at 12 09 19 PM](https://github.com/user-attachments/assets/06c40ec8-1267-414e-910e-133f8ebd2bcd)|![Screenshot 2025-06-04 at 12 06 55 PM](https://github.com/user-attachments/assets/d3919b66-763d-4b8e-88c1-7c90c988f877)|

### Social security disability
| Before                 | After                  |
|------------------------|------------------------|
| Hint text is visible   | Hint text is removed   |
|![Screenshot 2025-06-04 at 12 06 46 PM](https://github.com/user-attachments/assets/c73a6fd7-61d8-4783-b8a3-a9c4929df8c6)|![Screenshot 2025-06-04 at 12 09 02 PM](https://github.com/user-attachments/assets/6e902114-7579-46a5-b022-97d0cc8495c3)|

### Medical history
| Before                 | After                  |
|------------------------|------------------------|
| Hint text is visible   | Hint text is removed   |
|![Screenshot 2025-06-04 at 12 07 47 PM](https://github.com/user-attachments/assets/e3aae450-0a2a-492e-99dc-9482cb0a2ac7)|![Screenshot 2025-06-04 at 12 08 53 PM](https://github.com/user-attachments/assets/b0b0b95a-c493-4861-8487-a168f74d49a8)

### Quality Assurance & Testing
- [ ] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
None at this time — change was straightforward content removal.
