### PR TITLE
112025 - Updated form flow to respond to resubmit question - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/healthInsuranceInformation.js
@@ -212,7 +212,9 @@ export const insurancePages = arrayBuilderPages(
     insuranceIntro: pageBuilder.introPage({
       path: 'insurance-intro',
       title: '[noun plural]',
-      depends: formData => get('hasOhi', formData),
+      depends: formData =>
+        get('hasOhi', formData) &&
+        get('claimStatus', formData) !== 'resubmission',
       uiSchema: {
         ...titleUI('Health insurance information', ({ formData }) => (
           <p>
@@ -235,19 +237,25 @@ export const insurancePages = arrayBuilderPages(
     insuranceSummary: pageBuilder.summaryPage({
       title: 'Review your [noun plural]',
       path: 'insurance-review',
-      depends: formData => get('hasOhi', formData),
+      depends: formData =>
+        get('hasOhi', formData) &&
+        get('claimStatus', formData) !== 'resubmission',
       ...summaryPage,
     }),
     insurancePolicy: pageBuilder.itemPage({
       title: 'Policy information',
       path: 'policy-info/:index',
-      depends: formData => get('hasOhi', formData),
+      depends: formData =>
+        get('hasOhi', formData) &&
+        get('claimStatus', formData) !== 'resubmission',
       ...policyPage,
     }),
     insuranceType: pageBuilder.itemPage({
       title: 'Type',
       path: 'insurance-type/:index',
-      depends: formData => get('hasOhi', formData),
+      depends: formData =>
+        get('hasOhi', formData) &&
+        get('claimStatus', formData) !== 'resubmission',
       ...insuranceProviderPage,
     }),
   }),

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -254,6 +254,7 @@ const formConfig = {
               `${fnp(props.formData ?? props)} health insurance status`,
             );
           },
+          depends: formData => get('claimStatus', formData) !== 'resubmission',
           ...insuranceStatusSchema,
         },
         ...insurancePages, // Array builder/list loop pages
@@ -270,11 +271,13 @@ const formConfig = {
         page5: {
           path: 'claim-work',
           title: 'Claim relationship to work',
+          depends: formData => get('claimStatus', formData) !== 'resubmission',
           ...claimWorkSchema,
         },
         page6: {
           path: 'claim-auto-accident',
           title: 'Claim relationship to a car accident',
+          depends: formData => get('claimStatus', formData) !== 'resubmission',
           ...claimAutoSchema,
         },
         page7: {

--- a/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959a/tests/10-7959a.cypress.spec.js
@@ -31,6 +31,7 @@ const testConfig = createTestConfig(
 
     // Rename and modify the test data as needed.
     dataSets: [
+      'basic-resubmission.json',
       'test-data.json',
       'military-address-no-ohi-pharmacy-work.json',
       'third-party-foreign-address-ohi-medical-claim-work-auto.json',

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/basic-resubmission.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/basic-resubmission.json
@@ -1,0 +1,46 @@
+{
+  "description": "Resubmission, military base sponsor address, pharmacy claim",
+  "data": {
+    "claimStatus": "resubmission",
+    "view:hasPolicies": false,
+    "pharmacyUpload": [
+      {
+        "name": "file.png",
+        "confirmationCode": "36650811-4af5-4992-87d2-1aea872245c9",
+        "attachmentId": "",
+        "isEncrypted": false
+      }
+    ],
+    "claimType": "pharmacy",
+    "applicantPhone": "4106541234",
+    "applicantEmail": "app@email.gov",
+    "applicantAddress": {
+      "isMilitary": true,
+      "country": "USA",
+      "street": "109 Street Lane",
+      "street2": "Street 2",
+      "city": "APO",
+      "state": "AA",
+      "postalCode": "34012"
+    },
+    "applicantNewAddress": "no",
+    "applicantMemberNumber": "123123123",
+    "applicantName": {
+      "first": "Beneficiary",
+      "middle": "Terry",
+      "last": "Jones",
+      "suffix": "II"
+    },
+    "applicantDOB": "2022-03-23",
+    "sponsorName": {
+      "first": "Sponsor",
+      "middle": "Quincy",
+      "last": "Jones",
+      "suffix": "Sr."
+    },
+    "certifierRole": "applicant",
+    "certifierReceivedPacket": true,
+    "statementOfTruthSignature": "Beneficiary Terry Jones",
+    "statementOfTruthCertified": true
+  }
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the `depends` functions in form 10-7959a to bypass certain screens if the user is resubmitting an existing claim.

If user is resubmitting:
- No Health Insurance Chapter
- No question for work related injury
- No question for car accident

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112025

## Testing done

- Manual
- E2E

## Screenshots

NA (certain pages are now hidden)

## What areas of the site does it impact?

This form only - this feature is also controlled by a feature flag (`champva_enable_claim_resubmit_question`).

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
