### PR TITLE
Add date received by page

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/dateReceivedBy.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/dateReceivedBy.js
@@ -1,0 +1,29 @@
+import {
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  title: 'Reporting period',
+  path: 'claimant/has-reporting-period',
+  uiSchema: {
+    title: 'Reporting period',
+    dateReceivedByVa: yesNoUI({
+      title:
+        'Are you submitting an initial application for Veterans Pension or Parents’ DIC, or are you already receiving these benefits?',
+      labelHeaderLevel: '3',
+      labels: {
+        Y: 'I’m applying for Veterans Pension or Parents’ DIC benefits',
+        N: 'I’m already receiving Veterans Pension or Parents’ DIC benefits',
+      },
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['dateReceivedByVa'],
+    properties: {
+      dateReceivedByVa: yesNoSchema,
+    },
+  },
+};

--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/incomeNetWorthDateRange.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/incomeNetWorthDateRange.js
@@ -7,29 +7,27 @@ import {
 
 export const Description = (
   <>
-    This form is designed to provide VA with your income and net worth during a
-    specific date range to determine your eligibility or adjust your benefits.
-    If you are submitting an initial application, report current information.
-    Your effective date is typically the earliest of the following dates:
-    <ul>
-      <li>Date VA receives your application</li>
-      <li>Date VA receives your intent to file</li>
-      <li>Date of Veteran’s death (Survivor’s Benefits only)</li>
-    </ul>{' '}
-    If you are submitting this form as a response to VA correspondence, report
-    your income and net worth information during the date range specified in
-    that correspondence. If you are reporting an income change, report changes
-    from the date the change took effect.
+    <p>
+      Enter the date range that your income and asset statement will report. You
+      don’t need to have exact dates.
+    </p>
+    <p className="vads-u-margin-bottom--0">
+      <strong>Note:</strong> If you need to report information for multiple date
+      ranges, submit a new form for each date range.
+    </p>
   </>
 );
 
 /** @type {PageSchema} */
 export default {
-  title: 'Statement Period',
-  path: 'claimant/statement-period',
+  title: 'Reporting period',
+  path: 'claimant/reporting-period',
+  depends: formData => {
+    return !formData?.dateReceivedByVa;
+  },
   uiSchema: {
-    ...titleUI('Statement Period', Description),
-    incomeNetWorthDateRange: currentOrPastDateRangeUI(),
+    ...titleUI('Reporting period', Description),
+    incomeNetWorthDateRange: currentOrPastDateRangeUI('Start date', 'End date'),
   },
   schema: {
     type: 'object',

--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/index.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-and-claimant-information/index.js
@@ -8,6 +8,7 @@ import editEmailAddress from './editEmailAddress';
 import editPhoneNumber from './editPhoneNumber';
 import emailAddress from './emailAddress';
 import phoneNumber from './phoneNumber';
+import dateReceivedBy from './dateReceivedBy';
 import incomeNetWorthDateRange from './incomeNetWorthDateRange';
 
 const customConfig = {
@@ -38,6 +39,7 @@ export default {
     emailAddress,
     phoneNumber,
     veteranInformation,
+    dateReceivedBy,
     incomeNetWorthDateRange,
   },
 };

--- a/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "dateReceivedByVa": false,
     "incomeNetWorthDateRange": {
       "from": "2023-07-01",
       "to": "2024-01-01"

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/01-veteran-and-claimant-information/dateReceivedBy.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/01-veteran-and-claimant-information/dateReceivedBy.unit.spec.jsx
@@ -1,0 +1,50 @@
+import testData from '../../../e2e/fixtures/data/test-data.json';
+
+import {
+  testNumberOfErrorsOnSubmitForWebComponents,
+  testNumberOfFieldsByType,
+  testNumberOfWebComponentFields,
+  testSubmitsWithoutErrors,
+} from '../pageTests.spec';
+import formConfig from '../../../../config/form';
+import dateReceivedBy from '../../../../config/chapters/01-veteran-and-claimant-information/dateReceivedBy';
+
+const { schema, uiSchema } = dateReceivedBy;
+
+describe('income and asset statement date received by page', () => {
+  const expectedNumberOfFields = 1;
+  testNumberOfWebComponentFields(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfFields,
+    'date received by',
+  );
+
+  const expectedNumberOfErrors = 1;
+  testNumberOfErrorsOnSubmitForWebComponents(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfErrors,
+    'date received by',
+  );
+
+  testSubmitsWithoutErrors(
+    formConfig,
+    schema,
+    uiSchema,
+    'date received by',
+    testData.data,
+  );
+
+  testNumberOfFieldsByType(
+    formConfig,
+    schema,
+    uiSchema,
+    {
+      'va-radio': 1,
+    },
+    'date received by',
+  );
+});


### PR DESCRIPTION
## Summary
Added the **Date received by** page to the Income and Asset Statement form (VA Form 21P-0969). This page includes a yes/no question that maps to the `dateReceivedByVa` schema field as a boolean. When `dateReceivedByVa` is `false`, the form will conditionally display the **Reporting period** page to collect additional date information.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106216

## Design Reference
[Figma file](https://www.figma.com/design/tJhSwyQorlgdVPC2UKx1fQ/WIP---21P-0969-Income-and-Asset?node-id=1093-144897&t=0vc3dAgMEYcKh7RQ-0)

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Ensure email is required and captured and saved in form data
4. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969/` in your browser

## How to verify
1. Continue to the **Date received by** 'claimant/has-reporting-period' page
2. Select 'I’m applying for Veterans Pension or Parents’ DIC benefits' — verify that the **Reporting period** page is skipped
3. Select 'I’m already receiving Veterans Pension or Parents’ DIC benefits' — verify that the **Reporting period** page is shown next
4. Confirm form data correctly captures `dateReceivedByVa` as a boolean

## What areas of the site does it impact?
Income and Asset Statement Application — Date received by page and Reporting period page logic

## Screenshots
### Date received by page
| Pristine  | Required error |
| ----------- | ----------- |
|![Screenshot 2025-06-18 at 2 06 10 PM](https://github.com/user-attachments/assets/348fb308-db80-49ea-b616-125830f02e1b)|![Screenshot 2025-06-18 at 2 06 20 PM](https://github.com/user-attachments/assets/eab9dff5-9b12-44c0-bdad-3dee4ad863be)



### Reporting period page
| Before      | After       |
| ----------- | ----------- |
|![Screenshot 2025-06-18 at 1 40 25 PM](https://github.com/user-attachments/assets/e2ab23e2-dc2e-4fd0-a9f6-ded82208ce43)|![Screenshot 2025-06-18 at 2 06 35 PM](https://github.com/user-attachments/assets/929d4735-613a-4cea-a2d0-d3aa209843dd)

### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
Please review the conditional logic to ensure the **Reporting period** page is displayed only when `dateReceivedByVa` is `false`. Let me know if additional refinements are needed for edge cases or wording on the **Date received by** page.
