### PR TITLE
Burial | Add home hospice pages

### DIFF
--- a/src/applications/burials-ez/config/chapters/02-veteran-information/homeHospiceCare.js
+++ b/src/applications/burials-ez/config/chapters/02-veteran-information/homeHospiceCare.js
@@ -1,0 +1,24 @@
+import {
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { generateTitle } from '../../../utils/helpers';
+
+export default {
+  uiSchema: {
+    'ui:title': generateTitle('Home hospice care'),
+    homeHospiceCare: yesNoUI({
+      title:
+        'Did the Veteran receive home hospice care that was paid for by VA?',
+      required: () => true,
+      labelHeaderLevel: '',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['homeHospiceCare'],
+    properties: {
+      homeHospiceCare: yesNoSchema,
+    },
+  },
+};

--- a/src/applications/burials-ez/config/chapters/02-veteran-information/homeHospiceCareAfterDischarge.js
+++ b/src/applications/burials-ez/config/chapters/02-veteran-information/homeHospiceCareAfterDischarge.js
@@ -1,0 +1,24 @@
+import {
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { generateTitle } from '../../../utils/helpers';
+
+export default {
+  uiSchema: {
+    'ui:title': generateTitle('Home hospice care after discharge'),
+    homeHospiceCareAfterDischarge: yesNoUI({
+      title:
+        'Did the Veteran receive home hospice care after being discharged from a VA hospital or nursing home?',
+      required: () => true,
+      labelHeaderLevel: '',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['homeHospiceCareAfterDischarge'],
+    properties: {
+      homeHospiceCareAfterDischarge: yesNoSchema,
+    },
+  },
+};

--- a/src/applications/burials-ez/config/form.js
+++ b/src/applications/burials-ez/config/form.js
@@ -19,6 +19,8 @@ import contactInformation from './chapters/01-claimant-information/contactInform
 import veteranInformation from './chapters/02-veteran-information/veteranInformation';
 import burialInformation from './chapters/02-veteran-information/burialInformation';
 import locationOfDeath from './chapters/02-veteran-information/locationOfDeath';
+import homeHospiceCare from './chapters/02-veteran-information/homeHospiceCare';
+import homeHospiceCareAfterDischarge from './chapters/02-veteran-information/homeHospiceCareAfterDischarge';
 
 import separationDocuments from './chapters/03-military-history/separationDocuments';
 import uploadDD214 from './chapters/03-military-history/uploadDD214';
@@ -45,7 +47,12 @@ import deathCertificate from './chapters/05-additional-information/deathCertific
 import transportationReceipts from './chapters/05-additional-information/transportationReceipts';
 import additionalEvidence from './chapters/05-additional-information/additionalEvidence';
 
-import { generateDeathFacilitySchemas } from '../utils/helpers';
+import {
+  pageAndReviewTitle,
+  generateDeathFacilitySchemas,
+  showHomeHospiceCarePage,
+  showHomeHospiceCareAfterDischargePage,
+} from '../utils/helpers';
 import { submit } from './submit';
 import manifest from '../manifest.json';
 import migrations from '../migrations';
@@ -183,6 +190,21 @@ const formConfig = {
           path: 'veteran-information/location-of-death',
           uiSchema: locationOfDeath.uiSchema,
           schema: locationOfDeath.schema,
+        },
+        homeHospiceCare: {
+          ...pageAndReviewTitle('Home hospice care'),
+          path: 'veteran-information/location-of-death/home-hospice-care',
+          depends: showHomeHospiceCarePage,
+          uiSchema: homeHospiceCare.uiSchema,
+          schema: homeHospiceCare.schema,
+        },
+        homeHospiceCareAfterDischarge: {
+          ...pageAndReviewTitle('Home hospice care after discharge'),
+          path:
+            'veteran-information/location-of-death/hme-hospice-care-after-discharge',
+          depends: showHomeHospiceCareAfterDischargePage,
+          uiSchema: homeHospiceCareAfterDischarge.uiSchema,
+          schema: homeHospiceCareAfterDischarge.schema,
         },
         nursingHomeUnpaid: {
           title: 'Veteran death location details',

--- a/src/applications/burials-ez/tests/config/chapters/02-veteran-information/homeHospiceCare.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/config/chapters/02-veteran-information/homeHospiceCare.unit.spec.jsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import React from 'react';
+import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import { $$ } from 'platform/forms-system/src/js/utilities/ui';
+import formConfig from '../../../../config/form';
+
+const defaultStore = createCommonStore();
+
+describe('Home hospice care', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.veteranInformation.pages.homeHospiceCare;
+
+  it('should render', () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{}}
+        />
+      </Provider>,
+    );
+
+    expect($$('va-radio-option', container).length).to.equal(2);
+  });
+});

--- a/src/applications/burials-ez/tests/config/chapters/02-veteran-information/homeHospiceCareAfterDischarge.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/config/chapters/02-veteran-information/homeHospiceCareAfterDischarge.unit.spec.jsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import React from 'react';
+import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import { $$ } from 'platform/forms-system/src/js/utilities/ui';
+import formConfig from '../../../../config/form';
+
+const defaultStore = createCommonStore();
+
+describe('Home hospice care after discharge', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.veteranInformation.pages.homeHospiceCareAfterDischarge;
+
+  it('should render', () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{}}
+        />
+      </Provider>,
+    );
+
+    expect($$('va-radio-option', container).length).to.equal(2);
+  });
+});

