### PR TITLE
111997 - Update intro page on 10-10d/10-7959c merged form - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -61,6 +61,7 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   submissionError: SubmissionError,
+  customText: { appType: 'form' },
   dev: {
     showNavLinks: true,
     collapsibleNavLinks: true,

--- a/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect } from 'react';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { focusElement } from 'platform/utilities/ui/focus';
 import { scrollToTop } from 'platform/utilities/scroll';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { TITLE, SUBTITLE } from '../constants';
 
-const OMB_RES_BURDEN = 30;
+const OMB_RES_BURDEN = 15;
 const OMB_NUMBER = '2900-0219';
 const OMB_EXP_DATE = '10/31/2024';
 
@@ -55,7 +57,6 @@ const ProcessList = () => {
 export const IntroductionPage = props => {
   const { route } = props;
   const { formConfig, pageList } = route;
-
   useEffect(() => {
     scrollToTop();
     focusElement('h1');
@@ -69,16 +70,25 @@ export const IntroductionPage = props => {
         10-7959c).
       </h2>
       <ProcessList />
-      <SaveInProgressIntro
-        headingLevel={2}
-        prefillEnabled={formConfig.prefillEnabled}
-        messages={formConfig.savedFormMessages}
-        pageList={pageList}
-        startText="Start the application"
-        devOnly={{
-          forceShowFormControls: true,
-        }}
-      />
+      <va-alert-sign-in variant="signInOptionalNoPrefill" visible>
+        <span slot="SignInButton">
+          <VaButton
+            text="Sign in or create an account"
+            onClick={() => props.toggleLoginModal(true)}
+          />
+
+          <p>
+            <Link
+              to={pageList?.[1]?.path}
+              className="schemaform-start-button"
+              aria-label="test-aria-label"
+              aria-describedby="test-aria-desc-by"
+            >
+              Start your {formConfig?.customText?.appType} without signing in
+            </Link>
+          </p>
+        </span>
+      </va-alert-sign-in>
       <p />
       <va-omb-info
         res-burden={OMB_RES_BURDEN}
@@ -94,12 +104,18 @@ IntroductionPage.propTypes = {
     formConfig: PropTypes.shape({
       prefillEnabled: PropTypes.bool.isRequired,
       savedFormMessages: PropTypes.object.isRequired,
+      customText: PropTypes.shape({ appType: PropTypes.string }),
     }).isRequired,
     pageList: PropTypes.arrayOf(PropTypes.object).isRequired,
   }).isRequired,
   location: PropTypes.shape({
     basename: PropTypes.string,
   }),
+  toggleLoginModal: PropTypes.func,
+};
+
+const mapDispatchToProps = {
+  toggleLoginModal,
 };
 
 const mapStateToProps = state => {
@@ -108,4 +124,7 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(IntroductionPage);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(IntroductionPage);

--- a/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
@@ -16,39 +16,48 @@ const OMB_EXP_DATE = '10/31/2024';
 const ProcessList = () => {
   return (
     <va-process-list>
-      <va-process-list-item header="Prepare">
-        <h4>To fill out this application, you’ll need your:</h4>
+      <va-process-list-item header="Check your eligibility">
+        <p>Make sure you meet our eligibility requirements before you apply.</p>
+        <va-link
+          text="Find out if you’re eligible for CHAMPVA benefits"
+          href="https://www.va.gov/family-and-caregiver-benefits/health-and-disability/champva/"
+        />
+      </va-process-list-item>
+      <va-process-list-item header="Gather your information">
+        <p>
+          <b>Here’s what you need to apply:</b>
+        </p>
         <ul>
-          <li>Social Security number (required)</li>
+          <li>
+            <b>Personal information about you</b> and anyone else you’re
+            applying for
+          </li>
+          <li>
+            <b>Personal information about your sponsor</b> (the Veteran or
+            service member you’re connected to)
+          </li>
         </ul>
         <p>
-          <strong>What if I need help filling out my application?</strong> An
-          accredited representative, like a Veterans Service Officer (VSO), can
-          help you fill out your claim.{' '}
-          <a href="/disability-benefits/apply/help/index.html">
-            Get help filing your claim
-          </a>
+          This includes dates of birth, Social Security numbers, and contact
+          information.
+        </p>
+        <p>
+          You may also need to submit supporting documents, like copies of your
+          health insurance cards or proof of school enrollment.
+        </p>
+        <va-link
+          text="Find out which documents you’ll need to apply for CHAMPVA"
+          href="https://www.va.gov/family-and-caregiver-benefits/health-and-disability/champva/#supporting-documents-for-your-"
+        />
+      </va-process-list-item>
+      <va-process-list-item header="Start your application">
+        <p>
+          We’ll take you through each step of the process. It should take about{' '}
+          {OMB_RES_BURDEN} minutes.
         </p>
       </va-process-list-item>
-      <va-process-list-item header="Apply">
-        <p>Complete this benefits form.</p>
-        <p>
-          After submitting the form, you’ll get a confirmation message. You can
-          print this for your records.
-        </p>
-      </va-process-list-item>
-      <va-process-list-item header="VA Review">
-        <p>
-          We process claims within a week. If more than a week has passed since
-          you submitted your application and you haven’t heard back, please
-          don’t apply again. Call us at.
-        </p>
-      </va-process-list-item>
-      <va-process-list-item header="Decision">
-        <p>
-          Once we’ve processed your claim, you’ll get a notice in the mail with
-          our decision.
-        </p>
+      <va-process-list-item header="After you apply">
+        <p>We’ll contact you if we have questions or need more information.</p>
       </va-process-list-item>
     </va-process-list>
   );
@@ -66,8 +75,7 @@ export const IntroductionPage = props => {
     <article className="schemaform-intro">
       <FormTitle title={TITLE} subTitle={SUBTITLE} />
       <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-        Follow the steps below to apply for CHAMPVA application (includes
-        10-7959c).
+        Follow the steps to apply for CHAMPVA benefits
       </h2>
       <ProcessList />
       <va-alert-sign-in variant="signInOptionalNoPrefill" visible>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the intro page for the (unreleased) 10-10d/10-7959c merged form with updated process steps and an alternate SIP intro (the `va-alert-sign-in` "signInOptionalNoPrefill" [variant](https://design.va.gov/storybook/?path=/story/components-va-alert-sign-in--optional-sign-in-verified-no-prefill).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111997

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![before](https://github.com/user-attachments/assets/169fac39-6fee-4514-a4a4-83c0113fe473)|![after](https://github.com/user-attachments/assets/7e857316-dd51-456a-b99e-234fc5d69985)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA