### PR TITLE
Add axe check locally instead of only CI + fix heading order issues

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -693,12 +693,6 @@ jobs:
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
-      - name: Checkout new-axe-checks branch
-        run: git fetch origin new-axe-checks --depth=1
-
-      - name: Checkout axeCheck.js from new-axe-checks branch
-        run: git checkout origin/new-axe-checks src/platform/testing/e2e/cypress/support/commands/axeCheck.js
-
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests != '[]'
         uses: ./.github/workflows/configure-aws-credentials

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -34,8 +34,13 @@ const processAxeCheckResults = violations => {
  * @param {string} [context=main] - CSS/HTML selector for the container element to check with aXe.
  * @param {Object} [tempOptions={}] - Rules object to enable _13647 exception or modify aXe config.
  */
-Cypress.Commands.add('axeCheck', (context = 'main', tempOptions = {}) => {
-  const { _13647Exception } = tempOptions;
+Cypress.Commands.add('axeCheck', (context = 'main', options = {}) => {
+  const {
+    _13647Exception,
+    headingOrder = true,
+    emptyHeading = true,
+    pageHasHeadingOne = true,
+  } = options;
 
   /**
    * Default required ruleset to meet Section 508 compliance.
@@ -53,13 +58,22 @@ Cypress.Commands.add('axeCheck', (context = 'main', tempOptions = {}) => {
       'color-contrast': {
         enabled: false,
       },
+      'empty-heading': {
+        enabled: emptyHeading,
+      },
+      'heading-order': {
+        enabled: headingOrder,
+      },
+      'page-has-heading-one': {
+        enabled: pageHasHeadingOne,
+      },
     },
   };
 
   /**
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
    */
-  axeBuilder = Object.assign(axeBuilder, tempOptions);
+  axeBuilder = Object.assign(axeBuilder, options);
 
   const axeConfig = _13647Exception
     ? { includedImpacts: ['critical'] }

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -159,7 +159,9 @@ const getFieldSelectors = () => {
 const performPageActions = (pathname, _13647Exception = false) => {
   cy.axeCheck('main', {
     _13647Exception,
-    // ignore this check because headers may be in shadow dom which is asyncronously loaded
+    // Ignore heading order from the first axe check because headers
+    // may be in the shadow dom which may not be loaded yet.
+    // There is another axe check below which DOES check heading order.
     headingOrder: false,
   });
 

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -157,7 +157,11 @@ const getFieldSelectors = () => {
  * @param {string} pathname - The pathname of the page to run the page hook on.
  */
 const performPageActions = (pathname, _13647Exception = false) => {
-  cy.axeCheck('main', { _13647Exception });
+  cy.axeCheck('main', {
+    _13647Exception,
+    // ignore this check because headers may be in shadow dom which is asyncronously loaded
+    headingOrder: false,
+  });
 
   cy.execHook(pathname).then(({ hookExecuted, postHook }) => {
     const shouldAutofill = !pathname.match(


### PR DESCRIPTION
## Summary

- Remove axe check merge from CI, and add locally - so we can see results when testing locally
- There has been an ongoing issue where some forms cannot merge code due to shadow dom loading asynchronously, and heading order always failing, so disabled that initial check.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4214

## Testing done

- local cypress tests

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
