### PR TITLE
DV | Code cleanup

### DIFF
--- a/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
@@ -6,6 +6,7 @@ import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { scrollAndFocus } from 'platform/utilities/scroll';
 
+import { DEPENDENT_CHOICES } from '../constants';
 import { maskID, getFullName } from '../../shared/utils';
 
 export const DependentsInformation = ({
@@ -32,7 +33,7 @@ export const DependentsInformation = ({
         setShowError(true);
         return;
       }
-      if (data.hasDependentsStatusChanged === 'Y') {
+      if (data.hasDependentsStatusChanged === 'N') {
         goToPath('/exit-form', { force: true });
       } else {
         goForward(data);
@@ -152,14 +153,14 @@ export const DependentsInformation = ({
         <va-radio-option
           name="hasDependentsStatusChanged"
           value="Y"
-          label="Yes, I need to add, remove, or update my dependent information."
+          label={DEPENDENT_CHOICES.Y}
           tile
           checked={data.hasDependentsStatusChanged === 'Y'}
         />
         <va-radio-option
           name="hasDependentsStatusChanged"
           value="N"
-          label="No, my dependent information is correct."
+          label={DEPENDENT_CHOICES.N}
           tile
           checked={data.hasDependentsStatusChanged === 'N'}
         />

--- a/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
@@ -9,7 +9,7 @@ import { scrollAndFocus } from 'platform/utilities/scroll';
 import { maskID, getFullName } from '../../shared/utils';
 
 export const DependentsInformation = ({
-  data,
+  data = {},
   goForward,
   goToPath,
   setFormData,
@@ -47,49 +47,77 @@ export const DependentsInformation = ({
     },
   };
 
+  const dependents = Array.isArray(data.dependents) ? data.dependents : [];
+
   return (
     <>
       <h3>Dependents on your VA benefits</h3>
-      {data.dependents?.length > 0 ? (
-        data.dependents.map((dep = {}, index) => (
+      {dependents.length > 0 ? (
+        dependents.map((dep = {}, index) => (
           <div className="vads-u-margin-bottom--2" key={index}>
             <va-card>
               <h4 className="vads-u-font-size--h4 vads-u-margin-top--0">
                 {getFullName(dep.fullName)}
               </h4>
-              <ul className="remove-bullets">
-                <li>Relationship: {dep.relationship}</li>
-                <li>Date of birth: {dep.dob}</li>
-                {dep.age && <li>Age: {dep.age} years old</li>}
-                <li>
-                  SSN:{' '}
-                  <span
+              <dl>
+                <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                  <dt>Relationship:&nbsp;</dt>
+                  <dd>{dep.relationship}</dd>
+                </div>
+                <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                  <dt>Date of birth:&nbsp;</dt>
+                  <dd>{dep.dob}</dd>
+                </div>
+                {dep.age && (
+                  <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                    <dt>Age:&nbsp;</dt>
+                    <dd
+                      className="dd-privacy-mask"
+                      data-dd-action-name="Dependent's age"
+                    >
+                      {dep.age} years old
+                    </dd>
+                  </div>
+                )}
+                <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                  <dt>SSN:&nbsp;</dt>
+                  <dd
                     className="dd-privacy-mask"
                     data-dd-action-name="Dependent's SSN"
                   >
                     {maskID(dep.ssnLastFour)}
-                  </span>
-                </li>
+                  </dd>
+                </div>
                 {dep.removalDate && (
-                  <li>
-                    <p>
-                      <strong>Automatic removal date:</strong> {dep.removalDate}
-                    </p>
-                    <va-alert status="info" background-only visible>
-                      <strong>Note:</strong> If no other action is taken, this
-                      dependent will be removed automatically when they turn 18,
-                      which may reduce the amount you receive each month. If
-                      this child is continuing education, they need to be added
-                      back to your benefits.{' '}
-                      <va-link
-                        href="/exit-form"
-                        text="Learn about how to add a dependent"
-                        onClick={handlers.goToExitPage}
-                      />
-                    </va-alert>
-                  </li>
+                  <div className="vads-u-margin-top--2">
+                    <dt className="vads-u-display--inline-block vads-u-width--auto">
+                      <strong>Automatic removal date:&nbsp;</strong>
+                    </dt>
+                    <dd className="vads-u-display--inline-block vads-u-width--auto">
+                      <span
+                        className="dd-privacy-mask"
+                        data-dd-action-name="Dependent's removal date"
+                      >
+                        {dep.removalDate}
+                      </span>
+                    </dd>
+                    <dd className="vads-u-margin-top--1">
+                      <va-alert status="info" background-only visible>
+                        <strong>Note:</strong> If no other action is taken, this
+                        dependent will be removed automatically when they turn
+                        18, which may reduce the amount you receive each month.
+                        If this child is continuing education, they need to be
+                        added back to your benefits.{' '}
+                        <va-link
+                          href="/exit-form"
+                          text="Learn about how to add a dependent"
+                          onClick={handlers.goToExitPage}
+                        />
+                      </va-alert>
+                    </dd>
+                  </div>
                 )}
-              </ul>
+              </dl>
             </va-card>
           </div>
         ))

--- a/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
@@ -61,16 +61,16 @@ export const DependentsInformation = ({
                 {getFullName(dep.fullName)}
               </h4>
               <dl>
-                <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                <div className="item vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
                   <dt>Relationship:&nbsp;</dt>
                   <dd>{dep.relationship}</dd>
                 </div>
-                <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                <div className="item vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
                   <dt>Date of birth:&nbsp;</dt>
                   <dd>{dep.dob}</dd>
                 </div>
                 {dep.age && (
-                  <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                  <div className="item vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
                     <dt>Age:&nbsp;</dt>
                     <dd
                       className="dd-privacy-mask"
@@ -80,7 +80,7 @@ export const DependentsInformation = ({
                     </dd>
                   </div>
                 )}
-                <div className="vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
+                <div className="item vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
                   <dt>SSN:&nbsp;</dt>
                   <dd
                     className="dd-privacy-mask"
@@ -90,7 +90,7 @@ export const DependentsInformation = ({
                   </dd>
                 </div>
                 {dep.removalDate && (
-                  <div className="vads-u-margin-top--2">
+                  <div className="removal-date vads-u-margin-top--2">
                     <dt className="vads-u-display--inline-block vads-u-width--auto">
                       <strong>Automatic removal date:&nbsp;</strong>
                     </dt>

--- a/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { DEPENDENT_CHOICES } from '../constants';
 import { maskID } from '../../shared/utils';
 
 export const DependentsInformationReview = ({ data, goToPath }) => {
@@ -133,7 +134,7 @@ export const DependentsInformationReview = ({ data, goToPath }) => {
       <dl className="review">
         <div className="review-row">
           <dt>Has the status of your dependents changed</dt>
-          <dd>{hasDependentsStatusChanged === 'Y' ? 'Yes' : 'No'}</dd>
+          <dd>{DEPENDENT_CHOICES[hasDependentsStatusChanged]}</dd>
         </div>
       </dl>
     </div>

--- a/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
@@ -36,20 +36,44 @@ export const DependentsInformationReview = ({ data, goToPath }) => {
             <dl key={index} className="review vads-u-margin-y--4">
               <div className="review-row">
                 <dt>First name</dt>
-                <dd>{dep.fullName.first}</dd>
+                <dd
+                  className="dd-privacy-mask"
+                  data-dd-action-name="Dependent's first name"
+                >
+                  {dep.fullName.first}
+                </dd>
               </div>
-              <div className="review-row">
-                <dt>Middle name</dt>
-                <dd>{dep.fullName.middle}</dd>
-              </div>
+              {dep.fullName.middle && (
+                <div className="review-row">
+                  <dt>Middle name</dt>
+                  <dd
+                    className="dd-privacy-mask"
+                    data-dd-action-name="Dependent's middle name"
+                  >
+                    {dep.fullName.middle}
+                  </dd>
+                </div>
+              )}
               <div className="review-row">
                 <dt>Last name</dt>
-                <dd>{dep.fullName.last}</dd>
+                <dd
+                  className="dd-privacy-mask"
+                  data-dd-action-name="Dependent's last name"
+                >
+                  {dep.fullName.last}
+                </dd>
               </div>
-              <div className="review-row">
-                <dt>Suffix</dt>
-                <dd>{dep.fullName.suffix}</dd>
-              </div>
+              {dep.fullName.suffix && (
+                <div className="review-row">
+                  <dt>Suffix</dt>
+                  <dd
+                    className="dd-privacy-mask"
+                    data-dd-action-name="Dependent's name suffix"
+                  >
+                    {dep.fullName.suffix}
+                  </dd>
+                </div>
+              )}
               <div className="review-row">
                 <dt>Social Security number</dt>
                 <dd
@@ -61,15 +85,30 @@ export const DependentsInformationReview = ({ data, goToPath }) => {
               </div>
               <div className="review-row">
                 <dt>Date of birth</dt>
-                <dd>{dep.dob}</dd>
+                <dd
+                  className="dd-privacy-mask"
+                  data-dd-action-name="Dependent's date of birth"
+                >
+                  {dep.dob}
+                </dd>
               </div>
               <div className="review-row">
                 <dt>Age</dt>
-                <dd>{dep.age} years old</dd>
+                <dd
+                  className="dd-privacy-mask"
+                  data-dd-action-name="Dependent's age"
+                >
+                  {dep.age} years old
+                </dd>
               </div>
               <div className="review-row">
                 <dt>Relationship</dt>
-                <dd>{dep.relationship}</dd>
+                <dd
+                  className="dd-privacy-mask"
+                  data-dd-action-name="Dependent's relationship"
+                >
+                  {dep.relationship}
+                </dd>
               </div>
             </dl>
           </React.Fragment>

--- a/src/applications/dependents/dependents-verification/components/VeteranInformationComponent.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranInformationComponent.jsx
@@ -35,7 +35,7 @@ export const VeteranInformation = ({ formData }) => {
           Personal information
         </h4>
         <dl>
-          <div className="vads-u-display--flex vads-u-justify-content--start">
+          <div className="item vads-u-display--flex vads-u-justify-content--start">
             <dt className="vads-u-margin-bottom--1">
               <strong>Name:&nbsp;</strong>
             </dt>
@@ -47,7 +47,7 @@ export const VeteranInformation = ({ formData }) => {
             </dd>
           </div>
           {ssnLastFour ? (
-            <div className="vads-u-display--flex vads-u-justify-content--start">
+            <div className="item vads-u-display--flex vads-u-justify-content--start">
               <dt className="ssn vads-u-margin-bottom--1">
                 <strong>Last 4 digits of Social Security number:&nbsp;</strong>
               </dt>
@@ -59,7 +59,7 @@ export const VeteranInformation = ({ formData }) => {
               </dd>
             </div>
           ) : null}
-          <div className="vads-u-display--flex vads-u-justify-content--start">
+          <div className="item vads-u-display--flex vads-u-justify-content--start">
             <dt>
               <strong>Date of birth:&nbsp;</strong>
             </dt>

--- a/src/applications/dependents/dependents-verification/components/VeteranInformationComponent.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranInformationComponent.jsx
@@ -7,14 +7,13 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 import { selectProfile } from 'platform/user/selectors';
 import { formatDateParsedZoneLong } from 'platform/utilities/date/index';
 
-import { maskID } from '../../shared/utils';
+import { maskID, getFullName } from '../../shared/utils';
 
 export const VeteranInformation = ({ formData }) => {
   const { ssnLastFour } = formData?.veteranInformation || {};
   const { dob, userFullName = {} } = useSelector(selectProfile);
-  const { first, middle, last, suffix } = userFullName;
 
-  const dobDateObj = dob ? formatDateParsedZoneLong(dob) : null;
+  const dobDate = dob ? formatDateParsedZoneLong(dob) : null;
 
   return (
     <>
@@ -35,41 +34,46 @@ export const VeteranInformation = ({ formData }) => {
         <h4 className="vads-u-font-size--h3 vads-u-margin-top--1">
           Personal information
         </h4>
-        <p
-          className="name dd-privacy-hidden"
-          data-dd-action-name="Veteran's name"
-        >
-          <strong>Name:</strong>{' '}
-          {[first, middle, last].filter(Boolean).join(' ')}
-          {suffix ? `, ${suffix}` : null}
-        </p>
-        {ssnLastFour ? (
-          <p className="ssn">
-            <strong>Last 4 digits of Social Security number:</strong>{' '}
-            <span
-              className="dd-privacy-mask"
-              data-dd-action-name="Veteran's SSN"
+        <dl>
+          <div className="vads-u-display--flex vads-u-justify-content--start">
+            <dt className="vads-u-margin-bottom--1">
+              <strong>Name:&nbsp;</strong>
+            </dt>
+            <dd
+              className="name dd-privacy-hidden"
+              data-dd-action-name="Veteran's name"
             >
-              {maskID(ssnLastFour, '')}
-            </span>
-          </p>
-        ) : null}
-        <p>
-          <strong>Date of birth:</strong>{' '}
-          {dobDateObj ? (
-            <span
+              {getFullName(userFullName)}
+            </dd>
+          </div>
+          {ssnLastFour ? (
+            <div className="vads-u-display--flex vads-u-justify-content--start">
+              <dt className="ssn vads-u-margin-bottom--1">
+                <strong>Last 4 digits of Social Security number:&nbsp;</strong>
+              </dt>
+              <dd
+                className="dd-privacy-mask"
+                data-dd-action-name="Veteran's SSN"
+              >
+                {maskID(ssnLastFour, '')}
+              </dd>
+            </div>
+          ) : null}
+          <div className="vads-u-display--flex vads-u-justify-content--start">
+            <dt>
+              <strong>Date of birth:&nbsp;</strong>
+            </dt>
+            <dd
               className="dob dd-privacy-mask"
               data-dd-action-name="Veteran's date of birth"
             >
-              {dobDateObj}
-            </span>
-          ) : null}
-        </p>
+              {dobDate}
+            </dd>
+          </div>
+        </dl>
       </va-card>
 
-      <br role="presentation" />
-
-      <p>
+      <p className="vads-u-margin-top--2">
         <strong>Note:</strong> To protect your personal information, we don’t
         allow online changes to your name, date of birth, or Social Security
         number. If you need to change this information, call us at{' '}

--- a/src/applications/dependents/dependents-verification/components/VeteranInformationReviewPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranInformationReviewPage.jsx
@@ -51,7 +51,7 @@ const VeteranInformationReviewPage = ({ formData }) => {
         <div className="review-row">
           <dt>First Name</dt>
           <dd className="dd-privacy-hidden" data-dd-action-name="first name">
-            {first ?? ''}
+            {first || ''}
           </dd>
         </div>
         {middle ? (
@@ -65,7 +65,7 @@ const VeteranInformationReviewPage = ({ formData }) => {
         <div className="review-row">
           <dt>Last name</dt>
           <dd className="dd-privacy-hidden" data-dd-action-name="last name">
-            <strong>{last ?? showError('Missing last name')}</strong>
+            <strong>{last || showError('Missing last name')}</strong>
           </dd>
         </div>
         {suffix ? (
@@ -80,7 +80,7 @@ const VeteranInformationReviewPage = ({ formData }) => {
           <dt>Social Security number</dt>
           <dd className="dd-privacy-hidden" data-dd-action-name="SSN">
             <strong>
-              {(ssnLastFour && maskID(ssnLastFour)) ?? showError('Missing SSN')}
+              {(ssnLastFour && maskID(ssnLastFour)) || showError('Missing SSN')}
             </strong>
           </dd>
         </div>

--- a/src/applications/dependents/dependents-verification/constants.js
+++ b/src/applications/dependents/dependents-verification/constants.js
@@ -1,2 +1,7 @@
 export const TITLE = 'Verify your VA dependents';
 export const SUBTITLE = 'VA Form 21-0538';
+
+export const DEPENDENT_CHOICES = {
+  Y: 'Yes, my dependent information is correct.',
+  N: 'No, I need to add, remove, or update my dependent information.',
+};

--- a/src/applications/dependents/dependents-verification/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/dependents/dependents-verification/tests/e2e/fixtures/data/maximal-test.json
@@ -11,7 +11,7 @@
       "city": "Beverly Hills",
       "state": "CA",
       "postalCode": "90210",
-      "country": "UK"
+      "country": "USA"
     },
     "internationalPhone": "63123456789",
     "dependents": [
@@ -20,7 +20,7 @@
           "first": "Morty",
           "middle": "Charles",
           "last": "Smith",
-          "suffix": "None"
+          "suffix": ""
         },
         "relationship": "Child",
         "dob": "January 4, 2011",
@@ -32,7 +32,7 @@
           "first": "Summer",
           "middle": "Susan",
           "last": "Smith",
-          "suffix": "None"
+          "suffix": ""
         },
         "relationship": "Child",
         "dob": "August 1, 2008",

--- a/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformation.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformation.unit.spec.jsx
@@ -44,22 +44,25 @@ describe('DependentsInformation', () => {
 
     const cards = $$('va-card', container);
     expect(cards).to.have.lengthOf(2);
-    const firstList = $$('li', cards[0]);
+    const firstList = $$('div.item', cards[0]);
     expect($('h4', cards[0]).textContent).to.include('Morty Charles Smith');
-    expect(firstList[0].textContent).to.include('Relationship: Child');
+    expect(firstList[0].textContent).to.include('Relationship:\u00a0Child');
     expect(firstList[1].textContent).to.include(
-      'Date of birth: January 4, 2011',
+      'Date of birth:\u00a0January 4, 2011',
     );
-    expect(firstList[2].textContent).to.include('Age: 14 years old');
-    expect(firstList[3].textContent).to.include('SSN: ●●●–●●-6791');
+    expect(firstList[2].textContent).to.include('Age:\u00a014 years old');
+    expect(firstList[3].textContent).to.include('SSN:\u00a0●●●–●●-6791');
 
     expect($('h4', cards[1]).textContent).to.include('Summer Susan Smith');
-    expect($('li:last-child', cards[1]).textContent).to.include(
-      'Automatic removal date: August 1, 2026',
+    expect($('.removal-date', cards[1]).textContent).to.include(
+      'Automatic removal date:\u00a0August 1, 2026',
     );
     expect($('va-alert[status="info"]', cards[1]));
 
     expect($$('va-radio-option', container)).to.have.lengthOf(2);
+    expect(
+      $$('.dd-privacy-mask[data-dd-action-name]', container),
+    ).to.have.lengthOf(5);
   });
 
   it('should set form data with radio choice', () => {
@@ -89,10 +92,10 @@ describe('DependentsInformation', () => {
     );
   });
 
-  it('navigates forward to exit page when "Yes" is selected', () => {
+  it('navigates forward to exit page when "No" is selected', () => {
     const goToPathSpy = sinon.spy();
     const { container } = renderPage({
-      data: { hasDependentsStatusChanged: 'Y' },
+      data: { hasDependentsStatusChanged: 'N' },
       goToPath: goToPathSpy,
     });
 
@@ -101,11 +104,11 @@ describe('DependentsInformation', () => {
     expect(goToPathSpy.calledWith('/exit-form')).to.be.true;
   });
 
-  it('navigates forward when "No" is selected', () => {
+  it('navigates forward when "Yes" is selected', () => {
     const goToPathSpy = sinon.spy();
     const goForwardSpy = sinon.spy();
     const { container } = renderPage({
-      data: { hasDependentsStatusChanged: 'N' },
+      data: { hasDependentsStatusChanged: 'Y' },
       goToPath: goToPathSpy,
       goForward: goForwardSpy,
     });

--- a/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
@@ -45,8 +45,11 @@ describe('DependentsInformationReview', () => {
       'Date of birthAugust 1, 2008',
       'Age17 years old',
       'RelationshipChild',
-      'Has the status of your dependents changedNo',
+      'Has the status of your dependents changedYes, my dependent information is correct.',
     ]);
+    expect(
+      $$('.dd-privacy-mask[data-dd-action-name]', container),
+    ).to.have.lengthOf(14);
   });
 
   it('should render "No dependents found" when no dependents are present', () => {

--- a/src/applications/dependents/dependents-verification/tests/unit/components/dependent-data.js
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/dependent-data.js
@@ -26,5 +26,5 @@ export const defaultData = {
       removalDate: 'August 1, 2026',
     },
   ],
-  hasDependentsStatusChanged: 'N',
+  hasDependentsStatusChanged: 'Y',
 };

--- a/src/applications/dependents/dependents-verification/tests/unit/config/chapters/veteran-information/veteranInforamtion.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/config/chapters/veteran-information/veteranInforamtion.unit.spec.jsx
@@ -132,7 +132,7 @@ describe('VeteranInformation component', () => {
       { veteranInformation: { ssnLastFour: '1234' } },
       {
         dob: '1985-04-12',
-        userFullName: undefined,
+        userFullName: { last: 'Doe' },
       },
     );
 
@@ -140,7 +140,7 @@ describe('VeteranInformation component', () => {
       '[data-dd-action-name="Veteran\'s name"]',
     );
     expect(nameText).to.exist;
-    expect(nameText.textContent).to.include('Name:');
+    expect(nameText.textContent).to.include('Doe');
   });
 
   it('should skip DOB if not provided', () => {
@@ -154,7 +154,7 @@ describe('VeteranInformation component', () => {
     const dobField = container.querySelector(
       '[data-dd-action-name="Veteran\'s date of birth"]',
     );
-    expect(dobField).to.be.null;
+    expect(dobField.textContent).to.eq('');
   });
 
   it('should render alert message', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Switching unordered list to a definition list per [list usage guidance](https://design.va.gov/components/list#choosing-between-variations)
  > - Added missing Datadog privacy classes & action names
  > - Fix Veteran information missing field messages
  > - Switch dependent [updated choices per Slack conversation](https://dsva.slack.com/archives/C05NEL4DKMX/p1751036321293329)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/112851

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Dependents correct  | <img width="517" alt="Screenshot 2025-06-27 at 11 05 12 AM" src="https://github.com/user-attachments/assets/536f72e3-ae65-4036-96a2-a66b2c637d2b" /> | <img width="517" alt="Screenshot 2025-06-27 at 11 05 27 AM" src="https://github.com/user-attachments/assets/8ba9171d-522f-44a5-b089-3d1f28909fd8" /> |
| Review page | <img width="676" alt="Screenshot 2025-06-27 at 11 25 42 AM" src="https://github.com/user-attachments/assets/a378dc1c-1037-4a2c-86d3-d342462bb493" /> | <img width="678" alt="Screenshot 2025-06-27 at 11 21 29 AM" src="https://github.com/user-attachments/assets/7fe85359-4860-4a58-b13e-b806e1c2100c" /> |

## What areas of the site does it impact?

Dependents Verification (Form 21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
