### PR TITLE
Unit test coverage improvements (part 1)

### DIFF
--- a/src/applications/discover-your-benefits/containers/PreSubmitInfo.jsx
+++ b/src/applications/discover-your-benefits/containers/PreSubmitInfo.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 // platform - form-system actions
 import { setPreSubmit as setPreSubmitAction } from 'platform/forms-system/src/js/actions';
 
-function PreSubmitInfo({ formData, showError, setPreSubmit }) {
+export const PreSubmitInfo = ({ formData, showError, setPreSubmit }) => {
   useEffect(
     () => {
       // This ensures the user will always have to accept the privacy agreement.
@@ -28,7 +28,7 @@ function PreSubmitInfo({ formData, showError, setPreSubmit }) {
       showError={showError && !privacyAgreementAccepted}
     />
   );
-}
+};
 
 const mapDispatchToProps = {
   setPreSubmit: setPreSubmitAction,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Improves the unit test coverage for the `ConfirmationPage` and `PreSubmitInfo`.

## Related issue(s)

https://jira.devops.va.gov/browse/PTEMSVT-471

## Testing done

Verified unit tests pass locally.

## Screenshots

N/A

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

Coverage for all segments of `ConfirmationPage` and `PreSubmitInfo` is above 80%.

### Quality Assurance & Testing

N/A

### Error Handling

N/A

### Authentication

N/A

## Requested Feedback

N/A
