### PR TITLE
[DD] Add unit tests for dispute-debt pages

### DIFF
--- a/src/applications/dispute-debt/tests/pages/debtSelection.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/pages/debtSelection.unit.spec.jsx
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import debtSelection from '../../pages/debtSelection';
+import DebtSelection from '../../components/DebtSelection';
+
+describe('debtSelection page', () => {
+  it('exports a valid page configuration', () => {
+    expect(debtSelection).to.be.an('object');
+    expect(debtSelection.uiSchema).to.exist;
+    expect(debtSelection.schema).to.exist;
+  });
+
+  describe('uiSchema', () => {
+    it('has correct title function', () => {
+      const titleFunction = debtSelection.uiSchema['ui:title'];
+      expect(titleFunction).to.be.a('function');
+
+      const titleElement = titleFunction();
+      expect(titleElement).to.exist;
+      expect(titleElement.type).to.exist;
+    });
+
+    it('has selectedDebts field configuration', () => {
+      const selectedDebtsConfig = debtSelection.uiSchema.selectedDebts;
+      expect(selectedDebtsConfig).to.exist;
+      expect(selectedDebtsConfig['ui:field']).to.equal(DebtSelection);
+      expect(selectedDebtsConfig['ui:options']).to.exist;
+      expect(selectedDebtsConfig['ui:options'].hideOnReview).to.be.true;
+    });
+
+    it('has validation function', () => {
+      const validations =
+        debtSelection.uiSchema.selectedDebts['ui:validations'];
+      expect(validations).to.be.an('array');
+      expect(validations).to.have.length(1);
+      expect(validations[0]).to.be.a('function');
+    });
+
+    it('validation function adds error for empty debts', () => {
+      const validation =
+        debtSelection.uiSchema.selectedDebts['ui:validations'][0];
+      const mockErrors = {
+        addError: sinon.stub(),
+      };
+
+      validation(mockErrors, []);
+
+      expect(mockErrors.addError.calledOnce).to.be.true;
+      expect(mockErrors.addError.calledWith('Please select at least one debt.'))
+        .to.be.true;
+    });
+
+    it('validation function does not add error for non-empty debts', () => {
+      const validation =
+        debtSelection.uiSchema.selectedDebts['ui:validations'][0];
+      const mockErrors = {
+        addError: sinon.stub(),
+      };
+
+      validation(mockErrors, [{ id: '1' }]);
+
+      expect(mockErrors.addError.called).to.be.false;
+    });
+  });
+
+  describe('schema', () => {
+    it('has correct structure', () => {
+      expect(debtSelection.schema.type).to.equal('object');
+      expect(debtSelection.schema.properties).to.exist;
+      expect(debtSelection.schema.properties.selectedDebts).to.exist;
+    });
+
+    it('has selectedDebts array configuration', () => {
+      const selectedDebtsSchema = debtSelection.schema.properties.selectedDebts;
+      expect(selectedDebtsSchema.type).to.equal('array');
+      expect(selectedDebtsSchema.items).to.exist;
+      expect(selectedDebtsSchema.items.type).to.equal('object');
+      expect(selectedDebtsSchema.items.properties).to.exist;
+    });
+  });
+
+  describe('title rendering', () => {
+    it('renders correct title text', () => {
+      const titleFunction = debtSelection.uiSchema['ui:title'];
+      const titleElement = titleFunction();
+
+      // Check that it's a React fragment with h3
+      expect(titleElement.props.children.type).to.equal('h3');
+      expect(titleElement.props.children.props.children).to.equal(
+        'Which debt are you disputing?',
+      );
+      expect(titleElement.props.children.props.className).to.include(
+        'vads-u-margin--0',
+      );
+      expect(titleElement.props.children.props.className).to.include(
+        'vads-u-font-size--h2',
+      );
+    });
+  });
+});

