### PR TITLE
Fix validation detection after save in progress resume back to summary page of array builder

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import navigationState from 'platform/forms-system/src/js/utilities/navigation/navigationState';
 import { useEditOrAddForm } from './useEditOrAddForm';
 import ArrayBuilderCancelButton from './ArrayBuilderCancelButton';
 import { getArrayUrlSearchParams } from './helpers';
@@ -58,6 +59,13 @@ export default function ArrayBuilderItemPage({
         required(props.data) && introRoute && !data?.length
           ? introRoute
           : summaryRoute;
+
+      // We might end up here from a save in progress continue,
+      // but ?add=true or ?edit=true won't be set...
+      // Consider how to handle this in the future, so save in progress can work.
+      // In the meantime, go back to intro or summary, and set navigation event
+      // so that validation for missing info will work properly.
+      navigationState.setNavigationEvent();
       props.goToPath(path);
       return null;
     }


### PR DESCRIPTION
## Summary

- Fix validation working when using save in progress to return to array builder

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1650

## Testing done

- Tested with saving in middle array builder flow and resuming

## Screenshots

<img width="554" height="575" alt="image" src="https://github.com/user-attachments/assets/b04a79ea-8fb0-4ab6-842e-2128899eee40" />

## What areas of the site does it impact?

array builder

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
