### PR TITLE
[#110427] Travel Pay, Deductible info render condition fix

### DIFF
--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -128,7 +128,7 @@ export default function ClaimDetailsContent({
               )}
             </div>
           )}
-          {!!reimbursementAmount &&
+          {reimbursementAmount > 0 &&
             totalCostRequested !== reimbursementAmount && (
               <va-additional-info
                 class="vads-u-margin-y--2"

--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -128,28 +128,30 @@ export default function ClaimDetailsContent({
               )}
             </div>
           )}
-          {totalCostRequested !== reimbursementAmount && (
-            <va-additional-info
-              class="vads-u-margin-y--2"
-              trigger="Why are my amounts different"
-            >
-              <p>
-                The VA travel pay deductible is $3 for a one-way trip and $6 for
-                a round trip, with a maximum of $18 per month. After a Veteran
-                reaches the $18 monthly deductible, the VA will pay the full
-                cost of their approved travel for the rest of that month.{' '}
-                <va-link
-                  href="/resources/reimbursed-va-travel-expenses-and-mileage-rate#monthlydeductible"
-                  text="Learn more about travel expenses monthly deductible"
-                />
-              </p>
-              <p>
-                If the difference is greater than the deductible, then the
-                Beneficiary Travel team may have issued a partial payment. You
-                can review the decision letter for more information.
-              </p>
-            </va-additional-info>
-          )}
+          {!!reimbursementAmount &&
+            totalCostRequested !== reimbursementAmount && (
+              <va-additional-info
+                class="vads-u-margin-y--2"
+                trigger="Why are my amounts different"
+              >
+                <p>
+                  The VA travel pay deductible is $3 for a one-way trip and $6
+                  for a round trip, with a maximum of $18 per month. After a
+                  Veteran reaches the $18 monthly deductible, the VA will pay
+                  the full cost of their approved travel for the rest of that
+                  month.{' '}
+                  <va-link
+                    href="/resources/reimbursed-va-travel-expenses-and-mileage-rate#monthlydeductible"
+                    text="Learn more about travel expenses monthly deductible"
+                  />
+                </p>
+                <p>
+                  If the difference is greater than the deductible, then the
+                  Beneficiary Travel team may have issued a partial payment. You
+                  can review the decision letter for more information.
+                </p>
+              </va-additional-info>
+            )}
         </>
       )}
       <p className="vads-u-font-weight--bold vads-u-margin-bottom--0">When</p>

--- a/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
@@ -307,6 +307,27 @@ describe('ClaimDetailsContent', () => {
       ).to.exist;
     });
 
+    it('does not render deductible info when submitted amount is present but reimbursement amount is not', () => {
+      const screen = renderWithStoreAndRouter(
+        <ClaimDetailsContent
+          {...claimDetailsProps}
+          totalCostRequested={100}
+          reimbursementAmount={0}
+        />,
+        {
+          initialState: getState(),
+        },
+      );
+
+      expect($('va-additional-info[trigger="Why are my amounts different"]')).to
+        .not.exist;
+      expect(
+        screen.queryByText(
+          /The VA travel pay deductible is \$3 for a one-way trip/i,
+        ),
+      ).to.not.exist;
+    });
+
     it('does not render deductible info when submitted and reimbursement amounts are equal', () => {
       const screen = renderWithStoreAndRouter(
         <ClaimDetailsContent


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Don't show deducible info help text if there is not a reimbursement amount.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/110427

## Testing done

Local testing with mock scenario for non zero submitted amount and zero reimbursement amount.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![mobile_before](https://github.com/user-attachments/assets/c1854c25-51e1-4584-b4f6-27b41f7634d0) | ![mobile_after](https://github.com/user-attachments/assets/72deb4dd-aaf5-470f-88ba-7e38bbfccd5a) |
| Desktop | ![desktop_before](https://github.com/user-attachments/assets/b9e9db3a-2a37-482e-8acc-85fdcc175ec4) | ![desktop_after](https://github.com/user-attachments/assets/e069b40b-7d5b-43da-ab59-11a9e23de1cd) |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user