### PR TITLE
MHV-70286: Added front end datadog metric tracking for statsd

### DIFF
--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -332,12 +332,10 @@ export const downloadCCD = timestamp => {
 /**
  * Send Datadog actions to the backend to be recorded in StatsD metrics
  */
-export const postRecordDatadogAction = async action => {
-  return apiRequest(
-    `${apiBasePath}/medical_records/datadog_actions?action=${action}`,
-    {
-      method: 'POST',
-      headers,
-    },
-  );
+export const postRecordDatadogAction = async metric => {
+  return apiRequest(`${environment.API_URL}/v0/datadog_actions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ metric }),
+  });
 };

--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -332,10 +332,10 @@ export const downloadCCD = timestamp => {
 /**
  * Send Datadog actions to the backend to be recorded in StatsD metrics
  */
-export const postRecordDatadogAction = async metric => {
-  return apiRequest(`${environment.API_URL}/v0/datadog_actions`, {
+export const postRecordDatadogAction = async (metric, tags = []) => {
+  return apiRequest(`${environment.API_URL}/v0/datadog_action`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ metric }),
+    body: JSON.stringify({ metric, tags }),
   });
 };

--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -328,3 +328,16 @@ export const downloadCCD = timestamp => {
     },
   );
 };
+
+/**
+ * Send Datadog actions to the backend to be recorded in StatsD metrics
+ */
+export const postRecordDatadogAction = async action => {
+  return apiRequest(
+    `${apiBasePath}/medical_records/datadog_actions?action=${action}`,
+    {
+      method: 'POST',
+      headers,
+    },
+  );
+};

--- a/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
+++ b/src/applications/mhv-medical-records/components/DownloadRecords/DownloadFileType.jsx
@@ -41,11 +41,12 @@ import {
   ALERT_TYPE_BB_ERROR,
   pageTitles,
   refreshExtractTypes,
+  statsdFrontEndActions,
 } from '../../util/constants';
 import { Actions } from '../../util/actionTypes';
 import useFocusOutline from '../../hooks/useFocusOutline';
 import { updateReportFileType } from '../../actions/downloads';
-import { postCreateAAL } from '../../api/MrApi';
+import { postCreateAAL, postRecordDatadogAction } from '../../api/MrApi';
 
 const DownloadFileType = props => {
   const { runningUnitTest = false } = props;
@@ -454,6 +455,7 @@ const DownloadFileType = props => {
     } else if (fileType === 'txt') {
       generateTxt().then(() => history.push('/download'));
     }
+    postRecordDatadogAction(statsdFrontEndActions.DOWNLOAD_BLUE_BUTTON);
     sendDataDogAction('Download report');
   };
 

--- a/src/applications/mhv-medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv-medical-records/containers/Allergies.jsx
@@ -23,6 +23,7 @@ import {
   accessAlertTypes,
   refreshExtractTypes,
   CernerAlertContent,
+  statsdFrontEndActions,
 } from '../util/constants';
 import { getAllergiesList, reloadRecords } from '../actions/allergies';
 import PrintHeader from '../components/shared/PrintHeader';
@@ -41,6 +42,7 @@ import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import useAcceleratedData from '../hooks/useAcceleratedData';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const Allergies = props => {
   const { runningUnitTest } = props;
@@ -71,6 +73,8 @@ const Allergies = props => {
   const dispatchAction = isCurrent => {
     return getAllergiesList(isCurrent, isAcceleratingAllergies);
   };
+
+  useTrackAction(statsdFrontEndActions.ALLERGIES_LIST);
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/AllergyDetails.jsx
@@ -26,6 +26,7 @@ import {
   ALERT_TYPE_ERROR,
   accessAlertTypes,
   pageTitles,
+  statsdFrontEndActions,
 } from '../util/constants';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import useAlerts from '../hooks/use-alerts';
@@ -36,6 +37,7 @@ import HeaderSection from '../components/shared/HeaderSection';
 import LabelValue from '../components/shared/LabelValue';
 
 import useAcceleratedData from '../hooks/useAcceleratedData';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const AllergyDetails = props => {
   const { runningUnitTest } = props;
@@ -68,6 +70,8 @@ const AllergyDetails = props => {
     },
     [allergy, isAcceleratingAllergies],
   );
+
+  useTrackAction(statsdFrontEndActions.ALLERGIES_DETAILS);
 
   useEffect(
     () => {

--- a/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesAndNotes.jsx
@@ -15,12 +15,14 @@ import {
   pageTitles,
   recordType,
   refreshExtractTypes,
+  statsdFrontEndActions,
 } from '../util/constants';
 import useAlerts from '../hooks/use-alerts';
 import RecordListSection from '../components/shared/RecordListSection';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const CareSummariesAndNotes = () => {
   const dispatch = useDispatch();
@@ -38,6 +40,8 @@ const CareSummariesAndNotes = () => {
   );
   const refresh = useSelector(state => state.mr.refresh);
   const activeAlert = useAlerts(dispatch);
+
+  useTrackAction(statsdFrontEndActions.CARE_SUMMARIES_AND_NOTES_LIST);
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/CareSummariesDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/CareSummariesDetails.jsx
@@ -13,9 +13,11 @@ import {
   accessAlertTypes,
   loincCodes,
   pageTitles,
+  statsdFrontEndActions,
 } from '../util/constants';
 import useAlerts from '../hooks/use-alerts';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const CareSummariesDetails = () => {
   const dispatch = useDispatch();
@@ -27,6 +29,8 @@ const CareSummariesDetails = () => {
   );
   const { summaryId } = useParams();
   const activeAlert = useAlerts(dispatch);
+
+  useTrackAction(statsdFrontEndActions.CARE_SUMMARIES_AND_NOTES_DETAILS);
 
   useEffect(
     () => {

--- a/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/ConditionDetails.jsx
@@ -29,6 +29,7 @@ import {
   ALERT_TYPE_ERROR,
   accessAlertTypes,
   pageTitles,
+  statsdFrontEndActions,
 } from '../util/constants';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import useAlerts from '../hooks/use-alerts';
@@ -37,6 +38,7 @@ import { generateConditionContent } from '../util/pdfHelpers/conditions';
 import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import HeaderSection from '../components/shared/HeaderSection';
 import LabelValue from '../components/shared/LabelValue';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const ConditionDetails = props => {
   const { runningUnitTest } = props;
@@ -55,6 +57,8 @@ const ConditionDetails = props => {
   const dispatch = useDispatch();
   const activeAlert = useAlerts(dispatch);
   const [downloadStarted, setDownloadStarted] = useState(false);
+
+  useTrackAction(statsdFrontEndActions.CARE_SUMMARIES_AND_NOTES_DETAILS);
 
   useEffect(
     () => {

--- a/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadReportPage.jsx
@@ -24,12 +24,14 @@ import {
   documentTypes,
   pageTitles,
   refreshExtractTypes,
+  statsdFrontEndActions,
 } from '../util/constants';
 import { genAndDownloadCCD } from '../actions/downloads';
 import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import { Actions } from '../util/actionTypes';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import useAlerts from '../hooks/use-alerts';
+import { postRecordDatadogAction } from '../api/MrApi';
 
 /**
  * Formats failed domain lists with display names.
@@ -164,6 +166,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
         userProfile?.userFullName?.last,
       ),
     );
+    postRecordDatadogAction(statsdFrontEndActions.DOWNLOAD_CCD);
     sendDataDogAction('Download Continuity of Care Document xml Link');
   };
 
@@ -186,6 +189,7 @@ const DownloadReportPage = ({ runningUnitTest }) => {
         setSeiPdfGenerationError(err);
         setSelfEnteredPdfLoading(false);
       });
+    postRecordDatadogAction(statsdFrontEndActions.DOWNLOAD_CCD);
     sendDataDogAction('Download self-entered health information PDF link');
   };
 

--- a/src/applications/mhv-medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv-medical-records/containers/HealthConditions.jsx
@@ -11,6 +11,7 @@ import {
   accessAlertTypes,
   refreshExtractTypes,
   CernerAlertContent,
+  statsdFrontEndActions,
 } from '../util/constants';
 import RecordListSection from '../components/shared/RecordListSection';
 import useAlerts from '../hooks/use-alerts';
@@ -18,6 +19,7 @@ import useListRefresh from '../hooks/useListRefresh';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const HealthConditions = () => {
   const ABOUT_THE_CODES_LABEL = 'About the codes in some condition names';
@@ -32,6 +34,8 @@ const HealthConditions = () => {
   const conditionsCurrentAsOf = useSelector(
     state => state.mr.conditions.listCurrentAsOf,
   );
+
+  useTrackAction(statsdFrontEndActions.CARE_SUMMARIES_AND_NOTES_LIST);
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/LabAndTestDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/LabAndTestDetails.jsx
@@ -16,9 +16,11 @@ import {
   accessAlertTypes,
   labTypes,
   pageTitles,
+  statsdFrontEndActions,
 } from '../util/constants';
 import useAlerts from '../hooks/use-alerts';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const LabAndTestDetails = () => {
   const dispatch = useDispatch();
@@ -31,6 +33,8 @@ const LabAndTestDetails = () => {
   const fullState = useSelector(state => state);
   const { labId } = useParams();
   const activeAlert = useAlerts(dispatch);
+
+  useTrackAction(statsdFrontEndActions.LABS_AND_TESTS_DETAILS);
 
   useEffect(
     () => {

--- a/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv-medical-records/containers/LabsAndTests.jsx
@@ -11,6 +11,7 @@ import {
   pageTitles,
   recordType,
   refreshExtractTypes,
+  statsdFrontEndActions,
 } from '../util/constants';
 import RecordListSection from '../components/shared/RecordListSection';
 import useAlerts from '../hooks/use-alerts';
@@ -18,6 +19,7 @@ import useListRefresh from '../hooks/useListRefresh';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const LabsAndTests = () => {
   const dispatch = useDispatch();
@@ -33,6 +35,8 @@ const LabsAndTests = () => {
   const labsAndTestsCurrentAsOf = useSelector(
     state => state.mr.labsAndTests.listCurrentAsOf,
   );
+
+  useTrackAction(statsdFrontEndActions.LABS_AND_TESTS_LIST);
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/RadiologyImagesList.jsx
+++ b/src/applications/mhv-medical-records/containers/RadiologyImagesList.jsx
@@ -16,9 +16,11 @@ import {
   accessAlertTypes,
   ALERT_TYPE_ERROR,
   pageTitles,
+  statsdFrontEndActions,
   studyJobStatus,
 } from '../util/constants';
 import { sendDataDogAction } from '../util/helpers';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const RadiologyImagesList = ({ isTesting }) => {
   const apiImagingPath = `${
@@ -54,6 +56,8 @@ const RadiologyImagesList = ({ isTesting }) => {
       null,
     [studyJobs, radiologyDetails?.studyId],
   );
+
+  useTrackAction(statsdFrontEndActions.RADIOLOGY_IMAGES_LIST);
 
   useEffect(
     () => {

--- a/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VaccineDetails.jsx
@@ -25,6 +25,7 @@ import {
   ALERT_TYPE_ERROR,
   accessAlertTypes,
   pageTitles,
+  statsdFrontEndActions,
 } from '../util/constants';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import useAlerts from '../hooks/use-alerts';
@@ -33,6 +34,7 @@ import { generateVaccineItem } from '../util/pdfHelpers/vaccines';
 import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import HeaderSection from '../components/shared/HeaderSection';
 import LabelValue from '../components/shared/LabelValue';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const VaccineDetails = props => {
   const { runningUnitTest } = props;
@@ -49,6 +51,8 @@ const VaccineDetails = props => {
   const dispatch = useDispatch();
   const activeAlert = useAlerts(dispatch);
   const [downloadStarted, setDownloadStarted] = useState(false);
+
+  useTrackAction(statsdFrontEndActions.VACCINES_DETAILS);
 
   useEffect(
     () => {

--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -27,6 +27,7 @@ import {
   accessAlertTypes,
   refreshExtractTypes,
   CernerAlertContent,
+  statsdFrontEndActions,
 } from '../util/constants';
 import PrintDownload from '../components/shared/PrintDownload';
 import DownloadingRecordsInfo from '../components/shared/DownloadingRecordsInfo';
@@ -46,6 +47,7 @@ import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const Vaccines = props => {
   const { runningUnitTest } = props;
@@ -66,6 +68,8 @@ const Vaccines = props => {
   );
   const activeAlert = useAlerts(dispatch);
   const [downloadStarted, setDownloadStarted] = useState(false);
+
+  useTrackAction(statsdFrontEndActions.VACCINES_LIST);
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv-medical-records/containers/VitalDetails.jsx
@@ -41,6 +41,7 @@ import {
   accessAlertTypes,
   refreshExtractTypes,
   loadStates as LOAD_STATES,
+  statsdFrontEndActions,
 } from '../util/constants';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import useAlerts from '../hooks/use-alerts';
@@ -49,14 +50,13 @@ import {
   generateVitalContent,
   generateVitalsIntro,
 } from '../util/pdfHelpers/vitals';
-
 import DownloadSuccessAlert from '../components/shared/DownloadSuccessAlert';
 import NewRecordsIndicator from '../components/shared/NewRecordsIndicator';
 import useListRefresh from '../hooks/useListRefresh';
 import HeaderSection from '../components/shared/HeaderSection';
 import LabelValue from '../components/shared/LabelValue';
-
 import useAcceleratedData from '../hooks/useAcceleratedData';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const VitalDetails = props => {
   const { runningUnitTest } = props;
@@ -98,6 +98,8 @@ const VitalDetails = props => {
   const dispatchAction = isCurrent => {
     return getVitals(isCurrent, isAcceleratingVitals, urlVitalsDate);
   };
+
+  useTrackAction(statsdFrontEndActions.VITALS_LIST);
 
   useListRefresh({
     listState,

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -17,10 +17,12 @@ import {
   ALERT_TYPE_ERROR,
   accessAlertTypes,
   refreshExtractTypes,
+  loadStates,
+  statsdFrontEndActions,
+  CernerAlertContent,
 } from '../util/constants';
 import { getMonthFromSelectedDate } from '../util/helpers';
 import { Actions } from '../util/actionTypes';
-import * as Constants from '../util/constants';
 import useAlerts from '../hooks/use-alerts';
 import PrintHeader from '../components/shared/PrintHeader';
 import useListRefresh from '../hooks/useListRefresh';
@@ -29,6 +31,7 @@ import useAcceleratedData from '../hooks/useAcceleratedData';
 import AcceleratedCernerFacilityAlert from '../components/shared/AcceleratedCernerFacilityAlert';
 import RecordListSection from '../components/shared/RecordListSection';
 import NoRecordsMessage from '../components/shared/NoRecordsMessage';
+import { useTrackAction } from '../hooks/useTrackAction';
 
 const Vitals = () => {
   const dispatch = useDispatch();
@@ -56,7 +59,7 @@ const Vitals = () => {
 
   const { isLoading, isAcceleratingVitals } = useAcceleratedData();
   const isLoadingAcceleratedData =
-    isAcceleratingVitals && listState === Constants.loadStates.FETCHING;
+    isAcceleratingVitals && listState === loadStates.FETCHING;
 
   const dispatchAction = useMemo(
     () => {
@@ -70,6 +73,9 @@ const Vitals = () => {
     },
     [acceleratedVitalsDate, isAcceleratingVitals],
   );
+
+  useTrackAction(statsdFrontEndActions.VITALS_LIST);
+
   useListRefresh({
     listState,
     listCurrentAsOf: vitalsCurrentAsOf,
@@ -235,7 +241,7 @@ const Vitals = () => {
     setDisplayDate(acceleratedVitalsDate);
     dispatch({
       type: Actions.Vitals.UPDATE_LIST_STATE,
-      payload: Constants.loadStates.PRE_FETCH,
+      payload: loadStates.PRE_FETCH,
     });
   };
 
@@ -275,9 +281,7 @@ const Vitals = () => {
         appointments.`}
       </p>
 
-      <AcceleratedCernerFacilityAlert
-        {...Constants.CernerAlertContent.VITALS}
-      />
+      <AcceleratedCernerFacilityAlert {...CernerAlertContent.VITALS} />
 
       {isLoading && (
         <div className="vads-u-margin-y--8">

--- a/src/applications/mhv-medical-records/hooks/useTrackAction.js
+++ b/src/applications/mhv-medical-records/hooks/useTrackAction.js
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { postRecordDatadogAction } from '../api/MrApi';
+
+export const useTrackAction = action => {
+  useEffect(
+    () => {
+      postRecordDatadogAction(action);
+    },
+    [action],
+  );
+};

--- a/src/applications/mhv-medical-records/util/constants.js
+++ b/src/applications/mhv-medical-records/util/constants.js
@@ -463,3 +463,25 @@ export const radiologyErrors = {
   ERROR_TRY_LATER:
     'We’re sorry. There was a problem with our system. Try again later.',
 };
+
+export const statsdFrontEndActions = {
+  // list calls
+  LABS_AND_TESTS_LIST: 'labs_and_tests_list',
+  CARE_SUMMARIES_AND_NOTES_LIST: 'care_summaries_and_notes_list',
+  VACCINES_LIST: 'vaccines_list',
+  ALLERGIES_LIST: 'allergies_list',
+  HEALTH_CONDITIONS_LIST: 'health_conditions_list',
+  VITALS_LIST: 'vitals_list',
+  // detail calls
+  LABS_AND_TESTS_DETAILS: 'labs_and_tests_details',
+  RADIOLOGY_IMAGES_LIST: 'radiology_images_list',
+  CARE_SUMMARIES_AND_NOTES_DETAILS: 'care_summaries_and_notes_details',
+  VACCINES_DETAILS: 'vaccines_details',
+  ALLERGIES_DETAILS: 'allergies_details',
+  HEALTH_CONDITIONS_DETAILS: 'health_conditions_details',
+  VITALS_DETAILS: 'vitals_details',
+  // download calls
+  DOWNLOAD_BLUE_BUTTON: 'download_blue_button',
+  DOWNLOAD_CCD: 'download_ccd',
+  DOWNLOAD_SEI: 'download_sei',
+};


### PR DESCRIPTION
## Summary
Datadog metrics tracking front end implementation added. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-70286

> ### Milestone 2: Logging to be fixed so the MR DataDog metrics are accurate
> Description
> Logging to be fixed so the MR DataDog metrics are accurate
> 
> Note: Work with Mike and Stephen to get details. We should create custom DD StatsD metrics in vets-api by using, e.g., a parameter passed down from the client. A good use case for this is Allergies, which can be triggered by the Veteran or by medications app.

## Testing done
...

## Screenshots
No UI changes. 

## What areas of the site does it impact?
MHV medical records

## Acceptance criteria
Front end metrics being tracked by Datadog StatsD

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
