### PR TITLE
0969 | Flatten recipientName

### DIFF
--- a/src/applications/income-and-asset-statement/config/submit.js
+++ b/src/applications/income-and-asset-statement/config/submit.js
@@ -3,7 +3,19 @@ import { apiRequest } from 'platform/utilities/api';
 import { format } from 'date-fns-tz';
 import { cloneDeep } from 'lodash';
 
-const disallowedFields = ['vaFileNumberLastFour', 'veteranSsnLastFour'];
+const disallowedFields = [
+  '_metadata',
+  'vaFileNumberLastFour',
+  'veteranSsnLastFour',
+];
+
+export function flattenRecipientName({ first, middle, last }) {
+  // Filter out undefined values and join with spaces
+  const parts = [first, middle, last].filter(part => !!part);
+
+  // Join remaining parts with space and trim extra spaces
+  return parts.join(' ').trim();
+}
 
 export function replacer(key, value) {
   // clean up empty objects, which we have no reason to send
@@ -19,6 +31,15 @@ export function replacer(key, value) {
 
   if (value === null) {
     return undefined;
+  }
+
+  if (key === 'recipientName') {
+    // If the value is an object, flatten it to a string
+    if (typeof value === 'object' && value !== null) {
+      return flattenRecipientName(value);
+    }
+    // If it's already a string, return it as is
+    return value;
   }
 
   return value;

--- a/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/submit.unit.spec.jsx
@@ -92,5 +92,62 @@ describe('Income and asset submit', () => {
       expect(transformed).not.to.haveOwnProperty('mailingAddress');
       expect(transformed).not.to.haveOwnProperty('telephone');
     });
+
+    it('should fix arrays', () => {
+      const formConfig = {
+        chapters: {},
+      };
+      const formData = {
+        data: {
+          someArray: [{ recipientName: { first: 'John', last: 'Doe' } }, 2, 3],
+        },
+      };
+      const transformed = transformForSubmit(formConfig, formData, replacer);
+
+      expect(transformed).to.equal(
+        JSON.stringify({
+          someArray: [{ recipientName: 'John Doe' }, null, null],
+        }),
+      );
+    });
+  });
+
+  describe('flattenRecipientName', () => {
+    context('should correctly flatten recipient name object to string', () => {
+      it('when only first and last are present', () => {
+        const recipientName = {
+          first: 'John',
+          last: 'Doe',
+        };
+        const flattenedName = replacer('recipientName', recipientName);
+        expect(flattenedName).to.equal('John Doe');
+      });
+
+      it('when first, middle, and last are present', () => {
+        const recipientName = {
+          first: 'John',
+          middle: 'M',
+          last: 'Doe',
+        };
+        const flattenedName = replacer('recipientName', recipientName);
+        expect(flattenedName).to.equal('John M Doe');
+      });
+
+      it('when first and last are strings and middle is null', () => {
+        const recipientName = {
+          first: 'John',
+          middle: null,
+          last: 'Doe',
+        };
+        const flattenedName = replacer('recipientName', recipientName);
+        expect(flattenedName).to.equal('John Doe');
+      });
+    });
+
+    it('should return string as is', () => {
+      const recipientName = 'Jane Doe';
+      const flattenedName = replacer('recipientName', recipientName);
+      expect(flattenedName).to.equal('Jane Doe');
+    });
   });
 });


### PR DESCRIPTION
## Summary
The schema for the 0969 expects that the `recipientName` field for income / asset entries is a string, but the form splits each part of the name into individual fields (first, middle, last). The appropriate long term solution is to update `vets-json-schema` and `vets-api`, but this PR acts as a temporary solution so that we can launch the form on time

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#113866

## Testing done
Wrote unit tests for the new `flattenRecipientName` function and update the unit tests for the `replacer` function to ensure it worked as expected

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
