### PR TITLE
10-10EZ | Skip content review e2e tests for CI

### DIFF
--- a/src/applications/hca/tests/e2e/hca-enrollment-status.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-enrollment-status.cypress.spec.js
@@ -4,9 +4,14 @@ import {
 } from '../../utils/constants';
 import { setupForAuth } from './utils';
 
+// NOTE: These tests are skipped in CI as they are simply a way to visually-review
+// alert content. The display conditions are tested in unit testing and fully covered.
 Object.values(HCA_ENROLLMENT_STATUSES).forEach(status => {
   describe(`HCA-Enrollment-Status: ${status}`, () => {
-    beforeEach(() => {
+    // eslint-disable-next-line func-names
+    beforeEach(function() {
+      if (Cypress.env('CI')) this.skip();
+
       const enrollmentStatus = {
         statusCode: 200,
         body: {
@@ -34,7 +39,10 @@ Object.values(HCA_ENROLLMENT_STATUSES).forEach(status => {
 });
 
 describe('HCA-Enrollment-Status: Server Error', () => {
-  beforeEach(() => {
+  // eslint-disable-next-line func-names
+  beforeEach(function() {
+    if (Cypress.env('CI')) this.skip();
+
     const enrollmentStatus = {
       statusCode: 500,
       body: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

There is a Cypress test run for the HCA that is nothing more than a visual check for a various alert content. This allows us to review the alerts without having various test users with a specific enrollment status. Since enabling the heading level accessibility checks, there has been flakiness with this test suite in CI based on render order. This PR skips this test suite in CI, as it is not checking for anything that hasn't already been tested in unit testing or other Cypress specs.

## Acceptance criteria

- CI failures do not resonate from unnecessary test suites

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution