### PR TITLE
Form statuses display regardless of Save-in-Progress implementation #113447

### DIFF
--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
@@ -115,10 +115,12 @@ const ApplicationsInProgress = ({
               const formId = form.form;
               const formStatus = form.status;
               const { pdfSupport } = form;
-              const formTitle = `application for ${
-                MY_VA_SIP_FORMS.find(e => e.id === formId).benefit
-              }`;
-              const presentableFormId = presentableFormIDs[formId];
+              const formMeta = MY_VA_SIP_FORMS.find(e => e.id === formId);
+              const hasBenefit = !!formMeta?.benefit;
+              const formTitle = hasBenefit
+                ? `application for ${formMeta.benefit}`
+                : `VA Form ${form.form}`;
+              const presentableFormId = presentableFormIDs[formId] || '';
               const { lastUpdated } = form || {};
               const lastSavedDate = format(
                 fromUnixTime(lastUpdated),
@@ -142,7 +144,7 @@ const ApplicationsInProgress = ({
                     formId={formId}
                     formTitle={formTitle}
                     lastSavedDate={lastSavedDate}
-                    presentableFormId={presentableFormId}
+                    {...(hasBenefit ? { presentableFormId } : {})}
                   />
                 );
               }
@@ -164,7 +166,7 @@ const ApplicationsInProgress = ({
                     lastSavedDate={lastSavedDate}
                     submittedDate={submittedDate}
                     pdfSupport={pdfSupport}
-                    presentableFormId={presentableFormId}
+                    {...(hasBenefit ? { presentableFormId } : {})}
                     status={normalizeSubmissionStatus(formStatus)}
                   />
                 );

--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationsInProgress.jsx
@@ -115,6 +115,8 @@ const ApplicationsInProgress = ({
               const formId = form.form;
               const formStatus = form.status;
               const { pdfSupport } = form;
+              // Determine form title: use benefit name for SiP forms,
+              // otherwise use "VA Form {formId}" for non-SiP forms
               const formMeta = MY_VA_SIP_FORMS.find(e => e.id === formId);
               const hasBenefit = !!formMeta?.benefit;
               const formTitle = hasBenefit
@@ -144,7 +146,7 @@ const ApplicationsInProgress = ({
                     formId={formId}
                     formTitle={formTitle}
                     lastSavedDate={lastSavedDate}
-                    {...(hasBenefit ? { presentableFormId } : {})}
+                    presentableFormId={hasBenefit ? presentableFormId : false}
                   />
                 );
               }
@@ -166,7 +168,7 @@ const ApplicationsInProgress = ({
                     lastSavedDate={lastSavedDate}
                     submittedDate={submittedDate}
                     pdfSupport={pdfSupport}
-                    {...(hasBenefit ? { presentableFormId } : {})}
+                    presentableFormId={hasBenefit ? presentableFormId : false}
                     status={normalizeSubmissionStatus(formStatus)}
                   />
                 );

--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/DraftCard.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/DraftCard.jsx
@@ -25,13 +25,15 @@ const Draft = ({
             {formatFormTitle(formTitle)}
           </span>
         </h3>
-        <p
-          id={formId}
-          className="vads-u-text-transform--uppercase vads-u-margin-top--0p5 vads-u-margin-bottom--2"
-        >
-          {/* TODO: rethink our helpers for presentable form ID */}
-          VA {presentableFormId.replace(/\bFORM\b/, 'Form')}
-        </p>
+        {presentableFormId && (
+          <p
+            id={formId}
+            className="vads-u-text-transform--uppercase vads-u-margin-top--0p5 vads-u-margin-bottom--2"
+          >
+            {/* TODO: rethink our helpers for presentable form ID */}
+            VA {presentableFormId.replace(/\bFORM\b/, 'Form')}
+          </p>
+        )}
         <div className="vads-u-display--flex">
           <span className="vads-u-margin-right--1 vads-u-margin-top--0p5">
             <va-icon icon="error" size={3} />
@@ -78,7 +80,7 @@ Draft.propTypes = {
   // The display-ready date when the application was last updated by the user
   lastSavedDate: PropTypes.string.isRequired,
   // String to show at the very top of the component, usually `Form ${formId}`
-  presentableFormId: PropTypes.string.isRequired,
+  presentableFormId: PropTypes.string,
 };
 
 export default Draft;

--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/SubmissionCard.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/SubmissionCard.jsx
@@ -194,13 +194,15 @@ const SubmissionCard = ({
             {formatFormTitle(formTitle)}
           </span>
         </h3>
-        <p
-          id={formId}
-          className="vads-u-text-transform--uppercase vads-u-margin-top--0p5 vads-u-margin-bottom--2"
-        >
-          {/* TODO: rethink our helpers for presentable form ID */}
-          VA {presentableFormId.replace(/\bFORM\b/, 'Form')}
-        </p>
+        {presentableFormId && (
+          <p
+            id={formId}
+            className="vads-u-text-transform--uppercase vads-u-margin-top--0p5 vads-u-margin-bottom--2"
+          >
+            {/* TODO: rethink our helpers for presentable form ID */}
+            VA {presentableFormId.replace(/\bFORM\b/, 'Form')}
+          </p>
+        )}
 
         <Toggler toggleName={Toggler.TOGGLE_NAMES.myVaFormPdfLink}>
           <Toggler.Enabled>
@@ -247,11 +249,11 @@ SubmissionCard.propTypes = {
   // The display-ready date when the application was last updated by the user
   lastSavedDate: PropTypes.string.isRequired,
   pdfSupport: PropTypes.bool.isRequired,
-  presentableFormId: PropTypes.string.isRequired,
   status: PropTypes.oneOf(['inProgress', 'actionNeeded', 'received'])
     .isRequired,
   submittedDate: PropTypes.string.isRequired,
   getPdfDownloadUrl: PropTypes.func,
+  presentableFormId: PropTypes.string,
   showLoadingIndicator: PropTypes.bool,
 };
 

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -85,7 +85,7 @@ export function sipFormSorter(formA, formB) {
 }
 
 export const formatFormTitle = (title = '') =>
-  capitalize(title).replace(/\bva\b/, 'VA');
+  capitalize(title).replace(/\bva\b/gi, 'VA');
 
 export const recordDashboardClick = (
   product,

--- a/src/applications/personalization/dashboard/mocks/benefit-applications/index.js
+++ b/src/applications/personalization/dashboard/mocks/benefit-applications/index.js
@@ -34,6 +34,21 @@ const createApplications = (updatedDaysAgo = 1) => {
           pdfSupport: false,
         },
       },
+      {
+        // Error 'API DOC105' on form submission from the Benefits Intake API
+        id: '417f5024-1154-4949-9e2e-4a196726014e',
+        type: 'submission_status',
+        attributes: {
+          id: '417f5024-1154-4949-9e2e-4a196726014e',
+          detail: 'Invalid or unknown id',
+          formType: '686C-674-V2',
+          message: null,
+          status: 'error',
+          createdAt: '2025-04-30T14:50:48.504Z',
+          updatedAt: null,
+          pdfSupport: false,
+        },
+      },
     ],
     errors: [
       // {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes an issue where MyVA failed to load when the submission_statuses endpoint included a form not supported by the Save-in-Progress (SiP) feature.

After discussions with the team and CAIA, we chose to implement a fallback title—displayed as "VA form XX-XXX-X" - for forms that do not support SiP.

This approach was selected to avoid:
	- The least performant option of making a separate call per user to fetch form metadata for a single value
	- The maintenance burden and risk of inconsistency from manually managing two overlapping lists (SiP-supported vs unsupported forms)

Team: Authenticated Experience

Flipper used: `my_va_display_all_lighthouse_benefits_intake_forms`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113447

## Testing done

To test this locally, you can:

1️⃣ checkout this branch

2️⃣ start your FE server

3️⃣ start your profile mock data `yarn mock-api --responses src/applications/personalization/dashboard/mocks/server.js`

4️⃣ start a user session on localhost using `localStorage.setItem('hasSession', true);`

⭐ under the applications in progress for the user, you should see the application shown in the screenshot below

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

![Screenshot 2025-07-09 at 18 33 43](https://github.com/user-attachments/assets/dc1693bb-994d-48f9-9012-b9c83f4b9969)

## What areas of the site does it impact?

MyVA

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

I am primarily a backend dev so all feedback/suggestions/thoughts are welcome
