### PR TITLE
110880 - Content changes for supporting docs in 10-10d/10-7959c merged form - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/ApplicantRelOriginPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/ApplicantRelOriginPage.jsx
@@ -36,6 +36,8 @@ function generateOptions({ data, pagePerItemIndex }) {
     relativeBeingVerb,
     keyname: KEYNAME,
     customTitle,
+    customHint:
+      'Depending on your response, you may need to submit proof of dependent status with this application.',
     description: `What’s ${customTitle}?`,
   };
 }

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -473,6 +473,7 @@ const applicantSchoolCertUploadPage = {
             <br />
             <br />
             Fill out a School Enrollment Certification Form.
+            <br />
             <va-link
               href="https://www.va.gov/COMMUNITYCARE/docs/pubfiles/forms/School-Enrollment.pdf"
               text="Get school enrollment certification form to download"

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -398,42 +398,59 @@ const applicantAdoptionUploadPage = {
   },
 };
 
-const applicantStepChildConfig = uploadWithInfoComponent(
-  undefined, // acceptableFiles.stepCert,
-  'marriage certificates',
-);
-
 const applicantStepChildUploadPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
-      'Upload parental marriage documents',
+      'Upload proof of parent’s marriage or legal union',
       ({ formData }) => (
         <>
-          To help us process this application faster, submit a copy of{' '}
+          You’ll need to submit a document showing proof of the marriage or
+          legal union between{' '}
           <b className="dd-privacy-hidden">
             {applicantWording(formData, true, false)}
           </b>{' '}
-          parental marriage documents.
+          sponsor and{' '}
+          <b className="dd-privacy-hidden">
+            {applicantWording(formData, true, false)}
+          </b>{' '}
+          parent.
           <br />
-          Submitting a copy can help us process this application faster.
           <br />
-          {MAIL_OR_FAX_LATER_MSG}
+          Upload a copy of one of these documents:
+          <ul>
+            <li>
+              Marriage certificate, <b>or</b>
+            </li>
+            <li>
+              A document showing proof of a civil union, <b>or</b>
+            </li>
+            <li>Common-law marriage affidavit</li>
+          </ul>
         </>
       ),
     ),
-    ...applicantStepChildConfig.uiSchema,
+    ...fileUploadBlurbCustom(),
     applicantStepMarriageCert: fileUploadUI({
-      label: 'Upload a copy of parental marriage documents',
+      label: 'Upload proof of marriage or legal union',
     }),
   },
   schema: {
     type: 'object',
+    required: ['applicantStepMarriageCert'],
     properties: {
       titleSchema,
-      ...applicantStepChildConfig.schema,
-      applicantStepMarriageCert: fileWithMetadataSchema(
-        acceptableFiles.stepCert,
-      ),
+      'view:fileUploadBlurb': blankSchema,
+      applicantStepMarriageCert: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
     },
   },
 };
@@ -830,7 +847,7 @@ export const applicantPages = arrayBuilderPages(
     }),
     page18e: pageBuilder.itemPage({
       path: 'applicant-child-marriage-file/:index',
-      title: item => `${applicantWording(item)} parental marriage documents`,
+      title: 'Upload proof of parent’s marriage or legal union',
       depends: (formData, index) =>
         get(
           'applicantRelationshipToSponsor.relationshipToVeteran',
@@ -840,7 +857,6 @@ export const applicantPages = arrayBuilderPages(
           'applicantRelationshipOrigin.relationshipToVeteran',
           formData?.applicants?.[index],
         ) === 'step',
-      CustomPage: FileFieldCustom,
       ...applicantStepChildUploadPage,
     }),
     page18b1: pageBuilder.itemPage({

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -33,7 +33,10 @@ import { ApplicantAddressCopyPage } from '../../shared/components/applicantLists
 import { fileUploadUi as fileUploadUI } from '../../shared/components/fileUploads/upload';
 import ApplicantRelationshipPage from '../../shared/components/applicantLists/ApplicantRelationshipPage';
 import FileFieldCustom from '../../shared/components/fileUploads/FileUpload';
-import { fileWithMetadataSchema } from '../../shared/components/fileUploads/attachments';
+import {
+  fileUploadBlurbCustom,
+  fileWithMetadataSchema,
+} from '../../shared/components/fileUploads/attachments';
 import {
   applicantWording,
   getAgeInYears,
@@ -579,42 +582,65 @@ const applicantRemarriedPage = {
   },
 };
 
-const applicantMarriageCertConfig = uploadWithInfoComponent(
-  undefined, // acceptableFiles.spouseCert,
-  'marriage certificates',
-);
-
-const applicantMarriageCertUploadPage = {
+const applicantReMarriageCertUploadPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
-      'Upload marriage documents',
+      'Upload proof of remarriage',
       ({ formData }) => (
         <>
-          To help us process this application faster, submit a copy of{' '}
-          <b className="dd-privacy-hidden">
-            {applicantWording(formData, true, false)}
-          </b>{' '}
-          marriage documents.
+          If {applicantWording(formData, false)} remarried after the death of
+          the sponsor, you can help us process your application faster by
+          submitting documents showing proof of that remarriage.
           <br />
-          Submitting a copy can help us process this application faster.
           <br />
-          {MAIL_OR_FAX_LATER_MSG}
+          Upload a copy of one of these documents:
+          <ul>
+            <li>
+              Marriage certificate, <b>or</b>
+            </li>
+            <li>
+              A document showing proof of a civil union, <b>or</b>
+            </li>
+            <li>Common-law marriage affidavit</li>
+          </ul>
+          <b>If the remarriage has ended,</b> upload a copy of one of these
+          documents:
+          <ul>
+            <li>
+              Divorce decree, <b>or</b>
+            </li>
+            <li>
+              Annulment decree, <b>or</b>
+            </li>
+            <li>Death certificate</li>
+          </ul>
         </>
       ),
     ),
-    ...applicantMarriageCertConfig.uiSchema,
+    ...fileUploadBlurbCustom(
+      <li key="final-bullet">You can upload more than one file here.</li>,
+    ),
     applicantRemarriageCert: fileUploadUI({
-      label: 'Upload proof of marriage or legal union',
+      label: 'Upload proof of remarriage',
     }),
   },
   schema: {
     type: 'object',
+    required: ['applicantRemarriageCert'],
     properties: {
       titleSchema,
-      ...applicantMarriageCertConfig.schema,
-      applicantRemarriageCert: fileWithMetadataSchema(
-        acceptableFiles.spouseCert,
-      ),
+      'view:fileUploadBlurb': blankSchema,
+      applicantRemarriageCert: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      },
     },
   },
 };
@@ -880,16 +906,17 @@ export const applicantPages = arrayBuilderPages(
         ) === 'spouse' && get('sponsorIsDeceased', formData),
       ...applicantRemarriedPage,
     }),
