### PR TITLE
Use platform util for scroll functionality

### DIFF
--- a/src/applications/pensions/containers/ConfirmationPage.jsx
+++ b/src/applications/pensions/containers/ConfirmationPage.jsx
@@ -6,12 +6,9 @@ import { useSelector } from 'react-redux';
 import { isLoggedIn } from 'platform/user/selectors';
 
 import { focusElement } from 'platform/utilities/ui';
+import { scrollToTop } from 'platform/utilities/scroll';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
-import {
-  formatFullName,
-  obfuscateAccountNumber,
-  scrollToTop,
-} from '../helpers';
+import { formatFullName, obfuscateAccountNumber } from '../helpers';
 
 const centralTz = 'America/Chicago';
 

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Scroll from 'react-scroll';
 import { isBefore, isAfter, isEqual, parseISO } from 'date-fns';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
@@ -9,15 +8,6 @@ export const isSameOrBefore = (date1, date2) => {
 
 export const isSameOrAfter = (date1, date2) => {
   return isAfter(date1, date2) || isEqual(date1, date2);
-};
-
-const { scroller } = Scroll;
-export const scrollToTop = () => {
-  scroller.scrollTo('topScrollElement', {
-    duration: 500,
-    delay: 0,
-    smooth: true,
-  });
 };
 
 export const formatCurrency = num => `$${num.toLocaleString()}`;

--- a/src/applications/pensions/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -3,10 +3,7 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-import sinon from 'sinon';
-import * as Scroll from 'react-scroll';
 import ConfirmationPage from '../../../containers/ConfirmationPage';
-import { scrollToTop } from '../../../helpers';
 import formConfig from '../../../config/form';
 
 const getData = ({
@@ -61,28 +58,6 @@ const getData = ({
     subscribe: () => {},
     dispatch: () => {},
   },
-});
-
-describe('scrollToTop function', () => {
-  let scrollToSpy;
-  beforeEach(() => {
-    scrollToSpy = sinon.stub(Scroll.scroller, 'scrollTo');
-  });
-  afterEach(() => {
-    scrollToSpy.restore();
-  });
-
-  it('should call scroller.scrollTo with correct parameters', () => {
-    scrollToTop();
-    expect(scrollToSpy.calledOnce).to.be.true;
-    expect(
-      scrollToSpy.calledWith('topScrollElement', {
-        duration: 500,
-        delay: 0,
-        smooth: true,
-      }),
-    ).to.be.true;
-  });
 });
 
 describe('Pension benefits confirmation page', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

This PR splits out the changes to pensions (to get a small enough set for unit tests to run) from #36799, which removes all usages of the react-scroll library, in favor of the platform scroll utilities. This has been slated to be deprecated for some time, and is blocking the node version upgrade.