### PR TITLE
Fix selection bug after choosing sort facilies by current location

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -35,6 +35,7 @@ export default function FacilitiesRadioWidget({
     ? sortOptions.find(type => type.value === sortMethod).label
     : sortOptions[0].label;
   const requestingLocationFailed =
+    sortMethod === 'distanceFromCurrentLocation' &&
     requestLocationStatus === FETCH_STATUS.failed;
 
   // If user has already selected a value, and the index of that value is > 4,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Currently we always display the "Your browser is blocked from finding your current location." alert when the user blocks the browser from getting the current location, regardless of the option in the sort method dropdown.
- We should only display the alert when the user selected the "Closest to your current location" option in the dropdown.
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112180#event-18174409193

## Testing done

- Tested locally

## Screenshots

After selecting "Closest to your current location" and rejecting the request to share location, choose a different option and observe the following

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   ![image](https://github.com/user-attachments/assets/3d3e0559-b611-4a10-a832-81fc2fa4e23b)    |   ![image](https://github.com/user-attachments/assets/7999fb53-5c5e-4e61-bd19-d0bba75ffc31)   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user