### PR TITLE
SA-113948: Prevent empty personal information submission

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/components/PersonalInformation.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/components/PersonalInformation.jsx
@@ -4,15 +4,29 @@ import PropTypes from 'prop-types';
 import { formatReadableDate } from '../helpers';
 
 function PersonalInformation({ claimant }) {
-  const fullName = () => {
-    const firstName = claimant?.userFullName?.first;
-    const middleName = claimant?.userFullName?.middle || '';
-    const lastName = claimant?.userFullName?.last;
+  if (
+    !claimant?.userFullName?.first ||
+    !claimant?.userFullName?.last ||
+    !claimant?.dob
+  ) {
+    return (
+      <va-alert status="info">
+        <h3 slot="headline">Personal Information Not Available</h3>
+        <p>
+          To complete this form, we need your name and date of birth. Please
+          update your <a href="/profile">VA.gov profile</a> with this
+          information.
+        </p>
+      </va-alert>
+    );
+  }
 
-    if (firstName && lastName) {
-      return `${firstName} ${middleName} ${lastName}`;
-    }
-    return 'Not available';
+  const fullName = () => {
+    const firstName = claimant.userFullName.first;
+    const middleName = claimant.userFullName.middle || '';
+    const lastName = claimant.userFullName.last;
+
+    return `${firstName} ${middleName} ${lastName}`;
   };
 
   return (
@@ -24,10 +38,7 @@ function PersonalInformation({ claimant }) {
         <div>
           <h6>{fullName()}</h6>
           <p>
-            <strong>Date of birth:</strong>{' '}
-            {claimant?.dob
-              ? formatReadableDate(claimant?.dob)
-              : 'Not available'}
+            <strong>Date of birth:</strong> {formatReadableDate(claimant.dob)}
           </p>
         </div>
       </div>
@@ -44,17 +55,6 @@ PersonalInformation.propTypes = {
       middle: PropTypes.string,
     }),
   }),
-};
-
-PersonalInformation.defaultProps = {
-  claimant: {
-    dob: '',
-    userFullName: {
-      first: '',
-      last: '',
-      middle: '',
-    },
-  },
 };
 
 const mapStateToProps = state => ({

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/components/PersonalInformation.unit.spec.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/components/PersonalInformation.unit.spec.jsx
@@ -7,45 +7,119 @@ import PersonalInformation from '../../components/PersonalInformation';
 
 describe('PersonalInformation component', () => {
   const mockStore = configureStore();
-  const initialState = {
-    user: {
-      profile: {
-        userFullName: {
-          first: 'John',
-          middle: 'M',
-          last: 'Doe',
-        },
-        dob: '1990-01-01',
-      },
-    },
+
+  const validName = {
+    first: 'John',
+    middle: 'M',
+    last: 'Doe',
   };
 
-  it('renders the PersonalInformation footer', () => {
-    expect(<PersonalInformation />);
-  });
+  const validProfile = {
+    userFullName: validName,
+    dob: '1990-01-01',
+  };
 
-  it('should render the user full name and formatted date of birth', () => {
-    const store = mockStore(initialState);
-    const wrapper = mount(
+  const createWrapper = profile => {
+    const store = mockStore({ user: { profile } });
+    return mount(
       <Provider store={store}>
         <PersonalInformation />
       </Provider>,
     );
-    expect(wrapper.text()).to.include('John M Doe');
-    expect(wrapper.text()).to.include('Date of birth: January 1, 1990');
+  };
+
+  const expectAlertWithMessage = wrapper => {
+    expect(wrapper.find('va-alert').exists()).to.be.true;
+    expect(wrapper.text()).to.include('Personal Information Not Available');
+    expect(wrapper.text()).to.include('VA.gov profile');
     wrapper.unmount();
+  };
+
+  describe('when all data is present', () => {
+    it('renders complete profile information correctly', () => {
+      const wrapper = createWrapper(validProfile);
+
+      expect(wrapper.find('.usa-alert.background-color-only').exists()).to.be
+        .true;
+      expect(
+        wrapper.find('.usa-alert.background-color-only').text(),
+      ).to.include('Your personal information');
+      expect(wrapper.find('.personal-info-border').exists()).to.be.true;
+      expect(wrapper.find('.personal-info-border').text()).to.include(
+        'John M Doe',
+      );
+      expect(wrapper.find('.personal-info-border').text()).to.include(
+        'Date of birth: January 1, 1990',
+      );
+
+      wrapper.unmount();
+    });
   });
 
-  it('should render the user full name and formatted date of birth', () => {
-    initialState.user.profile.dob = '';
-    const store = mockStore(initialState);
-    const wrapper = mount(
-      <Provider store={store}>
-        <PersonalInformation />
-      </Provider>,
-    );
-    expect(wrapper.text()).to.include('John M Doe');
-    expect(wrapper.text()).to.include('Date of birth: Not available');
-    wrapper.unmount();
+  describe('when data is missing', () => {
+    const testCases = [
+      {
+        name: 'missing first name',
+        profile: {
+          userFullName: { ...validName, first: '' },
+          dob: '1990-01-01',
+        },
+      },
+      {
+        name: 'missing last name',
+        profile: {
+          userFullName: { ...validName, last: '' },
+          dob: '1990-01-01',
+        },
+      },
+      {
+        name: 'missing DOB',
+        profile: {
+          userFullName: validName,
+          dob: '',
+        },
+      },
+      {
+        name: 'undefined profile',
+        profile: undefined,
+      },
+      {
+        name: 'null profile',
+        profile: null,
+      },
+      {
+        name: 'missing userFullName',
+        profile: {
+          dob: '1990-01-01',
+        },
+      },
+    ];
+
+    testCases.forEach(({ name, profile }) => {
+      it(`shows alert when ${name}`, () => {
+        const wrapper = createWrapper(profile);
+        expectAlertWithMessage(wrapper);
+      });
+    });
+  });
+
+  describe('alert message rendering', () => {
+    it('includes correct status and content', () => {
+      const wrapper = createWrapper({
+        userFullName: { first: '', last: '' },
+        dob: '',
+      });
+
+      const alert = wrapper.find('va-alert');
+      expect(alert.prop('status')).to.equal('info');
+      expect(wrapper.find('h3[slot="headline"]').text()).to.equal(
+        'Personal Information Not Available',
+      );
+      expect(wrapper.find('a[href="/profile"]').text()).to.equal(
+        'VA.gov profile',
+      );
+
+      wrapper.unmount();
+    });
   });
 });

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/utils/form-submit-transform.unit.spec.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/utils/form-submit-transform.unit.spec.jsx
@@ -213,6 +213,76 @@ describe('form submit transform', () => {
         expect(submissionObject.serviceMember.ssn).to.eql('123123123');
       });
     });
+    describe('transform5490Form', () => {
+      it('handles valid claimant data correctly', () => {
+        const form = {
+          data: {
+            claimantFullName: {
+              first: 'John',
+              middle: 'M',
+              last: 'Doe',
+            },
+            relativeDateOfBirth: '1990-01-01',
+          },
+        };
+
+        const result = JSON.parse(transform5490Form(null, form));
+        expect(result.claimant.firstName).to.equal('John');
+        expect(result.claimant.lastName).to.equal('Doe');
+      });
+
+      it('uses loadedData when form data is missing', () => {
+        const form = {
+          data: {},
+          loadedData: {
+            formData: {
+              claimantFullName: {
+                first: 'Jane',
+                middle: 'A',
+                last: 'Smith',
+              },
+              relativeDateOfBirth: '1985-05-05',
+            },
+          },
+        };
+
+        const result = JSON.parse(transform5490Form(null, form));
+        expect(result.claimant.firstName).to.equal('Jane');
+        expect(result.claimant.lastName).to.equal('Smith');
+      });
+
+      it('handles empty name fields appropriately', () => {
+        const form = {
+          data: {
+            claimantFullName: {
+              first: '',
+              middle: 'M',
+              last: 'Doe',
+            },
+            relativeDateOfBirth: '1990-01-01',
+          },
+        };
+
+        const result = JSON.parse(transform5490Form(null, form));
+        expect(result.claimant.firstName).to.be.undefined;
+      });
+
+      it('handles whitespace-only name values', () => {
+        const form = {
+          data: {
+            claimantFullName: {
+              first: 'John',
+              middle: 'M',
+              last: '   ',
+            },
+            relativeDateOfBirth: '1990-01-01',
+          },
+        };
+
+        const result = JSON.parse(transform5490Form(null, form));
+        expect(result.claimant.lastName).to.be.undefined;
+      });
+    });
 
     describe('creates Direct Deposit information', () => {
       it('sets up direct deposit account type', () => {

--- a/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
@@ -321,16 +321,58 @@ export function getAddressType(mailingAddress) {
   return 'FOREIGN';
 }
 
+// Helper to validate that a string field has content
+const isValidStringField = field => {
+  return field !== undefined && field !== null && field.trim() !== '';
+};
+
+// Helper to validate full name fields
+const isValidFullName = fullName => {
+  return (
+    fullName &&
+    typeof fullName === 'object' &&
+    isValidStringField(fullName.first) &&
+    isValidStringField(fullName.last)
+  );
+};
+
 export function transform5490Form(_formConfig, form) {
   const formFieldUserFullName = form?.data?.claimantFullName;
   const viewComponentUserFullName =
     form?.loadedData?.formData?.claimantFullName;
 
-  const userFullName =
+  const formFieldDateOfBirth = form?.data?.relativeDateOfBirth;
+  const viewComponentDateOfBirth =
+    form?.loadedData?.formData?.relativeDateOfBirth;
+
+  // Enhanced validation for userFullName to ensure we have valid, non-empty values
+  let userFullName = null;
+  if (
     formFieldUserFullName !== undefined &&
-    Object.keys(formFieldUserFullName).length > 0
-      ? formFieldUserFullName
-      : viewComponentUserFullName;
+    Object.keys(formFieldUserFullName).length > 0 &&
+    isValidFullName(formFieldUserFullName)
+  ) {
+    userFullName = formFieldUserFullName;
+  } else if (isValidFullName(viewComponentUserFullName)) {
+    userFullName = viewComponentUserFullName;
+  }
+  // If both sources fail validation, userFullName remains null
+
+  // Enhanced validation for dateOfBirth
+  let dateOfBirth = null;
+  if (isValidStringField(formFieldDateOfBirth)) {
+    dateOfBirth = formFieldDateOfBirth;
+  } else if (isValidStringField(viewComponentDateOfBirth)) {
+    dateOfBirth = viewComponentDateOfBirth;
+  }
+  // If both sources fail validation, dateOfBirth remains null
+
+  // Log warnings if we have missing data, but don't throw errors
+  // These should never happen if the component validation works properly
+  if (!userFullName || !dateOfBirth) {
+    // eslint-disable-next-line no-console
+    console.warn('Missing required personal information in form submission');
+  }
 
   const payload = {
     formId: form?.formId,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updates form validations:
- Adds strict validation for claimant name and DOB in transform
- Removes defaultProps in favor of explicit validation
- Adds early return in the PersonalInformation component
- Adds comprehensive test coverage for validation cases
- Mirrors the TOE form's pattern of safe data handling

This prevents forms from being submitted with empty personal information by validating data at both the component and transform levels.

## Related issue(s)
SA-113948

## Testing done
Updated Unit tests for touched files. 100% coverage for the Personal Information component

## Screenshots


## What areas of the site does it impact?
Survivor Dependent Benefits 5490 Form

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

