### PR TITLE
Updated Authentication Tests for Node 22 Upgrade

### DIFF
--- a/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/LoginHeader.unit.spec.jsx
@@ -21,11 +21,14 @@ describe('LoginHeader', () => {
 
   it('should display the SessionTimeoutAlert component when the session is expired', () => {
     const originalLocation = window.location;
-    delete window.location;
-    window.location = {
-      ...originalLocation,
-      search: '?status=session_expired',
-    };
+    window.location.search = '?status=session_expired';
+    if (!window.location.search) {
+      delete window.location;
+      window.location = {
+        ...originalLocation,
+        search: '?status=session_expired',
+      };
+    }
     const screen = renderInReduxProvider(<LoginHeader />, {
       initialState: generateState({}),
     });

--- a/src/platform/user/tests/authentication/components/LoginInfo.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/LoginInfo.unit.spec.jsx
@@ -4,7 +4,7 @@ import { renderInReduxProvider } from 'platform/testing/unit/react-testing-libra
 import LoginInfo from 'platform/user/authentication/components/LoginInfo';
 
 describe('LoginInfo', () => {
-  it('renders 6 links', () => {
+  it('renders 5 links', () => {
     const { container } = renderInReduxProvider(<LoginInfo />);
     const links = container.querySelectorAll('a');
     expect(links.length).to.eq(5);

--- a/src/platform/user/tests/authentication/components/SessionTimeoutAlert.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/SessionTimeoutAlert.unit.spec.jsx
@@ -23,10 +23,13 @@ describe('SessionTimeoutAlert', () => {
 
   it('renders when session has expired and there is no downtime', () => {
     const originalLocation = global.window.location;
-    global.window.location = {
-      ...originalLocation,
-      search: '?status=session_expired',
-    };
+    window.location.search = '?status=session_expired';
+    if (!window.location.search) {
+      global.window.location = {
+        ...originalLocation,
+        search: '?status=session_expired',
+      };
+    }
 
     const screen = renderInReduxProvider(<SessionTimeoutAlert />, {
       initialState: generateState({}),

--- a/src/platform/user/tests/authentication/utilities.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.jsx
@@ -450,7 +450,8 @@ describe('Authentication Utilities', () => {
     afterEach(() => cleanup());
     it('should redirect to the provided redirectUrl in its simplest use case', () => {
       authUtilities.redirect(base);
-      expect(global.window.location).to.equal(base);
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.be.oneOf([base, `${base}/`]);
     });
 
     it('should set sessionStorage `authReturnUrl` correctly based on internal or external authentication', () => {
@@ -491,7 +492,8 @@ describe('Authentication Utilities', () => {
     afterEach(() => cleanup());
     it('should redirect to proper mockLogin url', async () => {
       await authUtilities.mockLogin({ type: 'idme' });
-      expect(global.window.location).to.include(`client_id=vamock`);
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.include(`client_id=vamock`);
     });
     it('should throw an error when no `type` is provided', () => {
       expect(authUtilities.mockLogin()).to.throw;
@@ -555,9 +557,8 @@ describe('Authentication Utilities', () => {
     it('should redirect to the mfa session url', () => {
       setup({ path: nonUsipPath });
       authUtilities.mfa();
-      expect(global.window.location).to.equal(
-        API_SESSION_URL({ type: POLICY_TYPES.MFA }),
-      );
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.equal(API_SESSION_URL({ type: POLICY_TYPES.MFA }));
     });
   });
 
@@ -588,7 +589,8 @@ describe('Authentication Utilities', () => {
     });
     it('should kickoff identity-verification (SAML)', async () => {
       await authUtilities.verify({ policy: 'idme' });
-      expect(global.window.location).to.include('idme_signup_verified');
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.include('idme_signup_verified');
     });
     it('should kickoff identity-verification (OAuth)', async () => {
       await authUtilities.verify({
@@ -596,8 +598,9 @@ describe('Authentication Utilities', () => {
         useOAuth: true,
         acr: 'ial2',
       });
-      expect(global.window.location).to.include('type=logingov');
-      expect(global.window.location).to.include('acr=ial2');
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.include('type=logingov');
+      expect(location).to.include('acr=ial2');
     });
     it('should pass along query parameters', async () => {
       const samlLink = await authUtilities.verify({
@@ -643,7 +646,8 @@ describe('Authentication Utilities', () => {
 
       it(`should generate the default URL link and redirect for signup '${policy}_signup'`, async () => {
         await authUtilities.signupOrVerify({ policy });
-        expect(global.window.location).contain(
+        const location = global.window.location.href || global.window.location;
+        expect(location).contain(
           API_SESSION_URL({
             type: SIGNUP_TYPES[policy],
           }),
@@ -666,9 +670,8 @@ describe('Authentication Utilities', () => {
     it('should redirect to the logout session url', () => {
       setup({ path: nonUsipPath });
       authUtilities.logout();
-      expect(global.window.location).to.equal(
-        API_SESSION_URL({ type: POLICY_TYPES.SLO }),
-      );
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.equal(API_SESSION_URL({ type: POLICY_TYPES.SLO }));
     });
 
     it('should redirect to the logout session url with appended params if provided', () => {
@@ -679,7 +682,8 @@ describe('Authentication Utilities', () => {
         clickedEvent: AUTH_EVENTS.LOGOUT,
         queryParams: params,
       });
-      expect(global.window.location).to.equal(
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.equal(
         appendQuery(API_SESSION_URL({ type: POLICY_TYPES.SLO }), params),
       );
     });
@@ -692,7 +696,8 @@ describe('Authentication Utilities', () => {
         clickedEvent: AUTH_EVENTS.LOGOUT,
         queryParams: params,
       });
-      expect(global.window.location).to.eql(
+      const location = global.window.location.href || global.window.location;
+      expect(location).to.eql(
         appendQuery(API_SESSION_URL({ type: POLICY_TYPES.SLO }), params),
       );
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated Authentication tests so that all tests pass in both Node 14 and Node 22.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/470)

## Testing done
- Updated `LoginHeader.unit.spec.jsx`, `LoginInfo.unit.spec.jsx`, `SessionTimeoutAlert.unit.spec.jsx`, `utilities.unit.spec.jsx` and ran tests locally on both the `main` and `node-22-dev-branch` branches.
- Can be replicated by running:
  - `yarn test:unit src/platform/user/tests/authentication/components/LoginHeader.unit.spec.jsx`
  - `yarn test:unit src/platform/user/tests/authentication/components/LoginInfo.unit.spec.jsx`
  - `yarn test:unit src/platform/user/tests/authentication/components/SessionTimeoutAlert.unit.spec.jsx`
  - `yarn test:unit src/platform/user/tests/authentication/utilities.unit.spec.jsx`

## What areas of the site does it impact?
This only impacts the Authentication tests.

## Acceptance criteria
- [x] Authentication tests pass on Node 22
- [x] Authentication tests continue to pass on Node 14