### PR TITLE
SC 112080: Add DowntimeNotification component at app level

### DIFF
--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -137,7 +137,7 @@ export const App = ({
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       <DowntimeNotification
         appTitle="Supplemental Claims"
-        dependencies={[externalServices.decision_reviews]}
+        dependencies={[externalServices.decisionReviews]}
       >
         <ITFWrapper
           loggedIn={loggedIn}

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { getStoredSubTask } from '@department-of-veterans-affairs/platform-forms/sub-task';
 
@@ -133,17 +135,22 @@ export const App = ({
 
   let content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      <ITFWrapper
-        loggedIn={loggedIn}
-        pathname={pathname}
-        title={formConfig.title}
-        benefitType={subTaskBenefitType}
-        router={router}
-        accountUuid={accountUuid}
-        inProgressFormId={inProgressFormId}
+      <DowntimeNotification
+        appTitle="Supplemental Claims"
+        dependencies={[externalServices.decision_reviews]}
       >
-        {children}
-      </ITFWrapper>
+        <ITFWrapper
+          loggedIn={loggedIn}
+          pathname={pathname}
+          title={formConfig.title}
+          benefitType={subTaskBenefitType}
+          router={router}
+          accountUuid={accountUuid}
+          inProgressFormId={inProgressFormId}
+        >
+          {children}
+        </ITFWrapper>
+      </DowntimeNotification>
     </RoutedSavableApp>
   );
 

--- a/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
@@ -5,7 +5,6 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
 import { setStoredSubTask } from '@department-of-veterans-affairs/platform-forms/sub-task';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { SET_DATA } from 'platform/forms-system/src/js/actions';
@@ -50,6 +49,15 @@ const getData = ({
       routes: [{ path: pathname }],
     },
     data: {
+      scheduledDowntime: {
+        globalDowntime: null,
+        isReady: true,
+        isPending: false,
+        serviceMap: {
+          get() {},
+        },
+        dismissedDowntimeWarnings: [],
+      },
       routes: [{ path: pathname }],
       user: {
         login: {

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -9,6 +9,7 @@ export default {
   bgs: 'bgs',
   // CARMA (Caregiver Record Management Application)
   carma: 'carma',
+  decisionReviews: 'decision_reviews',
   // Debt Management Services
   dmc: 'dmc',
   dslogon: 'dslogon',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Implement the app-level `<DowntimeNotification>` to support our production release for 4142 forms. This will enable us to add a maintenance window in PagerDuty that will automatically block Supplemental Claims access to users with [this message](https://depo-platform-documentation.scrollhelp.site/developer-docs/downtime-notifications#Downtimenotifications-Thisiswhatthedowntimenotificationlookslikeduringdowntimeperiod).

In the hour leading up to our maintenance window, users will see [this message](https://depo-platform-documentation.scrollhelp.site/developer-docs/downtime-notifications#Downtimenotifications-Whatthenotificationlookslikeonehourbeforeservicegoesdownwithnocustomcontent).

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/112080

## Testing done

Tested with the steps on [this Notion page](https://www.notion.so/kindsystems/E2E-Flow-Notes-1de1e93f7cbb80c68bd4df983b6c6a33#2141e93f7cbb80d3bfbed10c765f517f) (see "Testing Maintenance Windows Locally" section).

## Screenshots

This banner will appear in place of all app content for Supplemental Claims when the maintenance window is active.

<img width="458" alt="Screenshot 2025-06-16 at 11 05 23 AM" src="https://github.com/user-attachments/assets/b54a35e3-a386-4991-bdba-e8e203835d76" />


## What areas of the site does it impact?

Supplemental Claims only.