### PR TITLE
Update app name: VA Online Scheduling to Appointments

### DIFF
--- a/src/applications/manifest-catalog.json
+++ b/src/applications/manifest-catalog.json
@@ -749,7 +749,7 @@
     },
     {
       "directoryPath": "src/applications/vaos",
-      "appName": "VA Online Scheduling",
+      "appName": "Appointments",
       "entryName": "vaos",
       "rootUrl": "/my-health/appointments"
     },

--- a/src/applications/vaos/README.md
+++ b/src/applications/vaos/README.md
@@ -1,4 +1,4 @@
-# VA Online Scheduling
+# Appointments
 
 This is the front end source for the Appointments application. Veterans can schedule, request, and view appointments through this application.
 

--- a/src/applications/vaos/manifest.json
+++ b/src/applications/vaos/manifest.json
@@ -1,5 +1,5 @@
 {
-  "appName": "VA Online Scheduling",
+  "appName": "Appointments",
   "entryFile": "./vaos-entry",
   "entryName": "vaos",
   "rootUrl": "/my-health/appointments",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

Note for @simiadebowale it seems like the PR template wants us to update vets-website before content-build. Do we need to clarify the exact sequence of how this should work?

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We are updating the app name from VA Online Scheduling to Appointments
- We need to coordinate these changes with those in content build contained [here](https://github.com/department-of-veterans-affairs/content-build/pull/2587)
- Appointments FE Team
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113645

## Testing done

- N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
