### PR TITLE
add setFormData to dependency array for claimant info

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
@@ -56,7 +56,12 @@ function App({
 
   useEffect(
     () => {
-      if (user?.profile) {
+      if (
+        user?.profile &&
+        (!formData?.claimantFullName.first ||
+          !formData?.claimantFullName.last ||
+          !formData?.claimantDateOfBirth)
+      ) {
         setFormData({
           ...formData,
           claimantFullName: {

--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
@@ -11,6 +11,7 @@ import {
 } from '../actions';
 import formConfig from '../config/form';
 import { getAppData } from '../selectors';
+import { prefillTransformer } from '../helpers';
 
 function App({
   children,
@@ -179,11 +180,19 @@ App.propTypes = {
   user: PropTypes.object,
 };
 
-const mapStateToProps = state => ({
-  ...getAppData(state),
-  formData: state.form?.data || {},
-  user: state.user,
-});
+const mapStateToProps = state => {
+  const appData = getAppData(state);
+  const transformedData =
+    prefillTransformer(null, null, null, state)?.formData || {};
+  return {
+    ...appData,
+    formData: {
+      ...(state.form?.data || {}),
+      ...transformedData,
+    },
+    user: state.user,
+  };
+};
 
 const mapDispatchToProps = {
   getPersonalInformation: fetchPersonalInformation,

--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
@@ -58,8 +58,8 @@ function App({
     () => {
       if (
         user?.profile &&
-        (!formData?.claimantFullName.first ||
-          !formData?.claimantFullName.last ||
+        (!formData?.claimantFullName?.first ||
+          !formData?.claimantFullName?.last ||
           !formData?.claimantDateOfBirth)
       ) {
         setFormData({

--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
@@ -69,7 +69,7 @@ function App({
         });
       }
     },
-    [user?.profile],
+    [user?.profile, setFormData],
   );
 
   useEffect(

--- a/src/applications/toe/containers/ToeApp.jsx
+++ b/src/applications/toe/containers/ToeApp.jsx
@@ -291,8 +291,8 @@ const mapStateToProps = state => {
       state?.user?.profile?.dob ||
       state?.data?.formData?.data?.attributes?.claimant?.dateOfBirth,
     formData: {
-      ...transformedData,
       ...(state.form?.data || {}),
+      ...transformedData,
     },
     fetchedSponsorsComplete: state.data?.fetchedSponsorsComplete,
     sponsors: state.form?.data?.sponsors,

--- a/src/applications/toe/containers/ToeApp.jsx
+++ b/src/applications/toe/containers/ToeApp.jsx
@@ -282,7 +282,6 @@ ToeApp.propTypes = {
 };
 
 const mapStateToProps = state => {
-  // Get transformed data from prefillTransformer
   const transformedData =
     prefillTransformer(null, null, null, state)?.formData || {};
   return {
@@ -292,8 +291,8 @@ const mapStateToProps = state => {
       state?.user?.profile?.dob ||
       state?.data?.formData?.data?.attributes?.claimant?.dateOfBirth,
     formData: {
-      ...(state.form?.data || {}),
       ...transformedData,
+      ...(state.form?.data || {}),
     },
     fetchedSponsorsComplete: state.data?.fetchedSponsorsComplete,
     sponsors: state.form?.data?.sponsors,

--- a/src/applications/toe/containers/ToeApp.jsx
+++ b/src/applications/toe/containers/ToeApp.jsx
@@ -293,8 +293,8 @@ const mapStateToProps = state => {
       state?.user?.profile?.dob ||
       state?.data?.formData?.data?.attributes?.claimant?.dateOfBirth,
     formData: {
-      ...prefillData,
       ...formStateData,
+      ...prefillData,
       sponsors: formStateData.sponsors || prefillData.sponsors,
     },
     fetchedSponsorsComplete: state.data?.fetchedSponsorsComplete,

--- a/src/applications/toe/containers/ToeApp.jsx
+++ b/src/applications/toe/containers/ToeApp.jsx
@@ -282,13 +282,19 @@ ToeApp.propTypes = {
 };
 
 const mapStateToProps = state => {
+  // Get transformed data from prefillTransformer
+  const transformedData =
+    prefillTransformer(null, null, null, state)?.formData || {};
   return {
     ...getAppData(state),
+    claimant: state?.data?.formData?.data?.attributes?.claimant,
     dob:
       state?.user?.profile?.dob ||
       state?.data?.formData?.data?.attributes?.claimant?.dateOfBirth,
-    formData: state.form?.data || {},
-    claimant: prefillTransformer(null, null, null, state)?.formData,
+    formData: {
+      ...(state.form?.data || {}),
+      ...transformedData,
+    },
     fetchedSponsorsComplete: state.data?.fetchedSponsorsComplete,
     sponsors: state.form?.data?.sponsors,
     sponsorsInitial: state?.data?.sponsors,

--- a/src/applications/toe/containers/ToeApp.jsx
+++ b/src/applications/toe/containers/ToeApp.jsx
@@ -282,8 +282,10 @@ ToeApp.propTypes = {
 };
 
 const mapStateToProps = state => {
-  const transformedData =
+  const prefillData =
     prefillTransformer(null, null, null, state)?.formData || {};
+  const formStateData = state.form?.data || {};
+
   return {
     ...getAppData(state),
     claimant: state?.data?.formData?.data?.attributes?.claimant,
@@ -291,8 +293,9 @@ const mapStateToProps = state => {
       state?.user?.profile?.dob ||
       state?.data?.formData?.data?.attributes?.claimant?.dateOfBirth,
     formData: {
-      ...(state.form?.data || {}),
-      ...transformedData,
+      ...prefillData,
+      ...formStateData,
+      sponsors: formStateData.sponsors || prefillData.sponsors,
     },
     fetchedSponsorsComplete: state.data?.fetchedSponsorsComplete,
     sponsors: state.form?.data?.sponsors,


### PR DESCRIPTION
## Summary

- Due to an issue where the save_in_progress call fails which results in the prefill transformer not running.  The claimant information for the 5490 was not being mapped to the formData.  This resulted in missing claimant first/last name and dateOfBirth in the form submission which caused it to fail.  This fix will provide a way for the formData to recieve the profile data outside of the prefill transformer call.

