### PR TITLE
Add upload documents page

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/index.js
+++ b/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/index.js
@@ -1,6 +1,7 @@
 import supportingDocuments from './supportingDocuments';
+import uploadDocuments from './uploadDocuments';
 
 export default {
   title: 'Supporting documents',
-  pages: { supportingDocuments },
+  pages: { supportingDocuments, uploadDocuments },
 };

--- a/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/uploadDocuments.jsx
+++ b/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/uploadDocuments.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import environment from 'platform/utilities/environment';
+import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
+
+const MAX_FILE_SIZE_MB = 20;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1000 ** 2;
+
+const Description = (
+  <>
+    <p>
+      You can submit your supporting documents using any of the options listed
+      on this page.
+    </p>
+    <p>Guidelines to upload a file:</p>
+    <ul>
+      <li>You can upload a .pdf, .jpeg, or .png file.</li>
+      <li>Your file should be no larger than 20MB</li>
+    </ul>
+  </>
+);
+
+const UploadMessage = (
+  <p>
+    <strong>Note:</strong> You can choose to submit your supporting documents
+    and additional evidence after submitting this form. You’ll need to submit
+    them by mail or upload them using the Claim Status Tool.
+  </p>
+);
+
+export default {
+  title: 'Upload documents',
+  path: 'additional-information/upload-documents',
+  uiSchema: {
+    ...titleUI('Upload supporting documents'),
+    'ui:description': Description,
+    files: fileUploadUI('', {
+      buttonText: 'Upload supporting document',
+      fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
+      maxSize: MAX_FILE_SIZE_BYTES,
+      fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
+      fileUploadNetworkErrorMessage:
+        'We’re sorry. There was problem with our system and we couldn’t upload your file. You can try again later.',
+      fileUploadNetworkErrorAlert: {
+        header: 'We couldn’t upload your file',
+        body: [
+          'We’re sorry. There was a problem with our system and we couldn’t upload your file. Try uploading your file again.',
+          'Or select Continue to fill out the rest of your form. And then follow the instructions at the end to learn how to submit your documents.',
+        ],
+      },
+      hideLabelText: true,
+    }),
+    'view:uploadMessage': {
+      'ui:description': UploadMessage,
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      files: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+            size: {
+              type: 'integer',
+            },
+            confirmationCode: {
+              type: 'string',
+            },
+          },
+        },
+      },
+      'view:uploadMessage': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/12-supporting-documents/uploadDocuments.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/12-supporting-documents/uploadDocuments.unit.spec.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import { uploadStore } from 'platform/forms-system/test/config/helpers';
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../../../config/form';
+import uploadDocuments from '../../../../config/chapters/12-supporting-documents/uploadDocuments';
+
+describe('document upload', () => {
+  const { schema, uiSchema } = uploadDocuments;
+
+  it('should render', () => {
+    const form = render(
+      <Provider store={uploadStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{}}
+        />
+      </Provider>,
+    );
+    const formDOM = getFormDOM(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(1);
+  });
+
+  it('should submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = render(
+      <Provider store={uploadStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}
+          data={{}}
+        />
+      </Provider>,
+    );
+
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('should submit with valid data', () => {
+    const onSubmit = sinon.spy();
+    const form = render(
+      <Provider store={uploadStore}>
+        <DefinitionTester
+          schema={schema}
+          data={{
+            files: [
+              {
+                confirmationCode: 'testing',
+              },
+              {
+                confirmationCode: 'testing2',
+              },
+            ],
+          }}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}
+        />
+      </Provider>,
+    );
+
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+    expect(onSubmit.called).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
Added the “Upload supporting documents” page to the Supporting Documents chapter of the Income and Asset Statement form (VA Form 21P-0969). This page allows users to upload files relevant to their application, including trust documentation, business records, and farm ownership proof.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110866

## Related issue(s)
- N/A

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969/` in your browser

## How to verify
1. Navigate to the “Upload supporting documents” page in the Supporting Documents chapter
2. Upload a file (PDF, JPG, PNG, etc.)
3. Confirm that the file appears in the list and validation behaves as expected (e.g. size/type errors are shown)

## What areas of the site does it impact?
Income and Asset Statement 

## Screenshots
### Desktop
![Screenshot 2025-06-11 at 9 03 51 AM](https://github.com/user-attachments/assets/7b8da9a3-faae-4828-b5c0-4f16f19b464c)


### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded
