### PR TITLE
Updated AutoSSO Tests for Node 22 Upgrade

### DIFF
--- a/src/platform/site-wide/user-nav/tests/mocks/msw-mocks.js
+++ b/src/platform/site-wide/user-nav/tests/mocks/msw-mocks.js
@@ -1,6 +1,8 @@
-import { rest, HttpResponse } from 'msw';
+import { rest, http, HttpResponse } from 'msw';
 
-export const headKeepAliveSuccess = rest.head(
+const restOrHttp = rest || http;
+
+export const headKeepAliveSuccess = restOrHttp.head(
   'https://int.eauth.va.gov/keepalive',
   () => new HttpResponse(null, { status: 200 }),
 );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated `msw-mocks.js` so that `AutoSSO.unit.spec.jsx` passes in both Node 14 and Node 22.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/469)

## Testing done
- Updated `src/platform/site-wide/user-nav/tests/mocks/msw-mocks.js` and ran tests locally on both the `main` and `node-22-dev-branch` branches.
- Can be replicated by running `yarn test:unit src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `msw-mocks.js` and `AutoSSO.unit.spec.jsx`.

## Acceptance criteria
- [x] AutoSSO tests pass on Node 22
- [x] AutoSSO tests continue to pass on Node 14