### PR TITLE
Prevent LOA1 users from accessing 21a form

### DIFF
--- a/src/applications/accreditation/21a/components/common/Header/Nav.jsx
+++ b/src/applications/accreditation/21a/components/common/Header/Nav.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Toggler } from 'platform/utilities/feature-toggles';
-import { SIGN_IN_URL } from '../../../constants';
+import { SIGN_IN_URL_21A } from '../../../constants';
 import UserNav from './UserNav';
 import { selectUserProfile } from '../../../selectors/user';
 
@@ -10,7 +10,7 @@ function SignInButton() {
     <a
       data-testid="user-nav-sign-in-link"
       className="nav__btn is--sign-in"
-      href={SIGN_IN_URL}
+      href={SIGN_IN_URL_21A}
     >
       Sign in
     </a>

--- a/src/applications/accreditation/21a/containers/IntroductionPage.jsx
+++ b/src/applications/accreditation/21a/containers/IntroductionPage.jsx
@@ -146,10 +146,6 @@ const IntroductionPage = ({ route }) => {
         </va-process-list-item>
       </va-process-list>
 
-      <div className="vads-u-margin-y--4">
-        <VerifyAlert headingLevel={3} dataTestId="ezr-identity-alert" />
-      </div>
-
       {isUserLOA1 ? (
         <div className="vads-u-margin-y--4">
           <VerifyAlert headingLevel={3} dataTestId="ezr-identity-alert" />

--- a/src/applications/accreditation/21a/containers/IntroductionPage.jsx
+++ b/src/applications/accreditation/21a/containers/IntroductionPage.jsx
@@ -5,8 +5,10 @@ import { useSelector } from 'react-redux';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { focusElement } from 'platform/utilities/ui';
+import VerifyAlert from 'platform/user/authorization/components/VerifyAlert';
+
 import { SIGN_IN_URL_21A } from '../constants';
-import { selectIsUserLoggedIn } from '../selectors/user';
+import { selectIsUserLoggedIn, selectAuthStatus } from '../selectors/user';
 
 const SIGN_IN_LINK_PROPS = {
   onClick: undefined,
@@ -29,6 +31,8 @@ function StartLink({ children, ...props }) {
 
 const IntroductionPage = ({ route }) => {
   const { formConfig, pageList } = route;
+
+  const { isUserLOA1 } = useSelector(selectAuthStatus);
 
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
@@ -141,16 +145,27 @@ const IntroductionPage = ({ route }) => {
           <p>Review your answers before submitting.</p>
         </va-process-list-item>
       </va-process-list>
-      <SaveInProgressIntro
-        headingLevel={2}
-        prefillEnabled={formConfig.prefillEnabled}
-        messages={formConfig.savedFormMessages}
-        pageList={pageList}
-        startText="Start your Application"
-        customLink={StartLink}
-        hideUnauthedStartLink
-        displayNonVeteranMessaging
-      />
+
+      <div className="vads-u-margin-y--4">
+        <VerifyAlert headingLevel={3} dataTestId="ezr-identity-alert" />
+      </div>
+
+      {isUserLOA1 ? (
+        <div className="vads-u-margin-y--4">
+          <VerifyAlert headingLevel={3} dataTestId="ezr-identity-alert" />
+        </div>
+      ) : (
+        <SaveInProgressIntro
+          headingLevel={2}
+          prefillEnabled={formConfig.prefillEnabled}
+          messages={formConfig.savedFormMessages}
+          pageList={pageList}
+          startText="Start your Application"
+          customLink={StartLink}
+          hideUnauthedStartLink
+          displayNonVeteranMessaging
+        />
+      )}
       <va-omb-info
         res-burden={45}
         omb-number="2900-0605"

--- a/src/applications/accreditation/21a/selectors/user.js
+++ b/src/applications/accreditation/21a/selectors/user.js
@@ -1,4 +1,17 @@
+import { isLOA1, isLOA3 } from 'platform/user/selectors';
+
 export const selectIsUserLoading = state => state.user.profile.loading;
 export const selectIsUserLoggedIn = state => state.user.login.currentlyLoggedIn;
 export const selectUserProfile = state =>
   selectIsUserLoggedIn(state) ? state.user.profile : null;
+
+export function selectAuthStatus(state) {
+  const isLoggedOut =
+    !state.user.login.currentlyLoggedIn && !state.user.profile.loading;
+
+  return {
+    isUserLOA1: !isLoggedOut && isLOA1(state),
+    isUserLOA3: !isLoggedOut && isLOA3(state),
+    isLoggedOut,
+  };
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No


## Summary

- Added check to prevent LOA1 users from proceeding on form 21a
## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/107346

## Screenshots

<img width="762" alt="image" src="https://github.com/user-attachments/assets/fe63e2b5-a55d-41f0-86e2-c86711dd033f" />

