### PR TITLE
10-10EZ | Add prop to disable analytics in submit transformer

### DIFF
--- a/src/applications/hca/components/ApplicationDownloadLink.jsx
+++ b/src/applications/hca/components/ApplicationDownloadLink.jsx
@@ -15,7 +15,7 @@ const ApplicationDownloadLink = ({ formConfig }) => {
 
   // define local use variables
   const form = useSelector(state => state.form);
-  const formData = useMemo(() => submitTransformer(formConfig, form), [
+  const formData = useMemo(() => submitTransformer(formConfig, form, true), [
     formConfig,
     form,
   ]);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

During a monthly metrics review, we found an issue where Google Analytics is showing severe spikes of applications with future discharge dates since the ability to download a PDF copy of the submitted application. There are some GA events within the submit transformer (which is utilized on both submission and PDF download). This PR adds a prop to the submit transformer to allow for suppression of the GA events to ensure accuracy of calls to GA.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#111096

## Acceptance criteria

 - GA events in the submit transformer can be suppressed as needed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution