### PR TITLE
Add hasAvailabilityBefore parameter to relationships API call

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -263,6 +263,7 @@ export function getPatientRelationships() {
     const typeOfCare = getTypeOfCare(newAppointment.data);
     const typeOfCareId = typeOfCare;
     const facilityId = newAppointment.data.vaFacility;
+    const hasAvailabilityBefore = addDays(new Date(), 395);
 
     dispatch({
       type: FORM_FETCH_PATIENT_PROVIDER_RELATIONSHIPS,
@@ -272,6 +273,7 @@ export function getPatientRelationships() {
       patientProviderRelationships = await fetchPatientRelationships(
         facilityId,
         typeOfCareId,
+        hasAvailabilityBefore,
       );
     } catch (error) {
       dispatch({ type: FORM_FETCH_PATIENT_PROVIDER_RELATIONSHIPS_FAILED });

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -102,7 +102,7 @@ async function fetchPatientEligibility({ typeOfCare, location, type = null }) {
  * @async
  * @param {TypeOfCare} params.typeOfCare Type of care object for which to check patient relationships
  * @param {string} params.facilityId of facility to check for relationships
- * @param {Date} params.hasAvailabilityBefore Whether or not to consider the patient's appointment history when filtering results.
+ * @param {Date} params.hasAvailabilityBefore A date object for determining how long into the future to look for appointment availability
  * @returns {Array<PatientProviderRelationship>} Returns an array of PatientProviderRelationship objects
  */
 

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -102,14 +102,20 @@ async function fetchPatientEligibility({ typeOfCare, location, type = null }) {
  * @async
  * @param {TypeOfCare} params.typeOfCare Type of care object for which to check patient relationships
  * @param {string} params.facilityId of facility to check for relationships
+ * @param {Date} params.hasAvailabilityBefore Whether or not to consider the patient's appointment history when filtering results.
  * @returns {Array<PatientProviderRelationship>} Returns an array of PatientProviderRelationship objects
  */
 
-export async function fetchPatientRelationships(facilityId, typeOfCare) {
+export async function fetchPatientRelationships(
+  facilityId,
+  typeOfCare,
+  hasAvailabilityBefore,
+) {
   try {
     const data = await getPatientRelationships({
       locationId: facilityId,
       typeOfCareId: typeOfCare.idV2,
+      hasAvailabilityBefore,
     });
 
     return transformPatientRelationships(data || []);

--- a/src/applications/vaos/services/patient/index.unit.spec.jsx
+++ b/src/applications/vaos/services/patient/index.unit.spec.jsx
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { addDays } from 'date-fns';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import { fetchPatientRelationships } from '.';
 
@@ -45,7 +46,11 @@ describe('VAOS Services: Patient ', () => {
 
       setFetchJSONResponse(global.fetch, { data: relationships });
 
-      const data = await fetchPatientRelationships('123', typeOfCare);
+      const data = await fetchPatientRelationships(
+        '123',
+        typeOfCare,
+        addDays(new Date(), 395),
+      );
 
       expect(global.fetch.firstCall.args[0]).to.contain(
         `/vaos/v2/relationships`,

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -1,6 +1,8 @@
 import appendQuery from 'append-query';
 import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { getTestFacilityId } from '../../utils/appointment';
+import { DATE_FORMATS } from '../../utils/constants';
 import {
   apiRequestWithUrl,
   parseApiList,
@@ -122,9 +124,17 @@ export function getPatientEligibility(
   ).then(parseApiObject);
 }
 
-export function getPatientRelationships({ locationId, typeOfCareId }) {
+export function getPatientRelationships({
+  locationId,
+  typeOfCareId,
+  hasAvailabilityBefore,
+}) {
   return apiRequestWithUrl(
-    `/vaos/v2/relationships?facility_id=${locationId}&clinical_service_id=${typeOfCareId}`,
+    `/vaos/v2/relationships?facility_id=${locationId}&clinical_service_id=${typeOfCareId}&has_availability_before=${formatInTimeZone(
+      hasAvailabilityBefore,
+      'UTC',
+      DATE_FORMATS.ISODateTimeUTC,
+    )}`,
   );
 }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add hasAvailabilityBefore to relationships API call
- Appointments FE Team
- This is behind the `vaOnlineSchedulingOhDirectSchedule` toggle in `useGetPatientRelationships`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111805

## Testing done

- Tested locally and in unit test

## Screenshots

<img width="1052" height="398" alt="image" src="https://github.com/user-attachments/assets/1b43278d-69e1-4a4e-bb10-1ad8ae42e526" />


## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
