### PR TITLE
Updated MhvTemporaryAccess Content

### DIFF
--- a/src/applications/login/containers/MhvTemporaryAccess.jsx
+++ b/src/applications/login/containers/MhvTemporaryAccess.jsx
@@ -36,13 +36,13 @@ export default function MhvTemporaryAccess() {
         />
       </div>
       <div className="columns small-12 vads-u-padding--0">
-        <h2>Manage your My HealtheVet account</h2>
+        <h2>Manage your account</h2>
         <h3 className="vads-u-margin-top--0">
-          View or update account information
+          Account information and password
         </h3>
         <p className="vads-u-measure--4 vads-u-margin-bottom--0">
-          To view your account activity or change your password, sign in here
-          and navigate to <strong>Account Information</strong>.
+          Sign in here and navigate to <strong>Account Information</strong> to
+          view your My HealtheVet account activity or change your password.
         </p>
         <va-link-action
           text="Manage your account"

--- a/src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx
+++ b/src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('MhvTemporaryAccess', () => {
     const loginStub = sinon.stub(authUtilities, 'login');
     const screen = renderInReduxProvider(<MhvTemporaryAccess />);
     const updateHeading = screen.getByRole('heading', {
-      name: /View or update account information/i,
+      name: /Account information and password/i,
     });
     expect(updateHeading).to.exist;
     const accessButton = await screen.findByTestId('updateMhvBtn');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated the content in `MhvTemporaryAccess.jsx`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/401)

## Testing done
- Updated `MhvTemporaryAccess.unit.spec.jsx` and ran tests locally.
- Can be replicated by running `yarn test:unit src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx` as well as `yarn cy:run --spec src/applications/login/tests/mhv-access-page.cypress.spec.js`.

## Screenshots
| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/6100eb39-0dbb-4f86-a884-ef6e5a359115) | ![after](https://github.com/user-attachments/assets/c569e6e7-5061-40ed-90b2-9fc6037cd125) |

## What areas of the site does it impact?
This only impacts `MhvTemporaryAccess.jsx` and its related tests.

## Acceptance criteria
- [x] Update content in `MhvTemporaryAccess.jsx`
- [x] Update tests