### PR TITLE
Update to use api as source of truth for Video at VA appointments

### DIFF
--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -418,10 +418,6 @@ export function selectAppointmentLocality(
   return `${isCommunityCare ? 'Community care' : 'VA appointment'}`;
 }
 
-export function selectIsClinicVideo(appointment) {
-  return isClinicVideoAppointment(appointment);
-}
-
 export function selectVideoData(appointment) {
   return appointment?.videoData || {};
 }
@@ -442,7 +438,7 @@ export function selectModalityText(appointment, isPendingAppointment = false) {
   const isInPerson = isInPersonVisit(appointment);
   const isPhone = selectIsPhone(appointment);
   const isVideoAtlas = isAtlasVideoAppointment(appointment);
-  const isVideoClinic = selectIsClinicVideo(appointment);
+  const isVideoClinic = isClinicVideoAppointment(appointment);
   const isVideoHome = isVideoAtHome(appointment);
   const { name: facilityName } = appointment.vaos.facilityData || {
     name: '',
@@ -543,7 +539,7 @@ export function selectModalityIcon(appointment) {
   const isInPerson = isInPersonVisit(appointment);
   const isPhone = selectIsPhone(appointment);
   const isVideoAtlas = isAtlasVideoAppointment(appointment);
-  const isVideoClinic = selectIsClinicVideo(appointment);
+  const isVideoClinic = isClinicVideoAppointment(appointment);
   const isVideoHome = isVideoAtHome(appointment);
 
   let icon = '';
@@ -570,7 +566,7 @@ export function selectAppointmentTravelClaim(appointment) {
 export function selectIsEligibleForTravelClaim(appointment) {
   return (
     selectIsPast(appointment) &&
-    (isInPersonVisit(appointment) || selectIsClinicVideo(appointment)) &&
+    (isInPersonVisit(appointment) || isClinicVideoAppointment(appointment)) &&
     selectAppointmentTravelClaim(appointment)
   );
 }

--- a/src/applications/vaos/components/AppointmentCard/AppointmentCardIcon.unit.spec.jsx
+++ b/src/applications/vaos/components/AppointmentCard/AppointmentCardIcon.unit.spec.jsx
@@ -78,6 +78,7 @@ describe('VAOS Component: AppointmentCardIcon', () => {
         vaos: {
           isVideo: true,
           isAtlas: false,
+          isVideoAtVA: true,
         },
         videoData: {
           kind: 'CLINIC_BASED',

--- a/src/applications/vaos/components/AppointmentTasksSection.unit.spec.jsx
+++ b/src/applications/vaos/components/AppointmentTasksSection.unit.spec.jsx
@@ -34,6 +34,7 @@ describe('VAOS Component: AppointmentTasks', () => {
           isCommunityCare: false,
           isPhoneAppointment: false,
           isVideo: true,
+          isVideoAtVA: true,
         },
         videoData: {
           kind,

--- a/src/applications/vaos/components/TravelReimbursementSection.unit.spec.jsx
+++ b/src/applications/vaos/components/TravelReimbursementSection.unit.spec.jsx
@@ -33,6 +33,7 @@ describe('VAOS Component: TravelReimbursement', () => {
           isCommunityCare: false,
           isPhone: false,
           isVideo: true,
+          isVideoAtVA: true,
         },
         videoData: {
           kind,

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -15,7 +15,6 @@ import { mapToFHIRErrors } from '../utils';
 import {
   APPOINTMENT_TYPES,
   APPOINTMENT_STATUS,
-  VIDEO_TYPES,
   GA_PREFIX,
 } from '../../utils/constants';
 import { formatFacilityAddress, getFacilityPhone } from '../location';
@@ -310,10 +309,7 @@ export function isVAPhoneAppointment(appointment) {
  * @returns {boolean} True if appointment is a clinic or store forward appointment
  */
 export function isClinicVideoAppointment(appointment) {
-  return (
-    appointment?.videoData?.kind === VIDEO_TYPES.clinic ||
-    appointment?.videoData?.kind === VIDEO_TYPES.storeForward
-  );
+  return appointment?.vaos.isVideoAtVA;
 }
 
 /**

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -167,6 +167,8 @@ export function transformVAOSAppointment(
   let isVideoAtHome =
     !isAtlas &&
     (vvsKind === VIDEO_TYPES.mobile || vvsKind === VIDEO_TYPES.adhoc);
+  let isVideoAtVA =
+    vvsKind === VIDEO_TYPES.clinic || vvsKind === VIDEO_TYPES.storeForward;
   let isCompAndPen = serviceCategoryName === 'COMPENSATION & PENSION';
   let isPhone = appt.kind === 'phone';
   let isCovid = appt.serviceType === TYPE_OF_CARE_IDS.COVID_VACCINE_ID;
@@ -184,6 +186,7 @@ export function transformVAOSAppointment(
       appt.modality === 'vaVideoCareAtAVaLocation';
     isVideoAtHome = appt.modality === 'vaVideoCareAtHome';
     isAtlas = appt.modality === 'vaVideoCareAtAnAtlasLocation';
+    isVideoAtVA = appt.modality === 'vaVideoCareAtAVaLocation';
   }
 
   const isCancellable = appt.cancellable;
@@ -358,6 +361,7 @@ export function transformVAOSAppointment(
       isCOVIDVaccine: isCovid,
       isInPersonVisit,
       isVideoAtHome,
+      isVideoAtVA,
       isCerner,
       apiData: appt,
       timeZone: appointmentTZ,

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
 
 import { MockAppointment } from '../../tests/fixtures/MockAppointment';
-import { getAppointmentType, transformVAOSAppointment } from './transformers';
+import MockAppointmentResponse from '../../tests/fixtures/MockAppointmentResponse';
 import { VIDEO_TYPES } from '../../utils/constants';
+import { parseApiObject } from '../utils';
+import { getAppointmentType, transformVAOSAppointment } from './transformers';
 
 describe('getAppointmentType util', () => {
   it('should return appointment type as request', async () => {
@@ -248,30 +250,15 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isAtlas).to.be.true;
       expect(a.vaos.isVideoAtVA).to.be.false;
     });
-    it('should set modality fields for video at ATLAS appointments', async () => {
+    it('should set modality fields for video at VA appointments', async () => {
       // Arrange
-      const appointment = new MockAppointment();
-      appointment.setModality('vaVideoCareAtAVaLocation');
-      appointment.telehealth = {
-        atlas: {
-          siteCode: 'VFW-DC-20011-01',
-          confirmationCode: '271631',
-          address: {
-            streetAddress: '5929 Georgia Ave NW',
-            city: 'Washington',
-            state: 'DC',
-            zipCode: '20011',
-            country: 'USA',
-            latitutde: 38.96198,
-            longitude: -77.02791,
-            additionalDetails: '',
-          },
-        },
-      };
+      const response = MockAppointmentResponse.createClinicResponse({
+        localStartTime: new Date(),
+      });
 
       // Act
       const a = transformVAOSAppointment(
-        appointment,
+        parseApiObject({ data: response }),
         false,
         false,
         false,
@@ -456,20 +443,18 @@ describe('VAOS <transformVAOSAppointment>', () => {
     });
     it('should set modality fields for video at VA appointments', async () => {
       // Arrange
-      const mobile = new MockAppointment();
-      mobile.kind = 'telehealth';
-      mobile.telehealth = {
+      const mobile = MockAppointmentResponse.createClinicResponse({
+        localStartTime: new Date(),
         vvsKind: VIDEO_TYPES.clinic,
-      };
-      const adhoc = new MockAppointment();
-      adhoc.kind = 'telehealth';
-      adhoc.telehealth = {
+      });
+      const storeForward = MockAppointmentResponse.createClinicResponse({
+        localStartTime: new Date(),
         vvsKind: VIDEO_TYPES.storeForward,
-      };
+      });
 
       // Act
       const a = transformVAOSAppointment(
-        mobile,
+        parseApiObject({ data: mobile }),
         false,
         false,
         false,
@@ -477,7 +462,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
         useFeSourceOfTruthTelehealth,
       );
       const b = transformVAOSAppointment(
-        adhoc,
+        parseApiObject({ data: storeForward }),
         false,
         false,
         false,

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -105,6 +105,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for phone appointments', async () => {
       // Arrange
@@ -129,6 +130,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for vaccine appointments', async () => {
       // Arrange
@@ -153,6 +155,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for in person appointments', async () => {
       // Arrange
@@ -177,6 +180,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for video at home appointments', async () => {
       // Arrange
@@ -201,6 +205,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.true;
       expect(a.vaos.isVideoAtHome).to.be.true;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for video at ATLAS appointments', async () => {
       // Arrange
@@ -241,6 +246,48 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.true;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.true;
+      expect(a.vaos.isVideoAtVA).to.be.false;
+    });
+    it('should set modality fields for video at ATLAS appointments', async () => {
+      // Arrange
+      const appointment = new MockAppointment();
+      appointment.setModality('vaVideoCareAtAVaLocation');
+      appointment.telehealth = {
+        atlas: {
+          siteCode: 'VFW-DC-20011-01',
+          confirmationCode: '271631',
+          address: {
+            streetAddress: '5929 Georgia Ave NW',
+            city: 'Washington',
+            state: 'DC',
+            zipCode: '20011',
+            country: 'USA',
+            latitutde: 38.96198,
+            longitude: -77.02791,
+            additionalDetails: '',
+          },
+        },
+      };
+
+      // Act
+      const a = transformVAOSAppointment(
+        appointment,
+        false,
+        false,
+        false,
+        useFeSourceOfTruthModality,
+        useFeSourceOfTruthTelehealth,
+      );
+
+      // Assert
+      expect(a.vaos.isCompAndPenAppointment).to.be.false;
+      expect(a.vaos.isPhoneAppointment).to.be.false;
+      expect(a.vaos.isCOVIDVaccine).to.be.false;
+      expect(a.vaos.isInPersonVisit).to.be.false;
+      expect(a.vaos.isVideo).to.be.true;
+      expect(a.vaos.isVideoAtHome).to.be.false;
+      expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.true;
     });
   });
   describe('When modality flag is off', () => {
@@ -281,6 +328,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for phone appointments', async () => {
       // Arrange
@@ -305,6 +353,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for vaccine appointments', async () => {
       // Arrange
@@ -329,6 +378,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for in person appointments', async () => {
       // Arrange
@@ -352,6 +402,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.false;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
     it('should set modality fields for video at home appointments', async () => {
       // Arrange
@@ -392,6 +443,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.true;
       expect(a.vaos.isVideoAtHome).to.be.true;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
 
       expect(b.vaos.isCompAndPenAppointment).to.be.false;
       expect(b.vaos.isPhoneAppointment).to.be.false;
@@ -400,6 +452,57 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(b.vaos.isVideo).to.be.true;
       expect(b.vaos.isVideoAtHome).to.be.true;
       expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.false;
+    });
+    it('should set modality fields for video at VA appointments', async () => {
+      // Arrange
+      const mobile = new MockAppointment();
+      mobile.kind = 'telehealth';
+      mobile.telehealth = {
+        vvsKind: VIDEO_TYPES.clinic,
+      };
+      const adhoc = new MockAppointment();
+      adhoc.kind = 'telehealth';
+      adhoc.telehealth = {
+        vvsKind: VIDEO_TYPES.storeForward,
+      };
+
+      // Act
+      const a = transformVAOSAppointment(
+        mobile,
+        false,
+        false,
+        false,
+        useFeSourceOfTruthModality,
+        useFeSourceOfTruthTelehealth,
+      );
+      const b = transformVAOSAppointment(
+        adhoc,
+        false,
+        false,
+        false,
+        useFeSourceOfTruthModality,
+        useFeSourceOfTruthTelehealth,
+      );
+
+      // Assert
+      expect(a.vaos.isCompAndPenAppointment).to.be.false;
+      expect(a.vaos.isPhoneAppointment).to.be.false;
+      expect(a.vaos.isCOVIDVaccine).to.be.false;
+      expect(a.vaos.isInPersonVisit).to.be.false;
+      expect(a.vaos.isVideo).to.be.true;
+      expect(a.vaos.isVideoAtHome).to.be.false;
+      expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.true;
+
+      expect(b.vaos.isCompAndPenAppointment).to.be.false;
+      expect(b.vaos.isPhoneAppointment).to.be.false;
+      expect(b.vaos.isCOVIDVaccine).to.be.false;
+      expect(b.vaos.isInPersonVisit).to.be.false;
+      expect(b.vaos.isVideo).to.be.true;
+      expect(b.vaos.isVideoAtHome).to.be.false;
+      expect(a.vaos.isAtlas).to.be.false;
+      expect(a.vaos.isVideoAtVA).to.be.true;
     });
     it('should set modality fields for video at ATLAS appointments', async () => {
       // Arrange
@@ -441,6 +544,7 @@ describe('VAOS <transformVAOSAppointment>', () => {
       expect(a.vaos.isVideo).to.be.true;
       expect(a.vaos.isVideoAtHome).to.be.false;
       expect(a.vaos.isAtlas).to.be.true;
+      expect(a.vaos.isVideoAtVA).to.be.false;
     });
   });
 });

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -445,11 +445,9 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Arrange
       const mobile = MockAppointmentResponse.createClinicResponse({
         localStartTime: new Date(),
-        vvsKind: VIDEO_TYPES.clinic,
       });
-      const storeForward = MockAppointmentResponse.createClinicResponse({
+      const storeForward = MockAppointmentResponse.createStoreForwardResponse({
         localStartTime: new Date(),
-        vvsKind: VIDEO_TYPES.storeForward,
       });
 
       // Act

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -996,6 +996,7 @@
         ],
         "kind": "telehealth",
         "type": "VA",
+        "modality": "vaInPerson",
         "status": "booked",
         "serviceType": "outpatientMentalHealth",
         "serviceTypes": [
@@ -1324,12 +1325,13 @@
           ]
         },
         "description": "Upcoming VA location telehealth appointment",
-        "end": "2024-08-22T14:00:00Z",
+        "end": "2025-08-22T14:00:00Z",
         "id": "05aa456vvc",
         "kind": "telehealth",
         "type": "VA",
+        "modality": "vaVideoCareAtAVaLocation",
         "locationId": "983",
-        "localStartTime": "2024-08-22T09:00:00.000-06:00",
+        "localStartTime": "2025-08-22T09:00:00.000-06:00",
         "physicalLocation": "PHYSICAL LOCATION TESTING",
         "minutesDuration": 30,
         "patientIcn": null,
@@ -1340,15 +1342,15 @@
         "requestedPeriods": null,
         "serviceType": "foodAndNutrition",
         "slot": null,
-        "created": "2024-08-22T13:00:00Z",
-        "start": "2024-08-22T13:00:00Z",
+        "created": "2025-08-22T13:00:00Z",
+        "start": "2025-08-22T13:00:00Z",
         "status": "booked",
         "telehealth": {
           "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
           "atlas": null,
           "vvsKind": "CLINIC_BASED"
         },
-        "past": true,
+        "past": false,
         "pending": false
       }
     },
@@ -1372,6 +1374,7 @@
         "id": "05aa456vvd",
         "kind": "telehealth",
         "type": "VA",
+        "modality": "vaVideoCareAtAVaLocation",
         "locationId": "983",
         "localStartTime": "2024-08-22T10:00:00.000-06:00",
         "physicalLocation": "PHYSICAL LOCATION TESTING",
@@ -4205,6 +4208,7 @@
         ],
         "kind": "telehealth",
         "type": "VA",
+        "modality": "vaVideoCareAtAVaLocation",
         "status": "booked",
         "serviceType": "outpatientMentalHealth",
         "serviceTypes": [
@@ -4335,6 +4339,7 @@
         ],
         "kind": "telehealth",
         "type": "VA",
+        "modality": "vaVideoCareAtAVaLocation",
         "status": "cancelled",
         "serviceType": "outpatientMentalHealth",
         "serviceTypes": [

--- a/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
+++ b/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
@@ -2,6 +2,11 @@
 import { addHours, format, startOfDay } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import {
+  transformVAOSAppointment,
+  transformVAOSAppointments,
+} from '../../services/appointment/transformers';
+import { parseApiList, parseApiObject } from '../../services/utils';
+import {
   APPOINTMENT_STATUS,
   DATE_FORMATS,
   TYPE_OF_VISIT_ID,
@@ -217,6 +222,7 @@ export default class MockAppointmentResponse {
    * @param {boolean} [arguments.future] - Flag to determine if appointment is a future appointment.
    * @param {boolean} [arguments.past] - Flag to determine if appointment is a past appointment.
    * @param {boolean} [arguments.pending] - Flag to determine if appointment is a pending appointment.
+   * @param {boolean} [arguments.vvsKind] - VVS king of the appointment. Default = VIDEO_TYPES.clinic.
    * @param {number} [arguments.count] - Number of MockAppointmentResponse objects to generate. Default = 1.
    * @returns Array of MockAppointmentResponse objects
    * @memberof MockAppointmentResponse
@@ -225,6 +231,7 @@ export default class MockAppointmentResponse {
     localStartTime,
     future = false,
     past = false,
+    vvsKind = VIDEO_TYPES.clinic,
     count = 1,
   } = {}) {
     return Array(count)
@@ -238,9 +245,42 @@ export default class MockAppointmentResponse {
         })
           .setKind(TYPE_OF_VISIT_ID.telehealth)
           .setModality('vaVideoCareAtAVaLocation')
-          .setType('COMMUNITY_CARE_APPOINTMENT')
-          .setVvsKind(VIDEO_TYPES.clinic),
+          .setType('VA')
+          .setVvsKind(vvsKind),
       );
+  }
+
+  /**
+   * Method to generate mock Clinic response object.
+   *
+   * @static
+   * @param {Object} arguments - Method arguments.
+   * @param {boolean} [arguments.future] - Flag to determine if appointment is a future appointment.
+   * @param {Date} [arguments.localStartTime] - Local start time.
+   * @param {boolean} [arguments.past] - Flag to determine if appointment is a past appointment.
+   * @param {boolean} [arguments.pending] - Flag to determine if appointment is a pending appointment.
+   * @param {boolean} [arguments.status] - Status of the appointment appointment.
+   * @param {boolean} [arguments.vvsKind] - VVS kind of the appointment.
+   * @returns Array of MockAppointmentResponse objects
+   * @memberof MockAppointmentResponse
+   */
+  static createClinicResponse({
+    future,
+    localStartTime,
+    past,
+    pending,
+    status,
+    vvsKind,
+  } = {}) {
+    return MockAppointmentResponse.createClinicResponses({
+      count: 1,
+      future,
+      localStartTime,
+      past,
+      pending,
+      status,
+      vvsKind,
+    })[0];
   }
 
   /**
@@ -529,6 +569,32 @@ export default class MockAppointmentResponse {
   setLocalStart(value) {
     this.attributes.localStartTime = value;
     return this;
+  }
+
+  /**
+   * Method to generate transformed mock appointment object. This object respresents
+   * the stored Redux appointment object.
+   *
+   * @static
+   * @param {MockAppointmentResponse} response MockAppointmentResponse object.
+   * @returns transformed object
+   * @memberof MockAppointmentResponse
+   */
+  static getTransformedResponse(response) {
+    return transformVAOSAppointment(parseApiObject({ data: response }));
+  }
+
+  /**
+   * Method to generate a collection of transformed mock appointment objects. These
+   * objects represent the stored Redux appointments objects.
+   *
+   * @static
+   * @param {Array<MockAppointmentResponse>} response - A collection of MockAppointmentResponse objects.
+   * @returns Transformed object
+   * @memberof MockAppointmentResponse
+   */
+  static getTransformedResponses(responses) {
+    return transformVAOSAppointments(parseApiList({ data: responses }));
   }
 
   /**

--- a/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
+++ b/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
@@ -222,7 +222,6 @@ export default class MockAppointmentResponse {
    * @param {boolean} [arguments.future] - Flag to determine if appointment is a future appointment.
    * @param {boolean} [arguments.past] - Flag to determine if appointment is a past appointment.
    * @param {boolean} [arguments.pending] - Flag to determine if appointment is a pending appointment.
-   * @param {boolean} [arguments.vvsKind] - VVS king of the appointment. Default = VIDEO_TYPES.clinic.
    * @param {number} [arguments.count] - Number of MockAppointmentResponse objects to generate. Default = 1.
    * @returns Array of MockAppointmentResponse objects
    * @memberof MockAppointmentResponse
@@ -231,7 +230,6 @@ export default class MockAppointmentResponse {
     localStartTime,
     future = false,
     past = false,
-    vvsKind = VIDEO_TYPES.clinic,
     count = 1,
   } = {}) {
     return Array(count)
@@ -246,7 +244,7 @@ export default class MockAppointmentResponse {
           .setKind(TYPE_OF_VISIT_ID.telehealth)
           .setModality('vaVideoCareAtAVaLocation')
           .setType('VA')
-          .setVvsKind(vvsKind),
+          .setVvsKind(VIDEO_TYPES.clinic),
       );
   }
 
@@ -260,7 +258,6 @@ export default class MockAppointmentResponse {
    * @param {boolean} [arguments.past] - Flag to determine if appointment is a past appointment.
    * @param {boolean} [arguments.pending] - Flag to determine if appointment is a pending appointment.
    * @param {boolean} [arguments.status] - Status of the appointment appointment.
-   * @param {boolean} [arguments.vvsKind] - VVS kind of the appointment.
    * @returns Array of MockAppointmentResponse objects
    * @memberof MockAppointmentResponse
    */
@@ -270,7 +267,6 @@ export default class MockAppointmentResponse {
     past,
     pending,
     status,
-    vvsKind,
   } = {}) {
     return MockAppointmentResponse.createClinicResponses({
       count: 1,
@@ -279,7 +275,6 @@ export default class MockAppointmentResponse {
       past,
       pending,
       status,
-      vvsKind,
     })[0];
   }
 
@@ -407,6 +402,28 @@ export default class MockAppointmentResponse {
           .setModality('vaVideoCareAtAVaLocation')
           .setVvsKind(VIDEO_TYPES.storeForward),
       );
+  }
+
+  /**
+   * Method to generate mock Store Forward response object.
+   *
+   * @static
+   * @param {Object} arguments - Method arguments.
+   * @param {Date} [arguments.localStartTime] - Local start time.
+   * @param {boolean} [arguments.future] - Flag to determine if appointment is a future appointment.
+   * @returns Array of MockAppointmentResponse objects
+   * @memberof MockAppointmentResponse
+   */
+  static createStoreForwardResponse({
+    localStartTime,
+    future = false,
+    count = 1,
+  } = {}) {
+    return MockAppointmentResponse.createStoreForwardResponses({
+      count,
+      localStartTime,
+      future,
+    })[0];
   }
 
   /**

--- a/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
+++ b/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
@@ -364,7 +364,7 @@ export default class MockAppointmentResponse {
           future,
         })
           .setKind(TYPE_OF_VISIT_ID.telehealth)
-          .setModality('vaVideoCareAtHome')
+          .setModality('vaVideoCareAtAVaLocation')
           .setVvsKind(VIDEO_TYPES.storeForward),
       );
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated FE to use data from vets-api as source of truth for Video at VA appointments 
- Appointments tool team
- This is behind the [`va_online_scheduling_fe_source_of_truth_telehealth`](https://dev-api.va.gov/flipper/features/va_online_scheduling_fe_source_of_truth_telehealth) feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/108265

## Testing done

- Tested locally, see screenshot. No changes are observed since this is a data layer level change without any UI difference
- Updated unit and e2e tests

## Screenshots

|         | Before | After (toggle on) | After (toggle off) |
| ------- | ------ | ----- | ----- |
| past appointment list | ![image](https://github.com/user-attachments/assets/1d1deee4-543a-4a1f-a89d-5de94eb45b67) | ![image](https://github.com/user-attachments/assets/e77a62a2-5b6a-4eb9-a623-790140309d84) | ![image](https://github.com/user-attachments/assets/4eb8f6f3-be44-4217-b1d9-0e5549051dab) |
| Video at VA | ![image](https://github.com/user-attachments/assets/44701599-ad7e-4dab-9e43-340b9aa8f1c6) | ![image](https://github.com/user-attachments/assets/e374f8cf-7698-46f0-a2b1-cb1761b57b34) | ![image](https://github.com/user-attachments/assets/e072f922-cd6b-49a2-ba82-33fa893568db) |

## What areas of the site does it impact?

Appointments tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
