### PR TITLE
[DD] Add unit tests for dispute-debt components

### DIFF
--- a/src/applications/dispute-debt/tests/components/AlertCard.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/AlertCard.unit.spec.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import AlertCard from '../../components/AlertCard';
+
+describe('<AlertCard>', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<AlertCard debtType="DEBT" />);
+    // Check that the component renders with the expected alert
+    expect(container.querySelector('va-alert')).to.exist;
+    expect(container.querySelector('[data-testid="balance-card-alert-debt"]'))
+      .to.exist;
+  });
+});

--- a/src/applications/dispute-debt/tests/components/DebtSelection.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/DebtSelection.unit.spec.jsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import DebtSelection from '../../components/DebtSelection';
+import * as utils from '../../utils';
+
+// Mock Redux store
+const createMockStore = initialState => {
+  const mockReducer = (state = initialState) => state;
+  return createStore(mockReducer);
+};
+
+// Helper to render component with Redux store
+const renderWithStore = (component, initialState) => {
+  const store = createMockStore(initialState);
+  return render(<Provider store={store}>{component}</Provider>);
+};
+
+describe('DebtSelection Component', () => {
+  let setFocusStub;
+
+  beforeEach(() => {
+    setFocusStub = sinon.stub(utils, 'setFocus');
+  });
+
+  afterEach(() => {
+    setFocusStub.restore();
+  });
+
+  it('renders without crashing', () => {
+    // Simple smoke test to ensure component can be imported and instantiated
+    expect(DebtSelection).to.be.a('function');
+  });
+
+  it('renders AlertCard when isDebtError is true', () => {
+    const initialState = {
+      availableDebts: { availableDebts: [], isDebtError: true },
+      form: { data: { selectedDebts: [] } },
+    };
+
+    const { container } = renderWithStore(
+      <DebtSelection formContext={{ submitted: false }} />,
+      initialState,
+    );
+
+    // Should render AlertCard instead of debt selection content
+    expect(container.querySelector('[data-testid="balance-card-alert-debt"]'))
+      .to.exist;
+    expect(container.querySelector('[data-testid="debt-selection-content"]')).to
+      .not.exist;
+  });
+
+  it('renders AlertCard when no debts are available', () => {
+    const initialState = {
+      availableDebts: { availableDebts: [], isDebtError: false },
+      form: { data: { selectedDebts: [] } },
+    };
+
+    const { container } = renderWithStore(
+      <DebtSelection formContext={{ submitted: false }} />,
+      initialState,
+    );
+
+    // Should render AlertCard when no debts available
+    expect(container.querySelector('[data-testid="balance-card-alert-debt"]'))
+      .to.exist;
+    expect(container.querySelector('[data-testid="debt-selection-content"]')).to
+      .not.exist;
+  });
+
+  it('renders debt selection content when debts are available', () => {
+    const mockDebt = {
+      compositeDebtId: '123',
+      label: 'Test Debt',
+      description: 'Test debt description',
+    };
+
+    const initialState = {
+      availableDebts: { availableDebts: [mockDebt], isDebtError: false },
+      form: { data: { selectedDebts: [] } },
+    };
+
+    const { container } = renderWithStore(
+      <DebtSelection formContext={{ submitted: false }} />,
+      initialState,
+    );
+
+    // Should render debt selection content
+    expect(container.querySelector('[data-testid="debt-selection-content"]')).to
+      .exist;
+    expect(container.querySelector('va-checkbox-group')).to.exist;
+    expect(container.querySelector('va-checkbox')).to.exist;
+    expect(container.querySelector('va-additional-info')).to.exist;
+  });
+
+  it('renders multiple debt checkboxes when multiple debts available', () => {
+    const mockDebts = [
+      { compositeDebtId: '123', label: 'Debt 1', description: 'Description 1' },
+      { compositeDebtId: '456', label: 'Debt 2', description: 'Description 2' },
+      { compositeDebtId: '789', label: 'Debt 3', description: 'Description 3' },
+    ];
+
+    const initialState = {
+      availableDebts: { availableDebts: mockDebts, isDebtError: false },
+      form: { data: { selectedDebts: [] } },
+    };
+
+    const { container } = renderWithStore(
+      <DebtSelection formContext={{ submitted: false }} />,
+      initialState,
+    );
+
+    // Should render all debt checkboxes
+    const checkboxes = container.querySelectorAll('va-checkbox');
+    expect(checkboxes).to.have.length(3);
+  });
+
+  it('shows validation error when submitted with no debts selected', () => {
+    const mockDebt = {
+      compositeDebtId: '123',
+      label: 'Test Debt',
+      description: 'Test debt description',
+    };
+
+    const initialState = {
+      availableDebts: { availableDebts: [mockDebt], isDebtError: false },
+      form: { data: { selectedDebts: [] } },
+    };
+
+    renderWithStore(
+      <DebtSelection formContext={{ submitted: true }} />,
+      initialState,
+    );
+
+    // Should call setFocus when validation error occurs
+    expect(setFocusStub.calledWith('va-checkbox-group')).to.be.true;
+  });
+
+  it('calls setFocus utility when available', () => {
+    // Test that the utility function is available
+    expect(utils.setFocus).to.be.a('function');
+  });
+
+  it('exports as default function', () => {
+    // Test that component exports correctly
+    expect(DebtSelection).to.be.a('function');
+    expect(DebtSelection.name).to.equal('DebtSelection');
+  });
+});

