### PR TITLE
Send vaos-facilities-not-listed-click when user opens additional infobox

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -20,7 +20,7 @@ export default function FacilitiesNotShown() {
         <va-additional-info
           data-testid="facility-not-listed"
           trigger="If you can't find your facility on the list"
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={() => setIsOpen(true)}
           uswds
         >
           <p className="vads-u-margin-top--0">

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -4,14 +4,14 @@ import NewTabAnchor from '../../../components/NewTabAnchor';
 import { GA_PREFIX } from '../../../utils/constants';
 
 export default function FacilitiesNotShown() {
-  const [isOpen, setIsOpen] = useState(false);
+  const [infoClicked, setInfoClicked] = useState(false);
   useEffect(
     () => {
-      if (isOpen) {
+      if (infoClicked) {
         recordEvent({ event: `${GA_PREFIX}-facilities-not-listed-click` });
       }
     },
-    [isOpen],
+    [infoClicked],
   );
 
   return (
@@ -20,7 +20,7 @@ export default function FacilitiesNotShown() {
         <va-additional-info
           data-testid="facility-not-listed"
           trigger="If you can't find your facility on the list"
-          onClick={() => setIsOpen(true)}
+          onClick={() => setInfoClicked(true)}
           uswds
         >
           <p className="vads-u-margin-top--0">

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -1,25 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 
 // eslint-disable-next-line import/no-unresolved
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import { GA_PREFIX } from '../../../utils/constants';
 import NewTabAnchor from '../../../components/NewTabAnchor';
 
-export default function FacilitiesNotShown({ sortMethod }) {
+export default function FacilitiesNotShown() {
   const [isOpen, setIsOpen] = useState(false);
   useEffect(
     () => {
-      setIsOpen(false);
-    },
-    [sortMethod],
-  );
-  useEffect(
-    () => {
       if (isOpen) {
-        recordEvent({
-          event: `${GA_PREFIX}-facilities-not-listed-click`,
-        });
+        recordEvent({ event: `${GA_PREFIX}-facilities-not-listed-click` });
       }
     },
     [isOpen],
@@ -31,6 +22,7 @@ export default function FacilitiesNotShown({ sortMethod }) {
         <va-additional-info
           data-testid="facility-not-listed"
           trigger="If you can't find your facility on the list"
+          onClick={() => setIsOpen(!isOpen)}
           uswds
         >
           <p className="vads-u-margin-top--0">
@@ -51,9 +43,3 @@ export default function FacilitiesNotShown({ sortMethod }) {
     </div>
   );
 }
-FacilitiesNotShown.propTypes = {
-  cernerSiteIds: PropTypes.array,
-  facilities: PropTypes.array,
-  sortMethod: PropTypes.string,
-  typeOfCareId: PropTypes.string,
-};

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -1,9 +1,7 @@
-import React, { useState, useEffect } from 'react';
-
-// eslint-disable-next-line import/no-unresolved
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
-import { GA_PREFIX } from '../../../utils/constants';
+import React, { useEffect, useState } from 'react';
 import NewTabAnchor from '../../../components/NewTabAnchor';
+import { GA_PREFIX } from '../../../utils/constants';
 
 export default function FacilitiesNotShown() {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -51,7 +51,6 @@ export default function VAFacilityPageV2() {
   const {
     address,
     canScheduleAtChosenFacility,
-    cernerSiteIds,
     childFacilitiesStatus,
     data,
     eligibility,
@@ -256,12 +255,7 @@ export default function VAFacilityPageV2() {
           sortMethod={sortMethod}
           typeOfCareName={typeOfCare.name}
         />
-        <FacilitiesNotShown
-          facilities={facilities}
-          sortMethod={sortMethod}
-          typeOfCareId={typeOfCare?.id}
-          cernerSiteIds={cernerSiteIds}
-        />
+        <FacilitiesNotShown />
         <FormButtons
           onBack={() =>
             dispatch(routeToPreviousAppointmentPage(history, pageKey))
@@ -311,12 +305,7 @@ export default function VAFacilityPageV2() {
             }}
             data={data}
           >
-            <FacilitiesNotShown
-              facilities={facilities}
-              sortMethod={sortMethod}
-              typeOfCareId={typeOfCare?.id}
-              cernerSiteIds={cernerSiteIds}
-            />
+            <FacilitiesNotShown />
             <FormButtons
               continueLabel=""
               pageChangeInProgress={pageChangeInProgress}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update FacilitiesNotShown component to start sending vaos-facilities-not-listed-click events.
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111655

## Testing done

- Tested locally

## Screenshots

N/A This change has no visible change

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

