### PR TITLE
EZR: Fixes prefill bug for EC and NoK

### DIFF
--- a/src/applications/ezr/tests/unit/utils/helpers/prefill-transformer.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/utils/helpers/prefill-transformer.unit.spec.jsx
@@ -89,6 +89,43 @@ describe('ezr prefill transformer', () => {
       isMedicaidEligible: false,
       isEnrolledMedicarePartA: false,
       maritalStatus: 'never married',
+      emergencyContacts: [
+        {
+          fullName: {
+            first: 'MARYEDITED',
+            middle: 'SIL',
+            last: 'MARMSEDITED',
+          },
+          relationship: 'WIFE',
+          contactType: 'Emergency Contact',
+          primaryPhone: '6123526123',
+          address: {
+            street: '8990 RALSTON RD',
+            city: 'ARVADA',
+            country: 'USA',
+            state: 'CO',
+            postalCode: '80002',
+          },
+        },
+      ],
+      nextOfKins: [
+        {
+          fullName: {
+            first: 'Dave',
+            last: 'Guy',
+          },
+          relationship: 'BROTHER',
+          contactType: 'Primary Next of Kin',
+          primaryPhone: '7038888888',
+          address: {
+            street: '25434 ELM TERR',
+            city: 'ALDIE',
+            country: 'USA',
+            state: 'VA',
+            postalCode: '20105',
+          },
+        },
+      ],
     };
 
     context('when profile data omits all addresses', () => {
@@ -107,12 +144,63 @@ describe('ezr prefill transformer', () => {
           null,
           state,
         );
-        expect(Object.keys(prefillData)).to.have.lengthOf(9);
+        expect(Object.keys(prefillData)).to.have.lengthOf(11);
         expect(Object.keys(prefillData).veteranAddress).to.not.exist;
         expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
         expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(
           undefined,
         );
+      });
+    });
+
+    context('when contacts have an address', () => {
+      const state = {
+        user: {
+          profile: {
+            vapContactInfo: {},
+          },
+        },
+      };
+
+      it('should auto-fill correct formData from user state', () => {
+        const { formData: prefillData } = prefillTransformer(
+          null,
+          formData,
+          null,
+          state,
+        );
+        expect(
+          prefillData.emergencyContacts[0]['view:hasEmergencyContactAddress'],
+        ).to.be.true;
+        expect(prefillData.nextOfKins[0]['view:hasNextOfKinAddress']).to.be
+          .true;
+      });
+    });
+
+    context('when contacts does not have an address', () => {
+      const state = {
+        user: {
+          profile: {
+            vapContactInfo: {},
+          },
+        },
+      };
+
+      it('should auto-fill correct formData from user state', () => {
+        const newFormData = { ...formData };
+        delete newFormData.emergencyContacts[0].address;
+        delete newFormData.nextOfKins[0].address;
+        const { formData: prefillData } = prefillTransformer(
+          null,
+          newFormData,
+          null,
+          state,
+        );
+        expect(
+          prefillData.emergencyContacts[0]['view:hasEmergencyContactAddress'],
+        ).to.be.false;
+        expect(prefillData.nextOfKins[0]['view:hasNextOfKinAddress']).to.be
+          .false;
       });
     });
 
@@ -158,7 +246,7 @@ describe('ezr prefill transformer', () => {
           null,
           state,
         );
-        expect(Object.keys(prefillData)).to.have.lengthOf(10);
+        expect(Object.keys(prefillData)).to.have.lengthOf(12);
         expect(prefillData.veteranAddress).to.equal(undefined);
         expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(8);
         expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(
@@ -234,7 +322,7 @@ describe('ezr prefill transformer', () => {
             null,
             state,
           );
-          expect(Object.keys(prefillData)).to.have.lengthOf(11);
+          expect(Object.keys(prefillData)).to.have.lengthOf(13);
           expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(8);
           expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(
             8,
@@ -311,7 +399,7 @@ describe('ezr prefill transformer', () => {
             null,
             state,
           );
-          expect(Object.keys(prefillData)).to.have.lengthOf(10);
+          expect(Object.keys(prefillData)).to.have.lengthOf(12);
           expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
           expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(8);
           expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.true;
@@ -345,7 +433,7 @@ describe('ezr prefill transformer', () => {
           null,
           state,
         );
-        expect(Object.keys(prefillData)).to.have.lengthOf(9);
+        expect(Object.keys(prefillData)).to.have.lengthOf(11);
       });
     });
   });

--- a/src/applications/ezr/utils/helpers/prefill-transformer.js
+++ b/src/applications/ezr/utils/helpers/prefill-transformer.js
@@ -90,6 +90,20 @@ export function prefillTransformer(pages, formData, metadata, state) {
     newData = { ...newData, veteranHomeAddress };
   }
 
+  if (newData.emergencyContacts && newData.emergencyContacts.length > 0) {
+    newData.emergencyContacts = newData.emergencyContacts.map(contact => {
+      const hasAddress = !!contact.address;
+      return { ...contact, 'view:hasEmergencyContactAddress': hasAddress };
+    });
+  }
+
+  if (newData.nextOfKins && newData.nextOfKins.length > 0) {
+    newData.nextOfKins = newData.nextOfKins.map(contact => {
+      const hasAddress = !!contact.address;
+      return { ...contact, 'view:hasNextOfKinAddress': hasAddress };
+    });
+  }
+
   return {
     metadata,
     formData: newData,


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes a prefill bug when a user supplied an address for Emergency Contact or Next Of Kin

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#104869

## Testing done

- Updated specs
- Manual QA

## What areas of the site does it impact?
Form 10-10 EZR

## Acceptance criteria
- Can successfully submit the EZR form when prefill is enabled

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
