### PR TITLE
Remove va_online_scheduling_fe_source_of_truth_cc feature toggle

### DIFF
--- a/src/applications/vaos/appointment-list/pages/RequestedAppointmentDetailsPage/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/RequestedAppointmentDetailsPage/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -122,50 +122,19 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     });
   });
 
-  it('should display CC document title, vaOnlineSchedulingFeSourceOfTruthCC=false', async () => {
-    // Arrange
-    const response = MockAppointmentResponse.createCCResponse();
-    response
-      .setStatus(APPOINTMENT_STATUS.proposed)
-      .setPending(true)
-      .setTypeOfCare('audiology-hearing aid support');
-
-    mockAppointmentApi({ response });
-
-    // Act
-    renderWithStoreAndRouter(<AppointmentList />, {
-      initialState,
-      path: `/pending/${response.id}`,
-    });
-
-    // Assert
-    await waitFor(() => {
-      expect(global.document.title).to.equal(
-        `Pending Request For Community Care Appointment | Veterans Affairs`,
-      );
-    });
-  });
-
-  it('should display CC document title, vaOnlineSchedulingFeSourceOfTruthCC=true', async () => {
+  it('should display CC document title', async () => {
     // Arrange
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.proposed,
     })
       .setKind('cc')
-      .setStatus(APPOINTMENT_STATUS.proposed)
       .setPending(true);
 
     mockAppointmentApi({ response });
 
     // Act
     renderWithStoreAndRouter(<AppointmentList />, {
-      initialState: {
-        ...initialState,
-        featureToggles: {
-          ...initialState.featureToggles,
-          vaOnlineSchedulingFeSourceOfTruthCC: true,
-        },
-      },
+      initialState,
       path: `/pending/${response.id}`,
     });
 
@@ -360,13 +329,14 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
       const response = new MockAppointmentResponse({
         status: APPOINTMENT_STATUS.proposed,
         pending: true,
-      });
+      }).setType('COMMUNITY_CARE_REQUEST');
       const canceledResponse = MockAppointmentResponse.createCCResponse();
       canceledResponse
         .setCancelationReason('pat')
         .setRequestedPeriods(requestedPeriods)
         .setStatus(APPOINTMENT_STATUS.cancelled)
