### PR TITLE
Add global hooks for mocha and cypress

### DIFF
--- a/src/platform/testing/e2e/cypress/support/index.js
+++ b/src/platform/testing/e2e/cypress/support/index.js
@@ -5,27 +5,6 @@ import 'cypress-real-events/support';
 import '@cypress/code-coverage/support';
 import addContext from 'mochawesome/addContext';
 import './commands';
-// import { setupWorker, rest } from 'msw';
-
-// if (typeof window !== 'undefined') {
-//   const worker = setupWorker(
-//     rest.get('/feature_toggles', (req, res, ctx) => {
-//       return res(ctx.status(200), ctx.body(''));
-//     }),
-//   );
-
-//   before(() => {
-//     return worker.start({ onUnhandledRequest: 'bypass' });
-//   });
-
-//   beforeEach(() => {
-//     worker.resetHandlers();
-//   });
-
-//   after(() => {
-//     worker.stop();
-//   });
-// }
 
 beforeEach(() => {
   cy.intercept('GET', '/feature_toggles', {

--- a/src/platform/testing/e2e/cypress/support/index.js
+++ b/src/platform/testing/e2e/cypress/support/index.js
@@ -5,6 +5,34 @@ import 'cypress-real-events/support';
 import '@cypress/code-coverage/support';
 import addContext from 'mochawesome/addContext';
 import './commands';
+// import { setupWorker, rest } from 'msw';
+
+// if (typeof window !== 'undefined') {
+//   const worker = setupWorker(
+//     rest.get('/feature_toggles', (req, res, ctx) => {
+//       return res(ctx.status(200), ctx.body(''));
+//     }),
+//   );
+
+//   before(() => {
+//     return worker.start({ onUnhandledRequest: 'bypass' });
+//   });
+
+//   beforeEach(() => {
+//     worker.resetHandlers();
+//   });
+
+//   after(() => {
+//     worker.stop();
+//   });
+// }
+
+beforeEach(() => {
+  cy.intercept('GET', '/feature_toggles', {
+    statusCode: 200,
+    body: '',
+  }).as('getFeatureToggles');
+});
 
 // workaround for 'AssertionError: Timed out retrying after 4000ms: Invalid string length'
 // https://github.com/testing-library/cypress-testing-library/issues/241

--- a/src/platform/testing/unit/feature-toggles.spec.js
+++ b/src/platform/testing/unit/feature-toggles.spec.js
@@ -1,0 +1,11 @@
+import fetch from 'isomorphic-fetch';
+import { expect } from 'chai';
+
+describe('MSW hook is active', () => {
+  it('should return an empty body for GET /feature_toggles', async () => {
+    const res = await fetch('http://localhost/feature_toggles');
+    expect(res.status).to.equal(200);
+    const text = await res.text();
+    expect(text).to.equal('');
+  });
+});

--- a/src/platform/testing/unit/feature-toggles.spec.js
+++ b/src/platform/testing/unit/feature-toggles.spec.js
@@ -6,6 +6,6 @@ describe('MSW hook is active', () => {
     const res = await fetch('http://localhost/feature_toggles');
     expect(res.status).to.equal(200);
     const text = await res.text();
-    expect(text).to.equal('123');
+    expect(text).to.equal('');
   });
 });

--- a/src/platform/testing/unit/feature-toggles.spec.js
+++ b/src/platform/testing/unit/feature-toggles.spec.js
@@ -6,6 +6,6 @@ describe('MSW hook is active', () => {
     const res = await fetch('http://localhost/feature_toggles');
     expect(res.status).to.equal(200);
     const text = await res.text();
-    expect(text).to.equal('');
+    expect(text).to.equal('123');
   });
 });

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -174,7 +174,7 @@ function flushPromises() {
 
 const server = setupServer(
   rest.get('/feature_toggles', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.body(''));
+    return res(ctx.status(200), ctx.body('123'));
   }),
 );
 

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -174,7 +174,7 @@ function flushPromises() {
 
 const server = setupServer(
   rest.get('/feature_toggles', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.body('123'));
+    return res(ctx.status(200), ctx.body(''));
   }),
 );
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _While most engineers when writing tests do mock their API calls that are centered around the work they're doing, many of them forget to mock global endpoints that are called on all pages. The biggest one of those is the feature flags endpoint. If the test does not require specific feature flags, this endpoint should be mocked to return an empty set of feature flags. This can be done at the global level, in the "beforeAll" hook in our Cypress config as well as our mocha config._
- _This work is being performed on behalf of the Platform SRE Team._

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/106845)

## Testing done

- _Local testing performed with dummy data in the stubbed response body for feature_toggles._
- _Unit test written for the changed functionality._