### PR TITLE
Update externalService naming to 'vaoswarning'

### DIFF
--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
@@ -87,7 +87,7 @@ describe('VAOS Page: AppointmentsPage', () => {
             id: '139',
             type: 'maintenance_windows',
             attributes: {
-              externalService: 'vaosWarning',
+              externalService: 'vaoswarning',
               description: 'My description',
               startTime: subDays(new Date(), '1')?.toISOString(),
               endTime: addDays(new Date(), '1')?.toISOString(),

--- a/src/applications/vaos/covid-19-vaccine/index.unit.spec.jsx
+++ b/src/applications/vaos/covid-19-vaccine/index.unit.spec.jsx
@@ -165,7 +165,7 @@ describe('VAOS vaccine flow: NewBookingSection', () => {
             id: '139',
             type: 'maintenance_windows',
             attributes: {
-              externalService: 'vaosWarning',
+              externalService: 'vaoswarning',
               description: 'My description',
               startTime: format(
                 subDays(new Date(), '1'),

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.unit.spec.jsx
@@ -388,7 +388,7 @@ describe('VAOS Page: TypeOfCarePage', () => {
             id: '139',
             type: 'maintenance_windows',
             attributes: {
-              externalService: 'vaosWarning',
+              externalService: 'vaoswarning',
               description: 'My description',
               startTime: format(
                 subDays(new Date(), '1'),

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -65,7 +65,7 @@ export default {
   // Online appointment scheduling
   vaos: 'vaos',
   // Online appointment scheduling warning message
-  vaosWarning: 'vaosWarning',
+  vaosWarning: 'vaoswarning',
   // VA Profile (formerly Vet360) - data source for centralized veteran contact information
   vaProfile: 'vet360',
   // Veteran Benefits Management System


### PR DESCRIPTION
**Note**: I noticed the maintenance window wasn’t displaying as expected while testing in staging. After investigating, I found that a member of the platform team recently [migrated environment settings and variables](https://github.com/department-of-veterans-affairs/vets-api/pull/20916/files) into the vets-api config file. During that process, two service names—vaoswarning and vaosWarning—were added.
As a result, the maintenance_windows endpoint (used by the front end to display maintenance windows) is now returning the externalService value as vaoswarning instead of the expected vaosWarning.
This change was made about three months ago, but since we're not code owners of the affected file, we didn’t receive a notification.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

## Testing done
Tested with mock api response

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

![Screenshot 2025-06-24 at 11 22 27 PM](https://github.com/user-attachments/assets/c0eb0bd1-e3df-44ab-87a5-14c89ab55aa0)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

