### PR TITLE
112649 readd mhv portal link

### DIFF
--- a/src/applications/mhv-landing-page/components/HeaderLayout.jsx
+++ b/src/applications/mhv-landing-page/components/HeaderLayout.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { datadogRum } from '@datadog/browser-rum';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { VaLink } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import WelcomeContainer from '../containers/WelcomeContainer';
 
 const learnMoreLink = {
@@ -14,7 +16,11 @@ const ledeContent = `Welcome. You can now manage your health care
   here on VA.gov. Here, you’ll find new, improved versions of your trusted
   health tools and more features.`;
 
-const HeaderLayout = ({ showWelcomeMessage = false }) => (
+const HeaderLayout = ({
+  showWelcomeMessage = false,
+  isCerner = false,
+  ssoe = false,
+}) => (
   <>
     <div
       className={classnames(
@@ -46,6 +52,22 @@ const HeaderLayout = ({ showWelcomeMessage = false }) => (
             Want to learn more about what’s new? <VaLink {...learnMoreLink} />
           </p>
         </div>
+        {isCerner && (
+          <p>
+            If your facility uses My VA Health, go to the My VA Health portal to
+            manage your care.
+            <br />
+            <a
+              onClick={() =>
+                datadogRum.addAction('Click on My VA Health portal link')
+              }
+              data-testid="mhv-go-back-1"
+              href={mhvUrl(ssoe, 'home')}
+            >
+              Go to the My VA Health portal
+            </a>
+          </p>
+        )}
       </div>
       <div
         className={classnames(
@@ -78,6 +100,7 @@ const HeaderLayout = ({ showWelcomeMessage = false }) => (
 );
 
 HeaderLayout.propTypes = {
+  isCerner: PropTypes.bool,
   showMhvGoBack: PropTypes.bool,
   showWelcomeMessage: PropTypes.bool,
   ssoe: PropTypes.bool,

--- a/src/applications/mhv-landing-page/components/LandingPage.jsx
+++ b/src/applications/mhv-landing-page/components/LandingPage.jsx
@@ -16,7 +16,12 @@ import HubLinks from './HubLinks';
 import NewsletterSignup from './NewsletterSignup';
 import HelpdeskInfo from './HelpdeskInfo';
 import Alerts from '../containers/Alerts';
-import { isLOA3, isVAPatient, personalizationEnabled } from '../selectors';
+import {
+  isCerner,
+  isLOA3,
+  isVAPatient,
+  personalizationEnabled,
+} from '../selectors';
 import manifest from '../manifest.json';
 
 const LandingPage = ({ data = {} }) => {
@@ -25,6 +30,7 @@ const LandingPage = ({ data = {} }) => {
   const vaPatient = useSelector(isVAPatient);
   const userRegistered = userVerified && vaPatient;
   const showWelcomeMessage = useSelector(personalizationEnabled);
+  const userHasCernerFacility = useSelector(isCerner);
 
   return (
     <>
@@ -46,7 +52,10 @@ const LandingPage = ({ data = {} }) => {
             dependencies={[externalServices.mhvPlatform]}
             render={renderMHVDowntime}
           />
-          <HeaderLayout showWelcomeMessage={showWelcomeMessage} />
+          <HeaderLayout
+            showWelcomeMessage={showWelcomeMessage}
+            isCerner={userHasCernerFacility}
+          />
           <Alerts />
           {userRegistered && <CardLayout data={cards} />}
         </div>

--- a/src/applications/mhv-landing-page/selectors/facilities.js
+++ b/src/applications/mhv-landing-page/selectors/facilities.js
@@ -1,3 +1,13 @@
+import { selectProfile } from '~/platform/user/selectors';
+
+/**
+ * Determines if the profile has Cerner facilities.
+ * @param {Object} state The current application state.
+ * @returns {Boolean} The isCerner state.
+ */
+export const isCerner = state =>
+  selectProfile(state).facilities?.some(facility => facility.isCerner);
+
 /**
  * Determines if the profile has EHRM(isCerner) facilities
  * @param {user.profile} profile Current user profile.

--- a/src/applications/mhv-landing-page/selectors/index.js
+++ b/src/applications/mhv-landing-page/selectors/index.js
@@ -41,7 +41,7 @@ import {
   seiSuccessfulDownload,
   seiFailedDownload,
 } from './seiPdf';
-import { profileHasEHRM, profileHasVista } from './facilities';
+import { profileHasEHRM, profileHasVista, isCerner } from './facilities';
 import {
   selectVaPatient,
   selectProfileLoa,
@@ -54,6 +54,7 @@ export {
   hasMhvBasicAccount,
   hasMessagingAccess,
   isAuthenticatedWithSSOe,
+  isCerner,
   isInMPI,
   isLOA1,
   isLOA3,

--- a/src/applications/mhv-landing-page/tests/selectors/facilities.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/selectors/facilities.unit.spec.jsx
@@ -1,7 +1,33 @@
 import { expect } from 'chai';
-import { profileHasEHRM, profileHasVista } from '../../selectors/facilities';
+import {
+  isCerner,
+  profileHasEHRM,
+  profileHasVista,
+} from '../../selectors/facilities';
 
 describe('facilities selectors', () => {
+  describe('isCerner', () => {
+    it('should return true if the profile has Cerner facilities', () => {
+      const state = {
+        user: {
+          profile: {
+            facilities: [{ isCerner: true }],
+          },
+        },
+      };
+      expect(isCerner(state)).to.be.true;
+    });
+    it('should return false if the profile lacks Cerner facilities', () => {
+      const state = {
+        user: {
+          profile: {
+            facilities: [{ isCerner: false }],
+          },
+        },
+      };
+      expect(isCerner(state)).to.be.false;
+    });
+  });
   describe('profileHasEHRM', () => {
     it('should return true if the profile has EHRM facilities', () => {
       const profile = { facilities: [{ isCerner: true }] };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Add a conditional "My VA Health" portal link, and associated text, to the landing page. This link [apparently existed](https://github.com/department-of-veterans-affairs/vets-website/commit/2d6d7e5beff427bdd3b16bdb0981a8a809ae1aa1) as part of milestone 1 but has since been removed. [Stakeholders have requested that the link make a comeback](https://dsva.slack.com/archives/C0581MN69TJ/p1750172653076619).

## Related issue(s)
[112649](https://github.com/department-of-veterans-affairs/va.gov-team/issues/112649)

## Testing done
Specs added

## Screenshots
**With** Cerner facilities
<img width="1130" alt="Screenshot 2025-06-24 at 12 33 27 PM" src="https://github.com/user-attachments/assets/ce31f276-7564-4d3e-9eed-598b8692ab16" />

**Without** Cerner facilities
<img width="1161" alt="Screenshot 2025-06-24 at 12 34 05 PM" src="https://github.com/user-attachments/assets/08237ed5-27f0-484f-8d11-f15bf2ce47c9" />

## What areas of the site does it impact?
MHV Landing Page

## Acceptance criteria
When the user has any Cerner facilities the landing page renders a link to the My VA Health portal
When the user does not have any Cerner facilities the landing page will not render this link
