### PR TITLE
Consolidate facility fetches on choose a facility page

### DIFF
--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/index.unit.spec.jsx
@@ -22,12 +22,12 @@ const defaultState = {
       typeOfCareId: TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID,
     },
     facilities: {
-      '123': [
+      [TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID]: [
         {
           vistaId: '692',
           legacyVAR: {
             settings: {
-              '123': {
+              [TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID]: {
                 id: TYPE_OF_CARE_IDS.FOOD_AND_NUTRITION_ID,
                 name: 'Food and Nutrition',
                 stopCodes: [

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -68,7 +68,6 @@ export default function VAFacilityPageV2() {
     sortMethod,
     typeOfCare,
     fetchRecentLocationStatus,
-    recentLocations,
   } = useSelector(state => getFacilityPageV2Info(state), shallowEqual);
 
   const sortOptions = useMemo(
@@ -84,7 +83,7 @@ export default function VAFacilityPageV2() {
         },
         { value: 'alphabetical', label: 'Alphabetically' },
       ];
-      if (featureRecentLocationsFilter && recentLocations?.length) {
+      if (featureRecentLocationsFilter && facilities?.length) {
         options.push({
           value: 'recentLocations',
           label: 'By recent locations',
@@ -92,7 +91,7 @@ export default function VAFacilityPageV2() {
       }
       return options;
     },
-    [featureRecentLocationsFilter, recentLocations],
+    [facilities, featureRecentLocationsFilter],
   );
 
   const uiSchema = {
@@ -305,7 +304,7 @@ export default function VAFacilityPageV2() {
                 dispatch(updateFacilitySortMethod(value, uiSchema)).then(
                   recordEvent({
                     event: `${GA_PREFIX}-updated-locations-sort--${
-                      sortOptions.find(option => option.value === value).label
+                      sortOptions.find(option => option.value === value)?.label
                     }`,
                   }),
                 ),

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -74,15 +74,17 @@ export default function VAFacilityPageV2() {
     () => {
       const options = [
         {
-          value: 'distanceFromResidentialAddress',
-          label: 'Closest to your home',
-        },
-        {
           value: 'distanceFromCurrentLocation',
           label: 'Closest to your current location',
         },
         { value: 'alphabetical', label: 'Alphabetically' },
       ];
+      if (!!address?.latitude && !!address?.longitude) {
+        options.push({
+          value: 'distanceFromResidentialAddress',
+          label: 'Closest to your home',
+        });
+      }
       if (featureRecentLocationsFilter && facilities?.length) {
         options.push({
           value: 'recentLocations',
@@ -91,7 +93,7 @@ export default function VAFacilityPageV2() {
       }
       return options;
     },
-    [facilities, featureRecentLocationsFilter],
+    [address, facilities?.length, featureRecentLocationsFilter],
   );
 
   const uiSchema = {

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -74,17 +74,15 @@ export default function VAFacilityPageV2() {
     () => {
       const options = [
         {
+          value: 'distanceFromResidentialAddress',
+          label: 'Closest to your home',
+        },
+        {
           value: 'distanceFromCurrentLocation',
           label: 'Closest to your current location',
         },
         { value: 'alphabetical', label: 'Alphabetically' },
       ];
-      if (!!address?.latitude && !!address?.longitude) {
-        options.push({
-          value: 'distanceFromResidentialAddress',
-          label: 'Closest to your home',
-        });
-      }
       if (featureRecentLocationsFilter && facilities?.length) {
         options.push({
           value: 'recentLocations',
@@ -93,7 +91,7 @@ export default function VAFacilityPageV2() {
       }
       return options;
     },
-    [address, facilities?.length, featureRecentLocationsFilter],
+    [facilities?.length, featureRecentLocationsFilter],
   );
 
   const uiSchema = {

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -83,7 +83,7 @@ export default function VAFacilityPageV2() {
         },
         { value: 'alphabetical', label: 'Alphabetically' },
       ];
-      if (featureRecentLocationsFilter && facilities?.length) {
+      if (featureRecentLocationsFilter) {
         options.push({
           value: 'recentLocations',
           label: 'By recent locations',
@@ -91,7 +91,7 @@ export default function VAFacilityPageV2() {
       }
       return options;
     },
-    [facilities?.length, featureRecentLocationsFilter],
+    [featureRecentLocationsFilter],
   );
 
   const uiSchema = {

--- a/src/applications/vaos/new-appointment/hooks/useOHDirectScheduling.js
+++ b/src/applications/vaos/new-appointment/hooks/useOHDirectScheduling.js
@@ -1,15 +1,13 @@
 import { shallowEqual, useSelector } from 'react-redux';
-import { getFacilityPageV2Info } from '../redux/selectors';
+import { getTypeOfCare, getFormData } from '../redux/selectors';
 import { selectFeatureOHDirectSchedule } from '../../redux/selectors';
 import { OH_ENABLED_TYPES_OF_CARE } from '../../utils/constants';
 
 export function useOHDirectScheduling() {
   const featureOHDirectSchedule = useSelector(selectFeatureOHDirectSchedule);
 
-  const { typeOfCare } = useSelector(
-    state => getFacilityPageV2Info(state),
-    shallowEqual,
-  );
+  const data = useSelector(state => getFormData(state), shallowEqual);
+  const typeOfCare = getTypeOfCare(data);
 
   return (
     featureOHDirectSchedule &&

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -38,13 +38,12 @@ import {
 } from './redux/actions';
 import { startNewVaccineFlow } from '../appointment-list/redux/actions';
 
-const AUDIOLOGY = '203';
 const VA_FACILITY_V2_KEY = 'vaFacilityV2';
 
 function isCCAudiology(state) {
   return (
     getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE &&
-    getFormData(state).typeOfCareId === AUDIOLOGY
+    getFormData(state).typeOfCareId === TYPE_OF_CARE_IDS.AUDIOLOGY_ID
   );
 }
 

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.unit.spec.jsx
@@ -355,7 +355,7 @@ describe('VAOS newAppointmentFlow', () => {
           newAppointment: {
             data: {
               facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-              typeOfCareId: '203',
+              typeOfCareId: TYPE_OF_CARE_IDS.AUDIOLOGY_ID,
             },
           },
         };
@@ -393,7 +393,7 @@ describe('VAOS newAppointmentFlow', () => {
           newAppointment: {
             data: {
               facilityType: 'va',
-              typeOfCareId: '203',
+              typeOfCareId: TYPE_OF_CARE_IDS.AUDIOLOGY_ID,
             },
           },
           featureToggles: {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -400,10 +400,6 @@ export default function formReducer(state = initialState, action) {
           ...state.facilities,
           [typeOfCareId]: facilities,
         },
-        sortedFacilities: {
-          ...state.sortedFacilities,
-          [typeOfCareId]: sortedFacilities,
-        },
         childFacilitiesStatus: FETCH_STATUS.succeeded,
         facilityPageSortMethod: sortMethod,
         showEligibilityModal: false,
@@ -521,8 +517,8 @@ export default function formReducer(state = initialState, action) {
         'properties.vaFacility',
         {
           type: 'string',
-          enum: typeOfCareFacilities?.map(facility => facility.id),
-          enumNames: typeOfCareFacilities,
+          enum: sortedFacilities?.map(facility => facility.id),
+          enumNames: sortedFacilities,
         },
         newSchema,
       );
@@ -534,10 +530,6 @@ export default function formReducer(state = initialState, action) {
         pages: {
           ...state.pages,
           vaFacilityV2: schema,
-        },
-        sortedFacilities: {
-          ...state.sortedFacilities,
-          [typeOfCareId]: sortedFacilities,
         },
         childFacilitiesStatus: FETCH_STATUS.succeeded,
         facilityPageSortMethod: sortMethod,

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -256,7 +256,7 @@ export function getFacilityPageV2Info(state) {
   } = newAppointment;
 
   const address = selectVAPResidentialAddress(state);
-  const facilities = newAppointment.facilities[(typeOfCare?.id)];
+  const facilities = newAppointment.sortedFacilities[(typeOfCare?.id)];
   const eligibility = selectEligibility(state);
 
   return {
@@ -279,7 +279,6 @@ export function getFacilityPageV2Info(state) {
     typeOfCare,
     cernerSiteIds: selectRegisteredCernerFacilityIds(state),
     fetchRecentLocationStatus: selectRecentLocationsStatus(state),
-    recentLocations: selectRecentLocations(state),
   };
 }
 

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -250,7 +250,7 @@ export function getFacilityPageV2Info(state) {
   } = newAppointment;
 
   const address = selectVAPResidentialAddress(state);
-  const facilities = newAppointment.sortedFacilities[(typeOfCare?.id)];
+  const facilities = newAppointment.facilities[(typeOfCare?.id)];
   const eligibility = selectEligibility(state);
 
   return {

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -49,8 +49,6 @@ export function getFormPageInfo(state, pageKey) {
   };
 }
 
-const AUDIOLOGY = '203';
-
 export function getTypeOfCare(data) {
   if (data.typeOfCareId === TYPE_OF_CARE_IDS.SLEEP_MEDICINE_ID) {
     return TYPES_OF_SLEEP_CARE.find(care => care.id === data.typeOfSleepCareId);
@@ -61,7 +59,7 @@ export function getTypeOfCare(data) {
   }
 
   if (
-    data.typeOfCareId === AUDIOLOGY &&
+    data.typeOfCareId === TYPE_OF_CARE_IDS.AUDIOLOGY_ID &&
     data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
   ) {
     return AUDIOLOGY_TYPES_OF_CARE.find(
@@ -237,10 +235,6 @@ export function selectSingleSupportedVALocation(state) {
 
 export function selectRecentLocationsStatus(state) {
   return getNewAppointment(state).fetchRecentLocationStatus;
-}
-
-export function selectRecentLocations(state) {
-  return getNewAppointment(state).recentLocations;
 }
 
 export function getFacilityPageV2Info(state) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated redux code to ensure only one facilities API call is made on the choose a facility page
- Consolidated and cleaned up code to reduce duplication
- Appointments FE Team
- This work is behind the Flipper toggle `vaOnlineSchedulingRecentLocationsFilter`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110235

## Testing done

- Tested locally under the following scenarios
  - vaOnlineSchedulingRecentLocationsFilter = true, residential address available
  - vaOnlineSchedulingRecentLocationsFilter = true, residential address not available
  - vaOnlineSchedulingRecentLocationsFilter = false, residential address available
  - vaOnlineSchedulingRecentLocationsFilter = false, residential address not available
- For each scenario:
  - Tested to ensure the correct default sort method is used upon reaching the page
  - Tested to ensure switching between the different sort methods work as intended
- Ensured existing tests pass
- Ensured that only one facilities API call is made instead of two

## Screenshots

Captured locally so the measured timing is not representative of real API calls.

|         | API Calls |
| ------- | ------ |
| Before  |    <img width="727" alt="image" src="https://github.com/user-attachments/assets/cd5eed6b-9256-40c6-aade-d1b1dd83ebc4" />    |
| After  |    <img width="722" alt="image" src="https://github.com/user-attachments/assets/61df5507-c38d-4d12-af53-32a33918ec05" />    |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
