### PR TITLE
111193 Add phone number and content to the "Need help?" section of the Supply Reorder app

### DIFF
--- a/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
+++ b/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
@@ -3,10 +3,14 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 
 const FooterInfo = () => (
   <section className="need-help-footer row vads-u-padding-x--1p5">
-    For benefit-related questions, or if the form isn’t working right, please
+    For help filling out this form, or if the form isn’t working right, please
     call VA Benefits and Services at{' '}
     <va-telephone contact={CONTACTS.VA_BENEFITS} />. If you have hearing loss,
-    call <va-telephone contact={CONTACTS['711']} tty />.
+    call <va-telephone contact={CONTACTS['711']} tty />. For help ordering
+    hearing aid or CPAP supplies, please call the DLC Customer Service Section
+    at <va-telephone contact="8776778710" /> (
+    <va-telephone contact={CONTACTS['711']} tty />) or email{' '}
+    <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
   </section>
 );
 

--- a/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
+++ b/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
@@ -3,14 +3,21 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 
 const FooterInfo = () => (
   <section className="need-help-footer row vads-u-padding-x--1p5">
-    <b>For help filling out this form, or if the form isn’t working right,</b>{' '}
-    please call VA Benefits and Services at{' '}
-    <va-telephone contact={CONTACTS.VA_BENEFITS} />. If you have hearing loss,
-    call <va-telephone contact={CONTACTS['711']} tty />.<br />
-    <b>For help ordering hearing aid or CPAP supplies,</b> please call the DLC
-    Customer Service Section at <va-telephone contact="8776778710" /> (
-    <va-telephone contact={CONTACTS['711']} tty />) or email{' '}
-    <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+    <p>
+      <strong>
+        For help filling out this form, or if the form isn’t working right,
+      </strong>{' '}
+      please call VA Benefits and Services at{' '}
+      <va-telephone contact={CONTACTS.VA_BENEFITS} />. If you have hearing loss,
+      call <va-telephone contact={CONTACTS['711']} tty />.
+    </p>
+    <p>
+      <strong>For help ordering hearing aid or CPAP supplies,</strong> please
+      call the DLC Customer Service Section at{' '}
+      <va-telephone contact="8776778710" /> (
+      <va-telephone contact={CONTACTS['711']} tty />) or email{' '}
+      <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+    </p>
   </section>
 );
 

--- a/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
+++ b/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
@@ -3,12 +3,12 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 
 const FooterInfo = () => (
   <section className="need-help-footer row vads-u-padding-x--1p5">
-    For help filling out this form, or if the form isn’t working right, please
-    call VA Benefits and Services at{' '}
+    <b>For help filling out this form, or if the form isn’t working right,</b>{' '}
+    please call VA Benefits and Services at{' '}
     <va-telephone contact={CONTACTS.VA_BENEFITS} />. If you have hearing loss,
-    call <va-telephone contact={CONTACTS['711']} tty />. For help ordering
-    hearing aid or CPAP supplies, please call the DLC Customer Service Section
-    at <va-telephone contact="8776778710" /> (
+    call <va-telephone contact={CONTACTS['711']} tty />.<br />
+    <b>For help ordering hearing aid or CPAP supplies,</b> please call the DLC
+    Customer Service Section at <va-telephone contact="8776778710" /> (
     <va-telephone contact={CONTACTS['711']} tty />) or email{' '}
     <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
   </section>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Minor copy update to the "Need help?" section of the Classic Supply Reorder application

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#111193


## Testing done
Specs green. Verified locally that copy appears as expected.

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |    <img  src="https://github.com/user-attachments/assets/e25ab122-3d27-4ef4-b200-924d93555d44" /> |
| Desktop |        |    <img  src="https://github.com/user-attachments/assets/a179bd7c-0313-4191-8fc5-9a3e28c8bd46" />   |

## What areas of the site does it impact?
[Classic Supply Reorder](http://localhost:3001/health-care/order-hearing-aid-or-CPAP-supplies-form/introduction)

## Acceptance criteria
Copy is up to date