### PR TITLE
Update current email page

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/emailAddress.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/emailAddress.js
@@ -3,13 +3,17 @@ import {
   emailSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { hasSession } from '../../../helpers';
 
 /** @type {PageSchema} */
 export default {
   title: 'Current email',
   path: 'claimant/email',
   depends: formData => {
-    return formData?.claimantType !== 'VETERAN';
+    return (
+      formData?.claimantType !== 'VETERAN' ||
+      !(formData?.claimantType === 'VETERAN' && hasSession())
+    );
   },
   uiSchema: {
     ...titleUI('Current email'),

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/01-veteran-and-claimant-information/emailAddress.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/01-veteran-and-claimant-information/emailAddress.unit.spec.jsx
@@ -1,0 +1,38 @@
+import testData from '../../../e2e/fixtures/data/test-data.json';
+
+import formConfig from '../../../../config/form';
+import emailAddress from '../../../../config/chapters/01-veteran-and-claimant-information/emailAddress';
+import {
+  testNumberOfErrorsOnSubmitForWebComponents,
+  testNumberOfFieldsByType,
+  testSubmitsWithoutErrors,
+} from '../pageTests.spec';
+
+const { schema, uiSchema } = emailAddress;
+
+describe('income and asset current email page', () => {
+  testNumberOfFieldsByType(
+    formConfig,
+    schema,
+    uiSchema,
+    {
+      'va-text-input': 1,
+    },
+    'current email',
+  );
+  testNumberOfErrorsOnSubmitForWebComponents(
+    formConfig,
+    schema,
+    uiSchema,
+    1,
+    'current email',
+  );
+  testSubmitsWithoutErrors(
+    formConfig,
+    schema,
+    uiSchema,
+    'current email',
+    testData.data,
+    { loggedIn: true },
+  );
+});

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/01-veteran-and-claimant-information/phoneNumber.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/01-veteran-and-claimant-information/phoneNumber.unit.spec.jsx
@@ -1,0 +1,38 @@
+import testData from '../../../e2e/fixtures/data/test-data.json';
+
+import formConfig from '../../../../config/form';
+import phoneNumber from '../../../../config/chapters/01-veteran-and-claimant-information/phoneNumber';
+import {
+  testNumberOfErrorsOnSubmitForWebComponents,
+  testNumberOfFieldsByType,
+  testSubmitsWithoutErrors,
+} from '../pageTests.spec';
+
+const { schema, uiSchema } = phoneNumber;
+
+describe('income and asset phone number page', () => {
+  testNumberOfFieldsByType(
+    formConfig,
+    schema,
+    uiSchema,
+    {
+      'va-text-input': 1,
+    },
+    'phone number',
+  );
+  testNumberOfErrorsOnSubmitForWebComponents(
+    formConfig,
+    schema,
+    uiSchema,
+    0,
+    'phone number',
+  );
+  testSubmitsWithoutErrors(
+    formConfig,
+    schema,
+    uiSchema,
+    'phone number',
+    testData.data,
+    { loggedIn: true },
+  );
+});


### PR DESCRIPTION
## Summary
Updated the **Current email** page logic on the Income and Asset Statement form (VA Form 21P-0969) so that it displays when `claimantType` is `"VETERAN"` and the Veteran is not authenticated. This ensures we collect email information for unauthenticated Veterans as required for sending confirmation emails.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112399

## Related issue(s)
- N/A

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Ensure the `income_and_assets_form_enabled ` feature toggle is enabled
4. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969/` in your browser

## How to verify
1. Navigate through the form as an unauthenticated user with `claimantType: "VETERAN"`
2. Confirm that the **Current email** page is displayed during the flow
3. Ensure email is required and captured and saved in form data
4. Verify the page does not appear for authenticated Veterans

## What areas of the site does it impact?
Income and Asset Statement Application — Current email page logic

## Screenshots
### Desktop
| Before      | After       |
| ----------- | ----------- |
| Current email page not shown for unauthenticated Veterans | Current email page correctly shown for unauthenticated Veterans |

### Mobile (if applicable)
| Before      | After       |
| ----------- | ----------- |
| Current email page not shown for unauthenticated Veterans | Current email page correctly shown for unauthenticated Veterans |

### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated and unauthenticated routes work as expected with a test user

## Requested Feedback
Please review the conditional logic for displaying the page and let me know if additional edge cases should be considered.
