### PR TITLE
Ask VA: Do not overwrite existing businessEmail/businessPhone values

### DIFF
--- a/src/applications/ask-va/config/submit-transformer.js
+++ b/src/applications/ask-va/config/submit-transformer.js
@@ -52,13 +52,17 @@ export default function submitTransformer(formData, uploadFiles) {
   let schoolCode;
 
   if (formData?.emailAddress) {
-    formData.businessEmail = formData.emailAddress;
+    if (!formData?.businessEmail) {
+      formData.businessEmail = formData.emailAddress;
+    }
   } else {
     formData.emailAddress = formData.businessEmail;
   }
 
   if (formData?.phoneNumber) {
-    formData.businessPhone = formData.phoneNumber;
+    if (!formData?.businessPhone) {
+      formData.businessPhone = formData.phoneNumber;
+    }
   } else {
     formData.phoneNumber = formData.businessPhone;
   }

--- a/src/applications/ask-va/tests/config/submit-transformer.unit.spec.jsx
+++ b/src/applications/ask-va/tests/config/submit-transformer.unit.spec.jsx
@@ -112,4 +112,62 @@ describe('Ask VA submit transformer', () => {
       },
     });
   });
+
+  it('should use businessEmail when emailAddress is not present', () => {
+    const formData = {
+      businessEmail: 'business@test.com',
+      school: null,
+      stateOfTheFacility: 'NY',
+    };
+    const result = submitTransformer(formData);
+    expect(result.emailAddress).to.equal('business@test.com');
+    expect(result.businessEmail).to.equal('business@test.com');
+  });
+
+  it('should use businessPhone when phoneNumber is not present', () => {
+    const formData = {
+      businessPhone: '123-456-7890',
+      school: null,
+      stateOfTheFacility: 'NY',
+    };
+    const result = submitTransformer(formData);
+    expect(result.phoneNumber).to.equal('123-456-7890');
+    expect(result.businessPhone).to.equal('123-456-7890');
+  });
+
+  it('should preserve businessEmail when both email fields exist', () => {
+    const formData = {
+      school: null,
+      stateOfTheFacility: 'NY',
+      emailAddress: 'personal@test.com',
+      businessEmail: 'business@test.com',
+    };
+    const result = submitTransformer(formData);
+    expect(result.emailAddress).to.equal('personal@test.com');
+    expect(result.businessEmail).to.equal('business@test.com');
+  });
+
+  it('should preserve businessPhone when both phone fields exist', () => {
+    const formData = {
+      phoneNumber: '111-222-3333',
+      school: null,
+      stateOfTheFacility: 'NY',
+      businessPhone: '123-456-7890',
+    };
+    const result = submitTransformer(formData);
+    expect(result.phoneNumber).to.equal('111-222-3333');
+    expect(result.businessPhone).to.equal('123-456-7890');
+  });
+
+  it('should handle missing email and phone fields', () => {
+    const formData = {
+      school: null,
+      stateOfTheFacility: 'NY',
+    };
+    const result = submitTransformer(formData);
+    expect(result.emailAddress).to.be.undefined;
+    expect(result.businessEmail).to.be.undefined;
+    expect(result.phoneNumber).to.be.undefined;
+    expect(result.businessPhone).to.be.undefined;
+  });
 });


### PR DESCRIPTION
Add a check that prevents the businessEmail/businessPhone from being overwritten

See [1877](https://github.com/department-of-veterans-affairs/ask-va/issues/1877). In [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/35826), new logic was added to prevent an empty businessEmail or businessPhone being submitted.  This accidentally overwrote these fields if values *are* included.  This PR makes a check to see if that field is empty before overwriting it

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

I work on the VA-IIR team, but we are watching the Ask VA component while that team is experiencing a contract gap.  @beckyphung raised this issue with me in this [DSVA Slack Thread](https://dsva.slack.com/archives/C06LN37RT47/p1749244530502039).  In short, the form submit transformer is currently overwriting the user's email address, ignoring what is submitted in the form and instead preferring what comes from Profile.

The original PR to do this work is lacking in tests and much explanation, and the original engineer is not reachable.  I am relatively confident that this fix will do the trick, but this code is located in an area where it is difficult to get a feature toggle.  We will monitor form submissions once the code makes it up to staging.

## Related issue(s)

- [Slack Convo](https://dsva.slack.com/archives/C06LN37RT47/p1749244530502039)
- [Github Issue](https://github.com/department-of-veterans-affairs/ask-va/issues/1877)

## Testing done

- In the formData, the `businessEmail` was being overwritten on submit
- Now, if the `businessEmail` or `businessPhone` value already exists, do not overwrite them.
- Code manually executed in terminal.

## What areas of the site does it impact?

* https://staging.va.gov/contact-us/ask-va

## Acceptance criteria

- when form us submitted, do not overwrite the fields if values exist.

### Quality Assurance & Testing

- [x] I **added** unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