--- a/src/applications/burials-ez/tests/e2e/burials-max.cypress.spec.js
+++ b/src/applications/burials-ez/tests/e2e/burials-max.cypress.spec.js
@@ -1,8 +1,8 @@
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
-import minimalFixture from '../schema/minimal-test.json';
-import overflowFixture from '../schema/overflow-test.json';
+import maximalFixture from '../schema/maximal-test.json';
+import maximalAtHomeFixture from '../schema/maximal-at-home-test.json';
 
 import mockUser from '../fixtures/mocks/user.json';
 import formConfig from '../../config/form';
@@ -17,8 +17,8 @@ const testConfig = createTestConfig(
     dataPrefix: 'data',
     dataDir: null,
     dataSets: [
-      { title: 'overflow', data: overflowFixture },
-      { title: 'minimal', data: minimalFixture },
+      { title: 'maximal', data: maximalFixture },
+      { title: 'maximal at home', data: maximalAtHomeFixture },
     ],
     pageHooks: pageHooks(cy),
     setupPerTest: () => {

--- a/src/applications/burials-ez/tests/e2e/helpers/index.js
+++ b/src/applications/burials-ez/tests/e2e/helpers/index.js
@@ -1,3 +1,8 @@
+import loggedInUser from '../../fixtures/mocks/loggedInUser.json';
+import featuresEnabled from '../../fixtures/mocks/featuresEnabled.json';
+import mockStatus from '../../fixtures/mocks/profile-status.json';
+import pagePaths from '../pagePaths';
+
 // navigation helpers
 export const goToNextPage = pagePath => {
   // clicks Continue button, and optionally checks destination path.
@@ -40,3 +45,132 @@ export const selectRadioWebComponent = (fieldName, value) => {
     cy.get(`va-radio-option[name="${fieldName}"][value="${value}"]`).click();
   }
 };
+
+const TEST_URL =
+  '/burials-memorials/veterans-burial-allowance/apply-for-allowance-form-21p-530ez/introduction';
+const IN_PROGRESS_URL = '/v0/in_progress_forms/21P-530EZ';
+const BURIALS_CLAIMS_URL = '/burials/v0/claims';
+const CLAIM_ATTACHMENTS_URL = '/v0/claim_attachments';
+const SUBMISSION_DATE = new Date().toISOString();
+
+const SUBMISSION_CONFIRMATION_NUMBER = '01e77e8d-79bf-4991-a899-4e2defff11e0';
+
+export const setup = ({ authenticated } = {}) => {
+  cy.intercept('GET', '/v0/feature_toggles*', featuresEnabled);
+
+  cy.get('@testData').then(testData => {
+    cy.intercept('GET', IN_PROGRESS_URL, {
+      formData: {},
+      metadata: {
+        version: 0,
+        prefill: true,
+        returnUrl: '/applicant/information',
+      },
+    });
+    cy.intercept('PUT', IN_PROGRESS_URL, testData);
+  });
+
+  cy.intercept('POST', BURIALS_CLAIMS_URL, {
+    data: {
+      id: '8',
+      type: 'saved_claim',
+      attributes: {
+        submittedAt: SUBMISSION_DATE,
+        regionalOffice: [
+          'Attention:  Philadelphia Pension Center',
+          'P.O. Box 5206',
+          'Janesville, WI 53547-5206',
+        ],
+        confirmationNumber: SUBMISSION_CONFIRMATION_NUMBER,
+        guid: '01e77e8d-79bf-4991-a899-4e2defff11e0',
+        form: '21P-530EZ',
+      },
+    },
+  }).as('submitApplication');
+
+  cy.intercept('POST', CLAIM_ATTACHMENTS_URL, {
+    data: {
+      attributes: {
+        confirmationCode: 'f3111a5f-e86f-4c8d-96c7-9bba6eee13e5',
+        name: 'image.png',
+        size: 65645,
+      },
+      id: '11',
+      type: 'persistent_attachments',
+    },
+  });
+
+  if (!authenticated) {
+    cy.visit(TEST_URL);
+    return;
+  }
+  cy.intercept('GET', '/v0/profile/status', mockStatus).as('loggedIn');
+  cy.login(loggedInUser);
+  cy.visit(TEST_URL);
+};
+
+export const pageHooks = cy => ({
+  introduction: () => {
+    // skip wizard
+    cy.findAllByText(
+      /Start the burial allowance and transportation benefits application/i,
+    )
+      .first()
+      .click();
+  },
+  [pagePaths.mailingAddress]: () => {
+    cy.get('@testData').then(data => {
+      cy.fillAddressWebComponentPattern(
+        'claimantAddress',
+        data.claimantAddress,
+      );
+    });
+  },
+  [pagePaths.separationDocuments]: () => {
+    cy.get('@testData').then(() => {
+      selectRadioWebComponent('root_view:separationDocuments', 'N');
+    });
+  },
+  [pagePaths.previousNamesQuestion]: () => {
+    cy.get('@testData').then(() => {
+      selectRadioWebComponent('root_view:servedUnderOtherNames', 'N');
+    });
+  },
+  [pagePaths.benefitsSelection]: () => {
+    cy.get('@testData').then(() => {
+      selectCheckboxWebComponent(
+        'root_view:claimedBenefits_burialAllowance',
+        true,
+      );
+    });
+  },
+  [pagePaths.burialAllowancePartOne]: () => {
+    cy.get('@testData').then(() => {
+      selectCheckboxWebComponent('root_burialAllowanceRequested_service', true);
+    });
+  },
+  [pagePaths.burialAllowancePartTwo]: () => {
+    cy.get('@testData').then(() => {
+      selectRadioWebComponent('root_burialExpenseResponsibility', 'N');
+      if (
+        Cypress.$('va-radio-option[name="root_previouslyReceivedAllowance"]')
+          .length
+      ) {
+        cy.get(
+          `va-radio-option[name="root_previouslyReceivedAllowance"][value="N"]`,
+        )?.click();
+      }
+    });
+  },
+  [pagePaths.finalRestingPlace]: () => {
+    cy.get('@testData').then(() => {
+      selectRadioWebComponent('root_finalRestingPlace_location', 'cemetery');
+    });
+  },
+  [pagePaths.cemeteryLocationQuestion]: () => {
+    cy.get('@testData').then(() => {
+      selectRadioWebComponent('root_cemetaryLocationQuestion', 'none');
+    });
+  },
+  [pagePaths.confirmation]: () => {},
+});

--- a/src/applications/burials-ez/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/helpers.unit.spec.jsx
@@ -5,7 +5,12 @@ import { waitFor } from '@testing-library/react';
 import * as api from 'platform/utilities/api';
 import { fullNameUI } from 'platform/forms-system/src/js/web-component-patterns';
 import * as recordEventModule from 'platform/monitoring/record-event';
-import { benefitsIntakeFullNameUI } from '../utils/helpers';
+import {
+  benefitsIntakeFullNameUI,
+  pageAndReviewTitle,
+  showHomeHospiceCarePage,
+  showHomeHospiceCareAfterDischargePage,
+} from '../utils/helpers';
 import { submit } from '../config/submit';
 
 describe('Burials helpers', () => {
@@ -108,6 +113,46 @@ describe('Burials helpers', () => {
       );
       expect(benefitsUiSchema.first['ui:validations']).to.have.lengthOf(2);
       expect(benefitsUiSchema.last['ui:validations']).to.have.lengthOf(2);
+    });
+  });
+
+  describe('pageAndReviewTitle', () => {
+    it('should return the correct title for a page', () => {
+      const title = pageAndReviewTitle('Testing page');
+      expect(Object.keys(title)).to.deep.equal(['title', 'reviewTitle']);
+      expect(title.title).to.equal('Testing page');
+    });
+  });
+
+  describe('showHomeHospiceCarePage', () => {
+    const data = { locationOfDeath: { location: 'atHome' } };
+    const date = new Date('2025-07-30').getTime();
+    it('should return true if home is selected & before end date', () => {
+      expect(showHomeHospiceCarePage(data, date)).to.be.true;
+    });
+    it('should return false if home is not selected & before end date', () => {
+      expect(
+        showHomeHospiceCarePage(
+          { locationOfDeath: { location: 'other' } },
+          date,
+        ),
+      ).to.be.false;
+    });
+    it('should return false if home is selected & past the end date', () => {
+      const expiredDate = new Date('2030-01-01').getTime();
+      expect(showHomeHospiceCarePage(data, expiredDate)).to.be.false;
+    });
+  });
+
+  describe('showHomeHospiceCareAfterDischargePage', () => {
+    it('should return true if home hospice care is selected', () => {
+      const data = { homeHospiceCare: true };
+      expect(showHomeHospiceCareAfterDischargePage(data)).to.be.true;
+    });
+
+    it('should return false if home hospice care is not selected', () => {
+      const data = { homeHospiceCare: false };
+      expect(showHomeHospiceCareAfterDischargePage(data)).to.be.false;
     });
   });
 });

