### PR TITLE
Add optometry filter

### DIFF
--- a/src/applications/vaos/referral-appointments/ReferralsAndRequests.jsx
+++ b/src/applications/vaos/referral-appointments/ReferralsAndRequests.jsx
@@ -9,6 +9,7 @@ import { getRequestedAppointmentListInfo } from '../redux/selectors';
 import RequestList from './components/RequestsList';
 import { useGetPatientReferralsQuery } from '../redux/api/vaosApi';
 import { FETCH_STATUS } from '../utils/constants';
+import { filterReferrals } from './utils/referrals';
 
 export default function ReferralsAndRequests() {
   const dispatch = useDispatch();
@@ -47,6 +48,8 @@ export default function ReferralsAndRequests() {
     );
   }
 
+  const filteredReferrals = filterReferrals(referrals || []);
+
   if (referralError && appointmentError) {
     return (
       <ReferralLayout>
@@ -76,7 +79,10 @@ export default function ReferralsAndRequests() {
           text="Find out more about community care referrals"
         />
       </p>
-      <ReferralList referrals={referrals} referralsError={!!referralError} />
+      <ReferralList
+        referrals={filteredReferrals}
+        referralsError={!!referralError}
+      />
       <h2>Active requests</h2>
       <p className="vaos-hide-for-print">
         We’ll contact you to finish scheduling these appointments.

--- a/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.jsx
@@ -13,7 +13,10 @@ describe('VAOS referral generator', () => {
   describe('createReferrals', () => {
     it('Create specified number of referrals', () => {
       const referrals = referralUtil.createReferrals(2);
-      // There are currently 4 error referrals appended to the array so this is 6
+      expect(referrals.length).to.equal(2);
+    });
+    it('Creates referrals with extra error referrals when specified', () => {
+      const referrals = referralUtil.createReferrals(2, null, null, true);
       expect(referrals.length).to.equal(6);
     });
     it('Creates each referral on day later', () => {
@@ -36,14 +39,25 @@ describe('VAOS referral generator', () => {
       null,
       'non-physical-therapy',
     );
+    const missingCategoryReferral = referralUtil.createReferralById(
+      '2024-10-30',
+      'uid2',
+      '111',
+      null,
+      null,
+    );
 
-    referrals = [nonPhysicalTherapyReferral, ...referrals];
-    // TODO: add this back for production
-    it.skip('Filters out non-physical therapy referrals', () => {
+    referrals = [
+      nonPhysicalTherapyReferral,
+      missingCategoryReferral,
+      ...referrals,
+    ];
+
+    it('Filters out non-physical therapy referrals', () => {
       const filteredReferrals = referralUtil.filterReferrals(referrals);
       expect(filteredReferrals.length).to.equal(1);
       expect(filteredReferrals[0].attributes.categoryOfCare).to.equal(
-        'Physical Therapy',
+        'OPTOMETRY',
       );
     });
   });

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -115,6 +115,7 @@ const createReferrals = (
   numberOfReferrals = 3,
   baseDate,
   numberOfExpiringReferrals = 0,
+  includeErrorReferrals = false,
 ) => {
   // create a date object for today that is not affected by the time zone
   const dateOjbect = baseDate ? new Date(baseDate) : new Date();
@@ -144,8 +145,11 @@ const createReferrals = (
       ),
     );
   }
+  if (includeErrorReferrals) {
+    return [...referrals, ...errorReferralsList];
+  }
 
-  return [...referrals, ...errorReferralsList];
+  return [...referrals];
 };
 
 /**
@@ -169,7 +173,8 @@ const filterReferrals = referrals => {
   }
 
   return referrals.filter(
-    referral => referral.attributes.categoryOfCare === 'Physical Therapy',
+    referral =>
+      referral.attributes.categoryOfCare?.toLowerCase() === 'optometry',
   );
 };
 

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -401,7 +401,7 @@ const responses = {
   },
   'GET /vaos/v2/referrals': (req, res) => {
     return res.json({
-      data: referralUtils.createReferrals(4),
+      data: referralUtils.createReferrals(4, null, null, true),
     });
   },
   'GET /vaos/v2/referrals/:referralId': (req, res) => {

--- a/src/applications/vaos/tests/fixtures/MockReferralListResponse.js
+++ b/src/applications/vaos/tests/fixtures/MockReferralListResponse.js
@@ -27,7 +27,7 @@ class MockReferralListResponse {
     id = `referral-${Math.random()
       .toString(36)
       .substring(2, 10)}`,
-    categoryOfCare = 'Physical Therapy',
+    categoryOfCare = 'OPTOMETRY',
     referralNumber = `VA${Math.floor(1000 + Math.random() * 9000)}`,
     expirationDate = format(addMonths(new Date(), 6), 'yyyy-MM-dd'),
   } = {}) {
@@ -55,19 +55,19 @@ class MockReferralListResponse {
     return [
       MockReferralListResponse.createReferral({
         id: 'PmDYsBz-egEtG13flMnHUQ==',
-        categoryOfCare: 'Physical Therapy',
+        categoryOfCare: 'OPTOMETRY',
         referralNumber: 'VA0000005682',
         expirationDate: format(addMonths(today, 2), formatStr),
       }),
       MockReferralListResponse.createReferral({
         id: 'oSI3vEVkzuR-JJomdWA6Fw==',
-        categoryOfCare: 'Physical Therapy',
+        categoryOfCare: 'OPTOMETRY',
         referralNumber: 'VA0000006569',
         expirationDate: format(addMonths(today, 6), formatStr),
       }),
       MockReferralListResponse.createReferral({
         id: 'add2f0f4-a1ea-4dea-a504-a54ab57c6801',
-        categoryOfCare: 'Physical Therapy',
+        categoryOfCare: 'OPTOMETRY',
         referralNumber: 'VA0000007123',
         expirationDate: format(addMonths(today, 5), formatStr),
       }),


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds the optometry filter back in

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111449

## Testing done

- Check list of referrals they should all be optometry
- If you change the filter to check against something other than optometry it should show no referrals

- _Describe what the old behavior was prior to the change

## What areas of the site does it impact?

Community Care Direct Scheduling

http://localhost:3001/my-health/appointments/referrals-requests

## Acceptance criteria

- [ ] Filter works as intended

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
