### PR TITLE
VEBT-1361: 22-8794 - E2E keyboard testing

### DIFF
--- a/src/applications/edu-benefits/8794/components/AdditionalOfficialExemptInfo.jsx
+++ b/src/applications/edu-benefits/8794/components/AdditionalOfficialExemptInfo.jsx
@@ -17,12 +17,11 @@ const AdditionalOfficialExemptInfo = props => {
           <li>
             Existing SCOs at a school not currently identified as a "covered
             educational institution."{' '}
-            <a
-              href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/covered-educational-institutions.asp"
+            <va-link
               external
-            >
-              Get more information about covered institutions.
-            </a>
+              text="Get more information about covered institutions"
+              href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/covered-educational-institutions.asp"
+            />
           </li>
           <li>
             Transferring SCOs from the same type of school (IHL, NCD, OJT/APP,

--- a/src/applications/edu-benefits/8794/components/PrimaryOfficialExemptInfo.jsx
+++ b/src/applications/edu-benefits/8794/components/PrimaryOfficialExemptInfo.jsx
@@ -17,12 +17,11 @@ const PrimaryOfficialExemptInfo = props => {
           <li>
             Existing SCOs at a school not currently identified as a "covered
             educational institution."{' '}
-            <a
-              href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/covered-educational-institutions.asp"
+            <va-link
               external
-            >
-              Get more information about covered institutions.
-            </a>
+              text="Get more information about covered institutions"
+              href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/covered-educational-institutions.asp"
+            />
           </li>
           <li>
             Transferring SCOs from the same type of school (IHL, NCD, OJT/APP,

--- a/src/applications/edu-benefits/8794/helpers.js
+++ b/src/applications/edu-benefits/8794/helpers.js
@@ -188,10 +188,10 @@ export const childContent = (pdfUrl, trackingPrefix, goBack) => (
           itemProp="itemListElement"
           className="confirmation-save-pdf-download-section"
         >
-          <p>
+          <div>
             To submit this form, make sure that your completed form is saved as
             a PDF on your device.{' '}
-            <p className="vads-u-margin-y--0">
+            <p className="vads-u-margin-top--0">
               <va-link
                 download
                 filetype="PDF"
@@ -204,7 +204,7 @@ export const childContent = (pdfUrl, trackingPrefix, goBack) => (
                 text="Download VA Form 22-8794"
               />
             </p>
-          </p>
+          </div>
         </div>
       </va-process-list-item>
       <va-process-list-item header="Upload your PDF to the Education File Upload Portal or email it to your State Approving Agency (SAA)">

--- a/src/applications/edu-benefits/8794/tests/8794-keyboard-only.cypress.spec.js
+++ b/src/applications/edu-benefits/8794/tests/8794-keyboard-only.cypress.spec.js
@@ -1,5 +1,6 @@
 import maximalData from './fixtures/data/maximal-test.json';
 import formConfig from '../config/form';
+import manifest from '../manifest.json';
 
 describe('22-8794 EDU Form', () => {
   const { designatingOfficial } = maximalData.data;
@@ -25,7 +26,7 @@ describe('22-8794 EDU Form', () => {
     });
 
     // Navigate to the Introduction Page
-    cy.visit('/school-administrators/update-certifying-officials');
+    cy.visit(manifest.rootUrl);
     cy.injectAxeThenAxeCheck();
     // Tab to and press 'Start your form without signing in'
     cy.repeatKey('Tab', 3);
@@ -61,7 +62,7 @@ describe('22-8794 EDU Form', () => {
     cy.typeInFocused(designatingOfficial.emailAddress);
     cy.tabToContinueForm();
 
-    // Institution details page
+    // Institution details page - Step 1
     cy.url().should(
       'include',
       formConfig.chapters.institutionDetailsChapter.pages.institutionDetails
@@ -78,6 +79,8 @@ describe('22-8794 EDU Form', () => {
     );
     cy.chooseRadio('Y');
     cy.tabToContinueForm();
+
+    // Institution details page - Step 2 (already assigned facility code)
     cy.url().should(
       'include',
       formConfig.chapters.institutionDetailsChapter.pages
@@ -88,7 +91,7 @@ describe('22-8794 EDU Form', () => {
     cy.typeInFocused(maximalData.data.institutionDetails.facilityCode);
     cy.tabToContinueForm();
 
-    // Primary certifying official page
+    // Primary certifying official page - Step 1
     cy.url().should(
       'include',
       formConfig.chapters.primaryOfficialChapter.pages.primaryOfficialDetails
@@ -117,6 +120,8 @@ describe('22-8794 EDU Form', () => {
     cy.repeatKey('Tab', 2);
     cy.typeInFocused(maximalData.data.primaryOfficialDetails.emailAddress);
     cy.tabToContinueForm();
+
+    // Primary certifying official page - Step 2
     cy.url().should(
       'include',
       formConfig.chapters.primaryOfficialChapter.pages.primaryOfficialTraining
@@ -124,18 +129,25 @@ describe('22-8794 EDU Form', () => {
     );
     cy.injectAxeThenAxeCheck();
     cy.realPress('Tab');
-    cy.focused().should(
-      'contain.text',
-      "Go to this page to find out what's required",
-    );
+    cy.get('va-link')
+      .first()
+      .shadow()
+      .get('a')
+      .should('contain.text', "Go to this page to find out what's required");
     cy.repeatKey('Tab', 4);
-    cy.focused().should(
-      'contain.text',
-      'Get more information about covered institutions.',
-    );
+    cy.get('div.info')
+      .first()
+      .get('a')
+      .should(
+        'contain.text',
+        'Get more information about covered institutions.',
+      );
     cy.realPress('Tab');
     cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
+    cy.setCheckboxFromData('input#checkbox-element', true);
     cy.tabToContinueForm();
+
+    // Primary certifying official page - Step 3
     cy.url().should(
       'include',
       formConfig.chapters.primaryOfficialChapter.pages
@@ -153,9 +165,10 @@ describe('22-8794 EDU Form', () => {
     cy.chooseRadio('Y');
     cy.realPress('Tab');
     cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
+    cy.setCheckboxFromData('input#checkbox-element', true);
     cy.tabToContinueForm();
 
-    // Additional certifying officials page
+    // Additional certifying officials page - Step 1
     cy.url().should(
       'include',
       formConfig.chapters.additionalOfficialChapter.pages
@@ -163,16 +176,17 @@ describe('22-8794 EDU Form', () => {
     );
     cy.injectAxeThenAxeCheck();
     cy.realPress('Tab');
-    // Have to check radio buttons
-    // cy.allyEvaluateRadioButtons(
-    //   [
-    //     'input#root:additionalOfficialSummaryYesinput',
-    //     'input#root:additionalOfficialSummaryNoinput',
-    //   ],
-    //   'ArrowDown',
-    // );
+    cy.allyEvaluateRadioButtons(
+      [
+        'input[id="root_view:additionalOfficialSummaryYesinput"]',
+        'input[id="root_view:additionalOfficialSummaryNoinput"]',
+      ],
+      'ArrowDown',
+    );
     cy.chooseRadio('Y');
     cy.tabToContinueForm();
+
+    // Additional certifying officials page - Step 2
     cy.url().should(
       'include',
       `${
@@ -224,6 +238,8 @@ describe('22-8794 EDU Form', () => {
         .additionalOfficialDetails.emailAddress,
     );
     cy.tabToContinueForm();
+
+    // Additional certifying officials page - Step 3
     cy.url().should(
       'include',
       `${
@@ -233,18 +249,22 @@ describe('22-8794 EDU Form', () => {
     );
     cy.injectAxeThenAxeCheck();
     cy.realPress('Tab');
-    cy.focused().should(
-      'contain.text',
-      "Go to this page to find out what's required",
-    );
+    cy.get('va-link')
+      .first()
+      .shadow()
+      .get('a')
+      .should('contain.text', "Go to this page to find out what's required");
     cy.repeatKey('Tab', 4);
-    cy.focused().should(
-      'contain.text',
-      'Get more information about covered institutions.',
-    );
+    cy.get('div.info')
+      .first()
+      .get('a')
+      .should(
+        'contain.text',
+        'Get more information about covered institutions.',
+      );
     cy.realPress('Tab');
     cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
-    cy.realPress('Space');
+    cy.setCheckboxFromData('input#checkbox-element', false);
     cy.repeatKey(['Shift', 'Tab'], 4);
     cy.fillVaMemorableDate(
       'root_additionalOfficialTraining_trainingCompletionDate',
@@ -253,6 +273,8 @@ describe('22-8794 EDU Form', () => {
       true,
     );
     cy.tabToContinueForm();
+
+    // Additional certifying officials page - Step 4
     cy.url().should(
       'include',
       `${
@@ -271,6 +293,8 @@ describe('22-8794 EDU Form', () => {
     );
     cy.chooseRadio('N');
     cy.tabToContinueForm();
+
+    // Additional certifying officials page - Step 5 (summary)
     cy.url().should(
       'include',
       formConfig.chapters.additionalOfficialChapter.pages
@@ -278,18 +302,17 @@ describe('22-8794 EDU Form', () => {
     );
     cy.injectAxeThenAxeCheck();
     cy.repeatKey('Tab', 3);
-    // Have to check radio buttons
-    // cy.allyEvaluateRadioButtons(
-    //   [
-    //     'input#root:additionalOfficialSummaryYesinput',
-    //     'input#root:additionalOfficialSummaryNoinput',
-    //   ],
-    //   'ArrowDown',
-    // );
+    cy.allyEvaluateRadioButtons(
+      [
+        'input[id="root_view:additionalOfficialSummaryYesinput"]',
+        'input[id="root_view:additionalOfficialSummaryNoinput"]',
+      ],
+      'ArrowDown',
+    );
     cy.chooseRadio('N');
     cy.tabToContinueForm();
 
-    // Read-only certifying officials page
+    // Read-only certifying officials page - Step 1
     cy.url().should(
       'include',
       formConfig.chapters.readOnlyCertifyingOfficialChapter.pages
@@ -297,16 +320,17 @@ describe('22-8794 EDU Form', () => {
     );
     cy.injectAxeThenAxeCheck();
     cy.realPress('Tab');
-    // Have to check radio buttons
-    // cy.allyEvaluateRadioButtons(
-    //   [
-    //     'input#root:additionalOfficialSummaryYesinput',
-    //     'input#root:additionalOfficialSummaryNoinput',
-    //   ],
-    //   'ArrowDown',
-    // );
+    cy.allyEvaluateRadioButtons(
+      [
+        'input[id="root_hasReadOnlyCertifyingOfficialYesinput"]',
+        'input[id="root_hasReadOnlyCertifyingOfficialNoinput"]',
+      ],
+      'ArrowDown',
+    );
     cy.chooseRadio('Y');
     cy.tabToContinueForm();
+
+    // Read-only certifying officials page - Step 2
     cy.url().should('include', 'read-only-certifying-officials/0');
     cy.injectAxeThenAxeCheck();
     cy.realPress('Tab');
@@ -322,6 +346,8 @@ describe('22-8794 EDU Form', () => {
       maximalData.data.readOnlyCertifyingOfficials[0].fullName.last,
     );
     cy.tabToContinueForm();
+
+    // Read-only certifying officials page - Step 3 (summary)
     cy.url().should(
       'include',
       formConfig.chapters.readOnlyCertifyingOfficialChapter.pages
@@ -329,14 +355,13 @@ describe('22-8794 EDU Form', () => {
     );
     cy.injectAxeThenAxeCheck();
     cy.repeatKey('Tab', 3);
-    // Have to check radio buttons
-    // cy.allyEvaluateRadioButtons(
-    //   [
-    //     'input#root:additionalOfficialSummaryYesinput',
-    //     'input#root:additionalOfficialSummaryNoinput',
-    //   ],
-    //   'ArrowDown',
-    // );
+    cy.allyEvaluateRadioButtons(
+      [
+        'input[id="root_hasReadOnlyCertifyingOfficialYesinput"]',
+        'input[id="root_hasReadOnlyCertifyingOfficialNoinput"]',
+      ],
+      'ArrowDown',
+    );
     cy.chooseRadio('N');
     cy.tabToContinueForm();
 
@@ -345,7 +370,6 @@ describe('22-8794 EDU Form', () => {
       'include',
       formConfig.chapters.remarksChapter.pages.remarks.path,
     );
-    cy.injectAxeThenAxeCheck();
     cy.realPress('Tab');
     cy.typeInFocused(maximalData.data.remarks);
     cy.tabToContinueForm();

--- a/src/applications/edu-benefits/8794/tests/8794-keyboard-only.cypress.spec.js
+++ b/src/applications/edu-benefits/8794/tests/8794-keyboard-only.cypress.spec.js
@@ -1,0 +1,379 @@
+import maximalData from './fixtures/data/maximal-test.json';
+import formConfig from '../config/form';
+
+describe('22-8794 EDU Form', () => {
+  const { designatingOfficial } = maximalData.data;
+
+  beforeEach(function() {
+    if (Cypress.env('CI')) this.skip();
+  });
+
+  it('should be keyboard-only navigable', () => {
+    cy.intercept('GET', '/v0/gi/institutions/*', {
+      data: {
+        attributes: {
+          name: 'INSTITUTE OF TESTING',
+          facilityCode: '10002000',
+          type: 'FOR PROFIT',
+          city: 'SAN FRANCISCO',
+          state: 'CA',
+          zip: '13579',
+          country: 'USA',
+          address1: '123 STREET WAY',
+        },
+      },
+    });
+
+    // Navigate to the Introduction Page
+    cy.visit('/school-administrators/update-certifying-officials');
+    cy.injectAxeThenAxeCheck();
+    // Tab to and press 'Start your form without signing in'
+    cy.repeatKey('Tab', 3);
+    cy.realPress(['Enter']);
+
+    // Designating official page
+    cy.url().should(
+      'include',
+      formConfig.chapters.designatingOfficialChapter.pages.designatingOfficial
+        .path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.typeInFocused(designatingOfficial.fullName.first);
+    cy.realPress('Tab');
+    cy.typeInFocused(designatingOfficial.fullName.middle);
+    cy.realPress('Tab');
+    cy.typeInFocused(designatingOfficial.fullName.last);
+    cy.realPress('Tab');
+    cy.typeInFocused(designatingOfficial.title);
+    cy.realPress('Tab');
+    cy.allyEvaluateRadioButtons(
+      [
+        'input#root_designatingOfficial_phoneTypeusinput',
+        'input#root_designatingOfficial_phoneTypeintlinput',
+      ],
+      'ArrowDown',
+    );
+    cy.chooseRadio(designatingOfficial.phoneType);
+    cy.realPress('Tab');
+    cy.typeInFocused(designatingOfficial.phoneNumber);
+    cy.repeatKey('Tab', 2);
+    cy.typeInFocused(designatingOfficial.emailAddress);
+    cy.tabToContinueForm();
+
+    // Institution details page
+    cy.url().should(
+      'include',
+      formConfig.chapters.institutionDetailsChapter.pages.institutionDetails
+        .path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.allyEvaluateRadioButtons(
+      [
+        'input#root_institutionDetails_hasVaFacilityCodeYesinput',
+        'input#root_institutionDetails_hasVaFacilityCodeNoinput',
+      ],
+      'ArrowDown',
+    );
+    cy.chooseRadio('Y');
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      formConfig.chapters.institutionDetailsChapter.pages
+        .institutionDetailsFacility.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.typeInFocused(maximalData.data.institutionDetails.facilityCode);
+    cy.tabToContinueForm();
+
+    // Primary certifying official page
+    cy.url().should(
+      'include',
+      formConfig.chapters.primaryOfficialChapter.pages.primaryOfficialDetails
+        .path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.typeInFocused(maximalData.data.primaryOfficialDetails.fullName.first);
+    cy.realPress('Tab');
+    cy.typeInFocused(maximalData.data.primaryOfficialDetails.fullName.middle);
+    cy.realPress('Tab');
+    cy.typeInFocused(maximalData.data.primaryOfficialDetails.fullName.last);
+    cy.realPress('Tab');
+    cy.typeInFocused(maximalData.data.primaryOfficialDetails.title);
+    cy.realPress('Tab');
+    cy.allyEvaluateRadioButtons(
+      [
+        'input#root_primaryOfficialDetails_phoneTypeusinput',
+        'input#root_primaryOfficialDetails_phoneTypeintlinput',
+      ],
+      'ArrowDown',
+    );
+    cy.chooseRadio(maximalData.data.primaryOfficialDetails.phoneType);
+    cy.realPress('Tab');
+    cy.typeInFocused(maximalData.data.primaryOfficialDetails.phoneNumber);
+    cy.repeatKey('Tab', 2);
+    cy.typeInFocused(maximalData.data.primaryOfficialDetails.emailAddress);
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      formConfig.chapters.primaryOfficialChapter.pages.primaryOfficialTraining
+        .path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.focused().should(
+      'contain.text',
+      "Go to this page to find out what's required",
+    );
+    cy.repeatKey('Tab', 4);
+    cy.focused().should(
+      'contain.text',
+      'Get more information about covered institutions.',
+    );
+    cy.realPress('Tab');
+    cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      formConfig.chapters.primaryOfficialChapter.pages
+        .primaryOfficialBenefitStatus.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.allyEvaluateRadioButtons(
+      [
+        'input#root_primaryOfficialBenefitStatus_hasVaEducationBenefitsYesinput',
+        'input#root_primaryOfficialBenefitStatus_hasVaEducationBenefitsNoinput',
+      ],
+      'ArrowDown',
+    );
+    cy.chooseRadio('Y');
+    cy.realPress('Tab');
+    cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
+    cy.tabToContinueForm();
+
+    // Additional certifying officials page
+    cy.url().should(
+      'include',
+      formConfig.chapters.additionalOfficialChapter.pages
+        .additionalOfficialSummary.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    // Have to check radio buttons
+    // cy.allyEvaluateRadioButtons(
+    //   [
+    //     'input#root:additionalOfficialSummaryYesinput',
+    //     'input#root:additionalOfficialSummaryNoinput',
+    //   ],
+    //   'ArrowDown',
+    // );
+    cy.chooseRadio('Y');
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      `${
+        formConfig.chapters.additionalOfficialChapter.pages
+          .additionalOfficialSummary.path
+      }/0`,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialDetails.fullName.first,
+    );
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialDetails.fullName.middle,
+    );
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialDetails.fullName.last,
+    );
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialDetails.title,
+    );
+    cy.realPress('Tab');
+    cy.allyEvaluateRadioButtons(
+      [
+        'input#root_additionalOfficialDetails_phoneTypeusinput',
+        'input#root_additionalOfficialDetails_phoneTypeintlinput',
+      ],
+      'ArrowDown',
+    );
+    cy.chooseRadio(
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialDetails.phoneType,
+    );
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialDetails.phoneNumber,
+    );
+    cy.repeatKey('Tab', 2);
+    cy.typeInFocused(
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialDetails.emailAddress,
+    );
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      `${
+        formConfig.chapters.additionalOfficialChapter.pages
+          .additionalOfficialSummary.path
+      }-1/0`,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.focused().should(
+      'contain.text',
+      "Go to this page to find out what's required",
+    );
+    cy.repeatKey('Tab', 4);
+    cy.focused().should(
+      'contain.text',
+      'Get more information about covered institutions.',
+    );
+    cy.realPress('Tab');
+    cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
+    cy.realPress('Space');
+    cy.repeatKey(['Shift', 'Tab'], 4);
+    cy.fillVaMemorableDate(
+      'root_additionalOfficialTraining_trainingCompletionDate',
+      maximalData.data['additional-certifying-official'][0]
+        .additionalOfficialTraining.trainingCompletionDate,
+      true,
+    );
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      `${
+        formConfig.chapters.additionalOfficialChapter.pages
+          .additionalOfficialSummary.path
+      }-2/0`,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.allyEvaluateRadioButtons(
+      [
+        'input#root_additionalOfficialBenefitStatus_hasVaEducationBenefitsYesinput',
+        'input#root_additionalOfficialBenefitStatus_hasVaEducationBenefitsNoinput',
+      ],
+      'ArrowDown',
+    );
+    cy.chooseRadio('N');
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      formConfig.chapters.additionalOfficialChapter.pages
+        .additionalOfficialSummary.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.repeatKey('Tab', 3);
+    // Have to check radio buttons
+    // cy.allyEvaluateRadioButtons(
+    //   [
+    //     'input#root:additionalOfficialSummaryYesinput',
+    //     'input#root:additionalOfficialSummaryNoinput',
+    //   ],
+    //   'ArrowDown',
+    // );
+    cy.chooseRadio('N');
+    cy.tabToContinueForm();
+
+    // Read-only certifying officials page
+    cy.url().should(
+      'include',
+      formConfig.chapters.readOnlyCertifyingOfficialChapter.pages
+        .readOnlyPrimaryOfficialSummary.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    // Have to check radio buttons
+    // cy.allyEvaluateRadioButtons(
+    //   [
+    //     'input#root:additionalOfficialSummaryYesinput',
+    //     'input#root:additionalOfficialSummaryNoinput',
+    //   ],
+    //   'ArrowDown',
+    // );
+    cy.chooseRadio('Y');
+    cy.tabToContinueForm();
+    cy.url().should('include', 'read-only-certifying-officials/0');
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data.readOnlyCertifyingOfficials[0].fullName.first,
+    );
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data.readOnlyCertifyingOfficials[0].fullName.middle,
+    );
+    cy.realPress('Tab');
+    cy.typeInFocused(
+      maximalData.data.readOnlyCertifyingOfficials[0].fullName.last,
+    );
+    cy.tabToContinueForm();
+    cy.url().should(
+      'include',
+      formConfig.chapters.readOnlyCertifyingOfficialChapter.pages
+        .readOnlyPrimaryOfficialSummary.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.repeatKey('Tab', 3);
+    // Have to check radio buttons
+    // cy.allyEvaluateRadioButtons(
+    //   [
+    //     'input#root:additionalOfficialSummaryYesinput',
+    //     'input#root:additionalOfficialSummaryNoinput',
+    //   ],
+    //   'ArrowDown',
+    // );
+    cy.chooseRadio('N');
+    cy.tabToContinueForm();
+
+    // Remarks page
+    cy.url().should(
+      'include',
+      formConfig.chapters.remarksChapter.pages.remarks.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.realPress('Tab');
+    cy.typeInFocused(maximalData.data.remarks);
+    cy.tabToContinueForm();
+
+    // Submission instructions page
+    cy.url().should(
+      'include',
+      formConfig.chapters.submissionInstructionsChapter.pages
+        .submissionInstructions.path,
+    );
+    cy.injectAxeThenAxeCheck();
+    cy.tabToContinueForm();
+
+    // Review page
+    cy.url().should('include', 'review-and-submit');
+    cy.injectAxeThenAxeCheck();
+    cy.get('#veteran-signature')
+      .shadow()
+      .get('#inputField')
+      .type(
+        `${designatingOfficial.fullName.first} ${
+          designatingOfficial.fullName.middle
+        } ${designatingOfficial.fullName.last}`,
+      );
+    cy.tabToElementAndPressSpace('va-checkbox');
+    cy.tabToSubmitForm();
+
+    // Confirmation page
+    cy.url().should('include', '/confirmation');
+  });
+});

--- a/src/applications/edu-benefits/8794/tests/8794-keyboard-only.cypress.spec.js
+++ b/src/applications/edu-benefits/8794/tests/8794-keyboard-only.cypress.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable cypress/unsafe-to-chain-command */
 import maximalData from './fixtures/data/maximal-test.json';
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
@@ -28,6 +29,10 @@ describe('22-8794 EDU Form', () => {
     // Navigate to the Introduction Page
     cy.visit(manifest.rootUrl);
     cy.injectAxeThenAxeCheck();
+    cy.focused().should(
+      'contain.text',
+      'Update your institution’s list of certifying officials',
+    );
     // Tab to and press 'Start your form without signing in'
     cy.repeatKey('Tab', 3);
     cy.realPress(['Enter']);
@@ -39,6 +44,7 @@ describe('22-8794 EDU Form', () => {
         .path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'Your information');
     cy.realPress('Tab');
     cy.typeInFocused(designatingOfficial.fullName.first);
     cy.realPress('Tab');
@@ -69,6 +75,7 @@ describe('22-8794 EDU Form', () => {
         .path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'VA facility code');
     cy.realPress('Tab');
     cy.allyEvaluateRadioButtons(
       [
@@ -87,6 +94,7 @@ describe('22-8794 EDU Form', () => {
         .institutionDetailsFacility.path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'Please enter your VA facility code');
     cy.realPress('Tab');
     cy.typeInFocused(maximalData.data.institutionDetails.facilityCode);
     cy.tabToContinueForm();
@@ -98,6 +106,10 @@ describe('22-8794 EDU Form', () => {
         .path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should(
+      'contain.text',
+      'Tell us about your primary certifying official',
+    );
     cy.realPress('Tab');
     cy.typeInFocused(maximalData.data.primaryOfficialDetails.fullName.first);
     cy.realPress('Tab');
@@ -128,20 +140,17 @@ describe('22-8794 EDU Form', () => {
         .path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'Section 305 training');
     cy.realPress('Tab');
-    cy.get('va-link')
-      .first()
-      .shadow()
-      .get('a')
-      .should('contain.text', "Go to this page to find out what's required");
+    cy.focused().should(
+      'contain.text',
+      "Go to this page to find out what's required",
+    );
     cy.repeatKey('Tab', 4);
-    cy.get('div.info')
-      .first()
-      .get('a')
-      .should(
-        'contain.text',
-        'Get more information about covered institutions.',
-      );
+    cy.focused().should(
+      'contain.text',
+      'Get more information about covered institutions',
+    );
     cy.realPress('Tab');
     cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
     cy.setCheckboxFromData('input#checkbox-element', true);
@@ -154,6 +163,7 @@ describe('22-8794 EDU Form', () => {
         .primaryOfficialBenefitStatus.path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'VA benefit status');
     cy.realPress('Tab');
     cy.allyEvaluateRadioButtons(
       [
@@ -195,6 +205,10 @@ describe('22-8794 EDU Form', () => {
       }/0`,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should(
+      'contain.text',
+      'Tell us about your certifying official',
+    );
     cy.realPress('Tab');
     cy.typeInFocused(
       maximalData.data['additional-certifying-official'][0]
@@ -248,20 +262,17 @@ describe('22-8794 EDU Form', () => {
       }-1/0`,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'Section 305 training');
     cy.realPress('Tab');
-    cy.get('va-link')
-      .first()
-      .shadow()
-      .get('a')
-      .should('contain.text', "Go to this page to find out what's required");
+    cy.focused().should(
+      'contain.text',
+      "Go to this page to find out what's required",
+    );
     cy.repeatKey('Tab', 4);
-    cy.get('div.info')
-      .first()
-      .get('a')
-      .should(
-        'contain.text',
-        'Get more information about covered institutions.',
-      );
+    cy.focused().should(
+      'contain.text',
+      'Get more information about covered institutions',
+    );
     cy.realPress('Tab');
     cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
     cy.setCheckboxFromData('input#checkbox-element', false);
@@ -283,6 +294,7 @@ describe('22-8794 EDU Form', () => {
       }-2/0`,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'VA benefit status');
     cy.realPress('Tab');
     cy.allyEvaluateRadioButtons(
       [
@@ -301,6 +313,10 @@ describe('22-8794 EDU Form', () => {
         .additionalOfficialSummary.path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should(
+      'contain.text',
+      'Review your additional certifying official',
+    );
     cy.repeatKey('Tab', 3);
     cy.allyEvaluateRadioButtons(
       [
@@ -333,6 +349,10 @@ describe('22-8794 EDU Form', () => {
     // Read-only certifying officials page - Step 2
     cy.url().should('include', 'read-only-certifying-officials/0');
     cy.injectAxeThenAxeCheck();
+    cy.focused().should(
+      'contain.text',
+      'Tell us about your read-only school certifying official',
+    );
     cy.realPress('Tab');
     cy.typeInFocused(
       maximalData.data.readOnlyCertifyingOfficials[0].fullName.first,
@@ -354,6 +374,10 @@ describe('22-8794 EDU Form', () => {
         .readOnlyPrimaryOfficialSummary.path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should(
+      'contain.text',
+      'Review your read-only certifying official',
+    );
     cy.repeatKey('Tab', 3);
     cy.allyEvaluateRadioButtons(
       [
@@ -370,6 +394,10 @@ describe('22-8794 EDU Form', () => {
       'include',
       formConfig.chapters.remarksChapter.pages.remarks.path,
     );
+    cy.focused().should(
+      'contain.text',
+      'Please enter any remarks you would like to share',
+    );
     cy.realPress('Tab');
     cy.typeInFocused(maximalData.data.remarks);
     cy.tabToContinueForm();
@@ -381,6 +409,7 @@ describe('22-8794 EDU Form', () => {
         .submissionInstructions.path,
     );
     cy.injectAxeThenAxeCheck();
+    cy.focused().should('contain.text', 'How to submit your form');
     cy.tabToContinueForm();
 
     // Review page
@@ -399,5 +428,9 @@ describe('22-8794 EDU Form', () => {
 
     // Confirmation page
     cy.url().should('include', '/confirmation');
+    cy.focused().should(
+      'contain.text',
+      'To submit your form, follow the steps below',
+    );
   });
 });

--- a/src/applications/edu-benefits/8794/tests/fixtures/data/maximal-test.json
+++ b/src/applications/edu-benefits/8794/tests/fixtures/data/maximal-test.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "remarks": "Here are some remarks for the VA Form 22-8794.",
+    "hasReadOnlyCertifyingOfficial": false,
+    "view:introduction": {},
+    "view:additionalOfficialSummary": false,
+    "primaryOfficialBenefitStatus": {
+      "hasVaEducationBenefits": true,
+      "view:benefitsDisclaimer": true
+    },
+    "primaryOfficialDetails": {
+      "fullName": { "first": "Bob", "middle": "Test", "last": "Smith" },
+      "title": "Certifying Official",
+      "phoneType": "us",
+      "phoneNumber": "1112223333",
+      "emailAddress": "bob.smith@test.com"
+    },
+    "institutionDetails": {
+      "facilityCode": "10002000",
+      "institutionName": "INSTITUTE OF TESTING",
+      "institutionAddress": {
+        "street": "123 STREET WAY",
+        "street2": "",
+        "street3": "",
+        "city": "SAN FRANCISCO",
+        "state": "CA",
+        "postalCode": "13579",
+        "country": "USA"
+      },
+      "hasVaFacilityCode": true
+    },
+    "designatingOfficial": {
+      "fullName": { "first": "John", "middle": "William", "last": "Doe" },
+      "title": "President",
+      "phoneType": "us",
+      "phoneNumber": "1234567890",
+      "emailAddress": "john.doe@test.com"
+    },
+    "view:description": {},
+    "primaryOfficialTraining": { "trainingExempt": true },
+    "additional-certifying-official": [
+      {
+        "additionalOfficialBenefitStatus": { "hasVaEducationBenefits": false },
+        "additionalOfficialTraining": {
+          "trainingCompletionDate": "2025-07-02"
+        },
+        "additionalOfficialDetails": {
+          "fullName": {
+            "first": "Certifying",
+            "middle": "Test",
+            "last": "Official"
+          },
+          "title": "Vice Certifying Official",
+          "phoneType": "us",
+          "phoneNumber": "1231231234",
+          "emailAddress": "certifying.official@test.com"
+        }
+      }
+    ],
+    "readOnlyCertifyingOfficials": [
+      { "fullName": { "first": "Read", "middle": "Only", "last": "Official" } }
+    ],
+    "statementOfTruthSignature": "John William Doe",
+    "statementOfTruthCertified": true
+  }
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This adds the E2E keyboard-only tests for the 22-8794 which also includes accessibility checks
- Fixed a console error on the 22-8794 Confirmation Page for nested `<p>` tags
- Update/fix for the exempt info component link to open in a new tab

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-1361

Acceptance Criteria

All keyboard navigation can be accessed and operated.

## Testing done

- E2E Cypress test for the 22-8794 ran to completion successfully
- Local testing that the console error no longer appears on the 22-8794 Confirmation Page
- Local testing to verify the exempt info component link opens in a new tab

## Screenshots

**Before:**

![Section 305 Info (Before)](https://github.com/user-attachments/assets/56e8b3c8-a0cf-4eec-8a68-e6078135bb38)

**After:**

![Section 305 Info (After)](https://github.com/user-attachments/assets/508f60ae-dcaf-41d8-ae71-6143cdb8d292)

## What areas of the site does it impact?

- Form 22-8794

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
