### PR TITLE
Remove va_online_scheduling_fe_source_of_truth feature toggle

### DIFF
--- a/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
@@ -207,6 +207,7 @@ describe('VAOS Backend Service Alert', () => {
     const appointment = new MockAppointmentResponse({
       localStartTime: yesterday,
       status: APPOINTMENT_STATUS.proposed,
+      pending: true,
     }).setLocation(new MockFacilityResponse());
 
     mockAppointmentsApi({
@@ -239,6 +240,7 @@ describe('VAOS Backend Service Alert', () => {
     const appointment = new MockAppointmentResponse({
       localStartTime: yesterday,
       status: APPOINTMENT_STATUS.proposed,
+      pending: true,
     }).setLocation(new MockFacilityResponse());
 
     mockAppointmentsApi({

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/AppointmentColumnLayout.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 import moment from 'moment';
-import { selectFeatureFeSourceOfTruth } from '../../../redux/selectors';
 import AppointmentRow from '../../../components/AppointmentRow';
 import {
   selectAppointmentLocality,
@@ -27,16 +26,11 @@ export default function AppointmentColumnLayout({
   const appointmentLocality = useSelector(() =>
     selectAppointmentLocality(data),
   );
-  const useFeSourceOfTruth = useSelector(state =>
-    selectFeatureFeSourceOfTruth(state),
-  );
   const isCanceled = useSelector(() => selectIsCanceled(data));
   const isCommunityCare = useSelector(() => selectIsCommunityCare(data));
   const modalityText = useSelector(() => selectModalityText(data));
   const modalityIcon = useSelector(() => selectModalityIcon(data));
-  const startDate = useSelector(() =>
-    selectStartDate(data, useFeSourceOfTruth),
-  );
+  const startDate = useSelector(() => selectStartDate(data));
   const parsedDate = moment.parseZone(startDate);
   const timezoneAbbr = useSelector(() => selectTimeZoneAbbr(data));
 

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
@@ -58,14 +58,14 @@ describe('VAOS Page: AppointmentsPage', () => {
       start: subDays(new Date(), 120),
       end: addDays(new Date(), 1),
       statuses: ['proposed', 'cancelled'],
-      response: MockAppointmentResponse.createCCResponses(),
+      response: MockAppointmentResponse.createCCResponses({ pending: true }),
     });
     mockAppointmentsApi({
       start: subDays(new Date(), 120),
       end: addDays(new Date(), 1),
       includes: ['facilities', 'clinics', 'eps'],
       statuses: ['proposed', 'cancelled'],
-      response: MockAppointmentResponse.createCCResponses(),
+      response: MockAppointmentResponse.createCCResponses({ pending: true }),
     });
   });
   afterEach(() => {
@@ -314,139 +314,6 @@ describe('VAOS Page: AppointmentsPage', () => {
 
     // Then it should display the tertiary print button
     expect(screen.getByTestId('print-list')).to.be.ok;
-  });
-
-  describe('when scheduling breadcrumb url update flag is on', () => {
-    const defaultState = {
-      featureToggles: {
-        ...initialState.featureToggles,
-        vaOnlineSchedulingDirect: true,
-        vaOnlineSchedulingCommunityCare: false,
-      },
-      user: userState,
-    };
-
-    it('should display updated title on upcoming appointments page', async () => {
-      // Given the veteran lands on the VAOS homepage
-      // When the page displays
-      const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
-        initialState: defaultState,
-      });
-
-      // Then it should display the upcoming appointments
-      expect(
-        await screen.findByRole('heading', {
-          level: 1,
-          name: 'Appointments',
-        }),
-      );
-      await waitFor(() => {
-        expect(global.document.title).to.equal(
-          `Appointments | Veterans Affairs`,
-        );
-      });
-
-      // and breadcrumbs should be updated
-      const navigation = screen.getByTestId('vaos-breadcrumbs');
-      expect(navigation).to.be.ok;
-      expect(within(navigation).queryByRole('link', { name: 'Pending' })).not.to
-        .exist;
-      expect(within(navigation).queryByRole('link', { name: 'Past' })).not.to
-        .exist;
-
-      // and scheduling link should be displayed
-      expect(screen.getByRole('link', { name: 'Start scheduling' })).to.be.ok;
-
-      // and appointment list navigation should be displayed
-      expect(screen.getByRole('navigation', { name: 'Appointment list' })).to.be
-        .ok;
-      expect(screen.getByRole('link', { name: 'Upcoming' })).to.be.ok;
-      expect(screen.getByRole('link', { name: /Pending \(\d\)/ })).to.be.ok;
-      expect(screen.getByRole('link', { name: 'Past' })).to.be.ok;
-
-      // and status dropdown should not be displayed
-      expect(screen.queryByLabelText('Show by status')).not.to.exists;
-    });
-
-    it('should display updated title on pending appointments page', async () => {
-      // Given the veteran lands on the VAOS homepage
-      // When the page displays
-      const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
-        initialState: defaultState,
-      });
-
-      // Then it should display upcoming appointments
-      await screen.findByRole('heading', { name: 'Appointments' });
-
-      // When the veteran clicks the Pending button
-      const navigation = await screen.findByRole('link', {
-        name: /^Pending \(1\)/,
-      });
-      userEvent.click(navigation);
-      await waitFor(() => {
-        expect(screen.history.push.lastCall.args[0].pathname).to.equal(
-          '/pending',
-        );
-      });
-
-      // Then it should display the requested appointments
-      await waitFor(() => {
-        expect(
-          screen.findByRole('heading', {
-            level: 1,
-            name: 'Pending appointments',
-          }),
-        );
-      });
-      await waitFor(() => {
-        expect(global.document.title).to.equal(
-          `Pending appointments | Veterans Affairs`,
-        );
-      });
-
-      expect(
-        global.window.dataLayer.some(
-          e => e === `vaos-status-pending-link-clicked`,
-        ),
-      );
-    });
-
-    it('should display updated past appointments page title', async () => {
-      // Given the veteran lands on the VAOS homepage
-      // When the page displays
-      const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
-        initialState: defaultState,
-      });
-
-      // Then it should display the upcoming appointments
-      await screen.findByRole('heading', { name: 'Appointments' });
-
-      // When the veteran clicks the Past button
-      const navigation = screen.getByRole('link', { name: 'Past' });
-      userEvent.click(navigation);
-      await waitFor(() =>
-        expect(screen.history.push.lastCall.args[0].pathname).to.equal('/past'),
-      );
-
-      // Then it should display the past appointments
-      expect(
-        await screen.findByRole('heading', {
-          level: 1,
-          name: 'Past appointments',
-        }),
-      ).to.be.ok;
-      await waitFor(() => {
-        expect(global.document.title).to.equal(
-          `Past appointments | Veterans Affairs`,
-        );
-      });
-
-      expect(
-        global.window.dataLayer.some(
-          e => e === `vaos-status-past-link-clicked`,
-        ),
-      );
-    });
   });
 
   describe('when CC direct scheduling flag is on', () => {

--- a/src/applications/vaos/appointment-list/pages/CancelAppointmentPage/CancelConfirmationPage.jsx
+++ b/src/applications/vaos/appointment-list/pages/CancelAppointmentPage/CancelConfirmationPage.jsx
@@ -5,13 +5,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
 import AppointmentCard from '../../../components/AppointmentCard';
 import BackLink from '../../../components/BackLink';
-import { APPOINTMENT_TYPES, GA_PREFIX } from '../../../utils/constants';
+import { GA_PREFIX } from '../../../utils/constants';
 import { startNewAppointmentFlow } from '../../redux/actions';
 // eslint-disable-next-line import/no-restricted-paths
 import getNewAppointmentFlow from '../../../new-appointment/newAppointmentFlow';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
-import { selectAppointmentType } from '../../redux/selectors';
-import { selectFeatureFeSourceOfTruth } from '../../../redux/selectors';
 
 import CancelPageContent from './CancelPageContent';
 
@@ -31,16 +29,9 @@ function handleClick(history, dispatch, url) {
 export default function CancelConfirmationPage({ appointment, cancelInfo }) {
   const dispatch = useDispatch();
   const history = useHistory();
-  const useFeSourceOfTruth = useSelector(state =>
-    selectFeatureFeSourceOfTruth(state),
-  );
   const { typeOfCare: page } = useSelector(getNewAppointmentFlow);
   const { showCancelModal } = cancelInfo;
-  const type = selectAppointmentType(appointment);
-  const isRequest = useFeSourceOfTruth
-    ? appointment.vaos.isPendingAppointment
-    : APPOINTMENT_TYPES.request === type ||
-      APPOINTMENT_TYPES.ccRequest === type;
+  const isRequest = appointment.vaos.isPendingAppointment;
 
   let heading = 'You have canceled your appointment';
   if (isRequest) heading = 'You have canceled your request';

--- a/src/applications/vaos/appointment-list/pages/CancelAppointmentPage/CancelWarningPage.jsx
+++ b/src/applications/vaos/appointment-list/pages/CancelAppointmentPage/CancelWarningPage.jsx
@@ -1,17 +1,14 @@
 /* eslint-disable @department-of-veterans-affairs/prefer-button-component */
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import AppointmentCard from '../../../components/AppointmentCard';
 import BackLink from '../../../components/BackLink';
-import { APPOINTMENT_TYPES } from '../../../utils/constants';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import {
   closeCancelAppointment,
   confirmCancelAppointment,
 } from '../../redux/actions';
-import { selectAppointmentType } from '../../redux/selectors';
-import { selectFeatureFeSourceOfTruth } from '../../../redux/selectors';
 
 import CancelPageContent from './CancelPageContent';
 
@@ -25,19 +22,11 @@ function handleClose(dispatch) {
 
 export default function CancelWarningPage({ appointment, cancelInfo }) {
   const dispatch = useDispatch();
-  const useFeSourceOfTruth = useSelector(state =>
-    selectFeatureFeSourceOfTruth(state),
-  );
-
   const { showCancelModal } = cancelInfo;
-  const type = selectAppointmentType(appointment);
+  const isRequest = appointment.vaos.isPendingAppointment;
 
   let heading = 'Would you like to cancel this appointment?';
   let buttonText = 'Yes, cancel appointment';
-  const isRequest = useFeSourceOfTruth
-    ? appointment.vaos.isPendingAppointment
-    : APPOINTMENT_TYPES.request === type ||
-      APPOINTMENT_TYPES.ccRequest === type;
   if (isRequest) {
     heading = 'Would you like to cancel this request?';
     buttonText = 'Yes, cancel request';

--- a/src/applications/vaos/appointment-list/pages/RequestedAppointmentDetailsPage/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/RequestedAppointmentDetailsPage/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -44,6 +44,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     // Arrange
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.proposed,
+      pending: true,
     });
     mockAppointmentsApi({
       end: addDays(new Date(), 2),
@@ -102,6 +103,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     // Arrange
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.proposed,
+      pending: true,
     });
 
     mockAppointmentApi({ response });
@@ -125,6 +127,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     const response = MockAppointmentResponse.createCCResponse();
     response
       .setStatus(APPOINTMENT_STATUS.proposed)
+      .setPending(true)
       .setTypeOfCare('audiology-hearing aid support');
 
     mockAppointmentApi({ response });
@@ -149,7 +152,8 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
       status: APPOINTMENT_STATUS.proposed,
     })
       .setKind('cc')
-      .setStatus(APPOINTMENT_STATUS.proposed);
+      .setStatus(APPOINTMENT_STATUS.proposed)
+      .setPending(true);
 
     mockAppointmentApi({ response });
 
@@ -177,6 +181,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     // Arrange
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.cancelled,
+      pending: true,
     });
     response.setRequestedPeriods([new Date()]);
 
@@ -202,6 +207,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     const requestedPeriods = [new Date()];
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.proposed,
+      pending: true,
     });
     const canceledResponse = MockAppointmentResponse.createCCResponse();
     canceledResponse
@@ -239,6 +245,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     const requestedPeriods = [new Date()];
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.proposed,
+      pending: true,
     });
     const canceledResponse = MockAppointmentResponse.createCCResponse();
     canceledResponse
@@ -280,49 +287,6 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     });
   });
 
