### PR TITLE
1010d Extended Sponsor Headings

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -49,7 +49,7 @@ export const sponsorNameDobSchema = {
 export const sponsorIdentificationSchema = {
   uiSchema: {
     ...titleUI(({ formData }) => {
-      return `${formData?.certifierRole === 'applicant' ? 'Your' : `Sponsor's`} 
+      return `${formData?.certifierRole === 'sponsor' ? 'Your' : `Sponsor's`} 
         identification information`;
     }, `You must enter either a Social Security number or VA File number`),
     sponsorSsn: ssnOrVaFileNumberNoHintUI(),
@@ -68,9 +68,7 @@ export const sponsorStatus = {
   uiSchema: {
     ...titleUI(
       ({ formData }) => {
-        return `${
-          formData.certifierRole === 'applicant' ? 'Your' : `Sponsor's`
-        } 
+        return `${formData.certifierRole === 'sponsor' ? 'Your' : `Sponsor's`} 
     status`;
       },
       `Now we'll ask you questions about the death of the sponsor (if they have died).
@@ -124,12 +122,12 @@ export const sponsorAddress = {
     ...titleUI(
       ({ formData }) => {
         return `${
-          formData.certifierRole === 'applicant' ? 'Your' : `Sponsor's`
+          formData.certifierRole === 'sponsor' ? 'Your' : `Sponsor's`
         } mailing address`;
       },
       ({ formData }) => {
         return `We'll send any important information about this application to ${
-          formData.certifierRole === 'applicant' ? 'your' : `the sponsor's`
+          formData.certifierRole === 'sponsor' ? 'your' : `the sponsor's`
         } address.`;
       },
     ),
@@ -158,15 +156,15 @@ export const sponsorContactInfo = {
     ...titleUI(
       ({ formData }) => {
         return `${
-          formData.certifierRole === 'applicant' ? 'Your' : `Sponsor's`
+          formData.certifierRole === 'sponsor' ? 'Your' : `Sponsor's`
         } contact information`;
       },
       ({ formData }) => {
         return `We'll use this phone number to contact ${
-          formData.certifierRole === 'applicant' ? `you` : `the sponsor`
+          formData.certifierRole === 'sponsor' ? `you` : `the sponsor`
         }
              if we have any questions about ${
-               formData.certifierRole === 'applicant' ? 'your' : 'their'
+               formData.certifierRole === 'sponsor' ? 'your' : 'their'
              } information.`;
       },
     ),


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR updates the sponsor headings to actually be for the sponsor and not the applicant.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/109704

## Testing done
e2e
unit

## What areas of the site does it impact?
just this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
