### PR TITLE
Release pending features to production

### DIFF
--- a/src/applications/discover-your-benefits/config/form.js
+++ b/src/applications/discover-your-benefits/config/form.js
@@ -102,7 +102,6 @@ export const formConfig = {
           title: 'Military Branch Served',
           uiSchema: militaryBranch.uiSchema,
           schema: militaryBranch.schema,
-          depends: () => !environment.isProduction(),
         },
         titleTenActiveDuty: {
           path: 'service/active-duty',
@@ -110,17 +109,14 @@ export const formConfig = {
           uiSchema: activeDuty.uiSchema,
           schema: activeDuty.schema,
           depends: formData => {
-            return (
-              !environment.isProduction() &&
-              Object.values(formData.branchComponents).some(
-                branchComponent =>
-                  branchComponent[
-                    militaryBranchComponentTypes.NATIONAL_GUARD_SERVICE
-                  ] === true ||
-                  branchComponent[
-                    militaryBranchComponentTypes.RESERVE_SERVICE
-                  ] === true,
-              )
+            return Object.values(formData.branchComponents).some(
+              branchComponent =>
+                branchComponent[
+                  militaryBranchComponentTypes.NATIONAL_GUARD_SERVICE
+                ] === true ||
+                branchComponent[
+                  militaryBranchComponentTypes.RESERVE_SERVICE
+                ] === true,
             );
           },
         },
@@ -130,10 +126,7 @@ export const formConfig = {
           uiSchema: titleTenServiceTime.uiSchema,
           schema: titleTenServiceTime.schema,
           depends: formData => {
-            return (
-              !environment.isProduction() &&
-              formData.titleTenActiveDuty === true
-            );
+            return formData.titleTenActiveDuty === true;
           },
         },
         militaryService: {

--- a/src/applications/discover-your-benefits/tests/e2e/discover-your-benefits.cypress.spec.js
+++ b/src/applications/discover-your-benefits/tests/e2e/discover-your-benefits.cypress.spec.js
@@ -112,9 +112,6 @@ const testConfig = createTestConfig(
           .then($el => cy.selectVaCheckbox($el, true));
       },
     },
-    // Skip tests in CI until the form is released.
-    // Remove this setting when the form has a content page in production.
-    skip: Cypress.env('CI'),
   },
   manifest,
   formConfig,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removes production environment check for the military branch and title 10 active duty questions, making them available to production users.

## Related issue(s)

https://jira.devops.va.gov/browse/PTEMSVT-507

## Testing done



## Screenshots

N/A

## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

N/A

## Requested Feedback

N/A