### PR TITLE
rel: `vets-json-schema` Version Bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#81ef719d1a1e948346fe5490882b5f29628e26f0",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#82f6fed76802255b901f3415ea3bb4bdfb6c0aac",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22705,9 +22705,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#81ef719d1a1e948346fe5490882b5f29628e26f0":
-  version "25.1.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#81ef719d1a1e948346fe5490882b5f29628e26f0"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#82f6fed76802255b901f3415ea3bb4bdfb6c0aac":
+  version "25.1.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#82f6fed76802255b901f3415ea3bb4bdfb6c0aac"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR bumps the `vets-json-schema` dependency to the latest version "25.1.1".

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1007/

## Acceptance criteria

- Dependency version is the latest 

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution