### PR TITLE
Cc/113745/display referral without provider

### DIFF
--- a/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.jsx
@@ -42,6 +42,26 @@ export default function ScheduleReferral(props) {
   return (
     <ReferralLayout hasEyebrow heading={`Referral for ${categoryOfCare}`}>
       <div>
+        {!currentReferral.provider?.name && (
+          <va-alert
+            status="warning"
+            data-testid="referral-alert"
+            class="vads-u-margin-bottom--2"
+          >
+            <p className="vads-u-margin-top--0">
+              Online scheduling is not available for this referral at this time.
+              Please call your provider directly for help scheduling an
+              appointment.
+            </p>
+            <p className="vads-u-margin-bottom--0">
+              <va-link
+                href="https://www.va.gov/find-locations"
+                text="Find your Community Care provider's phone number"
+              />
+            </p>
+          </va-alert>
+        )}
+
         <p data-testid="subtitle">
           We’ve approved your referral for community care. You can schedule your
           first appointment now.
@@ -62,15 +82,17 @@ export default function ScheduleReferral(props) {
             text="Find your VA health facility"
           />
         </va-additional-info>
-        <va-link-action
-          className="vads-u-margin-top--1"
-          href={`/my-health/appointments/schedule-referral?id=${
-            currentReferral.uuid
-          }`}
-          text="Schedule your appointment"
-          onClick={handleClick()}
-          data-testid="schedule-appointment-button"
-        />
+        {currentReferral.provider?.name && (
+          <va-link-action
+            className="vads-u-margin-top--1"
+            href={`/my-health/appointments/schedule-referral?id=${
+              currentReferral.uuid
+            }`}
+            text="Schedule your appointment"
+            onClick={handleClick()}
+            data-testid="schedule-appointment-button"
+          />
+        )}
         <h2>Details about your referral</h2>
         <p data-testid="referral-details">
           <strong>Expiration date: </strong>
@@ -81,11 +103,13 @@ export default function ScheduleReferral(props) {
           <span data-dd-privacy="mask">{categoryOfCare}</span>
           <br />
           <strong>Provider: </strong>
-          <span data-dd-privacy="mask">{currentReferral.provider.name}</span>
+          <span data-dd-privacy="mask">
+            {currentReferral.provider?.name || 'Not available'}
+          </span>
           <br />
           <strong>Location: </strong>
           <span data-dd-privacy="mask">
-            {currentReferral.provider.facilityName}
+            {currentReferral.provider?.facilityName || 'Not available'}
           </span>
           <br />
           <strong>Referral number: </strong>

--- a/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ScheduleReferral.unit.spec.jsx
@@ -66,4 +66,97 @@ describe('VAOS Component: ScheduleReferral', () => {
       expect(sessionStorage.getItem(selectedSlotKey)).to.be.null;
     });
   });
+  it('should display warning alert when provider name is not available', async () => {
+    const referral = createReferralById(referralDate, '333');
+    // Ensure provider is defined but name is not available
+    referral.attributes.provider = {};
+
+    const store = createTestStore();
+
+    const screen = renderWithStoreAndRouter(
+      <ScheduleReferral currentReferral={referral} />,
+      {
+        store,
+      },
+    );
+
+    const alert = await screen.findByTestId('referral-alert');
+    expect(alert).to.exist;
+    expect(alert).to.contain.text(
+      'Online scheduling is not available for this referral at this time',
+    );
+
+    // Verify that the schedule appointment button is not rendered
+    const scheduleButton = screen.queryByTestId('schedule-appointment-button');
+    expect(scheduleButton).to.be.null;
+
+    // Verify provider info shows "Not available"
+    const details = await screen.findByTestId('referral-details');
+    expect(details).to.contain.text('Provider: Not available');
+    expect(details).to.contain.text('Location: Not available');
+  });
+
+  it('should display schedule appointment button when provider name is available', async () => {
+    const referral = createReferralById(referralDate, '444');
+    // Add provider data
+    referral.attributes.provider = {
+      name: 'Dr. Jane Smith',
+      facilityName: 'Community Care Clinic',
+    };
+
+    const store = createTestStore();
+
+    const screen = renderWithStoreAndRouter(
+      <ScheduleReferral currentReferral={referral} />,
+      {
+        store,
+      },
+    );
+
+    // Verify that the schedule appointment button is rendered
+    const scheduleButton = await screen.findByTestId(
+      'schedule-appointment-button',
+    );
+    expect(scheduleButton).to.exist;
+    expect(scheduleButton).to.have.attribute(
+      'text',
+      'Schedule your appointment',
+    );
+
+    // Verify warning alert is not displayed
+    const alert = screen.queryByTestId('referral-alert');
+    expect(alert).to.be.null;
+
+    // Verify provider info shows correct values
+    const details = await screen.findByTestId('referral-details');
+    expect(details).to.contain.text('Provider: Dr. Jane Smith');
+    expect(details).to.contain.text('Location: Community Care Clinic');
+  });
+
+  it('should handle undefined provider field gracefully', async () => {
+    const referral = createReferralById(referralDate, '555');
+    // Ensure provider is undefined (removed completely)
+    delete referral.attributes.provider;
+
+    const store = createTestStore();
+
+    const screen = renderWithStoreAndRouter(
+      <ScheduleReferral currentReferral={referral} />,
+      {
+        store,
+      },
+    );
+
+    const alert = await screen.findByTestId('referral-alert');
+    expect(alert).to.exist;
+
+    // Verify that the schedule appointment button is not rendered
+    const scheduleButton = screen.queryByTestId('schedule-appointment-button');
+    expect(scheduleButton).to.be.null;
+
+    // Verify provider info shows "Not available"
+    const details = await screen.findByTestId('referral-details');
+    expect(details).to.contain.text('Provider: Not available');
+    expect(details).to.contain.text('Location: Not available');
+  });
 });

