### PR TITLE
yarn watch --env lightweightWatch

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -282,6 +282,7 @@ module.exports = async (env = {}) => {
     scaffold: false,
     watch: false,
     destination: buildtype,
+    lightweightWatch: false,
     ...env,
   };
 
@@ -580,6 +581,13 @@ module.exports = async (env = {}) => {
         saveReportTo: `build/${buildtype}/generated/statoscope-report.html`,
       }),
     );
+  }
+
+  if (buildOptions.lightweightWatch) {
+    baseConfig.watchOptions = {
+      ignored: '**/node_modules',
+      poll: true,
+    };
   }
 
   return baseConfig;

--- a/script/build-help.js
+++ b/script/build-help.js
@@ -53,6 +53,12 @@ const helpSections = [
           'Set NODE_OPTION --max-old-space-size to: 1024, 2048, 3072, 4096, 5120, 6144, 7168, or 8192 (e.g. --env memory=8192)',
       },
       {
+        name: 'env lightweightWatch',
+        type: Boolean,
+        description:
+          'If watching does not work for you, try out this option. This may help issues with NFS and machines in VirtualBox, WSL, Containers, or Docker. In those cases, use a polling interval and ignore large folders like /node_modules/ to keep CPU usage minimal. (https://webpack.js.org/configuration/watch/)',
+      },
+      {
         name: 'env openTo',
         typeLabel: '{underline URL}',
         description:


### PR DESCRIPTION
webpack dev server was crashing. reported [here](https://dsva.slack.com/archives/CBU0KDSB1/p1747846786796739)

this PR gives an option for still using webpack dev server but with a lightweight option for file watching that doesn't use fsevents which was overflowing the stack.

repro'd on my machine and produced crash report in Console.app. Looks like they investigated and fixed this in nodejs too: [FSEvents-related SIGBUS crashes on macOS 10.15.7](https://github.com/nodejs/node/issues/37697)

crash:
```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               node [7675]
Path:                  /Users/USER/*/node
Identifier:            node
Version:               ???
Code Type:             X86-64 (Translated)
Parent Process:        Exited process [7674]
Responsible:           ghostty [1409]
User ID:               501

Date/Time:             2025-06-21 00:30:03.1733 -0400
OS Version:            macOS 15.5 (24F74)
Report Version:        12
Anonymous UUID:        B93170B2-B0DA-F6B6-1360-ED7FDC3A5E21


Time Awake Since Boot: 4600 seconds

System Integrity Protection: enabled

Crashed Thread:        13

Exception Type:        EXC_BAD_ACCESS (SIGBUS)
Exception Codes:       KERN_PROTECTION_FAILURE at 0x0000000a919f0ff8
Exception Codes:       0x0000000000000002, 0x0000000a919f0ff8

Termination Reason:    Namespace SIGNAL, Code 10 Bus error: 10
Terminating Process:   exc handler [7675]

VM Region Info: 0xa919f0ff8 is in 0xa919f0000-0xa919f1000;  bytes after start: 4088  bytes before end: 7
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      Memory Tag 255              a899f0000-a919f0000    [128.0M] ---/rwx SM=NUL  
--->  Stack Guard                 a919f0000-a919f1000    [    4K] ---/rwx SM=NUL  
      Stack                       a919f1000-a919fb000    [   40K] rw-/rwx SM=PRV  

Thread 0::  Dispatch queue: com.apple.main-thread
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036f1822 kevent + 10
2   node                          	       0x1009f2dde uv__io_poll + 942
3   node                          	       0x1009e0319 uv_run + 345
4   node                          	       0x1000eca0b node::NodeMainInstance::Run() + 379
5   node                          	       0x10007ea8a node::Start(int, char**) + 266
6   dyld                          	       0x204855530 start + 3056

Thread 1:: com.apple.rosetta.exceptionserver
0   runtime                       	    0x7ff7ffcb60e4 0x7ff7ffcb2000 + 16612

Thread 2:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036f1822 kevent + 10
2   node                          	       0x1009f2dde uv__io_poll + 942
3   node                          	       0x1009e0319 uv_run + 345
4   node                          	       0x100119414 node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Run() + 340
5   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
6   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 3:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x100119645 node::TaskQueue<v8::Task>::BlockingPop() + 69
5   node                          	       0x100116ffb node::(anonymous namespace)::PlatformWorkerThread(void*) + 347
6   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
7   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 4:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x100119645 node::TaskQueue<v8::Task>::BlockingPop() + 69
5   node                          	       0x100116ffb node::(anonymous namespace)::PlatformWorkerThread(void*) + 347
6   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
7   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 5:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x100119645 node::TaskQueue<v8::Task>::BlockingPop() + 69
5   node                          	       0x100116ffb node::(anonymous namespace)::PlatformWorkerThread(void*) + 347
6   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
7   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 6:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x100119645 node::TaskQueue<v8::Task>::BlockingPop() + 69
5   node                          	       0x100116ffb node::(anonymous namespace)::PlatformWorkerThread(void*) + 347
6   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
7   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 7:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ecac6 semaphore_wait_trap + 10
2   node                          	       0x1009edde7 uv_sem_wait + 23
3   node                          	       0x10017cd6a node::inspector::(anonymous namespace)::StartIoThreadMain(void*) + 26
4   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
5   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 8:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ecb4a mach_msg2_trap + 10
2   libsystem_kernel.dylib        	    0x7ff8036fb704 mach_msg2_internal + 83
3   libsystem_kernel.dylib        	    0x7ff8036f3bc3 mach_msg_overwrite + 574
4   libsystem_kernel.dylib        	    0x7ff8036ece3b mach_msg + 19
5   CoreFoundation                	    0x7ff803817744 __CFRunLoopServiceMachPort + 145
6   CoreFoundation                	    0x7ff8038161ad __CFRunLoopRun + 1430
7   CoreFoundation                	    0x7ff8038155d0 CFRunLoopRunSpecific + 536
8   CoreFoundation                	    0x7ff80388b500 CFRunLoopRun + 40
9   fsevents.node                 	       0x10fa8e6cd fse_run_loop + 93
10  libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
11  libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 9:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x1009dc025 worker + 85
5   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
6   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 10:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x1009dc025 worker + 85
5   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
6   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 11:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x1009dc025 worker + 85
5   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
6   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 12:
0   ???                           	    0x7ff890c5eae0 ???
1   libsystem_kernel.dylib        	    0x7ff8036ef6f6 __psynch_cvwait + 10
2   libsystem_pthread.dylib       	    0x7ff80372f27a _pthread_cond_wait + 988
3   node                          	       0x1009ed849 uv_cond_wait + 9
4   node                          	       0x1009dc025 worker + 85
5   libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
6   libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 13 Crashed:
0   libsystem_pthread.dylib       	    0x7ff80372a893 ___chkstk_darwin + 55
1   FSEvents                      	    0x7ff80d4e4a97 __chkstk_darwin + 23
2   FSEvents                      	    0x7ff80d4e4bce _Xcallback_rpc + 218
3   FSEvents                      	    0x7ff80d4e4ad7 FSEventsD2F_server + 55
4   FSEvents                      	    0x7ff80d4e856f FSEventsClientProcessMessageCallback + 46
5   CoreFoundation                	    0x7ff803841ff6 __CFMachPortPerform + 244
6   CoreFoundation                	    0x7ff803817b24 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 41
7   CoreFoundation                	    0x7ff803817a65 __CFRunLoopDoSource1 + 539
8   CoreFoundation                	    0x7ff8038166d7 __CFRunLoopRun + 2752
9   CoreFoundation                	    0x7ff8038155d0 CFRunLoopRunSpecific + 536
10  CoreFoundation                	    0x7ff80388b500 CFRunLoopRun + 40
11  node                          	       0x1009f1f26 uv__cf_loop_runner + 70
12  libsystem_pthread.dylib       	    0x7ff80372edf1 _pthread_start + 99
13  libsystem_pthread.dylib       	    0x7ff80372a857 thread_start + 15

Thread 14:
0   runtime                       	    0x7ff7ffcd49b0 0x7ff7ffcb2000 + 141744


Thread 13 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000002400  rbx: 0x0000000000000000  rcx: 0x0000000a919f1000  rdx: 0x0000000030b78fba
  rdi: 0x00007fd6c5708330  rsi: 0x0000000000000001  rbp: 0x0000000a919f3000  rsp: 0x0000000a919f2ec8
   r8: 0x0000000000000480   r9: 0x00007fd6c5708330  r10: 0x00007fd6d636ee00  r11: 0x00007fd6b1061800
  r12: 0x0000000000000480  r13: 0x0000000000000000  r14: 0x0000000000002400  r15: 0x0000000000000480
  rip: 0x00007ff80372a893  rfl: 0x0000000000000216
 tmp0: 0xffffffffffffffd8 tmp1: 0x0000000a919f90b8 tmp2: 0x00007ff89e534934


Binary Images:
       0x20484f000 -        0x2048e9fff dyld (*) <3771ea6a-0fe5-3b63-961d-c09e01d5e680> /usr/lib/dyld
    0x7ff7ffcb2000 -     0x7ff7ffce1fff runtime (*) <fe40a70a-33e8-3d5c-b196-d104da35046d> /usr/libexec/rosetta/runtime
       0x10f25a000 -        0x10f2c1fff libRosettaRuntime (*) <7742e99c-2006-3006-bc1e-1869448c6224> /Library/Apple/*/libRosettaRuntime
       0x100000000 -        0x10341efff node (*) <900be870-f73a-3a3d-a445-93b44a76da02> /Users/USER/*/node
       0x10fa8a000 -        0x10fa91fff fsevents.node (*) <900041af-31d4-3edb-82f2-3242455560d4> /Users/USER/*/fsevents.node
       0x10ffc8000 -        0x11018ffff binding.node (*) <447c735e-72db-31ca-bd3e-6edade7dc795> /Users/USER/*/binding.node
               0x0 - 0xffffffffffffffff ??? (*) <00000000-0000-0000-0000-000000000000> ???
    0x7ff8036ec000 -     0x7ff803728b4f libsystem_kernel.dylib (*) <dab10aa4-8afa-3d02-9cde-6023554ac858> /usr/lib/system/libsystem_kernel.dylib
    0x7ff803729000 -     0x7ff803734dcf libsystem_pthread.dylib (*) <a6d1f05a-0743-31b7-9fe2-268f06ccd51a> /usr/lib/system/libsystem_pthread.dylib
    0x7ff80379c000 -     0x7ff803c4eff2 com.apple.CoreFoundation (6.9) <5adbf847-e5a7-3b3c-8a58-0cf8aa1097bc> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
    0x7ff80d4e3000 -     0x7ff80d4f042f com.apple.CoreServices.FSEvents (1400.100.1) <d2e47fab-0e20-32af-a77f-1effe35f75eb> /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/FSEvents.framework/Versions/A/FSEvents

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0

VM Region Summary:
ReadOnly portion of Libraries: Total=476.6M resident=0K(0%) swapped_out_or_unallocated=476.6M(100%)
Writable regions: Total=3.1G written=8352K(0%) resident=8336K(0%) swapped_out=16K(0%) unallocated=3.1G(100%)

                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Activity Tracing                   256K        1 
Kernel Alloc Once                    8K        1 
MALLOC                             2.1G       53 
MALLOC guard page                   96K        6 
Memory Tag 255                    30.8G     2506 
Rosetta Arena                     4096K        2 
Rosetta Generic                   11.4M     2918 
Rosetta IndirectBranch             512K        1 
Rosetta JIT                      128.0M        1 
Rosetta Return Stack               348K       30 
Rosetta Thread Context             300K       30 
STACK GUARD                          4K        1 
Stack                            161.0M       14 
Stack Guard                       48.1M       13 
VM_ALLOCATE                         56K        7 
VM_ALLOCATE (reserved)               4K        1         reserved VM address space (unallocated)
__DATA                            5131K      285 
__DATA_CONST                      21.9M      298 
__DATA_DIRTY                       438K       91 
__FONT_DATA                        2352        1 
__LINKEDIT                       181.1M        9 
__OBJC_RO                         61.3M        1 
__OBJC_RW                         2393K        2 
__TEXT                           295.6M      309 
__TPRO_CONST                         8K        2 
mapped file                       48.3M       14 
page table in kernel              8336K        1 
shared memory                       48K        2 
===========                     =======  ======= 
TOTAL                             33.9G     6600 
TOTAL, minus reserved VM space    33.9G     6600 



-----------
Full Report
-----------

{"app_name":"node","timestamp":"2025-06-21 00:30:04.00 -0400","app_version":"","slice_uuid":"900be870-f73a-3a3d-a445-93b44a76da02","build_version":"","platform":1,"share_with_app_devs":0,"is_first_party":1,"bug_type":"309","os_version":"macOS 15.5 (24F74)","roots_installed":0,"incident_id":"8DF4DC64-8679-4090-B4EB-1976CAA163C5","name":"node"}
{
  "uptime" : 4600,
  "procRole" : "Unspecified",
  "version" : 2,
  "userID" : 501,
  "deployVersion" : 210,
  "modelCode" : "Mac15,7",
  "coalitionID" : 1091,
  "osVersion" : {
    "train" : "macOS 15.5",
    "build" : "24F74",
    "releaseType" : "User"
  },
  "captureTime" : "2025-06-21 00:30:03.1733 -0400",
  "codeSigningMonitor" : 1,
  "incident" : "8DF4DC64-8679-4090-B4EB-1976CAA163C5",
  "pid" : 7675,
  "translated" : true,
  "cpuType" : "X86-64",
  "roots_installed" : 0,
  "bug_type" : "309",
  "procLaunch" : "2025-06-21 00:27:11.6900 -0400",
  "procStartAbsTime" : 108615855773,
  "procExitAbsTime" : 112730619705,
  "procName" : "node",
  "procPath" : "\/Users\/USER\/*\/node",
  "parentProc" : "Exited process",
  "parentPid" : 7674,
  "coalitionName" : "com.mitchellh.ghostty",
  "crashReporterKey" : "B93170B2-B0DA-F6B6-1360-ED7FDC3A5E21",
  "appleIntelligenceStatus" : {"state":"unavailable","reasons":["assetIsNotReady","notOptedIn"]},
  "responsiblePid" : 1409,
  "responsibleProc" : "ghostty",
  "codeSigningID" : "",
  "codeSigningTeamID" : "",
  "codeSigningValidationCategory" : 0,
  "codeSigningTrustLevel" : 4294967295,
  "codeSigningAuxiliaryInfo" : 0,
  "bootSessionUUID" : "A4133C36-3773-43A6-BB64-D8372826F541",
  "sip" : "enabled",
  "vmRegionInfo" : "0xa919f0ff8 is in 0xa919f0000-0xa919f1000;  bytes after start: 4088  bytes before end: 7\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      Memory Tag 255              a899f0000-a919f0000    [128.0M] ---\/rwx SM=NUL  \n--->  Stack Guard                 a919f0000-a919f1000    [    4K] ---\/rwx SM=NUL  \n      Stack                       a919f1000-a919fb000    [   40K] rw-\/rwx SM=PRV  ",
  "exception" : {"codes":"0x0000000000000002, 0x0000000a919f0ff8","rawCodes":[2,45392793592],"type":"EXC_BAD_ACCESS","signal":"SIGBUS","subtype":"KERN_PROTECTION_FAILURE at 0x0000000a919f0ff8"},
  "termination" : {"flags":0,"code":10,"namespace":"SIGNAL","indicator":"Bus error: 10","byProc":"exc handler","byPid":7675},
  "vmregioninfo" : "0xa919f0ff8 is in 0xa919f0000-0xa919f1000;  bytes after start: 4088  bytes before end: 7\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      Memory Tag 255              a899f0000-a919f0000    [128.0M] ---\/rwx SM=NUL  \n--->  Stack Guard                 a919f0000-a919f1000    [    4K] ---\/rwx SM=NUL  \n      Stack                       a919f1000-a919fb000    [   40K] rw-\/rwx SM=PRV  ",
  "extMods" : {"caller":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"system":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"targeted":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"warnings":0},
  "faultingThread" : 13,
  "threads" : [{"id":82558,"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":13028925024},"r12":{"value":4294967295},"rosetta":{"tmp2":{"value":140703186229272},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":13028925136},"r8":{"value":4696954},"r15":{"value":0},"r10":{"value":13028925136},"rdx":{"value":0},"rdi":{"value":242000000},"r9":{"value":13028925024},"r13":{"value":4350474800,"symbolLocation":0,"symbol":"default_loop_struct"},"rflags":{"value":646},"rax":{"value":4},"rsp":{"value":1024},"r11":{"value":0},"rcx":{"value":0},"r14":{"value":242},"rsi":{"value":0}},"queue":"com.apple.main-thread","frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":22562,"symbol":"kevent","symbolLocation":10,"imageIndex":7},{"imageOffset":10431966,"symbol":"uv__io_poll","symbolLocation":942,"imageIndex":3},{"imageOffset":10355481,"symbol":"uv_run","symbolLocation":345,"imageIndex":3},{"imageOffset":969227,"symbol":"node::NodeMainInstance::Run()","symbolLocation":379,"imageIndex":3},{"imageOffset":518794,"symbol":"node::Start(int, char**)","symbolLocation":266,"imageIndex":3},{"imageOffset":25904,"symbol":"start","symbolLocation":3056,"imageIndex":0}]},{"id":82559,"name":"com.apple.rosetta.exceptionserver","threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":9908489551872},"r12":{"value":8589934592},"rosetta":{"tmp2":{"value":0},"tmp1":{"value":4496830791059},"tmp0":{"value":10337986281472}},"rbx":{"value":4496830791059},"r8":{"value":2307},"r15":{"value":5033168896},"r10":{"value":3},"rdx":{"value":0},"rdi":{"value":0},"r9":{"value":1},"r13":{"value":4573190768},"rflags":{"value":582},"rax":{"value":268451845},"rsp":{"value":10337986281472},"r11":{"value":0},"rcx":{"value":17314086914},"r14":{"value":140705562985232},"rsi":{"value":2616}},"frames":[{"imageOffset":16612,"imageIndex":1}]},{"id":82560,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":22562,"symbol":"kevent","symbolLocation":10,"imageIndex":7},{"imageOffset":10431966,"symbol":"uv__io_poll","symbolLocation":942,"imageIndex":3},{"imageOffset":10355481,"symbol":"uv_run","symbolLocation":345,"imageIndex":3},{"imageOffset":1152020,"symbol":"node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Run()","symbolLocation":340,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":0},"r12":{"value":4294967295},"rosetta":{"tmp2":{"value":140703186229272},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":13045726896},"r8":{"value":4525727},"r15":{"value":0},"r10":{"value":13045726896},"rdx":{"value":2},"rdi":{"value":0},"r9":{"value":0},"r13":{"value":140561218601192},"rflags":{"value":646},"rax":{"value":4},"rsp":{"value":1024},"r11":{"value":2095104},"rcx":{"value":0},"r14":{"value":4294967295},"rsi":{"value":0}}},{"id":82561,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":1152581,"symbol":"node::TaskQueue<v8::Task>::BlockingPop()","symbolLocation":69,"imageIndex":3},{"imageOffset":1142779,"symbol":"node::(anonymous namespace)::PlatformWorkerThread(void*)","symbolLocation":347,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13062532736},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":1116672},"r10":{"value":0},"rdx":{"value":1116672},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":4796069721476608},"rflags":{"value":658},"rax":{"value":4},"rsp":{"value":0},"r11":{"value":582741162856960},"rcx":{"value":0},"r14":{"value":140561217512744},"rsi":{"value":0}}},{"id":82562,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":1152581,"symbol":"node::TaskQueue<v8::Task>::BlockingPop()","symbolLocation":69,"imageIndex":3},{"imageOffset":1142779,"symbol":"node::(anonymous namespace)::PlatformWorkerThread(void*)","symbolLocation":347,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13079305856},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":1117184},"r10":{"value":0},"rdx":{"value":1117184},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":4798268744732672},"rflags":{"value":658},"rax":{"value":4},"rsp":{"value":0},"r11":{"value":582741162856960},"rcx":{"value":0},"r14":{"value":140561217512744},"rsi":{"value":0}}},{"id":82563,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":1152581,"symbol":"node::TaskQueue<v8::Task>::BlockingPop()","symbolLocation":69,"imageIndex":3},{"imageOffset":1142779,"symbol":"node::(anonymous namespace)::PlatformWorkerThread(void*)","symbolLocation":347,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13096078976},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":1117184},"r10":{"value":0},"rdx":{"value":1117184},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":4798268744732416},"rflags":{"value":658},"rax":{"value":4},"rsp":{"value":0},"r11":{"value":582741162856960},"rcx":{"value":0},"r14":{"value":140561217512744},"rsi":{"value":0}}},{"id":82564,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":1152581,"symbol":"node::TaskQueue<v8::Task>::BlockingPop()","symbolLocation":69,"imageIndex":3},{"imageOffset":1142779,"symbol":"node::(anonymous namespace)::PlatformWorkerThread(void*)","symbolLocation":347,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13112852096},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":1116416},"r10":{"value":0},"rdx":{"value":1116416},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":4794970209848576},"rflags":{"value":658},"rax":{"value":260},"rsp":{"value":0},"r11":{"value":582741162856960},"rcx":{"value":0},"r14":{"value":140561217512744},"rsi":{"value":0}}},{"id":82565,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":2758,"symbol":"semaphore_wait_trap","symbolLocation":10,"imageIndex":7},{"imageOffset":10411495,"symbol":"uv_sem_wait","symbolLocation":23,"imageIndex":3},{"imageOffset":1559914,"symbol":"node::inspector::(anonymous namespace)::StartIoThreadMain(void*)","symbolLocation":26,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":419432703},"r12":{"value":0},"rosetta":{"tmp2":{"value":140703186219343},"tmp1":{"value":140705557506736},"tmp0":{"value":18446744073709551615}},"rbx":{"value":4868},"r8":{"value":13112897456},"r15":{"value":0},"r10":{"value":4868},"rdx":{"value":0},"rdi":{"value":13112897536},"r9":{"value":419432703},"r13":{"value":0},"rflags":{"value":663},"rax":{"value":14},"rsp":{"value":13112897536},"r11":{"value":0},"rcx":{"value":4867},"r14":{"value":0},"rsi":{"value":4867}}},{"id":82583,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":2890,"symbol":"mach_msg2_trap","symbolLocation":10,"imageIndex":7},{"imageOffset":63236,"symbol":"mach_msg2_internal","symbolLocation":83,"imageIndex":7},{"imageOffset":31683,"symbol":"mach_msg_overwrite","symbolLocation":574,"imageIndex":7},{"imageOffset":3643,"symbol":"mach_msg","symbolLocation":19,"imageIndex":7},{"imageOffset":505668,"symbol":"__CFRunLoopServiceMachPort","symbolLocation":145,"imageIndex":9},{"imageOffset":500141,"symbol":"__CFRunLoopRun","symbolLocation":1430,"imageIndex":9},{"imageOffset":497104,"symbol":"CFRunLoopRunSpecific","symbolLocation":536,"imageIndex":9},{"imageOffset":980224,"symbol":"CFRunLoopRun","symbolLocation":40,"imageIndex":9},{"imageOffset":18125,"symbol":"fse_run_loop","symbolLocation":93,"imageIndex":4},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":53888954662912},"r12":{"value":53888954662912},"rosetta":{"tmp2":{"value":140703186269956},"tmp1":{"value":140705557507024},"tmp0":{"value":18446744073709551615}},"rbx":{"value":53888954662912},"r8":{"value":0},"r15":{"value":2},"r10":{"value":53888954662912},"rdx":{"value":8589934592},"rdi":{"value":4294967295},"r9":{"value":53888954662912},"r13":{"value":21592279046},"rflags":{"value":643},"rax":{"value":268451845},"rsp":{"value":0},"r11":{"value":0},"rcx":{"value":21592279046},"r14":{"value":53888954662912},"rsi":{"value":2}}},{"id":82584,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":10338341,"symbol":"worker","symbolLocation":85,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13130206944},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":12393728},"r10":{"value":0},"rdx":{"value":12393728},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":53230656447914240},"rflags":{"value":658},"rax":{"value":4},"rsp":{"value":0},"r11":{"value":39406496748666880},"rcx":{"value":0},"r14":{"value":4350474688,"symbolLocation":0,"symbol":"cond"},"rsi":{"value":0}}},{"id":82585,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":10338341,"symbol":"worker","symbolLocation":85,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13146980064},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":12393728},"r10":{"value":0},"rdx":{"value":12393728},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":53230656447913984},"rflags":{"value":658},"rax":{"value":4},"rsp":{"value":0},"r11":{"value":39406496748666880},"rcx":{"value":0},"r14":{"value":4350474688,"symbolLocation":0,"symbol":"cond"},"rsi":{"value":0}}},{"id":82586,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":10338341,"symbol":"worker","symbolLocation":85,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13163753184},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":12393728},"r10":{"value":0},"rdx":{"value":12393728},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":53230656447913728},"rflags":{"value":658},"rax":{"value":4},"rsp":{"value":0},"r11":{"value":39406496748666880},"rcx":{"value":0},"r14":{"value":4350474688,"symbolLocation":0,"symbol":"cond"},"rsi":{"value":0}}},{"id":82587,"frames":[{"imageOffset":140705557506784,"imageIndex":6},{"imageOffset":14070,"symbol":"__psynch_cvwait","symbolLocation":10,"imageIndex":7},{"imageOffset":25210,"symbol":"_pthread_cond_wait","symbolLocation":988,"imageIndex":8},{"imageOffset":10410057,"symbol":"uv_cond_wait","symbolLocation":9,"imageIndex":3},{"imageOffset":10338341,"symbol":"worker","symbolLocation":85,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":164},"r12":{"value":13180526304},"rosetta":{"tmp2":{"value":140703186220780},"tmp1":{"value":140705557506740},"tmp0":{"value":18446744073709551615}},"rbx":{"value":0},"r8":{"value":140703186488758,"symbolLocation":0,"symbol":"_pthread_psynch_cond_cleanup"},"r15":{"value":12393728},"r10":{"value":0},"rdx":{"value":12393728},"rdi":{"value":0},"r9":{"value":164},"r13":{"value":53230660742880768},"rflags":{"value":658},"rax":{"value":260},"rsp":{"value":0},"r11":{"value":39406496748666880},"rcx":{"value":0},"r14":{"value":4350474688,"symbolLocation":0,"symbol":"cond"},"rsi":{"value":0}}},{"triggered":true,"id":82877,"threadState":{"r13":{"value":0},"rflags":{"value":534},"rax":{"value":9216},"rosetta":{"tmp2":{"value":140705784875316},"tmp1":{"value":45392826552},"tmp0":{"value":18446744073709551576}},"r14":{"value":9216},"rsi":{"value":1},"r8":{"value":1152},"rdx":{"value":817336250},"r10":{"value":140560693652992},"r9":{"value":140560412214064},"r15":{"value":1152},"rbx":{"value":0},"r11":{"value":140560069695488},"rip":{"value":140703186462867,"matchesCrashFrame":1},"rbp":{"value":45392801792},"rsp":{"value":45392801480},"r12":{"value":1152},"rcx":{"value":45392793600},"flavor":"x86_THREAD_STATE","rdi":{"value":140560412214064}},"frames":[{"imageOffset":6291,"symbol":"___chkstk_darwin","symbolLocation":55,"imageIndex":8},{"imageOffset":6807,"symbol":"__chkstk_darwin","symbolLocation":23,"imageIndex":10},{"imageOffset":7118,"symbol":"_Xcallback_rpc","symbolLocation":218,"imageIndex":10},{"imageOffset":6871,"symbol":"FSEventsD2F_server","symbolLocation":55,"imageIndex":10},{"imageOffset":21871,"symbol":"FSEventsClientProcessMessageCallback","symbolLocation":46,"imageIndex":10},{"imageOffset":679926,"symbol":"__CFMachPortPerform","symbolLocation":244,"imageIndex":9},{"imageOffset":506660,"symbol":"__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__","symbolLocation":41,"imageIndex":9},{"imageOffset":506469,"symbol":"__CFRunLoopDoSource1","symbolLocation":539,"imageIndex":9},{"imageOffset":501463,"symbol":"__CFRunLoopRun","symbolLocation":2752,"imageIndex":9},{"imageOffset":497104,"symbol":"CFRunLoopRunSpecific","symbolLocation":536,"imageIndex":9},{"imageOffset":980224,"symbol":"CFRunLoopRun","symbolLocation":40,"imageIndex":9},{"imageOffset":10428198,"symbol":"uv__cf_loop_runner","symbolLocation":70,"imageIndex":3},{"imageOffset":24049,"symbol":"_pthread_start","symbolLocation":99,"imageIndex":8},{"imageOffset":6231,"symbol":"thread_start","symbolLocation":15,"imageIndex":8}]},{"id":82880,"frames":[{"imageOffset":141744,"imageIndex":1}],"threadState":{"flavor":"x86_THREAD_STATE","rbp":{"value":18446744073709551615},"r12":{"value":0},"rosetta":{"tmp2":{"value":0},"tmp1":{"value":0},"tmp0":{"value":0}},"rbx":{"value":0},"r8":{"value":0},"r15":{"value":0},"r10":{"value":0},"rdx":{"value":45393399808},"rdi":{"value":0},"r9":{"value":0},"r13":{"value":0},"rflags":{"value":531},"rax":{"value":45393936384},"rsp":{"value":409604},"r11":{"value":0},"rcx":{"value":19719},"r14":{"value":0},"rsi":{"value":0}}}],
  "usedImages" : [
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 8665755648,
    "size" : 634880,
    "uuid" : "3771ea6a-0fe5-3b63-961d-c09e01d5e680",
    "path" : "\/usr\/lib\/dyld",
    "name" : "dyld"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 140703125151744,
    "size" : 196608,
    "uuid" : "fe40a70a-33e8-3d5c-b196-d104da35046d",
    "path" : "\/usr\/libexec\/rosetta\/runtime",
    "name" : "runtime"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4549091328,
    "size" : 425984,
    "uuid" : "7742e99c-2006-3006-bc1e-1869448c6224",
    "path" : "\/Library\/Apple\/*\/libRosettaRuntime",
    "name" : "libRosettaRuntime"
  },
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 4294967296,
    "size" : 54652928,
    "uuid" : "900be870-f73a-3a3d-a445-93b44a76da02",
    "path" : "\/Users\/USER\/*\/node",
    "name" : "node"
  },
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 4557676544,
    "size" : 32768,
    "uuid" : "900041af-31d4-3edb-82f2-3242455560d4",
    "path" : "\/Users\/USER\/*\/fsevents.node",
    "name" : "fsevents.node"
  },
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 4563173376,
    "size" : 1867776,
    "uuid" : "447c735e-72db-31ca-bd3e-6edade7dc795",
    "path" : "\/Users\/USER\/*\/binding.node",
    "name" : "binding.node"
  },
  {
    "size" : 0,
    "source" : "A",
    "base" : 0,
    "uuid" : "00000000-0000-0000-0000-000000000000"
  },
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 140703186206720,
    "size" : 248656,
    "uuid" : "dab10aa4-8afa-3d02-9cde-6023554ac858",
    "path" : "\/usr\/lib\/system\/libsystem_kernel.dylib",
    "name" : "libsystem_kernel.dylib"
  },
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 140703186456576,
    "size" : 48592,
    "uuid" : "a6d1f05a-0743-31b7-9fe2-268f06ccd51a",
    "path" : "\/usr\/lib\/system\/libsystem_pthread.dylib",
    "name" : "libsystem_pthread.dylib"
  },
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 140703186927616,
    "CFBundleShortVersionString" : "6.9",
    "CFBundleIdentifier" : "com.apple.CoreFoundation",
    "size" : 4927475,
    "uuid" : "5adbf847-e5a7-3b3c-8a58-0cf8aa1097bc",
    "path" : "\/System\/Library\/Frameworks\/CoreFoundation.framework\/Versions\/A\/CoreFoundation",
    "name" : "CoreFoundation",
    "CFBundleVersion" : "3502.1.401"
  },
  {
    "source" : "P",
    "arch" : "x86_64",
    "base" : 140703351844864,
    "CFBundleShortVersionString" : "1400.100.1",
    "CFBundleIdentifier" : "com.apple.CoreServices.FSEvents",
    "size" : 54320,
    "uuid" : "d2e47fab-0e20-32af-a77f-1effe35f75eb",
    "path" : "\/System\/Library\/Frameworks\/CoreServices.framework\/Versions\/A\/Frameworks\/FSEvents.framework\/Versions\/A\/FSEvents",
    "name" : "FSEvents",
    "CFBundleVersion" : "1400.100.1"
  }
],
  "sharedCache" : {
  "base" : 140703154192384,
  "size" : 25769803776,
  "uuid" : "6e28f2b9-5b29-30c6-af7c-47d23bf9ec34"
},
  "vmSummary" : "ReadOnly portion of Libraries: Total=476.6M resident=0K(0%) swapped_out_or_unallocated=476.6M(100%)\nWritable regions: Total=3.1G written=8352K(0%) resident=8336K(0%) swapped_out=16K(0%) unallocated=3.1G(100%)\n\n                                VIRTUAL   REGION \nREGION TYPE                        SIZE    COUNT (non-coalesced) \n===========                     =======  ======= \nActivity Tracing                   256K        1 \nKernel Alloc Once                    8K        1 \nMALLOC                             2.1G       53 \nMALLOC guard page                   96K        6 \nMemory Tag 255                    30.8G     2506 \nRosetta Arena                     4096K        2 \nRosetta Generic                   11.4M     2918 \nRosetta IndirectBranch             512K        1 \nRosetta JIT                      128.0M        1 \nRosetta Return Stack               348K       30 \nRosetta Thread Context             300K       30 \nSTACK GUARD                          4K        1 \nStack                            161.0M       14 \nStack Guard                       48.1M       13 \nVM_ALLOCATE                         56K        7 \nVM_ALLOCATE (reserved)               4K        1         reserved VM address space (unallocated)\n__DATA                            5131K      285 \n__DATA_CONST                      21.9M      298 \n__DATA_DIRTY                       438K       91 \n__FONT_DATA                        2352        1 \n__LINKEDIT                       181.1M        9 \n__OBJC_RO                         61.3M        1 \n__OBJC_RW                         2393K        2 \n__TEXT                           295.6M      309 \n__TPRO_CONST                         8K        2 \nmapped file                       48.3M       14 \npage table in kernel              8336K        1 \nshared memory                       48K        2 \n===========                     =======  ======= \nTOTAL                             33.9G     6600 \nTOTAL, minus reserved VM space    33.9G     6600 \n",
  "legacyInfo" : {
  "threadTriggered" : {

  }
},
  "logWritingSignature" : "03b693df42966d845640de6db501acb2b299cbb7",
  "trialInfo" : {
  "rollouts" : [
    {
      "rolloutId" : "670e9bd77a111748a97092a1",
      "factorPackIds" : {
        "SIRI_TTS_DEVICE_TRAINING" : "67d07fb744f1a3655d87002b"
      },
      "deploymentId" : 240000016
    },
    {
      "rolloutId" : "64c17a9925d75a7281053d4c",
      "factorPackIds" : {
        "SIRI_AUDIO_DISABLE_MEDIA_ENTITY_SYNC" : "64d29746ad29a465b3bbeace"
      },
      "deploymentId" : 240000002
    }
  ],
  "experiments" : [
    {
      "treatmentId" : "d5322b03-2bc4-481a-817e-3640bda0eeee",
      "experimentId" : "67f4692f84eaf455d73c6090",
      "deploymentId" : 400000001
    }
  ]
}
}
```