### PR TITLE
ARP - Two small claimant search fixes

### DIFF
--- a/src/applications/accredited-representative-portal/containers/ClaimantSearchPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/ClaimantSearchPage.jsx
@@ -68,16 +68,15 @@ const SearchResults = ({ claimant, searchData }) => {
     return (
       <>
         <p data-testid="poa-requests-table-fetcher-no-poa-requests">
-          No result found for{' '}
-          <strong>
-            “{searchData.first_name} {searchData.last_name}”
-          </strong>
+          No result found for <strong>"{searchData.first_name}"</strong>
           {', '}
-          <strong>“{searchData.dob}”</strong>
+          <strong>"{searchData.last_name}"</strong>
+          {', '}
+          <strong>"{searchData.dob}"</strong>
           {', '}
           <strong>
-            “***-**-
-            {lastFour(searchData.ssn)}”
+            "***-**-
+            {lastFour(searchData.ssn)}"
           </strong>
         </p>
         <va-banner
@@ -101,15 +100,15 @@ const SearchResults = ({ claimant, searchData }) => {
   return (
     <>
       <p data-testid="poa-requests-table-fetcher-poa-requests">
-        Showing result for <strong>“{searchData.first_name}“</strong>
+        Showing result for <strong>"{searchData.first_name}"</strong>
         {', '}
-        <strong>“{searchData.last_name}“</strong>
+        <strong>"{searchData.last_name}"</strong>
         {', '}
-        <strong>“{searchData.dob}”</strong>
+        <strong>"{searchData.dob}"</strong>
         {', '}
         <strong>
-          “***-**-
-          {lastFour(searchData.ssn)}”
+          "***-**-
+          {lastFour(searchData.ssn)}"
         </strong>
       </p>
       <h2 className="claimant-name">

--- a/src/applications/accredited-representative-portal/tests/e2e/poa-request-individual-search.cypress.spec.js
+++ b/src/applications/accredited-representative-portal/tests/e2e/poa-request-individual-search.cypress.spec.js
@@ -141,7 +141,7 @@ describe('Accredited Representative Portal', () => {
         "[data-testid='poa-requests-table-fetcher-no-poa-requests']",
       ).should(
         'have.text',
-        'No result found for “asdf ghjkl”, “2024-01-01”, “***-**-6666”',
+        'No result found for "asdf", "ghjkl", "2024-01-01", "***-**-6666"',
       );
     });
   });


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No


## Summary

- 2 small fixes. See screenshots below

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/6?sliceBy%5Bvalue%5D=In+Progress&pane=issue&itemId=116684383&issue=department-of-veterans-affairs%7Cva.gov-team%7C112701


## Screenshots

This is what it looked like before

Backward quotation marks
<img width="282" height="44" alt="Screenshot 2025-07-10 at 4 56 56 PM" src="https://github.com/user-attachments/assets/882cdde9-26ac-45a1-a4b6-1c5f0fe736a4" />

On no claimant found, first name and last name were in one string

<img width="481" height="67" alt="Screenshot 2025-07-10 at 4 56 36 PM" src="https://github.com/user-attachments/assets/a8f744c2-dd0c-4065-a9d2-e638399d429b" />


## What areas of the site does it impact?

representative/claimant-search

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user