-  describe('When FE source of truth toggle is on', () => {
-    const defaultState = {
-      featureToggles: {
-        ...initialState.featureToggles,
-        vaOnlineSchedulingFeSourceOfTruth: true,
-      },
-    };
-    it('should go back to requests page when clicking top link', async () => {
-      // Arrange
-      const response = new MockAppointmentResponse({
-        status: APPOINTMENT_STATUS.proposed,
-        pending: true,
-      });
-
-      mockAppointmentsApi({
-        end: addDays(new Date(), 2),
-        start: subDays(new Date(), 120),
-        statuses: ['proposed', 'cancelled'],
-        response: [response],
-      });
-
-      // Act
-      const screen = renderWithStoreAndRouter(<AppointmentList />, {
-        initialState: defaultState,
-        path: '/pending',
-      });
-
-      // Assert
-      const detailLinks = await screen.findByRole('link', { name: /Details/i });
-
-      fireEvent.click(detailLinks);
-      expect(await screen.findByText('Request for appointment')).to.be.ok;
-      const link = screen.container.querySelector(
-        'va-link[text="Back to pending appointments"]',
-      );
-      userEvent.click(link);
-      expect(screen.history.push.called).to.be.true;
-      await waitFor(() => {
-        expect(screen.history.push.lastCall.args[0]).to.equal('/pending');
-      });
-    });
-  });
-
   describe('When on cancel warning page', () => {
     it('should go back to pending appointments detail page when breadcrumb is clicked', async () => {
       // Arrange
@@ -330,6 +294,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
       const requestedPeriods = [new Date()];
       const response = new MockAppointmentResponse({
         status: APPOINTMENT_STATUS.proposed,
+        pending: true,
       });
       const canceledResponse = MockAppointmentResponse.createCCResponse();
       canceledResponse
@@ -394,12 +359,14 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
       const requestedPeriods = [new Date()];
       const response = new MockAppointmentResponse({
         status: APPOINTMENT_STATUS.proposed,
+        pending: true,
       });
       const canceledResponse = MockAppointmentResponse.createCCResponse();
       canceledResponse
         .setCancelationReason('pat')
         .setRequestedPeriods(requestedPeriods)
-        .setStatus(APPOINTMENT_STATUS.cancelled);
+        .setStatus(APPOINTMENT_STATUS.cancelled)
+        .setPending(true);
 
       mockAppointmentApi({ response });
 
@@ -460,6 +427,7 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
       const store = createTestStore(initialState);
       const response = new MockAppointmentResponse({
         status: APPOINTMENT_STATUS.proposed,
+        pending: true,
       });
 
       mockAppointmentApi({ response });

--- a/src/applications/vaos/appointment-list/pages/RequestedAppointmentsPage/RequestedAppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/RequestedAppointmentsPage/RequestedAppointmentsPage.unit.spec.jsx
@@ -15,10 +15,9 @@ import {
 import { APPOINTMENT_STATUS, TYPE_OF_CARE_IDS } from '../../../utils/constants';
 import RequestedAppointmentsPage from './RequestedAppointmentsPage';
 
-const initialStateVAOSService = {
+const initialState = {
   featureToggles: {
     vaOnlineSchedulingCancel: true,
-    vaOnlineSchedulingFeSourceOfTruth: true,
     vaOnlineSchedulingFeSourceOfTruthVA: true,
   },
 };
@@ -52,7 +51,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
 
     // When veteran selects the Requested dropdown selection
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: initialStateVAOSService,
+      initialState,
       reducers,
     });
     // Then it should display the requested appointments
@@ -83,7 +82,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
     });
     // When veteran selects the Requested dropdown selection
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: initialStateVAOSService,
+      initialState,
       reducers,
     });
 
