### PR TITLE
[BUG] Set nested margin to 0 in Win11 + Firefox

### DIFF
--- a/src/applications/letters/containers/EditAddress.jsx
+++ b/src/applications/letters/containers/EditAddress.jsx
@@ -79,7 +79,7 @@ export function EditAddress() {
           </va-additional-info>
         </>
       )}
-      <div className="vads-u-margin-bottom--1">
+      <div className="vads-u-margin-bottom--1 letters--edit-address">
         <InitializeVAPServiceID>
           <ProfileInformationFieldController
             forceEditView

--- a/src/applications/letters/sass/letters.scss
+++ b/src/applications/letters/sass/letters.scss
@@ -223,3 +223,7 @@ label + div {
 .edit-link {
   margin: 0.5em 0;
 }
+
+.letters--edit-address va-radio::part(legend) {
+  margin-top: 0;
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
PR closes a bug wherein Firefox latest on Win11 was calculating a `margin-top` incorrectly and causing radio buttons on the Letters edit address flow to be too far apart. Screenshot of the "before" shown below, along with corrected after screenshots.

## Related issue(s)

- PR closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/112772

## Testing done

- Old behavior: Radio buttons were spaced too far apart vertically in Win11 + Firefox latest
- New behavior: Radio buttons are consistently spaced across browsers

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |   ![Screenshot 2025-06-24 160228](https://github.com/user-attachments/assets/dbe8115a-1792-454f-9909-0d491a32fba7)    |
| Desktop |  ![Screenshot 2025-06-24 133010](https://github.com/user-attachments/assets/cd84b706-80c2-4a9b-b6f1-7b0f8632058f) |    ![Screenshot 2025-06-24 160215](https://github.com/user-attachments/assets/9a6e7375-aeb0-4f4b-bfee-5b17f6f54b76)   |

## What areas of the site does it impact?

- This change affects only one view on the new Your VA Letters and Documents (edit address) flow 

## Acceptance criteria

### Quality Assurance & Testing

- [x] Screenshot of the developed feature is added
- [x] Tested in multiple browsers (see issue ticket success criteria for complete list

