### PR TITLE
MHV-72193: AUDIT: Remove “# refills left” from all medication cards

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -5,7 +5,6 @@ import { useSelector } from 'react-redux';
 import FillRefillButton from '../shared/FillRefillButton';
 import ExtraDetails from '../shared/ExtraDetails';
 import LastFilledInfo from '../shared/LastFilledInfo';
-import { dispStatusForRefillsLeft } from '../../util/constants';
 import { selectRefillContentFlag } from '../../util/selectors';
 import { dateFormat } from '../../util/helpers';
 import { dataDogActionNames } from '../../util/dataDogConstants';
@@ -17,17 +16,6 @@ const MedicationsListCard = ({ rx }) => {
   const pendingRenewal =
     rx.prescriptionSource === 'PD' && rx?.dispStatus === 'Renew';
   const latestTrackingStatus = rx?.trackingList?.[0];
-  let showRefillRemaining = false;
-
-  if (dispStatusForRefillsLeft.includes(rx.dispStatus)) {
-    showRefillRemaining = true;
-  }
-  const refillsRemaining = () => {
-    if (rx.refillRemaining === 1) {
-      return <p data-dd-privacy="mask">{rx.refillRemaining} refill left</p>;
-    }
-    return <p data-dd-privacy="mask">{rx.refillRemaining} refills left</p>;
-  };
 
   const cardBodyContent = () => {
     if (pendingRenewal || pendingMed) {
@@ -61,7 +49,6 @@ const MedicationsListCard = ({ rx }) => {
     return (
       <>
         {rx && <LastFilledInfo {...rx} />}
-        {showRefillRemaining && refillsRemaining()}
         {latestTrackingStatus && (
           <p
             className="vads-u-margin-top--1p5 vads-u-padding-bottom--1p5 vads-u-border-bottom--1px vads-u-border-color--gray-lighter"

--- a/src/applications/mhv-medications/tests/e2e/medications-validate-information-for-active-refills-left.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-validate-information-for-active-refills-left.cypress.spec.js
@@ -10,6 +10,6 @@ describe('Medications List Page Information based on Medication Status', () => {
     listPage.visitMedicationsListPageURL(rxList);
     cy.injectAxe();
     cy.axeCheck('main');
-    listPage.verifyInformationBasedOnStatusActiveRefillsLeft();
+    listPage.verifyNumberOfRefillsLeftNotDisplayedOnMedicationCard();
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -3,7 +3,6 @@ import prescriptions from '../fixtures/listOfPrescriptions.json';
 import allergies from '../fixtures/allergies.json';
 import allergiesList from '../fixtures/allergies-list.json';
 import tooltip from '../fixtures/tooltip-for-filtering-list-page.json';
-import activeRxRefills from '../fixtures/active-prescriptions-with-refills.json';
 import { Paths } from '../utils/constants';
 import nonVARx from '../fixtures/non-VA-prescription-on-list-page.json';
 import prescription from '../fixtures/prescription-details.json';
@@ -415,13 +414,8 @@ class MedicationsListPage {
       .and('contain', 'We’re sorry. There’s a problem with our system.');
   };
 
-  verifyInformationBasedOnStatusActiveRefillsLeft = () => {
-    cy.get(
-      '[data-testid="medication-list"] > :nth-child(2) > [data-testid="rx-card-info"] > :nth-child(4)',
-    ).should(
-      'contain',
-      `${activeRxRefills.data.attributes.refillRemaining} refills left`,
-    );
+  verifyNumberOfRefillsLeftNotDisplayedOnMedicationCard = () => {
+    cy.contains('refills left').should('not.be.visible');
   };
 
   verifyInformationBaseOnStatusSubmitted = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removed "#refills left" functionality from `MedicationsListCard`

## Acceptance Criteria:

AC1: Remove “# refills left” from all medication cards

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-72193

## Testing done

- Manual testing
- e2e testing

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
