### PR TITLE
Use extended scrollAndFocus from vaos app in layout component

### DIFF
--- a/src/applications/vaos/referral-appointments/components/ReferralLayout.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralLayout.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import DowntimeNotification, {
   externalServices,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
-import { scrollAndFocus } from 'platform/utilities/scroll';
+import { scrollAndFocus } from '../../utils/scrollAndFocus';
 import NeedHelp from '../../components/NeedHelp';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import WarningNotification from '../../components/WarningNotification';
@@ -23,17 +23,10 @@ export default function ReferralLayout({
   const location = useLocation();
 
   const content = apiFailure ? <ErrorAlert body={errorBody} /> : children;
-  const h1Ref = React.createRef();
 
-  useEffect(
-    () => {
-      // only on load
-      if (h1Ref.current) {
-        scrollAndFocus(h1Ref.current);
-      }
-    },
-    [h1Ref],
-  );
+  useEffect(() => {
+    scrollAndFocus();
+  }, []);
 
   return (
     <>
@@ -58,9 +51,7 @@ export default function ReferralLayout({
               </span>
             )}
             {heading && (
-              <h1 ref={h1Ref} data-testid="referral-layout-heading">
-                {heading}
-              </h1>
+              <h1 data-testid="referral-layout-heading">{heading}</h1>
             )}
             <ErrorBoundary>
               {!!loadingMessage && (


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Replace useRef and scrollAndFocus from platform, with the Vaos application extended scrollAndFocus that has some basic JS to target H1s. This fixes the issue where on some actions, like on the onChange when a time is chosen in the CalendarWidget, when the app re-renders focus is not stolen by the useEffect in the ReferralLayout component. 

## Related issue(s)

- [[LB]Staging Review finding: Focus management on calendar selection #111494](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111494)

## Testing done

- When a user clicked or interacted with a time form input in the calendar widget when scheduling an appointment, the browser focus would jump back to the H1 of the page.  
- To test if this is working, from the referral page (/my-health/appointments/referrals-requests), step through the process to schedule an appointment. When choosing a date and time, when clicking the time after choosing a date, the focus would jump back to the H1, showing it with the yellow border. 
- Besides clicking the button with a mouse, I also used keyboard navigation to make sure I didn't lose my place after selecting a date and using arrow keys to choose a time. 

## Screenshots

Before:

![LB111494_before](https://github.com/user-attachments/assets/7d31de96-2aaa-4402-8041-1e1f1b174b8a)
After:
![LB111494_after](https://github.com/user-attachments/assets/2d0eb26a-abc9-48bc-baee-3a837abe1ddf)

## What areas of the site does it impact?

This update only affects the layout component of the Referral portion of vaos application. 

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
