### PR TITLE
CHAMPVA/OHI merge sponsor headers 

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -12,13 +12,12 @@ import {
   phoneSchema,
   titleUI,
   titleSchema,
-  ssnOrVaFileNumberUI,
-  ssnOrVaFileNumberSchema,
+  ssnOrVaFileNumberNoHintUI,
+  ssnOrVaFileNumberNoHintSchema,
   yesNoSchema,
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import CustomPrefillMessage from '../components/CustomPrefillAlert';
-import { sponsorWording } from '../../10-10D/helpers/utilities';
 import { sponsorAddressCleanValidation } from '../../shared/validations';
 
 export const sponsorNameDobSchema = {
@@ -49,15 +48,18 @@ export const sponsorNameDobSchema = {
 
 export const sponsorIdentificationSchema = {
   uiSchema: {
-    ...titleUI(`Sponsor's identification information`),
-    sponsorSsn: ssnOrVaFileNumberUI(),
+    ...titleUI(({ formData }) => {
+      return `${formData?.certifierRole === 'applicant' ? 'Your' : `Sponsor's`} 
+        identification information`;
+    }, `You must enter either a Social Security number or VA File number`),
+    sponsorSsn: ssnOrVaFileNumberNoHintUI(),
   },
   schema: {
     type: 'object',
     required: ['sponsorSsn'],
     properties: {
       titleSchema,
-      sponsorSsn: ssnOrVaFileNumberSchema,
+      sponsorSsn: ssnOrVaFileNumberNoHintSchema,
     },
   },
 };
@@ -65,8 +67,14 @@ export const sponsorIdentificationSchema = {
 export const sponsorStatus = {
   uiSchema: {
     ...titleUI(
-      `Sponsor's status`,
-      'Now we’ll ask you questions about the death of the sponsor (if they died). Fill this out to the best of your knowledge.',
+      ({ formData }) => {
+        return `${
+          formData.certifierRole === 'applicant' ? 'Your' : `Sponsor's`
+        } 
+    status`;
+      },
+      `Now we'll ask you questions about the death of the sponsor (if they have died).
+     Fill this out to the best of your knowledge.`,
     ),
     sponsorIsDeceased: yesNoUI({
       title: 'Has the sponsor died?',
@@ -114,17 +122,16 @@ export const sponsorStatusDetails = {
 export const sponsorAddress = {
   uiSchema: {
     ...titleUI(
-      ({ formData }) => `${sponsorWording(formData)} mailing address`,
-      ({ formData }) => (
-        // Prefill message conditionally displays based on `certifierRole`
-        <>
-          <p>
-            We’ll send any important information about this application to this
-            address.
-          </p>
-          {CustomPrefillMessage(formData, 'sponsor')}
-        </>
-      ),
+      ({ formData }) => {
+        return `${
+          formData.certifierRole === 'applicant' ? 'Your' : `Sponsor's`
+        } mailing address`;
+      },
+      ({ formData }) => {
+        return `We'll send any important information about this application to ${
+          formData.certifierRole === 'applicant' ? 'your' : `the sponsor's`
+        } address.`;
+      },
     ),
     sponsorAddress: {
       ...addressUI({
@@ -148,18 +155,21 @@ export const sponsorAddress = {
 
 export const sponsorContactInfo = {
   uiSchema: {
-    ...titleUI(`Sponsor's contact information`, ({ formData }) => (
-      <>
-        <p>
-          We’ll use this phone number to contact{' '}
-          {formData.certifierRole === 'applicant' ? 'you' : 'the sponsor'} if we
-          have any questions about{' '}
-          {formData.certifierRole === 'applicant' ? 'your' : 'their'}{' '}
-          information.
-        </p>
-        {CustomPrefillMessage(formData, 'sponsor')}
-      </>
-    )),
+    ...titleUI(
+      ({ formData }) => {
+        return `${
+          formData.certifierRole === 'applicant' ? 'Your' : `Sponsor's`
+        } contact information`;
+      },
+      ({ formData }) => {
+        return `We'll use this phone number to contact ${
+          formData.certifierRole === 'applicant' ? `you` : `the sponsor`
+        }
+             if we have any questions about ${
+               formData.certifierRole === 'applicant' ? 'your' : 'their'
+             } information.`;
+      },
+    ),
     sponsorPhone: {
       ...phoneUI(),
       'ui:required': () => true,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR updates the headers and descriptions in the sponsor section to be dynamic (sponsors/your) depending on who the applicant is. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/109704

## Testing done
unit
e2e

## Screenshots
![Screenshot 2025-06-03 at 10 38 34 AM](https://github.com/user-attachments/assets/c244bb4f-ab1f-4811-bce5-eae93c9a0deb)
![Screenshot 2025-06-05 at 9 03 36 AM](https://github.com/user-attachments/assets/a68e4776-0f73-4b61-8519-3d9feb500f06)

![Screenshot 2025-06-05 at 8 41 48 AM](https://github.com/user-attachments/assets/1fd674a9-4181-4036-a965-a0fcdddfecd2)
![Screenshot 2025-06-05 at 9 04 34 AM](https://github.com/user-attachments/assets/6fcc6075-9b71-4b5c-a952-969cb9a154cc)

![Screenshot 2025-06-05 at 8 44 16 AM](https://github.com/user-attachments/assets/d56ca26f-4a60-4962-819a-e3a0973d4cb5)
![Screenshot 2025-06-05 at 9 04 20 AM](https://github.com/user-attachments/assets/e1293869-db29-4fd3-8714-7f5de3246d66)

![Screenshot 2025-06-05 at 8 44 49 AM](https://github.com/user-attachments/assets/fcf17083-4660-414f-8e2f-9fab353ddad0)
![Screenshot 2025-06-05 at 9 35 38 AM](https://github.com/user-attachments/assets/6eb2bc18-1e00-4a45-b6a6-9ca8182576dd)

## What areas of the site does it impact?
Just this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
