### PR TITLE
Updated ToU Tests for Node 22 Upgrade

### DIFF
--- a/src/applications/terms-of-use/tests/Declined.unit.spec.jsx
+++ b/src/applications/terms-of-use/tests/Declined.unit.spec.jsx
@@ -4,7 +4,6 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import Declined from '../components/Declined';
 
@@ -18,7 +17,7 @@ const generateStore = dispatch => ({
   dispatch,
 });
 
-const oldLocation = global.window.location;
+const oldLocation = window.location;
 
 describe('Declined', () => {
   let store;
@@ -35,7 +34,7 @@ describe('Declined', () => {
   });
 
   after(() => {
-    global.window.location = oldLocation;
+    window.location = oldLocation;
   });
 
   it('should render', () => {
@@ -45,8 +44,11 @@ describe('Declined', () => {
       </Provider>,
     );
 
-    expect($('h1', container).textContent).to.eql('We’ve signed you out');
-    expect($('va-button[text="Sign in"]', container)).to.not.be.null;
+    expect(container.querySelector('h1', container).textContent).to.eql(
+      'We’ve signed you out',
+    );
+    expect(container.querySelector('va-button[text="Sign in"]', container)).to
+      .not.be.null;
   });
 
   context('sign in button clicked', () => {
@@ -57,7 +59,7 @@ describe('Declined', () => {
         </Provider>,
       );
 
-      const signInButton = $('va-button', container);
+      const signInButton = container.querySelector('va-button', container);
       fireEvent.click(signInButton);
 
       expect(dispatchStub.calledOnce).to.be.true;
@@ -72,13 +74,12 @@ describe('Declined', () => {
         </Provider>,
       );
 
-      const signInButton = $('va-button', container);
+      const signInButton = container.querySelector('va-button', container);
       fireEvent.click(signInButton);
 
       await waitFor(() => {
-        expect(global.window.location).to.eql(
-          'vamobile://login-terms-rejected',
-        );
+        const location = window.location.href || window.location;
+        expect(location).to.eql('vamobile://login-terms-rejected');
       });
       sessionStorage.removeItem('ci');
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated Terms of Use tests so that all tests pass in both Node 14 and Node 22.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/423)

## Testing done
- Updated `Declined.unit.spec.jsx`, `MyVAHealth.unit.spec.jsx`, and `TermsOfUse.unit.spec.jsx`. Ran tests locally on both the `main` and `node-22-dev-branch` branches.
- Can be replicated by running `yarn test:unit --app-folder terms-of-use`.

## What areas of the site does it impact?
This only impacts the Terms of Use tests.

## Acceptance criteria
- [x] All ToU tests pass on Node 22
- [x] All ToU tests continue to pass on Node 14