### PR TITLE
Hotfix: Fix incorrect dates for slot fetch when choosing a different month

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -5,7 +5,7 @@ import {
   selectVAPMobilePhoneString,
 } from '@department-of-veterans-affairs/platform-user/exports';
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
-import { startOfMonth, endOfMonth, format, isAfter } from 'date-fns';
+import { startOfMonth, endOfMonth, format, isAfter, parse } from 'date-fns';
 
 import {
   selectSystemIds,
@@ -22,6 +22,7 @@ import {
 } from '../../services/location';
 import { getPreciseLocation } from '../../utils/address';
 import {
+  DATE_FORMATS,
   FACILITY_SORT_METHODS,
   GA_PREFIX,
   TYPES_OF_CARE,
@@ -269,8 +270,15 @@ export function getAppointmentSlots(startDate, endDate, initialFetch = false) {
     const { data } = newBooking;
     const featureConvertSlotsToUTC = selectFeatureConvertSlotsToUtc(state);
 
-    const startDateMonth = format(new Date(startDate), 'yyyy-MM');
-    const endDateMonth = format(new Date(endDate), 'yyyy-MM');
+    let startDateObject = new Date(startDate);
+    let endDateObject = new Date(endDate);
+    if (typeof startDate === 'string') {
+      startDateObject = parse(startDate, DATE_FORMATS.yearMonthDay, new Date());
+      endDateObject = parse(endDate, DATE_FORMATS.yearMonthDay, new Date());
+    }
+
+    const startDateMonth = format(startDateObject, DATE_FORMATS.yearMonth);
+    const endDateMonth = format(endDateObject, DATE_FORMATS.yearMonth);
 
     let fetchedAppointmentSlotMonths = [];
     let fetchedStartMonth = false;
@@ -293,11 +301,11 @@ export function getAppointmentSlots(startDate, endDate, initialFetch = false) {
 
       try {
         const startDateString = !fetchedStartMonth
-          ? format(new Date(startDate), 'yyyy-MM-dd')
-          : format(startOfMonth(new Date(endDate)), 'yyyy-MM-dd');
+          ? format(startDateObject, DATE_FORMATS.yearMonthDay)
+          : format(startOfMonth(endDateObject), DATE_FORMATS.yearMonthDay);
         const endDateString = !fetchedEndMonth
-          ? format(new Date(endDate), 'yyyy-MM-dd')
-          : format(endOfMonth(new Date(startDate)), 'yyyy-MM-dd');
+          ? format(endDateObject, DATE_FORMATS.yearMonthDay)
+          : format(endOfMonth(startDateObject), DATE_FORMATS.yearMonthDay);
 
         const fetchedSlots = await getSlots({
           siteId,

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -5,6 +5,7 @@ import { format, utcToZonedTime } from 'date-fns-tz';
 import moment from 'moment';
 
 import {
+  parse,
   addMinutes,
   areIntervalsOverlapping,
   startOfMonth,
@@ -651,8 +652,27 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
     const { data } = newAppointment;
     const featureConvertSlotsToUTC = selectFeatureConvertSlotsToUtc(state);
 
-    const startDateMonth = format(new Date(startDate), 'yyyy-MM');
-    const endDateMonth = format(new Date(endDate), 'yyyy-MM');
+    // console.log(`------------------------------------------------------------------------`);
+    // console.log(`Fetching appointment slots for ${siteId} from ${startDate} to ${endDate}`);
+
+    let startDateMonth = format(new Date(startDate), 'yyyy-MM');
+    let endDateMonth = format(new Date(endDate), 'yyyy-MM');
+    if (typeof startDate === 'string') {
+      startDateMonth = format(
+        parse(startDate, 'yyyy-MM-dd', new Date()),
+        'yyyy-MM',
+      );
+      endDateMonth = format(
+        parse(endDate, 'yyyy-MM-dd', new Date()),
+        'yyyy-MM',
+      );
+    }
+
+    // console.log(`Start date object ${new Date(startDate)} and end date object ${new Date(endDate)}`);
+    // if (typeof startDate === 'string') {
+    //   console.log(`Parsed start date object ${parse(startDate, 'yyyy-MM-dd', new Date())} and parsed end date object ${parse(endDate, 'yyyy-MM-dd', new Date())}`);
+    // }
+    // console.log(`Start date month ${startDateMonth} and end date month ${endDateMonth}`);
 
     const timezone = getTimezoneByFacilityId(data.vaFacility);
 
@@ -671,6 +691,8 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
       availableSlots = newAppointment.availableSlots || [];
     }
 
+    // console.log(`Fetched appointment slot months: ${fetchedAppointmentSlotMonths}`);
+
     if (!fetchedStartMonth || !fetchedEndMonth) {
       let mappedSlots = [];
       dispatch({ type: FORM_CALENDAR_FETCH_SLOTS });
@@ -682,6 +704,8 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
         const endDateString = !fetchedEndMonth
           ? format(new Date(endDate), 'yyyy-MM-dd')
           : format(endOfMonth(new Date(startDate)), 'yyyy-MM-dd');
+
+        // console.log(`Start date string: ${startDateString} end date string: ${endDateString}`);
 
         const fetchedSlots = await getSlots({
           siteId,

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -652,27 +652,14 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
     const { data } = newAppointment;
     const featureConvertSlotsToUTC = selectFeatureConvertSlotsToUtc(state);
 
-    // console.log(`------------------------------------------------------------------------`);
-    // console.log(`Fetching appointment slots for ${siteId} from ${startDate} to ${endDate}`);
-
-    let startDateMonth = format(new Date(startDate), 'yyyy-MM');
-    let endDateMonth = format(new Date(endDate), 'yyyy-MM');
+    let startDateObject = new Date(startDate);
+    let endDateObject = new Date(endDate);
     if (typeof startDate === 'string') {
-      startDateMonth = format(
-        parse(startDate, 'yyyy-MM-dd', new Date()),
-        'yyyy-MM',
-      );
-      endDateMonth = format(
-        parse(endDate, 'yyyy-MM-dd', new Date()),
-        'yyyy-MM',
-      );
+      startDateObject = parse(startDate, DATE_FORMATS.yearMonthDay, new Date());
+      endDateObject = parse(endDate, DATE_FORMATS.yearMonthDay, new Date());
     }
-
-    // console.log(`Start date object ${new Date(startDate)} and end date object ${new Date(endDate)}`);
-    // if (typeof startDate === 'string') {
-    //   console.log(`Parsed start date object ${parse(startDate, 'yyyy-MM-dd', new Date())} and parsed end date object ${parse(endDate, 'yyyy-MM-dd', new Date())}`);
-    // }
-    // console.log(`Start date month ${startDateMonth} and end date month ${endDateMonth}`);
+    const startDateMonth = format(startDateObject, DATE_FORMATS.yearMonth);
+    const endDateMonth = format(endDateObject, DATE_FORMATS.yearMonth);
 
     const timezone = getTimezoneByFacilityId(data.vaFacility);
 
@@ -691,21 +678,17 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
       availableSlots = newAppointment.availableSlots || [];
     }
 
-    // console.log(`Fetched appointment slot months: ${fetchedAppointmentSlotMonths}`);
-
     if (!fetchedStartMonth || !fetchedEndMonth) {
       let mappedSlots = [];
       dispatch({ type: FORM_CALENDAR_FETCH_SLOTS });
 
       try {
         const startDateString = !fetchedStartMonth
-          ? format(new Date(startDate), 'yyyy-MM-dd')
-          : format(startOfMonth(new Date(endDate)), 'yyyy-MM-dd');
+          ? format(startDateObject, DATE_FORMATS.yearMonthDay)
+          : format(startOfMonth(endDateObject), DATE_FORMATS.yearMonthDay);
         const endDateString = !fetchedEndMonth
-          ? format(new Date(endDate), 'yyyy-MM-dd')
-          : format(endOfMonth(new Date(startDate)), 'yyyy-MM-dd');
-
-        // console.log(`Start date string: ${startDateString} end date string: ${endDateString}`);
+          ? format(endDateObject, DATE_FORMATS.yearMonthDay)
+          : format(endOfMonth(startDateObject), DATE_FORMATS.yearMonthDay);
 
         const fetchedSlots = await getSlots({
           siteId,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- In production we were seeing occasional invalid slot request errors (400 status)
- The cause was tracked down to incorrect date parameters
- Datadog [logs of failing requests](https://vagov.ddog-gov.com/logs?query=%2Fvaos%2Fv2%2Flocations%2F%2A%2Fclinics%2F%2A%2Fslots%20service%3Arevproxy%20status%3Awarn&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1749523056731&to_ts=1750819056731&live=true)
- [Slack thread](https://dsva.slack.com/archives/C023EFZPX4K/p1750276104896739)
- We can reproduce this by clicking the next month button on the date time select page then clicking the prev month button
- The problem was caused by inconsistent handling of date objects and strings as well as the incorrect parsing of string date inputs using date-fns. The fix is to use an explicit date-fns parsing string.
- Appointments FE Team
- The feature is behind the `va_online_scheduling_convert_slots_to_utc` toggle.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/110237

## Testing done

- Tested scenarios locally
- Click prev and next months on the "Choose date and time" or "What date and time do you want for this appointment?" page
- Observe the slots API calls and ensure the dates match the months chosen

## Screenshots

Tested scenario:
1. Choose a date in July as the preferred date
2. Click next month twice to trigger a fetch for slots in Sep
3. Click prev month three times to trigger a fetch for slots in June

|         | Slots fetch |
| ------- | ------ |
| Before | <img width="520" alt="image" src="https://github.com/user-attachments/assets/b2eeeba7-1d43-48e7-9b2d-cfd828f859cf" />  |
| After | <img width="528" alt="image" src="https://github.com/user-attachments/assets/e92d709b-aa0f-4bbb-9dd0-32c54b0c7fc4" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

