### PR TITLE
Global | Allow link to exit form without alert

### DIFF
--- a/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
@@ -6,7 +6,7 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 
 import { axeCheck } from '../../config/helpers';
-import ProgressButton from '../../../src/js/components/ProgressButton.jsx';
+import ProgressButton from '../../../src/js/components/ProgressButton';
 
 chai.use(chaiAsPromised);
 

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -41,6 +41,8 @@ class RoutedSavableApp extends React.Component {
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     window.addEventListener('beforeunload', this.onbeforeunload);
+    document.body.addEventListener('click', this.checkExitFormLink);
+
     if (window.History) {
       window.History.scrollRestoration = 'manual';
     }
@@ -218,6 +220,17 @@ class RoutedSavableApp extends React.Component {
 
   removeOnbeforeunload = () => {
     window.removeEventListener('beforeunload', this.onbeforeunload);
+    document.body.removeEventListener('click', this.checkExitFormLink);
+  };
+
+  // Allow link to leave form flow without showing browser window unload alert
+  checkExitFormLink = ({ target }) => {
+    if (
+      target.tagName === 'VA-LINK' &&
+      target.getAttribute('exit-form') === 'true'
+    ) {
+      this.removeOnbeforeunload();
+    }
   };
 
   redirectOrLoad(props) {
@@ -347,6 +360,9 @@ RoutedSavableApp.propTypes = {
     }),
     dev: PropTypes.shape({
       disableWindowUnloadInCI: PropTypes.bool,
+    }),
+    formOptions: PropTypes.shape({
+      ignorePageUnloadAlertOnUrls: PropTypes.arrayOf(PropTypes.string),
     }),
     disableSave: PropTypes.bool,
     urlPrefix: PropTypes.string,

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -228,7 +228,7 @@ class RoutedSavableApp extends React.Component {
   checkExitFormLink = ({ target }) => {
     if (
       ['VA-LINK', 'VA-BUTTON', 'BUTTON'].includes(target.tagName) &&
-      target.getAttribute('exit-form') === 'true'
+      target.classList.contains('exit-form')
     ) {
       this.removeOnbeforeunload();
     }

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -41,7 +41,7 @@ class RoutedSavableApp extends React.Component {
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     window.addEventListener('beforeunload', this.onbeforeunload);
-    document.body.addEventListener('click', this.checkExitFormLink);
+    document.body.addEventListener('click', this.checkExitFormLink, true);
 
     if (window.History) {
       window.History.scrollRestoration = 'manual';
@@ -223,10 +223,11 @@ class RoutedSavableApp extends React.Component {
     document.body.removeEventListener('click', this.checkExitFormLink);
   };
 
-  // Allow link to leave form flow without showing browser window unload alert
+  // Allow va-link, va-button, or button (progress buttons) to leave form flow
+  // without showing browser window unload alert
   checkExitFormLink = ({ target }) => {
     if (
-      target.tagName === 'VA-LINK' &&
+      ['VA-LINK', 'VA-BUTTON', 'BUTTON'].includes(target.tagName) &&
       target.getAttribute('exit-form') === 'true'
     ) {
       this.removeOnbeforeunload();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Check for `exit-form` class name on `va-link`, `va-button` or plain `button` to allow navigating out of a form flow without showing the browser "Leave site?", "changes you made may not be saved" alert.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/112751

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > I attempted to add a unit test for the `RoutedSavableApp` component, but was not successful
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Any form that adds an "exit-form" class name to a `va-link`, `va-button`, or plain `button`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
