### PR TITLE
[ARP] Bugfix: hardcode ARP client ID so sign out works across browser…

### DIFF
--- a/src/applications/accreditation/21a/constants/index.js
+++ b/src/applications/accreditation/21a/constants/index.js
@@ -1,4 +1,6 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { externalApplicationsConfig } from 'platform/user/authentication/usip-config';
+
 import * as SIS from './sis';
 import * as USIP from './usip';
 
@@ -24,7 +26,7 @@ export const SIGN_OUT_URL = (() => {
   const url = new URL(SIS.API_URL({ endpoint: 'logout' }));
   url.searchParams.set(
     SIS.QUERY_PARAM_KEYS.CLIENT_ID,
-    sessionStorage.getItem('ci'),
+    externalApplicationsConfig[USIP.APPLICATIONS.ARP].oAuthOptions.clientId,
   );
   return url;
 })();

--- a/src/applications/accreditation/21a/utilities/constants.js
+++ b/src/applications/accreditation/21a/utilities/constants.js
@@ -4,6 +4,8 @@ import {
   EXTERNAL_APPS as USIP_APPLICATIONS,
 } from 'platform/user/authentication/constants';
 
+import { externalApplicationsConfig } from 'platform/user/authentication/usip-config';
+
 import {
   API_SIGN_IN_SERVICE_URL as SIS_API_URL,
   OAUTH_KEYS as SIS_QUERY_PARAM_KEYS,
@@ -26,7 +28,7 @@ export const SIGN_OUT_URL = (() => {
   const url = new URL(SIS_API_URL({ endpoint: 'logout' }));
   url.searchParams.set(
     SIS_QUERY_PARAM_KEYS.CLIENT_ID,
-    sessionStorage.getItem('ci'),
+    externalApplicationsConfig[USIP_APPLICATIONS.ARP].oAuthOptions.clientId,
   );
 
   return url;

--- a/src/applications/accredited-representative-portal/utilities/constants.js
+++ b/src/applications/accredited-representative-portal/utilities/constants.js
@@ -4,6 +4,8 @@ import {
   EXTERNAL_APPS as USIP_APPLICATIONS,
 } from 'platform/user/authentication/constants';
 
+import { externalApplicationsConfig } from 'platform/user/authentication/usip-config';
+
 import {
   API_SIGN_IN_SERVICE_URL as SIS_API_URL,
   OAUTH_KEYS as SIS_QUERY_PARAM_KEYS,
@@ -26,7 +28,7 @@ export const SIGN_OUT_URL = (() => {
   const url = new URL(SIS_API_URL({ endpoint: 'logout' }));
   url.searchParams.set(
     SIS_QUERY_PARAM_KEYS.CLIENT_ID,
-    sessionStorage.getItem('ci'),
+    externalApplicationsConfig[USIP_APPLICATIONS.ARP].oAuthOptions.clientId,
   );
 
   return url;

--- a/src/applications/representative-form-upload/utilities/constants.js
+++ b/src/applications/representative-form-upload/utilities/constants.js
@@ -3,10 +3,14 @@ import {
   AUTH_PARAMS as USIP_QUERY_PARAMS,
   EXTERNAL_APPS as USIP_APPLICATIONS,
 } from 'platform/user/authentication/constants';
+
+import { externalApplicationsConfig } from 'platform/user/authentication/usip-config';
+
 import {
   API_SIGN_IN_SERVICE_URL as SIS_API_URL,
   OAUTH_KEYS as SIS_QUERY_PARAM_KEYS,
 } from '~/platform/utilities/oauth/constants';
+
 import { getFormContent } from '../helpers';
 
 const USIP_PATH = '/sign-in';
@@ -30,7 +34,7 @@ export const SIGN_OUT_URL = (() => {
   const url = new URL(SIS_API_URL({ endpoint: 'logout' }));
   url.searchParams.set(
     SIS_QUERY_PARAM_KEYS.CLIENT_ID,
-    sessionStorage.getItem('ci'),
+    externalApplicationsConfig[USIP_APPLICATIONS.ARP].oAuthOptions.clientId,
   );
 
   return url;


### PR DESCRIPTION
… windows

https://github.com/department-of-veterans-affairs/va.gov-team/issues/112706

Session storage isn't shared across browser windows. Our applications can hardcode the client ID used for signing out, since it is perfectly unambiguous.