--- a/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('VAOS referral generator', () => {
     });
     it('Creates referrals with extra error referrals when specified', () => {
       const referrals = referralUtil.createReferrals(2, null, null, true);
-      expect(referrals.length).to.equal(6);
+      expect(referrals.length).to.equal(7);
     });
     it('Creates each referral on day later', () => {
       const referrals = referralUtil.createReferrals(2, '2025-10-11');

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -9,6 +9,7 @@ const errorUUIDs = [
   'details-retry-error',
   'details-error',
   'draft-no-slots-error',
+  'referral-without-provider-error',
 ];
 
 /**
@@ -50,6 +51,9 @@ const errorReferralsList = (errorUUIDs || []).map(uuid => {
  *
  * @param {String} uuid The UUID for the referral
  * @param {String} expirationDate The date in 'yyyy-MM-dd' format to expire the referral
+ * @param {String} startDate The date in 'yyyy-MM-dd' format to base the referrals around
+ * @param {String} categoryOfCare The category of care for the referral
+ * @param {Boolean} hasProvider Whether the referral has a provider
  * @returns {Object} Referral object
  */
 const createReferralById = (
@@ -57,11 +61,27 @@ const createReferralById = (
   uuid,
   expirationDate,
   categoryOfCare = 'OPTOMETRY',
+  hasProvider,
 ) => {
   const [year, month, day] = startDate.split('-');
   const relativeDate = new Date(year, month - 1, day);
 
   const mydFormat = 'yyyy-MM-dd';
+
+  const provider = hasProvider
+    ? {
+        name: 'Dr. Moreen S. Rafa',
+        npi: '1346206547',
+        phone: '(937) 236-6750',
+        facilityName: 'fake facility name',
+        address: {
+          street1: '76 Veterans Avenue',
+          city: 'BATH',
+          state: null,
+          zip: '14810',
+        },
+      }
+    : null;
 
   return {
     id: uuid,
@@ -87,18 +107,7 @@ const createReferralById = (
           zip: '14020',
         },
       },
-      provider: {
-        name: 'Dr. Moreen S. Rafa',
-        npi: '1346206547',
-        phone: '(937) 236-6750',
-        facilityName: 'fake facility name',
-        address: {
-          street1: '76 Veterans Avenue',
-          city: 'BATH',
-          state: null,
-          zip: '14810',
-        },
-      },
+      provider,
     },
   };
 };

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -61,7 +61,7 @@ const createReferralById = (
   uuid,
   expirationDate,
   categoryOfCare = 'OPTOMETRY',
-  hasProvider,
+  hasProvider = true,
 ) => {
   const [year, month, day] = startDate.split('-');
   const relativeDate = new Date(year, month - 1, day);

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -431,6 +431,19 @@ const responses = {
       });
     }
 
+    if (req.params.referralId === 'referral-without-provider-error') {
+      const expiredReferral = referralUtils.createReferralById(
+        '2024-12-02',
+        req.params.referralId,
+        undefined,
+        undefined,
+        false, // hasProvider
+      );
+      return res.json({
+        data: expiredReferral,
+      });
+    }
+
     const referral = referralUtils.createReferralById(
       '2024-12-02',
       req.params.referralId,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

When the referral details response comes back with no provider we show what data we can, an alert and hide the button to schedule an appointment.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113745

## Testing done

- Go to referral and requests
- Click on the last referral in the list
- It should show the alert and hide the button on the referral details view

## Screenshots

![image](https://github.com/user-attachments/assets/ba875c8a-1e33-4284-af49-2479d7ae733a)


## What areas of the site does it impact?

VAOS -> Referrals and requests

## Acceptance criteria

- [ ] display logic works as expected
- [ ] UI matches [wireframes](https://www.figma.com/design/DsRXEFiYLCFnY5nBkp9Dc4/CC-Referral-%7C-Appointments-FE?node-id=10602-11027&t=VFddWVIoKWEwc2Fw-0)
- [ ] Added features are covered with unit tests

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
