### PR TITLE
Vebt 2250

### DIFF
--- a/src/applications/edu-benefits/1919/config/form.js
+++ b/src/applications/edu-benefits/1919/config/form.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { focusElement } from 'platform/utilities/ui';
+import { scrollToTop } from 'platform/utilities/scroll';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -32,6 +34,11 @@ export const confirmFormLogic = ({ router, route }) => (
 );
 
 const { fullName, ssn, date, dateRange, usaPhone } = commonDefinitions;
+
+const scrollAndFocusTarget = () => {
+  scrollToTop('topScrollElement');
+  focusElement('h3');
+};
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -123,6 +130,7 @@ const formConfig = {
               path: 'proprietary-profit-1',
               uiSchema: affiliatedIndividualsSummary.uiSchema,
               schema: affiliatedIndividualsSummary.schema,
+              scrollAndFocusTarget,
             }),
             affiliatedIndividualsAssociation: pageBuilder.itemPage({
               title:
@@ -147,6 +155,7 @@ const formConfig = {
                 'Review the individuals with a potential conflict of interest that receive VA educational benefits',
               uiSchema: conflictOfInterestSummary.uiSchema,
               schema: conflictOfInterestSummary.schema,
+              scrollAndFocusTarget,
             }),
             conflictOfInterestCertifyingOfficial: pageBuilder.itemPage({
               path: 'conflict-of-interest/:index/certifying-official',

--- a/src/applications/edu-benefits/1919/containers/PrivacyPolicy.jsx
+++ b/src/applications/edu-benefits/1919/containers/PrivacyPolicy.jsx
@@ -51,7 +51,12 @@ const PrivacyPolicy = () => {
         I have read and accept the{' '}
         <va-link
           onClick={() => setShowModal(true)}
-          text="privacy policy"
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              setShowModal(true);
+            }
+          }}
+          text="privacy policy."
           aria-label="View the privacy policy"
           role="button"
           tabIndex="0"

--- a/src/applications/edu-benefits/1919/tests/containers/PrivacyPolicy.unit.spec.jsx
+++ b/src/applications/edu-benefits/1919/tests/containers/PrivacyPolicy.unit.spec.jsx
@@ -101,4 +101,22 @@ describe('22-1919 <PrivacyPolicy>', () => {
 
     expect(getByText('Custom Title')).to.exist;
   });
+
+  it('should open modal when Enter key is pressed on privacy policy link', () => {
+    const { container, getByTestId } = render(
+      <Provider store={fakeStore(formData)}>
+        <PrivacyPolicy />
+      </Provider>,
+    );
+
+    const vaLink = container.querySelector('va-link');
+    expect(vaLink).to.exist;
+
+    const enterKeyEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+    vaLink.dispatchEvent(enterKeyEvent);
+
+    const privacyActNotice = getByTestId('privacy-act-notice');
+    expect(privacyActNotice).to.exist;
+    expect(privacyActNotice).to.be.visible;
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Work performed
  - Changes:
      - Updated list and loop pages to focus on the h3 instead of the radio buttons upon first rendering. 
      - Enabled the privacy policy modal to open on the Review page, focus returns to the previous element when closing the modal tabbing further through the page.
  - Other checks:
      - Verified correct headers focus when navigating between Introduction page, forms pages, and confirmation page.
      - All links and clickable elements receive focus when moving through the page using tab and can be accessed by pressing  the Enter key.
- Team: Veteran Education Benefit Tools

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-2250

## Testing done
<img width="1437" alt="Screenshot 2025-07-03 at 8 23 44 AM" src="https://github.com/user-attachments/assets/9f5ed1b3-34d7-4c82-87ac-466767e2e564" />

## Screenshots

### Before

- On first rendering, the question attached to the radio buttons receives focus, not the header.
    - https://github.com/user-attachments/assets/9c629b77-7398-4056-bdfd-25e3fb3d4afa

- The privacy policy within the certification statement can't be opened via keyboard.
    - https://github.com/user-attachments/assets/688496dd-b9a2-4e98-a72f-f0b2af2b03d1

### After

- On first rendering, the header on the first page of either list and loop is focused, rather than the question attached to the radio buttons.
    - https://github.com/user-attachments/assets/14d0dc8f-1e0a-4ac5-bb27-4b1e7cf4b566

- The privacy policy link within the certification statement receives focus and can open the corresponding modal.
    - https://github.com/user-attachments/assets/6ed91cf1-0061-43b7-ac4f-67d8a7fff87b


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