-        .setPending(true);
+        .setPending(true)
+        .setType('COMMUNITY_CARE_REQUEST');
 
       mockAppointmentApi({ response });
 

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -5,7 +5,6 @@ import { format } from 'date-fns';
 import { selectPatientFacilities } from '@department-of-veterans-affairs/platform-user/cerner-dsot/selectors';
 import {
   selectFeatureCCDirectScheduling,
-  selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthVA,
   selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
@@ -93,7 +92,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
   return async (dispatch, getState) => {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
       state,
@@ -139,7 +137,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
           startDate: format(startDate, 'yyyy-MM-dd'), // Start 30 days in the past for canceled appointments
           endDate: format(endDate, 'yyyy-MM-dd'),
           includeEPS,
-          useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
@@ -157,7 +154,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             startDate: format(requestStartDate, 'yyyy-MM-dd'), // Start 120 days in the past for requests
             endDate: format(requestEndDate, 'yyyy-MM-dd'), // End 1 day in the future for requests
             includeEPS,
-            useFeSourceOfTruthCC,
             useFeSourceOfTruthVA,
             useFeSourceOfTruthModality,
             useFeSourceOfTruthTelehealth,
@@ -260,7 +256,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
   return async (dispatch, getState) => {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
       state,
@@ -290,7 +285,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
         avs: true,
         fetchClaimStatus: true,
         includeEPS,
-        useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -342,7 +336,6 @@ export function fetchRequestDetails(id) {
   return async (dispatch, getState) => {
     try {
       const state = getState();
-      const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
       const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
       const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
         state,
@@ -367,7 +360,6 @@ export function fetchRequestDetails(id) {
       if (!request) {
         request = await fetchRequestById({
           id,
-          useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
@@ -404,7 +396,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
   return async (dispatch, getState) => {
     try {
       const state = getState();
-      const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
       const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
       const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
         state,
@@ -432,7 +423,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
         appointment = await fetchBookedAppointment({
           id,
           type,
-          useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
@@ -497,7 +487,6 @@ export function confirmCancelAppointment() {
   return async (dispatch, getState) => {
     const state = getState();
     const appointment = state.appointments.appointmentToCancel;
-    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
       state,
@@ -513,7 +502,6 @@ export function confirmCancelAppointment() {
 
       const updatedAppointment = await cancelAppointment({
         appointment,
-        useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -9,7 +9,6 @@ import { startOfMonth, endOfMonth, format, isAfter } from 'date-fns';
 
 import {
   selectSystemIds,
-  selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthVA,
   selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
@@ -384,7 +383,6 @@ export function prefillContactInfo() {
 export function confirmAppointment(history) {
   return async (dispatch, getState) => {
     const state = getState();
-    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
       state,
@@ -410,7 +408,6 @@ export function confirmAppointment(history) {
     try {
       const appointment = await createAppointment({
         appointment: transformFormToVAOSAppointment(getState()),
-        useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -18,7 +18,6 @@ import {
 } from '../../redux/actions';
 import { selectTypeOfCarePage } from '../../redux/selectors';
 import {
-  selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
   selectFeatureFeSourceOfTruthVA,
@@ -35,9 +34,6 @@ const pageKey = 'typeOfCare';
 
 export default function TypeOfCarePage() {
   const pageTitle = useSelector(state => getPageTitle(state, pageKey));
-  const useFeSourceOfTruthCC = useSelector(state =>
-    selectFeatureFeSourceOfTruthCC(state),
-  );
   const useFeSourceOfTruthVA = useSelector(state =>
     selectFeatureFeSourceOfTruthVA(state),
   );
@@ -159,7 +155,6 @@ export default function TypeOfCarePage() {
             // and returns the previous promise if it eixsts
             if (showDirectScheduling) {
               getLongTermAppointmentHistoryV2(
-                useFeSourceOfTruthCC,
                 useFeSourceOfTruthVA,
                 useFeSourceOfTruthModality,
                 useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -16,7 +16,6 @@ import {
 import {
   selectFeatureCommunityCare,
   selectFeatureDirectScheduling,
-  selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
   selectFeatureFeSourceOfTruthVA,
@@ -319,7 +318,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
     const state = getState();
     const directSchedulingEnabled = selectFeatureDirectScheduling(state);
     const typeOfCare = getTypeOfCare(getState().newAppointment.data);
-    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
       state,
@@ -349,7 +347,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
             location,
             typeOfCare,
             directSchedulingEnabled,
-            useFeSourceOfTruthCC,
             useFeSourceOfTruthVA,
             useFeSourceOfTruthModality,
             useFeSourceOfTruthTelehealth,
@@ -386,7 +383,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
           location,
           typeOfCare,
           directSchedulingEnabled,
-          useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
@@ -855,7 +851,6 @@ export function checkCommunityCareEligibility() {
 export function submitAppointmentOrRequest(history) {
   return async (dispatch, getState) => {
     const state = getState();
-    const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
     const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
     const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
       state,
@@ -888,7 +883,6 @@ export function submitAppointmentOrRequest(history) {
         let appointment = null;
         appointment = await createAppointment({
           appointment: transformFormToVAOSAppointment(getState()),
-          useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
@@ -979,7 +973,6 @@ export function submitAppointmentOrRequest(history) {
 
         const requestData = await createAppointment({
           appointment: requestBody,
-          useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/redux/actions.js
+++ b/src/applications/vaos/redux/actions.js
@@ -7,7 +7,6 @@ import { GA_PREFIX } from '../utils/constants';
 import { captureError } from '../utils/error';
 import {
   selectFeatureCCDirectScheduling,
-  selectFeatureFeSourceOfTruthCC,
   selectFeatureFeSourceOfTruthVA,
   selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
@@ -45,7 +44,6 @@ export function fetchPendingAppointments() {
 
       const state = getState();
       const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-      const useFeSourceOfTruthCC = selectFeatureFeSourceOfTruthCC(state);
       const useFeSourceOfTruthVA = selectFeatureFeSourceOfTruthVA(state);
       const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
         state,
@@ -67,7 +65,6 @@ export function fetchPendingAppointments() {
           .add(2, 'days')
           .format('YYYY-MM-DD'),
         includeEPS,
-        useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -87,9 +87,6 @@ export const selectFeatureRemovePodiatry = state =>
 export const selectFeatureFeSourceOfTruthVA = state =>
   toggleValues(state).vaOnlineSchedulingFeSourceOfTruthVA;
 
-export const selectFeatureFeSourceOfTruthCC = state =>
-  toggleValues(state).vaOnlineSchedulingFeSourceOfTruthCC;
-
 export const selectFeatureFeSourceOfTruthModality = state =>
   toggleValues(state).vaOnlineSchedulingFeSourceOfTruthModality;
 

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -67,7 +67,6 @@ function apptRequestSort(a, b) {
  * @param {String} endDate Date in YYYY-MM-DD format
  * @param {Boolean} fetchClaimStatus Boolean to fetch travel claim data
  * @param {Boolean} includeEPS Boolean to include EPS appointments
- * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
  * @param {Boolean} useFeSourceOfTruthTelehealth whether to use vets-api payload as the FE source of truth for appointment telehealth modality
@@ -79,7 +78,6 @@ export async function fetchAppointments({
   avs = false,
   fetchClaimStatus = false,
   includeEPS = false,
-  useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
   useFeSourceOfTruthTelehealth = false,
@@ -98,9 +96,9 @@ export async function fetchAppointments({
     const filteredAppointments = allAppointments.data.filter(appt => {
       // Filter out appointments that are not VA or CC appointments
       return (
-        getAppointmentType(appt, useFeSourceOfTruthCC, useFeSourceOfTruthVA) ===
+        getAppointmentType(appt, useFeSourceOfTruthVA) ===
           APPOINTMENT_TYPES.vaAppointment ||
-        getAppointmentType(appt, useFeSourceOfTruthCC, useFeSourceOfTruthVA) ===
+        getAppointmentType(appt, useFeSourceOfTruthVA) ===
           APPOINTMENT_TYPES.ccAppointment
       );
     });
@@ -108,7 +106,6 @@ export async function fetchAppointments({
     appointments.push(
       ...transformVAOSAppointments(
         filteredAppointments,
-        useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -136,7 +133,6 @@ export async function fetchAppointments({
  * @param {String} startDate Date in YYYY-MM-DD format
  * @param {String} endDate Date in YYYY-MM-DD format
  * @param {Boolean} includeEPS Boolean to include EPS appointments
- * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
  * @param {Boolean} useFeSourceOfTruthTelehealth whether to use vets-api payload as the FE source of truth for appointment telehealth modality
@@ -146,7 +142,6 @@ export async function getAppointmentRequests({
   startDate,
   endDate,
   includeEPS = false,
-  useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
   useFeSourceOfTruthTelehealth = false,
@@ -168,7 +163,6 @@ export async function getAppointmentRequests({
 
     const transformRequests = transformVAOSAppointments(
       requestsWithoutAppointments,
-      useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
       useFeSourceOfTruthTelehealth,
@@ -194,7 +188,6 @@ export async function getAppointmentRequests({
  * @export
  * @async
  * @param {string} id Appointment request id
- * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
  * @param {Boolean} useFeSourceOfTruthTelehealth whether to use vets-api payload as the FE source of truth for appointment telehealth modality
@@ -202,7 +195,6 @@ export async function getAppointmentRequests({
  */
 export async function fetchRequestById({
   id,
-  useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
   useFeSourceOfTruthTelehealth = false,
@@ -212,7 +204,6 @@ export async function fetchRequestById({
 
     return transformVAOSAppointment(
       appointment,
-      useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
       useFeSourceOfTruthTelehealth,
@@ -233,7 +224,6 @@ export async function fetchRequestById({
  * @param {string} id MAS or community care booked appointment id
  * @param {avs} Boolean to fetch avs data
  * @param {fetchClaimStatus} Boolean to fetch travel claim data
- * @param {Boolean} useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
  * @param {Boolean} useFeSourceOfTruthTelehealth whether to use vets-api payload as the FE source of truth for appointment telehealth modality
@@ -243,7 +233,6 @@ export async function fetchBookedAppointment({
   id,
   avs = true,
   fetchClaimStatus = true,
-  useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
   useFeSourceOfTruthTelehealth = false,
@@ -252,7 +241,6 @@ export async function fetchBookedAppointment({
     const appointment = await getAppointment(id, avs, fetchClaimStatus);
     return transformVAOSAppointment(
       appointment,
-      useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
       useFeSourceOfTruthTelehealth,
@@ -570,7 +558,6 @@ export function groupAppointmentsByMonth(appointments) {
  * @export
  * @param {Object} params
  * @param {VAOSAppointment} params.appointment The appointment to send
- * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
  * @param {Boolean} params.useFeSourceOfTruthTelehealth whether to use vets-api payload as the FE source of truth for appointment telehealth modality
@@ -578,7 +565,6 @@ export function groupAppointmentsByMonth(appointments) {
  */
 export async function createAppointment({
   appointment,
-  useFeSourceOfTruthCC,
   useFeSourceOfTruthVA,
   useFeSourceOfTruthModality,
   useFeSourceOfTruthTelehealth,
@@ -587,7 +573,6 @@ export async function createAppointment({
 
   return transformVAOSAppointment(
     result,
-    useFeSourceOfTruthCC,
     useFeSourceOfTruthVA,
     useFeSourceOfTruthModality,
     useFeSourceOfTruthTelehealth,
@@ -602,7 +587,6 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  * @export
  * @param {Object} params
  * @param {Appointment} params.appointment The appointment to cancel
- * @param {Boolean} params.useFeSourceOfTruthCC whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthVA whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {Boolean} params.useFeSourceOfTruthModality whether to use vets-api payload as the FE source of truth for appointment modality
  * @param {Boolean} params.useFeSourceOfTruthTelehealth whether to use vets-api payload as the FE source of truth for appointment telehealth modality
@@ -610,7 +594,6 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  */
 export async function cancelAppointment({
   appointment,
-  useFeSourceOfTruthCC,
   useFeSourceOfTruthVA,
   useFeSourceOfTruthModality,
   useFeSourceOfTruthTelehealth,
@@ -641,7 +624,6 @@ export async function cancelAppointment({
 
     return transformVAOSAppointment(
       updatedAppointment,
-      useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
       useFeSourceOfTruthTelehealth,
@@ -829,7 +811,6 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
   let promise = null;
 
   return (
-    useFeSourceOfTruthCC,
     useFeSourceOfTruthVA,
     useFeSourceOfTruthModality,
     useFeSourceOfTruthTelehealth,
@@ -867,7 +848,6 @@ export const getLongTermAppointmentHistoryV2 = ((chunks = 1) => {
         const p1 = await fetchAppointments({
           startDate: curr.start,
           endDate: curr.end,
-          useFeSourceOfTruthCC,
           useFeSourceOfTruthVA,
           useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -10,11 +10,7 @@ import {
 } from '../../utils/constants';
 import { transformFacilityV2 } from '../location/transformers';
 
-export function getAppointmentType(
-  appt,
-  useFeSourceOfTruthCC,
-  useFeSourceOfTruthVA,
-) {
+export function getAppointmentType(appt, useFeSourceOfTruthVA) {
   // TODO: Update APPOINTMENT_TYPES enum to match API response values.
   const isCerner = appt?.id?.startsWith('CERN');
 
@@ -28,13 +24,11 @@ export function getAppointmentType(
     }
   }
 
-  if (useFeSourceOfTruthCC) {
-    if (appt?.type === 'COMMUNITY_CARE_APPOINTMENT') {
-      return APPOINTMENT_TYPES.ccAppointment;
-    }
-    if (appt?.type === 'COMMUNITY_CARE_REQUEST') {
-      return APPOINTMENT_TYPES.ccRequest;
-    }
+  if (appt?.type === 'COMMUNITY_CARE_APPOINTMENT') {
+    return APPOINTMENT_TYPES.ccAppointment;
+  }
+  if (appt?.type === 'COMMUNITY_CARE_REQUEST') {
+    return APPOINTMENT_TYPES.ccRequest;
   }
 
   if (isCerner && isEmpty(appt?.end)) {
@@ -91,24 +85,17 @@ function getAtlasLocation(appt) {
 
 export function transformVAOSAppointment(
   appt,
-  useFeSourceOfTruthCC,
   useFeSourceOfTruthVA,
   useFeSourceOfTruthModality,
   useFeSourceOfTruthTelehealth,
 ) {
-  const appointmentType = getAppointmentType(
-    appt,
-    useFeSourceOfTruthCC,
-    useFeSourceOfTruthVA,
-  );
+  const appointmentType = getAppointmentType(appt, useFeSourceOfTruthVA);
   const isCerner = appt?.id?.startsWith('CERN');
   const isCC = appt.kind === 'cc';
   const isPast = appt.past;
   const isRequest = appt.pending;
   const isUpcoming = appt.future;
-  const isCCRequest = useFeSourceOfTruthCC
-    ? appointmentType === APPOINTMENT_TYPES.ccRequest
-    : isCC && isRequest;
+  const isCCRequest = appointmentType === APPOINTMENT_TYPES.ccRequest;
   const providers = appt.practitioners;
   const start = moment(appt.localStartTime, 'YYYY-MM-DDTHH:mm:ss');
   const serviceCategoryName = appt.serviceCategory?.[0]?.text;
@@ -324,7 +311,6 @@ export function transformVAOSAppointment(
 
 export function transformVAOSAppointments(
   appts,
-  useFeSourceOfTruthCC,
   useFeSourceOfTruthVA,
   useFeSourceOfTruthModality,
   useFeSourceOfTruthTelehealth,
@@ -332,7 +318,6 @@ export function transformVAOSAppointments(
   return appts.map(appt =>
     transformVAOSAppointment(
       appt,
-      useFeSourceOfTruthCC,
       useFeSourceOfTruthVA,
       useFeSourceOfTruthModality,
       useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('getAppointmentType util', () => {
     const appointment = {
       id: 'CERN123',
     };
-    const result = getAppointmentType(appointment, false, false);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('request');
   });
   it('should return appointment type as vaAppointment for cerner appointment', async () => {
@@ -19,45 +19,23 @@ describe('getAppointmentType util', () => {
       id: 'CERN123',
       end: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment, false, false);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('vaAppointment');
   });
-  it('should return appointment type as ccAppointment, useFeSourceOfTruthCC=false', async () => {
-    const appointment = {
-      id: '123',
-      kind: 'cc',
-      start: '2021-08-31T17:00:00Z',
-    };
-    const result = getAppointmentType(appointment, false, false);
-    expect(result).to.equal('ccAppointment');
-  });
-  it('should return appointment type as ccAppointment, useFeSourceOfTruthCC=true', async () => {
+  it('should return appointment type as ccAppointment', async () => {
     const appointment = {
       id: '123',
       type: 'COMMUNITY_CARE_APPOINTMENT',
     };
-    const result = getAppointmentType(appointment, true, false);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('ccAppointment');
   });
-  it('should return appointment type as ccRequest, useFeSourceOfTruthCC=false', async () => {
-    const appointment = {
-      id: '123',
-      kind: 'cc',
-      requestedPeriods: [
-        {
-          start: '2021-08-31T17:00:00Z',
-        },
-      ],
-    };
-    const result = getAppointmentType(appointment, false, false);
-    expect(result).to.equal('ccRequest');
-  });
-  it('should return appointment type as ccRequest, useFeSourceOfTruthCC=true', async () => {
+  it('should return appointment type as ccRequest', async () => {
     const appointment = {
       id: '123',
       type: 'COMMUNITY_CARE_REQUEST',
     };
-    const result = getAppointmentType(appointment, true, false);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('ccRequest');
   });
   it('should return appointment type as vaAppointment, useFeSourceOfTruthVA=false', async () => {
@@ -66,7 +44,7 @@ describe('getAppointmentType util', () => {
       kind: 'clinic',
       start: '2021-08-31T17:00:00Z',
     };
-    const result = getAppointmentType(appointment, false, false);
+    const result = getAppointmentType(appointment, false);
     expect(result).to.equal('vaAppointment');
   });
   it('should return appointment type as vaAppointment, useFeSourceOfTruthVA=true', async () => {
@@ -74,7 +52,7 @@ describe('getAppointmentType util', () => {
       id: '123',
       type: 'VA',
     };
-    const result = getAppointmentType(appointment, false, true);
+    const result = getAppointmentType(appointment, true);
     expect(result).to.equal('vaAppointment');
   });
 });
@@ -92,7 +70,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -117,7 +94,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       const a = transformVAOSAppointment(
         appointment,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -140,7 +116,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -165,7 +140,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       const a = transformVAOSAppointment(
         appointment,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -188,7 +162,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -229,7 +202,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       const a = transformVAOSAppointment(
         appointment,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -253,7 +225,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         parseApiObject({ data: response }),
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -294,7 +265,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       const a = transformVAOSAppointment(
         appointment,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -317,7 +287,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -342,7 +311,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       const a = transformVAOSAppointment(
         appointment,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
@@ -364,7 +332,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -397,13 +364,11 @@ describe('VAOS <transformVAOSAppointment>', () => {
       const a = transformVAOSAppointment(
         mobile,
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
       const b = transformVAOSAppointment(
         adhoc,
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -441,13 +406,11 @@ describe('VAOS <transformVAOSAppointment>', () => {
       const a = transformVAOSAppointment(
         parseApiObject({ data: mobile }),
         false,
-        false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
       const b = transformVAOSAppointment(
         parseApiObject({ data: storeForward }),
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
@@ -497,7 +460,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        false,
         false,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -12,7 +12,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingOhRequest', value: true },
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
   { name: 'vaOnlineSchedulingFeSourceOfTruthVA', value: true },
-  { name: 'vaOnlineSchedulingFeSourceOfTruthCC', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthModality', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthTelehealth', value: true },
   { name: 'vaOnlineSchedulingConvertSlotsToUtc', value: true },

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -226,7 +226,6 @@ function logEligibilityExplanation(
  * @param {TypeOfCare} params.typeOfCare Type of care object for the currently chosen type of care
  * @param {Location} params.location The current location to check eligibility against
  * @param {boolean} params.directSchedulingEnabled If direct scheduling is currently enabled
- * @param {boolean} [params.useFeSourceOfTruthCC=false] whether to use vets-api payload as the FE source of truth for CC appointments and requests
  * @param {boolean} [params.useFeSourceOfTruthVA=false] whether to use vets-api payload as the FE source of truth for VA appointments and requests
  * @param {boolean} [params.usePastVisitMHFilter=false] whether to use past visits as a filter for scheduling MH appointments
  * @returns {FlowEligibilityReturnData} Eligibility results, plus clinics and past appointments
@@ -236,7 +235,6 @@ export async function fetchFlowEligibilityAndClinics({
   typeOfCare,
   location,
   directSchedulingEnabled,
-  useFeSourceOfTruthCC = false,
   useFeSourceOfTruthVA = false,
   useFeSourceOfTruthModality = false,
   useFeSourceOfTruthTelehealth = false,
@@ -274,7 +272,6 @@ export async function fetchFlowEligibilityAndClinics({
 
     if (isDirectAppointmentHistoryRequired) {
       apiCalls.pastAppointments = getLongTermAppointmentHistoryV2(
-        useFeSourceOfTruthCC,
         useFeSourceOfTruthVA,
         useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -307,7 +307,6 @@
   "vaOnlineSchedulingRequests": "va_online_scheduling_requests",
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
   "vaOnlineSchedulingFeSourceOfTruthVA": "va_online_scheduling_fe_source_of_truth_va",
-  "vaOnlineSchedulingFeSourceOfTruthCC": "va_online_scheduling_fe_source_of_truth_cc",
   "vaOnlineSchedulingFeSourceOfTruthModality": "va_online_scheduling_fe_source_of_truth_modality",
   "vaOnlineSchedulingFeSourceOfTruthTelehealth": "va_online_scheduling_fe_source_of_truth_telehealth",
   "vaOnlineSchedulingConvertSlotsToUtc": "va_online_scheduling_convert_slots_to_utc",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove a feature toggle `va_online_scheduling_fe_source_of_truth_cc`
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111820

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

