### PR TITLE
Remove address line 2 and 3 from covid location page

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/VAFacilityPage/ResidentialAddress.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/VAFacilityPage/ResidentialAddress.jsx
@@ -10,18 +10,6 @@ export default function ResidentialAddress({ address }) {
       <span className="vads-u-display--block vads-u-padding-y--0p5 vads-u-margin-bottom--3">
         {address.addressLine1}
         <br />
-        {!!address.addressLine2 && (
-          <>
-            address.addressLine2
-            <br />
-          </>
-        )}
-        {!!address.addressLine3 && (
-          <>
-            address.addressLine3
-            <br />
-          </>
-        )}
         {address.city}, <State state={address.stateCode} /> {address.zipCode}
       </span>
     </>

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -608,8 +608,8 @@ const responses = {
           },
           residentialAddress: {
             addressLine1: '345 Home Address St.',
-            addressLine2: null,
-            addressLine3: null,
+            addressLine2: 'line 2',
+            addressLine3: 'line 3',
             addressPou: 'RESIDENCE/CHOICE',
             addressType: 'DOMESTIC',
             city: 'San Francisco',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Do not try to display address line 2 and 3 on the Choose a VA location page of the covid appointment flow
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110997

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="418" alt="image" src="https://github.com/user-attachments/assets/e5e2c259-0489-4f5c-ae77-cbddac5b02c5" />    |   <img width="422" alt="image" src="https://github.com/user-attachments/assets/6726bcc5-c1db-41ee-a3f6-5b6b5f1fc91f" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