--- a/src/applications/dispute-debt/tests/components/DebtSelectionReview.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/DebtSelectionReview.unit.spec.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import DebtSelectionReview from '../../components/DebtSelectionReview';
+
+describe('<DebtSelectionReview>', () => {
+  it('renders without crashing with empty data', () => {
+    const { getByText } = render(
+      <DebtSelectionReview data={{}} editPage={() => {}} />,
+    );
+    expect(getByText('No debts selected')).to.exist;
+  });
+});

--- a/src/applications/dispute-debt/tests/components/DisputeSummaryReview.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/DisputeSummaryReview.unit.spec.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import * as Sentry from '@sentry/browser';
+import DisputeSummaryReview from '../../components/DisputeSummaryReview';
+
+describe('DisputeSummaryReview Component', () => {
+  let sentryStub;
+  let withScopeStub;
+
+  beforeEach(() => {
+    sentryStub = sinon.stub(Sentry, 'captureMessage');
+    withScopeStub = sinon.stub(Sentry, 'withScope').callsFake(callback => {
+      const mockScope = {
+        setLevel: sinon.stub(),
+        setExtra: sinon.stub(),
+      };
+      callback(mockScope);
+    });
+  });
+
+  afterEach(() => {
+    sentryStub.restore();
+    withScopeStub.restore();
+  });
+
+  it('renders without crashing', () => {
+    expect(DisputeSummaryReview).to.be.a('function');
+  });
+
+  it('renders no debts message when selectedDebts is empty', () => {
+    const data = { selectedDebts: [] };
+    const { container } = render(<DisputeSummaryReview data={data} />);
+
+    expect(container.textContent).to.include('No debts selected for dispute');
+    expect(container.querySelector('.dispute-summary-review')).to.exist;
+  });
+
+  it('logs to Sentry when no debts are selected', () => {
+    const data = { selectedDebts: [] };
+    render(<DisputeSummaryReview data={data} />);
+
+    expect(
+      sentryStub.calledWith(
+        'Dispute Debt - Veteran reached review page without selecting any debts',
+      ),
+    ).to.be.true;
+  });
+
+  it('renders debt summary when debts are selected', () => {
+    const mockDebt = {
+      selectedDebtId: '123',
+      label: 'Test Debt',
+      currentAr: 1000,
+      disputeReason: 'Test reason',
+      supportStatement: 'Test statement',
+    };
+
+    const data = { selectedDebts: [mockDebt] };
+    const { container } = render(<DisputeSummaryReview data={data} />);
+
+    expect(container.querySelector('.dispute-summary-content')).to.exist;
+    expect(container.querySelector('.debt-summary-entry')).to.exist;
+    expect(container.textContent).to.include('Test Debt');
+    expect(container.textContent).to.include('Test reason');
+    expect(container.textContent).to.include('Test statement');
+  });
+
+  it('renders multiple debt summaries', () => {
+    const mockDebts = [
+      {
+        selectedDebtId: '123',
+        label: 'Debt 1',
+        currentAr: 1000,
+        disputeReason: 'Reason 1',
+      },
+      {
+        selectedDebtId: '456',
+        label: 'Debt 2',
+        currentAr: 2000,
+        disputeReason: 'Reason 2',
+      },
+    ];
+
+    const data = { selectedDebts: mockDebts };
+    const { container } = render(<DisputeSummaryReview data={data} />);
+
+    const debtEntries = container.querySelectorAll('.debt-summary-entry');
+    expect(debtEntries).to.have.length(2);
+    expect(container.textContent).to.include('Debt 1');
+    expect(container.textContent).to.include('Debt 2');
+  });
+
+  it('renders navigation buttons when debts are present', () => {
+    const mockDebt = {
+      selectedDebtId: '123',
+      label: 'Test Debt',
+      currentAr: 1000,
+    };
+
+    const data = { selectedDebts: [mockDebt] };
+    const { container } = render(<DisputeSummaryReview data={data} />);
+
+    expect(container.querySelector('va-button[text="Back"]')).to.exist;
+    expect(container.querySelector('va-button[text="Submit dispute"]')).to
+      .exist;
+  });
+
+  it('handles debt without disputeReason gracefully', () => {
+    const mockDebt = {
+      selectedDebtId: '123',
+      label: 'Test Debt',
+      currentAr: 1000,
+      // No disputeReason
+    };
+
+    const data = { selectedDebts: [mockDebt] };
+    const { container } = render(<DisputeSummaryReview data={data} />);
+
+    expect(container.querySelector('.debt-summary-entry')).to.exist;
+    expect(container.textContent).to.include('Test Debt');
+  });
+
+  it('handles debt without supportStatement gracefully', () => {
+    const mockDebt = {
+      selectedDebtId: '123',
+      label: 'Test Debt',
+      currentAr: 1000,
+      disputeReason: 'Test reason',
+      // No supportStatement
+    };
+
+    const data = { selectedDebts: [mockDebt] };
+    const { container } = render(<DisputeSummaryReview data={data} />);
+
+    expect(container.querySelector('.debt-summary-entry')).to.exist;
+    expect(container.textContent).to.include('Test Debt');
+    expect(container.textContent).to.include('Test reason');
+  });
+
+  it('exports as default function', () => {
+    expect(DisputeSummaryReview).to.be.a('function');
+    expect(DisputeSummaryReview.name).to.equal('DisputeSummaryReview');
+  });
+});

