### PR TITLE
Fix 0% disability rating bug in Profile and NameTag

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -28,7 +28,7 @@ const disabilityRatingClassesSmall = prefixUtilityClasses(
 
 const dtRatingClasses = prefixUtilityClasses(['margin-right--0p5'], 'medium');
 
-const DisabilityRatingContent = ({ rating }) => {
+const DisabilityRatingContent = ({ rating, ratingIsValid }) => {
   const classes = [
     ...disabilityRatingClasses,
     ...disabilityRatingClassesMedium,
@@ -36,14 +36,14 @@ const DisabilityRatingContent = ({ rating }) => {
   ].join(' ');
   return (
     <div className={classes}>
-      <dt className={rating ? dtRatingClasses : null}>
-        {rating ? `Your disability rating:` : null}
+      <dt className={ratingIsValid ? dtRatingClasses : null}>
+        {ratingIsValid ? `Your disability rating:` : null}
       </dt>
       <dd>
         <a
           href="/disability/view-disability-rating/rating"
           aria-label={
-            rating
+            ratingIsValid
               ? `${rating} percent service connected disability rating`
               : 'Review your disability rating'
           }
@@ -51,7 +51,7 @@ const DisabilityRatingContent = ({ rating }) => {
           style={{ whiteSpace: 'nowrap' }}
         >
           <strong>
-            {rating
+            {ratingIsValid
               ? `${rating}% service connected`
               : 'Review your disability rating'}
           </strong>
@@ -68,6 +68,7 @@ const DisabilityRatingContent = ({ rating }) => {
 
 DisabilityRatingContent.propTypes = {
   rating: PropTypes.number,
+  ratingIsValid: PropTypes.bool,
 };
 
 const DisabilityRating = ({ rating, showFallbackLink }) => {
@@ -75,8 +76,12 @@ const DisabilityRating = ({ rating, showFallbackLink }) => {
     return <DisabilityRatingContent />;
   }
 
-  if (rating) {
-    return <DisabilityRatingContent rating={rating} />;
+  const ratingIsValid = rating !== undefined && rating !== null;
+
+  if (ratingIsValid) {
+    return (
+      <DisabilityRatingContent rating={rating} ratingIsValid={ratingIsValid} />
+    );
   }
 
   return null;

--- a/src/applications/personalization/components/NameTag.unit.spec.jsx
+++ b/src/applications/personalization/components/NameTag.unit.spec.jsx
@@ -84,6 +84,20 @@ describe('<NameTag>', () => {
       });
     });
   });
+  context('when `totalDisabilityRating` is zero', () => {
+    it('should render the disability rating', () => {
+      const initialState = getInitialState();
+      const view = render(<NameTag totalDisabilityRating={0} />, {
+        initialState,
+      });
+      view.getByText(/your disability rating:/i);
+      view.getByRole('link', {
+        name: /0 percent service connected disability rating/i,
+        text: /0% service connected/i,
+        href: /disability\/view-disability-rating\/rating/i,
+      });
+    });
+  });
   context(
     "when `totalDisabilityRating` is not set and there isn't a server error",
     () => {

--- a/src/applications/personalization/profile/components/personal-information/DisabilityRating.jsx
+++ b/src/applications/personalization/profile/components/personal-information/DisabilityRating.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { API_NAMES } from '~/applications/personalization/common/constants';
 import { canAccess } from '../../../common/selectors';
 import { totalDisabilityError } from '../../../common/selectors/ratedDisabilities';
 import { SingleFieldLoadFailAlert } from '../alerts/LoadFail';
-import { API_NAMES } from '~/applications/personalization/common/constants';
 
 const DisabilityRating = () => {
   const hasError = useSelector(totalDisabilityError);
   const rating = useSelector(state => state.totalRating?.totalDisabilityRating);
   const canAccessRatingInfo = useSelector(canAccess)?.[API_NAMES.RATING_INFO];
 
-  const shouldShowRating = canAccessRatingInfo && rating;
+  const shouldShowRating =
+    canAccessRatingInfo && rating !== undefined && rating !== null;
 
   return (
     <div>

--- a/src/applications/personalization/profile/tests/components/personal-information/DisabilityRating.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/DisabilityRating.unit.spec.jsx
@@ -23,6 +23,14 @@ describe('Personal Info - Disability Rating', () => {
     expect(tree.getByText(/40% service connected/i)).to.exist;
   });
 
+  it('should render a Disability Rating of zero', () => {
+    const happyState = createHappyState();
+    const tree = render(<DisabilityRating />, {
+      initialState: set(happyState, 'totalRating.totalDisabilityRating', 0),
+    });
+    expect(tree.getByText(/0% service connected/i)).to.exist;
+  });
+
   it('should render an error alert if totalRating has error state', () => {
     const happyState = createHappyState();
     const tree = render(<DisabilityRating />, {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

There is a bug in which users with a 0% disability rating don't see their rating in the nametag or in their personal information on the profile, because the code treated a rating of 0 as a falsey/null value. Since 0 is a valid rating, we need to display this information.

- Added an explicit check for valid rating values in the `NameTag` andd `DisabilityRating` components (e.g., instead of checking `if (rating)`, check for `rating !== null && rating !== undefined`)
- Added the `ratingIsValid` check in the `NameTag` component and passed it as a prop to `DisabilityRatingContent`

The Authenticated Experience team owns this work

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/110822

## Testing done

- Manually tested the profile personal information page and the nametag in local environment to confirm that the disability rating section behaves as expected for different user states
  - confirmed ratings >= 0 are displayed as "[X]% service connected" in both locations
  - for null/undefined ratings
    - confirmed nothing displays in the nametag
    - confirmed the personal information page shows "Our records show that you don't have a service rating"
- Added unit tests for the `rating = 0` case

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="948" alt="Screenshot 2025-06-06 at 2 06 15 PM" src="https://github.com/user-attachments/assets/2f6ffbc9-fc5d-48e7-8025-1a7fb9c69297" /> | <img width="915" alt="Screenshot 2025-06-06 at 2 07 40 PM" src="https://github.com/user-attachments/assets/94205cc3-cdde-4b24-89b8-c6c44d73443f" /> |

## What areas of the site does it impact?
Nametag, Profile > Personal Information

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
