### PR TITLE
Art/fix 686c form widths

### DIFF
--- a/src/applications/representative-form-upload/containers/App.jsx
+++ b/src/applications/representative-form-upload/containers/App.jsx
@@ -79,7 +79,7 @@ const App = ({ children }) => {
     <AccessTokenManager userLoggedIn={userLoggedIn}>
       <div className="container">
         <Header />
-        <div className="form_container form-686c row">{content}</div>
+        <div className="form_container row form-686c">{content}</div>
         <Footer />
       </div>
     </AccessTokenManager>

--- a/src/applications/representative-form-upload/pages/helpers.jsx
+++ b/src/applications/representative-form-upload/pages/helpers.jsx
@@ -22,7 +22,7 @@ export const form686cBcList = [
 export const uploadTitleAndDescription = {
   'view:uploadTitle': {
     'ui:description': Object.freeze(
-      <h3>{`Upload VA Form ${getFormNumber()}`}</h3>
+      <h3>{`Upload VA Form ${getFormNumber()}`}</h3>,
     ),
   },
   'view:uploadDescription': {

--- a/src/applications/representative-form-upload/pages/helpers.jsx
+++ b/src/applications/representative-form-upload/pages/helpers.jsx
@@ -21,7 +21,9 @@ export const form686cBcList = [
 
 export const uploadTitleAndDescription = {
   'view:uploadTitle': {
-    'ui:title': `Upload VA Form ${getFormNumber()}`,
+    'ui:description': Object.freeze(
+      <h3>{`Upload VA Form ${getFormNumber()}`}</h3>
+    ),
   },
   'view:uploadDescription': {
     'ui:description': Object.freeze(

--- a/src/applications/representative-form-upload/pages/upload.jsx
+++ b/src/applications/representative-form-upload/pages/upload.jsx
@@ -58,7 +58,11 @@ export const uploadPage = {
     },
     'ui:objectViewField': SupportingEvidenceViewField,
     supportingDocuments: {
-      'ui:title': <strong>Upload supporting evidence</strong>,
+      'ui:title': (
+        <div className="vads-u-font-size--h3 vads-u-font-weight--bold">
+          Upload supporting evidence
+        </div>
+      ),
       'ui:description': Object.freeze(
         <>
           <p className="form-686c__upload-text">

--- a/src/applications/representative-form-upload/sass/representative-form-upload.scss
+++ b/src/applications/representative-form-upload/sass/representative-form-upload.scss
@@ -121,6 +121,12 @@
   #root_supportingDocuments-label {
     font-family: Bitter, Georgia, Cambria, "Times New Roman", Times, serif;
   }
+
+  @media screen and (min-width: 768px) {
+    .form-panel {
+      max-width: unset;
+    }
+  }
 }
 .form-review-panel-page-representative-form-upload {
   margin-bottom: 0;

--- a/src/applications/representative-form-upload/sass/representative-form-upload.scss
+++ b/src/applications/representative-form-upload/sass/representative-form-upload.scss
@@ -29,6 +29,13 @@
 }
 //overriding default classes set at the forms level to match figma
 .form-686c {
+  .columns {
+    max-width: 627px;
+  }
+  va-alert {
+    max-width: 608px;
+  }
+
   .small-6.medium-5 {
     width: unset;
     padding-right: 0;
@@ -91,9 +98,6 @@
   }
   va-radio {
     margin-top: 16px;
-  }
-  va-alert {
-    width: 627px;
   }
   #root_supportingDocuments_add_label {
     margin: 0;


### PR DESCRIPTION
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Fixed the width of the content in representative-form-upload (686c form)
Fixed width of alerts to match said width
Updated 'Upload supporting evidence' heading to match H3 style
Fixed alerts getting cut off on the right on mobile

- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_ ART/ARF
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Mobile before:
<img width="395" alt="Screenshot 2025-06-27 at 3 02 45 PM" src="https://github.com/user-attachments/assets/1254bb0e-19b4-41fc-ab9e-dfa6a04d6994" />

Mobile after:
<img width="383" alt="Screenshot 2025-06-27 at 3 03 05 PM" src="https://github.com/user-attachments/assets/744ea7a2-edc0-4d33-ad8f-1bc34b033f0b" />


Desktop before:

<img width="715" alt="Screenshot 2025-06-27 at 3 02 34 PM" src="https://github.com/user-attachments/assets/8d9cc05c-5c38-4a0f-965f-6d88db9930b9" />

Desktop after:
<img width="658" alt="Screenshot 2025-06-27 at 3 02 06 PM" src="https://github.com/user-attachments/assets/b1722f55-7513-4725-a579-ffc520be1bea" />







## What areas of the site does it impact?
ARP 21-686 form upload (representative-form-upload)


*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
