### PR TITLE
108246e - Add new Medicare page schemas for 10-10d/10-7959c merged form - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -413,6 +413,300 @@ const medicarePartBCardUploadPage = {
   schema: medicarePartBCardSchema,
 };
 
+// Define the Medicare Part A denial page
+const medicarePartADenialPage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) => `${generateParticipantName(formData)} Medicare status`,
+      <va-alert
+        status="info"
+        class="vads-u-margin-bottom--3"
+        uswds
+        background-color="true"
+      >
+        <p>
+          Applicants that don’t have Medicare Part A and B or proof of
+          ineligibility may not be eligible for CHAMPVA.
+        </p>
+      </va-alert>,
+    ),
+    hasPartADenial: {
+      ...yesNoUI({
+        title:
+          'Do you have a notice of disallowance, denial, or other proof of ineligibility for Medicare Part A?',
+        hint: ADDITIONAL_FILES_HINT,
+        required: () => true,
+      }),
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['hasPartADenial'],
+    properties: {
+      titleSchema,
+      hasPartADenial: yesNoSchema,
+    },
+  },
+};
+
+const medicarePartADenialProofUploadPage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      'Upload proof of Medicare ineligibility',
+      ({ formData }) => {
+        return (
+          <>
+            {generateParticipantName(formData)} is 65 years or older and you
+            selected that they do not have Medicare Part A.
+            <br />
+            <br />
+            You’ll need to submit a copy of a letter from the Social Security
+            Administration that confirms that they don’t qualify for Medicare
+            benefits under anyone’s Social Security number.
+          </>
+        );
+      },
+    ),
+    ...fileUploadBlurb,
+    medicarePartADenialProof: fileUploadUI({
+      label: 'Upload proof of Medicare ineligibility',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['medicarePartADenialProof'],
+    properties: {
+      titleSchema,
+      'view:fileUploadBlurb': blankSchema,
+      medicarePartADenialProof: {
+        type: 'array',
+        maxItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// Medicare Part C carrier and effective date page definition
+const medicarePartCCarrierEffectiveDatePage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
+        `${generateParticipantName(
+          formData,
+        )} Medicare Part C carrier and effective date`,
+    ),
+    medicarePartCCarrier: textUI({
+      title: 'Name of insurance carrier',
+      hint: 'Your insurance carrier is your insurance company.',
+    }),
+    medicarePartCEffectiveDate: currentOrPastDateUI({
+      title: 'Medicare Part C effective date',
+      hint:
+        'You may find your effective date on the front of your Medicare card near "Coverage starts" or "Effective date."',
+      required: () => true,
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['medicarePartCCarrier', 'medicarePartCEffectiveDate'],
+    properties: {
+      titleSchema,
+      medicarePartCCarrier: textSchema,
+      medicarePartCEffectiveDate: currentOrPastDateSchema,
+    },
+  },
+};
+
+// Medicare Part C pharmacy benefits page definition
+const medicarePartCPharmacyBenefitsPage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
+        `${generateParticipantName(formData)} Medicare pharmacy benefits`,
+    ),
+    hasPharmacyBenefits: {
+      ...yesNoUI({
+        title:
+          'Does this Medicare Part C (Advantage Plan) provide pharmacy benefits?',
+        hint:
+          'This information can be found on your Medicare Part C (Advantage Plan) card.',
+        required: () => true,
+      }),
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['hasPharmacyBenefits'],
+    properties: {
+      titleSchema,
+      hasPharmacyBenefits: yesNoSchema,
+    },
+  },
+};
+
+// Define the Medicare Part C card upload page using the generic schema
+const medicarePartCCardUploadPage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      'Upload Medicare Part C card',
+      'You’ll need to submit a copy of the front and back of the applicant’s Medicare Part C (Medicare Advantage Plan) card.',
+    ),
+    ...fileUploadBlurb,
+    medicarePartCFrontCard: fileUploadUI({
+      label: 'Upload front of Part C Medicare card',
+    }),
+    medicarePartCBackCard: fileUploadUI({
+      label: 'Upload back of Part C Medicare card',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['medicarePartCFrontCard', 'medicarePartCBackCard'],
+    properties: {
+      titleSchema,
+      'view:fileUploadBlurb': blankSchema,
+      medicarePartCFrontCard: {
+        type: 'array',
+        maxItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      medicarePartCBackCard: {
+        type: 'array',
+        maxItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// Medicare Part D status page definition
+const medicarePartDStatusPage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
+        `${generateParticipantName(formData)} Medicare Part D status`,
+    ),
+    hasMedicarePartD: {
+      ...yesNoUI({
+        title:
+          'Do you have Medicare Part D (prescription drug coverage) information to provide or update at this time?',
+        hint: ADDITIONAL_FILES_HINT,
+        required: () => true,
+      }),
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['hasMedicarePartD'],
+    properties: {
+      titleSchema,
+      hasMedicarePartD: yesNoSchema,
+    },
+  },
+};
+
+// Medicare Part D carrier and effective date page definition
+const medicarePartDCarrierEffectiveDatePage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) =>
+        `${generateParticipantName(
+          formData,
+        )} Medicare Part D carrier and effective date`,
+    ),
+    medicarePartDCarrier: textUI({
+      title: 'Name of insurance carrier',
+      hint: 'Your insurance carrier is your insurance company.',
+    }),
+    medicarePartDEffectiveDate: currentOrPastDateUI({
+      title: 'Medicare Part D effective date',
+      hint:
+        'You may find your effective date on the front of your Medicare card near "Coverage starts" or "Effective date."',
+      required: () => true,
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['medicarePartDCarrier', 'medicarePartDEffectiveDate'],
+    properties: {
+      titleSchema,
+      medicarePartDCarrier: textSchema,
+      medicarePartDEffectiveDate: currentOrPastDateSchema,
+    },
+  },
+};
+
+// Define the Medicare Part D card upload page
+const medicarePartDCardUploadPage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      'Upload Medicare Part D card',
+      'You’ll need to submit a copy of the front and back of your Medicare Part D prescription drug coverage card.',
+    ),
+    ...fileUploadBlurb,
+    medicarePartDFrontCard: fileUploadUI({
+      label: 'Upload front of Part D Medicare card',
+    }),
+    medicarePartDBackCard: fileUploadUI({
+      label: 'Upload back of Part D Medicare card',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['medicarePartDFrontCard', 'medicarePartDBackCard'],
+    properties: {
+      titleSchema,
+      'view:fileUploadBlurb': blankSchema,
+      medicarePartDFrontCard: {
+        type: 'array',
+        maxItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      medicarePartDBackCard: {
+        type: 'array',
+        maxItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
 // PAGES NEEDED:
 // IF USER SPECIFIES ONLY A/B:
 //   - medicare parts a/b effective dates

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -421,7 +421,6 @@ const medicarePartADenialPage = {
       <va-alert
         status="info"
         class="vads-u-margin-bottom--3"
-        uswds
         background-color="true"
       >
         <p>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

(Part 5/n - breaking up [this large PR](https://github.com/department-of-veterans-affairs/vets-website/pull/36778))

This PR continues building out the medicare section of the merged 10-10d/10-7959c form. This form is not live in production, and none of the changes introduced in this PR are directly used in the form yet (that will come in a follow-on PR).

- Adds medicare parts C and D information
- Adds medicare part A ineligibility screens

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108246

## Testing done

- Manual (E2E tests are planned when this functionality is integrated in a followup PR)

## Screenshots



## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA