### PR TITLE
ASK-VA Issues 1888 Don't allow editing for prefilled fields

### DIFF
--- a/src/applications/ask-va/config/prefill-transformer.js
+++ b/src/applications/ask-va/config/prefill-transformer.js
@@ -1,4 +1,5 @@
 import { hasPrefillInformation } from '../constants';
+
 export default function prefillTransformer(pages, formData, metadata) {
   const prefillPersonalInformation = data => {
     const personalInfo = data?.personalInformation || {};

--- a/src/applications/ask-va/config/prefill-transformer.js
+++ b/src/applications/ask-va/config/prefill-transformer.js
@@ -1,3 +1,4 @@
+import { hasPrefillInformation } from '../constants';
 export default function prefillTransformer(pages, formData, metadata) {
   const prefillPersonalInformation = data => {
     const personalInfo = data?.personalInformation || {};
@@ -45,6 +46,13 @@ export default function prefillTransformer(pages, formData, metadata) {
     ...prefillPersonalInformation(formData || {}),
     ...prefillContactInformation(formData || {}),
   };
+
+  // FORCE setting the hasPrefillInformation flag
+  // The theory is that there might be race conditions where the flag is not set properly
+  if (prefillFormData.hasPrefillInformation === undefined) {
+    const hasPrefillFlag = hasPrefillInformation(prefillFormData);
+    prefillFormData.hasPrefillInformation = hasPrefillFlag;
+  }
 
   return {
     metadata,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
   - FORCED check a condition that determines what happens next. Current theory is it is a race condition.
- _(If bug, how to reproduce)_
   - Only 1 User has reported this issue. When they loging using Login.gov it works, through ID.me it doesn't.
- _(What is the solution, why is this the solution)_
    - Its defensive programming since the flag is critical in determining the form flow.
- _(Which team do you work for, does your team own the maintenance of this component?)_
   - Watchtower
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
  - N/A

## Related issue(s)
https://github.com/department-of-veterans-affairs/ask-va/issues/1888

## Testing done

## What areas of the site does it impact?

ASK-VA

## Acceptance criteria
See ticket https://github.com/department-of-veterans-affairs/ask-va/issues/1888
### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user