### PR TITLE
112540b - Update focus behavior when error present in applicant relationship page - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   VaButton,
   VaRadio,
@@ -187,6 +187,9 @@ export default function ApplicantRelationshipPage({
   const [checkError, setCheckError] = useState(undefined);
   const [inputError, setInputError] = useState(undefined);
   const [dirty, setDirty] = useState(false);
+
+  const radioRef = useRef(null); // Used to set focus when in error state
+
   const useTopBackLink =
     contentAfterButtons?.props?.formConfig?.useTopBackLink ?? false;
   const navButtons = useTopBackLink ? (
@@ -213,6 +216,14 @@ export default function ApplicantRelationshipPage({
     customWording, // For hint override when using default configuration
   });
 
+  const setFocusOnRadio = () => {
+    if (radioRef.current) {
+      const element =
+        radioRef.current.querySelector('input') || radioRef.current;
+      element.focus();
+    }
+  };
+
   const handlers = {
     validate() {
       let isValid = true;
@@ -236,6 +247,7 @@ export default function ApplicantRelationshipPage({
       } else {
         setInputError(null);
       }
+      if (!isValid) setFocusOnRadio(); // we have an error, set focus on the input
       return isValid;
     },
     radioUpdate: ({ detail }) => {
@@ -301,6 +313,7 @@ export default function ApplicantRelationshipPage({
           error={checkError}
           onVaValueChange={handlers.radioUpdate}
           name={`root_${keyname}`}
+          ref={radioRef}
         >
           {options.map(option => (
             <va-radio-option


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the applicant relationship page (used in multiple IVC CHAMPVA forms) so that it returns focus to the `<input>` when an error is set.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112540
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110909

## Testing done

- Manual

## Screenshots

|         | Before (clicked "continue" w/ no input) | After (clicked "continue" w/ no input) |
| ------- | ------ | ----- |
| Radio focus in error state |![Screenshot 2025-06-23 at 15 41 26](https://github.com/user-attachments/assets/75ac9284-fdb6-455a-869d-fc39f96b043f)|![Screenshot 2025-06-23 at 15 40 14](https://github.com/user-attachments/assets/c6889895-459e-47c3-97be-ccbdc17f1e3e)|

## What areas of the site does it impact?

IVC CHAMPVA forms 10-10d, 10-7959c, 10-10d-extended

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA