### PR TITLE
Add custom component to conditionally render statement of truth or privacy agreement components

### DIFF
--- a/src/applications/income-and-asset-statement/README.md
+++ b/src/applications/income-and-asset-statement/README.md
@@ -3,7 +3,7 @@
 #### Helpful installation tips
 
 1. Make sure to update the `content-build` package by pulling from `main` and running `yarn fetch-drupal-cache`.
-2. Update `vets-api` by pulling from `main`.
+2. Update `vets-api` by pulling from `master`.
 3. Enable the flipper feature `income_and_assets_form_enabled`
 4. Add the `income-and-asset-statement` to your `watch` configuration. Example: `yarn run watch --env entry=static-pages,auth,login-page,pensions,income-and-asset-statement`
 

--- a/src/applications/income-and-asset-statement/config/form.js
+++ b/src/applications/income-and-asset-statement/config/form.js
@@ -2,6 +2,7 @@
 import environment from 'platform/utilities/environment';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { minimalHeaderFormConfigOptions } from 'platform/forms-system/src/js/patterns/minimal-header';
+import PreSubmitInfo from '../containers/PreSubmitInfo';
 
 import manifest from '../manifest.json';
 import prefillTransformer from './prefill-transformer';
@@ -56,6 +57,7 @@ const formConfig = {
     noAuth: 'Please sign in again to continue your application for benefits.',
   },
   preSubmitInfo: {
+    CustomComponent: PreSubmitInfo,
     statementOfTruth: {
       body:
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
@@ -65,6 +67,7 @@ const formConfig = {
         formData?.claimantType === 'VETERAN'
           ? 'veteranFullName'
           : 'claimantFullName',
+      useProfileFullName: loggedIn => !!loggedIn,
     },
   },
   title: 'Income and Asset Statement',

--- a/src/applications/income-and-asset-statement/containers/PreSubmitInfo.jsx
+++ b/src/applications/income-and-asset-statement/containers/PreSubmitInfo.jsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect, useSelector } from 'react-redux';
+import {
+  VaPrivacyAgreement,
+  VaStatementOfTruth,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { isLoggedIn } from 'platform/user/selectors';
+import {
+  fullNameReducer,
+  statementOfTruthFullName,
+  statementOfTruthBodyElement,
+} from '~/platform/forms/components/review/PreSubmitSection';
+
+// platform - form-system actions
+import { setPreSubmit as setPreSubmitAction } from 'platform/forms-system/src/js/actions';
+
+const PreSubmitInfo = ({
+  formData,
+  preSubmitInfo,
+  showError,
+  setPreSubmit,
+  user,
+}) => {
+  const { statementOfTruth } = preSubmitInfo;
+  const statementOfTruthCertified = formData.statementOfTruthCertified || false;
+  const loggedIn = useSelector(isLoggedIn);
+  const [
+    statementOfTruthSignatureBlurred,
+    setStatementOfTruthSignatureBlurred,
+  ] = useState(false);
+
+  return (
+    <>
+      {loggedIn ? (
+        <>
+          <div className="vads-u-margin-y--2p5">
+            <strong>Note:</strong> According to federal law, there are criminal
+            penalties, including a fine and/or imprisonment for up to 5 years,
+            for withholding information or for providing incorrect information.
+            (See 18 U.S.C. 1001)
+          </div>
+          <VaPrivacyAgreement
+            name="statementOfTruthCertified"
+            onVaChange={event => {
+              setPreSubmit('statementOfTruthCertified', event.detail.checked);
+              setPreSubmit(
+                'statementOfTruthSignature',
+                statementOfTruthFullName(
+                  formData,
+                  statementOfTruth,
+                  user?.profile?.userFullName,
+                ),
+              );
+            }}
+            showError={showError && !statementOfTruthCertified}
+          />
+        </>
+      ) : (
+        <VaStatementOfTruth
+          heading={statementOfTruth.heading || 'Statement of truth'}
+          inputLabel={statementOfTruth.textInputLabel || 'Your full name'}
+          inputValue={formData.statementOfTruthSignature}
+          inputMessageAriaDescribedby={`${statementOfTruth.heading ||
+            'Statement of truth'}: ${statementOfTruth.messageAriaDescribedby}`}
+          inputError={
+            (showError || statementOfTruthSignatureBlurred) &&
+            fullNameReducer(formData.statementOfTruthSignature) !==
+              fullNameReducer(
+                statementOfTruthFullName(formData, statementOfTruth, null),
+              )
+              ? `Please enter your name exactly as it appears on your application: ${statementOfTruthFullName(
+                  formData,
+                  statementOfTruth,
+                  null,
+                )}`
+              : undefined
+          }
+          checked={formData.statementOfTruthCertified}
+          onVaInputChange={event =>
+            setPreSubmit('statementOfTruthSignature', event.detail.value)
+          }
+          onVaInputBlur={() => setStatementOfTruthSignatureBlurred(true)}
+          onVaCheckboxChange={event =>
+            setPreSubmit('statementOfTruthCertified', event.detail.checked)
+          }
+          checkboxError={
+            showError && !formData.statementOfTruthCertified
+              ? 'You must certify by checking the box'
+              : undefined
+          }
+        >
+          {statementOfTruthBodyElement(formData, statementOfTruth.body)}
+        </VaStatementOfTruth>
+      )}
+    </>
+  );
+};
+
+PreSubmitInfo.propTypes = {
+  formData: PropTypes.object.isRequired,
+  setPreSubmit: PropTypes.func.isRequired,
+  preSubmitInfo: PropTypes.shape({
+    statementOfTruth: PropTypes.shape({
+      heading: PropTypes.string,
+      textInputLabel: PropTypes.string,
+      messageAriaDescribedby: PropTypes.string,
+      body: PropTypes.string,
+    }),
+  }),
+  showError: PropTypes.bool,
+  user: PropTypes.shape({
+    login: PropTypes.shape({
+      currentlyLoggedIn: PropTypes.bool,
+    }),
+    profile: PropTypes.shape({
+      userFullName: PropTypes.object,
+    }),
+  }),
+};
+
+const mapDispatchToProps = {
+  setPreSubmit: setPreSubmitAction,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(PreSubmitInfo);

--- a/src/applications/income-and-asset-statement/tests/unit/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/containers/PreSubmitInfo.unit.spec.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import formConfig from '../../../config/form';
+import PreSubmitInfo from '../../../containers/PreSubmitInfo';
+
+const getData = ({ loggedIn = true } = {}) => ({
+  props: {
+    formData: {
+      formId: formConfig.formId,
+      loadedStatus: 'success',
+      savedStatus: '',
+      loadedData: {
+        metadata: {},
+      },
+      data: {},
+    },
+    preSubmitInfo: {
+      statementOfTruth: {
+        body:
+          'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+        messageAriaDescribedby:
+          'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+        fullNamePath: formData =>
+          formData?.claimantType === 'VETERAN'
+            ? 'veteranFullName'
+            : 'claimantFullName',
+        useProfileFullName: !!loggedIn,
+      },
+    },
+    showError: true,
+    user: {
+      login: {
+        currentlyLoggedIn: loggedIn,
+      },
+      profile: {
+        savedForms: [],
+        prefillsAvailable: [],
+        verified: false,
+      },
+    },
+  },
+  mockStore: {
+    getState: () => ({
+      user: {
+        login: {
+          currentlyLoggedIn: loggedIn,
+        },
+        profile: {
+          savedForms: [],
+          prefillsAvailable: [],
+          verified: false,
+        },
+      },
+      form: {
+        formId: formConfig.formId,
+        loadedStatus: 'success',
+        savedStatus: '',
+        loadedData: {
+          metadata: {},
+        },
+        data: {},
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => {},
+  },
+});
+
+describe('<PreSubmitInfo />', () => {
+  describe('when not logged in', () => {
+    it('should render the va-statement-of-truth component', () => {
+      const { props, mockStore } = getData({ loggedIn: false });
+      const { container } = render(
+        <Provider store={mockStore}>
+          <PreSubmitInfo {...props} />
+        </Provider>,
+      );
+      expect($('va-statement-of-truth', container)).to.exist;
+      expect($('va-statement-of-truth', container).textContent).to.include(
+        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+      );
+      expect($('va-privacy-agreement', container)).not.to.exist;
+    });
+  });
+  describe('when logged in', () => {
+    it('should render the va-privacy-agreement component', () => {
+      const { props, mockStore } = getData();
+      const { container } = render(
+        <Provider store={mockStore}>
+          <PreSubmitInfo {...props} />
+        </Provider>,
+      );
+      expect($('va-privacy-agreement', container)).to.exist;
+      expect($('va-statement-of-truth', container)).not.to.exist;
+    });
+  });
+});

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -64,7 +64,7 @@ export function fullNameReducer(fullNameString) {
   return fullNameString?.replaceAll(' ', '').toLowerCase();
 }
 
-function statementOfTruthBodyElement(formData, statementOfTruthBody) {
+export function statementOfTruthBodyElement(formData, statementOfTruthBody) {
   switch (typeof statementOfTruthBody) {
     case 'function':
       if (typeof statementOfTruthBody(formData) === 'string') {
@@ -135,6 +135,7 @@ export function PreSubmitSection(props) {
           formData={form?.data}
           preSubmitInfo={preSubmit}
           showError={showPreSubmitError}
+          user={user}
           onSectionComplete={value => setPreSubmit(preSubmit?.field, value)}
         />
         {saveFormLink}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added a custom component in the 0969 confirmation page that conditionally renders the privacy agreement component if the user is logged in, or the statement of truth component when a user is not logged in. If a user is logged in, the statement of truth signature should automatically be populated with the user's full name in the payload, and the checkbox for the privacy agreement should still map to `statementOfTruthCertified`.
- DEV NOTES: if this assumption is not correct, please let me know.
- Also modified the shared `PreSubmitSection` component to pass user info into a custom component's props. In addition, I added the export keyword to the `statementOfTruthBodyElement` helper function for code reusability.
- Pension and Burial Benefits team to own this change.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#112639

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![image](https://github.com/user-attachments/assets/4b338f60-7632-4d47-8ba4-b746fdd443fe) | ![image](https://github.com/user-attachments/assets/7e99ff6c-4dff-4d76-990e-a168ec713936) |
| Desktop | ![image](https://github.com/user-attachments/assets/a52c9825-93ab-4ed1-a66f-f6380d801f61) | ![image](https://github.com/user-attachments/assets/ecc5b84b-24f5-47d4-b26c-9f65599b3f2d) | 

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
