### PR TITLE
Dependents | Make date of divorce required

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartTwo.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformationPartTwo.js
@@ -23,7 +23,7 @@ export const schema = {
           type: 'string',
         },
       },
-      required: ['reasonMarriageEnded'],
+      required: ['date', 'reasonMarriageEnded'],
     },
   },
 };
@@ -31,10 +31,10 @@ export const schema = {
 export const uiSchema = {
   reportDivorce: {
     ...titleUI('When, where, and why did this marriage end?'),
-    date: {
-      ...currentOrPastDateUI('Date of divorce'),
-      'ui:required': () => true,
-    },
+    date: currentOrPastDateUI({
+      title: 'Date of divorce',
+      required: () => true,
+    }),
     divorceLocation: {
       outsideUsa: {
         'ui:title': 'This occurred outside the U.S.',
@@ -98,11 +98,11 @@ export const uiSchema = {
     'ui:options': {
       updateSchema: (formData, formSchema) => {
         if (formSchema.properties.explanationOfOther['ui:collapsed']) {
-          return { ...formSchema, required: ['reasonMarriageEnded'] };
+          return { ...formSchema, required: ['date', 'reasonMarriageEnded'] };
         }
         return {
           ...formSchema,
-          required: ['reasonMarriageEnded', 'explanationOfOther'],
+          required: ['date', 'reasonMarriageEnded', 'explanationOfOther'],
         };
       },
     },

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-divorce/formerSpouseInformation.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-divorce/formerSpouseInformation.unit.spec.jsx
@@ -1,10 +1,10 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
 import React from 'react';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
-import { $$ } from 'platform/forms-system/src/js/utilities/ui';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import formConfig from '../../../../config/form';
 
 const defaultStore = createCommonStore();
@@ -89,6 +89,56 @@ describe('686 report divorce: Former spouse information', () => {
     expect($$('va-text-input', container).length).to.equal(2);
     expect($$('va-radio', container).length).to.equal(1);
     expect($$('va-radio-option', container).length).to.equal(2);
+  });
+
+  it('should render error messages', () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{}}
+        />
+      </Provider>,
+    );
+
+    fireEvent.submit($('button[type="submit"]', container));
+    const errors = $$('[error]', container)?.map(
+      el => `${el.tagName}:${el.getAttribute('error')}`,
+    );
+    expect(errors.length).to.equal(4);
+    expect(errors).to.deep.equal([
+      'VA-MEMORABLE-DATE:Please enter a date',
+      'VA-TEXT-INPUT:Enter the city where this occurred',
+      'VA-SELECT:Select a state',
+      'VA-RADIO:You must provide a response',
+    ]);
+  });
+
+  it('should render error messages when reason marriage ended is "other"', () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{ reportDivorce: { reasonMarriageEnded: 'Other' } }}
+        />
+      </Provider>,
+    );
+
+    fireEvent.submit($('button[type="submit"]', container));
+    const errors = $$('[error]', container)?.map(
+      el => `${el.tagName}:${el.getAttribute('error')}`,
+    );
+    expect(errors.length).to.equal(4);
+    expect(errors).to.deep.equal([
+      'VA-MEMORABLE-DATE:Please enter a date',
+      'VA-TEXT-INPUT:Enter the city where this occurred',
+      'VA-SELECT:Select a state',
+      'VA-TEXT-INPUT:You must provide a response',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > The date of divorce is required within the design, so this PR updates the field to make it required
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/110687

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Divorce info | <img width="500" alt="date of divorce isn't required, no error message on submit" src="https://github.com/user-attachments/assets/e9f7daa4-52d9-4864-be36-298f69431958" /> | <img width="500" alt="date of divorce is required, showing all error messages on page" src="https://github.com/user-attachments/assets/0fda922d-b24d-4f7b-ab26-5391b8b24e5e" /> |

## What areas of the site does it impact?

Dependents Management Form (686c-674)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
