### PR TITLE
Remove va_online_scheduling_fe_source_of_truth_modality feature toggle

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -4,7 +4,6 @@ import { selectPatientFacilities } from '@department-of-veterans-affairs/platfor
 import * as Sentry from '@sentry/browser';
 import {
   selectFeatureCCDirectScheduling,
-  selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
   selectSystemIds,
 } from '../../redux/selectors';
@@ -90,9 +89,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
   return async (dispatch, getState) => {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-    const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-      state,
-    );
     const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
       state,
     );
@@ -134,7 +130,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
           startDate, // Start 30 days in the past for canceled appointments
           endDate,
           includeEPS,
-          useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
         }),
       ];
@@ -150,7 +145,6 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
             startDate: requestStartDate, // Start 120 days in the past for requests
             endDate: requestEndDate, // End 1 day in the future for requests
             includeEPS,
-            useFeSourceOfTruthModality,
             useFeSourceOfTruthTelehealth,
           })
             .then(requests => {
@@ -251,9 +245,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
   return async (dispatch, getState) => {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-    const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-      state,
-    );
     const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
       state,
     );
@@ -279,7 +270,6 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
         avs: true,
         fetchClaimStatus: true,
         includeEPS,
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       });
       const appointments = results.filter(appt => !appt.hasOwnProperty('meta'));
@@ -329,9 +319,6 @@ export function fetchRequestDetails(id) {
   return async (dispatch, getState) => {
     try {
       const state = getState();
-      const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-        state,
-      );
       const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
         state,
       );
@@ -352,7 +339,6 @@ export function fetchRequestDetails(id) {
       if (!request) {
         request = await fetchRequestById({
           id,
-          useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
         });
         facilityId = getVAAppointmentLocationId(request);
@@ -387,9 +373,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
   return async (dispatch, getState) => {
     try {
       const state = getState();
-      const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-        state,
-      );
       const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
         state,
       );
@@ -413,7 +396,6 @@ export function fetchConfirmedAppointmentDetails(id, type) {
         appointment = await fetchBookedAppointment({
           id,
           type,
-          useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
         });
       }
@@ -476,9 +458,6 @@ export function confirmCancelAppointment() {
   return async (dispatch, getState) => {
     const state = getState();
     const appointment = state.appointments.appointmentToCancel;
-    const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-      state,
-    );
     const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
       state,
     );
@@ -490,7 +469,6 @@ export function confirmCancelAppointment() {
 
       const updatedAppointment = await cancelAppointment({
         appointment,
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       });
 

--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -8,7 +8,6 @@ import {
 import { format, isAfter, isDate, parseISO, startOfMinute } from 'date-fns';
 import {
   selectFeatureConvertSlotsToUtc,
-  selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
   selectSystemIds,
 } from '../../redux/selectors';
@@ -388,9 +387,6 @@ export function prefillContactInfo() {
 export function confirmAppointment(history) {
   return async (dispatch, getState) => {
     const state = getState();
-    const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-      state,
-    );
     const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
       state,
     );
@@ -412,7 +408,6 @@ export function confirmAppointment(history) {
     try {
       const appointment = await createAppointment({
         appointment: transformFormToVAOSAppointment(getState()),
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       });
 

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -17,10 +17,7 @@ import {
   startDirectScheduleFlow,
 } from '../../redux/actions';
 import { selectTypeOfCarePage } from '../../redux/selectors';
-import {
-  selectFeatureFeSourceOfTruthModality,
-  selectFeatureFeSourceOfTruthTelehealth,
-} from '../../../redux/selectors';
+import { selectFeatureFeSourceOfTruthTelehealth } from '../../../redux/selectors';
 import { resetDataLayer } from '../../../utils/events';
 
 import { TYPE_OF_CARE_IDS, TYPES_OF_CARE } from '../../../utils/constants';
@@ -33,9 +30,6 @@ const pageKey = 'typeOfCare';
 
 export default function TypeOfCarePage() {
   const pageTitle = useSelector(state => getPageTitle(state, pageKey));
-  const useFeSourceOfTruthModality = useSelector(state =>
-    selectFeatureFeSourceOfTruthModality(state),
-  );
   const useFeSourceOfTruthTelehealth = useSelector(state =>
     selectFeatureFeSourceOfTruthTelehealth(state),
   );
@@ -150,10 +144,7 @@ export default function TypeOfCarePage() {
             // This could get called multiple times, but the function is memoized
             // and returns the previous promise if it eixsts
             if (showDirectScheduling) {
-              getLongTermAppointmentHistoryV2(
-                useFeSourceOfTruthModality,
-                useFeSourceOfTruthTelehealth,
-              );
+              getLongTermAppointmentHistoryV2(useFeSourceOfTruthTelehealth);
             }
 
             setData(newData);

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -19,7 +19,6 @@ import {
   selectFeatureCommunityCare,
   selectFeatureConvertSlotsToUtc,
   selectFeatureDirectScheduling,
-  selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
   selectFeatureRecentLocationsFilter,
   selectRegisteredCernerFacilityIds,
@@ -318,9 +317,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
     const state = getState();
     const directSchedulingEnabled = selectFeatureDirectScheduling(state);
     const typeOfCare = getTypeOfCare(getState().newAppointment.data);
-    const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-      state,
-    );
     const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
       state,
     );
@@ -346,7 +342,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
             location,
             typeOfCare,
             directSchedulingEnabled,
-            useFeSourceOfTruthModality,
             useFeSourceOfTruthTelehealth,
             isCerner: true,
           });
@@ -381,7 +376,6 @@ export function checkEligibility({ location, showModal, isCerner }) {
           location,
           typeOfCare,
           directSchedulingEnabled,
-          useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
           usePastVisitMHFilter,
         });
@@ -849,9 +843,6 @@ export function checkCommunityCareEligibility() {
 export function submitAppointmentOrRequest(history) {
   return async (dispatch, getState) => {
     const state = getState();
-    const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-      state,
-    );
     const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
       state,
     );
@@ -880,7 +871,6 @@ export function submitAppointmentOrRequest(history) {
         let appointment = null;
         appointment = await createAppointment({
           appointment: transformFormToVAOSAppointment(getState()),
-          useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
         });
 
@@ -969,7 +959,6 @@ export function submitAppointmentOrRequest(history) {
 
         const requestData = await createAppointment({
           appointment: requestBody,
-          useFeSourceOfTruthModality,
           useFeSourceOfTruthTelehealth,
         });
 

--- a/src/applications/vaos/redux/actions.js
+++ b/src/applications/vaos/redux/actions.js
@@ -8,7 +8,6 @@ import { GA_PREFIX } from '../utils/constants';
 import { captureError } from '../utils/error';
 import {
   selectFeatureCCDirectScheduling,
-  selectFeatureFeSourceOfTruthModality,
   selectFeatureFeSourceOfTruthTelehealth,
 } from './selectors';
 
@@ -43,9 +42,6 @@ export function fetchPendingAppointments() {
 
       const state = getState();
       const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
-      const useFeSourceOfTruthModality = selectFeatureFeSourceOfTruthModality(
-        state,
-      );
       const useFeSourceOfTruthTelehealth = selectFeatureFeSourceOfTruthTelehealth(
         state,
       );
@@ -59,7 +55,6 @@ export function fetchPendingAppointments() {
         startDate: subDays(new Date(), 120),
         endDate: addDays(new Date(), 2),
         includeEPS,
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       });
 

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -84,9 +84,6 @@ export const selectFeatureOHRequest = state =>
 export const selectFeatureRemovePodiatry = state =>
   toggleValues(state).vaOnlineSchedulingRemovePodiatry;
 
-export const selectFeatureFeSourceOfTruthModality = state =>
-  toggleValues(state).vaOnlineSchedulingFeSourceOfTruthModality;
-
 export const selectFeatureFeSourceOfTruthTelehealth = state =>
   toggleValues(state).vaOnlineSchedulingFeSourceOfTruthTelehealth;
 

--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -319,7 +319,7 @@ describe('VAOS Services: Appointment ', () => {
         });
       });
 
-      await getLongTermAppointmentHistoryV2(true, true);
+      await getLongTermAppointmentHistoryV2(true);
       expect(global.fetch.callCount).to.equal(3);
       expect(global.fetch.firstCall.args[0]).to.contain(
         `${format(dateRanges[0].start, 'yyyy-MM-dd')}`,

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -3,7 +3,6 @@ import moment from 'moment';
 import { getProviderName, getTypeOfCareById } from '../../utils/appointment';
 import {
   APPOINTMENT_TYPES,
-  TYPE_OF_CARE_IDS,
   PURPOSE_TEXT_V2,
   TYPE_OF_VISIT,
   VIDEO_TYPES,
@@ -59,11 +58,7 @@ function getAtlasLocation(appt) {
   };
 }
 
-export function transformVAOSAppointment(
-  appt,
-  useFeSourceOfTruthModality,
-  useFeSourceOfTruthTelehealth,
-) {
+export function transformVAOSAppointment(appt, useFeSourceOfTruthTelehealth) {
   const appointmentType = getAppointmentType(appt);
   const isCerner = appt?.id?.startsWith('CERN');
   const isCC = appt.kind === 'cc';
@@ -73,7 +68,6 @@ export function transformVAOSAppointment(
   const isCCRequest = appointmentType === APPOINTMENT_TYPES.ccRequest;
   const providers = appt.practitioners;
   const start = moment(appt.localStartTime, 'YYYY-MM-DDTHH:mm:ss');
-  const serviceCategoryName = appt.serviceCategory?.[0]?.text;
   const vvsKind = appt.telehealth?.vvsKind;
   let isVideo = appt.kind === 'telehealth' && !!appt.telehealth?.vvsKind;
   let isAtlas = !!appt.telehealth?.atlas;
@@ -82,16 +76,11 @@ export function transformVAOSAppointment(
     (vvsKind === VIDEO_TYPES.mobile || vvsKind === VIDEO_TYPES.adhoc);
   let isVideoAtVA =
     vvsKind === VIDEO_TYPES.clinic || vvsKind === VIDEO_TYPES.storeForward;
-  let isCompAndPen = serviceCategoryName === 'COMPENSATION & PENSION';
-  let isPhone = appt.kind === 'phone';
-  let isCovid = appt.serviceType === TYPE_OF_CARE_IDS.COVID_VACCINE_ID;
-  let isInPersonVisit = !isVideo && !isCC && !isPhone;
-  if (useFeSourceOfTruthModality) {
-    isCompAndPen = appt.modality === 'claimExamAppointment';
-    isPhone = appt.modality === 'vaPhone';
-    isCovid = appt.modality === 'vaInPersonVaccine';
-    isInPersonVisit = isCompAndPen || isCovid || appt.modality === 'vaInPerson';
-  }
+  const isCompAndPen = appt.modality === 'claimExamAppointment';
+  const isPhone = appt.modality === 'vaPhone';
+  const isCovid = appt.modality === 'vaInPersonVaccine';
+  const isInPersonVisit =
+    isCompAndPen || isCovid || appt.modality === 'vaInPerson';
   if (useFeSourceOfTruthTelehealth) {
     isVideo =
       appt.modality === 'vaVideoCareAtHome' ||
@@ -284,16 +273,8 @@ export function transformVAOSAppointment(
   };
 }
 
-export function transformVAOSAppointments(
-  appts,
-  useFeSourceOfTruthModality,
-  useFeSourceOfTruthTelehealth,
-) {
+export function transformVAOSAppointments(appts, useFeSourceOfTruthTelehealth) {
   return appts.map(appt =>
-    transformVAOSAppointment(
-      appt,
-      useFeSourceOfTruthModality,
-      useFeSourceOfTruthTelehealth,
-    ),
+    transformVAOSAppointment(appt, useFeSourceOfTruthTelehealth),
   );
 }

--- a/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/transformers.unit.spec.jsx
@@ -45,98 +45,82 @@ describe('getAppointmentType util', () => {
 });
 
 describe('VAOS <transformVAOSAppointment>', () => {
+  it('should set modality fields for claim exams', async () => {
+    // Arrange
+    const appointment = new MockAppointment();
+    appointment.setModality('claimExamAppointment');
+
+    // Act
+    const a = transformVAOSAppointment(appointment);
+
+    // Assert
+    expect(a.vaos.isCompAndPenAppointment).to.be.true;
+    expect(a.vaos.isPhoneAppointment).to.be.false;
+    expect(a.vaos.isCOVIDVaccine).to.be.false;
+    expect(a.vaos.isInPersonVisit).to.be.true;
+    expect(a.vaos.isVideo).to.be.false;
+    expect(a.vaos.isVideoAtHome).to.be.false;
+    expect(a.vaos.isAtlas).to.be.false;
+    expect(a.vaos.isVideoAtVA).to.be.false;
+  });
+  it('should set modality fields for phone appointments', async () => {
+    // Arrange
+    const appointment = new MockAppointment();
+    appointment.setModality('vaPhone');
+
+    // Act
+    const a = transformVAOSAppointment(appointment);
+
+    // Assert
+    expect(a.vaos.isCompAndPenAppointment).to.be.false;
+    expect(a.vaos.isPhoneAppointment).to.be.true;
+    expect(a.vaos.isCOVIDVaccine).to.be.false;
+    expect(a.vaos.isInPersonVisit).to.be.false;
+    expect(a.vaos.isVideo).to.be.false;
+    expect(a.vaos.isVideoAtHome).to.be.false;
+    expect(a.vaos.isAtlas).to.be.false;
+    expect(a.vaos.isVideoAtVA).to.be.false;
+  });
+  it('should set modality fields for vaccine appointments', async () => {
+    // Arrange
+    const appointment = new MockAppointment();
+    appointment.setModality('vaInPersonVaccine');
+
+    // Act
+    const a = transformVAOSAppointment(appointment);
+
+    // Assert
+    expect(a.vaos.isCompAndPenAppointment).to.be.false;
+    expect(a.vaos.isPhoneAppointment).to.be.false;
+    expect(a.vaos.isCOVIDVaccine).to.be.true;
+    expect(a.vaos.isInPersonVisit).to.be.true;
+    expect(a.vaos.isVideo).to.be.false;
+    expect(a.vaos.isVideoAtHome).to.be.false;
+    expect(a.vaos.isAtlas).to.be.false;
+    expect(a.vaos.isVideoAtVA).to.be.false;
+  });
+  it('should set modality fields for in person appointments', async () => {
+    // Arrange
+    const appointment = new MockAppointment();
+    appointment.setModality('vaInPerson');
+
+    // Act
+    const a = transformVAOSAppointment(appointment);
+
+    // Assert
+    expect(a.vaos.isCompAndPenAppointment).to.be.false;
+    expect(a.vaos.isPhoneAppointment).to.be.false;
+    expect(a.vaos.isCOVIDVaccine).to.be.false;
+    expect(a.vaos.isInPersonVisit).to.be.true;
+    expect(a.vaos.isVideo).to.be.false;
+    expect(a.vaos.isVideoAtHome).to.be.false;
+    expect(a.vaos.isAtlas).to.be.false;
+    expect(a.vaos.isVideoAtVA).to.be.false;
+  });
+
   describe('When modality feature flag is on', () => {
-    const useFeSourceOfTruthModality = true;
     const useFeSourceOfTruthTelehealth = true;
 
-    it('should set modality fields for claim exams', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-      appointment.setModality('claimExamAppointment');
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.true;
-      expect(a.vaos.isPhoneAppointment).to.be.false;
-      expect(a.vaos.isCOVIDVaccine).to.be.false;
-      expect(a.vaos.isInPersonVisit).to.be.true;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
-    it('should set modality fields for phone appointments', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-      appointment.setModality('vaPhone');
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.false;
-      expect(a.vaos.isPhoneAppointment).to.be.true;
-      expect(a.vaos.isCOVIDVaccine).to.be.false;
-      expect(a.vaos.isInPersonVisit).to.be.false;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
-    it('should set modality fields for vaccine appointments', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-      appointment.setModality('vaInPersonVaccine');
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.false;
-      expect(a.vaos.isPhoneAppointment).to.be.false;
-      expect(a.vaos.isCOVIDVaccine).to.be.true;
-      expect(a.vaos.isInPersonVisit).to.be.true;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
-    it('should set modality fields for in person appointments', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-      appointment.setModality('vaInPerson');
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.false;
-      expect(a.vaos.isPhoneAppointment).to.be.false;
-      expect(a.vaos.isCOVIDVaccine).to.be.false;
-      expect(a.vaos.isInPersonVisit).to.be.true;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
     it('should set modality fields for video at home appointments', async () => {
       // Arrange
       const appointment = new MockAppointment();
@@ -145,7 +129,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
 
@@ -183,7 +166,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
 
@@ -206,7 +188,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         parseApiObject({ data: response }),
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
 
@@ -222,107 +203,8 @@ describe('VAOS <transformVAOSAppointment>', () => {
     });
   });
   describe('When modality flag is off', () => {
-    const useFeSourceOfTruthModality = false;
     const useFeSourceOfTruthTelehealth = false;
 
-    it('should set modality fields for claim exams', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-      appointment.serviceCategory = [
-        {
-          coding: [
-            {
-              system: 'http://www.va.gov/Terminology/VistADefinedTerms/409_1',
-              code: 'COMPENSATION & PENSION',
-              display: 'COMPENSATION & PENSION',
-            },
-          ],
-          text: 'COMPENSATION & PENSION',
-        },
-      ];
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.true;
-      expect(a.vaos.isPhoneAppointment).to.be.false;
-      expect(a.vaos.isCOVIDVaccine).to.be.false;
-      expect(a.vaos.isInPersonVisit).to.be.true;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
-    it('should set modality fields for phone appointments', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-      appointment.kind = 'phone';
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.false;
-      expect(a.vaos.isPhoneAppointment).to.be.true;
-      expect(a.vaos.isCOVIDVaccine).to.be.false;
-      expect(a.vaos.isInPersonVisit).to.be.false;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
-    it('should set modality fields for vaccine appointments', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-      appointment.serviceType = 'covid';
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.false;
-      expect(a.vaos.isPhoneAppointment).to.be.false;
-      expect(a.vaos.isCOVIDVaccine).to.be.true;
-      expect(a.vaos.isInPersonVisit).to.be.true;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
-    it('should set modality fields for in person appointments', async () => {
-      // Arrange
-      const appointment = new MockAppointment();
-
-      // Act
-      const a = transformVAOSAppointment(
-        appointment,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-
-      // Assert
-      expect(a.vaos.isCompAndPenAppointment).to.be.false;
-      expect(a.vaos.isPhoneAppointment).to.be.false;
-      expect(a.vaos.isCOVIDVaccine).to.be.false;
-      expect(a.vaos.isInPersonVisit).to.be.true;
-      expect(a.vaos.isVideo).to.be.false;
-      expect(a.vaos.isVideoAtHome).to.be.false;
-      expect(a.vaos.isAtlas).to.be.false;
-      expect(a.vaos.isVideoAtVA).to.be.false;
-    });
     it('should set modality fields for video at home appointments', async () => {
       // Arrange
       const mobile = new MockAppointment();
@@ -337,16 +219,8 @@ describe('VAOS <transformVAOSAppointment>', () => {
       };
 
       // Act
-      const a = transformVAOSAppointment(
-        mobile,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
-      const b = transformVAOSAppointment(
-        adhoc,
-        useFeSourceOfTruthModality,
-        useFeSourceOfTruthTelehealth,
-      );
+      const a = transformVAOSAppointment(mobile, useFeSourceOfTruthTelehealth);
+      const b = transformVAOSAppointment(adhoc, useFeSourceOfTruthTelehealth);
 
       // Assert
       expect(a.vaos.isCompAndPenAppointment).to.be.false;
@@ -379,12 +253,10 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         parseApiObject({ data: mobile }),
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
       const b = transformVAOSAppointment(
         parseApiObject({ data: storeForward }),
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
 
@@ -432,7 +304,6 @@ describe('VAOS <transformVAOSAppointment>', () => {
       // Act
       const a = transformVAOSAppointment(
         appointment,
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       );
 

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -11,7 +11,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingOhDirectSchedule', value: true },
   { name: 'vaOnlineSchedulingOhRequest', value: true },
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
-  { name: 'vaOnlineSchedulingFeSourceOfTruthModality', value: true },
   { name: 'vaOnlineSchedulingFeSourceOfTruthTelehealth', value: true },
   { name: 'vaOnlineSchedulingConvertSlotsToUtc', value: true },
   { name: 'edu_section_103', value: true },

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -234,7 +234,6 @@ export async function fetchFlowEligibilityAndClinics({
   typeOfCare,
   location,
   directSchedulingEnabled,
-  useFeSourceOfTruthModality = false,
   useFeSourceOfTruthTelehealth = false,
   usePastVisitMHFilter = false,
   isCerner = false,
@@ -270,7 +269,6 @@ export async function fetchFlowEligibilityAndClinics({
 
     if (isDirectAppointmentHistoryRequired) {
       apiCalls.pastAppointments = getLongTermAppointmentHistoryV2(
-        useFeSourceOfTruthModality,
         useFeSourceOfTruthTelehealth,
       ).catch(createErrorHandler('direct-no-matching-past-clinics-error'));
     }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -308,7 +308,6 @@
   "vaOnlineSchedulingRecentLocationsFilter": "va_online_scheduling_recent_locations_filter",
   "vaOnlineSchedulingRequests": "va_online_scheduling_requests",
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
-  "vaOnlineSchedulingFeSourceOfTruthModality": "va_online_scheduling_fe_source_of_truth_modality",
   "vaOnlineSchedulingFeSourceOfTruthTelehealth": "va_online_scheduling_fe_source_of_truth_telehealth",
   "vaOnlineSchedulingConvertSlotsToUtc": "va_online_scheduling_convert_slots_to_utc",
   "vaOnlineSchedulingMentalHealthHistoryFiltering": "va_online_scheduling_mental_health_history_filtering",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove a feature toggle `va_online_scheduling_fe_source_of_truth_modality`
- Appointments Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111828

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

