### PR TITLE
Update DowntimeNotification language

### DIFF
--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -136,7 +136,7 @@ export const App = ({
   let content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       <DowntimeNotification
-        appTitle="Supplemental Claims"
+        appTitle="Supplemental Claims application"
         dependencies={[externalServices.decisionReviews]}
       >
         <ITFWrapper

--- a/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
@@ -23,7 +23,8 @@ class DowntimeApproaching extends React.Component {
     } = this.props;
     const close = () => dismissDowntimeWarning(appTitle);
     const modalTitle =
-      messaging.title || `The ${appTitle} will be down for maintenance soon`;
+      messaging.title ||
+      `The ${appTitle} application will be down for maintenance soon`;
     return (
       <DowntimeNotificationWrapper
         status={externalServiceStatus.downtimeApproaching}
@@ -39,9 +40,9 @@ class DowntimeApproaching extends React.Component {
         >
           {messaging.content || (
             <p>
-              We’ll be doing some work on the {appTitle} on{' '}
+              We’ll be doing some work on the {appTitle} application on{' '}
               {format(startTime, 'MMMM do')} between {format(startTime, 'p')}{' '}
-              and {format(endTime, 'p')} If you have trouble using this tool
+              and {format(endTime, 'p')}. If you have trouble using this tool
               during that time, please check back soon.
             </p>
           )}

--- a/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
@@ -23,8 +23,7 @@ class DowntimeApproaching extends React.Component {
     } = this.props;
     const close = () => dismissDowntimeWarning(appTitle);
     const modalTitle =
-      messaging.title ||
-      `The ${appTitle} application will be down for maintenance soon`;
+      messaging.title || `The ${appTitle} will be down for maintenance soon`;
     return (
       <DowntimeNotificationWrapper
         status={externalServiceStatus.downtimeApproaching}
@@ -40,7 +39,7 @@ class DowntimeApproaching extends React.Component {
         >
           {messaging.content || (
             <p>
-              We’ll be doing some work on the {appTitle} application on{' '}
+              We’ll be doing some work on the {appTitle} on{' '}
               {format(startTime, 'MMMM do')} between {format(startTime, 'p')}{' '}
               and {format(endTime, 'p')}. If you have trouble using this tool
               during that time, please check back soon.


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update language for DowntimeNotification per Platform request. [The date formatting has been fixed already](https://github.com/department-of-veterans-affairs/vets-website/pull/37317), but we just needed to add a period before the last sentence in the description.

<img src="https://github.com/user-attachments/assets/b8a12605-ee7e-42e5-890b-91fb9e5ead99" width="500" />

I was going to add the word "application" after the `appTitle` but teams are inconsistently naming their apps with "application" and "tool" and various other designations at the end, so I didn't want to apply this unilaterally. I updated Supplemental Claims' `appTitle` so it would read a bit better, instead.


