### PR TITLE
DR 111799: Update tests to pass with Node 22

### DIFF
--- a/src/applications/appeals/10182/tests/pages/boardReview.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/boardReview.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
@@ -55,7 +55,7 @@ describe('NOD board review page', () => {
   });
 
   // board option is required
-  it('should prevent continuing', () => {
+  it('should prevent continuing', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -70,8 +70,10 @@ describe('NOD board review page', () => {
 
     fireEvent.submit($('form', container));
 
-    expect($$('[error]').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+    await waitFor(() => {
+      expect($$('[error]').length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 });
 

--- a/src/applications/appeals/10182/tests/pages/evidenceUpload.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/evidenceUpload.unit.spec.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { mount } from 'enzyme';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import { Provider } from 'react-redux';
-
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import environment from '~/platform/utilities/environment';
 import {
@@ -18,7 +18,7 @@ describe('Additional evidence upload', () => {
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
-    const form = mount(
+    const { container } = render(
       <Provider store={uploadStore}>
         <DefinitionTester
           arrayPath={arrayPath}
@@ -31,14 +31,13 @@ describe('Additional evidence upload', () => {
       </Provider>,
     );
 
-    expect(form.find('input[type="file"]').length).to.equal(1);
-    expect(form.find('va-additional-info').length).to.equal(1);
-    form.unmount();
+    expect($$('input[type="file"]', container).length).to.equal(1);
+    expect($$('va-additional-info', container).length).to.equal(1);
   });
 
-  it('should not submit without required upload', () => {
+  it('should not submit without required upload', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <Provider store={uploadStore}>
         <DefinitionTester
           arrayPath={arrayPath}
@@ -52,15 +51,17 @@ describe('Additional evidence upload', () => {
       </Provider>,
     );
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    fireEvent.submit($('form', container));
+
+    waitFor(() => {
+      expect($$('.usa-input-error-message', container).length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
-  it('should submit with uploaded form', () => {
+  it('should submit with uploaded form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <Provider store={uploadStore}>
         <DefinitionTester
           arrayPath={arrayPath}
@@ -81,13 +82,15 @@ describe('Additional evidence upload', () => {
       </Provider>,
     );
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
-    const { evidence } = onSubmit.args[0][0].uiSchema;
-    expect(evidence['ui:options'].fileUploadUrl).to.eq(
-      `${environment.API_URL}${EVIDENCE_UPLOAD_API}`,
-    );
-    form.unmount();
+    fireEvent.submit($('form', container));
+
+    await waitFor(() => {
+      expect($$('.usa-input-error-message', container).length).to.equal(0);
+      expect(onSubmit.called).to.be.true;
+      const { evidence } = onSubmit.args[0][0].uiSchema;
+      expect(evidence['ui:options'].fileUploadUrl).to.eq(
+        `${environment.API_URL}${EVIDENCE_UPLOAD_API}`,
+      );
+    });
   });
 });

--- a/src/applications/appeals/10182/tests/pages/extensionReason.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/extensionReason.unit.spec.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
-
 import { ExtensionReasonReviewField } from '../../content/extensionReason';
 
 const {
@@ -35,7 +32,7 @@ describe('extension request page', () => {
     expect($('va-textarea', container)).to.exist;
   });
 
-  it('should not allow submit with no value (required)', () => {
+  it('should not allow submit with no value (required)', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -47,14 +44,17 @@ describe('extension request page', () => {
         onSubmit={onSubmit}
       />,
     );
+
     fireEvent.submit($('form', container));
 
-    expect($('va-textarea', container).outerHTML).to.contain('value=""');
-    expect($('va-textarea[error]', container)).to.exist;
-    expect(onSubmit.called).to.be.false;
+    await waitFor(() => {
+      expect($('va-textarea', container).outerHTML).to.contain('value=""');
+      expect($('va-textarea[error]', container)).to.exist;
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
-  it('should allow submit with some text', () => {
+  it('should allow submit with some text', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -66,12 +66,16 @@ describe('extension request page', () => {
         onSubmit={onSubmit}
       />,
     );
+
     fireEvent.submit($('form', container));
-    expect($('va-textarea', container).outerHTML).to.contain(
-      'value="Lorem ipsum"',
-    );
-    expect($('va-textarea[error]', container)).to.not.exist;
-    expect(onSubmit.called).to.be.true;
+
+    await waitFor(() => {
+      expect($('va-textarea', container).outerHTML).to.contain(
+        'value="Lorem ipsum"',
+      );
+      expect($('va-textarea[error]', container)).to.not.exist;
+      expect(onSubmit.called).to.be.true;
+    });
   });
 });
 

--- a/src/applications/appeals/10182/tests/pages/hearingType.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/hearingType.unit.spec.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
-
 import { HearingTypeReviewField } from '../../content/hearingType';
 
 describe('NOD board review page', () => {
@@ -31,7 +28,7 @@ describe('NOD board review page', () => {
     expect($$('va-radio-option', container).length).to.equal(3);
   });
 
-  it('should allow submit', () => {
+  it('should allow submit', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -50,12 +47,14 @@ describe('NOD board review page', () => {
 
     fireEvent.submit($('form', container));
 
-    expect($$('[error]', container).length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
+    await waitFor(() => {
+      expect($$('[error]', container).length).to.equal(0);
+      expect(onSubmit.called).to.be.true;
+    });
   });
 
   // board option is required
-  it('should prevent continuing', () => {
+  it('should prevent continuing', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -69,8 +68,11 @@ describe('NOD board review page', () => {
     );
 
     fireEvent.submit($('form', container));
-    expect($$('[error]', container).length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+
+    await waitFor(() => {
+      expect($$('[error]', container).length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 });
 

--- a/src/applications/appeals/995/tests/components/EvidenceSummary.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceSummary.unit.spec.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import EvidenceSummary from '../../components/EvidenceSummary';
 import { content } from '../../content/evidenceSummary';
 import {
@@ -152,11 +150,9 @@ describe('<EvidenceSummary>', () => {
     expect($$('.usa-input-error-message', container).length).to.eq(9);
     expect($$('.form-nav-buttons button', container).length).to.eq(2);
 
-    await fireEvent.click(
-      $('.form-progress-buttons .usa-button-primary', container),
-    );
+    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -186,8 +182,8 @@ describe('<EvidenceSummary>', () => {
 
   it('should include the correct edit URL links', () => {
     const { container } = setupSummary({ limit: 'test' });
-
     const links = $$('.edit-item', container);
+
     expect(links.length).to.eq(9);
     expect(links[0].getAttribute('data-link')).to.contain(
       `${EVIDENCE_VA_PATH}?index=0`,
@@ -215,11 +211,15 @@ describe('<EvidenceSummary>', () => {
     expect(links[8].getAttribute('data-link')).to.contain(EVIDENCE_UPLOAD_PATH);
   });
 
-  it('should submit page without error', () => {
+  it('should submit page without error', async () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({ goForward });
+
     fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
-    expect(goForward.called).to.be.true;
+
+    await waitFor(() => {
+      expect(goForward.called).to.be.true;
+    });
   });
 
   it('should not navigate forward with errors', async () => {
@@ -232,11 +232,9 @@ describe('<EvidenceSummary>', () => {
       goForward,
     });
 
-    await fireEvent.click(
-      $('.form-progress-buttons .usa-button-primary', container),
-    );
+    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -252,14 +250,14 @@ describe('<EvidenceSummary>', () => {
       updatePage: updateSpy,
     });
 
-    await fireEvent.click($('.form-nav-buttons va-button', container));
+    fireEvent.click($('.form-nav-buttons va-button', container));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(updateSpy.called).to.be.false;
     });
   });
 
-  it('should navigate forward with not-included partial data', () => {
+  it('should navigate forward with not-included partial data', async () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({
       vaMR: false,
@@ -275,10 +273,13 @@ describe('<EvidenceSummary>', () => {
     });
 
     fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
-    expect(goForward.called).to.be.true;
+
+    await waitFor(() => {
+      expect(goForward.called).to.be.true;
+    });
   });
 
-  it('should call goBack to get to the private limitation page, even with errors', () => {
+  it('should call goBack to get to the private limitation page, even with errors', async () => {
     const goBack = sinon.spy();
     const { container } = setupSummary({
       vaMR: false,
@@ -291,7 +292,10 @@ describe('<EvidenceSummary>', () => {
     fireEvent.click(
       $('.form-progress-buttons .usa-button-secondary', container),
     );
-    expect(goBack.called).to.be.true;
+
+    await waitFor(() => {
+      expect(goBack.called).to.be.true;
+    });
   });
 
   // Move SC limitation
@@ -315,11 +319,9 @@ describe('<EvidenceSummary>', () => {
       goForward,
     });
 
-    await fireEvent.click(
-      $('.form-progress-buttons .usa-button-primary', container),
-    );
+    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -348,9 +350,8 @@ describe('<EvidenceSummary>', () => {
 
     // remove second VA entry
     fireEvent.click($('va-button[label="Remove VAMC Location 2"]', container));
-
-    const modal = $('va-modal', container);
-    modal.__events.secondaryButtonClick(); // Cancel removal
+    const secondaryButton = $('va-button[secondary]', container);
+    fireEvent.click(secondaryButton);
 
     await waitFor(() => {
       expect(setFormData.called).to.be.false;
@@ -381,8 +382,8 @@ describe('<EvidenceSummary>', () => {
     // remove second VA entry
     fireEvent.click($('va-button[label="Remove Private Hospital"]', container));
 
-    const modal = $('va-modal', container);
-    modal.__events.secondaryButtonClick(); // Cancel removal
+    const secondaryButton = $('va-button[secondary]', container);
+    fireEvent.click(secondaryButton);
 
     await waitFor(() => {
       expect(setFormData.called).to.be.false;
@@ -434,8 +435,8 @@ describe('<EvidenceSummary>', () => {
     // remove second VA entry
     fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
 
-    const modal = $('va-modal', container);
-    modal.__events.secondaryButtonClick(); // Cancel delete
+    const secondaryButton = $('va-button[secondary]', container);
+    fireEvent.click(secondaryButton);
 
     await waitFor(() => {
       expect(setFormData.called).to.be.false;
@@ -453,7 +454,8 @@ describe('<EvidenceSummary>', () => {
       $('.form-nav-buttons va-button', container).getAttribute('text'),
     ).to.eq(content.update);
   });
-  it('should call updatePage on review & submit in edit mode', () => {
+
+  it('should call updatePage on review & submit in edit mode', async () => {
     const updateSpy = sinon.spy();
     const { container } = setupSummary({
       onReviewPage: true,
@@ -461,6 +463,9 @@ describe('<EvidenceSummary>', () => {
     });
 
     fireEvent.click($('.form-nav-buttons va-button', container));
-    expect(updateSpy.called).to.be.true;
+
+    await waitFor(() => {
+      expect(updateSpy.called).to.be.true;
+    });
   });
 });

--- a/src/applications/appeals/995/tests/components/EvidenceSummary.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceSummary.unit.spec.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
+
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+
 import EvidenceSummary from '../../components/EvidenceSummary';
 import { content } from '../../content/evidenceSummary';
 import {
@@ -150,9 +152,11 @@ describe('<EvidenceSummary>', () => {
     expect($$('.usa-input-error-message', container).length).to.eq(9);
     expect($$('.form-nav-buttons button', container).length).to.eq(2);
 
-    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
+    await fireEvent.click(
+      $('.form-progress-buttons .usa-button-primary', container),
+    );
 
-    await waitFor(() => {
+    waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -182,8 +186,8 @@ describe('<EvidenceSummary>', () => {
 
   it('should include the correct edit URL links', () => {
     const { container } = setupSummary({ limit: 'test' });
-    const links = $$('.edit-item', container);
 
+    const links = $$('.edit-item', container);
     expect(links.length).to.eq(9);
     expect(links[0].getAttribute('data-link')).to.contain(
       `${EVIDENCE_VA_PATH}?index=0`,
@@ -211,15 +215,11 @@ describe('<EvidenceSummary>', () => {
     expect(links[8].getAttribute('data-link')).to.contain(EVIDENCE_UPLOAD_PATH);
   });
 
-  it('should submit page without error', async () => {
+  it('should submit page without error', () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({ goForward });
-
     fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
-
-    await waitFor(() => {
-      expect(goForward.called).to.be.true;
-    });
+    expect(goForward.called).to.be.true;
   });
 
   it('should not navigate forward with errors', async () => {
@@ -232,9 +232,11 @@ describe('<EvidenceSummary>', () => {
       goForward,
     });
 
-    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
+    await fireEvent.click(
+      $('.form-progress-buttons .usa-button-primary', container),
+    );
 
-    await waitFor(() => {
+    waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -250,14 +252,14 @@ describe('<EvidenceSummary>', () => {
       updatePage: updateSpy,
     });
 
-    fireEvent.click($('.form-nav-buttons va-button', container));
+    await fireEvent.click($('.form-nav-buttons va-button', container));
 
-    await waitFor(() => {
+    waitFor(() => {
       expect(updateSpy.called).to.be.false;
     });
   });
 
-  it('should navigate forward with not-included partial data', async () => {
+  it('should navigate forward with not-included partial data', () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({
       vaMR: false,
@@ -273,13 +275,10 @@ describe('<EvidenceSummary>', () => {
     });
 
     fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
-
-    await waitFor(() => {
-      expect(goForward.called).to.be.true;
-    });
+    expect(goForward.called).to.be.true;
   });
 
-  it('should call goBack to get to the private limitation page, even with errors', async () => {
+  it('should call goBack to get to the private limitation page, even with errors', () => {
     const goBack = sinon.spy();
     const { container } = setupSummary({
       vaMR: false,
@@ -292,10 +291,7 @@ describe('<EvidenceSummary>', () => {
     fireEvent.click(
       $('.form-progress-buttons .usa-button-secondary', container),
     );
-
-    await waitFor(() => {
-      expect(goBack.called).to.be.true;
-    });
+    expect(goBack.called).to.be.true;
   });
 
   // Move SC limitation
@@ -319,9 +315,11 @@ describe('<EvidenceSummary>', () => {
       goForward,
     });
 
-    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
+    await fireEvent.click(
+      $('.form-progress-buttons .usa-button-primary', container),
+    );
 
-    await waitFor(() => {
+    waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -350,6 +348,7 @@ describe('<EvidenceSummary>', () => {
 
     // remove second VA entry
     fireEvent.click($('va-button[label="Remove VAMC Location 2"]', container));
+
     const secondaryButton = $('va-button[secondary]', container);
     fireEvent.click(secondaryButton);
 
@@ -454,8 +453,7 @@ describe('<EvidenceSummary>', () => {
       $('.form-nav-buttons va-button', container).getAttribute('text'),
     ).to.eq(content.update);
   });
-
-  it('should call updatePage on review & submit in edit mode', async () => {
+  it('should call updatePage on review & submit in edit mode', () => {
     const updateSpy = sinon.spy();
     const { container } = setupSummary({
       onReviewPage: true,
@@ -463,9 +461,6 @@ describe('<EvidenceSummary>', () => {
     });
 
     fireEvent.click($('.form-nav-buttons va-button', container));
-
-    await waitFor(() => {
-      expect(updateSpy.called).to.be.true;
-    });
+    expect(updateSpy.called).to.be.true;
   });
 });

--- a/src/applications/appeals/995/tests/components/EvidenceSummaryOld.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceSummaryOld.unit.spec.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import EvidenceSummary from '../../components/EvidenceSummary';
 import { content } from '../../content/evidenceSummary';
 import {
@@ -140,11 +138,9 @@ describe('<EvidenceSummary>', () => {
     expect($$('.usa-input-error-message', container).length).to.eq(9);
     expect($$('.form-nav-buttons button', container).length).to.eq(2);
 
-    await fireEvent.click(
-      $('.form-progress-buttons .usa-button-primary', container),
-    );
+    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -201,10 +197,11 @@ describe('<EvidenceSummary>', () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({ goForward });
 
-    await fireEvent.click(
-      $('.form-progress-buttons .usa-button-primary', container),
-    );
-    expect(goForward.called).to.be.true;
+    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
+
+    await waitFor(() => {
+      expect(goForward.called).to.be.true;
+    });
   });
 
   it('should not navigate forward with errors', async () => {
@@ -217,9 +214,7 @@ describe('<EvidenceSummary>', () => {
       goForward,
     });
 
-    await fireEvent.click(
-      $('.form-progress-buttons .usa-button-primary', container),
-    );
+    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
 
     waitFor(() => {
       expect(goForward.called).to.be.false;
@@ -237,14 +232,14 @@ describe('<EvidenceSummary>', () => {
       updatePage: updateSpy,
     });
 
-    await fireEvent.click($('.form-nav-buttons va-button', container));
+    fireEvent.click($('.form-nav-buttons va-button', container));
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(updateSpy.called).to.be.false;
     });
   });
 
-  it('should navigate forward with not-included partial data', () => {
+  it('should navigate forward with not-included partial data', async () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({
       vaMR: false,
@@ -260,7 +255,10 @@ describe('<EvidenceSummary>', () => {
     });
 
     fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
-    expect(goForward.called).to.be.true;
+
+    await waitFor(() => {
+      expect(goForward.called).to.be.true;
+    });
   });
 
   it('should call goBack to get to the private limitation page, even with errors', async () => {
@@ -273,10 +271,13 @@ describe('<EvidenceSummary>', () => {
       goBack,
     });
 
-    await fireEvent.click(
+    fireEvent.click(
       $('.form-progress-buttons .usa-button-secondary', container),
     );
-    expect(goBack.called).to.be.true;
+
+    await waitFor(() => {
+      expect(goBack.called).to.be.true;
+    });
   });
 
   // Remove entries
@@ -286,12 +287,10 @@ describe('<EvidenceSummary>', () => {
     const result = records().locations[0];
 
     // remove second VA entry
-    await fireEvent.click(
-      $('va-button[label="Remove VAMC Location 2"]', container),
-    );
+    fireEvent.click($('va-button[label="Remove VAMC Location 2"]', container));
 
     const modal = await $('va-modal', container);
-    await modal.__events.primaryButtonClick(); // Remove entry
+    modal.__events.primaryButtonClick(); // Remove entry
 
     await waitFor(() => {
       expect(setFormData.called).to.be.true;
@@ -304,12 +303,10 @@ describe('<EvidenceSummary>', () => {
     const { container } = setupSummary({ setFormData });
 
     // remove second VA entry
-    await fireEvent.click(
-      $('va-button[label="Remove VAMC Location 2"]', container),
-    );
+    fireEvent.click($('va-button[label="Remove VAMC Location 2"]', container));
 
-    const modal = await $('va-modal', container);
-    await modal.__events.secondaryButtonClick(); // Cancel removal
+    const secondaryButton = $('va-button[secondary]', container);
+    fireEvent.click(secondaryButton);
 
     await waitFor(() => {
       expect(setFormData.called).to.be.false;
@@ -322,9 +319,7 @@ describe('<EvidenceSummary>', () => {
     const result = records().providerFacility[0];
 
     // remove second private entry
-    await fireEvent.click(
-      $('va-button[label="Remove Private Hospital"]', container),
-    );
+    fireEvent.click($('va-button[label="Remove Private Hospital"]', container));
 
     const modal = await $('va-modal', container);
     await modal.__events.primaryButtonClick(); // Remove entry
@@ -340,12 +335,10 @@ describe('<EvidenceSummary>', () => {
     const { container } = setupSummary({ setFormData });
 
     // remove second VA entry
-    await fireEvent.click(
-      $('va-button[label="Remove Private Hospital"]', container),
-    );
+    fireEvent.click($('va-button[label="Remove Private Hospital"]', container));
 
-    const modal = await $('va-modal', container);
-    await modal.__events.secondaryButtonClick(); // Cancel removal
+    const secondaryButton = $('va-button[secondary]', container);
+    fireEvent.click(secondaryButton);
 
     await waitFor(() => {
       expect(setFormData.called).to.be.false;
@@ -359,9 +352,7 @@ describe('<EvidenceSummary>', () => {
       limit: 'Pizza addiction',
     });
     // remove limitation
-    await fireEvent.click(
-      $('va-button[label="Remove limitations"]', container),
-    );
+    fireEvent.click($('va-button[label="Remove limitations"]', container));
 
     const modal = await $('va-modal', container);
     await modal.__events.primaryButtonClick(); // Remove entry
@@ -380,12 +371,10 @@ describe('<EvidenceSummary>', () => {
     });
 
     // remove second VA entry
-    await fireEvent.click(
-      $('va-button[label="Remove limitations"]', container),
-    );
+    fireEvent.click($('va-button[label="Remove limitations"]', container));
 
-    const modal = await $('va-modal', container);
-    await modal.__events.secondaryButtonClick(); // Cancel removal
+    const secondaryButton = $('va-button[secondary]', container);
+    fireEvent.click(secondaryButton);
 
     await waitFor(() => {
       expect(setFormData.called).to.be.false;
@@ -398,7 +387,7 @@ describe('<EvidenceSummary>', () => {
     const result = records().additionalDocuments[0];
 
     // remove second upload entry
-    await fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
+    fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
 
     const modal = await $('va-modal', container);
     await modal.__events.primaryButtonClick(); // Remove entry
@@ -416,10 +405,10 @@ describe('<EvidenceSummary>', () => {
     const { container } = setupSummary({ setFormData });
 
     // remove second VA entry
-    await fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
+    fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
 
-    const modal = await $('va-modal', container);
-    await modal.__events.secondaryButtonClick(); // Cancel delete
+    const secondaryButton = $('va-button[secondary]', container);
+    fireEvent.click(secondaryButton);
 
     await waitFor(() => {
       expect(setFormData.called).to.be.false;
@@ -446,7 +435,7 @@ describe('<EvidenceSummary>', () => {
       updatePage: updateSpy,
     });
 
-    await fireEvent.click($('.form-nav-buttons va-button', container));
+    fireEvent.click($('.form-nav-buttons va-button', container));
     expect(updateSpy.called).to.be.true;
   });
 });

--- a/src/applications/appeals/995/tests/components/EvidenceSummaryOld.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceSummaryOld.unit.spec.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
+
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+
 import EvidenceSummary from '../../components/EvidenceSummary';
 import { content } from '../../content/evidenceSummary';
 import {
@@ -138,9 +140,11 @@ describe('<EvidenceSummary>', () => {
     expect($$('.usa-input-error-message', container).length).to.eq(9);
     expect($$('.form-nav-buttons button', container).length).to.eq(2);
 
-    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
+    await fireEvent.click(
+      $('.form-progress-buttons .usa-button-primary', container),
+    );
 
-    await waitFor(() => {
+    waitFor(() => {
       expect(goForward.called).to.be.false;
     });
   });
@@ -197,11 +201,10 @@ describe('<EvidenceSummary>', () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({ goForward });
 
-    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
-
-    await waitFor(() => {
-      expect(goForward.called).to.be.true;
-    });
+    await fireEvent.click(
+      $('.form-progress-buttons .usa-button-primary', container),
+    );
+    expect(goForward.called).to.be.true;
   });
 
   it('should not navigate forward with errors', async () => {
@@ -214,7 +217,9 @@ describe('<EvidenceSummary>', () => {
       goForward,
     });
 
-    fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
+    await fireEvent.click(
+      $('.form-progress-buttons .usa-button-primary', container),
+    );
 
     waitFor(() => {
       expect(goForward.called).to.be.false;
@@ -232,14 +237,14 @@ describe('<EvidenceSummary>', () => {
       updatePage: updateSpy,
     });
 
-    fireEvent.click($('.form-nav-buttons va-button', container));
+    await fireEvent.click($('.form-nav-buttons va-button', container));
 
-    await waitFor(() => {
+    waitFor(() => {
       expect(updateSpy.called).to.be.false;
     });
   });
 
-  it('should navigate forward with not-included partial data', async () => {
+  it('should navigate forward with not-included partial data', () => {
     const goForward = sinon.spy();
     const { container } = setupSummary({
       vaMR: false,
@@ -255,10 +260,7 @@ describe('<EvidenceSummary>', () => {
     });
 
     fireEvent.click($('.form-progress-buttons .usa-button-primary', container));
-
-    await waitFor(() => {
-      expect(goForward.called).to.be.true;
-    });
+    expect(goForward.called).to.be.true;
   });
 
   it('should call goBack to get to the private limitation page, even with errors', async () => {
@@ -271,13 +273,10 @@ describe('<EvidenceSummary>', () => {
       goBack,
     });
 
-    fireEvent.click(
+    await fireEvent.click(
       $('.form-progress-buttons .usa-button-secondary', container),
     );
-
-    await waitFor(() => {
-      expect(goBack.called).to.be.true;
-    });
+    expect(goBack.called).to.be.true;
   });
 
   // Remove entries
@@ -287,10 +286,12 @@ describe('<EvidenceSummary>', () => {
     const result = records().locations[0];
 
     // remove second VA entry
-    fireEvent.click($('va-button[label="Remove VAMC Location 2"]', container));
+    await fireEvent.click(
+      $('va-button[label="Remove VAMC Location 2"]', container),
+    );
 
     const modal = await $('va-modal', container);
-    modal.__events.primaryButtonClick(); // Remove entry
+    await modal.__events.primaryButtonClick(); // Remove entry
 
     await waitFor(() => {
       expect(setFormData.called).to.be.true;
@@ -303,7 +304,9 @@ describe('<EvidenceSummary>', () => {
     const { container } = setupSummary({ setFormData });
 
     // remove second VA entry
-    fireEvent.click($('va-button[label="Remove VAMC Location 2"]', container));
+    await fireEvent.click(
+      $('va-button[label="Remove VAMC Location 2"]', container),
+    );
 
     const secondaryButton = $('va-button[secondary]', container);
     fireEvent.click(secondaryButton);
@@ -319,7 +322,9 @@ describe('<EvidenceSummary>', () => {
     const result = records().providerFacility[0];
 
     // remove second private entry
-    fireEvent.click($('va-button[label="Remove Private Hospital"]', container));
+    await fireEvent.click(
+      $('va-button[label="Remove Private Hospital"]', container),
+    );
 
     const modal = await $('va-modal', container);
     await modal.__events.primaryButtonClick(); // Remove entry
@@ -335,7 +340,9 @@ describe('<EvidenceSummary>', () => {
     const { container } = setupSummary({ setFormData });
 
     // remove second VA entry
-    fireEvent.click($('va-button[label="Remove Private Hospital"]', container));
+    await fireEvent.click(
+      $('va-button[label="Remove Private Hospital"]', container),
+    );
 
     const secondaryButton = $('va-button[secondary]', container);
     fireEvent.click(secondaryButton);
@@ -352,7 +359,9 @@ describe('<EvidenceSummary>', () => {
       limit: 'Pizza addiction',
     });
     // remove limitation
-    fireEvent.click($('va-button[label="Remove limitations"]', container));
+    await fireEvent.click(
+      $('va-button[label="Remove limitations"]', container),
+    );
 
     const modal = await $('va-modal', container);
     await modal.__events.primaryButtonClick(); // Remove entry
@@ -371,7 +380,9 @@ describe('<EvidenceSummary>', () => {
     });
 
     // remove second VA entry
-    fireEvent.click($('va-button[label="Remove limitations"]', container));
+    await fireEvent.click(
+      $('va-button[label="Remove limitations"]', container),
+    );
 
     const secondaryButton = $('va-button[secondary]', container);
     fireEvent.click(secondaryButton);
@@ -387,7 +398,7 @@ describe('<EvidenceSummary>', () => {
     const result = records().additionalDocuments[0];
 
     // remove second upload entry
-    fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
+    await fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
 
     const modal = await $('va-modal', container);
     await modal.__events.primaryButtonClick(); // Remove entry
@@ -405,7 +416,7 @@ describe('<EvidenceSummary>', () => {
     const { container } = setupSummary({ setFormData });
 
     // remove second VA entry
-    fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
+    await fireEvent.click($('va-button[label="Delete x-rays.pdf"]', container));
 
     const secondaryButton = $('va-button[secondary]', container);
     fireEvent.click(secondaryButton);
@@ -435,7 +446,7 @@ describe('<EvidenceSummary>', () => {
       updatePage: updateSpy,
     });
 
-    fireEvent.click($('.form-nav-buttons va-button', container));
+    await fireEvent.click($('.form-nav-buttons va-button', container));
     expect(updateSpy.called).to.be.true;
   });
 });

--- a/src/applications/appeals/995/tests/content/evidenceSummary.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/content/evidenceSummary.unit.spec.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import { content } from '../../content/evidenceSummary';
+import * as helpers from '../../../shared/utils/helpers';
 
 describe('evidenceSummary', () => {
   it('should render an h5 on the review page', () => {
-    global.window.location.href = '/review-and-submit';
+    const isOnReviewPageStub = sinon
+      .stub(helpers, 'isOnReviewPage')
+      .returns(true);
+
     const { getByRole } = render(<div>{content.addMoreLink()}</div>);
     expect(getByRole('heading').tagName).to.eq('H5');
+    isOnReviewPageStub.restore();
   });
 });

--- a/src/applications/appeals/995/tests/content/evidenceSummary.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/content/evidenceSummary.unit.spec.jsx
@@ -5,7 +5,7 @@ import { content } from '../../content/evidenceSummary';
 
 describe('evidenceSummary', () => {
   it('should render an h5 on the review page', () => {
-    window.location = { pathname: '/review-and-submit' };
+    global.window.location.href = '/review-and-submit';
     const { getByRole } = render(<div>{content.addMoreLink()}</div>);
     expect(getByRole('heading').tagName).to.eq('H5');
   });

--- a/src/applications/appeals/995/tests/pages/evidencePrivateLimitationRequest.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidencePrivateLimitationRequest.unit.spec.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-
+import sinon from 'sinon';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
 import { EVIDENCE_LIMIT } from '../../constants';
+import * as helpers from '../../../shared/utils/helpers';
 
 describe('Supplemental Claims private limitation request page', () => {
   const {
@@ -36,12 +36,16 @@ describe('Supplemental Claims private limitation request page', () => {
 
   it('should call updateUiSchema and updateSchema and return US phone patterns when checkbox is false', () => {
     const options = uiSchema[EVIDENCE_LIMIT]['ui:options'];
-    global.window.location.href = '/review-and-submit';
+    const isOnReviewPageStub = sinon
+      .stub(helpers, 'isOnReviewPage')
+      .returns(true);
 
     expect(options.updateUiSchema()).to.deep.equal({
       'ui:options': {
         labelHeaderLevel: 4,
       },
     });
+
+    isOnReviewPageStub.restore();
   });
 });

--- a/src/applications/appeals/995/tests/pages/evidencePrivateLimitationRequest.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidencePrivateLimitationRequest.unit.spec.jsx
@@ -36,7 +36,7 @@ describe('Supplemental Claims private limitation request page', () => {
 
   it('should call updateUiSchema and updateSchema and return US phone patterns when checkbox is false', () => {
     const options = uiSchema[EVIDENCE_LIMIT]['ui:options'];
-    window.location = { pathname: '/review-and-submit' };
+    global.window.location.href = '/review-and-submit';
 
     expect(options.updateUiSchema()).to.deep.equal({
       'ui:options': {

--- a/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
@@ -34,7 +33,7 @@ describe('Additional evidence upload', () => {
     expect($('input[type="file"]', container)).to.exist;
   });
 
-  it('should not submit without required upload', () => {
+  it('should not submit without required upload', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={uploadStore}>
@@ -51,11 +50,14 @@ describe('Additional evidence upload', () => {
     );
 
     fireEvent.submit($('form', container));
-    expect($$('.usa-input-error-message', container).length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+
+    await waitFor(() => {
+      expect($$('.usa-input-error-message', container).length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
-  it('should submit with uploaded form', () => {
+  it('should submit with uploaded form', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={uploadStore}>
@@ -84,13 +86,16 @@ describe('Additional evidence upload', () => {
     fireEvent.submit($('form', container));
     const content = container.textContent;
     const select = $('va-select[value="L049"]', container);
-    expect($('.usa-input-error-message', container)).to.not.exist;
-    expect(onSubmit.called).to.be.true;
-    expect(content).to.contain('test.pdf');
-    expect(content).to.contain('98KB');
-    expect(select).to.exist;
-    expect(select.getAttribute('message-aria-describedby')).to.eq(
-      'Choose a document type for test.pdf',
-    );
+
+    await waitFor(() => {
+      expect($('.usa-input-error-message', container)).to.not.exist;
+      expect(onSubmit.called).to.be.true;
+      expect(content).to.contain('test.pdf');
+      expect(content).to.contain('98KB');
+      expect(select).to.exist;
+      expect(select.getAttribute('message-aria-describedby')).to.eq(
+        'Choose a document type for test.pdf',
+      );
+    });
   });
 });

--- a/src/applications/appeals/995/tests/pages/facilityType.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/facilityType.unit.spec.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import readableList from 'platform/forms-system/src/js/utilities/data/readableList';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
 import {
   facilityTypeChoices,
@@ -17,7 +15,7 @@ import {
 describe('Supplemental Claims option for facility type page', () => {
   const { schema, uiSchema } = formConfig.chapters.evidence.pages.facilityTypes;
 
-  it('should render', () => {
+  it('should render', async () => {
     const onSubmitSpy = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -37,11 +35,13 @@ describe('Supplemental Claims option for facility type page', () => {
 
     fireEvent.click($('button[type="submit"]', container));
 
-    expect($('va-checkbox-group[error]', container)).to.exist;
-    expect(onSubmitSpy.called).to.be.false;
+    await waitFor(() => {
+      expect($('va-checkbox-group[error]', container)).to.exist;
+      expect(onSubmitSpy.called).to.be.false;
+    });
   });
 
-  it('should submit when a checkbox is checked', () => {
+  it('should submit when a checkbox is checked', async () => {
     const onSubmitSpy = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -56,11 +56,13 @@ describe('Supplemental Claims option for facility type page', () => {
 
     fireEvent.click($('button[type="submit"]', container));
 
-    expect($('va-checkbox-group[error]', container)).to.not.exist;
-    expect(onSubmitSpy.called).to.be.true;
+    await waitFor(() => {
+      expect($('va-checkbox-group[error]', container)).to.not.exist;
+      expect(onSubmitSpy.called).to.be.true;
+    });
   });
 
-  it('should submit when the "other" input is filled', () => {
+  it('should submit when the "other" input is filled', async () => {
     const onSubmitSpy = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -75,8 +77,10 @@ describe('Supplemental Claims option for facility type page', () => {
 
     fireEvent.click($('button[type="submit"]', container));
 
-    expect($('va-checkbox-group[error]', container)).to.not.exist;
-    expect(onSubmitSpy.called).to.be.true;
+    await waitFor(() => {
+      expect($('va-checkbox-group[error]', container)).to.not.exist;
+      expect(onSubmitSpy.called).to.be.true;
+    });
   });
 });
 

--- a/src/applications/appeals/995/tests/pages/housingRisk.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/housingRisk.unit.spec.jsx
@@ -32,7 +32,7 @@ describe('Supplemental Claims housing risk page', () => {
 
   // Increase test coverage
   it('should updateUiSchema for review page', () => {
-    window.location = { pathname: '/review-and-submit' };
+    global.window.location.href = '/review-and-submit';
     const result = uiSchema.housingRisk['ui:options'].updateUiSchema();
     expect(result).to.deep.equal({
       'ui:options': { labelHeaderLevel: 4 },

--- a/src/applications/appeals/995/tests/pages/housingRisk.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/housingRisk.unit.spec.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-
+import sinon from 'sinon';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
+import * as helpers from '../../../shared/utils/helpers';
 
 describe('Supplemental Claims housing risk page', () => {
   const { schema, uiSchema } = formConfig.chapters.infoPages.pages.housingRisk;
@@ -32,10 +32,14 @@ describe('Supplemental Claims housing risk page', () => {
 
   // Increase test coverage
   it('should updateUiSchema for review page', () => {
-    global.window.location.href = '/review-and-submit';
+    const isOnReviewPageStub = sinon
+      .stub(helpers, 'isOnReviewPage')
+      .returns(true);
+
     const result = uiSchema.housingRisk['ui:options'].updateUiSchema();
     expect(result).to.deep.equal({
       'ui:options': { labelHeaderLevel: 4 },
     });
+    isOnReviewPageStub.restore();
   });
 });

--- a/src/applications/appeals/995/tests/pages/livingSituation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/livingSituation.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('Supplemental Claims living situation page', () => {
   });
 
   it('should render an h4 on the review & submit page', () => {
-    window.location = { pathname: '/review-and-submit' };
+    global.window.location.href = '/review-and-submit';
     const { container } = render(
       <DefinitionTester
         definitions={{}}

--- a/src/applications/appeals/995/tests/pages/livingSituation.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/livingSituation.unit.spec.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { render, fireEvent, waitFor } from '@testing-library/react';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import readableList from 'platform/forms-system/src/js/utilities/data/readableList';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
-
 import {
   livingSituationList,
   livingSituationReviewField as ReviewField,
@@ -15,6 +13,7 @@ import {
   livingSituationChoicesShortened,
   livingSituationError,
 } from '../../content/livingSituation';
+import * as helpers from '../../../shared/utils/helpers';
 
 describe('Supplemental Claims living situation page', () => {
   const {
@@ -44,7 +43,10 @@ describe('Supplemental Claims living situation page', () => {
   });
 
   it('should render an h4 on the review & submit page', () => {
-    global.window.location.href = '/review-and-submit';
+    const isOnReviewPageStub = sinon
+      .stub(helpers, 'isOnReviewPage')
+      .returns(true);
+
     const { container } = render(
       <DefinitionTester
         definitions={{}}
@@ -64,6 +66,7 @@ describe('Supplemental Claims living situation page', () => {
     expect($('va-additional-info', container)).to.exist;
 
     expect($('button[type="submit"]', container)).to.exist;
+    isOnReviewPageStub.restore();
   });
 
   it('should prevent submission & show error if none & any other option selected', () => {

--- a/src/applications/appeals/995/tests/pages/optionForMst.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/optionForMst.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('Supplemental Claims option for MST page', () => {
 
   // Increase test coverage
   it('should updateUiSchema for review page', () => {
-    window.location = { pathname: '/review-and-submit' };
+    global.window.location.href = '/review-and-submit';
     const result = uiSchema[MST_OPTION]['ui:options'].updateUiSchema();
     expect(result).to.deep.equal({
       'ui:options': { labelHeaderLevel: 4 },

--- a/src/applications/appeals/995/tests/pages/optionForMst.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/optionForMst.unit.spec.jsx
@@ -2,12 +2,11 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
 import { MST_OPTION } from '../../constants';
+import * as helpers from '../../../shared/utils/helpers';
 
 describe('Supplemental Claims option for MST page', () => {
   const {
@@ -44,10 +43,14 @@ describe('Supplemental Claims option for MST page', () => {
 
   // Increase test coverage
   it('should updateUiSchema for review page', () => {
-    global.window.location.href = '/review-and-submit';
+    const isOnReviewPageStub = sinon
+      .stub(helpers, 'isOnReviewPage')
+      .returns(true);
+
     const result = uiSchema[MST_OPTION]['ui:options'].updateUiSchema();
     expect(result).to.deep.equal({
       'ui:options': { labelHeaderLevel: 4 },
     });
+    isOnReviewPageStub.restore();
   });
 });

--- a/src/applications/appeals/995/tests/pages/optionIndicator.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/optionIndicator.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('Supplemental Claims option for MST page', () => {
 
   // Increase test coverage
   it('should updateUiSchema for review page', () => {
-    window.location = { pathname: '/review-and-submit' };
+    global.window.location.href = '/review-and-submit';
     const result = uiSchema.optionIndicator['ui:options'].updateUiSchema();
     expect(result).to.deep.equal({
       'ui:options': { labelHeaderLevel: 4 },

--- a/src/applications/appeals/995/tests/pages/optionIndicator.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/optionIndicator.unit.spec.jsx
@@ -2,16 +2,15 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
 import {
   optionIndicatorLabel,
   optionIndicatorChoices,
   OptionIndicatorReviewField,
 } from '../../content/optionIndicator';
+import * as helpers from '../../../shared/utils/helpers';
 
 describe('Supplemental Claims option for MST page', () => {
   const {
@@ -48,11 +47,15 @@ describe('Supplemental Claims option for MST page', () => {
 
   // Increase test coverage
   it('should updateUiSchema for review page', () => {
-    global.window.location.href = '/review-and-submit';
+    const isOnReviewPageStub = sinon
+      .stub(helpers, 'isOnReviewPage')
+      .returns(true);
+
     const result = uiSchema.optionIndicator['ui:options'].updateUiSchema();
     expect(result).to.deep.equal({
       'ui:options': { labelHeaderLevel: 4 },
     });
+    isOnReviewPageStub.restore();
   });
 });
 

--- a/src/applications/appeals/995/tests/utils/focus.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/utils/focus.unit.spec.jsx
@@ -18,19 +18,31 @@ describe('focusEvidence', () => {
       </div>,
     );
 
-  it('should focus on header', async () => {
-    const { container } = await renderPage();
+  const renderPageWithError = () =>
+    render(
+      <div id="main">
+        <h3>Title</h3>
+        <div error="true" />
+        <div />
+      </div>,
+    );
 
-    await focusEvidence(null, container);
+  it('should focus on header', async () => {
+    const { container } = renderPage();
+
+    focusEvidence(null, container);
+
     await waitFor(() => {
       const target = $('h3', container);
       expect(document.activeElement).to.eq(target);
     });
   });
-  it('should focus on error', async () => {
-    const { container } = await renderPage(true);
 
-    await focusEvidence(null, container);
+  it('should focus on error', async () => {
+    const { container } = renderPageWithError();
+
+    focusEvidence(null, container);
+
     await waitFor(() => {
       const target = $('[error]', container);
       expect(document.activeElement).to.eq(target);

--- a/src/applications/appeals/995/tests/utils/focus.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/utils/focus.unit.spec.jsx
@@ -18,15 +18,6 @@ describe('focusEvidence', () => {
       </div>,
     );
 
-  const renderPageWithError = () =>
-    render(
-      <div id="main">
-        <h3>Title</h3>
-        <div error="true" />
-        <div />
-      </div>,
-    );
-
   it('should focus on header', async () => {
     const { container } = renderPage();
 
@@ -39,7 +30,7 @@ describe('focusEvidence', () => {
   });
 
   it('should focus on error', async () => {
-    const { container } = renderPageWithError();
+    const { container } = renderPage(true);
 
     focusEvidence(null, container);
 

--- a/src/applications/appeals/996/tests/pages/InformalConference.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/pages/InformalConference.unit.spec.jsx
@@ -48,6 +48,7 @@ describe('Higher-Level Review 0996 informal conference', () => {
     );
 
     fireEvent.submit($('form', container));
+
     waitFor(() => {
       expect($$('[error]', container).length).to.equal(0);
       expect(onSubmit.called).to.be.true;
@@ -55,7 +56,7 @@ describe('Higher-Level Review 0996 informal conference', () => {
   });
 
   /* Unsuccessful submits */
-  it('prevents submit when informal conference is not selected', () => {
+  it('prevents submit when informal conference is not selected', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={mockStore()}>
@@ -71,7 +72,10 @@ describe('Higher-Level Review 0996 informal conference', () => {
     );
 
     fireEvent.submit($('form', container));
-    expect($$('[error]', container).length).to.equal(1);
-    expect(onSubmit.called).not.to.be.true;
+
+    await waitFor(() => {
+      expect($$('[error]', container).length).to.equal(1);
+      expect(onSubmit.called).not.to.be.true;
+    });
   });
 });

--- a/src/applications/appeals/996/tests/pages/informalConferenceRep.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/pages/informalConferenceRep.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 import {
@@ -35,6 +35,7 @@ describe('HLR informal conference rep v2 page', () => {
 
     expect($$('va-text-input', container).length).to.equal(5);
   });
+
   it('should allow submit', () => {
     const onSubmit = sinon.spy();
     const { container } = render(
@@ -74,12 +75,16 @@ describe('HLR informal conference rep v2 page', () => {
       'x@x.com',
       '[name="root_informalConferenceRep_email"]',
     );
+
     fireEvent.submit($('form', container));
 
-    expect($$('[error]', container).length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
+    waitFor(() => {
+      expect($$('[error]', container).length).to.equal(0);
+      expect(onSubmit.called).to.be.true;
+    });
   });
-  it('should prevent continuing when data is missing', () => {
+
+  it('should prevent continuing when data is missing', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={mockStore()}>
@@ -95,9 +100,12 @@ describe('HLR informal conference rep v2 page', () => {
 
     fireEvent.submit($('form', container));
 
-    expect($$('[error]', container).length).to.equal(3);
-    expect(onSubmit.called).to.be.false;
+    await waitFor(() => {
+      expect($$('[error]', container).length).to.equal(3);
+      expect(onSubmit.called).to.be.false;
+    });
   });
+
   it('should prevent continuing when phone is missing', () => {
     const onSubmit = sinon.spy();
     const { container } = render(
@@ -122,9 +130,12 @@ describe('HLR informal conference rep v2 page', () => {
       'Sullivan',
       '[name="root_informalConferenceRep_lastName"]',
     );
+
     fireEvent.submit($('form', container));
 
-    expect($$('[error]', container).length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+    waitFor(() => {
+      expect($$('[error]', container).length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 });

--- a/src/applications/appeals/996/tests/pages/informalConferenceTime.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/pages/informalConferenceTime.unit.spec.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import sinon from 'sinon';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
-
 import { mockStore } from '../../../shared/tests/test-helpers';
 
 describe('HLR conference times page', () => {
@@ -33,7 +30,7 @@ describe('HLR conference times page', () => {
     expect($$('va-radio-option', container).length).to.equal(2);
   });
 
-  it('should allow submit', () => {
+  it('should allow submit', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={mockStore()}>
@@ -51,13 +48,17 @@ describe('HLR conference times page', () => {
       detail: { value: 'time0800to1200' },
     });
     $('va-radio', container).__events.vaValueChange(changeEvent);
+
     fireEvent.submit($('form', container));
-    expect($('.usa-input-error-message', container)).to.not.exist;
-    expect(onSubmit.called).to.be.true;
+
+    await waitFor(() => {
+      expect($('.usa-input-error-message', container)).to.not.exist;
+      expect(onSubmit.called).to.be.true;
+    });
   });
 
   // board option is required
-  it('should prevent continuing', () => {
+  it('should prevent continuing', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={mockStore()}>
@@ -73,7 +74,10 @@ describe('HLR conference times page', () => {
     );
 
     fireEvent.submit($('form', container));
-    expect($$('[error]', container).length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+
+    await waitFor(() => {
+      expect($$('[error]', container).length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 });

--- a/src/applications/appeals/996/tests/pages/informalConferenceTimeRep.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/pages/informalConferenceTimeRep.unit.spec.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import sinon from 'sinon';
-
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import formConfig from '../../config/form';
-
 import { mockStore } from '../../../shared/tests/test-helpers';
 
 describe('HLR conference times page', () => {
@@ -33,7 +30,7 @@ describe('HLR conference times page', () => {
     expect($$('va-radio-option', container).length).to.equal(2);
   });
 
-  it('should allow submit', () => {
+  it('should allow submit', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={mockStore()}>
@@ -51,13 +48,17 @@ describe('HLR conference times page', () => {
       detail: { value: 'time0800to1200' },
     });
     $('va-radio', container).__events.vaValueChange(changeEvent);
+
     fireEvent.submit($('form', container));
-    expect($('[error]', container)).to.not.exist;
-    expect(onSubmit.called).to.be.true;
+
+    await waitFor(() => {
+      expect($('[error]', container)).to.not.exist;
+      expect(onSubmit.called).to.be.true;
+    });
   });
 
   // board option is required
-  it('should prevent continuing', () => {
+  it('should prevent continuing', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <Provider store={mockStore()}>
@@ -73,7 +74,10 @@ describe('HLR conference times page', () => {
     );
 
     fireEvent.submit($('form', container));
-    expect($$('[error]', container).length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+
+    await waitFor(async () => {
+      expect($$('[error]', container).length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 });

--- a/src/applications/appeals/shared/components/ConfirmationDecisionReviews.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationDecisionReviews.jsx
@@ -31,7 +31,7 @@ export const ConfirmationDecisionReviews = ({
       if (alertRef?.current) {
         scrollTo('topScrollElement');
         // delay focus for Safari
-        waitForRenderThenFocus('#main h2', alertRef.current);
+        waitForRenderThenFocus('va-alert h2', alertRef.current);
       }
     },
     [alertRef],

--- a/src/applications/appeals/shared/components/FileField.jsx
+++ b/src/applications/appeals/shared/components/FileField.jsx
@@ -643,10 +643,10 @@ const FileField = props => {
       // review mode
       showButtons && (
         <div
-          id="upload-wrap"
-          className={
-            showUpload ? 'vads-u-margin-bottom--2' : 'vads-u-display--none'
-          }
+          className={classNames('upload-wrap', {
+            'vads-u-margin-bottom--2': showUpload,
+            'vads-u-display--none': !showUpload,
+          })}
         >
           {/* eslint-disable jsx-a11y/label-has-associated-control */}
           <label

--- a/src/applications/appeals/shared/content/submissionError.jsx
+++ b/src/applications/appeals/shared/content/submissionError.jsx
@@ -11,7 +11,7 @@ const SubmissionError = ({ form }) => {
   useEffect(
     () => {
       if (alertRef?.current) {
-        scrollTo(alertRef.current);
+        scrollTo('.submission-error');
         focusElement('h3', {}, alertRef.current);
       }
     },
@@ -33,7 +33,7 @@ const SubmissionError = ({ form }) => {
       ref={alertRef}
       id="submission-error"
       status="error"
-      class="vads-u-margin-y--2"
+      class="submission-error vads-u-margin-y--2"
       uswds
     >
       <h3 slot="headline">Your decision review request didn’t go through</h3>

--- a/src/applications/appeals/shared/content/submissionError.jsx
+++ b/src/applications/appeals/shared/content/submissionError.jsx
@@ -11,7 +11,7 @@ const SubmissionError = ({ form }) => {
   useEffect(
     () => {
       if (alertRef?.current) {
-        scrollTo('.submission-error');
+        scrollTo(alertRef.current);
         focusElement('h3', {}, alertRef.current);
       }
     },
@@ -33,7 +33,7 @@ const SubmissionError = ({ form }) => {
       ref={alertRef}
       id="submission-error"
       status="error"
-      class="submission-error vads-u-margin-y--2"
+      class="vads-u-margin-y--2"
       uswds
     >
       <h3 slot="headline">Your decision review request didn’t go through</h3>

--- a/src/applications/appeals/shared/tests/components/ConfirmationDecisionReviews.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationDecisionReviews.unit.spec.jsx
@@ -146,7 +146,7 @@ describe('Confirmation page', () => {
     expect($$('span.dd-privacy-hidden', container).length).to.eq(1);
   });
 
-  it('should focus on H2 inside va-alert', () => {
+  it('should focus on H2 inside va-alert', async () => {
     const { container } = render(
       <Provider store={mockStore(getData())}>
         <main id="main">
@@ -156,7 +156,7 @@ describe('Confirmation page', () => {
     );
     const h2 = $('va-alert h2', container);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(document.activeElement).to.eq(h2);
     });
   });

--- a/src/applications/appeals/shared/tests/components/ConfirmationDecisionReviews.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationDecisionReviews.unit.spec.jsx
@@ -4,9 +4,7 @@ import { expect } from 'chai';
 import { render, waitFor } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-
 import ConfirmationDecisionReviews from '../../components/ConfirmationDecisionReviews';
 import { parseDate } from '../../utils/dates';
 import { SELECTED, FORMAT_READABLE_DATE_FNS } from '../../constants';
@@ -66,6 +64,7 @@ describe('Confirmation page', () => {
       </Provider>,
     );
     const alert = $('va-alert[status="success"]', container);
+
     expect(alert).to.exist;
     expect(alert.innerHTML).to.contain('successfully requested a snack');
 
@@ -99,6 +98,7 @@ describe('Confirmation page', () => {
       'Foo Man Choo, Esq.',
     );
   });
+
   it('should render the user name without suffix', () => {
     const { container } = render(
       <Provider store={mockStore(getData({ suffix: '' }))}>
@@ -109,6 +109,7 @@ describe('Confirmation page', () => {
       'Foo Man Choo',
     );
   });
+
   it('should not render the user name', () => {
     const { container } = render(
       <Provider store={mockStore(getData({ renderName: false }))}>
@@ -132,6 +133,7 @@ describe('Confirmation page', () => {
     );
     expect($('va-summary-box', container).innerHTML).to.contain(date);
   });
+
   it('should render the selected contested issue', () => {
     const { container } = render(
       <Provider store={mockStore(getData())}>
@@ -143,7 +145,8 @@ describe('Confirmation page', () => {
     expect(list.textContent).not.to.contain('test 987');
     expect($$('span.dd-privacy-hidden', container).length).to.eq(1);
   });
-  it('should focus on H2 inside va-alert', async () => {
+
+  it('should focus on H2 inside va-alert', () => {
     const { container } = render(
       <Provider store={mockStore(getData())}>
         <main id="main">
@@ -152,7 +155,8 @@ describe('Confirmation page', () => {
       </Provider>,
     );
     const h2 = $('va-alert h2', container);
-    await waitFor(() => {
+
+    waitFor(() => {
       expect(document.activeElement).to.eq(h2);
     });
   });
@@ -170,11 +174,13 @@ describe('Confirmation page', () => {
         data: {},
       },
     });
+
     const { container } = render(
       <Provider store={mockStore(getEmptyData())}>
         <ConfirmationDecisionReviews />
       </Provider>,
     );
+
     expect($('va-alert', container)).to.exist;
     expect($('va-summary-box', container)).to.exist;
   });

--- a/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 import {
@@ -671,7 +671,7 @@ describe('Schemaform <FileField>', () => {
       />,
     );
 
-    expect($('#upload-wrap', container).className).to.include('display--none');
+    expect($('.upload-wrap', container).className).to.include('display--none');
   });
 
   it('should not render upload or delete button on review & submit page while in review mode', () => {

--- a/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
 import {

--- a/src/applications/appeals/shared/tests/utils/focus.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/utils/focus.unit.spec.jsx
@@ -150,7 +150,7 @@ describe('focusCancelButton', () => {
             )}
           </li>
         </ul>
-        <div id="upload-wrap">
+        <div className="upload-wrap">
           <va-button
             id="upload-button"
             secondary
@@ -352,7 +352,7 @@ describe('focusAddAnotherButton', () => {
       <div id="main">
         <h3>Title</h3>
         <ul className="schemaform-file-list" />
-        <div id="upload-wrap">
+        <div className="upload-wrap">
           {showButton && (
             <va-button
               id="upload-button"

--- a/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.jsx
@@ -183,9 +183,9 @@ describe('focusEvidence', () => {
   });
 
   it('should focus on error', async () => {
-    const { container } = await renderPage();
+    const { container } = await renderPage(true);
 
-    focusEvidence(null, container);
+    await focusEvidence(null, container);
 
     await waitFor(() => {
       const target = $('[error]', container);

--- a/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.jsx
@@ -181,10 +181,12 @@ describe('focusEvidence', () => {
       expect(document.activeElement).to.eq(target);
     });
   });
-  it('should focus on error', async () => {
-    const { container } = await renderPage(true);
 
-    await focusEvidence(null, container);
+  it('should focus on error', async () => {
+    const { container } = await renderPage();
+
+    focusEvidence(null, container);
+
     await waitFor(() => {
       const target = $('[error]', container);
       expect(document.activeElement).to.eq(target);

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -100,7 +100,6 @@ export const focusAddAnotherButton = root => {
   // Add a timeout to allow for the upload button to reappear in the DOM
   // before trying to focus on it
   setTimeout(() => {
-    // scrollTo($('#upload-wrap', root));
     scrollTo('.upload-wrap');
     // focus on upload button, not the label
     focusElement(

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -100,7 +100,8 @@ export const focusAddAnotherButton = root => {
   // Add a timeout to allow for the upload button to reappear in the DOM
   // before trying to focus on it
   setTimeout(() => {
-    scrollTo($('#upload-wrap', root));
+    // scrollTo($('#upload-wrap', root));
+    scrollTo('.upload-wrap');
     // focus on upload button, not the label
     focusElement(
       // including `#upload-button` because RTL can't access the shadowRoot


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Preemptively update failing unit tests against the `node-22-dev-branch` so these will be forward-compatible.

Guide for teams updating unit tests is [here](https://depo-platform-documentation.scrollhelp.site/developer-docs/guide-for-vfs-teams-to-update-tests-for-node-22).

I did drop the changes into that branch and be sure everything passed, but they changed the way the test output looks so I would have to get quite a few screenshots to prove that everything passed (example below):

<img width="600" alt="Screenshot 2025-06-25 at 5 08 52 PM" src="https://github.com/user-attachments/assets/c89b415c-e228-4e95-bb3b-040a5da8781b" />

On this branch, the same command has more consolidated output:

<img width="600" alt="Screenshot 2025-06-25 at 5 11 23 PM" src="https://github.com/user-attachments/assets/ba4e9974-0035-4ac7-8972-63250c4baf73" />


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111799

## Testing done

- Ran all the unit tests locally (and in CI) on this branch ✅ 
- Ran all the unit tests locally on the `node-22-dev-branch` ✅ 