### PR TITLE
Commented out pilot station check for now

### DIFF
--- a/src/applications/vaos/referral-appointments/tests/utils/pilot.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/tests/utils/pilot.unit.spec.jsx
@@ -6,20 +6,20 @@ describe('VAOS CC pilot utils', () => {
     it('Returns false when the user has a facility within the pilot list but the feature is off', () => {
       expect(getIsInCCPilot(false)).to.be.false;
     });
-    it('should return false if patientFacilities is empty', () => {
+    it.skip('should return false if patientFacilities is empty', () => {
       expect(getIsInCCPilot(true, [])).to.be.false;
     });
-    it('Returns false when the user has no facilities in the pilot list', () => {
+    it.skip('Returns false when the user has no facilities in the pilot list', () => {
       expect(
         getIsInCCPilot(true, [{ facilityId: '123' }, { facilityId: '456' }]),
       ).to.be.false;
     });
-    it('Returns true when the user has a facility within the pilot list', () => {
+    it.skip('Returns true when the user has a facility within the pilot list', () => {
       expect(
         getIsInCCPilot(true, [{ facilityId: '123' }, { facilityId: '984' }]),
       ).to.be.true;
     });
-    it('Returns true when the user has a facility within the pilot list as well as some outside', () => {
+    it.skip('Returns true when the user has a facility within the pilot list as well as some outside', () => {
       expect(
         getIsInCCPilot(true, [{ facilityId: '983' }, { facilityId: '400' }]),
       ).to.be.true;

--- a/src/applications/vaos/referral-appointments/utils/pilot.js
+++ b/src/applications/vaos/referral-appointments/utils/pilot.js
@@ -6,13 +6,32 @@
  * @returns {boolean} - Returns true if the patient is in the CC pilot program, otherwise false.
  */
 const getIsInCCPilot = (featureCCDirectScheduling, patientFacilities = []) => {
-  const pilotStations = ['984', '983'];
-  if (!featureCCDirectScheduling) {
-    return false;
-  }
-  return patientFacilities.some(station =>
+  const stagingStations = ['984', '983'];
+  const prodStations = [
+    '659',
+    '659BY',
+    '659BZ',
+    '659GA',
+    '657A5',
+    '657GJ',
+    '657GK',
+    '657GL',
+    '657GM',
+    '657GO',
+    '657GP',
+    '657GQ',
+    '657GR',
+    '657GT',
+    '657GU',
+    '657QD',
+  ];
+  const pilotStations = [...stagingStations, ...prodStations];
+  // eslint-disable-next-line no-unused-vars
+  const hasPilotStation = patientFacilities.some(station =>
     pilotStations.includes(station.facilityId),
   );
+
+  return featureCCDirectScheduling; // & hasPilotStation;
 };
 
 export { getIsInCCPilot };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Temporarily removed check for user's stations for the VAOS referral pilot. This is only for the initial testing.
- Team: UAE Check In

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/112758

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
VAOS Referral pilot

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

