### PR TITLE
Trusts summary page conditional alert logic 

### DIFF
--- a/src/applications/income-and-asset-statement/components/FormAlerts/index.jsx
+++ b/src/applications/income-and-asset-statement/components/FormAlerts/index.jsx
@@ -1,11 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export const TrustSupplementaryFormsAlert = () => (
-  <va-alert status="info" visible>
-    <h2 slot="headline">Additional documents needed</h2>
-    <p>
-      You’ve added a trust, so you will need to submit supporting documents. You
-      can upload them at a later part of this process.
-    </p>
-  </va-alert>
-);
+export const TrustSupplementaryFormsAlert = ({ formData }) => {
+  const trusts = formData?.trusts || [];
+  if (trusts.length === 0) return null;
+  return (
+    <va-alert status="info" visible>
+      <h2 slot="headline">Additional documents needed</h2>
+      <p>
+        You’ve added a trust, so you will need to submit supporting documents.
+        You can upload them at a later part of this process.
+      </p>
+    </va-alert>
+  );
+};
+
+TrustSupplementaryFormsAlert.propTypes = {
+  formData: PropTypes.shape({
+    trusts: PropTypes.array,
+  }),
+};

--- a/src/applications/income-and-asset-statement/config/chapters/07-trusts/trustPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/07-trusts/trustPages.js
@@ -111,6 +111,10 @@ const summaryPage = {
   schema: {
     type: 'object',
     properties: {
+      'view:TrustSupplementaryFormsAlert': {
+        type: 'object',
+        properties: {},
+      },
       'view:isAddingTrusts': arrayBuilderYesNoSchema,
     },
     required: ['view:isAddingTrusts'],

--- a/src/applications/income-and-asset-statement/tests/unit/components/FormAlerts.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/components/FormAlerts.unit.spec.jsx
@@ -5,10 +5,27 @@ import { expect } from 'chai';
 import { TrustSupplementaryFormsAlert } from '../../../components/FormAlerts';
 
 describe('pension <TrustSupplementaryFormsAlert>', () => {
-  it('should render', () => {
-    const { container } = render(<TrustSupplementaryFormsAlert />);
+  it('should render when trusts are present', () => {
+    const { container } = render(
+      <TrustSupplementaryFormsAlert formData={{ trusts: [{}] }} />,
+    );
     const selector = container.querySelector('va-alert');
     expect(selector).to.exist;
-    expect(selector).to.contain.attr('status', 'info');
+    expect(selector).to.have.attribute('status', 'info');
+    expect(container.textContent).to.include('Additional documents needed');
+  });
+
+  it('should not render when trusts are empty', () => {
+    const { container } = render(
+      <TrustSupplementaryFormsAlert formData={{ trusts: [] }} />,
+    );
+    const selector = container.querySelector('va-alert');
+    expect(selector).to.not.exist;
+  });
+
+  it('should not render when formData is undefined', () => {
+    const { container } = render(<TrustSupplementaryFormsAlert />);
+    const selector = container.querySelector('va-alert');
+    expect(selector).to.not.exist;
   });
 });


### PR DESCRIPTION
## Summary
Updated the conditional logic for the **Trusts** summary page alert on the Income and Asset Statement form (VA Form 21P-0969). This refinement ensures the alert is only displayed when the user has actually added one or more trusts, preventing it from appearing unnecessarily when the array is empty or incomplete.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112802

## Related issue(s)
- N/A

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969/` in your browser

## How to verify
1. Navigate to the **Trusts** section
2. Confirm that no alert is shown when no trusts have been added
3. Add one or more trust entries
4. Confirm that the alert is displayed only when at least one trust is present
5. Verify alert text and layout match the design

## What areas of the site does it impact?
Income and Asset Statement Application — Trusts section summary page

## Screenshots
### Desktop
| Before      | After       |
| ----------- | ----------- |
|![image](https://github.com/user-attachments/assets/0e85d382-2331-45bc-a585-bbd4e7acacff)|![Screenshot 2025-06-27 at 10 41 58 AM](https://github.com/user-attachments/assets/420c648f-df93-4d9b-93d7-233fee57cc4c)

### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [ ] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated and unauthenticated routes work as expected with a test user

## Requested Feedback
Please review the updated conditional logic to confirm that the alert visibility accurately reflects the presence of trust entries and no edge cases have been overlooked.