-    page18f: pageBuilder.itemPage({
-      path: 'applicant-marriage-upload/:index',
-      title: item => `${applicantWording(item)} marriage documents`,
+    page18g: pageBuilder.itemPage({
+      path: 'applicant-remarriage-upload/:index',
+      title: 'Upload proof of remarriage',
       depends: (formData, index) =>
         get(
           'applicantRelationshipToSponsor.relationshipToVeteran',
           formData?.applicants?.[index],
-        ) === 'spouse' && get('sponsorIsDeceased', formData),
-      CustomPage: FileFieldCustom,
-      ...applicantMarriageCertUploadPage,
+        ) === 'spouse' &&
+        get('sponsorIsDeceased', formData) &&
+        get('applicantRemarried', formData?.applicants?.[index]),
+      ...applicantReMarriageCertUploadPage,
     }),
     page19: pageBuilder.itemPage({
       path: 'applicant-medicare/:index',

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -729,7 +729,14 @@ export const applicantPages = arrayBuilderPages(
       path: 'applicant-relationship/:index',
       title: item => `${applicantWording(item)} relationship to the sponsor`,
       ...applicantRelationshipPage,
-      CustomPage: ApplicantRelationshipPage,
+      CustomPage: props =>
+        ApplicantRelationshipPage({
+          ...props,
+          customWording: {
+            customHint:
+              'Depending on your response, you may need to submit proof of marriage or dependent status with this application.',
+          },
+        }),
     }),
     page18c: pageBuilder.itemPage({
       path: 'applicant-relationship-child/:index',

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -539,9 +539,9 @@ const applicantMarriageDatesPage = {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
         `${applicantWording(formData)} date of marriage to the sponsor`,
-      'If you don’t know the exact date, enter your best guess',
+      'If you don’t know the exact date, enter your best guess. We won’t need the marriage certificate unless we can’t find a record of the marriage in our system.',
     ),
-    dateOfMarriageToSponsor: currentOrPastDateUI(),
+    dateOfMarriageToSponsor: currentOrPastDateUI('Date of marriage'),
   },
   schema: {
     type: 'object',

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -24,6 +24,8 @@ import {
   emailUI,
   emailSchema,
   radioSchema,
+  yesNoUI,
+  yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
 
@@ -552,6 +554,31 @@ const applicantMarriageDatesPage = {
   },
 };
 
+const applicantRemarriedPage = {
+  uiSchema: {
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      ({ formData }) => `${applicantWording(formData)} marriage status`,
+    ),
+    applicantRemarried: {
+      ...yesNoUI({
+        updateUiSchema: formData => {
+          return {
+            'ui:title': `Has ${applicantWording(formData, false)} remarried?`,
+          };
+        },
+      }),
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['applicantRemarried'],
+    properties: {
+      titleSchema,
+      applicantRemarried: yesNoSchema,
+    },
+  },
+};
+
 const applicantMarriageCertConfig = uploadWithInfoComponent(
   undefined, // acceptableFiles.spouseCert,
   'marriage certificates',
@@ -842,6 +869,16 @@ export const applicantPages = arrayBuilderPages(
           formData?.applicants?.[index],
         ) === 'spouse',
       ...applicantMarriageDatesPage,
+    }),
+    page18f4: pageBuilder.itemPage({
+      path: 'applicant-remarried/:index',
+      title: 'Marriage status',
+      depends: (formData, index) =>
+        get(
+          'applicantRelationshipToSponsor.relationshipToVeteran',
+          formData?.applicants?.[index],
+        ) === 'spouse' && get('sponsorIsDeceased', formData),
+      ...applicantRemarriedPage,
     }),
     page18f: pageBuilder.itemPage({
       path: 'applicant-marriage-upload/:index',

--- a/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
@@ -22,13 +22,35 @@ import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import { populateFirstApplicant } from '../helpers/utilities';
+import manifest from '../manifest.json';
 
 const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
 fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
+const signInAlert = loggedIn => (
+  <>
+    {!loggedIn && (
+      <va-alert status="info">
+        <p className="vads-u-margin-y--0">
+          It may take some time to complete this form. Sign in to save your
+          progress. We can also pre-fill some of the information for you to save
+          you time.
+          <br />
+          <va-link
+            href={`${manifest.rootUrl}?next=loginModal`}
+            text="Sign in to start your application"
+          />
+        </p>
+      </va-alert>
+    )}
+  </>
+);
+
 export const certifierRoleSchema = {
   uiSchema: {
-    ...titleUI('Your information'),
+    ...titleUI('Your information', ({ formContext }) =>
+      signInAlert(formContext?.isLoggedIn),
+    ),
     certifierRole: radioUI({
       title: 'Which of these best describes you?',
       required: () => true,

--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -48,12 +48,11 @@ export const sponsorIntroSchema = {
 
 export const sponsorNameDobSchema = {
   uiSchema: {
-    ...titleUI(`Sponsor's name and date of birth`, ({ formData }) => (
+    ...titleUI(`Sponsor’s name and date of birth`, ({ formData }) => (
       <>
         <p>
-          Enter the personal information for the sponsor (the Veteran or service
-          member that the applicant is connected to). We’ll use the sponsor’s
-          information to confirm their eligibility for CHAMPVA benefits.
+          Enter the sponsor’s name and date of birth. We’ll use this information
+          to confirm their eligibility for CHAMPVA benefits.
         </p>
         {CustomPrefillMessage(formData, 'sponsor')}
       </>

--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -21,6 +21,31 @@ import CustomPrefillMessage from '../components/CustomPrefillAlert';
 import { sponsorWording } from '../../10-10D/helpers/utilities';
 import { sponsorAddressCleanValidation } from '../../shared/validations';
 
+export const sponsorIntroSchema = {
+  uiSchema: {
+    ...titleUI(
+      'Sponsor information',
+      <>
+        <p>
+          Now we’ll ask you to enter information about the Veteran or service
+          member that the applicant is connected to, also called the sponsor.
+        </p>
+        <p>
+          We’ll use the sponsor’s name, social security number, and status to
+          confirm their eligibility for CHAMPVA benefits. We will not need you
+          to upload their DD-214.
+        </p>
+      </>,
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      titleSchema,
+    },
+  },
+};
+
 export const sponsorNameDobSchema = {
   uiSchema: {
     ...titleUI(`Sponsor's name and date of birth`, ({ formData }) => (

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -29,6 +29,7 @@ import {
   sponsorStatusDetails,
   sponsorAddress,
   sponsorContactInfo,
+  sponsorIntroSchema,
 } from '../chapters/sponsorInformation';
 import { applicantPages } from '../chapters/applicantInformation';
 import { medicarePages } from '../chapters/medicareInformation';
@@ -122,6 +123,11 @@ const formConfig = {
     sponsorInformation: {
       title: 'Sponsor information',
       pages: {
+        page5a: {
+          path: 'sponsor-intro',
+          title: 'Sponsor information',
+          ...sponsorIntroSchema,
+        },
         page6: {
           path: 'sponsor-info',
           title: 'Sponsor’s name and date of birth',

--- a/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { focusElement, scrollToTop } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
@@ -100,4 +101,10 @@ IntroductionPage.propTypes = {
   }),
 };
 
-export default IntroductionPage;
+const mapStateToProps = state => {
+  return {
+    isLoggedIn: state.user.login.currentlyLoggedIn,
+  };
+};
+
+export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
@@ -85,24 +85,4 @@ describe('applicantPages depends functions', () => {
       expect(res).to.not.be.undefined;
     });
   });
-
-  // Example of calling a specific depends function inside array builder
-  it('page18b2 depends fn should return true if applicant is over 18 and helpless', () => {
-    expect(
-      applicantPages.page18b2.depends(
-        {
-          applicants: [
-            {
-              applicantRelationshipToSponsor: {
-                relationshipToVeteran: 'child',
-              },
-              applicantDob: '1990-01-01',
-              applicantDependentStatus: { status: 'over18HelplessChild' },
-            },
-          ],
-        },
-        0,
-      ),
-    ).to.be.true;
-  });
 });

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
@@ -44,7 +44,16 @@ export function appRelBoilerplate({ data, pagePerItemIndex }) {
   };
 }
 
-function generateOptions({ data, pagePerItemIndex }) {
+/**
+ * Assembles radio options and returns customized wording for use in the display
+ * @param {Object} param0.data Formdata object
+ * @param {Number|String} param0.pagePerItemIndex list loop current index
+ * @param {Object} param0.customWordingloop Object containing custom wording overrides.
+ *  Wording that may be overridden includes: personTitle, customTitle, customHint,
+ *  description, customOtherDescription.
+ * @returns
+ */
+function generateOptions({ data, pagePerItemIndex, customWording }) {
   const {
     keyname,
     currentListItem,
@@ -71,6 +80,7 @@ function generateOptions({ data, pagePerItemIndex }) {
   ];
 
   return {
+    ...customWording,
     options,
     useFirstPerson,
     relativePossessive,
@@ -162,6 +172,7 @@ export default function ApplicantRelationshipPage({
   pagePerItemIndex,
   updatePage,
   onReviewPage,
+  customWording,
 }) {
   // fulldata is present in array builder pages:
   const fullOrItemData = fullData ?? data;
@@ -199,6 +210,7 @@ export default function ApplicantRelationshipPage({
   } = genOps({
     data: fullOrItemData,
     pagePerItemIndex,
+    customWording, // For hint override when using default configuration
   });
 
   const handlers = {
@@ -347,6 +359,7 @@ ApplicantRelationshipReviewPage.propTypes = {
 
 ApplicantRelationshipPage.propTypes = {
   contentAfterButtons: PropTypes.object,
+  customWording: PropTypes.object,
   data: PropTypes.object,
   fullData: PropTypes.object,
   genOp: PropTypes.func,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the applicant information section of the merged 10-10d/10-7959c form to include the latest copy changes and changes to file upload requirements.

This form is not live in production.

- Updates file upload page copy for the adoption, step child, and school certification pages
- Adds alert recommending user sign in to first page of form (hidden when already authenticated)
- Numerous small copy changes across the sponsor/applicant information sections

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110880

## Testing done

- Manual (E2E tests planned in an upcoming PR)

## Screenshots

|         | Before/after |
| ------- | ------  |
| Step child parent marriage doc |![step_marriage](https://github.com/user-attachments/assets/e9f4bc7b-c5bc-4200-a1a0-e6c7fa6c44ca)|
|Applicant relationship to sponsor hint|![sponsor_relationship_hint](https://github.com/user-attachments/assets/bc9af891-66fa-45a7-864c-cad7fbb2a210)|
|Sponsor intro|(did not previously exist) - ![sponsor_intro](https://github.com/user-attachments/assets/7452b88d-2538-490f-9b43-49a9cb3fdd8e)|
|Extra sign-in prompt on first page|![signer_info](https://github.com/user-attachments/assets/75e7609d-f8ce-4329-a764-05de8419e43b)|
|Proof of school enrollment|![school_docs](https://github.com/user-attachments/assets/c60fedd8-0ac6-42ff-9d37-4fe1ca57b2f9)|
|Proof of adoption|![adoption_docs](https://github.com/user-attachments/assets/d51be7fd-c5ba-4fc8-a434-cbf4aed6a20c)|

|remarriage yes/no|Remarriage cert upload|
|-|-|
|![Screenshot 2025-06-05 at 14 33 17](https://github.com/user-attachments/assets/a76c6086-fc72-44a0-a470-9b067ed1c957)|![Screenshot 2025-06-05 at 14 33 25](https://github.com/user-attachments/assets/3ea575fe-dd8e-4ffc-8703-3aa9035f9cfb)|

## What areas of the site does it impact?

This form only.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA