### PR TITLE
111984 - fix address validation

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
+++ b/src/applications/personalization/profile/components/contact-information/addresses/CopyAddressModalController.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import set from 'lodash/set';
 
 // vap-svc deps
@@ -57,6 +57,10 @@ const CopyAddressModal = props => {
     [mailingAddress, homeAddress, updateCopyAddressModalAction],
   );
 
+  const validationKey = useSelector(
+    state => state?.vapService?.addressValidation?.validationKey,
+  );
+
   useEffect(
     () => {
       if (copyAddressModal === VAP_SERVICE.COPY_ADDRESS_MODAL_STATUS.CHECKING) {
@@ -75,6 +79,10 @@ const CopyAddressModal = props => {
 
       // make sure we are sending correct id in payload, or empty string if no mailing address for user
       const payloadWithUpdatedId = set(payload, 'id', mailingAddress?.id || '');
+
+      if (validationKey) {
+        payloadWithUpdatedId.validationKey = validationKey;
+      }
 
       const method = payloadWithUpdatedId.id ? 'PUT' : 'POST';
 

--- a/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
@@ -17,7 +17,7 @@ describe('Personal and contact information', () => {
       addressPage.validateSavedForm({
         ...formFields,
         address: '400 NW 65th St',
-        zipCode: 12345,
+        zipCode: 98117,
       });
     });
   });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -262,13 +262,6 @@ class AddressPage {
         'exist',
       );
       cy.get('#edit-mailing-address').should('exist');
-
-      // this linting warning is actually a bug in cypress
-      // https://github.com/cypress-io/eslint-plugin-cypress/issues/140
-      cy.focused().then($focused => {
-        expect($focused).to.have.attr('aria-label', 'Edit Mailing address');
-        expect($focused).to.have.text('Edit');
-      });
     }
 
     altText && cy.findByText(altText).should('exist');

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -145,6 +145,7 @@ class AddressValidationView extends React.Component {
       // if the user selected a suggested address, we need to remove the validationKey
       // so that the API doesn't throw an error
       delete payload.validationKey;
+      this.props.resetAddressValidation();
     }
     await this.props.createTransaction(
       VAP_SERVICE.API_ROUTES.ADDRESSES,
@@ -460,6 +461,7 @@ AddressValidationView.propTypes = {
   suggestedAddresses: PropTypes.array.isRequired,
   updateSelectedAddress: PropTypes.func.isRequired,
   updateValidationKeyAndSave: PropTypes.func.isRequired,
+  resetAddressValidation: PropTypes.func.isRequired,
   analyticsSectionName: PropTypes.string,
   confirmedSuggestions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -142,22 +142,17 @@ class AddressValidationView extends React.Component {
     }
 
     if (suggestedAddressSelected) {
-      this.props.updateValidationKeyAndSave(
-        VAP_SERVICE.API_ROUTES.ADDRESSES,
-        method,
-        addressValidationType,
-        payload,
-        analyticsSectionName,
-      );
-    } else {
-      await this.props.createTransaction(
-        VAP_SERVICE.API_ROUTES.ADDRESSES,
-        method,
-        addressValidationType,
-        payload,
-        analyticsSectionName,
-      );
+      // if the user selected a suggested address, we need to remove the validationKey
+      // so that the API doesn't throw an error
+      delete payload.validationKey;
     }
+    await this.props.createTransaction(
+      VAP_SERVICE.API_ROUTES.ADDRESSES,
+      method,
+      addressValidationType,
+      payload,
+      analyticsSectionName,
+    );
   };
 
   onEditClick = () => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This update resolves an issue where the validationKey isn't properly applied to different address change requests through the profile service
- Prior to this change, submitting an invalid USPS address would trigger a suggested address and when selecting the suggested address it would again re-validate the address and then submit it while including the validationKey, which is not necessary and in future API versions will cause an issue.
- This stops the frontend from calling the address validation endpoint more than the one time it is necessary and carries the validationKey forward to the second address update when selecting Yes on the "copy address to mailing address" modal that pops up.
- Authenticated Experience Team Authentiknights

## Related issue(s)

- _Current issue ticket:_ https://github.com/department-of-veterans-affairs/va.gov-team/issues/111984
- _Link to previous change of the code/bug (if applicable)_ https://github.com/department-of-veterans-affairs/vets-website/pull/35825

## Testing done

- Previous testing did not fully cover use cases that include when the address entered was not immediately validated by the address validation service.
- Updating the address using each of these addresses should allow any user actions to complete without error. Whether or not they are good decisions (like using the address they input instead of the suggested one by USPS) the address should properly save to the user's profile without throwing an error.
- Testing locally with mocked endpoints (and manually bypassing the localVAProfileService to better mirror the deployed instances) allowed all requests to succeed.

## Screenshots

None

## What areas of the site does it impact?

Mailing address updates made through the Profile's Contact Information page.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
