### PR TITLE
Update Slack group in allow list

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -75,7 +75,7 @@
     },
     {
       "rootFolder": "discover-your-benefits",
-      "slackGroup": "<@U022GNYPJ1L>"
+      "slackGroup": "@ves-te-engineers"
     },
     {
       "rootFolder": "dispute-debt",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates the Slack group for the `Discover your benefits` app to the Transition Experience engineering group in the changed apps build config.

## Related issue(s)

https://jira.devops.va.gov/browse/PTEMSVT-495

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

N/A

### Error Handling

N/A

### Authentication

N/A

## Requested Feedback

N/A
