### PR TITLE
[Income & Assets] Adding custom transformForSubmit function

### DIFF
--- a/src/applications/income-and-asset-statement/config/submit.js
+++ b/src/applications/income-and-asset-statement/config/submit.js
@@ -1,7 +1,7 @@
 import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
-import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 import { format } from 'date-fns-tz';
+import { cloneDeep } from 'lodash';
 
 export function replacer(key, value) {
   // clean up empty objects, which we have no reason to send
@@ -18,8 +18,29 @@ export function replacer(key, value) {
   return value;
 }
 
+export function transformForSubmit(formConfig, form, replacerFn) {
+  // Clone the form data to avoid mutating the original form
+  // This is to avoid mutating the redux store directly
+  const data = cloneDeep(form.data);
+
+  const fields = Object.keys(data);
+  fields.forEach(field => {
+    // Remove fields that are undefined, null, or starts with 'view:'
+    if (
+      data[field] === undefined ||
+      data[field] === null ||
+      field.startsWith('view:')
+    ) {
+      delete data[field];
+    }
+  });
+
+  return JSON.stringify(data, replacerFn);
+}
+
 export function transform(formConfig, form) {
   const formData = transformForSubmit(formConfig, form, replacer);
+
   return JSON.stringify({
     incomeAndAssetsClaim: {
       form: formData,

--- a/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
@@ -13,6 +13,7 @@ describe('Income and asset submit', () => {
         createObjectURL: sinon.stub().returns('test'),
       };
     });
+
     it('should reject if initial request fails', () => {
       mockFetch(new Error('fake error'), false);
       const formConfig = {
@@ -31,10 +32,36 @@ describe('Income and asset submit', () => {
         },
       );
     });
+
     afterEach(() => {
       delete window.URL;
     });
   });
+
+  describe('transformForSubmit', () => {
+    it('should remove undefined, null, and view: prefixed fields', () => {
+      const formConfig = {
+        chapters: {},
+      };
+      const formData = {
+        data: {
+          mailingAddress: { street: '123 Main St' },
+          view: 'someView',
+          undefinedField: undefined,
+          nullField: null,
+        },
+      };
+
+      const transformed = transformForSubmit(formConfig, formData, replacer);
+
+      expect(transformed).to.deep.equal(
+        JSON.stringify({
+          mailingAddress: { street: '123 Main St' },
+        }),
+      );
+    });
+  });
+
   describe('replacer', () => {
     it('should clean up empty objects', () => {
       const formConfig = {

--- a/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
@@ -46,7 +46,7 @@ describe('Income and asset submit', () => {
       const formData = {
         data: {
           mailingAddress: { street: '123 Main St' },
-          view: 'someView',
+          'view:viewField': 'someView',
           undefinedField: undefined,
           nullField: null,
         },


### PR DESCRIPTION
## Summary
Adding a custom `transformForSubmit` as the platform one removes certain fields on submission that we don't want removed. The new `transformForSubmit` behaves similarly to the platform one, but does not remove fields from inactive pages

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#111018

## Testing done
Added a unit test to cover the functionality of the new `transformForSubmit` function

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
