### PR TITLE
Removed MHV Content from Sign-In Page

### DIFF
--- a/src/platform/user/authentication/components/LoginActions.jsx
+++ b/src/platform/user/authentication/components/LoginActions.jsx
@@ -67,9 +67,6 @@ export default function LoginActions({ externalApplication, isUnifiedSignIn }) {
           <>
             <h2>Other sign-in options</h2>
 
-            {dslogonEnabled &&
-              renderRetiredNotice('mhvH3', 'My HealtheVet sign-in option')}
-
             {dslogonEnabled && (
               <>
                 <h3

--- a/src/platform/user/tests/authentication/components/loginActions.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/loginActions.unit.spec.jsx
@@ -76,46 +76,6 @@ describe('LoginActions component', () => {
     testLocation(undefined, 'modal');
   });
 
-  it('renders MHV retired notice when DS Logon is enabled', () => {
-    const state = {
-      featureToggles: {
-        dslogonButtonDisabled: false,
-      },
-    };
-    const config = {
-      OAuthEnabled: false,
-      allowedSignInProviders: [],
-      legacySignInProviders: { dslogon: true },
-    };
-
-    const originalConfig =
-      require.cache[require.resolve('../../../authentication/usip-config')];
-    require.cache[require.resolve('../../../authentication/usip-config')] = {
-      exports: {
-        externalApplicationsConfig: {
-          mhvApp: config,
-          default: config,
-        },
-      },
-    };
-
-    store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <LoginActions externalApplication="mhvApp" />
-      </Provider>,
-    );
-
-    expect(wrapper.text()).to.contain('My HealtheVet sign-in option');
-
-    wrapper.unmount();
-    if (originalConfig) {
-      require.cache[
-        require.resolve('../../../authentication/usip-config')
-      ] = originalConfig;
-    }
-  });
-
   it('renders DS Logon retired notice when feature flag disables it', () => {
     const state = {
       featureToggles: {
@@ -147,7 +107,9 @@ describe('LoginActions component', () => {
     );
 
     expect(wrapper.text()).to.contain('DS Logon sign-in option');
-    expect(wrapper.text()).to.contain('This option is no longer available');
+    expect(wrapper.text()).to.contain(
+      'We’ll remove this option after September 30, 2025',
+    );
 
     wrapper.unmount();
     if (originalConfig) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed MHV content from `LoginActions.jsx`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/363)

## Testing done
- Updated `loginActions.unit.spec.jsx` and ran tests locally.
- Can be replicated by running `yarn test:unit src/platform/user/tests/authentication/components/loginActions.unit.spec.jsx`.

## Screenshots
| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/0b5f1f15-e7d1-4ae9-a8dc-d6fcc48a6322) | ![after](https://github.com/user-attachments/assets/ecdbabae-ad57-42c8-8ab3-9966bb937292) |

## What areas of the site does it impact?
This only impacts `LoginActions.jsx` and its related tests.

## Acceptance criteria
- [x] The MHV content is fully removed from the sign-in page
- [x] Tests are updated as needed