### PR TITLE
Correct form ID

### DIFF
--- a/src/applications/new-28-1900/tests/e2e/save-in-progress.cypress.spec.jsx
+++ b/src/applications/new-28-1900/tests/e2e/save-in-progress.cypress.spec.jsx
@@ -1,0 +1,40 @@
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+
+import formConfig from '../../config/form';
+import manifest from '../../manifest.json';
+import userSip from '../fixtures/mocks/user-sip.json';
+import submit from '../fixtures/mocks/submit.json';
+import featureToggles from '../fixtures/mocks/featureToggles.json';
+import minimalFlow from '../fixtures/data/minimalFlow.json';
+import mockPrefill from '../fixtures/mocks/sip-get.json';
+import mockInProgress from '../fixtures/mocks/sip-put.json';
+// This test ensures that the save-in-progress functionality of the 28-1900 form works as expected.
+const testConfig = createTestConfig(
+  {
+    dataPrefix: 'data',
+    dataDir: null,
+    dataSets: [{ title: 'save in progress', data: minimalFlow }],
+
+    pageHooks: {
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.contains('button', 'Continue your application').click();
+        });
+      },
+    },
+
+    setupPerTest: () => {
+      cy.intercept('GET', '/v0/user', userSip);
+      cy.intercept('/v0/feature_toggles*', featureToggles);
+      cy.intercept('PUT', '/v0/in_progress_forms/28-1900_V2', mockInProgress);
+      cy.intercept('GET', '/v0/in_progress_forms/28-1900_V2', mockPrefill);
+      cy.intercept('POST', '/v0/veteran_readiness_employment_claims', submit);
+      cy.login(userSip);
+    },
+  },
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);

--- a/src/applications/new-28-1900/tests/fixtures/mocks/local-mock-responses.js
+++ b/src/applications/new-28-1900/tests/fixtures/mocks/local-mock-responses.js
@@ -1,6 +1,7 @@
 // use this file to mock api responses for local development
 // yarn mock-api --responses src/applications/new-28-1900/tests/fixtures/mocks/local-mock-responses.js
 const mockUser = require('./user.json');
+// const mockSipUser = require('./user-sip.json');
 const mockFeatureToggles = require('./featureToggles.json');
 const mockSipPut = require('./sip-put.json');
 const mockSipGet = require('./sip-get.json');
@@ -8,6 +9,7 @@ const submissionStatues = require('./submission-statuses.json');
 
 const responses = {
   'GET /v0/user': mockUser,
+  // 'GET /v0/user': mockSipUser,
 
   'GET /v0/maintenance_windows': { data: [] },
   'GET /v0/feature_toggles': mockFeatureToggles,

--- a/src/applications/new-28-1900/tests/fixtures/mocks/user-sip.json
+++ b/src/applications/new-28-1900/tests/fixtures/mocks/user-sip.json
@@ -24,7 +24,27 @@
         "is_veteran": true,
         "served_in_military": true
       },
-      "in_progress_forms": [],
+      "in_progress_forms": [
+        {
+          "form": "28-1900_V2",
+          "metadata": {
+            "version": 0,
+            "returnUrl": "/reason-for-visit",
+            "savedAt": 1608147143961,
+            "submission": {
+              "status": false,
+              "errorMessage": false,
+              "id": false,
+              "timestamp": false,
+              "hasAttemptedSubmit": false
+            },
+            "expiresAt": 9999999999,
+            "lastUpdated": 1608147144,
+            "inProgressFormId": 1234
+          },
+          "lastUpdated": 1608147144
+        }
+      ],
       "prefills_available": ["28-1900"],
       "services": [
         "facilities",

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -175,7 +175,7 @@ export const getAllFormLinks = getAppUrlImpl => {
     [VA_FORM_IDS.FORM_26_1880]: `${tryGetAppUrl('coe')}/`,
     [VA_FORM_IDS.FORM_26_4555]: `${tryGetAppUrl('4555-adapted-housing')}/`,
     [VA_FORM_IDS.FORM_28_1900]: `${tryGetAppUrl('28-1900-chapter-31')}/`,
-    [VA_FORM_IDS.FORM_28_1900]: `${tryGetAppUrl('new-28-1900-chapter-31')}/`,
+    [VA_FORM_IDS.FORM_28_1900_V2]: `${tryGetAppUrl('new-28-1900-chapter-31')}/`,
     [VA_FORM_IDS.FORM_28_8832]: `${tryGetAppUrl(
       '25-8832-planning-and-career-guidance',
     )}/`,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes an issue where when the form is saved for later, a draft doesn't appear on MyVA.
- I work for VA IIR and we own this form

## Related issue(s)

[VA IIR ticket #1768](https://github.com/department-of-veterans-affairs/va-iir/issues/1768)

## Testing done

### To run the test:
1. Run the site
```
yarn watch --env entry=new-28-1900-chapter-31
```
2. Run Cypress
```
3. yarn cy:run --spec "src/applications/new-28-1900/tests/e2e/*"
```
4. You should see a new test, `save-in-progress.cypress.spec.jsx`, that handles when the form is in progress.

### To manually test that the card appears on MyVA:

1. Run the API
```
yarn mock-api --responses src/applications/new-28-1900/tests/fixtures/mocks/local-mock-responses.js
```
2. Edit that file, commenting in `mockSipUser`.

3. Run `vets-website`
```
yarn watch
```
4. Visit http://localhost:3001/my-va/. At the bottom of the page you should see the "Benefit applications and forms" section and a draft listed for the new form.


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<img width="490" alt="Screenshot 2025-06-10 at 3 48 58 PM" src="https://github.com/user-attachments/assets/dc266f60-e2ee-4e6c-bbc8-80c67179e834" />

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
