### PR TITLE
109011a - Hide additional PII in RUM dashboard - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -124,7 +124,6 @@ export const applicantAddressInfoSchema = {
               name === 'your' ? name : 'their'
             } last CHAMPVA form submission?`,
             'ui:options': {
-              classNames: ['dd-pivacy-hidden'],
               labels,
               hint: `If yes, we will update our records with the new mailing address.`,
             },
@@ -138,6 +137,7 @@ export const applicantAddressInfoSchema = {
     ],
     'ui:options': {
       itemAriaLabel: () => 'mailing address',
+      classNames: ['dd-privacy-hidden'],
     },
     'ui:objectViewField': props => {
       return PrivWrappedReview(props);

--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
@@ -69,7 +69,6 @@ export function applicantHasInsuranceSchema(isPrimary) {
               } medical health insurance information to provide or update at this time?`,
               'ui:options': {
                 hint: ADDITIONAL_FILES_HINT,
-                classNames: ['dd-pivacy-hidden'],
               },
             };
           },
@@ -77,6 +76,7 @@ export function applicantHasInsuranceSchema(isPrimary) {
       },
       'ui:options': {
         itemAriaLabel: () => 'health insurance',
+        classNames: ['dd-privacy-hidden'],
       },
       'ui:objectViewField': props => {
         return PrivWrappedReview(props);
@@ -174,15 +174,13 @@ export function applicantInsuranceThroughEmployerSchema(isPrimary) {
                 false,
                 true,
               )} employer?`,
-              'ui:options': {
-                classNames: ['dd-pivacy-hidden'],
-              },
             };
           },
         }),
       },
       'ui:options': {
         itemAriaLabel: () => 'insurance type',
+        classNames: ['dd-privacy-hidden'],
       },
       'ui:objectViewField': props => {
         return PrivWrappedReview(props);
@@ -228,7 +226,6 @@ export function applicantInsurancePrescriptionSchema(isPrimary) {
               'ui:options': {
                 hint:
                   'You may find this information on the front of your health insurance card. You can also contact the phone number listed on the back of the card.',
-                classNames: ['dd-pivacy-hidden'],
               },
             };
           },
@@ -236,6 +233,7 @@ export function applicantInsurancePrescriptionSchema(isPrimary) {
       },
       'ui:options': {
         itemAriaLabel: () => 'prescription coverage',
+        classNames: ['dd-privacy-hidden'],
       },
       'ui:objectViewField': props => {
         return PrivWrappedReview(props);
@@ -386,7 +384,6 @@ export function applicantInsuranceTypeSchema(isPrimary) {
                 hint: `You may find this information on the front of ${
                   wording.posessive
                 } health insurance card.`,
-                classNames: ['dd-pivacy-hidden'],
               },
             };
           },
@@ -394,6 +391,7 @@ export function applicantInsuranceTypeSchema(isPrimary) {
       },
       'ui:options': {
         itemAriaLabel: () => 'insurance plan',
+        classNames: ['dd-privacy-hidden'],
       },
       'ui:objectViewField': props => {
         return PrivWrappedReview(props);
@@ -488,15 +486,13 @@ export function applicantInsuranceCommentsSchema(isPrimary) {
               false,
               true,
             )} health insurance?`,
-            'ui:options': {
-              classNames: ['dd-pivacy-hidden'],
-            },
           };
         },
         charcount: true,
       }),
       'ui:options': {
         itemAriaLabel: () => 'health insurance additional comments',
+        classNames: ['dd-privacy-hidden'],
       },
       'ui:objectViewField': props => {
         return PrivWrappedReview(props);

--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -137,7 +137,6 @@ export const applicantMedicarePharmacySchema = {
               true,
             )} Medicare plan provide pharmacy benefits?`,
             'ui:options': {
-              classNames: ['dd-pivacy-hidden'],
               hint:
                 'You can find this information on the front of your Medicare card.',
             },
@@ -145,7 +144,10 @@ export const applicantMedicarePharmacySchema = {
         },
       }),
     },
-    'ui:options': { itemAriaLabel: () => 'Medicare pharmacy benefits' },
+    'ui:options': {
+      itemAriaLabel: () => 'Medicare pharmacy benefits',
+      classNames: ['dd-privacy-hidden'],
+    },
     'ui:objectViewField': props => PrivWrappedReview(props),
   },
   schema: {

--- a/src/applications/ivc-champva/shared/components/fileUploads/MissingFileList.jsx
+++ b/src/applications/ivc-champva/shared/components/fileUploads/MissingFileList.jsx
@@ -26,7 +26,7 @@ function alertOrLink(file, entryName, index, fileNameMap = {}) {
     <>
       {file.uploaded ? (
         <VaAlert status="success" showIcon uswds>
-          <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+          <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 dd-privacy-hidden">
             {`${entryName}’s`} {fn} uploaded
           </p>
         </VaAlert>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Fixes a typo introduced in the [previous PII-hiding PR](https://github.com/department-of-veterans-affairs/vets-website/pull/37295), moved the `className` property to the top-level `ui:options` in certain pages, and updated the file upload overview screen to hide potential PII. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109011

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mailing address  |![mail_before](https://github.com/user-attachments/assets/7b5b3f20-9428-4dde-bce0-bbe9ef82c4a5)|![mail_after](https://github.com/user-attachments/assets/8dc414bf-75d0-487f-ae6c-e810d6b6977f)|
| Pharmacy benefits |![pharmacy_before](https://github.com/user-attachments/assets/14078334-7579-4db2-a5be-37bc085c2c2c)|![pharmacy_after](https://github.com/user-attachments/assets/35ddc2dc-fd87-4bb5-9d63-2797a47f6029)|
| Health insurance |![health_before](https://github.com/user-attachments/assets/8b6716f7-03f0-4bf6-ad45-8e88b75b102d)|![health_after](https://github.com/user-attachments/assets/4598f662-001b-4dd8-97ea-bba837c8eb98)|
| Plan type |![plan_before](https://github.com/user-attachments/assets/338b5e3f-fc82-49bf-a7f4-a362001680f2)|![plan_after](https://github.com/user-attachments/assets/528cef9e-ef87-428b-a90c-503e49c18c8d)|
| Employer-provided |![employer_before](https://github.com/user-attachments/assets/1d65e386-4544-4bd0-bf78-0f3a27a1f9c4)|![employer_after](https://github.com/user-attachments/assets/a31073dc-8c42-42b8-8765-b513169ddfb9)|
| Prescription benefits |![prescription_before](https://github.com/user-attachments/assets/6ca15e2b-e5a7-4067-94f8-2eaa6cbc4705)| ![prescription_after](https://github.com/user-attachments/assets/18e78c63-4843-4ee6-8bdc-fcfaac4bf539)|
| Comments |![comments_before](https://github.com/user-attachments/assets/6e040f79-0396-4f32-9557-16bfdc686690)|![comments_after](https://github.com/user-attachments/assets/7ac3bf38-4c57-48d3-9830-02b1efe19113)|
| File upload alert |![alert_before](https://github.com/user-attachments/assets/4d0885a8-1644-4eca-946a-f9e6d00fc27b)|![alert_after](https://github.com/user-attachments/assets/277df5d9-2d0a-4241-902e-1a9c4824b067)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
