### PR TITLE
Update preSubmitInfo implementation

### DIFF
--- a/src/applications/income-and-asset-statement/config/form.js
+++ b/src/applications/income-and-asset-statement/config/form.js
@@ -67,7 +67,6 @@ const formConfig = {
         formData?.claimantType === 'VETERAN'
           ? 'veteranFullName'
           : 'claimantFullName',
-      useProfileFullName: loggedIn => !!loggedIn,
     },
   },
   title: 'Income and Asset Statement',

--- a/src/applications/income-and-asset-statement/containers/PreSubmitInfo.jsx
+++ b/src/applications/income-and-asset-statement/containers/PreSubmitInfo.jsx
@@ -12,7 +12,6 @@ import {
   statementOfTruthBodyElement,
 } from '~/platform/forms/components/review/PreSubmitSection';
 
-// platform - form-system actions
 import { setPreSubmit as setPreSubmitAction } from 'platform/forms-system/src/js/actions';
 
 const PreSubmitInfo = ({
@@ -31,9 +30,20 @@ const PreSubmitInfo = ({
     setStatementOfTruthSignatureBlurred,
   ] = useState(false);
 
+  const useProfileFullName = loggedIn && claimantType === 'VETERAN';
+
+  const expectedFullName = statementOfTruthFullName(
+    formData,
+    {
+      ...statementOfTruth,
+      useProfileFullName,
+    },
+    user?.profile?.userFullName,
+  );
+
   return (
     <>
-      {loggedIn && claimantType === 'VETERAN' ? (
+      {useProfileFullName ? (
         <>
           <div className="vads-u-margin-y--2p5">
             <strong>Note:</strong> According to federal law, there are criminal
@@ -45,14 +55,7 @@ const PreSubmitInfo = ({
             name="statementOfTruthCertified"
             onVaChange={event => {
               setPreSubmit('statementOfTruthCertified', event.detail.checked);
-              setPreSubmit(
-                'statementOfTruthSignature',
-                statementOfTruthFullName(
-                  formData,
-                  statementOfTruth,
-                  user?.profile?.userFullName,
-                ),
-              );
+              setPreSubmit('statementOfTruthSignature', expectedFullName);
             }}
             showError={showError && !statementOfTruthCertified}
           />
@@ -67,14 +70,8 @@ const PreSubmitInfo = ({
           inputError={
             (showError || statementOfTruthSignatureBlurred) &&
             fullNameReducer(formData.statementOfTruthSignature) !==
-              fullNameReducer(
-                statementOfTruthFullName(formData, statementOfTruth, null),
-              )
-              ? `Please enter your name exactly as it appears on your application: ${statementOfTruthFullName(
-                  formData,
-                  statementOfTruth,
-                  null,
-                )}`
+              fullNameReducer(expectedFullName)
+              ? `Please enter your name exactly as it appears on your application: ${expectedFullName}`
               : undefined
           }
           checked={formData.statementOfTruthCertified}

--- a/src/applications/income-and-asset-statement/tests/unit/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/containers/PreSubmitInfo.unit.spec.jsx
@@ -3,75 +3,75 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { statementOfTruthFullName } from '~/platform/forms/components/review/PreSubmitSection';
 import formConfig from '../../../config/form';
 import PreSubmitInfo from '../../../containers/PreSubmitInfo';
 
-const getData = ({ loggedIn = true } = {}) => ({
-  props: {
-    formData: {
-      formId: formConfig.formId,
-      loadedStatus: 'success',
-      savedStatus: '',
-      loadedData: {
-        metadata: {},
-      },
-      data: {},
+const getData = ({
+  loggedIn = true,
+  claimantType = undefined,
+  profileFullName = { first: 'Jane', middle: 'Q', last: 'Doe' },
+} = {}) => {
+  const mockFormData = {
+    formId: formConfig.formId,
+    loadedStatus: 'success',
+    savedStatus: '',
+    loadedData: { metadata: {} },
+    data: {},
+    ...(claimantType ? { claimantType } : {}),
+    veteranFullName: {
+      first: 'Jane',
+      middle: 'Q',
+      last: 'Doe',
     },
-    preSubmitInfo: {
-      statementOfTruth: {
-        body:
-          'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-        messageAriaDescribedby:
-          'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-        fullNamePath: formData =>
-          formData?.claimantType === 'VETERAN'
-            ? 'veteranFullName'
-            : 'claimantFullName',
-        useProfileFullName: !!loggedIn,
+  };
+
+  return {
+    props: {
+      formData: mockFormData,
+      preSubmitInfo: {
+        statementOfTruth: {
+          body:
+            'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+          messageAriaDescribedby:
+            'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+          fullNamePath: formData =>
+            formData?.claimantType === 'VETERAN'
+              ? 'veteranFullName'
+              : 'claimantFullName',
+        },
       },
-    },
-    showError: true,
-    user: {
-      login: {
-        currentlyLoggedIn: loggedIn,
-      },
-      profile: {
-        savedForms: [],
-        prefillsAvailable: [],
-        verified: false,
-      },
-    },
-  },
-  mockStore: {
-    getState: () => ({
+      showError: true,
       user: {
         login: {
           currentlyLoggedIn: loggedIn,
         },
         profile: {
-          savedForms: [],
-          prefillsAvailable: [],
-          verified: false,
+          userFullName: profileFullName,
         },
       },
-      form: {
-        formId: formConfig.formId,
-        loadedStatus: 'success',
-        savedStatus: '',
-        loadedData: {
-          metadata: {},
+    },
+    mockStore: {
+      getState: () => ({
+        user: {
+          login: {
+            currentlyLoggedIn: loggedIn,
+          },
+          profile: {
+            userFullName: profileFullName,
+          },
         },
-        data: {},
-      },
-    }),
-    subscribe: () => {},
-    dispatch: () => {},
-  },
-});
+        form: mockFormData,
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    },
+  };
+};
 
 describe('<PreSubmitInfo />', () => {
   describe('when not logged in', () => {
-    it('should render the va-statement-of-truth component', () => {
+    it('should render the va-statement-of-truth and not va-privacy-agreement', () => {
       const { props, mockStore } = getData({ loggedIn: false });
       const { container } = render(
         <Provider store={mockStore}>
@@ -79,15 +79,16 @@ describe('<PreSubmitInfo />', () => {
         </Provider>,
       );
       expect($('va-statement-of-truth', container)).to.exist;
-      expect($('va-statement-of-truth', container).textContent).to.include(
-        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-      );
       expect($('va-privacy-agreement', container)).not.to.exist;
     });
   });
+
   describe('when logged in and is not a self-representing veteran', () => {
-    it('should render the va-statement-of-truth component', () => {
-      const { props, mockStore } = getData();
+    it('should render the va-statement-of-truth component and not va-privacy-agreement', () => {
+      const { props, mockStore } = getData({
+        loggedIn: true,
+        claimantType: 'SPOUSE',
+      });
       const { container } = render(
         <Provider store={mockStore}>
           <PreSubmitInfo {...props} />
@@ -100,17 +101,30 @@ describe('<PreSubmitInfo />', () => {
       expect($('va-privacy-agreement', container)).not.to.exist;
     });
   });
+
   describe('when logged in and is a self-representing veteran', () => {
-    it('should render the va-privacy-agreement component', () => {
-      const { props, mockStore } = getData();
-      props.formData.claimantType = 'VETERAN';
+    it('should render the va-privacy-agreement component and use profile name', () => {
+      const { props, mockStore } = getData({
+        loggedIn: true,
+        claimantType: 'VETERAN',
+      });
       const { container } = render(
         <Provider store={mockStore}>
           <PreSubmitInfo {...props} />
         </Provider>,
       );
+
       expect($('va-privacy-agreement', container)).to.exist;
       expect($('va-statement-of-truth', container)).not.to.exist;
+
+      const expectedName = 'Jane Q Doe';
+      const computedName = statementOfTruthFullName(
+        props.formData,
+        props.preSubmitInfo.statementOfTruth,
+        props.user.profile.userFullName,
+      );
+
+      expect(computedName).to.equal(expectedName);
     });
   });
 });


### PR DESCRIPTION
## Summary
Resolved a silent form submission failure on the Income and Asset Statement form (VA Form 21P-0969) by updating the `PreSubmitInfo` logic. Specifically, the `useProfileFullName` option has been moved out of the global `formConfig.preSubmitInfo` and into the `PreSubmitInfo` custom component. It is now conditionally applied only when the user is authenticated **and** the `claimantType` is `"VETERAN"`.

Previously, `useProfileFullName` was applied to all authenticated users, which caused validation to compare the profile name against the wrong fullNamePath — resulting in no network request being sent when clicking **Submit**.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113693

## Related issue(s)
- N/A

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969/` in your browser

## How to verify
### Authenticated Self-represented Veteran
1. Log in with a test user and select `"Veteran"` as the `claimantType`
2. Proceed to the **Review and submit** page
3. Confirm that the Statement of Truth is not displayed and pre-filled in form data using the profile name
4. Confirm that the Privacy Agreement is displayed and required
5. Submit the form and verify the network request is sent and completes successfully

### Authenticated Non-self-represented Veteran
1. Log in with a test user and select a `"Non-Veteran"` `claimantType`
2. Proceed to the **Review and submit** page
3. Confirm that the Statement of Truth is not displayed and pre-filled in form data using the profile name
4. Confirm that the Privacy Agreement is displayed and required
5. Submit the form and verify the network request is sent and completes successfully

### Unauthenticated 
1. Log out and repeat the flow as an unauthenticated user — confirm that a manual full name field is shown
2. Confirm that the Statement of Truth is displayed and required
3. Confirm that the full name must match either the veteran or claimant name based on claimant type
4. Confirm that the Privacy Agreement is displayed and required
5. Submit the form and verify the network request is sent and completes successfully

## What areas of the site does it impact?
Income and Asset Statement Application — PreSubmitInfo and form submission

## Screenshots
### Desktop
| Before      | After       |
| ----------- | ----------- |
| Submit silently fails due to full name mismatch | Submit works correctly based on user authentication and claimant type |


### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot style, layout and content matches the design references
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated and unauthenticated routes work as expected with a test user

## Requested Feedback
Please confirm that this logic safely covers both authenticated and unauthenticated cases and avoids false validation errors due to name mismatches.
