### PR TITLE
Add annotations for hard-coded waits in e2e tests

### DIFF
--- a/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
+++ b/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
@@ -38,6 +38,7 @@ const dateTimeHelpers = [
 ];
 
 const waitHelpers = ['cy.wait(', 'setTimeout(', 'sleep(', 'browser.sleep('];
+const waitRegex = /cy\.wait\(\s*(?!.*@)[^)]*\)/;
 
 function getSpecFiles(dir) {
   let results = [];
@@ -71,13 +72,22 @@ function checkSpecsForFlakyDatesAndTimes(file) {
           'Dynamically generated date or time found. Mocked dates and times should be used in testing to avoid flakiness.',
       });
     }
-    if (waitHelpers.some(helper => line.includes(helper))) {
+    if (waitRegex.test(line)) {
       dateTimeAnnotations.push({
         path: file,
         start_line: index + 1,
         end_line: index + 1,
         annotation_level: 'warning',
-        message: 'Hard-coded wait was found. ',
+        message: 'Hard-coded cy.wait() found. Use alias-based waits instead.',
+      });
+    } else if (waitHelpers.some(helper => line.includes(helper))) {
+      dateTimeAnnotations.push({
+        path: file,
+        start_line: index + 1,
+        end_line: index + 1,
+        annotation_level: 'warning',
+        message:
+          'Hard-coded wait was found. Use polling or explicit wait-for conditions instead.',
       });
     }
   });

--- a/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
+++ b/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
@@ -37,8 +37,7 @@ const dateTimeHelpers = [
   'toLocaleTimeString(',
 ];
 
-const waitRegex = /cy\.wait\(\s*\d+\s*\)/;
-const waitHelpers = ['setTimeout(', 'sleep(', 'browser.sleep('];
+const waitHelpers = ['cy.wait(', 'setTimeout(', 'sleep(', 'browser.sleep('];
 
 function getSpecFiles(dir) {
   let results = [];
@@ -72,33 +71,16 @@ function checkSpecsForFlakyDatesAndTimes(file) {
           'Dynamically generated date or time found. Mocked dates and times should be used in testing to avoid flakiness.',
       });
     }
-    const usesWaitHelper = waitHelpers.some(helper => {
-      if (helper === 'cy.wait(') {
-        return waitRegex.test(line);
-      }
-      return line.includes(helper);
-    });
-    if (usesWaitHelper) {
+    if (waitHelpers.some(helper => line.includes(helper))) {
       dateTimeAnnotations.push({
         path: file,
         start_line: index + 1,
         end_line: index + 1,
         annotation_level: 'warning',
-        message: waitRegex.test(line)
-          ? 'Hard-coded cy.wait(n) found.  Use alias-based waits instead.'
-          : 'Hard-coded wait was found.',
+        message: 'Hard-coded wait was found. ',
       });
     }
   });
-  // if (waitHelpers.some(helper => line.includes(helper))) {
-  //   dateTimeAnnotations.push({
-  //     path: file,
-  //     start_line: index + 1,
-  //     end_line: index + 1,
-  //     annotation_level: 'warning',
-  //     message: 'Hard-coded wait was found. ',
-  //   });
-  // }
   return dateTimeAnnotations;
 }
 

--- a/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
+++ b/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
@@ -37,7 +37,12 @@ const dateTimeHelpers = [
   'toLocaleTimeString(',
 ];
 
-const waitHelpers = ['cy.wait(', 'setTimeout(', 'sleep(', 'browser.sleep('];
+const waitHelpers = [
+  /cy\.wait\(\s*\d+\s*\)/,
+  'setTimeout(',
+  'sleep(',
+  'browser.sleep(',
+];
 
 function getSpecFiles(dir) {
   let results = [];

--- a/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
+++ b/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
@@ -37,6 +37,8 @@ const dateTimeHelpers = [
   'toLocaleTimeString(',
 ];
 
+const waitHelpers = ['cy.wait(', 'setTimeout(', 'sleep(', 'browser.sleep('];
+
 function getSpecFiles(dir) {
   let results = [];
   const list = fs.readdirSync(dir);
@@ -67,6 +69,15 @@ function checkSpecsForFlakyDatesAndTimes(file) {
         annotation_level: 'warning',
         message:
           'Dynamically generated date or time found. Mocked dates and times should be used in testing to avoid flakiness.',
+      });
+    }
+    if (waitHelpers.some(helper => line.includes(helper))) {
+      dateTimeAnnotations.push({
+        path: file,
+        start_line: index + 1,
+        end_line: index + 1,
+        annotation_level: 'warning',
+        message: 'Hard-coded wait was found. ',
       });
     }
   });

--- a/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
+++ b/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
@@ -37,12 +37,8 @@ const dateTimeHelpers = [
   'toLocaleTimeString(',
 ];
 
-const waitHelpers = [
-  /cy\.wait\(\s*\d+\s*\)/,
-  'setTimeout(',
-  'sleep(',
-  'browser.sleep(',
-];
+const waitRegex = /cy\.wait\(\s*\d+\s*\)/;
+const waitHelpers = [waitRegex, 'setTimeout(', 'sleep(', 'browser.sleep('];
 
 function getSpecFiles(dir) {
   let results = [];

--- a/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
+++ b/script/github-actions/annotate-flaky-dates-and-times-in-tests.js
@@ -37,7 +37,7 @@ const dateTimeHelpers = [
   'toLocaleTimeString(',
 ];
 
-const waitHelpers = ['cy.wait(', 'setTimeout(', 'sleep(', 'browser.sleep('];
+const waitHelpers = ['setTimeout(', 'sleep(', 'browser.sleep('];
 const waitRegex = /cy\.wait\(\s*(?!.*@)[^)]*\)/;
 
 function getSpecFiles(dir) {

--- a/src/applications/ezr/tests/e2e/ezr-dependents.cypress.spec.js
+++ b/src/applications/ezr/tests/e2e/ezr-dependents.cypress.spec.js
@@ -62,6 +62,8 @@ describe('EZR Dependents', () => {
       statusCode: 200,
       body: mockPrefill,
     }).as('mockSip');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(550);
     cy.intercept('POST', formConfig.submitUrl, {
       statusCode: 200,
       body: {

--- a/src/applications/ezr/tests/e2e/ezr-dependents.cypress.spec.js
+++ b/src/applications/ezr/tests/e2e/ezr-dependents.cypress.spec.js
@@ -62,8 +62,6 @@ describe('EZR Dependents', () => {
       statusCode: 200,
       body: mockPrefill,
     }).as('mockSip');
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(550);
     cy.intercept('POST', formConfig.submitUrl, {
       statusCode: 200,
       body: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Hard-coded waits for exact times in tests can result in tests failing unexpectedly for a multitude of factors. Poor connection speed, slight delays in automation, and numerous other factors can cause this wait time to be exceeded and tests timing out. A safer way to do waits, is to base your wait on a particular element loading, or some other dynamic factor that will reliably load before the thing you're trying to test.
- By adding additional criteria to our existing annotation scripts, we can flag

## Related issue(s)

- _[Link to ticket created in va.gov-team repo](https://github.com/department-of-veterans-affairs/va.gov-team/issues/106847)_


## Testing done

- _Trigger annotation scripts with dummy changes to e2e specs including the targeted functions._
