### PR TITLE
Add custom Cypress command to fill va-statement-of-truth

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -413,3 +413,24 @@ Cypress.Commands.add(
     );
   },
 );
+
+Cypress.Commands.add(
+  'fillVaStatementOfTruth',
+  (field, { name, checked } = {}) => {
+    if (!name && typeof checked !== 'boolean') return;
+
+    const element =
+      typeof field === 'string'
+        ? cy.get(`va-statement-of-truth[name="${field}"]`)
+        : cy.wrap(field);
+
+    element.shadow().within(() => {
+      if (name) {
+        cy.get('va-text-input').then($el => cy.fillVaTextInput($el, name));
+      }
+      if (checked) {
+        cy.get('va-checkbox').then($el => cy.selectVaCheckbox($el, checked));
+      }
+    });
+  },
+);

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -416,8 +416,8 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'fillVaStatementOfTruth',
-  (field, { name, checked } = {}) => {
-    if (!name && typeof checked !== 'boolean') return;
+  (field, { fullName, checked } = {}) => {
+    if (!fullName && typeof checked !== 'boolean') return;
 
     const element =
       typeof field === 'string'
@@ -425,8 +425,8 @@ Cypress.Commands.add(
         : cy.wrap(field);
 
     element.shadow().within(() => {
-      if (name) {
-        cy.get('va-text-input').then($el => cy.fillVaTextInput($el, name));
+      if (fullName) {
+        cy.get('va-text-input').then($el => cy.fillVaTextInput($el, fullName));
       }
       if (checked) {
         cy.get('va-checkbox').then($el => cy.selectVaCheckbox($el, checked));


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR creates a custom Cypress command to fill the `va-statement-of-truth` web component.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#99053

## Testing done

- Ran locally on a feature branch to ensure component correctly fills
- Added conditionals to the command to allow for both a valid and invalid fill, in case anyone needs to test validation
- Separated conditions to allow for the ability to just check the certification box if the text input is prefilled.

## Acceptance criteria

 - Command is flexible enough to allow for multiple conditional uses

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution