### PR TITLE
`forms-system` `FileField`: Handle API errors

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -333,7 +333,8 @@ export function uploadFile(
         let errorMessage = req.statusText;
         try {
           // detail contains a better error message
-          errorMessage = JSON.parse(req?.response)?.errors?.[0]?.detail;
+          errorMessage =
+            JSON.parse(req?.response)?.errors?.[0]?.detail ?? errorMessage;
         } catch (error) {
           // intentionally empty
         }


### PR DESCRIPTION
API errors were getting swallowed as `errorMessage = undefined`.

We get a lot of `403`s that can kill form flows that have uploads because the file uploading client doesn't refresh tokens. Probably something important to fix. This made it very easy to notice that we swallow API errors when uploading files.