--- a/src/applications/dispute-debt/tests/pages/disputeReason.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/pages/disputeReason.unit.spec.jsx
@@ -1,0 +1,114 @@
+import { expect } from 'chai';
+import VaRadioField from 'platform/forms-system/src/js/web-component-fields/VaRadioField';
+import disputeReason from '../../pages/disputeReason';
+import DebtTitle from '../../components/DebtTitle';
+
+describe('disputeReason page', () => {
+  const EXISTENCE = `I don't think I owe this debt to VA`;
+  const AMOUNT = `I don't think the amount is correct on this debt`;
+
+  it('exports a valid page configuration', () => {
+    expect(disputeReason).to.be.an('object');
+    expect(disputeReason.uiSchema).to.exist;
+    expect(disputeReason.schema).to.exist;
+  });
+
+  describe('uiSchema', () => {
+    it('has selectedDebts items configuration', () => {
+      const itemsConfig = disputeReason.uiSchema.selectedDebts.items;
+      expect(itemsConfig).to.exist;
+      expect(itemsConfig['ui:title']).to.equal(DebtTitle);
+    });
+
+    it('has disputeReason field configuration', () => {
+      const disputeReasonConfig =
+        disputeReason.uiSchema.selectedDebts.items.disputeReason;
+      expect(disputeReasonConfig).to.exist;
+      expect(disputeReasonConfig['ui:title']).to.equal(
+        "Select the reason you're disputing this debt.",
+      );
+      expect(disputeReasonConfig['ui:webComponentField']).to.equal(
+        VaRadioField,
+      );
+    });
+
+    it('has required function that returns true', () => {
+      const requiredFn =
+        disputeReason.uiSchema.selectedDebts.items.disputeReason['ui:required'];
+      expect(requiredFn).to.be.a('function');
+      expect(requiredFn()).to.be.true;
+    });
+
+    it('has correct option labels', () => {
+      const {
+        labels,
+      } = disputeReason.uiSchema.selectedDebts.items.disputeReason[
+        'ui:options'
+      ];
+      expect(labels).to.exist;
+      expect(labels.EXISTENCE).to.equal(EXISTENCE);
+      expect(labels.AMOUNT).to.equal(AMOUNT);
+    });
+
+    it('has error messages configured', () => {
+      const errorMessages =
+        disputeReason.uiSchema.selectedDebts.items.disputeReason[
+          'ui:errorMessages'
+        ];
+      expect(errorMessages).to.exist;
+      expect(errorMessages.required).to.equal(
+        'Please select a reason for disputing this debt',
+      );
+    });
+  });
+
+  describe('schema', () => {
+    it('has correct structure', () => {
+      expect(disputeReason.schema.type).to.equal('object');
+      expect(disputeReason.schema.properties).to.exist;
+      expect(disputeReason.schema.properties.selectedDebts).to.exist;
+    });
+
+    it('has selectedDebts array configuration', () => {
+      const selectedDebtsSchema = disputeReason.schema.properties.selectedDebts;
+      expect(selectedDebtsSchema.type).to.equal('array');
+      expect(selectedDebtsSchema.items).to.exist;
+      expect(selectedDebtsSchema.items.type).to.equal('object');
+    });
+
+    it('has disputeReason field in items', () => {
+      const itemProperties =
+        disputeReason.schema.properties.selectedDebts.items.properties;
+      expect(itemProperties.disputeReason).to.exist;
+      expect(itemProperties.disputeReason.type).to.equal('string');
+    });
+
+    it('has correct enum values', () => {
+      const disputeReasonField =
+        disputeReason.schema.properties.selectedDebts.items.properties
+          .disputeReason;
+      expect(disputeReasonField.enum).to.be.an('array');
+      expect(disputeReasonField.enum).to.include(EXISTENCE);
+      expect(disputeReasonField.enum).to.include(AMOUNT);
+      expect(disputeReasonField.enum).to.have.length(2);
+    });
+
+    it('has required fields specified', () => {
+      const { required } = disputeReason.schema.properties.selectedDebts.items;
+      expect(required).to.be.an('array');
+      expect(required).to.include('disputeReason');
+    });
+  });
+
+  describe('constants', () => {
+    it('defines correct dispute reason options', () => {
+      const enumValues =
+        disputeReason.schema.properties.selectedDebts.items.properties
+          .disputeReason.enum;
+      expect(enumValues[0]).to.equal(`I don't think I owe this debt to VA`);
+      expect(enumValues[1]).to.equal(
+        `I don't think the amount is correct on this debt`,
+      );
+    });
+  });
+});

