### PR TITLE
10-10CG | Pre-populate name values for statements of truth

### DIFF
--- a/src/applications/caregivers/tests/e2e/utils/setup.js
+++ b/src/applications/caregivers/tests/e2e/utils/setup.js
@@ -49,24 +49,37 @@ export const pageHooks = {
     });
   },
   'review-and-submit': () => {
-    cy.get('@testKey').then(testKey => {
-      const statementOfTruthActions = {
-        secondaryOneOnly: ['veteran', 'secondaryOne'],
-        oneSecondaryCaregiver: ['veteran', 'primary', 'secondaryOne'],
-        twoSecondaryCaregivers: [
-          'veteran',
-          'primary',
-          'secondaryOne',
-          'secondaryTwo',
-        ],
-        signAsRepresentativeYes: ['representative', 'primary'],
-        default: ['veteran', 'primary'],
+    cy.get('@testData').then(testData => {
+      const parties = {
+        veteran: testData.veteranSignature,
+        primary: testData.primarySignature,
+        representative: testData.primarySignature,
+        secondaryOne: testData.secondaryOneSignature,
+        secondaryTwo: testData.secondaryTwoSignature,
       };
-      const signatures =
-        statementOfTruthActions[testKey] || statementOfTruthActions.default;
-      signatures.forEach(role =>
-        cy.fillVaStatementOfTruth(LABELS[role], { checked: true }),
-      );
+
+      cy.get('@testKey').then(testKey => {
+        const statementOfTruthActions = {
+          secondaryOneOnly: ['veteran', 'secondaryOne'],
+          oneSecondaryCaregiver: ['veteran', 'primary', 'secondaryOne'],
+          twoSecondaryCaregivers: [
+            'veteran',
+            'primary',
+            'secondaryOne',
+            'secondaryTwo',
+          ],
+          signAsRepresentativeYes: ['representative', 'primary'],
+          default: ['veteran', 'primary'],
+        };
+        const signatures =
+          statementOfTruthActions[testKey] || statementOfTruthActions.default;
+        signatures.forEach(role =>
+          cy.fillVaStatementOfTruth(LABELS[role], {
+            fullName: role === 'representative' ? parties[role] : undefined,
+            checked: true,
+          }),
+        );
+      });
     });
   },
   confirmation: ({ afterHook }) => {

--- a/src/applications/caregivers/tests/e2e/utils/setup.js
+++ b/src/applications/caregivers/tests/e2e/utils/setup.js
@@ -49,37 +49,24 @@ export const pageHooks = {
     });
   },
   'review-and-submit': () => {
-    cy.get('@testData').then(testData => {
-      const parties = {
-        veteran: testData.veteranSignature,
-        primary: testData.primarySignature,
-        representative: testData.primarySignature,
-        secondaryOne: testData.secondaryOneSignature,
-        secondaryTwo: testData.secondaryTwoSignature,
+    cy.get('@testKey').then(testKey => {
+      const statementOfTruthActions = {
+        secondaryOneOnly: ['veteran', 'secondaryOne'],
+        oneSecondaryCaregiver: ['veteran', 'primary', 'secondaryOne'],
+        twoSecondaryCaregivers: [
+          'veteran',
+          'primary',
+          'secondaryOne',
+          'secondaryTwo',
+        ],
+        signAsRepresentativeYes: ['representative', 'primary'],
+        default: ['veteran', 'primary'],
       };
-
-      cy.get('@testKey').then(testKey => {
-        const statementOfTruthActions = {
-          secondaryOneOnly: ['veteran', 'secondaryOne'],
-          oneSecondaryCaregiver: ['veteran', 'primary', 'secondaryOne'],
-          twoSecondaryCaregivers: [
-            'veteran',
-            'primary',
-            'secondaryOne',
-            'secondaryTwo',
-          ],
-          signAsRepresentativeYes: ['representative', 'primary'],
-          default: ['veteran', 'primary'],
-        };
-        const signatures =
-          statementOfTruthActions[testKey] || statementOfTruthActions.default;
-        signatures.forEach(role =>
-          cy.fillVaStatementOfTruth(LABELS[role], {
-            fullName: parties[role],
-            checked: true,
-          }),
-        );
-      });
+      const signatures =
+        statementOfTruthActions[testKey] || statementOfTruthActions.default;
+      signatures.forEach(role =>
+        cy.fillVaStatementOfTruth(LABELS[role], { checked: true }),
+      );
     });
   },
   confirmation: ({ afterHook }) => {

--- a/src/applications/caregivers/tests/unit/hooks/useSignaturesSync.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/hooks/useSignaturesSync.unit.spec.jsx
@@ -109,7 +109,7 @@ describe('CG `useSignaturesSync` hook', () => {
     expect(result.current.signatures[LABELS.veteran].value).to.eq('John Smith');
   });
 
-  it('should prefill the full name for non-representative signatures', () => {
+  it('should populate the full name for non-representative signatures', () => {
     const { result } = subject();
     const { signatures } = result.current;
 
@@ -120,7 +120,7 @@ describe('CG `useSignaturesSync` hook', () => {
     expect(signatures[LABELS.primary].matches).to.be.true;
   });
 
-  it('should not prefill the full name for representative signature', () => {
+  it('should not populate the full name for representative signature', () => {
     const { result } = subject({
       formData: {
         ...DEFAULT_FORM_DATA,
@@ -134,7 +134,7 @@ describe('CG `useSignaturesSync` hook', () => {
     expect(repSig.matches).to.be.false;
   });
 
-  it('should update the prefill value for non-representative signatures when the form data changes', () => {
+  it('should update the populated value for non-representative signatures when the form data changes', () => {
     const { result, updateProps } = subject();
     expect(result.current.signatures[LABELS.primary].value).to.eq('John Smith');
 
@@ -152,7 +152,7 @@ describe('CG `useSignaturesSync` hook', () => {
     expect(result.current.signatures[LABELS.primary].matches).to.be.true;
   });
 
-  it('should not prefill or update representative signature when the form data changes', () => {
+  it('should not populate or update representative signature when the form data changes', () => {
     const { result, updateProps } = subject({
       formData: {
         ...DEFAULT_FORM_DATA,

--- a/src/applications/caregivers/tests/unit/hooks/useSignaturesSync.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/hooks/useSignaturesSync.unit.spec.jsx
@@ -142,11 +142,13 @@ describe('CG `useSignaturesSync` hook', () => {
     updateProps({
       formData: {
         ...DEFAULT_FORM_DATA,
-        primaryFullName: { first: 'Jane', last: 'Doe' },
+        primaryFullName: { first: 'Jane', middle: 'Marie', last: 'Doe' },
       },
     });
 
-    expect(result.current.signatures[LABELS.primary].value).to.eq('Jane Doe');
+    expect(result.current.signatures[LABELS.primary].value).to.eq(
+      'Jane Marie Doe',
+    );
     expect(result.current.signatures[LABELS.primary].matches).to.be.true;
   });
 

--- a/src/applications/caregivers/tests/unit/hooks/useSignaturesSync.unit.spec.jsx
+++ b/src/applications/caregivers/tests/unit/hooks/useSignaturesSync.unit.spec.jsx
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { LABELS, useSignaturesSync } from '../../../hooks/useSignatureSync';
-import { DEFAULT_SIGNATURE_STATE } from '../../../utils/constants';
 
 const MOCK_FULL_NAME = { first: 'John', last: 'Smith' };
 const DEFAULT_FORM_DATA = {
@@ -9,6 +8,12 @@ const DEFAULT_FORM_DATA = {
   primaryFullName: MOCK_FULL_NAME,
   signAsRepresentativeYesNo: 'no',
   'view:hasPrimaryCaregiver': true,
+};
+const EXPECTED_SIGNATURE_VALUE = {
+  checked: false,
+  dirty: false,
+  matches: true,
+  value: 'John Smith',
 };
 
 describe('CG `useSignaturesSync` hook', () => {
@@ -39,7 +44,7 @@ describe('CG `useSignaturesSync` hook', () => {
     const expectedKeys = [LABELS.veteran, LABELS.primary];
     expect(requiredElements.map(r => r.label)).to.include.members(expectedKeys);
     expect(Object.keys(signatures)).to.have.members(expectedKeys);
-    expect(signatures[LABELS.veteran]).to.deep.equal(DEFAULT_SIGNATURE_STATE);
+    expect(signatures[LABELS.veteran]).to.deep.eq(EXPECTED_SIGNATURE_VALUE);
   });
 
   it('should update signatures when required fields change', () => {
@@ -67,8 +72,8 @@ describe('CG `useSignaturesSync` hook', () => {
     expect(Object.keys(result.current.signatures)).to.have.members(
       updatedExpectedKeys,
     );
-    expect(result.current.signatures[LABELS.secondaryOne]).to.deep.equal(
-      DEFAULT_SIGNATURE_STATE,
+    expect(result.current.signatures[LABELS.secondaryOne]).to.deep.eq(
+      EXPECTED_SIGNATURE_VALUE,
     );
   });
 
@@ -102,5 +107,72 @@ describe('CG `useSignaturesSync` hook', () => {
     updateProps({ formData: { ...DEFAULT_FORM_DATA } });
 
     expect(result.current.signatures[LABELS.veteran].value).to.eq('John Smith');
+  });
+
+  it('should prefill the full name for non-representative signatures', () => {
+    const { result } = subject();
+    const { signatures } = result.current;
+
+    expect(signatures[LABELS.veteran].value).to.eq('John Smith');
+    expect(signatures[LABELS.veteran].matches).to.be.true;
+
+    expect(signatures[LABELS.primary].value).to.eq('John Smith');
+    expect(signatures[LABELS.primary].matches).to.be.true;
+  });
+
+  it('should not prefill the full name for representative signature', () => {
+    const { result } = subject({
+      formData: {
+        ...DEFAULT_FORM_DATA,
+        signAsRepresentativeYesNo: 'yes',
+      },
+      isRep: true,
+    });
+
+    const repSig = result.current.signatures[LABELS.representative];
+    expect(repSig.value).to.eq('');
+    expect(repSig.matches).to.be.false;
+  });
+
+  it('should update the prefill value for non-representative signatures when the form data changes', () => {
+    const { result, updateProps } = subject();
+    expect(result.current.signatures[LABELS.primary].value).to.eq('John Smith');
+
+    // update name in form data
+    updateProps({
+      formData: {
+        ...DEFAULT_FORM_DATA,
+        primaryFullName: { first: 'Jane', last: 'Doe' },
+      },
+    });
+
+    expect(result.current.signatures[LABELS.primary].value).to.eq('Jane Doe');
+    expect(result.current.signatures[LABELS.primary].matches).to.be.true;
+  });
+
+  it('should not prefill or update representative signature when the form data changes', () => {
+    const { result, updateProps } = subject({
+      formData: {
+        ...DEFAULT_FORM_DATA,
+        signAsRepresentativeYesNo: 'yes',
+      },
+      isRep: true,
+    });
+    expect(result.current.signatures[LABELS.representative].value).to.equal('');
+    expect(result.current.signatures[LABELS.representative].matches).to.be
+      .false;
+
+    updateProps({
+      isRep: true,
+      formData: {
+        ...DEFAULT_FORM_DATA,
+        signAsRepresentativeYesNo: 'yes',
+        veteranFullName: { first: 'John', last: 'Doe' },
+      },
+    });
+
+    expect(result.current.signatures[LABELS.representative].value).to.equal('');
+    expect(result.current.signatures[LABELS.representative].matches).to.be
+      .false;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds a pre-fill-type functionality to the Statements of Truth for the Caregivers application. The 10-10 team has found in research that typing this value can be frustrating for Veterans and Caregivers due to casing, adding extra spaces, etc. The goal of this update is to eliminate that pain point and make it easier for Veterans and Caregivers to get the application submitted.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#102073

## Testing done

- To test this update--fill the form and navigate to the review page. Notice the full names are pre-populated into the statements of truth components.
- To test updating data on the review page--fill the form and navigate to the review page. Now change one of the name values. Notice the value should have changed in the statement of truth component associated with that data value.

## Acceptance criteria

 - Full names are pre-populated for all entities except for when the Veteran has a legal representative that is signing for them
 - Name values update in the statements of truth if user changes the name value on the review page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