--- a/src/applications/dispute-debt/tests/components/GetFormHelp.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/GetFormHelp.unit.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import GetFormHelp from '../../components/GetFormHelp';
+
+describe('GetFormHelp Component', () => {
+  it('renders without crashing', () => {
+    expect(GetFormHelp).to.be.a('function');
+  });
+
+  it('renders help text content', () => {
+    const { container } = render(<GetFormHelp />);
+
+    expect(container.textContent).to.include(
+      'If you have questions or need help filling out this form',
+    );
+    expect(container.textContent).to.include(
+      'Monday through Friday, 8:00 a.m. to 9:00 p.m. ET',
+    );
+  });
+
+  it('renders VA benefits phone number', () => {
+    const { container } = render(<GetFormHelp />);
+
+    const phoneElements = container.querySelectorAll('va-telephone');
+    expect(phoneElements.length).to.be.at.least(1);
+  });
+
+  it('renders TTY phone number for hearing loss', () => {
+    const { container } = render(<GetFormHelp />);
+
+    expect(container.textContent).to.include('If you have hearing loss');
+    const phoneElements = container.querySelectorAll('va-telephone');
+    expect(phoneElements.length).to.be.at.least(2);
+  });
+
+  it('renders two paragraphs of help text', () => {
+    const { container } = render(<GetFormHelp />);
+
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs).to.have.length(2);
+  });
+
+  it('contains contact information for both regular and TTY users', () => {
+    const { container } = render(<GetFormHelp />);
+
+    const phoneElements = container.querySelectorAll('va-telephone');
+    expect(phoneElements).to.have.length(2);
+  });
+});

