### PR TITLE
updated to include op param value

### DIFF
--- a/src/applications/verify/components/UnifiedVerify.jsx
+++ b/src/applications/verify/components/UnifiedVerify.jsx
@@ -34,15 +34,29 @@ export default function Verify() {
   let buttonContent;
   if (!loading && isAuthenticated) {
     if (loginServiceName === 'idme') {
-      buttonContent = <VerifyIdmeButton />;
+      buttonContent = (
+        <VerifyIdmeButton
+          queryParams={{ operation: 'verify_page_authenticated' }}
+        />
+      );
     } else {
-      buttonContent = <VerifyLogingovButton />;
+      buttonContent = (
+        <VerifyLogingovButton
+          queryParams={{ operation: 'verify_page_authenticated' }}
+        />
+      );
     }
   } else {
     buttonContent = (
       <>
-        <VerifyLogingovButton useOAuth />
-        <VerifyIdmeButton useOAuth />
+        <VerifyLogingovButton
+          useOAuth
+          queryParams={{ operation: 'verify_page_unauthenticated' }}
+        />
+        <VerifyIdmeButton
+          useOAuth
+          queryParams={{ operation: 'verify_page_unauthenticated' }}
+        />
       </>
     );
   }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added support for logging `operation` query parameters to the `/verify` page’s Login.gov and ID.me buttons to distinguish between unauthenticated and authenticated entry points. Specifically, the following `operation` values are now passed in `queryParams`:
  - `verify_page_unauthenticated` (for unauthenticated users)
  - `verify_page_authenticated` (for users returning post-auth)

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1646/views/3?pane=issue&itemId=113715095&issue=department-of-veterans-affairs%7Cidentity-documentation%7C377

## Testing done
Manually confirmed the correct `operation` param is passed on click via DevTools (in redirect URLs)
Verified unauthenticated and authenticated states trigger appropriate query param values

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

- `/verify` page identity verification buttons (Login.gov & ID.me)
- Authentication initiation logic for ID verification (but **no changes to core redirect logic**)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
   - Went to update tests but suites already covered said addition. 
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
