### PR TITLE
Update cutoff time since release window was decided

### DIFF
--- a/src/applications/appeals/995/components/4142/Authorization.jsx
+++ b/src/applications/appeals/995/components/4142/Authorization.jsx
@@ -33,7 +33,7 @@ export const lastUpdatedIsBeforeCutoff = lastUpdated => {
     return false;
   }
 
-  const CUTOFF_DATE_4142 = '2025-06-30 19:00:00'; // CST
+  const CUTOFF_DATE_4142 = '2025-06-25 09:00:00'; // CST
 
   return formattedLastUpdated < CUTOFF_DATE_4142;
 };

--- a/src/applications/appeals/995/tests/components/4142/Authorization.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/4142/Authorization.unit.spec.jsx
@@ -116,25 +116,25 @@ describe('<Authorization>', () => {
 
   describe('lastUpdatedIsBeforeCutoff', () => {
     it('should return true if last updated is before cutoff date', () => {
-      const lastUpdated = 1727769600; // '2024-10-01 00:03:00' CST;
+      const lastUpdated = 1750704000; // '2025-06-23 00:00:00' CST
 
       expect(lastUpdatedIsBeforeCutoff(lastUpdated)).to.be.true;
     });
 
     it('should return true if last updated is before cutoff date', () => {
-      const lastUpdated = 1751327400; // '2025-06-30 18:50:00' CST;
+      const lastUpdated = 1750786800; // '2025-06-23 22:00:00' CST
 
       expect(lastUpdatedIsBeforeCutoff(lastUpdated)).to.be.true;
     });
 
     it('should return false if last updated is after cutoff date', () => {
-      const lastUpdated = 1751328060; // '2025-06-30 19:01:00' CST;
+      const lastUpdated = 1751328060; // '2025-06-25 09:01:00' CST
 
       expect(lastUpdatedIsBeforeCutoff(lastUpdated)).to.be.false;
     });
 
     it('should return false if last updated is exactly the cutoff date', () => {
-      const lastUpdated = 1751328000; // '2025-06-30 19:00:00' CST;
+      const lastUpdated = 1751328000; // '2025-06-25 09:00:00' CST
 
       expect(lastUpdatedIsBeforeCutoff(lastUpdated)).to.be.false;
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR updates the cutoff time for showing the banner alerting users returning to in-progress Supplemental Claims to match our planned release window which was [just approved](https://dsva.slack.com/archives/C5AGLBNRK/p1750778343703869?thread_ts=1750709546.144829&cid=C5AGLBNRK) by our enablement team.

Specifically, users coming back to in-progress Supplemental Claims who had previously authorized and filled out information in the 4142 subflow before June 25, 10AM, where the returnUrl is `/supporting-evidence/private-medical-records-authorization` will be shown a banner alerting them to the updated legalese for them to review.  
![Screenshot 2025-06-24 at 1 25 06 PM](https://github.com/user-attachments/assets/6df306e2-2c6d-48eb-8c98-e55e7d47f0e4)

Users who are returning to `/supporting-evidence/private-medical-records-authorization` after June 25, 10AM will not see this banner since they will see the updated legalese and don't need to be alerted.

## Related issue(s)

- Link to [issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111446)
- Release issue [111942](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111942)
- Related PRs: [1](https://github.com/department-of-veterans-affairs/vets-website/pull/37201)

## Testing done

- Testing mirrors that described in [37201](https://github.com/department-of-veterans-affairs/vets-website/pull/37201)

## Screenshots
![Screenshot 2025-06-24 at 1 10 15 PM](https://github.com/user-attachments/assets/571e4d24-45d8-4f4a-8633-71b46997d477)

## What areas of the site does it impact?

Decision Reviews > File a Supplemental Claim > users who had previously entered the 4142 pathway and saved their form