### PR TITLE
MHV-72353: Adjustments and fixes

### DIFF
--- a/src/platform/pdf/templates/blue_button_report.js
+++ b/src/platform/pdf/templates/blue_button_report.js
@@ -92,7 +92,7 @@ const generateTitleSection = (doc, parent, data) => {
     }),
   );
 
-  doc.moveDown();
+  doc.moveDown(0.75);
 
   titleSection.add(
     doc.struct('P', () => {
@@ -150,11 +150,11 @@ const generateTitleSection = (doc, parent, data) => {
       doc
         .font(config.text.font)
         .fontSize(config.text.size)
-        .text(data.lastUpdated, config.margins.left, doc.y, { lineGap: 20 });
+        .text(data.lastUpdated, config.margins.left, doc.y);
     }),
   );
 
-  doc.moveDown(0.5);
+  doc.moveDown();
   titleSection.end();
 };
 
@@ -207,6 +207,9 @@ const getEmptyRecordSets = (recordSets, failedDomains) => {
         recordSet.records.some(type => type?.results?.items?.length === 0) &&
         !failedDomains.includes('VA appointments')
       );
+    }
+    if (recordSet.type === 'demographics') {
+      return !failedDomains.includes('VA demographics records');
     }
     if (Array.isArray(recordSet.records)) {
       return recordSet.records.length === 0;
@@ -295,7 +298,7 @@ const generateInfoForAvailableRecords = (infoSection, doc, data) => {
   addBulletList(infoSection, doc, items, config, {
     bulletRadius: 2,
     bulletIndent: config.indents.bulletList,
-    paragraphGap: 4,
+    paragraphGap: 3,
     textOffset: 4,
   });
 };
@@ -333,7 +336,7 @@ const generateInfoForEmptyRecords = (infoSection, doc, recordSets) => {
   addBulletList(infoSection, doc, items, config, {
     bulletRadius: 2,
     bulletIndent: config.indents.bulletList,
-    paragraphGap: 4,
+    paragraphGap: 3,
     textOffset: 4,
   });
 };
@@ -373,7 +376,7 @@ const generateInfoForFailedRecordsets = (
   addBulletList(infoSection, doc, items, config, {
     bulletRadius: 2,
     bulletIndent: config.indents.bulletList,
-    paragraphGap: 4,
+    paragraphGap: 3,
     textOffset: 4,
   });
 };

--- a/src/platform/pdf/templates/blue_button_report.js
+++ b/src/platform/pdf/templates/blue_button_report.js
@@ -208,7 +208,7 @@ const getEmptyRecordSets = (recordSets, failedDomains) => {
         !failedDomains.includes('VA appointments')
       );
     }
-    if (recordSet.type === 'demographics') {
+    if (recordSet.type === 'demographics' && !recordSet.records.length) {
       return !failedDomains.includes('VA demographics records');
     }
     if (Array.isArray(recordSet.records)) {

--- a/src/platform/pdf/test/templates/blue_button_report/blue_button_report.unit.spec.jsx
+++ b/src/platform/pdf/test/templates/blue_button_report/blue_button_report.unit.spec.jsx
@@ -228,6 +228,79 @@ describe('Blue Button report PDF template', () => {
       expect(failedList).to.include('Upcoming appointments');
       expect(failedList.length).to.equal(3);
     });
+
+    it('includes demographics in the "Records not in this report" list when it has no records and hasn’t failed', async () => {
+      const data = cloneDeep(require('./fixtures/all_sections.json'));
+      // zero‐out demographics
+      const demoSet = data.recordSets.find(r => r.type === 'demographics');
+      demoSet.records = [];
+      data.failedDomains = []; // ensure no failures
+
+      const { pdf } = await generateAndParsePdf(data);
+      const page = await pdf.getPage(1);
+      const content = await page.getTextContent({ includeMarkedContent: true });
+
+      // locate the empty‐records list
+      const noRecIdx = content.items.findIndex(
+        item => item.str === 'Records not in this report',
+      );
+      const listStart = content.items.findIndex(
+        (item, i) => i > noRecIdx && item.tag === 'List',
+      );
+      const listEnd = content.items.findIndex(
+        (item, i) => i > listStart && item.type === 'endMarkedContent',
+      );
+      const emptyTitles = content.items
+        .slice(listStart + 1, listEnd)
+        .filter(i => i.str)
+        .map(i => i.str);
+
+      expect(emptyTitles).to.include(demoSet.title);
+    });
+
+    it('moves demographics into the failed list when "VA demographics records" is in failedDomains', async () => {
+      const data = cloneDeep(require('./fixtures/all_sections.json'));
+      // zero‐out demographics
+      const demoSet = data.recordSets.find(r => r.type === 'demographics');
+      demoSet.records = [];
+      data.failedDomains = ['VA demographics records'];
+
+      const { pdf } = await generateAndParsePdf(data);
+      const page = await pdf.getPage(1);
+      const content = await page.getTextContent({ includeMarkedContent: true });
+
+      // it should no longer appear in the empty‐records list
+      const noRecIdx = content.items.findIndex(
+        item => item.str === 'Records not in this report',
+      );
+      const listStart = content.items.findIndex(
+        (item, i) => i > noRecIdx && item.tag === 'List',
+      );
+      const listEnd = content.items.findIndex(
+        (item, i) => i > listStart && item.type === 'endMarkedContent',
+      );
+      const emptyTitles = content.items
+        .slice(listStart + 1, listEnd)
+        .filter(i => i.str)
+        .map(i => i.str);
+      expect(emptyTitles).to.not.include(demoSet.title);
+
+      // and it should show up under the failed‐domains section
+      const failHeading = content.items.findIndex(
+        item => item.str === "Information we can't access right now",
+      );
+      const failListStart = content.items.findIndex(
+        (item, i) => i > failHeading && item.tag === 'List',
+      );
+      const failListEnd = content.items.findIndex(
+        (item, i) => i > failListStart && item.type === 'endMarkedContent',
+      );
+      const failedTitles = content.items
+        .slice(failListStart + 1, failListEnd)
+        .filter(i => i.str)
+        .map(i => i.str);
+      expect(failedTitles).to.include('VA demographics records');
+    });
   });
 
   describe('Document section customization', () => {


### PR DESCRIPTION
Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- The demographics section has been added as a special case to the empty records list. 
- Element padding has been adjusted to ensure all cover page content fits on a single page. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-72353

> ### Self-entered report may incorrectly report info not entered
> Description
> The Self-Entered Report Download is designed to produce a report even if some of the dependent API calls fail. HOWEVER, currently in the report, we list those failed sections under "Types of information you haven't entered yet," which could be incorrect.
> 
> We should confer with UCD and come up with a more correct way of presenting this information.
> 
> Please see [this Slack thread](https://dsva.slack.com/archives/C04ER7MHX5E/p1750176102288509) for more information.
> 
>  
> 
> Figma link:
> 
> https://www.figma.com/design/gGU9oX4QVqbYdxzXfTqTEj/Medical-Records---Milestone-2?node-id=20587-77745&t=jVaW6uxy8LEasxYk-0

## Testing done
Unit tests were written for the missed cover page instance. 

## Screenshots
**Before:** 
<img width="341" alt="Screenshot 2025-07-08 at 5 39 20 PM" src="https://github.com/user-attachments/assets/1fe6a53a-ea67-4c6f-b6a4-945ec6fe5c8d" />

**After:** 
<img width="666" alt="Screenshot 2025-07-08 at 5 19 14 PM" src="https://github.com/user-attachments/assets/5c7138fa-fe78-4911-a37e-7cdbdfc092ea" />

## What areas of the site does it impact?
- Blue Button pdf

## Acceptance criteria
- A section on the cover page of both the Blue Button and Self-entered Information pdfs has been added that notes domains that failed to load. 
- The section listing domains with no information in the Self-entered pdf has been removed. 
- The section listing domains with no information in the Blue Button pdf has been updated to not show failed domains. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
