### PR TITLE
Add disability526ShowConfirmationReview toggle to confirmation page

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Toggler } from 'platform/utilities/feature-toggles';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import {
@@ -36,6 +37,18 @@ export default class ConfirmationPage extends React.Component {
         fullName={props.fullName}
         isSubmittingBDD={props.isSubmittingBDD}
       />
+      <Toggler
+        toggleName={Toggler.TOGGLE_NAMES.disability526ShowConfirmationReview}
+      >
+        <Toggler.Enabled>
+          <div
+            hidden
+            aria-hidden
+            id="new-confirmation-review-component"
+            data-testid="new-confirmation-review-component"
+          />
+        </Toggler.Enabled>
+      </Toggler>
       <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList
         item1Header="We’ll send you an email to confirm your submission"

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -64,6 +64,7 @@
   "dgiRudisillHideBenefitsSelectionStep": "dgi_rudisill_hide_benefits_selection_step",
   "dhpConnectedDevicesFitbit": "dhp_connected_devices_fitbit",
   "disability526ToxicExposure": "disability_526_toxic_exposure",
+  "disability526ShowConfirmationReview": "disability_526_show_confirmation_review",
   "disablityBenefitsBrowserMonitoringEnabled": "disablity_benefits_browser_monitoring_enabled",
   "dischargeWizardFeatures": "discharge_wizard_features",
   "disputeDebt": "dispute_debt",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- _(Summarize the changes that have been made to the platform)_
This PR introduces a feature toggle that will be used with an upcoming new review section on the confirmation page. 
Related backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/23535
- _(Which team do you work for, does your team own the maintenance of this component?)_
DBEX Core Form team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_ TBD, this will be decided later in release planning

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/116096

## Testing done

- _Describe what the old behavior was prior to the change_
None, this is a new toggle
- _Describe the steps required to verify your changes are working as expected_
Ensure toggle is on, submit a 526 form successfully, inspect the confirmation page and verify the only difference is the presence of hidden div `new-confirmation-review-component`
- _Describe the tests completed and the results_
Unit tests and manual testing
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before + flipper off | After with flipper on (with hidden test div) |
| ------ | ----- |
| <img width="1158" height="748" alt="Screenshot 2025-08-13 at 1 32 25 PM" src="https://github.com/user-attachments/assets/7279ae06-5c86-405f-ab42-45e346b4917d" />   | <img width="1169" height="755" alt="Screenshot 2025-08-13 at 1 29 45 PM" src="https://github.com/user-attachments/assets/8a01560d-9e27-4716-ba4a-7a1a8e923149" />   |

## What areas of the site does it impact?
Form 526 Confirmation Page

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

Note - the [backend PR](https://github.com/department-of-veterans-affairs/vets-api/pull/23535) needs to be merged first
