### PR TITLE
Add check before calling `onButtonClick()` in `ProgressButton` component

### DIFF
--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -15,7 +15,10 @@ class ProgressButton extends React.Component {
 
   handleClick = e => {
     navigationState.setNavigationEvent();
-    this.props.onButtonClick(e);
+    // onButtonClick may not be present (see FormNavButtons)
+    if (this.props.onButtonClick) {
+      this.props.onButtonClick(e);
+    }
   };
 
   render() {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the recently added `handleClick` method in `ProgressButton.jsx` to first check if a `onButtonClick` function is present before calling it. This is due to an edge case with how the progress buttons may be used.

Previously it was possible to use `<FormNavButton />` (which contains progress buttons) and not pass it a `goForward` prop directly - based on this [comment](https://github.com/department-of-veterans-affairs/vets-website/blob/1000c35aa7639b4f7ae5b7adb4a242c2af89a07a/src/platform/forms-system/src/js/components/FormNavButtons.jsx#L9), the `goForward` func in certain conditions should be passed directly to a `<form>` element rather than to the button. This PR adjusts the recent changes to the progress buttons component so that it continues to support this behavior.

## Related issue(s)

- [Slack thread](https://dsva.slack.com/archives/C01DBGX4P45/p1751053162899969?thread_ts=1751031151.213409&cid=C01DBGX4P45)
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4191 (introduced the change)

## Testing done

- Manual

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| On continuing to next page |![Screenshot 2025-06-27 at 14 41 52](https://github.com/user-attachments/assets/46ccead7-ce20-4cfa-a630-ae9788e855da)| No error and form proceeds to next page upon successful validation - _note_: this screenshot taken from IVC CHAMPVA form 10-7959a (error is currently visible in [staging](https://staging.va.gov/family-and-caregiver-benefits/health-and-disability/file-champva-claim-10-7959a) browser console when progressing from the `/medical-claim-upload` page)|

## What areas of the site does it impact?

Forms where the `<FormNavButtons />` were used without a `goForward` function should no longer display errors on nav forward, including:
- src/applications/hca/containers/AuthBenefitsPackagePage.jsx
- src/applications/representative-appoint/components/ClaimantTypeForm.jsx
- src/applications/financial-status-report/components/householdExpenses/InstallmentContractSummary.jsx
- src/applications/ivc-champva/shared/components/fileUploads/FileUpload.jsx

And potentially others

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA