### PR TITLE
Add tracking on "Finish this application later" click

### DIFF
--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -7,6 +7,7 @@ import {
   scrollToTop,
 } from 'platform/utilities/scroll';
 import { focusElement } from 'platform/utilities/ui/focus';
+import recordEvent from '../../monitoring/record-event';
 
 import { SAVE_STATUSES, saveErrors } from './actions';
 import { APP_TYPE_DEFAULT } from '../../forms-system/src/js/constants';
@@ -23,8 +24,13 @@ class SaveFormLink extends React.Component {
   handleSave = event => {
     event.preventDefault();
     const { route = {}, form, locationPathname } = this.props;
-    const { formId, version, submission } = form;
+    const { formId, version, submission, trackingPrefix } = form;
     let { data } = form;
+    if (trackingPrefix) {
+      recordEvent({
+        event: `${trackingPrefix}sip-form-save-intent`,
+      });
+    }
 
     // Save form on a specific page form exit callback
     if (typeof route.pageConfig?.onFormExit === 'function') {


### PR DESCRIPTION
## Summary

- Add google analytics event for when the user clicks "Finish this application later"

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/2155

## Testing done

- Nothing will actually show up in GA until we also add it on that side as well.

## Screenshots

n/a
## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
