### PR TITLE
[ARP] Fix feature toggle 403

### DIFF
--- a/src/applications/accredited-representative-portal/app-entry.jsx
+++ b/src/applications/accredited-representative-portal/app-entry.jsx
@@ -15,14 +15,14 @@ import './sass/GetHelp.scss';
 import './sass/SubmissionsPage.scss';
 
 import routes from './routes';
-import createReduxStore from './utilities/store';
+import store from './utilities/store';
 
 const router = createBrowserRouter(routes, {
   basename: '/representative',
 });
 
 startReactApp(
-  <Provider store={createReduxStore()}>
+  <Provider store={store}>
     <RouterProvider router={router} />
   </Provider>,
 );

--- a/src/applications/accredited-representative-portal/tests/unit/helpers/index.jsx
+++ b/src/applications/accredited-representative-portal/tests/unit/helpers/index.jsx
@@ -7,7 +7,9 @@ import {
 } from 'react-router-dom';
 import { render } from '@testing-library/react';
 
-import createReduxStore from '../../../utilities/store';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
+
+import { createReduxStore } from '../../../utilities/store';
 
 /**
  * Beginning to look like an overwrought wrapping of multiple underlying APIs'
@@ -15,6 +17,7 @@ import createReduxStore from '../../../utilities/store';
  */
 export function renderTestApp(children, { initAction, initialEntries } = {}) {
   const store = createReduxStore();
+  connectFeatureToggle(store.dispatch);
   if (initAction) store.dispatch(initAction);
 
   return render(

--- a/src/applications/accredited-representative-portal/utilities/auth.js
+++ b/src/applications/accredited-representative-portal/utilities/auth.js
@@ -1,5 +1,8 @@
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
+
 import api from './api';
 import mockApi, { configure as configureMockApi } from './mockApi';
+import store from './store';
 
 /**
  * `userPromise` is a singleton that is created when the app is created. It has
@@ -29,12 +32,27 @@ export const userPromise = (async () => {
       if (!serviceName)
         throw new Error('Missing user with sign in service name.');
 
-      // Needed for access token refreshing to function.
+      /**
+       * Needed for access token refreshing to function.
+       */
       sessionStorage.setItem('serviceName', serviceName);
     }
 
     return user;
   } catch (e) {
     return null;
+  } finally {
+    /**
+     * Platform's Flipper client doesn't attempt to refresh expired access
+     * tokens, so feature toggles simply don't load when the user's access token
+     * expires.
+     *
+     * To get around this for now, we make the feature toggle fetch occur
+     * serially after our user fetch singleton which _does_ refresh access
+     * tokens before replaying the fetch.
+     *
+     * TODO: Find something less hacky.
+     */
+    connectFeatureToggle(store.dispatch);
   }
 })();

--- a/src/applications/accredited-representative-portal/utilities/store.js
+++ b/src/applications/accredited-representative-portal/utilities/store.js
@@ -3,9 +3,8 @@ import thunk from 'redux-thunk';
 
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { FeatureToggleReducer } from 'platform/site-wide/feature-toggles/reducers';
-import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 
-export default function createReduxStore() {
+export function createReduxStore() {
   const rootReducer = combineReducers({
     featureToggles: FeatureToggleReducer,
   });
@@ -13,15 +12,13 @@ export default function createReduxStore() {
   const useDevTools =
     !environment.isProduction() && window.__REDUX_DEVTOOLS_EXTENSION__;
 
-  const store = createStore(
+  return createStore(
     rootReducer,
     compose(
       applyMiddleware(thunk),
       useDevTools ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f,
     ),
   );
-
-  connectFeatureToggle(store.dispatch);
-
-  return store;
 }
+
+export default createReduxStore();


### PR DESCRIPTION
Platform's Flipper client doesn't attempt to refresh expired access tokens, so feature toggles simply don't load when the user's access token expires.

To get around this for now, we make the feature toggle fetch occur serially after our user fetch singleton which _does_ refresh access tokens before replaying the fetch.