--- a/src/applications/dispute-debt/tests/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/NeedHelp.unit.spec.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import NeedHelp from '../../components/NeedHelp';
+
+describe('NeedHelp Component', () => {
+  it('renders without crashing', () => {
+    expect(NeedHelp).to.be.a('function');
+  });
+
+  it('renders help content in footer', () => {
+    const { container } = render(<NeedHelp />);
+
+    const footer = container.querySelector('footer[slot="content"]');
+    expect(footer).to.exist;
+  });
+
+  it('renders MyVA411 information line', () => {
+    const { container } = render(<NeedHelp />);
+
+    expect(container.textContent).to.include('MyVA411 main information line');
+    const phoneElement = container.querySelector(
+      'va-telephone[contact="8006982411"]',
+    );
+    expect(phoneElement).to.exist;
+  });
+
+  it('renders TTY number for MyVA411', () => {
+    const { container } = render(<NeedHelp />);
+
+    const ttyElement = container.querySelector(
+      'va-telephone[contact="711"][tty="true"]',
+    );
+    expect(ttyElement).to.exist;
+  });
+
+  it('renders link to get help filling out form', () => {
+    const { container } = render(<NeedHelp />);
+
+    expect(container.textContent).to.include(
+      'contact an accredited representative or VSO',
+    );
+    const helpLink = container.querySelector(
+      'a[href="/disability/get-help-filing-claim/"]',
+    );
+    expect(helpLink).to.exist;
+    expect(helpLink.textContent).to.include('Get help filling out your form');
+  });
+
+  it('renders benefit overpayments contact information', () => {
+    const { container } = render(<NeedHelp />);
+
+    expect(container.textContent).to.include(
+      'questions about your benefit overpayments',
+    );
+    expect(container.textContent).to.include(
+      'Monday through Friday, 7:30 a.m. to 7:00 p.m. ET',
+    );
+
+    const phoneElements = container.querySelectorAll('va-telephone');
+    expect(phoneElements.length).to.be.at.least(3);
+  });
+
+  it('renders copay bills contact information', () => {
+    const { container } = render(<NeedHelp />);
+
+    expect(container.textContent).to.include(
+      'questions about your copay bills',
+    );
+    expect(container.textContent).to.include(
+      'Monday through Friday, 8:00 a.m. to 8:00 p.m. ET',
+    );
+
+    const phoneElements = container.querySelectorAll('va-telephone');
+    expect(phoneElements.length).to.be.at.least(4);
+  });
+
+  it('renders all four help paragraphs', () => {
+    const { container } = render(<NeedHelp />);
+
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs).to.have.length(4);
+  });
+
+  it('contains multiple phone contact options', () => {
+    const { container } = render(<NeedHelp />);
+
+    const phoneElements = container.querySelectorAll('va-telephone');
+    expect(phoneElements.length).to.be.at.least(5); // MyVA411, TTY, DMC, DMC_OVERSEAS, Copay
+  });
+
+  it('provides comprehensive help information', () => {
+    const { container } = render(<NeedHelp />);
+
+    // Check for key help topics
+    expect(container.textContent).to.include('trouble using this online form');
+    expect(container.textContent).to.include('gather your information');
+    expect(container.textContent).to.include('benefit overpayments');
+    expect(container.textContent).to.include('copay bills');
+  });
+});

--- a/src/applications/dispute-debt/tests/components/NeedsToVerifyAlert.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/NeedsToVerifyAlert.unit.spec.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import NeedsToVerifyAlert from '../../components/NeedsToVerifyAlert';
+
+describe('<NeedsToVerifyAlert>', () => {
+  it('renders without crashing', () => {
+    const { container } = renderInReduxProvider(<NeedsToVerifyAlert />, {
+      initialState: { user: { profile: { signIn: { serviceName: 'idme' } } } },
+    });
+    expect(container).to.exist;
+  });
+});

--- a/src/applications/dispute-debt/tests/components/ShowAlertOrSip.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/ShowAlertOrSip.unit.spec.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { ShowAlertOrSip } from '../../components/ShowAlertOrSip';
+
+describe('<ShowAlertOrSip>', () => {
+  it('renders without crashing when not logged in', () => {
+    const { container } = renderInReduxProvider(
+      <ShowAlertOrSip
+        sipOptions={{ formId: 'test', pageList: [], startText: 'Start' }}
+      />,
+      { initialState: { user: { login: { currentlyLoggedIn: false } } } },
+    );
+    expect(container).to.exist;
+  });
+});

--- a/src/applications/dispute-debt/tests/components/VeteranInformation.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/components/VeteranInformation.unit.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import VeteranInformation from '../../components/VeteranInformation';
+
+describe('<VeteranInformation>', () => {
+  it('renders without crashing with minimal data', () => {
+    const { getByText } = renderInReduxProvider(
+      <VeteranInformation formData={{ veteran: {} }} />,
+      {
+        initialState: {
+          user: { profile: { userFullName: { first: 'John', last: 'Doe' } } },
+        },
+      },
+    );
+    expect(getByText('Your personal information')).to.exist;
+  });
+});


### PR DESCRIPTION
## Summary
Added unit test coverage for the following components:
- AlertCard
- DebtSelection
- DebtSelectionReview
- DisputeSummaryReview
- GetFormHelp
- NeedHelp
- NeedsToVerifyAlert
- ShowAlertOrSip
- VeteranInformation

Part of ticket #113116: Regression Test Plan and Unit Test Coverage


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#113116


## Testing done


- Unit tests and report

## Screenshots

<img width="1838" alt="Screenshot 2025-06-30 at 2 04 30 PM" src="https://github.com/user-attachments/assets/c97d8081-cf62-415f-9672-cb8c9c2eb0fa" />

## What areas of the site does it impact?

Dispute Debt

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
