### PR TITLE
Remove va_online_scheduling_direct_schedule_appointment_conflict feature toggle

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarOptions.jsx
+++ b/src/applications/vaos/components/calendar/CalendarOptions.jsx
@@ -1,10 +1,8 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { CalendarContext } from './CalendarContext';
 import CalendarOptionsSlots from './CalendarOptionsSlots';
-import { selectFeatureDirectScheduleAppointmentConflict } from '../../redux/selectors';
 
 const smallMediaQuery = '(min-width: 481px)';
 const smallDesktopMediaQuery = '(min-width: 1008px)';
@@ -42,9 +40,6 @@ export default function CalendarOptions({
     isAppointmentSelectionError,
     appointmentSelectionErrorMsg,
   } = useContext(CalendarContext);
-  const featureDirectScheduleAppointmentConflict = useSelector(
-    selectFeatureDirectScheduleAppointmentConflict,
-  );
   // Because we need to conditionally apply classes to get the right padding
   // and border radius for each cell, we need to know when the page size trips
   // a breakpoint
@@ -68,11 +63,7 @@ export default function CalendarOptions({
   }, []);
 
   useEffect(() => {
-    if (
-      featureDirectScheduleAppointmentConflict &&
-      optionsHeightRef?.current &&
-      buttonRef?.current
-    ) {
+    if (optionsHeightRef?.current && buttonRef?.current) {
       const newHeight =
         optionsHeightRef.current.getBoundingClientRect().height +
         buttonRef.current.getBoundingClientRect().height +

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -21,7 +21,6 @@ import {
   selectFeatureDirectScheduling,
   selectRegisteredCernerFacilityIds,
   selectFeatureRemovePodiatry,
-  selectFeatureDirectScheduleAppointmentConflict,
 } from '../../redux/selectors';
 import { removeDuplicateId } from '../../utils/data';
 
@@ -137,9 +136,6 @@ export function getChosenSlot(state) {
 }
 
 export function getDateTimeSelect(state, pageKey) {
-  const featureDirectScheduleAppointmentConflict = selectFeatureDirectScheduleAppointmentConflict(
-    state,
-  );
   const newAppointment = getNewAppointment(state);
   const {
     appointmentSlotsStatus,
@@ -164,9 +160,7 @@ export function getDateTimeSelect(state, pageKey) {
     timezone,
     timezoneDescription,
     typeOfCareId,
-    isAppointmentSelectionError: featureDirectScheduleAppointmentConflict
-      ? isAppointmentSelectionError
-      : false,
+    isAppointmentSelectionError,
   };
 }
 

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -99,9 +99,6 @@ export const selectFeatureFeSourceOfTruthModality = state =>
 export const selectFeatureFeSourceOfTruthTelehealth = state =>
   toggleValues(state).vaOnlineSchedulingFeSourceOfTruthTelehealth;
 
-export const selectFeatureDirectScheduleAppointmentConflict = state =>
-  toggleValues(state).vaOnlineSchedulingDirectScheduleAppointmentConflict;
-
 export const selectFeatureTravelPayViewClaimDetails = state =>
   toggleValues(state).travelPayViewClaimDetails;
 

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -18,7 +18,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingFeSourceOfTruthTelehealth', value: true },
   { name: 'vaOnlineSchedulingMHVRouteGuards', value: false },
   { name: 'vaOnlineSchedulingConvertSlotsToUTC', value: false },
-  { name: 'vaOnlineSchedulingDirectScheduleAppointmentConflict', value: true },
   { name: 'edu_section_103', value: true },
   { name: 'gibctEybBottomSheet', value: true },
   { name: 'travelPayViewClaimDetails', value: false },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -311,7 +311,6 @@
   "vaOnlineSchedulingFeSourceOfTruthTelehealth": "va_online_scheduling_fe_source_of_truth_telehealth",
   "vaOnlineSchedulingMHVRouteGuards": "va_online_scheduling_mhv_route_guards",
   "vaOnlineSchedulingConvertSlotsToUTC": "va_online_scheduling_convert_slots_to_utc",
-  "vaOnlineSchedulingDirectScheduleAppointmentConflict": "va_online_scheduling_direct_schedule_appointment_conflict",
   "vetStatusStage1": "vet_status_stage_1",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",
   "vetStatusPdfLogging": "vet_status_pdf_logging",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove a feature toggle `va_online_scheduling_direct_schedule_appointment_conflict`
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108733

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

