### PR TITLE
revised text for causeNew and added comma for causeSecondary

### DIFF
--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/causeNew.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/causeNew.js
@@ -15,11 +15,11 @@ const causeNewPage = {
     ),
     primaryDescription: textareaUI({
       title:
-        'Briefly describe the injury, event, disease or exposure that caused your condition. ',
+        'Briefly describe the injury, event, disease, or exposure that caused your condition. ',
       hint:
         'For example, I operated loud machinery while in the service, and this caused me to lose my hearing.',
       updateUiSchema: (_formData, fullData, index) => ({
-        'ui:title': `Briefly describe the injury, event, disease or exposure that caused ${createNewConditionName(
+        'ui:title': `Briefly describe the injury, event, disease, or exposure that caused ${createNewConditionName(
           fullData?.[arrayBuilderOptions.arrayPath]?.[index],
         )}.`,
       }),

--- a/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/causeSecondary.js
+++ b/src/applications/user-testing/disability-benefits-all-claims-conditions-chapter/pages/shared/causeSecondary.js
@@ -35,7 +35,7 @@ const causeSecondaryPage = {
     ),
     causedByCondition: selectUI({
       title:
-        'Choose the service-connected disability or condition that caused your condition.',
+        'Choose the service-connected disability that caused your new condition.',
       updateUiSchema: (_formData, fullData, index) => ({
         'ui:title': `Choose the service-connected disability or condition that caused ${createNewConditionName(
           fullData?.[arrayBuilderOptions.arrayPath]?.[index],
@@ -45,8 +45,7 @@ const causeSecondaryPage = {
         selectSchema(getOtherConditions(fullData, index)),
     }),
     causedByConditionDescription: textareaUI({
-      title:
-        'Briefly describe how this disability or condition caused your condition. ',
+      title: 'Briefly describe how this disability led to your new condition. ',
       updateUiSchema: (_formData, fullData, index) => ({
         'ui:title': `Briefly describe how this disability or condition caused ${createNewConditionName(
           fullData?.[arrayBuilderOptions.arrayPath]?.[index],


### PR DESCRIPTION
## Summary

This work is based on an earlier [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/37190).

The designer revised some text and requested a comma insert for the causeNew and causeSecondary files respectively.

closes https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/804

## Screenshots

**causeNew**

<img width="664" alt="text-rev" src="https://github.com/user-attachments/assets/56600148-0d95-4fc6-9a7d-62d9ba7b439f" />

<hr/>

**causeSecondary**

<img width="562" alt="comma" src="https://github.com/user-attachments/assets/4c670ce3-4e27-4224-ac6b-7a1d914ed1ec" />

## Updates implemented

**causeNew**

<img width="657" alt="Screenshot 2025-06-20 at 9 21 57 AM" src="https://github.com/user-attachments/assets/17eba37c-e947-4b8f-9447-ba0d97b6d5a6" />

**causeSecondary**

<img width="667" alt="Screenshot 2025-06-20 at 9 35 33 AM" src="https://github.com/user-attachments/assets/b9b03687-d7ed-45fd-ae61-7d94ff221b52" />

