### PR TITLE
[LETTERS] Manage focus when users successfully change their address

### DIFF
--- a/src/applications/letters/containers/NewAddressSection.jsx
+++ b/src/applications/letters/containers/NewAddressSection.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { selectVAPMailingAddress } from 'platform/user/selectors';
+import { focusElement } from 'platform/utilities/ui';
 import { TRANSACTION_CATEGORY_TYPES } from '@@vap-svc/constants';
 import PropTypes from 'prop-types';
 
@@ -10,12 +11,12 @@ import AddressView from '@@vap-svc/components/AddressField/AddressView';
 
 export function NewAddressSection({ success }) {
   const mailingAddress = useSelector(selectVAPMailingAddress);
-  const successHeadingRef = useRef(null);
+  const successRef = useRef(null);
 
   useEffect(
     () => {
-      if (success && successHeadingRef?.current) {
-        successHeadingRef.current.focus();
+      if (success && successRef?.current) {
+        focusElement('h3', {}, successRef.current);
       }
     },
     [success],
@@ -36,10 +37,9 @@ export function NewAddressSection({ success }) {
             <va-alert
               status="success"
               class="vads-u-margin-top--3 vads-u-margin-bottom--3"
+              ref={successRef}
             >
-              <h3 slot="headline" ref={successHeadingRef} tabindex="-1">
-                We've updated your mailing address
-              </h3>
+              <h3 slot="headline">We've updated your mailing address</h3>
               <p>
                 We've made these changes to the letters you download now and to
                 your VA.gov profile.

--- a/src/applications/letters/containers/NewAddressSection.jsx
+++ b/src/applications/letters/containers/NewAddressSection.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { selectVAPMailingAddress } from 'platform/user/selectors';
 import { TRANSACTION_CATEGORY_TYPES } from '@@vap-svc/constants';
@@ -10,6 +10,16 @@ import AddressView from '@@vap-svc/components/AddressField/AddressView';
 
 export function NewAddressSection({ success }) {
   const mailingAddress = useSelector(selectVAPMailingAddress);
+  const successHeadingRef = useRef(null);
+
+  useEffect(
+    () => {
+      if (success && successHeadingRef?.current) {
+        successHeadingRef.current.focus();
+      }
+    },
+    [success],
+  );
 
   return (
     <div className="va-profile-wrapper">
@@ -27,7 +37,9 @@ export function NewAddressSection({ success }) {
               status="success"
               class="vads-u-margin-top--3 vads-u-margin-bottom--3"
             >
-              <h3 slot="headline">We've updated your mailing address</h3>
+              <h3 slot="headline" ref={successHeadingRef} tabindex="-1">
+                We've updated your mailing address
+              </h3>
               <p>
                 We've made these changes to the letters you download now and to
                 your VA.gov profile.


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
Added logic to the Your VA letters and documents edit address flow to manage focus. When the green success alert appears, we are now setting focus on the H3 so screen readers announce the change to users.

## Related issue(s)

- PR closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/111594

## Testing done

- Tested locally with NVDA (Chrome, Firefox) and Narrator (Edge) to confirm focus was handled properly and heading was announced

## Screenshots

![Screenshot 2025-06-13 163506](https://github.com/user-attachments/assets/fc20e88d-a77f-4547-95f9-42448ea2bb0b)



## What areas of the site does it impact?

- Only one view on the Your VA letters and documents app

## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

