### PR TITLE
SC 109178: Add return URL logic

### DIFF
--- a/src/applications/appeals/995/components/4142/Authorization.jsx
+++ b/src/applications/appeals/995/components/4142/Authorization.jsx
@@ -54,6 +54,14 @@ const Authorization = ({
     state => state?.form?.loadedData?.metadata?.lastUpdated,
   );
 
+  const returnUrl = useSelector(
+    state => state?.form?.loadedData?.metadata?.returnUrl,
+  );
+
+  const returnUrlIs4142Auth =
+    returnUrl &&
+    returnUrl === '/supporting-evidence/private-medical-records-authorization';
+
   const toggle4142PrivacyModal = () => {
     setModalVisible(!modalVisible);
   };
@@ -61,10 +69,12 @@ const Authorization = ({
   useEffect(
     () => {
       if (lastUpdated && typeof lastUpdated === 'number') {
-        setShowLegaleseBanner(lastUpdatedIsBeforeCutoff(lastUpdated));
+        setShowLegaleseBanner(
+          returnUrlIs4142Auth && lastUpdatedIsBeforeCutoff(lastUpdated),
+        );
       }
     },
-    [lastUpdated],
+    [lastUpdated, returnUrlIs4142Auth],
   );
 
   useEffect(


### PR DESCRIPTION
## Summary

The criteria for showing the warning banner upon a user's return to an in-progress application require that the `returnUrl` is the 4142 authorization page (`/supporting-evidence/private-medical-records-authorization`). I forgot to add this logic in the previously-merged PR, so I'm adding it here.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111446

## Screenshots

### 1️⃣ Application saved before 4142 authorization page

This app's return URL is the page with the `Would you like us to request your non-VA medical records?` question.

<img width="500" alt="Screenshot 2025-06-18 at 3 23 42 PM" src="https://github.com/user-attachments/assets/d1d577dd-e12b-4fad-92aa-401ab9f94f05" />

<img width="400" alt="Screenshot 2025-06-18 at 3 23 49 PM" src="https://github.com/user-attachments/assets/d8f1f2b9-a1e2-4168-b332-735b58e7ed8b" />

<hr />

### 2️⃣ Application saved on the 4142 authorization page

This app was saved on the 4142 authorization page.

<img width="500" alt="Screenshot 2025-06-18 at 3 24 10 PM" src="https://github.com/user-attachments/assets/300e68b1-28d0-457d-b360-3a7e6706eb5e" />

<img width="400" alt="Screenshot 2025-06-18 at 3 24 19 PM" src="https://github.com/user-attachments/assets/f9c09167-9511-481c-afe0-73a377a442a7" />

<hr />

### 3️⃣ Application saved with "no" for 4142 records

This scenario wouldn't be affected by the rake task, but when I pulled up this saved app, I backed up and changed the 4142 response to get to the auth page, and I do not see the banner. This is the expected behavior as I wouldn't have seen it previously, having said "no" to getting non-VA records.

<img width="500" alt="Screenshot 2025-06-18 at 3 29 28 PM" src="https://github.com/user-attachments/assets/8a1ef6b3-682f-4058-90a2-48e31799094b" />

<img width="400" alt="Screenshot 2025-06-18 at 3 25 09 PM" src="https://github.com/user-attachments/assets/be741a8e-b8d1-49da-9ede-f507818f7a0e" />

<hr />

### 4️⃣ New application (not saved / in-progress)

<img width="400" alt="Screenshot 2025-06-18 at 3 33 05 PM" src="https://github.com/user-attachments/assets/b43dc387-0fed-45c4-b1d6-f3757a391103" />

<hr />

### 5️⃣ Application saved in 4142 flow after authorization AND after cutoff date (should not show banner)

For this scenario, I saved it on the limited consent page (after authorization), then ran the rake task to update the `returnUrl`. I also moved the `CUTOFF_DATE_4142` to yesterday. Not expecting to see the banner here:

#### When the app was saved:

<img width="500" alt="Screenshot 2025-06-18 at 3 34 59 PM" src="https://github.com/user-attachments/assets/9260d7e0-e670-41f4-a8ac-118bd8b59797" />

#### Post rake task, when the app was pulled up again:

<img width="500" alt="Screenshot 2025-06-18 at 3 35 14 PM" src="https://github.com/user-attachments/assets/12c888db-edb6-4ab6-877f-a7d1b3771a8b" />

#### Result
<img width="400" alt="Screenshot 2025-06-18 at 3 35 40 PM" src="https://github.com/user-attachments/assets/6fec2f92-5f22-4566-800e-16933213f078" />\

<hr />

### 6️⃣ Application saved in 4142 flow after authorization and BEFORE cutoff date (should show banner)

For this scenario, I saved it on the limited consent page (after authorization), then ran the rake task to update the `returnUrl`. I left the `CUTOFF_DATE_4142` as-is (in the future). Expecting to see the banner here:

#### When the app was saved:

<img width="500" alt="Screenshot 2025-06-18 at 3 38 48 PM" src="https://github.com/user-attachments/assets/d1711a19-18dc-46e3-8831-34dd13e4189e" />

#### Post rake task, when the app was pulled up again:

<img width="500" alt="Screenshot 2025-06-18 at 3 39 32 PM" src="https://github.com/user-attachments/assets/bac54342-a015-4b3e-97a6-b0be3fdbe2ef" />

#### Result

<img width="400" alt="Screenshot 2025-06-18 at 3 39 39 PM" src="https://github.com/user-attachments/assets/d85d3894-490b-44d6-851c-f810121e883e" />