### PR TITLE
Add Datadog error logging in transformForSubmit util

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -700,24 +700,29 @@ export function omitRequired(schema) {
  * @param {ReplacerOptions | (key, val) => any | any[]} [options] An object of options for the transform, or a JSON.stringify replacer argument
  */
 export function transformForSubmit(formConfig, form, options) {
-  const replacer =
-    typeof options === 'function' || Array.isArray(options)
-      ? options
-      : createStringifyFormReplacer(options);
-  const expandedPages = expandArrayPages(
-    createFormPageList(formConfig),
-    form.data,
-  );
-  const activePages = getActivePages(expandedPages, form.data);
-  const inactivePages = getInactivePages(expandedPages, form.data);
-  const withoutInactivePages = filterInactivePageData(
-    inactivePages,
-    activePages,
-    form,
-  );
-  const withoutViewFields = filterViewFields(withoutInactivePages);
+  try {
+    const replacer =
+      typeof options === 'function' || Array.isArray(options)
+        ? options
+        : createStringifyFormReplacer(options);
+    const expandedPages = expandArrayPages(
+      createFormPageList(formConfig),
+      form.data,
+    );
+    const activePages = getActivePages(expandedPages, form.data);
+    const inactivePages = getInactivePages(expandedPages, form.data);
+    const withoutInactivePages = filterInactivePageData(
+      inactivePages,
+      activePages,
+      form,
+    );
+    const withoutViewFields = filterViewFields(withoutInactivePages);
 
-  return JSON.stringify(withoutViewFields, replacer) || '{}';
+    return JSON.stringify(withoutViewFields, replacer) || '{}';
+  } catch (error) {
+    window.DD_LOGS?.logger.error('Transform for Submit error', {}, error);
+    return '{}';
+  }
 }
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

The 10-10 has been seeing a spike in prefill data that is creating issues in the submit transformer if its not presented to the user to adjust in the form. When this data is passed through the submit transformer, it has been tossing errors and not allowing for submission or PDF download. This PR adds Datadog logging to the `transformForSubmit` platform utility to better catch those errors and provide a more helpful stack trace.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#112466

## Acceptance criteria

 - Logs are available for debugging these types of failures

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution