### PR TITLE
[ARP] Fix claim submission response

### DIFF
--- a/src/applications/representative-form-upload/containers/ConfirmationPage.jsx
+++ b/src/applications/representative-form-upload/containers/ConfirmationPage.jsx
@@ -15,7 +15,7 @@ const ConfirmationPage = () => {
   const form = useSelector(state => state.form || {});
   const { submission } = form;
   const submitDate = submission.timestamp;
-  const confirmationNumber = submission.response?.confirmation_number;
+  const confirmationNumber = submission.response?.confirmationNumber;
 
   const { formNumber } = getFormContent();
 


### PR DESCRIPTION
We've standardized on camel key responses.

This change will play nicely with the backend's key casing middleware, whether or not it runs, since that makes camel key responses too.