### PR TITLE
111995 - Update insurance section array builder summary page on 10-10d/10-7959c merged form - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
@@ -3,7 +3,6 @@ import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import { arrayBuilderPages } from 'platform/forms-system/src/js/patterns/array-builder';
 import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
 import {
-  titleUI,
   titleSchema,
   radioUI,
   arrayBuilderItemFirstPageTitleUI,
@@ -68,6 +67,24 @@ export function generateParticipantNames(item) {
   return 'No participants';
 }
 
+/**
+ * Options for the yes/no text on summary page:
+ */
+const yesNoOptions = {
+  title:
+    'Do you have any other health insurance to report for one or more applicants?',
+  labelHeaderLevel: '5',
+  labelHeaderLevelStyle: '5',
+  hint:
+    'If any applicants have other health insurance, it is required to report it to process your application for CHAMPVA benefits.',
+};
+const yesNoOptionsMore = {
+  title: 'Do you have any other health insurance to report?',
+  labelHeaderLevel: '5',
+  labelHeaderLevelStyle: '5',
+  hint:
+    'If any applicants have other health insurance, it is required to report it to process your application for CHAMPVA benefits.',
+};
 const healthInsuranceOptions = {
   arrayPath: 'healthInsurance',
   nounSingular: 'plan',
@@ -75,8 +92,9 @@ const healthInsuranceOptions = {
   required: false,
   isItemIncomplete: item =>
     !(item.provider && item.insuranceType && item.effectiveDate),
-  // maxItems: MAX_APPLICANTS,
   text: {
+    summaryTitle: 'Report other health insurance',
+    summaryTitleWithoutItems: 'Report other health insurance',
     getItemName: item => item?.provider,
     cardDescription: item => (
       <ul className="no-bullets">
@@ -133,7 +151,11 @@ const healthInsuranceIntroPage = {
 
 const healthInsuranceSummaryPage = {
   uiSchema: {
-    'view:hasHealthInsurance': arrayBuilderYesNoUI(healthInsuranceOptions),
+    'view:hasHealthInsurance': arrayBuilderYesNoUI(
+      healthInsuranceOptions,
+      yesNoOptions,
+      yesNoOptionsMore,
+    ),
   },
   schema: {
     type: 'object',
@@ -290,29 +312,6 @@ const healthInsuranceCardUploadPage = {
 export const healthInsurancePages = arrayBuilderPages(
   healthInsuranceOptions,
   pageBuilder => ({
-    healthInsuranceIntro: pageBuilder.introPage({
-      path: 'health-insurance-intro',
-      title: '[noun plural]',
-      // initialData: mockData.data,
-      uiSchema: {
-        ...titleUI(
-          'Report other health insurance plans',
-          <>
-            Medicare and other health insurance certification is required to
-            process your application for CHAMPVA benefits.
-            <br />
-            If you and/or your applicants don’t have other health insurance,
-            select Continue to go to the next question.
-          </>,
-        ),
-      },
-      schema: {
-        type: 'object',
-        properties: {
-          titleSchema,
-        },
-      },
-    }),
     healthInsuranceSummary: pageBuilder.summaryPage({
       path: 'health-insurance-summary',
       title: 'Review your plans',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR introduces some small changes to the health insurance array builder in the (unreleased) 10-10d/10-7959c merged form.
- removes an unnecessary intro page at the start of health insurance section
- updates text of the yes/no summary page

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111995

## Testing done

- Manual

## Screenshots

| |Intro page| Yes/No summary page (no items) | Yes/No summary page (items)|
|-|-|-|-|
|Before|![Image](https://github.com/user-attachments/assets/cb50a237-9a5f-4851-bd9d-d9951042ecb1)|![Image](https://github.com/user-attachments/assets/bcc2308e-5ae7-4083-9db3-d1a84fd9e88c)|![Image](https://github.com/user-attachments/assets/6ffbb139-6a5e-4eea-bfd0-cb1e2b6f198e)|
|After|Removed|![Image](https://github.com/user-attachments/assets/baa8f605-c95c-428a-8e86-32afab040e34)|![Image](https://github.com/user-attachments/assets/42c139a0-c2c8-4f9d-8a64-4f4fe79c2ad0)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
