### PR TITLE
EZR: Enables the DELETE button on the EC and NoK forms

### DIFF
--- a/src/applications/ezr/definitions/emergencyContacts.js
+++ b/src/applications/ezr/definitions/emergencyContacts.js
@@ -119,7 +119,6 @@ export const emergencyContactsSummaryPage = (options = {}) => ({
   uiSchema: {
     'view:hasEmergencyContacts': arrayBuilderYesNoUI(options, {
       title: content['emergency-contact-add-contacts-label'],
-      titleHeaderLevel: 'h2',
       hint: content['emergency-contact-hint-text'],
     }),
   },

--- a/src/applications/ezr/definitions/nextOfKin.js
+++ b/src/applications/ezr/definitions/nextOfKin.js
@@ -119,7 +119,6 @@ export const nextOfKinSummaryPage = (options = {}) => ({
   uiSchema: {
     'view:hasNextOfKin': arrayBuilderYesNoUI(options, {
       title: content['next-of-kin-add-contacts-label'],
-      titleHeaderLevel: 'h2',
       hint: content['next-of-kin-hint-text'],
     }),
   },

--- a/src/applications/ezr/sass/_listLoopPattern.scss
+++ b/src/applications/ezr/sass/_listLoopPattern.scss
@@ -12,7 +12,3 @@ legend.schemaform-block-title:focus { outline: none !important; }
  // Hack to hide the contact type field, because we only allow Primary Next of Kin and
 // the forms pattern forces display of the field
 va-select[name$="_contactType"] { display: none; }
-
-// Hack to hide DELETE button in the list loop for EC/NoK until we implement Delete
-va-card[name^="next of kin"] va-button-icon[data-action="remove"] { display: none; }
-va-card[name^="emergency contact"] va-button-icon[data-action="remove"] { display: none; }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds back the DELETE buttons to the EC and NoK forms

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#106040

## Testing done

- Manual testing

## Screenshots

<img width="705" alt="image" src="https://github.com/user-attachments/assets/79074235-a448-4023-9976-f10a597c7936" />

<img width="707" alt="image" src="https://github.com/user-attachments/assets/bb98e260-b62b-473a-ad74-fb69a81b0620" />

## What areas of the site does it impact?

Form 10-10 EZR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