--- a/src/applications/burials-ez/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/helpers.unit.spec.jsx
@@ -125,22 +125,24 @@ describe('Burials helpers', () => {
   });
 
   describe('showHomeHospiceCarePage', () => {
-    const data = { locationOfDeath: { location: 'atHome' } };
-    const date = new Date('2025-07-30').getTime();
+    const data = {
+      deathDate: '2025-07-30',
+      locationOfDeath: { location: 'atHome' },
+    };
     it('should return true if home is selected & before end date', () => {
-      expect(showHomeHospiceCarePage(data, date)).to.be.true;
+      expect(showHomeHospiceCarePage(data)).to.be.true;
     });
     it('should return false if home is not selected & before end date', () => {
       expect(
-        showHomeHospiceCarePage(
-          { locationOfDeath: { location: 'other' } },
-          date,
-        ),
+        showHomeHospiceCarePage({
+          deathDate: '2025-07-30',
+          locationOfDeath: { location: 'other' },
+        }),
       ).to.be.false;
     });
     it('should return false if home is selected & past the end date', () => {
-      const expiredDate = new Date('2030-01-01').getTime();
-      expect(showHomeHospiceCarePage(data, expiredDate)).to.be.false;
+      const expiredDate = { ...data, deathDate: '2030-01-01' };
+      expect(showHomeHospiceCarePage(expiredDate)).to.be.false;
     });
   });
 