@@ -118,9 +117,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
 
     // When veteran selects requested appointments
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: {
-        ...initialStateVAOSService,
-      },
+      initialState,
       reducers,
     });
 
@@ -156,7 +153,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
 
     // When veteran selects the Requested dropdown selection
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: initialStateVAOSService,
+      initialState,
       reducers,
     });
 
@@ -186,9 +183,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
 
     // When veteran selects requested appointments
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: {
-        ...initialStateVAOSService,
-      },
+      initialState,
       reducers,
     });
 
@@ -223,9 +218,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
 
     // When veteran selects requested appointments
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: {
-        ...initialStateVAOSService,
-      },
+      initialState,
       reducers,
     });
 
@@ -255,9 +248,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
 
     // When veteran selects requested appointments
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: {
-        ...initialStateVAOSService,
-      },
+      initialState,
       reducers,
     });
 
@@ -288,7 +279,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
     });
 
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsPage />, {
-      initialState: initialStateVAOSService,
+      initialState,
       reducers,
     });
 
@@ -302,8 +293,7 @@ describe('VAOS Component: RequestedAppointmentsPage', () => {
   describe('When FE Source of Truth is off', () => {
     const defaultState = {
       featureToggles: {
-        ...initialStateVAOSService.featureToggles,
-        vaOnlineSchedulingFeSourceOfTruth: false,
+        ...initialState.featureToggles,
         vaOnlineSchedulingFeSourceOfTruthVA: true,
       },
     };

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsPage/UpcomingAppointmentsPage.unit.spec.jsx
@@ -36,6 +36,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     // Arrange
     const appointment = new MockAppointmentResponse({
       localStartTime: now,
+      future: true,
     })
       .setLocation(new MockFacilityResponse())
       .setTypeOfCare(null);
@@ -71,6 +72,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     // Arrange
     const appointment = new MockAppointmentResponse({
       localStartTime: now,
+      future: true,
     })
       .setLocation(new MockFacilityResponse())
       .setTypeOfCare(null);
@@ -113,6 +115,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     const appointments = MockAppointmentResponse.createCCResponses({
       localStartTime: now,
       status: APPOINTMENT_STATUS.booked,
+      future: true,
     });
 
     mockAppointmentsApi({
@@ -146,6 +149,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     // Arrange
     const appointments = MockAppointmentResponse.createGfeResponses({
       localStartTime: now,
+      future: true,
     });
 
     mockAppointmentsApi({
@@ -179,6 +183,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     // Arrange
     const appointments = MockAppointmentResponse.createPhoneResponses({
       localStartTime: now,
+      future: true,
     });
 
     mockAppointmentsApi({
@@ -213,6 +218,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
     const appointments = MockAppointmentResponse.createCCResponses({
       localStartTime: now,
       status: APPOINTMENT_STATUS.cancelled,
+      future: true,
     });
 
     mockAppointmentsApi({
@@ -244,6 +250,7 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
   it('should show VA appointment text for telehealth appointments without vvsKind', async () => {
     const appointments = MockAppointmentResponse.createVAResponses({
       localStartTime: now,
+      future: true,
     });
     appointments[0]
       .setLocation(new MockFacilityResponse())

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -5,7 +5,6 @@ import { format } from 'date-fns';
 import { selectPatientFacilities } from '@department-of-veterans-affairs/platform-user/cerner-dsot/selectors';
 import {
   selectFeatureCCDirectScheduling,
-  selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthVA,
   selectFeatureFeSourceOfTruthModality,
@@ -94,7 +93,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
   return async (dispatch, getState) => {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -141,7 +139,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
           startDate: format(startDate, 'yyyy-MM-dd'), // Start 30 days in the past for canceled appointments
           endDate: format(endDate, 'yyyy-MM-dd'),
           includeEPS,
-          useFeSourceOfTruth,
           useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
@@ -160,7 +157,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             startDate: format(requestStartDate, 'yyyy-MM-dd'), // Start 120 days in the past for requests
             endDate: format(requestEndDate, 'yyyy-MM-dd'), // End 1 day in the future for requests
             includeEPS,
-            useFeSourceOfTruth,
             useFeSourceOfTruthCC,
             useFeSourceOfTruthVA,
             useFeSourceOfTruthModality,
@@ -264,7 +260,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
   return async (dispatch, getState) => {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -295,7 +290,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
         avs: true,
         fetchClaimStatus: true,
         includeEPS,
-        useFeSourceOfTruth,
         useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
@@ -348,7 +342,6 @@ export function fetchRequestDetails(id) {
   return async (dispatch, getState) => {
     try {
       const state = getState();
-      const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
       const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
       const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
       const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -374,7 +367,6 @@ export function fetchRequestDetails(id) {
       if (!request) {
         request = await fetchRequestById({
           id,
-          useFeSourceOfTruth,
           useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
@@ -412,7 +404,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
   return async (dispatch, getState) => {
     try {
       const state = getState();
-      const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
       const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
       const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
       const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -441,7 +432,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
         appointment = await fetchBookedAppointment({
           id,
           type,
-          useFeSourceOfTruth,
           useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
@@ -507,7 +497,6 @@ export function confirmCancelAppointment() {
   return async (dispatch, getState) => {
     const state = getState();
     const appointment = state.appointments.appointmentToCancel;
-    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -524,7 +513,6 @@ export function confirmCancelAppointment() {
 
       const updatedAppointment = await cancelAppointment({
         appointment,
-        useFeSourceOfTruth,
         useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -30,7 +30,6 @@ import {
 import {
   selectFeatureRequests,
   selectFeatureCancel,
-  selectFeatureFeSourceOfTruth,
 } from '../../redux/selectors';
 import { getTypeOfCareById } from '../../utils/appointment';
 import { getTimezoneNameFromAbbr } from '../../utils/timezone';
@@ -100,29 +99,27 @@ export function selectFutureStatus(state) {
 export const selectFutureAppointments = createSelector(
   state => state.appointments.pending,
   state => state.appointments.confirmed,
-  state => selectFeatureFeSourceOfTruth(state),
-  (pending, confirmed, useFeSourceOfTruth) => {
+  (pending, confirmed) => {
     if (!confirmed || !pending) {
       return null;
     }
 
     return confirmed
       .concat(...pending)
-      .filter(item => isUpcomingAppointmentOrRequest(item, useFeSourceOfTruth))
+      .filter(item => isUpcomingAppointmentOrRequest(item))
       .sort(sortUpcoming);
   },
 );
 
 export const selectUpcomingAppointments = createSelector(
   state => state.appointments.confirmed,
-  state => selectFeatureFeSourceOfTruth(state),
-  (confirmed, useFeSourceOfTruth) => {
+  confirmed => {
     if (!confirmed) {
       return null;
     }
 
     const sortedAppointments = confirmed
-      .filter(item => isUpcomingAppointment(item, useFeSourceOfTruth))
+      .filter(item => isUpcomingAppointment(item))
       .sort(sortByDateAscending);
 
     return groupAppointmentsByMonth(sortedAppointments);
@@ -284,13 +281,8 @@ export function selectBackendServiceFailuresInfo(state) {
     backendServiceFailures,
   };
 }
-export function selectStartDate(appointment, useFeSourceOfTruth) {
-  if (
-    useFeSourceOfTruth
-      ? appointment.vaos.isPendingAppointment
-      : appointment.vaos.appointmentType === APPOINTMENT_TYPES.request ||
-        appointment.vaos.appointmentType === APPOINTMENT_TYPES.ccRequest
-  ) {
+export function selectStartDate(appointment) {
+  if (appointment.vaos.isPendingAppointment) {
     return moment(appointment.requestedPeriod[0].start);
   }
 

--- a/src/applications/vaos/components/EnrolledRoute.jsx
+++ b/src/applications/vaos/components/EnrolledRoute.jsx
@@ -35,8 +35,8 @@ export default function EnrolledRoute({ component: RouteComponent, ...rest }) {
 
   // Determine if the user should be redirected to the `/my-health` page.
   // Redirect if:
-  //   1. The `featureMhvRouteGuards` flag is enabled,
-  //   2. AND the user is either not LOA3 authenticated OR not registered with any facilities.
+  //   1. The user is not LOA3 authenticated
+  //   2. OR not registered with any facilities.
   const shouldRedirectToMyHealtheVet = !isUserLOA3 || !hasRegisteredSystems;
 
   if (shouldRedirectToMyHealtheVet) {

--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -9,7 +9,6 @@ import { startOfMonth, endOfMonth, format, isAfter } from 'date-fns';
 
 import {
   selectSystemIds,
-  selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthVA,
   selectFeatureFeSourceOfTruthModality,
@@ -385,7 +384,6 @@ export function prefillContactInfo() {
 export function confirmAppointment(history) {
   return async (dispatch, getState) => {
     const state = getState();
-    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -412,7 +410,6 @@ export function confirmAppointment(history) {
     try {
       const appointment = await createAppointment({
         appointment: transformFormToVAOSAppointment(getState()),
-        useFeSourceOfTruth,
         useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -18,7 +18,6 @@ import {
 } from '../../redux/actions';
 import { selectTypeOfCarePage } from '../../redux/selectors';
 import {
-  selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
@@ -36,9 +35,6 @@ const pageKey = 'typeOfCare';
 
 export default function TypeOfCarePage() {
   const pageTitle = useSelector(state => getPageTitle(state, pageKey));
-  const useFeSourceOfTruth = useSelector(state =>
-    selectFeatureFeSourceOfTruth(state),
-  );
   const useFeSourceOfTruthCC = useSelector(state =>
     selectFeatureFeSourceOfTruthCC(state),
   );
@@ -163,7 +159,6 @@ export default function TypeOfCarePage() {
             // and returns the previous promise if it eixsts
             if (showDirectScheduling) {
               getLongTermAppointmentHistoryV2(
-                useFeSourceOfTruth,
                 useFeSourceOfTruthCC,
                 useFeSourceOfTruthVA,
                 useFeSourceOfTruthModality,

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -16,7 +16,6 @@ import {
 import {
   selectFeatureCommunityCare,
   selectFeatureDirectScheduling,
-  selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
@@ -319,7 +318,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
     const state = getState();
     const directSchedulingEnabled = selectFeatureDirectScheduling(state);
     const typeOfCare = getTypeOfCare(getState().newAppointment.data);
-    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -344,7 +342,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
             location,
             typeOfCare,
             directSchedulingEnabled,
-            useFeSourceOfTruth,
             useFeSourceOfTruthCC,
             useFeSourceOfTruthVA,
             useFeSourceOfTruthModality,
@@ -382,7 +379,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
           location,
           typeOfCare,
           directSchedulingEnabled,
-          useFeSourceOfTruth,
           useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
@@ -851,7 +847,6 @@ export function checkCommunityCareEligibility() {
 export function submitAppointmentOrRequest(history) {
   return async (dispatch, getState) => {
     const state = getState();
-    const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
     const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -885,7 +880,6 @@ export function submitAppointmentOrRequest(history) {
         let appointment = null;
         appointment = await createAppointment({
           appointment: transformFormToVAOSAppointment(getState()),
-          useFeSourceOfTruth,
           useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
@@ -977,7 +971,6 @@ export function submitAppointmentOrRequest(history) {
 
         const requestData = await createAppointment({
           appointment: requestBody,
-          useFeSourceOfTruth,
           useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,

--- a/src/applications/vaos/redux/actions.js
+++ b/src/applications/vaos/redux/actions.js
@@ -7,7 +7,6 @@ import { GA_PREFIX } from '../utils/constants';
 import { captureError } from '../utils/error';
 import {
   selectFeatureCCDirectScheduling,
-  selectFeatureFeSourceOfTruth,
   selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthVA,
   selectFeatureFeSourceOfTruthModality,
@@ -46,7 +45,6 @@ export function fetchPendingAppointments() {
 
       const state = getState();
       const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-      const useFeSourceOfTruth = selectFeatureFeSourceOfTruth(state);
       const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
       const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
       const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
@@ -69,7 +67,6 @@ export function fetchPendingAppointments() {
           .add(2, 'days')
           .format('YYYY-MM-DD'),
         includeEPS,
-        useFeSourceOfTruth,
         useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -84,9 +84,6 @@ export const selectFeatureOHRequest = state =>
 export const selectFeatureRemovePodiatry = state =>
   toggleValues(state).vaOnlineSchedulingRemovePodiatry;
 
-export const selectFeatureFeSourceOfTruth = state =>
-  toggleValues(state).vaOnlineSchedulingFeSourceOfTruth;
-
 export const selectFeatureFeSourceOfTruthVA = state =>
   toggleValues(state).vaOnlineSchedulingFeSourceOfTruthVA;
 

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -67,7 +67,6 @@ function apptRequestSort(a, b) {
  * @param {String} endDate Date in YYYY-MM-DD format
  * @param {Boolean} fetchClaimStatus Boolean to fetch travel claim data
  * @param {Boolean} includeEPS Boolean to include EPS appointments
- * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
@@ -80,7 +79,6 @@ export async function fetchAppointments({
   avs = false,
   fetchClaimStatus = false,
   includeEPS = false,
-  useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
@@ -110,7 +108,6 @@ export async function fetchAppointments({
     appointments.push(
       ...transformVAOSAppointments(
         filteredAppointments,
-        useFeSourceOfTruth,
         useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
@@ -139,7 +136,6 @@ export async function fetchAppointments({
  * @param {String} startDate Date in YYYY-MM-DD format
  * @param {String} endDate Date in YYYY-MM-DD format
  * @param {Boolean} includeEPS Boolean to include EPS appointments
- * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
@@ -150,7 +146,6 @@ export async function getAppointmentRequests({
   startDate,
   endDate,
   includeEPS = false,
-  useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
@@ -166,25 +161,13 @@ export async function getAppointmentRequests({
 
     const requestsWithoutAppointments = appointments.data.filter(appt => {
       // Filter out appointments that are not requests
-      return useFeSourceOfTruth
-        ? appt.pending
-        : getAppointmentType(
-            appt,
-            useFeSourceOfTruthCC,
-            useFeSourceOfTruthVA,
-          ) === APPOINTMENT_TYPES.request ||
-            getAppointmentType(
-              appt,
-              useFeSourceOfTruthCC,
-              useFeSourceOfTruthVA,
-            ) === APPOINTMENT_TYPES.ccRequest;
+      return appt.pending;
     });
 
     requestsWithoutAppointments.sort(apptRequestSort);
 
     const transformRequests = transformVAOSAppointments(
       requestsWithoutAppointments,
-      useFeSourceOfTruth,
       useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
@@ -211,7 +194,6 @@ export async function getAppointmentRequests({
  * @export
  * @async
  * @param {string} id Appointment request id
- * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
@@ -220,7 +202,6 @@ export async function getAppointmentRequests({
  */
 export async function fetchRequestById({
   id,
-  useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
@@ -231,7 +212,6 @@ export async function fetchRequestById({
 
     return transformVAOSAppointment(
       appointment,
-      useFeSourceOfTruth,
       useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
@@ -253,7 +233,6 @@ export async function fetchRequestById({
  * @param {string} id MAS or community care booked appointment id
  * @param {avs} Boolean to fetch avs data
  * @param {fetchClaimStatus} Boolean to fetch travel claim data
- * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
@@ -264,7 +243,6 @@ export async function fetchBookedAppointment({
   id,
   avs = true,
   fetchClaimStatus = true,
-  useFeSourceOfTruth = true,
   useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
@@ -274,7 +252,6 @@ export async function fetchBookedAppointment({
     const appointment = await getAppointment(id, avs, fetchClaimStatus);
     return transformVAOSAppointment(
       appointment,
-      useFeSourceOfTruth,
       useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
@@ -416,21 +393,15 @@ export function isValidPastAppointment(appt) {
  *
  * @export
  * @param {Appointment} appt The FHIR Appointment to check
- * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @returns {boolean} Whether or not the appointment is a valid upcoming
  *  appointment or request
  */
-export function isUpcomingAppointmentOrRequest(appt, useFeSourceOfTruth) {
+export function isUpcomingAppointmentOrRequest(appt) {
   if (CONFIRMED_APPOINTMENT_TYPES.has(appt.vaos.appointmentType)) {
-    const apptDateTime = moment(appt.start);
-
-    return useFeSourceOfTruth
-      ? !FUTURE_APPOINTMENTS_HIDDEN_SET.has(appt.description) &&
-          appt.vaos.isUpcomingAppointment
-      : !appt.vaos.isPastAppointment &&
-          !FUTURE_APPOINTMENTS_HIDDEN_SET.has(appt.description) &&
-          apptDateTime.isValid() &&
-          apptDateTime.isBefore(moment().add(395, 'days'));
+    return (
+      !FUTURE_APPOINTMENTS_HIDDEN_SET.has(appt.description) &&
+      appt.vaos.isUpcomingAppointment
+    );
   }
 
   const today = moment().startOf('day');
@@ -470,26 +441,15 @@ export function isPendingOrCancelledRequest(appt) {
  *
  * @export
  * @param {Appointment} appt The FHIR Appointment to check
- * @param {Boolean} useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @returns {boolean} Whether or not the appointment is a valid upcoming
  *  appointment
  */
-export function isUpcomingAppointment(appt, useFeSourceOfTruth) {
+export function isUpcomingAppointment(appt) {
   if (CONFIRMED_APPOINTMENT_TYPES.has(appt.vaos.appointmentType)) {
-    const apptDateTime = moment(appt.start);
-
-    return useFeSourceOfTruth
-      ? !FUTURE_APPOINTMENTS_HIDDEN_SET.has(appt.description) &&
-          appt.vaos.isUpcomingAppointment
-      : !appt.vaos.isPastAppointment &&
-          !FUTURE_APPOINTMENTS_HIDDEN_SET.has(appt.description) &&
-          apptDateTime.isValid() &&
-          apptDateTime.isAfter(moment().startOf('day')) &&
-          apptDateTime.isBefore(
-            moment()
-              .endOf('day')
-              .add(395, 'days'),
-          );
+    return (
+      !FUTURE_APPOINTMENTS_HIDDEN_SET.has(appt.description) &&
+      appt.vaos.isUpcomingAppointment
+    );
   }
 
   return false;
@@ -610,7 +570,6 @@ export function groupAppointmentsByMonth(appointments) {
  * @export
  * @param {Object} params
  * @param {VAOSAppointment} params.appointment The appointment to send
- * @param {Boolean} params.useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
@@ -619,7 +578,6 @@ export function groupAppointmentsByMonth(appointments) {
  */
 export async function createAppointment({
   appointment,
-  useFeSourceOfTruth,
   useFeSourceOfTruthCC,
   useFeSourceOfTruthVA,
   useFeSourceOfTruthModality,
@@ -629,7 +587,6 @@ export async function createAppointment({
 
   return transformVAOSAppointment(
     result,
-    useFeSourceOfTruth,
     useFeSourceOfTruthCC,
     useFeSourceOfTruthVA,
     useFeSourceOfTruthModality,
@@ -645,7 +602,6 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  * @export
  * @param {Object} params
  * @param {Appointment} params.appointment The appointment to cancel
- * @param {Boolean} params.useFeSourceOfTruth whether to use vets-api payload as the FE source of truth
  * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
@@ -654,7 +610,6 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  */
 export async function cancelAppointment({
   appointment,
-  useFeSourceOfTruth,
   useFeSourceOfTruthCC,
   useFeSourceOfTruthVA,
   useFeSourceOfTruthModality,
@@ -686,7 +641,6 @@ export async function cancelAppointment({
 
     return transformVAOSAppointment(
       updatedAppointment,
-      useFeSourceOfTruth,
       useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
@@ -875,7 +829,6 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
   let promise = null;
 
   return (
-    useFeSourceOfTruth,
     useFeSourceOfTruthCC,
     useFeSourceOfTruthVA,
     useFeSourceOfTruthModality,
@@ -914,7 +867,6 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
         const p1 = await fetchAppointments({
           startDate: curr.start,
           endDate: curr.end,
-          useFeSourceOfTruth,
           useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,

--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -47,10 +47,7 @@ describe('VAOS Services: Appointment ', () => {
         response: MockAppointmentResponse.createVAResponse(),
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
       expect(v2Result.vaos.apiData.modality).to.equal('vaInPerson');
@@ -64,10 +61,7 @@ describe('VAOS Services: Appointment ', () => {
         }),
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -80,10 +74,7 @@ describe('VAOS Services: Appointment ', () => {
         }),
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -96,10 +87,7 @@ describe('VAOS Services: Appointment ', () => {
         }),
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -112,10 +100,7 @@ describe('VAOS Services: Appointment ', () => {
         }),
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -128,10 +113,7 @@ describe('VAOS Services: Appointment ', () => {
         })[0],
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -144,10 +126,7 @@ describe('VAOS Services: Appointment ', () => {
         })[0],
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -160,10 +139,7 @@ describe('VAOS Services: Appointment ', () => {
         })[0],
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -176,10 +152,7 @@ describe('VAOS Services: Appointment ', () => {
         })[0],
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -192,10 +165,7 @@ describe('VAOS Services: Appointment ', () => {
         })[0],
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -208,10 +178,7 @@ describe('VAOS Services: Appointment ', () => {
         }),
       });
 
-      const v2Result = await fetchBookedAppointment({
-        id: '1',
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await fetchBookedAppointment({ id: '1' });
 
       expect(v2Result).to.be.ok;
     });
@@ -225,10 +192,7 @@ describe('VAOS Services: Appointment ', () => {
 
       let v2Result = null;
       try {
-        await fetchBookedAppointment({
-          id: '1234',
-          useFeSourceOfTruth: true,
-        });
+        await fetchBookedAppointment({ id: '1234' });
       } catch (e) {
         v2Result = e;
       }
@@ -255,11 +219,7 @@ describe('VAOS Services: Appointment ', () => {
         response: MockAppointmentResponse.createVAResponses(),
       });
 
-      const v2Result = await getAppointmentRequests({
-        startDate,
-        endDate,
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await getAppointmentRequests({ startDate, endDate });
 
       // Then expect a VA appointment request to be returned.
       expect(v2Result.length).to.be.gt(0);
@@ -279,11 +239,7 @@ describe('VAOS Services: Appointment ', () => {
         response: MockAppointmentResponse.createCCResponses(),
       });
 
-      const v2Result = await getAppointmentRequests({
-        startDate,
-        endDate,
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await getAppointmentRequests({ startDate, endDate });
 
       // Then expect a CC appointment request to be returned.
       expect(v2Result.length).to.be.gt(0);
@@ -304,11 +260,7 @@ describe('VAOS Services: Appointment ', () => {
         response: MockAppointmentResponse.createCCResponses(),
       });
 
-      const v2Result = await getAppointmentRequests({
-        startDate,
-        endDate,
-        useFeSourceOfTruth: true,
-      });
+      const v2Result = await getAppointmentRequests({ startDate, endDate });
 
       // Then expect a canceled appointment request to be returned.
       expect(v2Result.length).to.be.gt(0);
@@ -339,11 +291,7 @@ describe('VAOS Services: Appointment ', () => {
       let v2Result = null;
 
       try {
-        await getAppointmentRequests({
-          startDate,
-          endDate,
-          useFeSourceOfTruth: true,
-        });
+        await getAppointmentRequests({ startDate, endDate });
       } catch (e) {
         v2Result = e;
       }

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -94,7 +94,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
         appointment,
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -117,7 +116,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         false,
         useFeSourceOfTruthModality,
@@ -144,7 +142,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
         appointment,
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -169,7 +166,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
         appointment,
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -192,7 +188,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         false,
         useFeSourceOfTruthModality,
@@ -235,7 +230,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
         appointment,
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -259,7 +253,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         parseApiObject({ data: response }),
-        false,
         false,
         false,
         useFeSourceOfTruthModality,
@@ -302,7 +295,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
         appointment,
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -325,7 +317,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         false,
         useFeSourceOfTruthModality,
@@ -352,7 +343,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
         appointment,
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -374,7 +364,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         false,
         useFeSourceOfTruthModality,
@@ -409,13 +398,11 @@ describe('VAOS <transformVAOSAppointment>', () => {
         mobile,
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
       const b = transformVAOSAppointment(
         adhoc,
-        false,
         false,
         false,
         useFeSourceOfTruthModality,
@@ -455,13 +442,11 @@ describe('VAOS <transformVAOSAppointment>', () => {
         parseApiObject({ data: mobile }),
         false,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
       const b = transformVAOSAppointment(
         parseApiObject({ data: storeForward }),
-        false,
         false,
         false,
         useFeSourceOfTruthModality,
@@ -512,7 +497,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         false,
         useFeSourceOfTruthModality,

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -11,7 +11,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingOhDirectSchedule', value: true },
   { name: 'vaOnlineSchedulingOhRequest', value: true },
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
-  { name: 'vaOnlineSchedulingFeSourceOfTruth', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthVA', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthCC', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthModality', value: true },

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -226,7 +226,6 @@ function logEligibilityExplanation(
  * @param {TypeOfCare} params.typeOfCare Type of care object for the currently chosen type of care
  * @param {Location} params.location The current location to check eligibility against
  * @param {boolean} params.directSchedulingEnabled If direct scheduling is currently enabled
- * @param {boolean} [params.useFeSourceOfTruth=false] whether to use vets-api payload as the FE source of truth
  * @param {boolean} [params.useFeSourceOfTruthCC=false] whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {boolean} [params.useFeSourceOfTruthVA=false] whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @returns {FlowEligibilityReturnData} Eligibility results, plus clinics and past appointments
@@ -236,7 +235,6 @@ export async function fetchFlowEligibilityAndClinics({
   typeOfCare,
   location,
   directSchedulingEnabled,
-  useFeSourceOfTruth = false,
   useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
@@ -273,7 +271,6 @@ export async function fetchFlowEligibilityAndClinics({
 
     if (isDirectAppointmentHistoryRequired) {
       apiCalls.pastAppointments = getLongTermAppointmentHistoryV2(
-        useFeSourceOfTruth,
         useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,

--- a/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/past-appointments.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/appointment-list-workflow/past-appointments.cypress.spec.js
@@ -18,7 +18,7 @@ describe('VAOS past appointment flow', () => {
     beforeEach(() => {
       vaosSetup();
 
-      mockFeatureToggles({ vaOnlineSchedulingFeSourceOfTruth: false });
+      mockFeatureToggles({});
       mockVamcEhrApi();
 
       cy.login(new MockUser());

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -304,7 +304,6 @@
   "vaOnlineSchedulingRecentLocationsFilter": "va_online_scheduling_recent_locations_filter",
   "vaOnlineSchedulingRequests": "va_online_scheduling_requests",
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
-  "vaOnlineSchedulingFeSourceOfTruth": "va_online_scheduling_fe_source_of_truth",
   "vaOnlineSchedulingFeSourceOfTruthVA": "va_online_scheduling_fe_source_of_truth_va",
   "vaOnlineSchedulingFeSourceOfTruthCC": "va_online_scheduling_fe_source_of_truth_cc",
   "vaOnlineSchedulingFeSourceOfTruthModality": "va_online_scheduling_fe_source_of_truth_modality",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove a feature toggle `va_online_scheduling_fe_source_of_truth `
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111823

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

