### PR TITLE
proof of concept - [ARP] Fix file upload 403

### DIFF
--- a/src/applications/representative-form-upload/helpers/index.js
+++ b/src/applications/representative-form-upload/helpers/index.js
@@ -1,3 +1,5 @@
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+import environment from '~/platform/utilities/environment';
 import { srSubstitute } from '~/platform/forms-system/src/js/utilities/ui/mask-string';
 import { focusByOrder } from 'platform/utilities/ui/focus';
 import { waitForShadowRoot } from 'platform/utilities/ui/webComponents';
@@ -128,7 +130,19 @@ export function parseResponse({ data }) {
   };
 }
 
-export function createPayload(file, formId, password) {
+export async function createPayload(file, formId, password) {
+  /**
+   * Platform's file upload client doesn't attempt to refresh expired access
+   * tokens, so it becomes impossible to make progress on the form without
+   * starting over when the user's access token expires.
+   *
+   * To get around this for now, we call another endpoint with a client that
+   * does refresh access tokens in this callback that runs right before
+   * uploading the file.
+   */
+  const path = '/accredited_representative_portal/v0/user';
+  await apiRequest(`${environment.API_URL}${path}`);
+
   const payload = new FormData();
   payload.set('form_id', formId);
   payload.append('file', file);

--- a/src/applications/representative-form-upload/pages/upload.jsx
+++ b/src/applications/representative-form-upload/pages/upload.jsx
@@ -37,6 +37,7 @@ export const uploadPage = {
     ...uploadTitleAndDescription,
     uploadedFile: {
       ...fileInputUI({
+        createPayload,
         errorMessages: { required: `Upload a completed VA Form ${formNumber}` },
         name: 'form-upload-file-input',
         fileUploadUrl,

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -230,7 +230,7 @@ export function uploadFile(
 ) {
   // This item should have been set in any previous API calls
   const csrfTokenStored = localStorage.getItem('csrfToken');
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     // PDFs may have a different max size based on where it is being uploaded
     // (form 526 & claim status)
     const maxSize =
@@ -313,7 +313,7 @@ export function uploadFile(
       onChange({ name: file.name, uploading: true });
     }
 
-    const payload = uiOptions.createPayload(
+    const payload = await uiOptions.createPayload(
       file,
       getState().form.formId,
       password,

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
@@ -18,7 +18,7 @@ const useFileValidator = options => {
   return { validateFileSize };
 };
 
-const useFileUpload = (fileUploadUrl, formNumber, dispatch) => {
+const useFileUpload = (fileUploadUrl, formNumber, createPayload, dispatch) => {
   const [isUploading, setIsUploading] = useState(false);
 
   const uploadFile = (file, onSuccess) => {
@@ -37,6 +37,7 @@ const useFileUpload = (fileUploadUrl, formNumber, dispatch) => {
       uploadScannedForm(
         fileUploadUrl,
         formNumber,
+        createPayload,
         file,
         onFileUploaded,
         onFileUploading,
@@ -78,7 +79,7 @@ const useFileUpload = (fileUploadUrl, formNumber, dispatch) => {
  * @param {WebComponentFieldProps} props */
 const VaFileInputField = props => {
   const { uiOptions = {}, childrenProps } = props;
-  const { formNumber } = uiOptions;
+  const { formNumber, createPayload } = uiOptions;
   const mappedProps = vaFileInputFieldMapping(props);
   const { fileUploadUrl } = mappedProps;
   const dispatch = useDispatch();
@@ -87,6 +88,7 @@ const VaFileInputField = props => {
   const { isUploading, uploadFile } = useFileUpload(
     fileUploadUrl,
     formNumber,
+    createPayload,
     dispatch,
   );
 

--- a/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldHelpers.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldHelpers.jsx
@@ -3,7 +3,7 @@ import { uploadFile } from 'platform/forms-system/src/js/actions';
 const MAX_FILE_SIZE_MB = 25;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1000 ** 2;
 
-const createPayload = (file, formId) => {
+const defaultCreatePayload = (file, formId) => {
   const payload = new FormData();
   payload.set('form_id', formId);
   payload.append('file', file);
@@ -13,6 +13,7 @@ const createPayload = (file, formId) => {
 export const uploadScannedForm = (
   fileUploadUrl,
   formNumber,
+  createPayload,
   fileToUpload,
   onFileUploaded,
   onProgress,
@@ -21,7 +22,7 @@ export const uploadScannedForm = (
     fileUploadUrl,
     fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
     maxSize: MAX_FILE_SIZE_BYTES,
-    createPayload,
+    createPayload: createPayload ?? defaultCreatePayload,
     parseResponse: ({ data }, file) => ({ ...data?.attributes, file }),
   };
 


### PR DESCRIPTION
Platform's file upload client doesn't attempt to refresh expired access tokens, so it becomes impossible to make progress on the form without starting over when the user's access token expires.

To get around this for now, we call another endpoint with a client that does refresh access tokens in this callback that runs right before uploading the file.