--- a/src/applications/burials-ez/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/helpers.unit.spec.jsx
@@ -148,12 +148,26 @@ describe('Burials helpers', () => {
 
   describe('showHomeHospiceCareAfterDischargePage', () => {
     it('should return true if home hospice care is selected', () => {
-      const data = { homeHospiceCare: true };
+      const data = {
+        locationOfDeath: { location: 'atHome' },
+        homeHospiceCare: true,
+      };
       expect(showHomeHospiceCareAfterDischargePage(data)).to.be.true;
     });
 
+    it('should return false if death was not at home', () => {
+      const data = {
+        locationOfDeath: { location: 'other' },
+        homeHospiceCare: true,
+      };
+      expect(showHomeHospiceCareAfterDischargePage(data)).to.be.false;
+    });
+
     it('should return false if home hospice care is not selected', () => {
-      const data = { homeHospiceCare: false };
+      const data = {
+        locationOfDeath: { location: 'atHome' },
+        homeHospiceCare: false,
+      };
       expect(showHomeHospiceCareAfterDischargePage(data)).to.be.false;
     });
   });

--- a/src/applications/burials-ez/tests/mock-api.js
+++ b/src/applications/burials-ez/tests/mock-api.js
@@ -1,0 +1,125 @@
+/**
+ * Run mock 21P-530EZ server with max data using
+ * > yarn mock-api --responses ./src/applications/burials-ez/tests/mock-api.js
+ * Run this in browser console
+ * > localStorage.setItem('hasSession', true)
+ */
+const dateFns = require('date-fns');
+const delay = require('mocker-api/lib/delay');
+const mockUser = require('./fixtures/mocks/user.json');
+
+// Mock data to use
+const mockMaxData = require('./schema/maximal-at-home-test.json');
+// First page of the form
+const returnUrl = '/claimant-information/relationship-to-veteran';
+
+const submission = {
+  formSubmissionId: '123fake-submission-id-567',
+  timestamp: '2020-11-12',
+  attributes: {
+    guid: '123fake-submission-id-567',
+  },
+};
+
+const mockSipGet = {
+  formData: mockMaxData,
+  metadata: {
+    version: 0,
+    prefill: true,
+    returnUrl,
+  },
+};
+
+const mockSipPut = {
+  data: {
+    id: '1234',
+    type: 'in_progress_forms',
+    attributes: {
+      formId: '21P-530EZ',
+      createdAt: '2021-06-03T00:00:00.000Z',
+      updatedAt: '2021-06-03T00:00:00.000Z',
+      metadata: {
+        version: 1,
+        returnUrl,
+        savedAt: 1593500000000,
+        lastUpdated: 1593500000000,
+        expiresAt: 99999999999,
+      },
+    },
+  },
+};
+
+/**
+ * @returns mock user data with inProgressForms
+ */
+const userData = () => {
+  const lastUpdated = new Date().getTime();
+  const twoMonthsAgo = dateFns.getUnixTime(
+    dateFns.add(new Date(), { months: -2 }),
+  );
+
+  const sipData = {
+    form: '21P-530EZ',
+    metadata: {
+      version: 1,
+      returnUrl,
+      savedAt: new Date().getTime(),
+      submission: {
+        status: false,
+        errorMessage: false,
+        id: false,
+        timestamp: false,
+        hasAttemptedSubmit: false,
+      },
+      createdAt: twoMonthsAgo,
+      expiresAt: dateFns.getUnixTime(dateFns.add(new Date(), { years: 1 })),
+      lastUpdated: twoMonthsAgo,
+      inProgressFormId: 1234,
+    },
+    lastUpdated,
+  };
+
+  return {
+    data: {
+      ...mockUser.data,
+      attributes: {
+        ...mockUser.data.attributes,
+        inProgressForms: [sipData],
+      },
+    },
+  };
+};
+
+const responses = {
+  'GET /v0/user': userData(),
+  'GET /v0/feature_toggles': {
+    data: {
+      features: [{ name: 'burialFormEnabled', value: true }],
+    },
+  },
+  'OPTIONS /v0/maintenance_windows': 'OK',
+  'GET /v0/maintenance_windows': { data: [] },
+  'GET /data/cms/vamc-ehr.json': {},
+
+  'GET /v0/in_progress_forms/21P-530EZ': mockSipGet,
+  'PUT /v0/in_progress_forms/21P-530EZ': mockSipPut,
+
+  'POST /v0/claim_attachments': {
+    data: {
+      attributes: {
+        guid: '123fake-submission-id-567',
+        name: 'test-file.pdf',
+        confirmationCode: '1234567890',
+        attachmentId: '1234567890',
+        size: 123456,
+        type: 'application/pdf',
+      },
+      id: '11',
+      type: 'upload',
+    },
+  },
+
+  'POST burials/v0/claims': submission,
+};
+
+module.exports = delay(responses, 200);

--- a/src/applications/burials-ez/tests/schema/maximal-at-home-test.json
+++ b/src/applications/burials-ez/tests/schema/maximal-at-home-test.json
@@ -1,0 +1,444 @@
+{
+  "relationshipToVeteran": "spouse",
+  "claimantFullName": {
+    "first": "John",
+    "middle": "Q",
+    "last": "Public",
+    "suffix": "Jr."
+  },
+  "claimantSocialSecurityNumber": "987654321",
+  "claimantDateOfBirth": "2000-01-01",
+  "claimantAddress": {
+    "view:militaryBaseDescription": {},
+    "country": "USA",
+    "street": "123 Main",
+    "street2": "Apt 2",
+    "city": "Juno",
+    "state": "AK",
+    "postalCode": "90999"
+  },
+  "processOption": true,
+  "fdcWarning": {},
+  "additionalEvidence": [
+    {
+      "name": "TEST4.pdf",
+      "confirmationCode": "1234567890",
+      "attachmentId": "",
+      "isEncrypted": false
+    }
+  ],
+  "transportationReceipts": [
+    {
+      "name": "TEST3.pdf",
+      "confirmationCode": "1234567890",
+      "attachmentId": "",
+      "isEncrypted": false
+    }
+  ],
+  "deathCertificate": [
+    {
+      "name": "TEST2.pdf",
+      "confirmationCode": "1234567890",
+      "attachmentId": "",
+      "isEncrypted": false
+    }
+  ],
+  "transportationExpenses": true,
+  "plotExpenseResponsibility": true,
+  "govtContributions": true,
+  "amountGovtContribution": "1000",
+  "nationalOrFederal": true,
+  "name": "National cemetery",
+  "finalRestingPlace": {
+    "location": "other",
+    "other": "Other place"
+  },
+  "previouslyReceivedAllowance": true,
+  "burialExpenseResponsibility": true,
+  "view:allowanceStatement": {
+    "confirmation": {
+      "checkBox": true
+    }
+  },
+  "burialAllowanceRequested": {
+    "nonService": true,
+    "service": true,
+    "unclaimed": true
+  },
+  "view:claimedBenefits": {
+    "burialAllowance": true,
+    "plotAllowance": true,
+    "transportation": true
+  },
+  "previousNames": [
+    {
+      "first": "name1",
+      "last": "last1",
+      "serviceBranch": "Air Force"
+    },
+    {
+      "first": "name2",
+      "last": "last2",
+      "serviceBranch": "Navy"
+    }
+  ],
+    "toursOfDuty": [
+    {
+      "serviceBranch": "Navy",
+      "dateRange": {
+        "from": "2001-04-22",
+        "to": "2010-05-01"
+      },
+      "placeOfEntry": "Los Angeles, CA",
+      "placeOfSeparation": "Dallas, TX",
+      "rank": "Sergeant",
+      "unit": "Unit test AF"
+    }
+  ],
+  "view:servedUnderOtherNames": true,
+  "militarySeparationDocuments": [
+    {
+      "name": "TEST1.pdf",
+      "confirmationCode": "1234567890",
+      "attachmentId": "",
+      "isEncrypted": false
+    }
+  ],
+  "view:separationDocuments": true,
+  "homeHospiceCareAfterDischarge": true,
+  "homeHospiceCare": true,
+  "locationOfDeath": {
+    "location": "atHome"
+  },
+  "deathDate": "2025-06-01",
+  "burialDate": "2025-06-07",
+  "claimantEmail": "test@test.com",
+  "claimantPhone": "8005551212",
+  "claimantIntPhone": "638885551213",
+  "privacyAgreementAccepted": true,
+  "veteranFullName": {
+    "first": "john",
+    "middle": "middle",
+    "last": "smith",
+    "suffix": "Sr."
+  },
+  "noBankAccount": true,
+  "vamcTreatmentCenters": [
+    {
+      "location": "location1"
+    },
+    {
+      "location": "location2"
+    }
+  ],
+  "powDateRange": {
+    "from": "2012-04-10",
+    "to": "2013-05-10"
+  },
+  "bankAccount": {
+    "accountNumber": "88888888888",
+    "accountType": "checking",
+    "bankName": "foo bank",
+    "routingNumber": "123456789"
+  },
+  "noRapidProcessing": true,
+  "spouseIsVeteran": true,
+  "liveWithSpouse": true,
+  "maritalStatus": "Married",
+  "reasonForNotLivingWithSpouse": "illness",
+  "spouseDateOfBirth": "2012-06-26",
+  "spouseSocialSecurityNumber": "111223334",
+  "monthlySpousePayment": 1,
+  "spouseOtherExpenses": [
+    {
+      "amount": 2,
+      "purpose": "purpose2",
+      "paidTo": "paidTo2",
+      "date": "2012-04-02"
+    }
+  ],
+  "otherExpenses": [
+    {
+      "amount": 1,
+      "purpose": "purpose1",
+      "paidTo": "paidTo1",
+      "date": "2012-04-01"
+    }
+  ],
+  "dependents": [
+    {
+      "childDateOfBirth": "2012-06-01",
+      "childSocialSecurityNumber": "111223331",
+      "childPlaceOfBirth": "place1",
+      "attendingCollege": true,
+      "married": true,
+      "disabled": true,
+      "childRelationship": "stepchild",
+      "previouslyMarried": true,
+      "childAddress": {
+        "city": "city1",
+        "country": "USA",
+        "postalCode": "21231",
+        "state": "MD",
+        "street": "str1"
+      },
+      "fullName": {
+        "first": "outside1",
+        "last": "Olson"
+      },
+      "personWhoLivesWithChild": {
+        "first": "person1",
+        "last": "Olson"
+      },
+      "otherExpenses": [
+        {
+          "amount": 4,
+          "purpose": "purpose4",
+          "paidTo": "paidTo4",
+          "date": "2012-04-04"
+        }
+      ],
+      "monthlyPayment": 1
+    },
+    {
+      "childDateOfBirth": "2012-06-02",
+      "childSocialSecurityNumber": "111223332",
+      "childPlaceOfBirth": "place2",
+      "attendingCollege": true,
+      "married": true,
+      "disabled": true,
+      "childRelationship": "biological",
+      "previouslyMarried": true,
+      "childAddress": {
+        "city": "city1",
+        "country": "USA",
+        "postalCode": "21231",
+        "state": "MD",
+        "street": "str2"
+      },
+      "fullName": {
+        "first": "outside2",
+        "last": "Olson"
+      },
+      "personWhoLivesWithChild": {
+        "first": "person2",
+        "last": "Olson"
+      },
+      "monthlyPayment": 2
+    },
+    {
+      "childAddress": {
+        "city": "city1",
+        "country": "USA",
+        "postalCode": "21231",
+        "state": "MD",
+        "street": "str3"
+      },
+      "fullName": {
+        "first": "outside3",
+        "last": "Olson"
+      },
+      "childDateOfBirth": "2012-06-03",
+      "childSocialSecurityNumber": "111223333",
+      "childPlaceOfBirth": "place3",
+      "attendingCollege": true,
+      "married": true,
+      "disabled": true,
+      "childRelationship": "adopted",
+      "previouslyMarried": true,
+      "personWhoLivesWithChild": {
+        "first": "person3",
+        "last": "Olson"
+      },
+      "otherExpenses": [
+        {
+          "amount": 3,
+          "purpose": "purpose3",
+          "paidTo": "paidTo3",
+          "date": "2012-04-03"
+        }
+      ],
+      "monthlyPayment": 3
+    }
+  ],
+  "spouseMarriages": [
+    {
+      "spouseFullName": {
+        "first": "spouse1",
+        "last": "Olson"
+      },
+      "otherExplanation": "spouse other",
+      "dateOfMarriage": "1985-03-01",
+      "locationOfMarriage": "marriagelocation1",
+      "locationOfSeparation": "location1",
+      "marriageType": "type1",
+      "dateOfSeparation": "1985-04-01",
+      "reasonForSeparation": "divorce1"
+    },
+    {
+      "spouseFullName": {
+        "first": "spouse2",
+        "last": "Olson"
+      },
+      "dateOfMarriage": "1985-03-02",
+      "dateOfSeparation": "1985-04-02",
+      "locationOfMarriage": "marriagelocation2",
+      "locationOfSeparation": "location2",
+      "marriageType": "type2",
+      "reasonForSeparation": "divorce2"
+    }
+  ],
+  "marriages": [
+    {
+      "spouseFullName": {
+        "first": "Mark1",
+        "last": "Olson"
+      },
+      "otherExplanation": "other",
+      "dateOfMarriage": "1985-03-01",
+      "dateOfSeparation": "1985-04-01",
+      "locationOfMarriage": "marriagelocation1",
+      "locationOfSeparation": "location1",
+      "marriageType": "type1",
+      "reasonForSeparation": "divorce1"
+    },
+    {
+      "spouseFullName": {
+        "first": "Mark2",
+        "last": "Olson"
+      },
+      "dateOfMarriage": "1985-03-02",
+      "dateOfSeparation": "1985-04-02",
+      "locationOfMarriage": "marriagelocation2",
+      "locationOfSeparation": "location2",
+      "marriageType": "type2",
+      "reasonForSeparation": "divorce2"
+    }
+  ],
+  "spouseMonthlyIncome": {
+    "socialSecurity": 2,
+    "civilService": 0,
+    "railroad": 4,
+    "blackLung": 0,
+    "ssi": 0,
+    "serviceRetirement": 6,
+    "additionalSources": [
+      {
+        "name": "name1",
+        "amount": 8
+      }
+    ]
+  },
+  "netWorth": {
+    "bank": 1,
+    "interestBank": 2.2,
+    "stocks": 0,
+    "realProperty": 0,
+    "ira": 3
+  },
+  "expectedIncome": {
+    "salary": 0,
+    "additionalSources": [
+      {
+        "name": "name1",
+        "amount": 4
+      }
+    ],
+    "interest": 3
+  },
+  "veteranDateOfBirth": "1985-03-07",
+  "veteranSocialSecurityNumber": "111223333",
+  "spouseAddress": {
+    "city": "city1",
+    "country": "USA",
+    "postalCode": "21231",
+    "state": "MD",
+    "street": "str1"
+  },
+  "jobs": [
+    {
+      "dateRange": {
+        "from": "2012-04-01",
+        "to": "2013-05-01"
+      },
+      "employer": "1",
+      "address": {
+        "city": "1",
+        "country": "USA",
+        "postalCode": "21231",
+        "state": "MD",
+        "street": "str1"
+      },
+      "annualEarnings": 10,
+      "jobTitle": "worker1",
+      "daysMissed": "1"
+    },
+    {
+      "dateRange": {
+        "from": "2012-04-02",
+        "to": "2013-05-02"
+      },
+      "employer": "2",
+      "address": {
+        "city": "2",
+        "country": "USA",
+        "postalCode": "21231",
+        "state": "MD",
+        "street": "str2"
+      },
+      "annualEarnings": 20,
+      "jobTitle": "worker2",
+      "daysMissed": "2"
+    }
+  ],
+  "nationalGuard": {
+    "date": "2013-04-11",
+    "name": "foo",
+    "address": {
+      "city": "Baltimore",
+      "country": "USA",
+      "postalCode": "21231",
+      "state": "MD",
+      "street": "111 Uni Drive"
+    },
+    "phone": "2123456789"
+  },
+  "nationalGuardActivation": true,
+  "combatSince911": true,
+  "severancePay": {
+    "amount": 1,
+    "type": "Longevity"
+  },
+  "placeOfSeparation": "city, state",
+  "veteranAddress": {
+    "city": "Baltimore",
+    "country": "USA",
+    "postalCode": "21231",
+    "street": "street",
+    "street2": "street2",
+    "state": "MD"
+  },
+  "servicePeriods": [
+    {
+      "activeServiceDateRange": {
+        "from": "2012-06-26",
+        "to": "2013-04-10"
+      },
+      "serviceBranch": "army"
+    }
+  ],
+  "email": "foo@foo.com",
+  "altEmail": "alt@foo.com",
+  "nightPhone": "0123456789",
+  "dayPhone": "1123456789",
+  "mobilePhone": "2123456789",
+  "spouseVaFileNumber": "22345678",
+  "vaFileNumber": "12345678",
+  "disabilities": [
+    {
+      "name": "disability 1",
+      "disabilityStartDate": "2016-12-01"
+    }
+  ],
+  "gender": "M"
+}

--- a/src/applications/burials-ez/utils/helpers.jsx
+++ b/src/applications/burials-ez/utils/helpers.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { endOfDay } from 'date-fns';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import set from 'platform/utilities/data/set';
 import get from 'platform/utilities/data/get';
@@ -99,3 +100,19 @@ export const isProductionEnv = () => {
     !window.Mocha
   );
 };
+
+export const pageAndReviewTitle = title => ({
+  title,
+  reviewTitle: () => <span className="vads-u-font-size--h3">{title}</span>,
+});
+
+// Elizabeth Dole Act law change for VA Home Hospice; ignoring start date of
+// July 1, 2025 to immediately
+const endDate = endOfDay(new Date('2026-09-30')).getTime();
+const today = Date.now();
+
+export const showHomeHospiceCarePage = (form, date = today) =>
+  get('locationOfDeath.location', form) === 'atHome' && date <= endDate;
+
+export const showHomeHospiceCareAfterDischargePage = form =>
+  get('homeHospiceCare', form);

--- a/src/applications/burials-ez/utils/helpers.jsx
+++ b/src/applications/burials-ez/utils/helpers.jsx
@@ -109,10 +109,15 @@ export const pageAndReviewTitle = title => ({
 // Elizabeth Dole Act law change for VA Home Hospice; ignoring start date of
 // July 1, 2025 to immediately
 const endDate = endOfDay(new Date('2026-09-30')).getTime();
-const today = Date.now();
 
-export const showHomeHospiceCarePage = (form, date = today) =>
-  get('locationOfDeath.location', form) === 'atHome' && date <= endDate;
+export const showHomeHospiceCarePage = form => {
+  const dayOfDeath = get('deathDate', form);
+  if (!dayOfDeath) {
+    return false;
+  }
+  const date = new Date(dayOfDeath).getTime();
+  return get('locationOfDeath.location', form) === 'atHome' && date <= endDate;
+};
 
 export const showHomeHospiceCareAfterDischargePage = form =>
   get('homeHospiceCare', form);

--- a/src/applications/burials-ez/utils/helpers.jsx
+++ b/src/applications/burials-ez/utils/helpers.jsx
@@ -120,4 +120,5 @@ export const showHomeHospiceCarePage = form => {
 };
 
 export const showHomeHospiceCareAfterDischargePage = form =>
+  get('locationOfDeath.location', form) === 'atHome' &&
   get('homeHospiceCare', form);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Adding 2 new pages that appear if the death location is set to "at home". Related to a recent legislative update to the   Elizabeth Dole act.
  > - Added unit tests
  > - Added new e2e test
  > - Added mock api server (for local testing) 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Pension & Burials Benefits
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/109326

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Added unit tests & updated e2e tests 
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Hospice |  N/A | <img width="518" alt="Screenshot 2025-06-23 at 12 32 01 PM" src="https://github.com/user-attachments/assets/a5a2fd33-7db8-4815-95e7-3ea46f528965" /> |
| Hospice after discharge | N/A | <img width="522" alt="Screenshot 2025-06-23 at 12 32 09 PM" src="https://github.com/user-attachments/assets/61786e03-b62d-4a2d-8730-ff58aac45f97" /> |
| Review page | <img width="673" alt="Screenshot 2025-06-23 at 2 44 58 PM" src="https://github.com/user-attachments/assets/422b785d-9261-4fa3-82f8-307af4d88a86" /> | <img width="672" alt="Screenshot 2025-06-23 at 1 38 42 PM" src="https://github.com/user-attachments/assets/52a0e4be-a2c0-4885-9f7e-2b1eca1a8ec0" /> |

## What areas of the site does it impact?

Burials (form 21P-530EZ)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
