### PR TITLE
21A login redirect

### DIFF
--- a/src/applications/accreditation/21a/utilities/constants.js
+++ b/src/applications/accreditation/21a/utilities/constants.js
@@ -14,7 +14,10 @@ const USIP_BASE_URL = environment.BASE_URL;
 
 export const getSignInUrl = ({ __returnUrl } = {}) => {
   const url = new URL(USIP_PATH, USIP_BASE_URL);
-  url.searchParams.set(USIP_QUERY_PARAMS.application, USIP_APPLICATIONS.ARP);
+  url.searchParams.set(
+    USIP_QUERY_PARAMS.application,
+    USIP_APPLICATIONS.FORM21A,
+  );
   url.searchParams.set(USIP_QUERY_PARAMS.OAuth, true);
 
   url.searchParams.set(USIP_QUERY_PARAMS.to, '/poa-requests');

--- a/src/platform/user/authentication/config/constants.js
+++ b/src/platform/user/authentication/config/constants.js
@@ -36,8 +36,15 @@ export const arpWebOAuthOptions = {
   acrSignup: { idme_signup: 'loa3', logingov_signup: 'ial2' },
 };
 
+export const form21AWebOAuthOptions = {
+  clientId: CLIENT_IDS.FORM21A,
+  acr: { idme: 'loa3', logingov: 'ial2' },
+  acrSignup: { idme_signup: 'loa3', logingov_signup: 'ial2' },
+};
+
 export const OAuthEnabledApplications = [
   undefined /* default */,
   EXTERNAL_APPS.VA_FLAGSHIP_MOBILE,
   EXTERNAL_APPS.ARP,
+  EXTERNAL_APPS.FORM21A,
 ];

--- a/src/platform/user/authentication/config/dev.config.js
+++ b/src/platform/user/authentication/config/dev.config.js
@@ -10,6 +10,7 @@ import {
   defaultWebOAuthOptions,
   defaultMobileOAuthOptions,
   arpWebOAuthOptions,
+  form21AWebOAuthOptions,
 } from './constants';
 
 export default {
@@ -94,6 +95,25 @@ export default {
     OAuthEnabled: true,
     requiresVerification: true,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.ARP],
+  },
+  [EXTERNAL_APPS.FORM21A]: {
+    allowedSignInProviders: {
+      idme: false,
+      logingov: true,
+    },
+    legacySignInProviders: {
+      dslogon: false,
+    },
+    isMobile: false,
+    queryParams: {
+      allowOAuth: true,
+      allowPostLogin: true,
+      allowRedirect: false,
+    },
+    oAuthOptions: form21AWebOAuthOptions,
+    OAuthEnabled: true,
+    requiresVerification: true,
+    externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.FORM21A],
   },
   [EXTERNAL_APPS.SMHD]: {
     allowedSignInProviders: {

--- a/src/platform/user/authentication/config/prod.config.js
+++ b/src/platform/user/authentication/config/prod.config.js
@@ -10,6 +10,7 @@ import {
   defaultWebOAuthOptions,
   defaultMobileOAuthOptions,
   arpWebOAuthOptions,
+  form21AWebOAuthOptions,
 } from './constants';
 
 export default {
@@ -97,6 +98,28 @@ export default {
     OAuthEnabled: true,
     requiresVerification: false,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.ARP],
+  },
+  [EXTERNAL_APPS.FORM21A]: {
+    allowedSignInProviders: {
+      idme: false,
+      logingov: true,
+    },
+    legacySignInProviders: {
+      dslogon: false,
+    },
+    isMobile: false,
+    queryParams: {
+      allowOAuth: true,
+      allowPostLogin: true,
+      allowRedirect: false,
+    },
+    oAuthOptions: {
+      ...form21AWebOAuthOptions,
+      clientId: 'fe0d4b2cac7935e7eec5946b8ee31643',
+    },
+    OAuthEnabled: true,
+    requiresVerification: false,
+    externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.FORM21A],
   },
   [EXTERNAL_APPS.SMHD]: {
     allowedSignInProviders: {

--- a/src/platform/user/authentication/config/staging.config.js
+++ b/src/platform/user/authentication/config/staging.config.js
@@ -10,6 +10,7 @@ import {
   defaultWebOAuthOptions,
   defaultMobileOAuthOptions,
   arpWebOAuthOptions,
+  form21AWebOAuthOptions,
 } from './constants';
 
 export default {
@@ -98,6 +99,29 @@ export default {
     OAuthEnabled: true,
     requiresVerification: false,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.ARP],
+  },
+  [EXTERNAL_APPS.FORM21A]: {
+    allowedSignInProviders: {
+      idme: false,
+      logingov: true,
+    },
+    legacySignInProviders: {
+      mhv: false,
+      dslogon: false,
+    },
+    isMobile: false,
+    queryParams: {
+      allowOAuth: true,
+      allowPostLogin: true,
+      allowRedirect: false,
+    },
+    oAuthOptions: {
+      ...form21AWebOAuthOptions,
+      clientId: 'ce6db4d7974daf061dccdd21ba9add14',
+    },
+    OAuthEnabled: true,
+    requiresVerification: false,
+    externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.FORM21A],
   },
   [EXTERNAL_APPS.SMHD]: {
     allowedSignInProviders: {

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -88,6 +88,7 @@ export const EXTERNAL_APPS = {
   VA_FLAGSHIP_MOBILE: 'vamobile',
   VA_OCC_MOBILE: 'vaoccmobile',
   ARP: 'arp',
+  FORM21A: '21a',
   SMHD: 'smhdweb',
 };
 
@@ -107,6 +108,10 @@ export const EXTERNAL_REDIRECTS = {
   [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE]: '',
   [EXTERNAL_APPS.VA_OCC_MOBILE]: `${eAuthURL}/MAP/users/v2/landing`,
   [EXTERNAL_APPS.ARP]: `${environment.BASE_URL}/representative`,
+  [EXTERNAL_APPS.FORM21A]: `
+    ${
+      environment.BASE_URL
+    }/representative/accreditation/attorney-claims-agent-form-21a/`,
   [EXTERNAL_APPS.SMHD]: `${eAuthURL}/MAP/users/v2/landing?application=vaoccmobile&redirect_uri=/smhdWeb/`,
 };
 

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -88,7 +88,7 @@ export const EXTERNAL_APPS = {
   VA_FLAGSHIP_MOBILE: 'vamobile',
   VA_OCC_MOBILE: 'vaoccmobile',
   ARP: 'arp',
-  FORM21A: '21a',
+  FORM21A: 'form21a',
   SMHD: 'smhdweb',
 };
 
@@ -111,7 +111,7 @@ export const EXTERNAL_REDIRECTS = {
   [EXTERNAL_APPS.FORM21A]: `
     ${
       environment.BASE_URL
-    }/representative/accreditation/attorney-claims-agent-form-21a/`,
+    }/representative/accreditation/attorney-claims-agent-form-21a`,
   [EXTERNAL_APPS.SMHD]: `${eAuthURL}/MAP/users/v2/landing?application=vaoccmobile&redirect_uri=/smhdWeb/`,
 };
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -144,7 +144,7 @@ export const createExternalApplicationUrl = () => {
     case EXTERNAL_APPS.MY_VA_HEALTH:
       URL = sanitizeOracleHealth({ application });
       break;
-    case EXTERNAL_APPS.ARP:
+    case (EXTERNAL_APPS.ARP, EXTERNAL_APPS.FORM21A):
       URL = sanitizeUrl(externalRedirectUrl, to);
       break;
     case EXTERNAL_APPS.SMHD:


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added form 21a to the authentication config to reroute form21a users back to form 21a upon login
- Auth config matches that of ARP

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107337
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107346
