### PR TITLE
renames test for ds logon deprecation

### DIFF
--- a/src/applications/sign-in-changes/containers/InterstitialChanges.jsx
+++ b/src/applications/sign-in-changes/containers/InterstitialChanges.jsx
@@ -66,7 +66,7 @@ export default function InterstitialChanges() {
         <CreateAccount />
       )}
       <h2 id="interstitialH2">Or continue using your old account</h2>
-      <p className="vads-u-font-size--base" id="interstitialMhvP">
+      <p className="vads-u-font-size--base" id="interstitialDslP">
         You can use your <strong>DS Logon</strong> account to sign in until
         September 30, 2025.
       </p>

--- a/src/applications/sign-in-changes/tests/SignInChangesReminder.cypress.spec.js
+++ b/src/applications/sign-in-changes/tests/SignInChangesReminder.cypress.spec.js
@@ -35,7 +35,7 @@ describe('Interstitial Changes Page', () => {
       cy.get('#interstitialH1').should('be.visible');
       cy.get('#interstitialP').should('be.visible');
       cy.get('#interstitialH2').should('be.visible');
-      cy.get('#interstitialMhvP').should('be.visible');
+      cy.get('#interstitialDslP').should('be.visible');
       cy.get('#interstitialVaLink').should('be.visible');
       cy.injectAxeThenAxeCheck();
     });
@@ -99,7 +99,7 @@ describe('Interstitial Changes Page', () => {
     });
   });
 
-  context('when user clicks on continue with My HealtheVet link', () => {
+  context('when user clicks on continue with DS Logon link', () => {
     beforeEach(() => {
       sessionStorage.setItem('authReturnUrl', '/return-path');
       interceptResponse(200, {});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[Github Issue](https://github.com/department-of-veterans-affairs/identity-documentation/issues/326)

## Testing done

- unit tests passing
- e2e tests passing


## What areas of the site does it impact?

```/sign-in-changes-reminder```

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
