### PR TITLE
Dependents | Update cancel modal content

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
@@ -39,8 +39,6 @@ export const uiSchema = {
     },
   },
   'view:cancelAddSpouse': {
-    'ui:description': (
-      <CancelButton dependentType="spouse" isAddChapter altMessage />
-    ),
+    'ui:description': <CancelButton dependentType="spouse" isAddChapter />,
   },
 };

--- a/src/applications/dependents/686c-674/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-child-stopped-attending-school/removeChildStoppedAttendingSchoolArrayPages.js
@@ -50,6 +50,7 @@ export const removeChildStoppedAttendingSchoolIntroPage = {
         </p>
         <CancelButton
           dependentType="children who left school"
+          dependentButtonType="children"
           isAddChapter={false}
         />
       </>

--- a/src/applications/dependents/686c-674/config/chapters/report-dependent-death/deceasedDependentArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-dependent-death/deceasedDependentArrayPages.js
@@ -89,6 +89,7 @@ export const deceasedDependentIntroPage = {
         </p>
         <CancelButton
           dependentType="dependents who have died"
+          dependentButtonType="dependents"
           isAddChapter={false}
         />
       </>

--- a/src/applications/dependents/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
@@ -39,11 +39,7 @@ export const uiSchema = {
     },
     'view:cancelDivorce': {
       'ui:description': (
-        <CancelButton
-          dependentType="divorced spouse"
-          isAddChapter={false}
-          altMessage
-        />
+        <CancelButton dependentType="divorced spouse" isAddChapter={false} />
       ),
     },
   },

--- a/src/applications/dependents/686c-674/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-marriage-of-child/removeMarriedChildArrayPages.js
@@ -50,6 +50,7 @@ export const removeMarriedChildIntroPage = {
         </p>
         <CancelButton
           dependentType="children who got married"
+          dependentButtonType="children"
           isAddChapter={false}
         />
       </>

--- a/src/applications/dependents/686c-674/config/helpers.js
+++ b/src/applications/dependents/686c-674/config/helpers.js
@@ -76,7 +76,7 @@ export const CancelButton = withRouter(
   ({
     isAddChapter = false,
     dependentType = 'dependents',
-    altMessage = false,
+    dependentButtonType,
     router,
   }) => {
     const buttonRef = useRef(null);
@@ -86,35 +86,35 @@ export const CancelButton = withRouter(
       focusElement('button', {}, buttonRef.current.shadowRoot);
     };
 
-    const cancelText =
+    const cancelButtonText =
       dependentType && typeof dependentType === 'string'
         ? `Cancel ${isAddChapter ? 'adding' : 'removing'} ${dependentType}`
         : 'Cancel';
 
-    const modalText = `Cancel ${
+    const modalTitle = `Cancel ${
       isAddChapter ? 'adding' : 'removing'
     } ${dependentType}?`;
 
-    const secondaryText = `No, continue ${
+    const secondaryButtonText = `No, continue ${
       isAddChapter ? 'adding' : 'removing'
-    } ${dependentType}`;
+    } ${dependentButtonType || dependentType}`;
 
     return (
       <>
         <va-button
           ref={buttonRef}
           data-testid="cancel-btn"
-          aria-label={cancelText}
+          aria-label={cancelButtonText}
           onClick={() => setIsVisible(true)}
           secondary
-          text={cancelText}
+          text={cancelButtonText}
         />
 
         <VaModal
           data-testid="cancel-modal"
-          modalTitle={modalText}
+          modalTitle={modalTitle}
           primaryButtonText="Yes, cancel"
-          secondaryButtonText={secondaryText}
+          secondaryButtonText={secondaryButtonText}
           visible={isVisible}
           status="warning"
           onPrimaryButtonClick={() => {
@@ -127,16 +127,10 @@ export const CancelButton = withRouter(
           onCloseEvent={closeModal}
           clickToClose
         >
-          {altMessage ? (
-            <p>
-              If you cancel, the information entered won’t be saved and you’ll
-              be taken to step 1, to update your selection.
-            </p>
-          ) : (
-            <p>
-              If you cancel, you’ll be taken to step 1 to update your selection.
-            </p>
-          )}
+          <p>
+            If you cancel, we’ll take you back to Step 1 to update your
+            selection.
+          </p>
         </VaModal>
       </>
     );

--- a/src/applications/dependents/686c-674/tests/config/helpers.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/helpers.unit.spec.jsx
@@ -91,6 +91,12 @@ describe('CancelButton Component (Web Components)', () => {
       await waitFor(() => {
         const modal = getByTestId('cancel-modal');
         expect(modal.getAttribute('modal-title')).to.include(expectedString);
+        expect(modal.getAttribute('primary-button-text')).to.equal(
+          'Yes, cancel',
+        );
+        expect(modal.getAttribute('secondary-button-text')).to.include(
+          `No, continue ${addOrRemove} spouse`,
+        );
       });
     });
 
@@ -101,13 +107,27 @@ describe('CancelButton Component (Web Components)', () => {
         : '/options-selection/remove-dependents';
       const props = {
         isAddChapter,
-        dependentType: 'spouse',
+        dependentType: 'children who got married',
+        dependentButtonType: 'children',
         router: { push: pushSpy },
       };
       const { getByTestId } = render(<CancelButton {...props} />);
 
       fireEvent.click(getByTestId('cancel-btn'));
       const modal = getByTestId('cancel-modal');
+
+      expect(modal.getAttribute('modal-title')).to.include(
+        `Cancel ${isAddChapter ? 'adding' : 'removing'} ${
+          props.dependentType
+        }?`,
+      );
+      expect(modal.getAttribute('primary-button-text')).to.equal('Yes, cancel');
+      expect(modal.getAttribute('secondary-button-text')).to.include(
+        `No, continue ${isAddChapter ? 'adding' : 'removing'} ${
+          props.dependentButtonType
+        }`,
+      );
+
       modal.__events.primaryButtonClick();
 
       await waitFor(() => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Updating all cancel modal content to match recommendations (see related issue)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/109531

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Cancel Modal | Before | After |
| ------- | ------ | ----- |
| Add spouse | <img width="501" alt="before-add-spouse" src="https://github.com/user-attachments/assets/ec06550d-ecf2-4e45-9e50-4dba05495676" /> | <img width="520" alt="after-add-spouse" src="https://github.com/user-attachments/assets/89093d5b-6ac1-4d04-9bc8-2498390e90ae" /> |
| Add child | <img width="503" alt="before-add-child" src="https://github.com/user-attachments/assets/b1b3eba9-2936-4eb2-8391-a002556b70e8" /> | <img width="501" alt="after-add-child" src="https://github.com/user-attachments/assets/8a0fce9e-836a-40ab-a2b7-201f40c08b53" /> |
| Add student | <img width="498" alt="before-add-student" src="https://github.com/user-attachments/assets/8ae2c628-dbba-40fb-a3d1-9ccb635f6f59" /> | <img width="501" alt="after-add-student" src="https://github.com/user-attachments/assets/66be47dd-2840-4529-9aad-cc5bf72e8464" /> |
| Remove spouse | <img width="495" alt="before-divorced" src="https://github.com/user-attachments/assets/463c57ea-8e3e-411f-83e1-0a03937c5120" /> | <img width="499" alt="after-divorced" src="https://github.com/user-attachments/assets/c4ed45b8-708d-493b-92dd-e2279c747c4d" /> |
| Remove dependent | <img width="495" alt="before-dep-died" src="https://github.com/user-attachments/assets/3007779d-9975-4092-9edb-a8d34f8bf2e3" /> | <img width="498" alt="after-dep-died" src="https://github.com/user-attachments/assets/0a40b2de-8359-46a3-85f2-7a212d73bdeb" /> |
| Remove stepchild | <img width="498" alt="before-stepchildren" src="https://github.com/user-attachments/assets/b2a7380f-6f8b-4901-8457-89703778d577" /> | <img width="500" alt="after-stepchildren" src="https://github.com/user-attachments/assets/394817b9-ddcb-4f30-b6e6-dbf6bb734524" /> |
| Remove married child | <img width="502" alt="before-child-married" src="https://github.com/user-attachments/assets/4ff35f05-5d45-4a17-b66d-0d4e44acb058" /> | <img width="492" alt="after-child-married" src="https://github.com/user-attachments/assets/a09daec4-336a-48d7-b506-64393cf12835" /> |
| Remove child left school | <img width="495" alt="before-left-school" src="https://github.com/user-attachments/assets/b42b6285-0fbf-4802-a350-29b651acd883" /> | <img width="494" alt="after-left-school" src="https://github.com/user-attachments/assets/01fc9dd6-ce10-4c71-993d-3799f9e9e7e7" /> |

## What areas of the site does it impact?

Dependents Management forms (686c-674)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
