### PR TITLE
Remove `VaFileNumber` from sponsor info section in 10-10d/10-7959c merged form - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -12,8 +12,8 @@ import {
   phoneSchema,
   titleUI,
   titleSchema,
-  ssnOrVaFileNumberNoHintUI,
-  ssnOrVaFileNumberNoHintSchema,
+  ssnUI,
+  ssnSchema,
   yesNoSchema,
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -75,15 +75,15 @@ export const sponsorIdentificationSchema = {
     ...titleUI(({ formData }) => {
       return `${formData?.certifierRole === 'sponsor' ? 'Your' : `Sponsor's`} 
         identification information`;
-    }, `You must enter either a Social Security number or VA File number`),
-    sponsorSsn: ssnOrVaFileNumberNoHintUI(),
+    }),
+    sponsorSsn: ssnUI(),
   },
   schema: {
     type: 'object',
     required: ['sponsorSsn'],
     properties: {
       titleSchema,
-      sponsorSsn: ssnOrVaFileNumberNoHintSchema,
+      sponsorSsn: ssnSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/pages/combinedPageTests.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/pages/combinedPageTests.unit.spec.jsx
@@ -49,7 +49,7 @@ testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.sponsorInformation.pages.page7.schema,
   formConfig.chapters.sponsorInformation.pages.page7.uiSchema,
-  2,
+  1,
   'Sponsor Information - Identification info',
   {},
 );
@@ -57,7 +57,7 @@ testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.sponsorInformation.pages.page7.schema,
   formConfig.chapters.sponsorInformation.pages.page7.uiSchema,
-  2,
+  1,
   'Sponsor Information - Identification info (role: sponsor)',
   { certifierRole: 'sponsor' },
 );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removes va file number field in favor of just having an ssn field.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113132

## Testing done

- Manual
- Unit

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2025-06-30 at 08 13 43](https://github.com/user-attachments/assets/507a911c-7929-4b33-8128-677a30648ed6)|![Screenshot 2025-06-30 at 08 13 27](https://github.com/user-attachments/assets/00bb0616-c07c-4a2c-af94-c9af538a19fa)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA