### PR TITLE
DMT | Remove v2 IPF requirement

### DIFF
--- a/src/applications/dependents/686c-674-old/containers/App.jsx
+++ b/src/applications/dependents/686c-674-old/containers/App.jsx
@@ -37,6 +37,9 @@ function App({
   const hasV1Form = savedForms?.some(
     form => form.form === VA_FORM_IDS.FORM_21_686C,
   );
+  const hasV2Form = savedForms?.some(
+    form => form.form === VA_FORM_IDS.FORM_21_686CV2,
+  );
 
   // TODO: Enable after 100% release
   // const v1Form = savedForms?.find(
@@ -50,7 +53,7 @@ function App({
 
   // const isGreaterThan60Days = calendarDays >= 60;
 
-  const shouldUseV2 = flipperV2 && !hasV1Form;
+  const shouldUseV2 = flipperV2(hasV2Form || !hasV1Form);
   // (flipperV2 && hasV1Form && isGreaterThan60Days);
 
   if (shouldUseV2) {

--- a/src/applications/dependents/686c-674-old/containers/App.jsx
+++ b/src/applications/dependents/686c-674-old/containers/App.jsx
@@ -37,9 +37,6 @@ function App({
   const hasV1Form = savedForms?.some(
     form => form.form === VA_FORM_IDS.FORM_21_686C,
   );
-  const hasV2Form = savedForms?.some(
-    form => form.form === VA_FORM_IDS.FORM_21_686CV2,
-  );
 
   // TODO: Enable after 100% release
   // const v1Form = savedForms?.find(
@@ -53,7 +50,7 @@ function App({
 
   // const isGreaterThan60Days = calendarDays >= 60;
 
-  const shouldUseV2 = hasV2Form || (flipperV2 && !hasV1Form);
+  const shouldUseV2 = flipperV2 && !hasV1Form;
   // (flipperV2 && hasV1Form && isGreaterThan60Days);
 
   if (shouldUseV2) {

--- a/src/applications/dependents/686c-674-old/containers/App.jsx
+++ b/src/applications/dependents/686c-674-old/containers/App.jsx
@@ -5,10 +5,10 @@ import { connect } from 'react-redux';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { useBrowserMonitoring } from '~/platform/utilities/real-user-monitoring';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
-import { VA_FORM_IDS } from '@department-of-veterans-affairs/platform-forms/constants';
 import manifest from '../manifest.json';
 import formConfig from '../config/form';
 import { DOC_TITLE } from '../config/constants';
+import { getShouldUseV2 } from '../../686c-674/utils/redirect';
 
 function App({
   location,
@@ -34,12 +34,6 @@ function App({
   }
 
   const flipperV2 = featureToggles.vaDependentsV2;
-  const hasV1Form = savedForms?.some(
-    form => form.form === VA_FORM_IDS.FORM_21_686C,
-  );
-  const hasV2Form = savedForms?.some(
-    form => form.form === VA_FORM_IDS.FORM_21_686CV2,
-  );
 
   // TODO: Enable after 100% release
   // const v1Form = savedForms?.find(
@@ -53,10 +47,9 @@ function App({
 
   // const isGreaterThan60Days = calendarDays >= 60;
 
-  const shouldUseV2 = flipperV2(hasV2Form || !hasV1Form);
   // (flipperV2 && hasV1Form && isGreaterThan60Days);
 
-  if (shouldUseV2) {
+  if (getShouldUseV2(flipperV2, savedForms)) {
     window.location.href =
       '/view-change-dependents/add-remove-form-21-686c-674/';
     return <></>;

--- a/src/applications/dependents/686c-674/containers/App.jsx
+++ b/src/applications/dependents/686c-674/containers/App.jsx
@@ -50,8 +50,11 @@ function App({
   const hasV1Form = savedForms.some(
     form => form.form === VA_FORM_IDS.FORM_21_686C,
   );
+  const hasV2Form = savedForms.some(
+    form => form.form === VA_FORM_IDS.FORM_21_686CV2,
+  );
 
-  const shouldUseV2 = flipperV2 && !hasV1Form;
+  const shouldUseV2 = flipperV2 && (hasV2Form || !hasV1Form);
   if (!shouldUseV2) {
     window.location.href = '/view-change-dependents/add-remove-form-21-686c/';
     return <></>;

--- a/src/applications/dependents/686c-674/containers/App.jsx
+++ b/src/applications/dependents/686c-674/containers/App.jsx
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog/';
 import environment from 'platform/utilities/environment';
-import { VA_FORM_IDS } from '@department-of-veterans-affairs/platform-forms/constants';
 
 import manifest from '../manifest.json';
 import formConfig from '../config/form';
 import { DOC_TITLE } from '../config/constants';
+import { getShouldUseV2 } from '../utils/redirect';
 
 function App({
   location,
@@ -47,15 +47,8 @@ function App({
   }
 
   const flipperV2 = featureToggles.vaDependentsV2;
-  const hasV1Form = savedForms.some(
-    form => form.form === VA_FORM_IDS.FORM_21_686C,
-  );
-  const hasV2Form = savedForms.some(
-    form => form.form === VA_FORM_IDS.FORM_21_686CV2,
-  );
 
-  const shouldUseV2 = flipperV2 && (hasV2Form || !hasV1Form);
-  if (!shouldUseV2) {
+  if (!getShouldUseV2(flipperV2, savedForms)) {
     window.location.href = '/view-change-dependents/add-remove-form-21-686c/';
     return <></>;
   }

--- a/src/applications/dependents/686c-674/containers/App.jsx
+++ b/src/applications/dependents/686c-674/containers/App.jsx
@@ -50,11 +50,8 @@ function App({
   const hasV1Form = savedForms.some(
     form => form.form === VA_FORM_IDS.FORM_21_686C,
   );
-  const hasV2Form = savedForms.some(
-    form => form.form === VA_FORM_IDS.FORM_21_686CV2,
-  );
 
-  const shouldUseV2 = hasV2Form || (flipperV2 && !hasV1Form);
+  const shouldUseV2 = flipperV2 && !hasV1Form;
   if (!shouldUseV2) {
     window.location.href = '/view-change-dependents/add-remove-form-21-686c/';
     return <></>;

--- a/src/applications/dependents/686c-674/tests/utils/redirect.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/utils/redirect.unit.spec.jsx
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { VA_FORM_IDS } from '@department-of-veterans-affairs/platform-forms/constants';
+import { getShouldUseV2 } from '../../utils/redirect';
+
+describe('getShouldUseV2', () => {
+  const v1Form = { form: VA_FORM_IDS.FORM_21_686C };
+  const v2Form = { form: VA_FORM_IDS.FORM_21_686CV2 };
+
+  it('should return true when V2 flag is on and no forms are present', () => {
+    const result = getShouldUseV2(true, []);
+    expect(result).to.be.true;
+  });
+
+  it('should return false when V2 flag is on and only V1 form is present', () => {
+    const result = getShouldUseV2(true, [v1Form]);
+    expect(result).to.be.false;
+  });
+
+  it('should return true when V2 flag is on and only V2 form is present', () => {
+    const result = getShouldUseV2(true, [v2Form]);
+    expect(result).to.be.true;
+  });
+
+  it('should return true when V2 flag is on and both V1 and V2 forms are present', () => {
+    const result = getShouldUseV2(true, [v1Form, v2Form]);
+    expect(result).to.be.true;
+  });
+
+  it('should return false when V2 flag is off and no forms are present', () => {
+    const result = getShouldUseV2(false, []);
+    expect(result).to.be.false;
+  });
+
+  it('should return false when V2 flag is off and only V1 form is present', () => {
+    const result = getShouldUseV2(false, [v1Form]);
+    expect(result).to.be.false;
+  });
+
+  it('should return false when V2 flag is off and only V2 form is present', () => {
+    const result = getShouldUseV2(false, [v2Form]);
+    expect(result).to.be.false;
+  });
+
+  it('should return false when V2 flag is off and both forms are present', () => {
+    const result = getShouldUseV2(false, [v1Form, v2Form]);
+    expect(result).to.be.false;
+  });
+});

--- a/src/applications/dependents/686c-674/utils/redirect.js
+++ b/src/applications/dependents/686c-674/utils/redirect.js
@@ -1,0 +1,12 @@
+import { VA_FORM_IDS } from '@department-of-veterans-affairs/platform-forms/constants';
+
+export function getShouldUseV2(isV2FlipperEnabled, savedForms) {
+  const hasV1Form = savedForms.some(
+    form => form.form === VA_FORM_IDS.FORM_21_686C,
+  );
+  const hasV2Form = savedForms.some(
+    form => form.form === VA_FORM_IDS.FORM_21_686CV2,
+  );
+
+  return isV2FlipperEnabled && (hasV2Form || !hasV1Form);
+}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates logic to require v2 flipper enabled to use experience.


User Experience Matrix - Current Logic

| V2 Feature Flag | V1 Form Present | V2 Form Present | User Experience |
|------------------|------------------|------------------|------------------|
| Yes              | No               | No               | V2               |
| Yes              | Yes              | No               | V1               |
| Yes              | No               | Yes              | V2               |
| Yes              | Yes              | Yes              | V2               |
| No               | No               | No               | V1               |
| No               | Yes              | No               | V1               |
| No               | No               | Yes              | V2 *             |
| No               | Yes              | Yes              | V2 *             |


User Experience Matrix - Proposed Logic

| V2 Feature Flag | V1 Form Present | V2 Form Present | User Experience |
|------------------|------------------|------------------|------------------|
| Yes              | No               | No               | V2               |
| Yes              | Yes              | No               | V1               |
| Yes              | No               | Yes              | V2               |
| Yes              | Yes              | Yes              | V2               |
| No               | No               | No               | V1               |
| No               | Yes              | No               | V1               |
| No               | No               | Yes              | V1               |
| No               | Yes              | Yes              | V1               |


## Related issue(s)

- No issue.

## Testing done

- Run 686c locally

## Screenshots


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
