### PR TITLE
Update breadcrumb for schedule referral to remove category

### DIFF
--- a/src/applications/vaos/referral-appointments/flow.js
+++ b/src/applications/vaos/referral-appointments/flow.js
@@ -25,7 +25,7 @@ export function getPageFlow(referralId, appointmentId) {
     },
     scheduleReferral: {
       url: `/schedule-referral?id=${referralId}`,
-      label: 'Referral for {{ categoryOfCare }}',
+      label: 'Appointment Referral',
       next: 'scheduleAppointment',
       previous: 'referralsAndRequests',
     },

--- a/src/applications/vaos/referral-appointments/flow.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/flow.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('Referral Appointments Flow', () => {
       {
         currentPage: 'scheduleReferral',
         categoryOfCare: 'Primary Care',
-        expected: 'Referral for Primary Care',
+        expected: 'Appointment Referral',
       },
       {
         currentPage: 'scheduleAppointment',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR removes the dynamic breadcrumb containing the category of care on the schedule referral page to a static breadcrumb of "Appointment Referral".

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111475
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111775

## Testing done

- When starting the process to schedule an appointment from a referral, the first page of the process the final breadcrumb contained the same category of care as the H1.
- If you visit the same page now, you will see the breadcrumb label is now Appointment Referral. This is the same for all categories.
- After testing manually, I updated the unit tests for the section to look for the new breadcrumb.

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Both  |  ![80703-erin-title-elements-phi](https://github.com/user-attachments/assets/d6fd06c8-2613-48ed-8548-59897d3b86bb) |  ![breadcrumb-update](https://github.com/user-attachments/assets/4012fe5f-f1fc-406f-afc0-bea892bf13c3)  |

## What areas of the site does it impact?

This only affects the breadcrumbs on the /sechedule-referral page.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
