### PR TITLE
Add dependents verification submit method

### DIFF
--- a/src/applications/dependents/dependents-verification/config/form.js
+++ b/src/applications/dependents/dependents-verification/config/form.js
@@ -1,6 +1,5 @@
 // import { externalServices } from 'platform/monitoring/DowntimeNotification';
 // import React from 'react';
-import environment from 'platform/utilities/environment';
 import footerContent from 'platform/forms/components/FormFooter';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { TITLE, SUBTITLE } from '../constants';
@@ -23,14 +22,13 @@ import NeedHelp from '../components/NeedHelp';
 import { dependents } from './chapters/dependents/dependents';
 import { DependentsInformation } from '../components/DependentsInformation';
 import { DependentsInformationReview } from '../components/DependentsInformationReview';
+import { submit } from '../util';
 
 /** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/dependents_verification/v0/claims`,
-  submit: () =>
-    Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
+  submit,
   trackingPrefix: '0538-dependents-verification-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,

--- a/src/applications/dependents/dependents-verification/util.js
+++ b/src/applications/dependents/dependents-verification/util.js
@@ -1,0 +1,93 @@
+import environment from 'platform/utilities/environment';
+import { apiRequest } from 'platform/utilities/api';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import recordEvent from 'platform/monitoring/record-event';
+
+export function transform(formConfig, form) {
+  const formData = transformForSubmit(formConfig, form);
+  return JSON.stringify({
+    dependentsVerificationClaim: {
+      form: formData,
+    },
+  });
+}
+
+const fetchNewCSRFToken = async () => {
+  const url = '/v0/maintenance_windows';
+  recordEvent({
+    event: 'dependents-verification-fetch-csrf-token-empty',
+  });
+  return apiRequest(`${environment.API_URL}${url}`, { method: 'HEAD' })
+    .then(() => {
+      recordEvent({
+        event: 'dependents-verification-fetch-csrf-token-success',
+      });
+    })
+    .catch(() => {
+      recordEvent({
+        event: 'dependents-verification-fetch-csrf-token-failure',
+      });
+    });
+};
+
+export const ensureValidCSRFToken = async () => {
+  const csrfToken = localStorage.getItem('csrfToken');
+  if (!csrfToken) {
+    await fetchNewCSRFToken();
+  } else {
+    recordEvent({
+      event: 'dependents-verification-fetch-csrf-token-present',
+    });
+  }
+};
+
+export async function submit(form, formConfig) {
+  const headers = { 'Content-Type': 'application/json' };
+  const body = transform(formConfig, form);
+  const apiRequestOptions = {
+    headers,
+    body,
+    method: 'POST',
+    mode: 'cors',
+  };
+
+  const onSuccess = resp => {
+    window.dataLayer.push({
+      event: `${formConfig.trackingPrefix}-submission-successful`,
+    });
+    return resp.data.attributes;
+  };
+
+  const onFailure = respOrError => {
+    if (respOrError instanceof Response && respOrError.status === 429) {
+      const error = new Error('vets_throttled_error_dependents_verification');
+      error.extra = parseInt(respOrError.headers.get('x-ratelimit-reset'), 10);
+
+      return Promise.reject(error);
+    }
+    return Promise.reject(respOrError);
+  };
+
+  const sendRequest = async () => {
+    await ensureValidCSRFToken();
+    return apiRequest(
+      `${environment.API_URL}/dependents_verification/v0/claims`,
+      apiRequestOptions,
+    ).then(onSuccess);
+  };
+
+  return sendRequest().catch(async respOrError => {
+    // if it's a CSRF error, clear CSRF and retry once
+    const errorResponse = respOrError?.errors?.[0];
+    if (
+      errorResponse?.status === '403' &&
+      errorResponse?.detail === 'Invalid Authenticity Token'
+    ) {
+      localStorage.setItem('csrfToken', '');
+      return sendRequest().catch(onFailure);
+    }
+
+    // in other cases, handle error regularly
+    return onFailure(respOrError);
+  });
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds the submit method for dependents verification to enable end-to-end testing of claims

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114105

## Testing done

- Previously submissions would fake a confirmation, but now they actually submit to the backend

## What areas of the site does it impact?

Dependents Verification

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user