### PR TITLE
[WIP] Testing chapter section review on confirmation page (do not merge)

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Toggler } from 'platform/utilities/feature-toggles';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import {
@@ -36,6 +37,18 @@ export default class ConfirmationPage extends React.Component {
         fullName={props.fullName}
         isSubmittingBDD={props.isSubmittingBDD}
       />
+      <Toggler
+        toggleName={Toggler.TOGGLE_NAMES.disability526ShowConfirmationReview}
+      >
+        <Toggler.Enabled>
+          <h2
+            id="confirmation-review-header"
+            data-testid="confirmation-review-header"
+          >
+            Review the information you provided
+          </h2>
+        </Toggler.Enabled>
+      </Toggler>
       <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList
         item1Header="We’ll send you an email to confirm your submission"

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -5,6 +5,7 @@ import environment from 'platform/utilities/environment';
 import { Toggler } from 'platform/utilities/feature-toggles';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
+import ReviewChapters from 'platform/forms-system/src/js/review/ReviewChapters';
 import {
   submissionStatuses,
   WIZARD_STATUS,
@@ -58,7 +59,16 @@ export default class ConfirmationPage extends React.Component {
           >
             Review the information you provided
           </h2>
-          <ConfirmationView.ChapterSectionCollection />
+          {/* // Test with confirmation accordion */}
+          {/* <ConfirmationView.ChapterSectionCollection /> */}
+
+          {/* // Test with review accordion */}
+          <ReviewChapters
+            formConfig={props.route.formConfig}
+            formContext={props.route.formContext}
+            pageList={props.route.pageList}
+            onSetData={() => this.debouncedAutoSave()}
+          />
         </Toggler.Enabled>
       </Toggler>
       <ConfirmationView.PrintThisPage />

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import environment from 'platform/utilities/environment';
 import { Toggler } from 'platform/utilities/feature-toggles';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
@@ -18,6 +19,12 @@ import { alertBody } from '../content/confirmation-poll';
 import { ClaimConfirmationInfo } from '../components/ClaimConfirmationInfo';
 import { BddConfirmationAlert } from '../content/bddConfirmationAlert';
 
+let mockData;
+if (!environment.isProduction() && !environment.isStaging()) {
+  mockData = require('../tests/fixtures/data/maximal-modern-0781-test.json');
+  // mockData = require('../tests/fixtures/data/maximal-toxic-exposure-test.json');
+  mockData = mockData?.data;
+}
 export default class ConfirmationPage extends React.Component {
   componentDidMount() {
     setTimeout(() => focusElement('va-alert h2'), 100);
@@ -27,6 +34,10 @@ export default class ConfirmationPage extends React.Component {
     <ConfirmationView
       submitDate={props.submittedAt}
       formConfig={props.route?.formConfig}
+      devOnly={{
+        showButtons: true,
+        mockData,
+      }}
     >
       <ConfirmationView.SubmissionAlert actions={<></>} content={alertBody} />
       {props.isSubmittingBDD && <BddConfirmationAlert />}
@@ -47,6 +58,7 @@ export default class ConfirmationPage extends React.Component {
           >
             Review the information you provided
           </h2>
+          <ConfirmationView.ChapterSectionCollection />
         </Toggler.Enabled>
       </Toggler>
       <ConfirmationView.PrintThisPage />

--- a/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -4,12 +4,19 @@ import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
+import { Toggler } from '~/platform/utilities/feature-toggles';
 import ConfirmationPage from '../../containers/ConfirmationPage';
 import { submissionStatuses } from '../../constants';
 import { bddConfirmationHeadline } from '../../content/bddConfirmationAlert';
 import formConfig from '../../config/form';
 
-const getData = ({ renderName = true, suffix = 'Esq.' } = {}) => ({
+const getData = ({
+  renderName = true,
+  suffix = 'Esq.',
+  featureToggles = {
+    [Toggler.TOGGLE_NAMES.disability526ShowConfirmationReview]: false,
+  },
+} = {}) => ({
   user: {
     profile: {
       userFullName: renderName
@@ -17,6 +24,7 @@ const getData = ({ renderName = true, suffix = 'Esq.' } = {}) => ({
         : {},
     },
   },
+  featureToggles,
   form: {
     data: {},
   },
@@ -139,5 +147,46 @@ describe('ConfirmationPage', () => {
   it('should render success when form submitted successfully but submission status has non retryable error', () => {
     // status code 200, but response has "status: non_retryable_error"
     verifyConfirmationPage('', false, submissionStatuses.failed);
+  });
+
+  context('confirmation review section', () => {
+    it('should not render confirmation review when toggle is off', () => {
+      const store = mockStore(getData()); // default mock data toggle is off
+      const props = {
+        ...defaultProps,
+        submissionStatus: submissionStatuses.succeeded,
+      };
+
+      const tree = render(
+        <Provider store={store}>
+          <ConfirmationPage {...props} />
+        </Provider>,
+      );
+      expect(tree.queryByText('Review the information you provided')).to.not
+        .exist;
+      expect(tree.queryByTestId('confirmation-review-header')).to.not.exist;
+    });
+
+    it('should render confirmation review when toggle is on', () => {
+      const store = mockStore(
+        getData({
+          featureToggles: {
+            [Toggler.TOGGLE_NAMES.disability526ShowConfirmationReview]: true,
+          },
+        }),
+      );
+      const props = {
+        ...defaultProps,
+        submissionStatus: submissionStatuses.succeeded,
+      };
+
+      const tree = render(
+        <Provider store={store}>
+          <ConfirmationPage {...props} />
+        </Provider>,
+      );
+      expect(tree.queryByText('Review the information you provided')).to.exist;
+      expect(tree.queryByTestId('confirmation-review-header')).to.exist;
+    });
   });
 });

--- a/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
@@ -81,22 +81,44 @@ export const reviewEntry = (description, key, uiSchema, label, data) => {
     return (
       <li key={keyString} className={className}>
         <div className="vads-u-color--gray">{label}</div>
-        {data.map((item, index) => {
-          return <div key={`${keyString}-${index}`}>{item}</div>;
-        })}
+        {data.map((item, index) => (
+          <div key={`${keyString}-${index}`}>{String(item)}</div>
+        ))}
       </li>
     );
+  }
+
+  if (
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    Object.keys(data).length === 0
+  ) {
+    return null;
+  }
+
+  let display;
+  if (React.isValidElement(data)) {
+    display = data;
+  } else if (typeof data === 'object' && data !== null) {
+    try {
+      display = JSON.stringify(data);
+    } catch {
+      display = data;
+    }
+  } else {
+    display = data;
   }
 
   return (
     <li key={keyString} className={className}>
       <div className="vads-u-color--gray">{label}</div>
-      <div>{data}</div>
+      <div>{display}</div>
     </li>
   );
 };
 
 const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
+  if (!uiSchema || !schema) return null;
   if (data === undefined || data === null) return null;
   if (key.startsWith('view:') || key.startsWith('ui:')) return null;
 
@@ -210,6 +232,7 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
 
     // multi page array data
     addMarginIfNewIndex(key, index);
+    if (!uiSchema?.items) return null;
     return Object.entries(uiSchema?.items).flatMap(([arrKey, arrVal]) => {
       return fieldEntries(
         arrKey,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -62,6 +62,7 @@
   "dgiRudisillHideBenefitsSelectionStep": "dgi_rudisill_hide_benefits_selection_step",
   "dhpConnectedDevicesFitbit": "dhp_connected_devices_fitbit",
   "disability526ToxicExposure": "disability_526_toxic_exposure",
+  "disability526ShowConfirmationReview": "disability_526_show_confirmation_review",
   "disablityBenefitsBrowserMonitoringEnabled": "disablity_benefits_browser_monitoring_enabled",
   "dischargeWizardFeatures": "discharge_wizard_features",
   "disputeDebt": "dispute_debt",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- _(Summarize the changes that have been made to the platform)_
This is an experimental branch, trying to see if we can use the existing patterns to display form526 submission data on the confirmation page. I will keep this open for awhile, just as a reference.
  - Test 1: confirmation view accordion (screenshots and issues below)
  - Test 2: review and submit accordion (screenshots and issues below)

- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
Yes, if this is implement it will be in a separate PR and behind the flipper this PR is branched off of: `disability_526_show_confirmation_review`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/112179

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

This section did not exist before the change in this PR. Both accordion options yield very long scrolls when expanded.

**Test 1: The confirmation view accordion**
This approach utilizes the existing confirmation view pattern, but will require customization to represent all 526 data. 
An initial list of issues to investigate: the supporting evidence chapter and toxic exposure data don't always show up. Some dates are invalid. Sometimes the page errors on a required country field that I haven't been able to identify yet. The displayed order of conditions + details and behavior changes + details could be a design concern.

![Screenshot 2025-06-27 at 12 38 04 PM](https://github.com/user-attachments/assets/7cbb319e-cd63-442b-9805-52a40445263a)
---------------------------------------------------------------------------------------------
![Screenshot 2025-06-27 at 12 38 25 PM](https://github.com/user-attachments/assets/a9440e14-da16-4013-97bc-36deef3ca932)
---------------------------------------------------------------------------------------------
![Screenshot 2025-06-27 at 12 38 42 PM](https://github.com/user-attachments/assets/7c18f3b0-59cf-4877-b9dd-075e91774160)
---------------------------------------------------------------------------------------------
![Screenshot 2025-06-27 at 12 38 54 PM](https://github.com/user-attachments/assets/f34af687-06db-4649-9d9d-004d5bb3dcf5)

**Test 2: The review and submit accordion**
This approach does not follow the platform pattern for a confirmation view, but does represent all 526 data that is displayed on the previous review and submit page. Customization will be required to remove the `edit` buttons and error states. 

<img width="346" height="751" alt="Screenshot 2025-07-10 at 3 27 17 PM" src="https://github.com/user-attachments/assets/2981be9b-d6a4-4e1e-9f8f-a4a1999bde10" />

<img width="343" height="753" alt="Screenshot 2025-07-10 at 3 27 43 PM" src="https://github.com/user-attachments/assets/00d3818f-e537-49b7-b409-d15a281b0a76" />

---------------------------------------------------------------------------------------------  

<img width="338" height="749" alt="Screenshot 2025-07-10 at 3 31 56 PM" src="https://github.com/user-attachments/assets/ad00ff97-fe9e-4c36-8ef1-3e0d7ee93782" />
<img width="338" height="717" alt="Screenshot 2025-07-10 at 3 33 58 PM" src="https://github.com/user-attachments/assets/f2b6d929-0e78-4d7c-abb8-de05cee34e68" />  

---------------------------------------------------------------------------------------------

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
