### PR TITLE
MHV-72214 SQA-Labs-Chemistry-And-Hematology-Site-Or-Sample-Tested-Display-As-Sample-Tested-In-Download-TxT-File

### DIFF
--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -88,7 +88,7 @@ ${reportGeneratedBy}\n
 Date entered: ${record.date}\n
 ${txtLine}\n\n
 Type of test: ${record.type} \n
-Sample tested: ${record.sampleTested} \n
+Site or sample tested: ${record.sampleTested} \n
 Ordered by: ${record.orderedBy} \n
 Location: ${record.collectingLocation} \n
 Lab comments: ${processList(record.comments)} \n


### PR DESCRIPTION
## Summary
"Under Labs - Chemistry and hematology: "Sample tested"  replaced with "Site or sample tested" in download txt file"

## Related issue(s)
[72214(https://jira.devops.va.gov/browse/MHV-72214) - SQA: Labs - Chemistry and hematology: Site or sample tested display as "Sample tested" in download txt file


Under Labs - Chemistry and hematology: Site or sample tested display as "Sample tested" in download txt file

## Testing done
Tested affected page using new string structure. 

## Screen Shot
![Screenshot 2025-06-18 at 10 14 10 AM (3)](https://github.com/user-attachments/assets/ef2a0b92-056e-471c-bd2e-40d6d325631c)



## What areas of the site does it impact?
Chemistry and hematology details report section of medical records

## Acceptance criteria
'Sample tested' replaced by 'Site or sample tested'.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


