### PR TITLE
Potential fix for code scanning alert no. 1072: Double escaping or unescaping

### DIFF
--- a/src/applications/combined-debt-portal/combined/containers/CombinedStatements.jsx
+++ b/src/applications/combined-debt-portal/combined/containers/CombinedStatements.jsx
@@ -30,11 +30,11 @@ const cleanHtmlEntities = text => {
   if (!text) return '';
   return text
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
 };
 
 const CombinedStatements = () => {


### PR DESCRIPTION
Potential fix for [https://github.com/department-of-veterans-affairs/vets-website/security/code-scanning/1072](https://github.com/department-of-veterans-affairs/vets-website/security/code-scanning/1072)

To fix the issue, the unescaping of the ampersand (`&`) should be performed last in the `cleanHtmlEntities` function. This ensures that other entities like `&lt;` and `&gt;` are correctly unescaped before the ampersand itself is processed. The order of the `.replace` calls should be adjusted accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
