### PR TITLE
Global | Conditionally render web component form nav buttons

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNavButtons.jsx
+++ b/src/platform/forms-system/src/js/components/FormNavButtons.jsx
@@ -11,7 +11,12 @@ import ProgressButton from './ProgressButton';
  * the `goForward` function to the form's `onSubmit` instead. Doing this will
  * navigate the user to the next page only if validation is successful.
  */
-const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
+const FormNavButtons = ({
+  goBack,
+  goForward,
+  submitToContinue,
+  useWebComponents,
+}) => (
   <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--2">
     <div className="small-6 medium-5 columns">
       {goBack && (
@@ -20,6 +25,7 @@ const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
           buttonText="Back"
           buttonClass="usa-button-secondary"
           beforeText="«"
+          useWebComponents={useWebComponents}
         />
       )}
     </div>
@@ -30,6 +36,7 @@ const FormNavButtons = ({ goBack, goForward, submitToContinue }) => (
         buttonText="Continue"
         buttonClass="usa-button-primary"
         afterText="»"
+        useWebComponents={useWebComponents}
       />
     </div>
   </div>
@@ -39,11 +46,16 @@ FormNavButtons.propTypes = {
   goBack: propTypes.func,
   goForward: propTypes.func,
   submitToContinue: propTypes.bool,
+  useWebComponents: propTypes.bool,
 };
 
 export default FormNavButtons;
 
-export const FormNavButtonContinue = ({ goForward, submitToContinue }) => (
+export const FormNavButtonContinue = ({
+  goForward,
+  submitToContinue,
+  useWebComponents,
+}) => (
   <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--2">
     <div className="medium-8 columns">
       <ProgressButton
@@ -52,6 +64,7 @@ export const FormNavButtonContinue = ({ goForward, submitToContinue }) => (
         buttonText="Continue"
         buttonClass="usa-button-primary"
         afterText="»"
+        useWebComponents={useWebComponents}
       />
     </div>
   </div>
@@ -60,4 +73,5 @@ export const FormNavButtonContinue = ({ goForward, submitToContinue }) => (
 FormNavButtonContinue.propTypes = {
   goForward: propTypes.func,
   submitToContinue: propTypes.bool,
+  useWebComponents: propTypes.bool,
 };

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -1,115 +1,168 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 import navigationState from '../utilities/navigation/navigationState';
 
 /**
  * A component for the continue button to navigate through panels of questions.
  */
+const ProgressButton = props => {
+  const {
+    ariaDescribedBy,
+    ariaLabel,
+    buttonText,
+    buttonClass,
+    disabled,
+    loading,
+    onButtonClick,
+    preventOnBlur,
+    submitButton,
+    // web component-only props
+    useWebComponents = false,
+    fullWidth,
+  } = props;
+  let { afterText = '', beforeText = '' } = props;
+  let webComponentProps = {};
 
-class ProgressButton extends React.Component {
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillMount() {
-    this.id = uniqueId();
-  }
+  const id = uniqueId();
 
-  handleClick = e => {
+  const handleClick = e => {
     navigationState.setNavigationEvent();
     // onButtonClick may not be present (see FormNavButtons)
-    if (this.props.onButtonClick) {
-      this.props.onButtonClick(e);
+    if (onButtonClick) {
+      onButtonClick(e);
     }
   };
 
-  render() {
-    let beforeText = '';
-
-    if (this.props.beforeText && this.props.beforeText === '«') {
+  if (!useWebComponents) {
+    if (beforeText && beforeText === '«') {
       beforeText = (
         <va-icon icon="navigate_far_before" class="vads-u-padding-right--1" />
       );
-    } else if (this.props.beforeText) {
+    } else if (beforeText) {
       beforeText = (
         <span className="button-icon" aria-hidden="true">
-          {this.props.beforeText}
+          {beforeText}
           &nbsp;
         </span>
       );
     }
 
-    let afterText = '';
-
-    if (this.props.afterText && this.props.afterText === '»') {
+    if (afterText && afterText === '»') {
       afterText = (
         <va-icon icon="navigate_far_next" class="vads-u-padding-left--1" />
       );
-    } else if (this.props.afterText) {
+    } else if (afterText) {
       afterText = (
         <span className="button-icon" aria-hidden="true">
           &nbsp;
-          {this.props.afterText}
+          {afterText}
         </span>
       );
     }
+  } else {
+    // Remove class names that may interfere with the web component
+    const vaButtonClass = buttonClass
+      .replace('usa-button-primary', '')
+      .replace('usa-button-secondary', '')
+      .replace('vads-u-width--auto', '')
+      .replace('usa-button-disabled', '')
+      .replace('vads-u-width--full', '')
+      .trim();
 
-    return (
-      // aria-describedby tag to match "By submitting this form"
-      // text for proper screen reader operation
-      <button
-        type={this.props.submitButton ? 'submit' : 'button'}
-        disabled={this.props.disabled}
-        className={`${this.props.buttonClass}${
-          this.props.disabled ? ' usa-button-disabled' : ''
-        }`}
-        id={`${this.id}-continueButton`}
-        // onClick={this.props.onButtonClick}
-        onClick={this.handleClick}
-        onMouseDown={this.props.preventOnBlur}
-        aria-label={this.props.ariaLabel || null}
-        aria-describedby={this.props.ariaDescribedBy}
-      >
-        {beforeText}
-        {this.props.buttonText}
-        {afterText}
-      </button>
-    );
+    webComponentProps = {
+      back: beforeText === '«' ? true : null,
+      class: vaButtonClass,
+      continue: afterText === '»' ? true : null,
+      disabled: disabled || null,
+      'full-width': fullWidth || null,
+      id: `${id}-continueButton`,
+      label: ariaLabel || null,
+      loading: loading || null,
+      'message-aria-describedby': ariaDescribedBy || null,
+      onClick: handleClick,
+      // The web component does not support onMouseDown
+      // onMouseDown: preventOnBlur,
+      secondary: buttonClass.includes('usa-button-secondary') || null,
+      submit: submitButton ? 'prevent' : null,
+      text: buttonText,
+    };
   }
-}
+
+  return useWebComponents ? (
+    <va-button {...webComponentProps} />
+  ) : (
+    // aria-describedby tag to match "By submitting this form"
+    // text for proper screen reader operation
+    // eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component
+    <button
+      type={submitButton ? 'submit' : 'button'}
+      disabled={disabled}
+      className={`${buttonClass}${disabled ? ' usa-button-disabled' : ''}`}
+      id={`${id}-continueButton`}
+      // onClick={this.props.onButtonClick}
+      onClick={handleClick}
+      onMouseDown={preventOnBlur}
+      aria-label={ariaLabel || null}
+      aria-describedby={ariaDescribedBy}
+    >
+      {beforeText}
+      {buttonText}
+      {afterText}
+    </button>
+  );
+};
 
 ProgressButton.defaultProps = {
   preventOnBlur: e => {
     e.preventDefault();
   },
+  fullWidth: true,
 };
 
 ProgressButton.propTypes = {
-  // function that changes the path to the next panel or submit.
-  onButtonClick: PropTypes.func,
-
-  // function that bypasses onBlur when clicking
-  preventOnBlur: PropTypes.func,
-
-  // what is the button's label
-  buttonText: PropTypes.string.isRequired,
-
   // what CSS class(es) does the button have
   buttonClass: PropTypes.string.isRequired,
-
-  // Stores the value for the icon that will appear before the button text.
-  beforeText: PropTypes.string,
+  // what is the button's label
+  buttonText: PropTypes.string.isRequired,
 
   // Stores the value for the icon that will appear after the button text.
   afterText: PropTypes.string,
 
+  // aria-described by attribute (id for button, text for va-button); needed to
+  // associate the button with some content
+  ariaDescribedBy: PropTypes.string,
+
+  // aria-label attribute (id for button, text for va-button); needed for the
+  // review & submit page "Update page" button
+  ariaLabel: PropTypes.string,
+
+  // Stores the value for the icon that will appear before the button text.
+  beforeText: PropTypes.string,
+
   // is the button disabled or not
   disabled: PropTypes.bool,
 
-  // aria-label attribute; needed for the review & submit page "Update page"
-  // button
-  ariaLabel: PropTypes.string,
+  // Web component-only prop
+  // If true, the button will take up the full width of its container
+  fullWidth: PropTypes.bool,
+
+  // web component-only loading state
+  loading: PropTypes.bool,
+
+  // function that bypasses onBlur when clicking
+  preventOnBlur: PropTypes.func,
 
   // is this a submit button or not
   submitButton: PropTypes.bool,
+
+  // If true, use the web component va-button
+  // If false, use the standard HTML button
+  // This is used to avoid a breaking change in the web component migration
+  useWebComponents: PropTypes.bool,
+
+  // function that changes the path to the next panel or submit.
+  onButtonClick: PropTypes.func,
 };
 
 export default ProgressButton;

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -75,7 +75,7 @@ const ProgressButton = props => {
       class: vaButtonClass,
       continue: afterText === '»' ? true : null,
       disabled: disabled || null,
-      'full-width': fullWidth || null,
+      'full-width': fullWidth ?? true,
       id: `${id}-continueButton`,
       label: ariaLabel || null,
       loading: loading || null,
@@ -100,7 +100,6 @@ const ProgressButton = props => {
       disabled={disabled}
       className={`${buttonClass}${disabled ? ' usa-button-disabled' : ''}`}
       id={`${id}-continueButton`}
-      // onClick={this.props.onButtonClick}
       onClick={handleClick}
       onMouseDown={preventOnBlur}
       aria-label={ariaLabel || null}
@@ -117,7 +116,6 @@ ProgressButton.defaultProps = {
   preventOnBlur: e => {
     e.preventDefault();
   },
-  fullWidth: true,
 };
 
 ProgressButton.propTypes = {

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -265,6 +265,8 @@ class FormPage extends React.Component {
     const pageClasses = classNames('form-panel', route.pageConfig.pageClass);
     const data = this.formData();
 
+    const formOptions = route.formConfig?.formOptions || {};
+
     if (
       route.pageConfig.showPagePerItem &&
       (!route.pageConfig.CustomPage ||
@@ -291,8 +293,7 @@ class FormPage extends React.Component {
       environment.isLocalhost() && route.formConfig?.dev?.showNavLinks;
     const hideNavButtons =
       !environment.isProduction() &&
-      (route.formConfig?.formOptions?.noBottomNav ||
-        route.pageConfig?.hideNavButtons);
+      (formOptions?.noBottomNav || route.pageConfig?.hideNavButtons);
 
     let pageContentBeforeButtons = route.pageConfig?.ContentBeforeButtons;
     if (
@@ -358,6 +359,7 @@ class FormPage extends React.Component {
             appStateData={appStateData}
             formContext={this.formContext}
             NavButtons={NavButtons}
+            formOptions={formOptions}
           />
         </div>
       );
@@ -385,7 +387,7 @@ class FormPage extends React.Component {
           uploadFile={this.props.uploadFile}
           onChange={this.onChange}
           onSubmit={this.onSubmit}
-          formOptions={route.formConfig?.formOptions || {}}
+          formOptions={formOptions}
         >
           {pageContentBeforeButtons}
           {hideNavButtons ? (
@@ -397,6 +399,7 @@ class FormPage extends React.Component {
                 goBack={!isFirstRoutePage && this.goBack}
                 goForward={this.onContinue}
                 submitToContinue
+                useWebComponents={formOptions.useWebComponentForNavigation}
               />
               {contentAfterNavButtons}
             </>
@@ -477,6 +480,7 @@ FormPage.propTypes = {
       }),
       formOptions: PropTypes.shape({
         noBottomNav: PropTypes.bool,
+        useWebComponentForNavigation: PropTypes.bool,
       }),
       showSaveLinkAfterButtons: PropTypes.bool,
       useTopBackLink: PropTypes.bool,

--- a/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
@@ -1,136 +1,237 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-import { shallow } from 'enzyme';
-import chaiAsPromised from 'chai-as-promised';
-import chai, { expect } from 'chai';
+import { render, fireEvent } from '@testing-library/react';
+import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { axeCheck } from '../../config/helpers';
 import ProgressButton from '../../../src/js/components/ProgressButton';
-
-chai.use(chaiAsPromised);
+import { $, $$ } from '../../../src/js/utilities/ui';
 
 describe('<ProgressButton>', () => {
-  it('should render with button text', () => {
-    const tree = shallow(
-      <ProgressButton
-        buttonText="Button text"
-        buttonClass="usa-button-primary"
-        disabled={false}
-      />,
-    );
-    expect(tree.text()).to.equal('Button text');
-    expect(tree).to.have.length.of(1);
-    tree.unmount();
-  });
-
-  it('calls handle() on click', () => {
-    let progressButton;
-
-    const updatePromise = new Promise((resolve, _reject) => {
-      progressButton = ReactTestUtils.renderIntoDocument(
+  context('React component', () => {
+    it('should render with button text', () => {
+      const { container } = render(
         <ProgressButton
           buttonText="Button text"
           buttonClass="usa-button-primary"
           disabled={false}
-          onButtonClick={() => {
-            resolve(true);
-          }}
         />,
       );
+      expect($('button', container).textContent).to.equal('Button text');
+      expect($$('button', container)).to.have.length.of(1);
     });
 
-    const button = ReactTestUtils.findRenderedDOMComponentWithTag(
-      progressButton,
-      'button',
-    );
-    ReactTestUtils.Simulate.click(button);
+    it('calls handle() on click', () => {
+      const clickSpy = sinon.spy();
 
-    return expect(updatePromise).to.eventually.eql(true);
-  });
-
-  it('calls handle() on click even if mouseDown happens', () => {
-    let progressButton;
-    const spy = sinon.spy();
-
-    const updatePromise = new Promise((resolve, _reject) => {
-      progressButton = ReactTestUtils.renderIntoDocument(
+      const { container } = render(
         <ProgressButton
           buttonText="Button text"
           buttonClass="usa-button-primary"
           disabled={false}
-          onButtonClick={() => {
-            resolve(true);
-          }}
-          preventOnBlur={spy}
+          onButtonClick={clickSpy}
         />,
       );
+
+      fireEvent.click($('button', container));
+      expect(clickSpy.calledOnce).to.be.true;
     });
 
-    const button = ReactTestUtils.findRenderedDOMComponentWithTag(
-      progressButton,
-      'button',
-    );
+    it('calls handle() on click even if mouseDown happens', () => {
+      const blurSpy = sinon.spy();
+      const clickSpy = sinon.spy();
 
-    ReactTestUtils.Simulate.mouseDown(button);
-    ReactTestUtils.Simulate.click(button);
+      const { container } = render(
+        <ProgressButton
+          buttonText="Button text"
+          buttonClass="usa-button-primary"
+          disabled={false}
+          onButtonClick={clickSpy}
+          preventOnBlur={blurSpy}
+        />,
+      );
 
-    expect(spy.calledOnce).to.be.true;
-    return expect(updatePromise).to.eventually.eql(true);
+      const button = $('button', container);
+
+      fireEvent.mouseDown(button);
+      fireEvent.click(button);
+
+      expect(blurSpy.calledOnce).to.be.true;
+      expect(clickSpy.calledOnce).to.be.true;
+    });
+
+    it('calls preventDefault() on mouseDown event when providing prop', () => {
+      const blurSpy = sinon.spy();
+
+      const { container } = render(
+        <ProgressButton
+          buttonText="Button text"
+          buttonClass="usa-button-primary"
+          disabled={false}
+          preventOnBlur={blurSpy}
+        />,
+      );
+
+      const button = $('button', container);
+      fireEvent.mouseDown(button);
+      expect(blurSpy.calledOnce).to.be.true;
+    });
+
+    it('calls preventDefault() on mouseDown event with defaultProperty', () => {
+      const blurSpy = sinon.spy();
+
+      ProgressButton.defaultProps = {
+        preventOnBlur: blurSpy,
+      };
+
+      const { container } = render(
+        <ProgressButton
+          buttonText="Button text"
+          buttonClass="usa-button-primary"
+          disabled={false}
+        />,
+      );
+
+      const button = $('button', container);
+      fireEvent.mouseDown(button);
+      expect(blurSpy.calledOnce).to.be.true;
+
+      ProgressButton.defaultProps = {
+        preventOnBlur: e => {
+          e.preventDefault();
+        },
+      };
+    });
+
+    it('should pass aXe check when enabled', () =>
+      axeCheck(
+        <ProgressButton
+          buttonText="Button text"
+          buttonClass="usa-button-primary"
+          disabled={false}
+        />,
+      ));
+
+    it('should pass aXe check when disabled', () =>
+      axeCheck(
+        <ProgressButton
+          buttonText="Button text"
+          buttonClass="usa-button-primary"
+          disabled
+        />,
+      ));
   });
 
-  it('calls preventDefault() on mouseDown event when providing prop', () => {
-    const spy = sinon.spy();
+  context('Web component', () => {
+    it('should render with button text', () => {
+      const { container } = render(
+        <ProgressButton
+          ariaDescribedBy="Description for button text"
+          ariaLabel="Specific label for button text"
+          buttonText="Button text"
+          buttonClass="usa-button-secondary"
+          disabled={false}
+          useWebComponents
+        />,
+      );
+      const button = $('va-button', container);
 
-    const progressButton = ReactTestUtils.renderIntoDocument(
-      <ProgressButton
-        buttonText="Button text"
-        buttonClass="usa-button-primary"
-        disabled={false}
-        preventOnBlur={spy}
-      />,
-    );
+      expect(button.getAttribute('text')).to.eq('Button text');
+      expect(button.getAttribute('full-width')).to.eq('true');
+      expect(button.getAttribute('class')).to.eq('');
+      expect(button.getAttribute('disabled')).to.eq(null);
+      expect(button.getAttribute('secondary')).to.eq('true');
+      expect(button.getAttribute('back')).to.eq(null);
+      expect(button.getAttribute('continue')).to.eq(null);
+      expect(button.getAttribute('label')).to.eq(
+        'Specific label for button text',
+      );
+      expect(button.getAttribute('message-aria-describedby')).to.eq(
+        'Description for button text',
+      );
+      expect($$('va-button, button', container)).to.have.length.of(1);
+    });
 
-    const button = ReactTestUtils.findRenderedDOMComponentWithTag(
-      progressButton,
-      'button',
-    );
+    it('renders back button', () => {
+      const { container } = render(
+        <div>
+          <ProgressButton
+            beforeText="«"
+            buttonText="Back"
+            buttonClass="usa-button-secondary vads-u-width--full"
+            useWebComponents
+          />
+        </div>,
+      );
 
-    ReactTestUtils.Simulate.mouseDown(button);
+      const button = $('va-button', container);
 
-    expect(spy.calledOnce).to.be.true;
+      expect(button.getAttribute('class')).to.eq('');
+      expect(button.getAttribute('back')).to.eq('true');
+      expect(button.getAttribute('continue')).to.eq(null);
+      expect(button.getAttribute('secondary')).to.eq('true');
+      expect(button.getAttribute('full-width')).to.eq('true');
+    });
+
+    it('renders continue button', () => {
+      const { container } = render(
+        <div>
+          <ProgressButton
+            afterText="»"
+            buttonText="Continue"
+            buttonClass="usa-button-primary"
+            useWebComponents
+          />
+        </div>,
+      );
+
+      const button = $('va-button', container);
+
+      expect(button.getAttribute('class')).to.eq('');
+      expect(button.getAttribute('back')).to.eq(null);
+      expect(button.getAttribute('continue')).to.eq('true');
+    });
+
+    it('calls handle() on click', () => {
+      const clickSpy = sinon.spy();
+
+      const { container } = render(
+        <div>
+          <ProgressButton
+            buttonText="Button text"
+            buttonClass="usa-button-primary"
+            disabled={false}
+            onButtonClick={clickSpy}
+            useWebComponents
+          />
+        </div>,
+      );
+
+      const button = $('va-button', container);
+
+      fireEvent.click(button);
+      expect(button.getAttribute('secondary')).to.eq(null);
+      expect(clickSpy.calledOnce).to.be.true;
+    });
+
+    it('should pass aXe check when enabled', () =>
+      axeCheck(
+        <ProgressButton
+          buttonText="Button text"
+          buttonClass="usa-button-primary"
+          disabled={false}
+          useWebComponents
+        />,
+      ));
+
+    it('should pass aXe check when disabled', () =>
+      axeCheck(
+        <ProgressButton
+          buttonText="Button text"
+          buttonClass="usa-button-primary"
+          disabled
+          useWebComponents
+        />,
+      ));
   });
-
-  it('calls preventDefault() on mouseDown event with defaultProperty', () => {
-    const wrapper = shallow(
-      <ProgressButton
-        buttonText="Button text"
-        buttonClass="usa-button-primary"
-        disabled={false}
-      />,
-    );
-
-    expect(
-      wrapper.find('button').simulate('mouseDown', { preventDefault() {} }),
-    );
-    wrapper.unmount();
-  });
-
-  it('should pass aXe check when enabled', () =>
-    axeCheck(
-      <ProgressButton
-        buttonText="Button text"
-        buttonClass="usa-button-primary"
-        disabled={false}
-      />,
-    ));
-
-  it('should pass aXe check when disabled', () =>
-    axeCheck(
-      <ProgressButton
-        buttonText="Button text"
-        buttonClass="usa-button-primary"
-        disabled
-      />,
-    ));
 });

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -12,6 +12,7 @@ import { FormPage } from '../../../src/js/containers/FormPage';
 // Build our mock objects
 function makeRoute(obj, pageConfig = {}) {
   return {
+    formConfig: { formOptions: {} },
     pageConfig: {
       pageKey: 'testPage',
       schema: {},

--- a/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
@@ -1,5 +1,7 @@
 import Timeouts from 'platform/testing/e2e/timeouts';
 
+const FORCE_OPTION = { force: true };
+
 Cypress.Commands.add('fillName', (baseName, name) => {
   cy.get(`input[name="${baseName}_first"]`, {
     timeout: Timeouts.normal,
@@ -124,4 +126,49 @@ Cypress.Commands.add('fillAddress', (baseName, address) => {
   if (address.postalCode) {
     cy.fill(`input[name="${baseName}_postalCode"]`, address.postalCode);
   }
+});
+
+// Using generic selectors to click on both the continue & submit button;
+// because the review page submit button has type="button", and the va-button
+// does not have a "continue" or "primary" (default appearance) attribute
+Cypress.Commands.add('clickFormContinue', () => {
+  cy.get('.form-progress-buttons')
+    .find(
+      'button.usa-button-primary, va-button[continue], va-button:not([secondary])',
+    )
+    .then($el => {
+      if ($el[0].tagName === 'VA-BUTTON') {
+        cy.wrap($el)
+          .shadow()
+          .find('button')
+          .should('be.visible')
+          .should('not.be', 'disabled')
+          .click(FORCE_OPTION);
+      } else {
+        cy.wrap($el)
+          .should('be.visible')
+          .should('not.be', 'disabled')
+          .click(FORCE_OPTION);
+      }
+    });
+});
+
+Cypress.Commands.add('clickFormBack', () => {
+  cy.get('.form-progress-buttons')
+    .find('button.usa-button-secondary, va-button[back]')
+    .then($el => {
+      if ($el[0].tagName === 'VA-BUTTON') {
+        cy.wrap($el)
+          .shadow()
+          .find('button')
+          .should('be.visible')
+          .should('not.be', 'disabled')
+          .click(FORCE_OPTION);
+      } else {
+        cy.wrap($el)
+          .should('be.visible')
+          .should('not.be', 'disabled')
+          .click(FORCE_OPTION);
+      }
+    });
 });

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -225,7 +225,7 @@ const defaultPostHook = pathname => {
         }
       });
 
-      cy.findByText(/submit/i, { selector: 'button' }).click(FORCE_OPTION);
+      cy.clickFormContinue();
     };
   }
 
@@ -236,12 +236,7 @@ const defaultPostHook = pathname => {
 
   // Everything else should click on the 'Continue' button.
   return () => {
-    cy.findByText(/continue/i, {
-      selector: 'button',
-      timeout: 30000,
-    })
-      .should('be.visible')
-      .click(FORCE_OPTION);
+    cy.clickFormContinue();
   };
 };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Adding a method to conditionally render `va-button` for the "Back" and "Continue" form navigation buttons
  > - `ProgressButton` rewritten into a functional component
  > - Update `FormPage`, `FormNavButtons` and `ProgressButton` to include a `useWebComponents` prop flag - this comes from the form config `formOptions` as `useWebComponentForNavigation`
  > - Add Cypress commands `clickFormContinue` and `clickFormBack` to handle clicking on a `button` or `va-button`
  > - Update unit tests
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/103783

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated appropriate unit tests
  > Performed targeted e2e tests to ensure the new commands work
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Form Nav | <img width="500" alt="before showing back and continue buttons as imposter components" src="https://github.com/user-attachments/assets/06ba4fa9-1460-47d4-b1fc-2cba5f8702e5" /> | <img width="500" alt="after showing the back and continue buttons are highlighted as web components, but the finish this application later and in progress menu links are highlighted" src="https://github.com/user-attachments/assets/4d338e44-2fa8-46cd-b26c-8ba1eb217c1b" /> |

## What areas of the site does it impact?

All apps that include a new form config `formOptions` property named `useWebComponentForNavigation`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
