### PR TITLE
Update back and continue order in schedule flows

### DIFF
--- a/src/applications/vaos/components/FormButtons.jsx
+++ b/src/applications/vaos/components/FormButtons.jsx
@@ -16,8 +16,9 @@ export default function FormButtons({
 }) {
   return (
     <div className="vads-l-row form-progress-buttons schemaform-buttons">
-      <div className="vaos__form-button-back mobile:vads-u-padding-right--1p5 medium-screen:vads-u-padding-right--0p5">
+      <div className="vaos__form-button mobile:vads-u-padding-right--1p5 medium-screen:vads-u-padding-right--0p5">
         <ProgressButton
+          submitButton={false}
           onButtonClick={onBack}
           buttonText={backButtonText || 'Back'}
           buttonClass="usa-button-secondary"
@@ -25,7 +26,7 @@ export default function FormButtons({
         />
       </div>
       {displayNextButton && (
-        <div className="vaos__form-button-next">
+        <div className="vaos__form-button">
           <LoadingButton
             isLoading={pageChangeInProgress}
             loadingText={loadingText}

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -53,20 +53,9 @@
   }
 }
 
-.vaos__form-button-back {
-  order: 2;
+.vaos__form-button {
   width: 100%;
   @media (min-width: $xsmall-screen) {
-    order: 1;
-    width: auto;
-  }
-}
-
-.vaos__form-button-next {
-  order: 1;
-  width: 100%;
-  @media (min-width: $xsmall-screen) {
-    order: 2;
     width: auto;
   }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The buttons orders have been updated to ensure back is above continue on small mobile screens
- Appointments FE Team
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111657

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    ![image](https://github.com/user-attachments/assets/1225c38c-ecc0-4076-aac3-956f4032b06b)   |   ![image](https://github.com/user-attachments/assets/9ad406d9-f33f-4793-aaa7-ea0be5756ade)   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

