### PR TITLE
Updated SSO Tests for Node 22 Upgrade

### DIFF
--- a/src/platform/utilities/tests/sso/sso.unit.spec.jsx
+++ b/src/platform/utilities/tests/sso/sso.unit.spec.jsx
@@ -92,9 +92,9 @@ describe('checkAutoSession', () => {
         `http://localhost/sign-in/?application=myvahealth&to=%2Fsession-api%2Frealm%2Ff0fded0d-d00b-4b28-9190-853247fd9f9d%3Fto%3Dhttps%253A%252F%252F${cernerEndpoint}-patientportal.myhealth.va.gov%252F`,
       );
       if (Window.prototype.href) {
-        window.location.href = startingLocation;
+        global.window.location.href = startingLocation;
       } else {
-        window.location = startingLocation;
+        global.window.location = startingLocation;
       }
       const profile = { verified: true };
       await checkAutoSession(true, 'X', profile);
@@ -116,9 +116,9 @@ describe('checkAutoSession', () => {
       'http://localhost/sign-in/?application=myvahealth',
     );
     if (Window.prototype.href) {
-      window.location.href = startingLocation;
+      global.window.location.href = startingLocation;
     } else {
-      window.location = startingLocation;
+      global.window.location = startingLocation;
     }
     const profile = { verified: false };
     await checkAutoSession(true, 'X', profile);
@@ -137,9 +137,9 @@ describe('checkAutoSession', () => {
     });
     const startingLocation = new URL('http://localhost/sign-in/');
     if (Window.prototype.href) {
-      window.location.href = startingLocation;
+      global.window.location.href = startingLocation;
     } else {
-      window.location = startingLocation;
+      global.window.location = startingLocation;
     }
     const profile = { verified: true };
 
@@ -160,9 +160,9 @@ describe('checkAutoSession', () => {
       'http://localhost/sign-in/?application=myvahealth',
     );
     if (Window.prototype.href) {
-      window.location.href = startingLocation;
+      global.window.location.href = startingLocation;
     } else {
-      window.location = startingLocation;
+      global.window.location = startingLocation;
     }
     const profile = { verified: true };
 
@@ -736,9 +736,9 @@ describe('verifySession', () => {
   it('should return false if the pathname is terms-of-use', () => {
     const startingLocation = new URL('http://localhost/terms-of-use/');
     if (Window.prototype.href) {
-      window.location.href = startingLocation;
+      global.window.location.href = startingLocation;
     } else {
-      window.location = startingLocation;
+      global.window.location = startingLocation;
     }
     localStorage.setItem('hasSessionSSO', true);
     localStorage.setItem('loginAttempted', true);

--- a/src/platform/utilities/tests/sso/sso.unit.spec.jsx
+++ b/src/platform/utilities/tests/sso/sso.unit.spec.jsx
@@ -88,13 +88,19 @@ describe('checkAutoSession', () => {
         authn: CSP_IDS.DS_LOGON,
         transactionid: 'X',
       });
-      global.window.location = new URL(
+      const startingLocation = new URL(
         `http://localhost/sign-in/?application=myvahealth&to=%2Fsession-api%2Frealm%2Ff0fded0d-d00b-4b28-9190-853247fd9f9d%3Fto%3Dhttps%253A%252F%252F${cernerEndpoint}-patientportal.myhealth.va.gov%252F`,
       );
+      if (Window.prototype.href) {
+        window.location.href = startingLocation;
+      } else {
+        window.location = startingLocation;
+      }
       const profile = { verified: true };
       await checkAutoSession(true, 'X', profile);
 
-      expect(global.window.location).to.eq(
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.eq(
         `https://${cernerEndpoint}-patientportal.myhealth.va.gov/session-api/realm/f0fded0d-d00b-4b28-9190-853247fd9f9d?authenticated=true`,
       );
     });
@@ -106,9 +112,14 @@ describe('checkAutoSession', () => {
       authn: CSP_IDS.DS_LOGON,
       transactionid: 'X',
     });
-    global.window.location.origin = 'http://localhost';
-    global.window.location.pathname = '/sign-in/';
-    global.window.location.search = '?application=myvahealth';
+    const startingLocation = new URL(
+      'http://localhost/sign-in/?application=myvahealth',
+    );
+    if (Window.prototype.href) {
+      window.location.href = startingLocation;
+    } else {
+      window.location = startingLocation;
+    }
     const profile = { verified: false };
     await checkAutoSession(true, 'X', profile);
 
@@ -124,14 +135,18 @@ describe('checkAutoSession', () => {
       [AUTHN_KEYS.CSP_TYPE]: CSP_IDS.DSLOGON,
       transactionid: 'X',
     });
-    global.window.location.origin = 'http://localhost';
-    global.window.location.pathname = '/sign-in/';
-    global.window.location.search = '';
+    const startingLocation = new URL('http://localhost/sign-in/');
+    if (Window.prototype.href) {
+      window.location.href = startingLocation;
+    } else {
+      window.location = startingLocation;
+    }
     const profile = { verified: true };
 
     await checkAutoSession(true, 'X', profile);
 
-    expect(global.window.location).to.eq('http://localhost');
+    const location = global.window.location.href || global.window.location;
+    expect(location).to.be.oneOf(['http://localhost', 'http://localhost/']);
   });
 
   it('should re login user before redirect to myvahealth because transactions are different', async () => {
@@ -141,9 +156,14 @@ describe('checkAutoSession', () => {
       authn: CSP_IDS.DS_LOGON,
       transactionid: 'X',
     });
-    global.window.location.origin = 'http://localhost';
-    global.window.location.pathname = '/sign-in/';
-    global.window.location.search = '?application=myvahealth';
+    const startingLocation = new URL(
+      'http://localhost/sign-in/?application=myvahealth',
+    );
+    if (Window.prototype.href) {
+      window.location.href = startingLocation;
+    } else {
+      window.location = startingLocation;
+    }
     const profile = { verified: true };
 
     const auto = sandbox.stub(authUtils, 'login');
@@ -343,6 +363,7 @@ describe('checkAutoSession', () => {
   });
 
   it('should log a user in if they `loginAttempted` is true but the `loggedIn` is false', async () => {
+    global.window.location.host = `dev.va.gov`;
     localStorage.setItem('loginAttempted', true);
     localStorage.setItem('hasSessionSSO', true);
     localStorage.setItem('sessionExpirationSSO', 'some date value');
@@ -477,13 +498,11 @@ describe('keepAlive', () => {
       }),
     );
     const KA_RESPONSE = await keepAliveMod.keepAlive();
-    expect(KA_RESPONSE).to.eql({
-      ttl: 0,
-      transactionid: null,
-      authn: 'NOT_FOUND',
-      [AUTHN_KEYS.CSP_TYPE]: 'idme',
-      [AUTHN_KEYS.CSP_METHOD]: 'IDME_DSL',
-    });
+    expect(KA_RESPONSE.ttl).to.equal(0);
+    expect(KA_RESPONSE.transactionid).to.be.oneOf([null, 'null']);
+    expect(KA_RESPONSE.authn).to.equal('NOT_FOUND');
+    expect(KA_RESPONSE[AUTHN_KEYS.CSP_TYPE]).to.equal('idme');
+    expect(KA_RESPONSE[AUTHN_KEYS.CSP_METHOD]).to.equal('IDME_DSL');
   });
 
   it('should return active dslogon session', async () => {
@@ -701,6 +720,7 @@ describe('verifySession', () => {
     localStorage.clear();
   });
   it('should return true when conditions', () => {
+    global.window.location.host = `dev.va.gov`;
     localStorage.setItem('hasSessionSSO', true);
     localStorage.setItem('loginAttempted', true);
     localStorage.setItem('sessionExpirationSSO', new Date());
@@ -714,8 +734,12 @@ describe('verifySession', () => {
     expect(verifySession()).to.eql(false);
   });
   it('should return false if the pathname is terms-of-use', () => {
-    global.window.location.origin = 'http://localhost';
-    global.window.location.pathname = '/terms-of-use/';
+    const startingLocation = new URL('http://localhost/terms-of-use/');
+    if (Window.prototype.href) {
+      window.location.href = startingLocation;
+    } else {
+      window.location = startingLocation;
+    }
     localStorage.setItem('hasSessionSSO', true);
     localStorage.setItem('loginAttempted', true);
     localStorage.setItem('sessionExpirationSSO', new Date());


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated SSO tests so that all tests pass in both Node 14 and Node 22.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/472)

## Testing done
- Updated `sso.unit.spec.jsx` and ran tests locally on both the `main` and `node-22-dev-branch` branches.
- Can be replicated by running `yarn test:unit src/platform/utilities/tests/sso/sso.unit.spec.jsx`.

## What areas of the site does it impact?
This only impacts `sso.unit.spec.jsx`.

## Acceptance criteria
- [x] SSO tests pass on Node 22
- [x] SSO tests continue to pass on Node 14