### PR TITLE
Updated Profile AccountUuid

### DIFF
--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -30,7 +30,7 @@ export function mapRawUserDataToState(json) {
   const {
     data: {
       attributes: {
-        account: { accountUuid } = {},
+        userAccount: { id: accountUuid } = {},
         inProgressForms: savedForms,
         prefillsAvailable,
         profile: {

--- a/src/platform/user/tests/profile/utilities/index.unit.spec.jsx
+++ b/src/platform/user/tests/profile/utilities/index.unit.spec.jsx
@@ -8,8 +8,8 @@ import { CSP_IDS } from 'platform/user/authentication/constants';
 function createDefaultData() {
   return {
     attributes: {
-      account: {
-        accountUuid: 'user-1234',
+      userAccount: {
+        id: 'user-1234',
       },
       profile: {
         sign_in: {
@@ -101,7 +101,7 @@ describe('Profile utilities', () => {
       });
 
       expect(mappedData.accountUuid).to.deep.equal(
-        data.attributes.account.accountUuid,
+        data.attributes.userAccount.id,
       );
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated `mapRawUserDataToState` to work with the new `vets-api` user profile serialization.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/410)

## Testing done
- Updated `profile/utilities/index.unit.spec.jsx` and ran tests locally.
- Can be replicated by running `yarn test:unit src/platform/user/tests/profile/utilities/index.unit.spec.jsx`.

## What areas of the site does it impact?
This primarily impacts `profile/utilities/index.js` and its related tests.

## Acceptance criteria
- [x] Update `accountUuid` in `mapRawUserDataToState` so that it utilizes the new `vets-api` syntax
- [x] Update tests accordingly 