### PR TITLE
[BUG] Pluralized header in Letters app.

### DIFF
--- a/src/applications/letters/containers/LetterPage.jsx
+++ b/src/applications/letters/containers/LetterPage.jsx
@@ -10,7 +10,7 @@ export function LetterPage() {
   return (
     <div className="letters vads-u-margin-top--neg2 ">
       <NewAddressSection success={success} />
-      <h2>Benefit letters and document</h2>
+      <h2>Benefit letters and documents</h2>
       <LetterList />
     </div>
   );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
Fixed a typo where the word "document" needed to be "documents" in the Letters page H2.

## Related issue(s)
PR closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/112397

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2025-06-17 152140](https://github.com/user-attachments/assets/94a626ad-6c13-4579-84aa-897e2f281f96) | ![Screenshot 2025-06-17 152743](https://github.com/user-attachments/assets/ed20ee4b-7576-4115-8163-23ac109c76a2) |

## What areas of the site does it impact?

- Letters page only

## Acceptance criteria

### Quality Assurance & Testing

- [x] Manually verified the updated heading in `localhost`
- [x] Screenshot of the developed feature is added