### PR TITLE
Revert "hooked partyown directly from the Builder CDN and test (#37444)"

### DIFF
--- a/src/applications/virtual-agent/hooks/useLoadWebChat.js
+++ b/src/applications/virtual-agent/hooks/useLoadWebChat.js
@@ -1,46 +1,22 @@
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
-function ensurePartytown() {
-  if (window.__PARTYTOWN__LOADED__) return;
-
-  const config = document.createElement('script');
-  config.innerHTML = `partytown = { lib: 'https://unpkg.com/@builder.io/partytown@0.8.0/lib/' };`;
-
-  const loader = document.createElement('script');
-  loader.src = 'https://unpkg.com/@builder.io/partytown@0.8.0/lib/partytown.js';
-  loader.crossOrigin = '';
-
-  document.head.appendChild(config);
-  document.head.appendChild(loader);
-
-  window.__PARTYTOWN__LOADED__ = true;
-}
-
-function loadWebChatWithPartytown() {
-  const existing = document.querySelector(
-    'script[data-testid="webchat-framework-script"]',
-  );
-  if (existing) return;
-
+function loadWebChat() {
   const script = document.createElement('script');
-  script.type = 'text/partytown';
+
   script.src =
     'https://cdn.botframework.com/botframework-webchat/4.17.0/webchat.js';
+
   script.crossOrigin = 'anonymous';
   script.dataset.testid = 'webchat-framework-script';
 
   document.body.appendChild(script);
-
-  window.dispatchEvent(new CustomEvent('ptupdate'));
 }
 
 export default function useLoadWebChat() {
   useEffect(() => {
     window.React = React;
     window.ReactDOM = ReactDOM;
-
-    ensurePartytown();
-    loadWebChatWithPartytown();
+    loadWebChat();
   }, []);
 }

--- a/src/applications/virtual-agent/tests/hooks/useLoadWebChat.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useLoadWebChat.unit.spec.jsx
@@ -19,12 +19,7 @@ describe('useLoadWebChat', () => {
     it('should load webchat v4.17.0', () => {
       renderHook(() => useLoadWebChat());
 
-      const script = document.querySelector(
-        'script[data-testid="webchat-framework-script"]',
-      );
-
-      expect(script).to.exist;
-      expect(script.getAttribute('type')).to.equal('text/partytown');
+      const script = document.querySelector('script');
       expect(script.src).to.equal(
         'https://cdn.botframework.com/botframework-webchat/4.17.0/webchat.js',
       );


### PR DESCRIPTION
This reverts commit 8af59bb639f767d7678e81537c496c8e485852b1.


## Summary

- Temporarily revert Partytown implementation due to chatbot loading issue.