--- a/src/applications/dispute-debt/tests/pages/index.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/pages/index.unit.spec.jsx
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import {
+  veteranInformation,
+  debtSelection,
+  disputeReason,
+  supportStatement,
+} from '../../pages/index';
+
+describe('Pages Index', () => {
+  it('exports veteranInformation', () => {
+    expect(veteranInformation).to.exist;
+    expect(veteranInformation).to.be.an('object');
+  });
+
+  it('exports debtSelection', () => {
+    expect(debtSelection).to.exist;
+    expect(debtSelection).to.be.an('object');
+  });
+
+  it('exports disputeReason', () => {
+    expect(disputeReason).to.exist;
+    expect(disputeReason).to.be.an('object');
+  });
+
+  it('exports supportStatement', () => {
+    expect(supportStatement).to.exist;
+    expect(supportStatement).to.be.an('object');
+  });
+
+  it('all exports have uiSchema and schema properties', () => {
+    const pages = [
+      veteranInformation,
+      debtSelection,
+      disputeReason,
+      supportStatement,
+    ];
+
+    pages.forEach((page, index) => {
+      const pageName = [
+        'veteranInformation',
+        'debtSelection',
+        'disputeReason',
+        'supportStatement',
+      ][index];
+      expect(page.uiSchema, `${pageName} should have uiSchema`).to.exist;
+      expect(page.schema, `${pageName} should have schema`).to.exist;
+    });
+  });
+
+  it('all schemas are valid objects', () => {
+    const pages = [
+      veteranInformation,
+      debtSelection,
+      disputeReason,
+      supportStatement,
+    ];
+
+    pages.forEach((page, index) => {
+      const pageName = [
+        'veteranInformation',
+        'debtSelection',
+        'disputeReason',
+        'supportStatement',
+      ][index];
+      expect(page.schema, `${pageName} schema should be an object`).to.be.an(
+        'object',
+      );
+      expect(page.schema.type, `${pageName} schema should have type`).to.exist;
+      expect(
+        page.schema.properties,
+        `${pageName} schema should have properties`,
+      ).to.exist;
+    });
+  });
+
+  it('all uiSchemas are valid objects', () => {
+    const pages = [
+      veteranInformation,
+      debtSelection,
+      disputeReason,
+      supportStatement,
+    ];
+
+    pages.forEach((page, index) => {
+      const pageName = [
+        'veteranInformation',
+        'debtSelection',
+        'disputeReason',
+        'supportStatement',
+      ][index];
+      expect(
+        page.uiSchema,
+        `${pageName} uiSchema should be an object`,
+      ).to.be.an('object');
+    });
+  });
+});

--- a/src/applications/dispute-debt/tests/pages/supportStatement.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/pages/supportStatement.unit.spec.jsx
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import VaTextareaField from 'platform/forms-system/src/js/web-component-fields/VaTextareaField';
+import supportStatement from '../../pages/supportStatement';
+import DebtTitle from '../../components/DebtTitle';
+
+describe('supportStatement page', () => {
+  it('exports a valid page configuration', () => {
+    expect(supportStatement).to.be.an('object');
+    expect(supportStatement.uiSchema).to.exist;
+    expect(supportStatement.schema).to.exist;
+  });
+
+  describe('uiSchema', () => {
+    it('has selectedDebts items configuration', () => {
+      const itemsConfig = supportStatement.uiSchema.selectedDebts.items;
+      expect(itemsConfig).to.exist;
+      expect(itemsConfig['ui:title']).to.equal(DebtTitle);
+    });
+
+    it('has supportStatement field configuration', () => {
+      const supportStatementConfig =
+        supportStatement.uiSchema.selectedDebts.items.supportStatement;
+      expect(supportStatementConfig).to.exist;
+      expect(supportStatementConfig['ui:title']).to.include('Tell us why');
+      expect(supportStatementConfig['ui:title']).to.include(
+        'disputing this debt',
+      );
+      expect(supportStatementConfig['ui:webComponentField']).to.equal(
+        VaTextareaField,
+      );
+    });
+
+    it('has required function that returns true', () => {
+      const requiredFn =
+        supportStatement.uiSchema.selectedDebts.items.supportStatement[
+          'ui:required'
+        ];
+      expect(requiredFn).to.be.a('function');
+      expect(requiredFn()).to.be.true;
+    });
+
+    it('has error messages configured', () => {
+      const errorMessages =
+        supportStatement.uiSchema.selectedDebts.items.supportStatement[
+          'ui:errorMessages'
+        ];
+      expect(errorMessages).to.exist;
+      expect(errorMessages.required).to.equal('Please provide a response');
+    });
+  });
+
+  describe('schema', () => {
+    it('has correct structure', () => {
+      expect(supportStatement.schema.type).to.equal('object');
+      expect(supportStatement.schema.properties).to.exist;
+      expect(supportStatement.schema.properties.selectedDebts).to.exist;
+    });
+
+    it('has selectedDebts array configuration', () => {
+      const selectedDebtsSchema =
+        supportStatement.schema.properties.selectedDebts;
+      expect(selectedDebtsSchema.type).to.equal('array');
+      expect(selectedDebtsSchema.items).to.exist;
+      expect(selectedDebtsSchema.items.type).to.equal('object');
+    });
+
+    it('has supportStatement field in items', () => {
+      const itemProperties =
+        supportStatement.schema.properties.selectedDebts.items.properties;
+      expect(itemProperties.supportStatement).to.exist;
+      expect(itemProperties.supportStatement.type).to.equal('string');
+    });
+
+    it('has required fields specified', () => {
+      const {
+        required,
+      } = supportStatement.schema.properties.selectedDebts.items;
+      expect(required).to.be.an('array');
+      expect(required).to.include('supportStatement');
+    });
+  });
+
+  describe('field validation', () => {
+    it('requires supportStatement field', () => {
+      const {
+        required,
+      } = supportStatement.schema.properties.selectedDebts.items;
+      expect(required).to.include('supportStatement');
+    });
+
+    it('has string type for supportStatement', () => {
+      const supportStatementField =
+        supportStatement.schema.properties.selectedDebts.items.properties
+          .supportStatement;
+      expect(supportStatementField.type).to.equal('string');
+    });
+  });
+});

--- a/src/applications/dispute-debt/tests/pages/veteranInformation.unit.spec.jsx
+++ b/src/applications/dispute-debt/tests/pages/veteranInformation.unit.spec.jsx
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import veteranInformation from '../../pages/veteranInformation';
+import VeteranInformation from '../../components/VeteranInformation';
+
+describe('veteranInformation page', () => {
+  it('exports a valid page configuration', () => {
+    expect(veteranInformation).to.be.an('object');
+    expect(veteranInformation.uiSchema).to.exist;
+    expect(veteranInformation.schema).to.exist;
+  });
+
+  describe('uiSchema', () => {
+    it('has VeteranInformation component as description', () => {
+      expect(veteranInformation.uiSchema['ui:description']).to.equal(
+        VeteranInformation,
+      );
+    });
+
+    it('has ui:options configured', () => {
+      const options = veteranInformation.uiSchema['ui:options'];
+      expect(options).to.exist;
+      expect(options.hideOnReview).to.be.true;
+    });
+
+    it('hides on review', () => {
+      expect(veteranInformation.uiSchema['ui:options'].hideOnReview).to.be.true;
+    });
+  });
+
+  describe('schema', () => {
+    it('has correct structure', () => {
+      expect(veteranInformation.schema.type).to.equal('object');
+      expect(veteranInformation.schema.properties).to.exist;
+    });
+
+    it('has empty properties object', () => {
+      expect(veteranInformation.schema.properties).to.be.an('object');
+      expect(Object.keys(veteranInformation.schema.properties)).to.have.length(
+        0,
+      );
+    });
+  });
+
+  describe('configuration', () => {
+    it('is a display-only page with no form fields', () => {
+      // This page only shows veteran information, no form inputs
+      expect(Object.keys(veteranInformation.schema.properties)).to.have.length(
+        0,
+      );
+      expect(veteranInformation.uiSchema['ui:description']).to.equal(
+        VeteranInformation,
+      );
+    });
+
+    it('uses VeteranInformation component for display', () => {
+      expect(veteranInformation.uiSchema['ui:description']).to.be.a('function');
+    });
+  });
+});


### PR DESCRIPTION

## Summary 

Added unit test coverage for the following pages:
- debtSelection
- disputeReason
- index
- supportStatement
- veteranInformation

Part of ticket #113116: Regression Test Plan and Unit Test Coverage

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#113116


## Testing done


- Unit tests and report

## Screenshots

<img width="1372" alt="Screenshot 2025-06-30 at 2 13 53 PM" src="https://github.com/user-attachments/assets/eca1a437-d88d-46a4-bf05-727acf9c29c8" />


## What areas of the site does it impact?

Dispute Debt

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
