### PR TITLE
MHV-71263 denies API call if not in 2 year, 13 month range

### DIFF
--- a/src/applications/mhv-medical-records/actions/blueButtonReport.js
+++ b/src/applications/mhv-medical-records/actions/blueButtonReport.js
@@ -1,3 +1,4 @@
+import { subYears, addMonths, startOfDay, endOfDay } from 'date-fns';
 import {
   getLabsAndTests,
   getNotes,
@@ -47,8 +48,25 @@ export const getBlueButtonReportData = (
           dateFilter.option === 'any' ? null : dateFilter.toDate,
         );
 
+        // Checking if selected date range is within the 2 years/13 months for appointments
+        const now = new Date();
+        const earliest = startOfDay(subYears(now, 2));
+        const latest = endOfDay(addMonths(now, 13));
+        if (
+          dateFilter.option !== 'any' &&
+          (new Date(dateFilter.toDate) < earliest ||
+            latest < new Date(dateFilter.fromDate))
+        ) {
+          return {
+            key: 'appointments',
+            response: new Response([], { status: 200 }),
+          };
+        }
+
         return fetchFn(startDate, endDate)
-          .then(response => ({ key, response }))
+          .then(response => {
+            return { key, response };
+          })
           .catch(error => {
             const newError = new Error(error);
             newError.key = key;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixes appointments in Blue Button download by pre-checking the 2 year/13 month range before dispatching api calls.

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-71263

> Appointment date-handling may fetch unnecessary appts
> When downloading the BB report, I had to make a decision about what to do for Appointments if the selected range is fully outside of the 2-year/13-month window. Without thinking too much about it, I implicitly made the decision to use the first or last day of the window respectively. This could lead to a Veteran getting an appointment outside of the range they selected.
> 
> The real solution to this is that we SHOULD NOT even attempt to fetch appointments if they are outside of this window. It generates unnecessary overhead.
> Implement this, and be wary of all the plumbing involved, e.g. it has to look identical to finding no records within the window.
> 
> UNIT testing, please

## Testing done
2 new unit tests added, one for date range before 2 years, one for date range after 13 months

## Screenshots
NO ui changes

## What areas of the site does it impact?
mhv-medical records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
