### PR TITLE
MHV-71308 Ensure we have a way to log failing PDF generation

### DIFF
--- a/src/platform/mhv/util/helpers.js
+++ b/src/platform/mhv/util/helpers.js
@@ -207,7 +207,7 @@ export const makePdf = async (
   } catch (error) {
     // Reset the pdfModulePromise so subsequent calls can try again
     pdfModulePromise = null;
-    datadogRum.addError(sentryErrorLabel);
+    datadogRum.addError(error, sentryErrorLabel);
     sendErrorToSentry(error, sentryErrorLabel);
   }
 };

--- a/src/platform/mhv/util/helpers.js
+++ b/src/platform/mhv/util/helpers.js
@@ -4,6 +4,7 @@ import {
 } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { format } from 'date-fns';
 import * as Sentry from '@sentry/browser';
+import { datadogRum } from '@datadog/browser-rum';
 import { reportGeneratedBy } from './constants';
 
 /**
@@ -206,7 +207,7 @@ export const makePdf = async (
   } catch (error) {
     // Reset the pdfModulePromise so subsequent calls can try again
     pdfModulePromise = null;
-
+    datadogRum.addError(sentryErrorLabel);
     sendErrorToSentry(error, sentryErrorLabel);
   }
 };


### PR DESCRIPTION
## Summary

- Created a log that goes to Datadog if the PDF generation fails  
  - Imported Datadog to helpers.js in platform
  - Incorporated Datadog.addError in the makePDF function
  - Passed message that was already going to Sentry.
- Edited JSX
- MHV Medical Records.

## Related issue(s)
### [MHV-71308](https://jira.devops.va.gov/browse/MHV-71308) Ensure we have a way to log failing PDF generation
<img width="793" alt="Screenshot 2025-06-20 at 3 11 14 PM" src="https://github.com/user-attachments/assets/4841ecb8-d98a-4054-a740-a050244b4696" />


## Screenshots
<img width="1037" alt="Screenshot 2025-06-20 at 2 21 02 PM" src="https://github.com/user-attachments/assets/ebf42092-c23f-45f8-b0bf-be0a6818787d" />

## Testing done

-  Tests are passing.

## What areas of the site does it impact?
MHV Medical Records
