### PR TITLE
removes reset password link from exemption page

### DIFF
--- a/src/applications/login/containers/MhvTemporaryAccess.jsx
+++ b/src/applications/login/containers/MhvTemporaryAccess.jsx
@@ -68,18 +68,6 @@ export default function MhvTemporaryAccess() {
           data-testid="updateMhvBtn"
         />
         <h2>Help and support</h2>
-        <h3 className="vads-u-margin-top--0">Recover forgotten password</h3>
-        <p className="vads-u-measure--4 vads-u-margin-bottom--0">
-          If you forgot your My HealtheVet password, you can submit personal
-          information to recover it.
-        </p>
-        <va-link-action
-          text="Recover your password"
-          type="secondary"
-          href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/forgot-password?action=new"
-          data-testid="recoverMhvBtn"
-        />
-        <h3>Get support</h3>
         <p>
           For all other questions, contact the administrator who gave you access
           to this page.

--- a/src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx
+++ b/src/applications/login/tests/containers/MhvTemporaryAccess.unit.spec.jsx
@@ -72,20 +72,6 @@ describe('MhvTemporaryAccess', () => {
     );
   });
 
-  it('renders recover password link', () => {
-    const screen = renderInReduxProvider(<MhvTemporaryAccess />);
-    const recoverHeading = screen.getByRole('heading', {
-      name: /Recover forgotten password/i,
-    });
-    expect(recoverHeading).to.exist;
-    const recoverLink = screen.getByTestId('recoverMhvBtn');
-    expect(recoverLink).to.exist;
-    expect(recoverLink).to.have.attribute(
-      'href',
-      'https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/forgot-password?action=new',
-    );
-  });
-
   it('renders help and support section', () => {
     const screen = renderInReduxProvider(<MhvTemporaryAccess />);
     const troubleHeading = screen.getByRole('heading', {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Remove 'reset password' section of exemption page

## Related issue(s)

- [GitHub Issue](https://github.com/department-of-veterans-affairs/identity-documentation/issues/407)
- 
## Testing done

- unit tests pass

## What areas of the site does it impact?

 - `/sign-in/mhv`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user