### PR TITLE
Display schedule link when showScheduleLink is true

### DIFF
--- a/src/applications/vaos/components/StatusAlert.jsx
+++ b/src/applications/vaos/components/StatusAlert.jsx
@@ -105,6 +105,7 @@ export default function StatusAlert({ appointment, facility }) {
   if (canceled) {
     const who = canceler.get(appointment?.cancelationReason) || 'Facility';
     let message;
+    let linkText;
     let displayScheduleLink = false;
     if (appointment.type === 'COMMUNITY_CARE_APPOINTMENT') {
       message = `${who} canceled this appointment. If you still want this appointment, call your community care provider to schedule.`;
@@ -113,8 +114,11 @@ export default function StatusAlert({ appointment, facility }) {
     } else if (appointment.vaos.isPendingAppointment) {
       message = `${who} canceled this request. If you still want this appointment, call your VA health facility or submit another request online.`;
       displayScheduleLink = true;
+      linkText = 'Request a new appointment';
     } else {
       message = `${who} canceled this appointment. If you still want this appointment, call your VA health facility to schedule.`;
+      displayScheduleLink = appointment.showScheduleLink;
+      linkText = 'Schedule a new appointment';
     }
     return (
       <>
@@ -125,7 +129,7 @@ export default function StatusAlert({ appointment, facility }) {
               <br />
               <br />
               <va-link
-                text="Request a new appointment"
+                text={linkText}
                 data-testid="schedule-appointment-link"
                 onClick={handleClick(dispatch)}
                 href={`${root.url}${typeOfCare.url}`}
@@ -173,6 +177,7 @@ StatusAlert.propTypes = {
     status: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     cancelationReason: PropTypes.string,
+    showScheduleLink: PropTypes.bool,
     created: PropTypes.string,
     avsPath: PropTypes.string,
     vaos: PropTypes.shape({

--- a/src/applications/vaos/components/StatusAlert.unit.spec.jsx
+++ b/src/applications/vaos/components/StatusAlert.unit.spec.jsx
@@ -128,6 +128,36 @@ describe('VAOS Component: StatusAlert', () => {
       expect(screen.queryByTestId('schedule-appointment-link')).to.not.exist;
     });
 
+    it('Should display schedule link for canceled VA appointments when showScheduleLink=true', () => {
+      const mockAppointment = new MockAppointment();
+      mockAppointment.setStatus('cancelled');
+      mockAppointment.setCancelationReason('pat');
+      mockAppointment.setShowScheduleLink(true);
+
+      const screen = renderWithStoreAndRouter(
+        <StatusAlert appointment={mockAppointment} facility={facilityData} />,
+        {
+          initialState,
+          path: `/${mockAppointment.id}`,
+        },
+      );
+      expect(screen.baseElement).to.contain('.usa-alert-error');
+      expect(screen.baseElement).to.contain.text(
+        'You canceled this appointment',
+      );
+      expect(screen.baseElement).to.contain.text(
+        'If you still want this appointment, call your VA health facility to schedule.',
+      );
+      expect(
+        screen.container.querySelector(
+          'va-link[text="Schedule a new appointment"]',
+        ),
+      ).to.be.ok;
+
+      expect(screen.queryByTestId('review-appointments-link')).to.not.exist;
+      expect(screen.queryByTestId('schedule-appointment-link')).to.exist;
+    });
+
     it('Should display for canceled CC appointments', () => {
       const mockAppointment = new MockAppointment();
       mockAppointment.setType('COMMUNITY_CARE_APPOINTMENT');
@@ -196,6 +226,11 @@ describe('VAOS Component: StatusAlert', () => {
       expect(screen.baseElement).to.contain.text(
         'If you still want this appointment, call your VA health facility or submit another request online.',
       );
+      expect(
+        screen.container.querySelector(
+          'va-link[text="Request a new appointment"]',
+        ),
+      ).to.be.ok;
 
       expect(screen.queryByTestId('review-appointments-link')).to.not.exist;
       expect(screen.queryByTestId('schedule-appointment-link')).to.exist;

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -274,6 +274,7 @@ export function transformVAOSAppointment(
     modality: appt.modality,
     status: appt.status,
     cancelationReason: appt.cancelationReason?.coding?.[0].code || null,
+    showScheduleLink: appt.showScheduleLink,
     avsPath: isPast ? appt.avsPath : null,
     // NOTE: Timezone will be converted to the local timezone when using 'format()'.
     // So use format without the timezone information.

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -5197,6 +5197,7 @@
         "pending": false,
         "past": true,
         "future": false,
+        "showScheduleLink": true,
         "travelPayClaim": {
           "metadata": {
             "status": 200,

--- a/src/applications/vaos/tests/fixtures/MockAppointment.js
+++ b/src/applications/vaos/tests/fixtures/MockAppointment.js
@@ -21,6 +21,7 @@ export class MockAppointment {
   constructor({ id = 1, start = new Date(), status = 'booked' } = {}) {
     this.avsPath = null;
     this.cancelationReason = null;
+    this.showScheduleLink = null;
     this.comment = null;
     this.communityCareProvider = null;
     this.description = null;
@@ -126,6 +127,11 @@ export class MockAppointment {
 
   setCancelationReason(value) {
     this.cancelationReason = value;
+    return this;
+  }
+
+  setShowScheduleLink(value) {
+    this.showScheduleLink = value;
     return this;
   }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Display schedule link on cancelled appointments when showScheduleLink is true
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110159

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   ![image](https://github.com/user-attachments/assets/a831025f-48f4-446a-a828-fecc63935c85)    |   ![image](https://github.com/user-attachments/assets/3f75fe40-f961-4c8f-9587-77d4c324b9bf)   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


