### PR TITLE
Update validation error focus logic for all scheduling flows

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/CommunityCare.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/CommunityCare.jsx
@@ -1,3 +1,4 @@
+import { scrollToFirstError } from 'platform/utilities/scroll';
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
@@ -40,8 +41,6 @@ function goForward({ dispatch, data, history, setSubmitted }) {
     !exceededMaxSelections(data.selectedDates)
   ) {
     dispatch(routeToNextAppointmentPage(history, pageKey));
-  } else {
-    scrollAndFocus('.usa-input-error-message');
   }
 }
 
@@ -56,10 +55,20 @@ export default function CCRequest() {
   const history = useHistory();
   const dispatch = useDispatch();
   const [submitted, setSubmitted] = useState(false);
+  // Add a counter state to trigger focusing
+  const [focusTrigger, setFocusTrigger] = useState(0);
   const appointmentSlotsStatus = useSelector(state =>
     selectAppointmentSlotsStatus(state),
   );
   const flowType = useSelector(state => getFlowType(state));
+
+  // Effect to focus on validation message whenever error state changes
+  useEffect(
+    () => {
+      scrollToFirstError();
+    },
+    [focusTrigger],
+  );
 
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
@@ -122,15 +131,17 @@ export default function CCRequest() {
 
           return dispatch(routeToPreviousAppointmentPage(history, pageKey));
         }}
-        onSubmit={() =>
+        onSubmit={() => {
+          // Increment the focus trigger to force re-focusing the validation message
+          setFocusTrigger(prev => prev + 1);
           goForward({
             dispatch,
             data,
             history,
             submitted,
             setSubmitted,
-          })
-        }
+          });
+        }}
         pageChangeInProgress={pageChangeInProgress}
         loadingText="Page change in progress"
       />

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/VA.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/VA.jsx
@@ -1,3 +1,4 @@
+import { scrollToFirstError } from 'platform/utilities/scroll';
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
@@ -40,8 +41,6 @@ function goForward({ dispatch, data, history, setSubmitted }) {
     !exceededMaxSelections(data.selectedDates)
   ) {
     dispatch(routeToNextAppointmentPage(history, pageKey));
-  } else {
-    scrollAndFocus('.usa-input-error-message');
   }
 }
 
@@ -54,10 +53,20 @@ export default function VARequest() {
   const history = useHistory();
   const dispatch = useDispatch();
   const [submitted, setSubmitted] = useState(false);
+  // Add a counter state to trigger focusing
+  const [focusTrigger, setFocusTrigger] = useState(0);
   const appointmentSlotsStatus = useSelector(state =>
     selectAppointmentSlotsStatus(state),
   );
   const flowType = useSelector(state => getFlowType(state));
+
+  // Effect to focus on validation message whenever error state changes
+  useEffect(
+    () => {
+      scrollToFirstError();
+    },
+    [focusTrigger],
+  );
 
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
@@ -120,15 +129,17 @@ export default function VARequest() {
 
           return dispatch(routeToPreviousAppointmentPage(history, pageKey));
         }}
-        onSubmit={() =>
+        onSubmit={() => {
+          // Increment the focus trigger to force re-focusing the validation message
+          setFocusTrigger(prev => prev + 1);
           goForward({
             dispatch,
             data,
             history,
             submitted,
             setSubmitted,
-          })
-        }
+          });
+        }}
         pageChangeInProgress={pageChangeInProgress}
         loadingText="Page change in progress"
       />

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -5,6 +5,7 @@ import {
   lastDayOfMonth,
   startOfMonth,
 } from 'date-fns';
+import { scrollToFirstError } from 'platform/utilities/scroll';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
@@ -114,8 +115,6 @@ function goForward({
 
   if (data.selectedDates?.length && !isAppointmentSelectionError) {
     dispatch(routeToNextAppointmentPage(history, pageKey));
-  } else {
-    scrollAndFocus('.usa-input-error-message');
   }
 }
 
@@ -142,6 +141,9 @@ export default function DateTimeSelectPage() {
   const dispatch = useDispatch();
   const history = useHistory();
   const [submitted, setSubmitted] = useState(false);
+  // Add a counter state to trigger focusing
+  const [focusTrigger, setFocusTrigger] = useState(0);
+
   const fetchFailed = appointmentSlotsStatus === FETCH_STATUS.failed;
   const loadingSlots =
     appointmentSlotsStatus === FETCH_STATUS.loading ||
@@ -153,6 +155,14 @@ export default function DateTimeSelectPage() {
   const eligibility = useSelector(selectEligibility);
   const clinic = useSelector(state => getChosenClinicInfo(state));
   const upcomingAppointments = useSelector(selectUpcomingAppointments);
+
+  // Effect to focus on validation message whenever error state changes
+  useEffect(
+    () => {
+      scrollToFirstError();
+    },
+    [focusTrigger],
+  );
 
   useEffect(
     () => {
@@ -274,15 +284,17 @@ export default function DateTimeSelectPage() {
         onBack={() =>
           dispatch(routeToPreviousAppointmentPage(history, pageKey))
         }
-        onSubmit={() =>
+        onSubmit={() => {
+          // Increment the focus trigger to force re-focusing the validation message
+          setFocusTrigger(prev => prev + 1);
           goForward({
             dispatch,
             data,
             history,
             setSubmitted,
             isAppointmentSelectionError,
-          })
-        }
+          });
+        }}
         disabled={loadingSlots || fetchFailed}
         pageChangeInProgress={pageChangeInProgress}
         loadingText="Page change in progress"

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -111,3 +111,8 @@ va-textarea::part(input-type-textarea) {
   outline: 2px solid var(--vads-color-action-focus-on-light);
   outline-offset: 2px;
 }
+
+.usa-input-error:focus {
+  outline: 2px solid var(--vads-color-action-focus-on-light);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR updates the focus logic for scheduling flow pages when validation errors occur
- The page will now scroll to and focus on the validation error if it exist and adds a highlight box around the error
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111659

## Testing done

- Tested locally, see screenshot
- Since all pages behave similarly, I won't be capturing screenshots of all 9 affected pages listed in the ticket

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |   ![image](https://github.com/user-attachments/assets/622c68bb-a605-43a8-b81e-51e076fa6db7)    |   ![image](https://github.com/user-attachments/assets/438352e3-b226-47f3-b052-1031e5ed0f0a)   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

