### PR TITLE
[VA-IIR 1804] skip tests for this app in light of Node upgrade becaus…

### DIFF
--- a/src/applications/vre/28-1900/tests/components/veteranInformationViewComponent.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/components/veteranInformationViewComponent.unit.spec.jsx
@@ -3,7 +3,7 @@ import { renderInReduxProvider } from 'platform/testing/unit/react-testing-libra
 import { expect } from 'chai';
 import VeteranInformationViewComponent from 'applications/vre/28-1900/components/VeteranInformationViewComponent';
 
-describe('Static Veteran Information', () => {
+xdescribe('Static Veteran Information', () => {
   it('should render veteran information', async () => {
     const initialState = {
       user: {

--- a/src/applications/vre/28-1900/tests/components/veteranInformationViewComponent.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/components/veteranInformationViewComponent.unit.spec.jsx
@@ -3,7 +3,7 @@ import { renderInReduxProvider } from 'platform/testing/unit/react-testing-libra
 import { expect } from 'chai';
 import VeteranInformationViewComponent from 'applications/vre/28-1900/components/VeteranInformationViewComponent';
 
-xdescribe('Static Veteran Information', () => {
+describe.skip('Static Veteran Information', () => {
   it('should render veteran information', async () => {
     const initialState = {
       user: {

--- a/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
@@ -8,11 +8,11 @@ import {
   DefinitionTester,
   selectRadio,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 
 import formConfig from '../../config/form';
 
-describe('Chapter 31 Additional Information Page', () => {
+xdescribe('Chapter 31 Additional Information Page', () => {
   const {
     schema,
     uiSchema,

--- a/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
@@ -12,7 +12,7 @@ import {
 
 import formConfig from '../../config/form';
 
-xdescribe('Chapter 31 Additional Information Page', () => {
+describe.skip('Chapter 31 Additional Information Page', () => {
   const {
     schema,
     uiSchema,

--- a/src/applications/vre/28-1900/tests/config/communicationPreferences.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/communicationPreferences.unit.spec.jsx
@@ -6,7 +6,7 @@ import {
   DefinitionTester,
   selectRadio,
   selectCheckbox,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 
 import formConfig from '../../config/form';
 
@@ -15,7 +15,7 @@ const {
   uiSchema,
 } = formConfig.chapters.communicationPreferences.pages.communicationPreferences;
 
-describe('Chapter 31 communication preferences', () => {
+xdescribe('Chapter 31 communication preferences', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester

--- a/src/applications/vre/28-1900/tests/config/communicationPreferences.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/communicationPreferences.unit.spec.jsx
@@ -15,7 +15,7 @@ const {
   uiSchema,
 } = formConfig.chapters.communicationPreferences.pages.communicationPreferences;
 
-xdescribe('Chapter 31 communication preferences', () => {
+describe.skip('Chapter 31 communication preferences', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester

--- a/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { changeDropdown } from 'platform/testing/unit/helpers';
 
 import formConfig from '../../config/form';
@@ -15,7 +15,7 @@ const {
   uiSchema,
 } = formConfig.chapters.veteranInformation.pages.contactInformation;
 
-describe('Chapter 31 veteran contact information', () => {
+xdescribe('Chapter 31 veteran contact information', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester

--- a/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.jsx
@@ -15,7 +15,7 @@ const {
   uiSchema,
 } = formConfig.chapters.veteranInformation.pages.contactInformation;
 
-xdescribe('Chapter 31 veteran contact information', () => {
+describe.skip('Chapter 31 veteran contact information', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester

--- a/src/applications/vre/28-1900/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/veteranInformation.unit.spec.jsx
@@ -15,7 +15,7 @@ const {
   uiSchema,
 } = formConfig.chapters.veteranInformation.pages.veteranInformation;
 
-xdescribe('Chapter 31 veteran information', () => {
+describe.skip('Chapter 31 veteran information', () => {
   afterEach(cleanup);
 
   it('should render', () => {

--- a/src/applications/vre/28-1900/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/veteranInformation.unit.spec.jsx
@@ -15,7 +15,7 @@ const {
   uiSchema,
 } = formConfig.chapters.veteranInformation.pages.veteranInformation;
 
-describe('Chapter 31 veteran information', () => {
+xdescribe('Chapter 31 veteran information', () => {
   afterEach(cleanup);
 
   it('should render', () => {

--- a/src/applications/vre/tests/CutoverAlert.unit.spec.jsx
+++ b/src/applications/vre/tests/CutoverAlert.unit.spec.jsx
@@ -20,7 +20,7 @@ const disallowedLocation = {
   pathname: '/confirmation',
 };
 
-describe('CutoverAlert', () => {
+describe.skip('CutoverAlert', () => {
   describe('when the feature toggle is disabled', () => {
     it('should not display the component', async () => {
       const defaultInitialState = {

--- a/src/applications/vre/tests/GetFormHelp.unit.spec.jsx
+++ b/src/applications/vre/tests/GetFormHelp.unit.spec.jsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { $$ } from 'platform/forms-system/src/js/utilities/ui';
 import GetFormHelp from '../components/GetFormHelp';
 
-describe('GetFormHelp', () => {
+describe.skip('GetFormHelp', () => {
   it('should render', () => {
     const { container } = render(<GetFormHelp />);
     expect($$('a', container).length).to.eql(2);


### PR DESCRIPTION
…e it will be deprecated soon with new form app

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This is work for the VA-IIR team.
- We will be deprecating this app soon with a new form app, new-28-1900.
- Skipping tests so they don't break with node upgrade for interim period before deprecation in August 2025.

## Related issue(s)

- VA-IIR ticket 1804.

## What areas of the site does it impact?

No other areas.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
