### PR TITLE
Updated MhvTemporaryAccess Redirect

### DIFF
--- a/src/applications/login/containers/MhvTemporaryAccess.jsx
+++ b/src/applications/login/containers/MhvTemporaryAccess.jsx
@@ -36,20 +36,22 @@ export default function MhvTemporaryAccess() {
         />
       </div>
       <div className="columns small-12 vads-u-padding--0">
-        <h2>Help and support</h2>
-        <h3>Change your password</h3>
-        <p className="vads-u-margin-bottom--0">
-          If you want to change your My HealtheVet password, sign in here
-          instead.
+        <h2>Manage your My HealtheVet account</h2>
+        <h3 className="vads-u-margin-top--0">
+          View or update account information
+        </h3>
+        <p className="vads-u-measure--4 vads-u-margin-bottom--0">
+          To view your account activity or change your password, sign in here
+          and navigate to <strong>Account Information</strong>.
         </p>
         <va-link-action
-          text="Update your password"
+          text="Manage your account"
           type="secondary"
           onClick={e => {
             e.preventDefault();
             sessionStorage.setItem(
               AUTHN_SETTINGS.RETURN_URL,
-              'https://eauth.va.gov/mhv-portal-web/change-password',
+              'https://eauth.va.gov/mhv-portal-web/eauth',
             );
             login({
               policy: 'mhv',
@@ -58,7 +60,8 @@ export default function MhvTemporaryAccess() {
           }}
           data-testid="updateMhvBtn"
         />
-        <h3>Forgot your password</h3>
+        <h2>Help and support</h2>
+        <h3 className="vads-u-margin-top--0">Recover forgotten password</h3>
         <p className="vads-u-measure--4 vads-u-margin-bottom--0">
           If you forgot your My HealtheVet password, you can submit personal
           information to recover it.
@@ -69,7 +72,7 @@ export default function MhvTemporaryAccess() {
           href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/forgot-password?action=new"
           data-testid="recoverMhvBtn"
         />
-        <h3>Get more support</h3>
+        <h3>Get support</h3>
         <p>
           For all other questions, contact the administrator who gave you access
           to this page.

--- a/src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx
+++ b/src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('MhvTemporaryAccess', () => {
     const loginStub = sinon.stub(authUtilities, 'login');
     const screen = renderInReduxProvider(<MhvTemporaryAccess />);
     const updateHeading = screen.getByRole('heading', {
-      name: /change your password/i,
+      name: /View or update account information/i,
     });
     expect(updateHeading).to.exist;
     const accessButton = await screen.findByTestId('updateMhvBtn');
@@ -56,7 +56,7 @@ describe('MhvTemporaryAccess', () => {
 
     fireEvent.click(accessButton);
     expect(sessionStorage.getItem(AUTHN_SETTINGS.RETURN_URL)).to.equal(
-      'https://eauth.va.gov/mhv-portal-web/change-password',
+      'https://eauth.va.gov/mhv-portal-web/eauth',
     );
 
     await waitFor(() => {
@@ -72,7 +72,7 @@ describe('MhvTemporaryAccess', () => {
   it('renders recover password link', () => {
     const screen = renderInReduxProvider(<MhvTemporaryAccess />);
     const recoverHeading = screen.getByRole('heading', {
-      name: /forgot your password/i,
+      name: /Recover forgotten password/i,
     });
     expect(recoverHeading).to.exist;
     const recoverLink = screen.getByTestId('recoverMhvBtn');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated the content in `MhvTemporaryAccess.jsx` and added a new redirect for the "Update Password" button.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/398)

## Testing done
- Updated `MhvTemporaryAccess.unit.spec.jsx` and ran tests locally.
- Can be replicated by running `yarn test:unit src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx` as well as `yarn cy:run --spec src/applications/login/tests/mhv-access-page.cypress.spec.js`.

## Screenshots
| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/e025e7d3-8fbc-41b2-81aa-9d56b577cd9c) | ![after](https://github.com/user-attachments/assets/5b644bcf-c23e-48f1-a7ba-efaf1b3156d0) |

## What areas of the site does it impact?
This only impacts `MhvTemporaryAccess.jsx` and its related tests.

## Acceptance criteria
- [x] Update content in `MhvTemporaryAccess.jsx`
- [x] Update "Change Password" button to redirect to `https://eauth.va.gov/mhv-portal-web/eauth`