### PR TITLE
Use API as source of truth for displaying scheduling link

### DIFF
--- a/src/applications/vaos/components/StatusAlert.jsx
+++ b/src/applications/vaos/components/StatusAlert.jsx
@@ -106,25 +106,22 @@ export default function StatusAlert({ appointment, facility }) {
     const who = canceler.get(appointment?.cancelationReason) || 'Facility';
     let message;
     let linkText;
-    let displayScheduleLink = false;
     if (appointment.type === 'COMMUNITY_CARE_APPOINTMENT') {
       message = `${who} canceled this appointment. If you still want this appointment, call your community care provider to schedule.`;
     } else if (appointment.vaos.isCompAndPenAppointment) {
       message = `${who} canceled this appointment. If you still want this appointment, call your VA health facility’s compensation and pension office to schedule.`;
     } else if (appointment.vaos.isPendingAppointment) {
       message = `${who} canceled this request. If you still want this appointment, call your VA health facility or submit another request online.`;
-      displayScheduleLink = true;
       linkText = 'Request a new appointment';
     } else {
       message = `${who} canceled this appointment. If you still want this appointment, call your VA health facility to schedule.`;
-      displayScheduleLink = appointment.showScheduleLink;
       linkText = 'Schedule a new appointment';
     }
     return (
       <>
         <InfoAlert status="error" backgroundOnly>
           {message}
-          {displayScheduleLink && (
+          {appointment.showScheduleLink && (
             <>
               <br />
               <br />

--- a/src/applications/vaos/components/StatusAlert.unit.spec.jsx
+++ b/src/applications/vaos/components/StatusAlert.unit.spec.jsx
@@ -213,6 +213,7 @@ describe('VAOS Component: StatusAlert', () => {
       mockAppointment.setIsPendingAppointment(true);
       mockAppointment.setStatus('cancelled');
       mockAppointment.setCancelationReason('pat');
+      mockAppointment.showScheduleLink = true;
 
       const screen = renderWithStoreAndRouter(
         <StatusAlert appointment={mockAppointment} facility={facilityData} />,

--- a/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.unit.spec.jsx
@@ -224,6 +224,7 @@ describe('VAOS Component: VARequestLayout', () => {
           },
         },
         status: 'cancelled',
+        showScheduleLink: true,
       };
 
       // Act


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We confirmed that we want to show schedule link for community care requests but not community care appointments so we want to update the appointments service to match this
- Appointment FE Team
- This is not behind a feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112994

## Testing done

- There is no observable behavior change but the custom logic has been removed in favor of API data
- Unit tests have been updated

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
