### PR TITLE
Remove va_online_scheduling_convert_slots_to_utc feature toggle

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/redux/actions.js
+++ b/src/applications/vaos/covid-19-vaccine/redux/actions.js
@@ -7,7 +7,6 @@ import {
 } from '@department-of-veterans-affairs/platform-user/exports';
 import { format, isAfter, isDate, parseISO, startOfMinute } from 'date-fns';
 import {
-  selectFeatureConvertSlotsToUtc,
   selectFeatureFeSourceOfTruthTelehealth,
   selectSystemIds,
 } from '../../redux/selectors';
@@ -263,7 +262,6 @@ export function getAppointmentSlots(start, end, initialFetch = false) {
     );
     const newBooking = selectCovid19VaccineNewBooking(state);
     const { data } = newBooking;
-    const featureConvertSlotsToUTC = selectFeatureConvertSlotsToUtc(state);
 
     let startDate = start;
     let endDate = end;
@@ -305,7 +303,6 @@ export function getAppointmentSlots(start, end, initialFetch = false) {
           clinicId: data.clinicId,
           startDate,
           endDate,
-          convertToUtc: featureConvertSlotsToUTC,
         });
 
         if (initialFetch) {

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -17,7 +17,6 @@ import {
 } from 'date-fns';
 import {
   selectFeatureCommunityCare,
-  selectFeatureConvertSlotsToUtc,
   selectFeatureDirectScheduling,
   selectFeatureFeSourceOfTruthTelehealth,
   selectFeatureRecentLocationsFilter,
@@ -636,7 +635,6 @@ export function getAppointmentSlots(start, end, forceFetch = false) {
     const siteId = getSiteIdFromFacilityId(getFormData(state).vaFacility);
     const newAppointment = getNewAppointment(state);
     const { data } = newAppointment;
-    const featureConvertSlotsToUTC = selectFeatureConvertSlotsToUtc(state);
 
     let startDate = start;
     let endDate = end;
@@ -684,7 +682,6 @@ export function getAppointmentSlots(start, end, forceFetch = false) {
           clinicId: data.clinicId,
           startDate: startDateString,
           endDate: endDateString,
-          convertToUtc: featureConvertSlotsToUTC,
         });
         const tomorrow = startOfDay(
           addDays(new Date(new Date().toISOString()), 1),

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -110,8 +110,6 @@ export function getRequestedAppointmentListInfo(state) {
     showScheduleButton: selectFeatureRequests(state),
   };
 }
-export const selectFeatureConvertSlotsToUtc = state =>
-  toggleValues(state).vaOnlineSchedulingConvertSlotsToUtc;
 
 export const selectFeatureMentalHealthHistoryFiltering = state =>
   toggleValues(state).vaOnlineSchedulingMentalHealthHistoryFiltering;

--- a/src/applications/vaos/services/mocks/featureFlags.js
+++ b/src/applications/vaos/services/mocks/featureFlags.js
@@ -12,7 +12,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingOhRequest', value: true },
   { name: 'vaOnlineSchedulingRemovePodiatry', value: false },
   { name: 'vaOnlineSchedulingFeSourceOfTruthTelehealth', value: true },
-  { name: 'vaOnlineSchedulingConvertSlotsToUtc', value: true },
   { name: 'edu_section_103', value: true },
   { name: 'gibctEybBottomSheet', value: true },
   { name: 'travelPayViewClaimDetails', value: false },

--- a/src/applications/vaos/services/slot/index.js
+++ b/src/applications/vaos/services/slot/index.js
@@ -38,7 +38,6 @@ import { transformV2Slots } from './transformers';
  * @param {string} [slotsRequest.provider=null] optional OH provider id
  * @param {string} slotsRequest.startDate start date to search for appointments slots
  * @param {string} slotsRequest.endDate end date to search for appointments slots
- * @param {boolean} slotsRequest.convertToUtc check if flag to convert the start and end dates to UTC is set to true
  * @returns {Array<Slot>} A list of Slot resources
  */
 export async function getSlots({
@@ -48,7 +47,6 @@ export async function getSlots({
   provider = null,
   startDate,
   endDate,
-  convertToUtc = false,
 }) {
   try {
     const data = await getAvailableV2Slots({
@@ -58,7 +56,6 @@ export async function getSlots({
       provider,
       startDate,
       endDate,
-      convertToUtc,
     });
 
     return transformV2Slots(data || []);

--- a/src/applications/vaos/services/slot/index.unit.spec.jsx
+++ b/src/applications/vaos/services/slot/index.unit.spec.jsx
@@ -54,15 +54,12 @@ describe('VAOS Services: Slot ', () => {
       const data = await getSlots({
         siteId: '983',
         clinicId: '983_308',
-        startDate: format(startDate, 'yyyy-MM-dd'),
-        endDate: format(endDate, 'yyyy-MM-dd'),
+        startDate,
+        endDate,
       });
 
       expect(decodeURIComponent(global.fetch.firstCall.args[0])).to.contain(
-        `/vaos/v2/locations/983/clinics/308/slots?start=${format(
-          startDate,
-          DATE_FORMATS.ISODateTimeLocal,
-        )}&end=${format(endDate, DATE_FORMATS.ISODateTimeLocal)}`,
+        `/vaos/v2/locations/983/clinics/308/slots?start=${startDate.toISOString()}&end=${endDate.toISOString()}`,
       );
       expect(data[0].start).to.equal(
         format(startDate, DATE_FORMATS.ISODateTimeUTC),
@@ -82,17 +79,14 @@ describe('VAOS Services: Slot ', () => {
         await getSlots({
           siteId: '983',
           clinicId: '983_308',
-          startDate: format(startDate, 'yyyy-MM-dd'),
-          endDate: format(endDate, 'yyyy-MM-dd'),
+          startDate,
+          endDate,
         });
       } catch (e) {
         error = e;
       }
       expect(decodeURIComponent(global.fetch.firstCall.args[0])).to.contain(
-        `/vaos/v2/locations/983/clinics/308/slots?start=${format(
-          startDate,
-          DATE_FORMATS.ISODateTimeLocal,
-        )}&end=${format(endDate, DATE_FORMATS.ISODateTimeLocal)}`,
+        `/vaos/v2/locations/983/clinics/308/slots?start=${startDate.toISOString()}&end=${endDate.toISOString()}`,
       );
       expect(error?.resourceType).to.equal('OperationOutcome');
     });
@@ -104,7 +98,6 @@ describe('VAOS Services: Slot ', () => {
         clinicId: '983_308',
         startDate: '2025-05-01T00:00:00+05:00',
         endDate: '2025-06-30T00:00:00+05:00',
-        convertToUtc: true,
       };
       const mockApiResponse = [{ id: 'slot1', start: '2025-05-01T10:00:00Z' }];
       const mockTransformed = [
@@ -155,7 +148,6 @@ describe('VAOS Services: Slot ', () => {
         provider: 'Practitioner/123456',
         startDate: '2025-05-01T00:00:00+05:00',
         endDate: '2025-06-30T00:00:00+05:00',
-        convertToUtc: true,
       };
       const mockApiResponse = [{ id: 'slot1', start: '2025-05-01T10:00:00Z' }];
       const mockTransformed = [

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -1,11 +1,5 @@
 import appendQuery from 'append-query';
-import {
-  format,
-  isDate,
-  lastDayOfMonth,
-  parseISO,
-  startOfMonth,
-} from 'date-fns';
+import { format } from 'date-fns';
 import { getTestFacilityId } from '../../utils/appointment';
 import {
   apiRequestWithUrl,
@@ -13,7 +7,6 @@ import {
   parseApiListWithErrors,
   parseApiObject,
 } from '../utils';
-import { DATE_FORMATS } from '../../utils/constants';
 
 const acheronHeader = {
   headers: { ACHERON_REQUESTS: 'true' },
@@ -162,25 +155,10 @@ export function getAvailableV2Slots({
   provider,
   startDate,
   endDate,
-  convertToUtc = false,
 }) {
   const queryParams = [];
-  const start = convertToUtc
-    ? startDate.toISOString()
-    : format(
-        isDate(startDate)
-          ? startOfMonth(startDate)
-          : startOfMonth(parseISO(startDate)),
-        DATE_FORMATS.ISODateTimeLocal,
-      );
-  const end = convertToUtc
-    ? endDate.toISOString()
-    : format(
-        isDate(endDate)
-          ? lastDayOfMonth(endDate)
-          : lastDayOfMonth(parseISO(endDate)),
-        DATE_FORMATS.ISODateTimeLocal,
-      );
+  const start = startDate.toISOString();
+  const end = endDate.toISOString();
 
   if (typeOfCare) queryParams.push(`clinical_service=${typeOfCare}`);
   if (provider) queryParams.push(`provider=${provider}`);

--- a/src/applications/vaos/tests/mocks/mockApis.js
+++ b/src/applications/vaos/tests/mocks/mockApis.js
@@ -17,7 +17,6 @@ import sinon from 'sinon';
 import metaWithoutFailures from '../../services/mocks/v2/meta.json';
 import metaWithFailures from '../../services/mocks/v2/meta_failures.json';
 import MockAppointmentResponse from '../fixtures/MockAppointmentResponse';
-import { DATE_FORMATS } from '../../utils/constants';
 
 /**
  * Return a collection of start and end dates. The start date starts from the current
@@ -518,10 +517,8 @@ export function mockAppointmentSlotApi({
     `${
       environment.API_URL
     }/vaos/v2/locations/${facilityId}/clinics/${clinicId}/slots?` +
-    `start=${encodeURIComponent(
-      format(start, DATE_FORMATS.ISODateTimeLocal),
-    )}` +
-    `&end=${encodeURIComponent(format(end, DATE_FORMATS.ISODateTimeLocal))}`;
+    `start=${encodeURIComponent(start.toISOString())}` +
+    `&end=${encodeURIComponent(end.toISOString())}`;
 
   if (responseCode === 200) {
     setFetchJSONResponse(global.fetch.withArgs(baseUrl), {

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -309,7 +309,6 @@
   "vaOnlineSchedulingRequests": "va_online_scheduling_requests",
   "vaOnlineSchedulingRemovePodiatry": "vaos_online_scheduling_remove_podiatry",
   "vaOnlineSchedulingFeSourceOfTruthTelehealth": "va_online_scheduling_fe_source_of_truth_telehealth",
-  "vaOnlineSchedulingConvertSlotsToUtc": "va_online_scheduling_convert_slots_to_utc",
   "vaOnlineSchedulingMentalHealthHistoryFiltering": "va_online_scheduling_mental_health_history_filtering",
   "vetStatusStage1": "vet_status_stage_1",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove a feature toggle `va_online_scheduling_convert_slots_to_utc`
- Appointments FE Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113241

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

