### PR TITLE
update breadcrumb and documen title

### DIFF
--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -27,14 +27,17 @@ import {
   updateField,
 } from '../actions';
 // START lighthouse_migration
-import { benefitsDocumentsUseLighthouse } from '../selectors';
+import {
+  benefitsDocumentsUseLighthouse,
+  cstFriendlyEvidenceRequests,
+} from '../selectors';
 // END lighthouse_migration
 import {
   setDocumentRequestPageTitle,
   getClaimType,
   isAutomated5103Notice,
   setPageTitle,
-  getDisplayFriendlyName,
+  getLabel,
 } from '../utils/helpers';
 import { setUpPage, setPageFocus } from '../utils/page';
 import withRouter from '../utils/withRouter';
@@ -51,7 +54,7 @@ const statusPath = '../status';
 class DocumentRequestPage extends React.Component {
   componentDidMount() {
     this.props.resetUploads();
-    setPageTitle(this.props.trackedItem);
+    setPageTitle(this.props.trackedItem, this.props.friendlyEvidenceRequests);
     if (!this.props.loading) {
       setUpPage(true, 'h1');
     } else {
@@ -78,7 +81,7 @@ class DocumentRequestPage extends React.Component {
     }
     if (!this.props.loading && prevProps.loading) {
       setPageFocus('h1');
-      setPageTitle(this.props.trackedItem);
+      setPageTitle(this.props.trackedItem, this.props.friendlyEvidenceRequests);
     }
   }
 
@@ -147,18 +150,7 @@ class DocumentRequestPage extends React.Component {
     const previousPageBreadcrumb = previousPageIsFilesTab()
       ? filesBreadcrumb
       : statusBreadcrumb;
-    const getLabel = () => {
-      if (
-        trackedItem?.friendlyName &&
-        trackedItem?.status === 'NEEDED_FROM_YOU'
-      ) {
-        return trackedItem.friendlyName;
-      }
-      if (trackedItem?.friendlyName) {
-        return `Your ${getDisplayFriendlyName(trackedItem)}`;
-      }
-      return trackedItem?.displayName;
-    };
+
     return (
       <Toggler.Hoc
         toggleName={Toggler.TOGGLE_NAMES.cstFriendlyEvidenceRequests}
@@ -174,7 +166,9 @@ class DocumentRequestPage extends React.Component {
                       : 'needed-from-others'
                   }/${params.trackedItemId}`
                 : `../document-request/${params.trackedItemId}`,
-              label: setDocumentRequestPageTitle(getLabel()),
+              label: setDocumentRequestPageTitle(
+                getLabel(toggleValue, trackedItem),
+              ),
               isRouterLink: true,
             },
           ];
@@ -266,6 +260,7 @@ function mapStateToProps(state, ownProps) {
     uploadError: uploads.uploadError,
     uploadField: uploads.uploadField,
     uploading: uploads.uploading,
+    friendlyEvidenceRequests: cstFriendlyEvidenceRequests(state),
   };
 }
 
@@ -300,6 +295,7 @@ DocumentRequestPage.propTypes = {
   documentsUseLighthouse: PropTypes.bool,
   // END lighthouse_migration
   files: PropTypes.array,
+  friendlyEvidenceRequests: PropTypes.bool,
   getClaim: PropTypes.func,
   lastPage: PropTypes.string,
   loading: PropTypes.bool,

--- a/src/applications/claims-status/selectors/index.js
+++ b/src/applications/claims-status/selectors/index.js
@@ -27,3 +27,7 @@ export const cstUseDataDogRUM = state =>
 
 // Backend Services
 export const getBackendServices = state => state.user.profile.services;
+
+// 'cst_friendly_evidence_requests'
+export const cstFriendlyEvidenceRequests = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.cstFriendlyEvidenceRequests];

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -542,7 +542,12 @@ describe('<DocumentRequestPage>', () => {
 
         const { container } = renderWithRouter(
           <Provider store={getStore()}>
-            <DocumentRequestPage {...defaultProps} trackedItem={item} />,
+            <DocumentRequestPage
+              {...defaultProps}
+              trackedItem={item}
+              friendlyEvidenceRequests
+            />
+            ,
           </Provider>,
         );
         const breadcrumbs = $('va-breadcrumbs', container);
@@ -556,6 +561,7 @@ describe('<DocumentRequestPage>', () => {
           'Authorization to Disclose Information | Veterans Affairs',
         );
       });
+
       it('should render Your {friendlyName} in breadcrumb for third party request', () => {
         const item = {
           closedDate: null,
@@ -578,7 +584,12 @@ describe('<DocumentRequestPage>', () => {
 
         const { container } = renderWithRouter(
           <Provider store={getStore()}>
-            <DocumentRequestPage {...defaultProps} trackedItem={item} />,
+            <DocumentRequestPage
+              {...defaultProps}
+              trackedItem={item}
+              friendlyEvidenceRequests
+            />
+            ,
           </Provider>,
         );
         const breadcrumbs = $('va-breadcrumbs', container);
@@ -588,7 +599,158 @@ describe('<DocumentRequestPage>', () => {
         expect(breadcrumbs.breadcrumbList[3].label).to.equal(
           'Your reserve records',
         );
-        expect(document.title).to.equal('Reserve records | Veterans Affairs');
+        expect(document.title).to.equal(
+          'Your reserve records | Veterans Affairs',
+        );
+      });
+      it('should render Request for evidence in breadcrumb for first party request with default content', () => {
+        const item = {
+          closedDate: null,
+          description: 'default content',
+          displayName: 'First party default request',
+          id: 467558,
+          overdue: true,
+          receivedDate: null,
+          requestedDate: '2024-03-21',
+          status: 'NEEDED_FROM_YOU',
+          suspenseDate: '2024-05-07',
+          uploadsAllowed: true,
+          documents: [],
+          date: '2024-03-21',
+        };
+
+        const { container } = renderWithRouter(
+          <Provider store={getStore()}>
+            <DocumentRequestPage
+              {...defaultProps}
+              trackedItem={item}
+              friendlyEvidenceRequests
+            />
+            ,
+          </Provider>,
+        );
+        const breadcrumbs = $('va-breadcrumbs', container);
+        expect(breadcrumbs.breadcrumbList[3].href).to.equal(
+          `../needed-from-you/${item.id}`,
+        );
+        expect(breadcrumbs.breadcrumbList[3].label).to.equal(
+          'Request for evidence',
+        );
+        expect(document.title).to.equal(
+          'Request for evidence | Veterans Affairs',
+        );
+      });
+      it('should render Request for evidence outside VA in breadcrumb for third party non DBQ request with default content', () => {
+        const item = {
+          closedDate: null,
+          description: 'default content',
+          displayName: 'Third party default request',
+          id: 467558,
+          overdue: true,
+          receivedDate: null,
+          requestedDate: '2024-03-28',
+          status: 'NEEDED_FROM_OTHERS',
+          suspenseDate: '2024-05-07',
+          uploadsAllowed: true,
+          documents: [],
+          date: '2024-03-21',
+        };
+
+        const { container } = renderWithRouter(
+          <Provider store={getStore()}>
+            <DocumentRequestPage
+              {...defaultProps}
+              trackedItem={item}
+              friendlyEvidenceRequests
+            />
+            ,
+          </Provider>,
+        );
+        const breadcrumbs = $('va-breadcrumbs', container);
+        expect(breadcrumbs.breadcrumbList[3].href).to.equal(
+          `../needed-from-others/${item.id}`,
+        );
+        expect(breadcrumbs.breadcrumbList[3].label).to.equal(
+          'Request for evidence outside VA',
+        );
+        expect(document.title).to.equal(
+          'Request for evidence outside VA | Veterans Affairs',
+        );
+      });
+      it('should render Request for an exam in breadcrumb for third party DBQ request with default content', () => {
+        const item = {
+          closedDate: null,
+          description: 'default content',
+          displayName: 'Third party DBQ default request',
+          id: 467558,
+          overdue: true,
+          receivedDate: null,
+          requestedDate: '2024-03-28',
+          status: 'NEEDED_FROM_OTHERS',
+          suspenseDate: '2024-05-07',
+          uploadsAllowed: true,
+          documents: [],
+          date: '2024-03-21',
+        };
+
+        const { container } = renderWithRouter(
+          <Provider store={getStore()}>
+            <DocumentRequestPage
+              {...defaultProps}
+              trackedItem={item}
+              friendlyEvidenceRequests
+            />
+            ,
+          </Provider>,
+        );
+        const breadcrumbs = $('va-breadcrumbs', container);
+        expect(breadcrumbs.breadcrumbList[3].href).to.equal(
+          `../needed-from-others/${item.id}`,
+        );
+        expect(breadcrumbs.breadcrumbList[3].label).to.equal(
+          'Request for an exam',
+        );
+        expect(document.title).to.equal(
+          'Request for an exam | Veterans Affairs',
+        );
+      });
+      it('should render Request for an exam in breadcrumb for third party DBQ request with override content', () => {
+        const item = {
+          closedDate: null,
+          description: 'default content',
+          displayName: 'Third party DBQ override request',
+          friendlyName: 'Friendly DBQ',
+          id: 467558,
+          overdue: true,
+          receivedDate: null,
+          requestedDate: '2024-03-28',
+          status: 'NEEDED_FROM_OTHERS',
+          suspenseDate: '2024-05-07',
+          uploadsAllowed: true,
+          documents: [],
+          date: '2024-03-21',
+        };
+
+        const { container } = renderWithRouter(
+          <Provider store={getStore()}>
+            <DocumentRequestPage
+              {...defaultProps}
+              trackedItem={item}
+              friendlyEvidenceRequests
+            />
+            ,
+          </Provider>,
+        );
+        const breadcrumbs = $('va-breadcrumbs', container);
+        expect(breadcrumbs.breadcrumbList[3].href).to.equal(
+          `../needed-from-others/${item.id}`,
+        );
+        expect(breadcrumbs.breadcrumbList[3].label).to.equal(
+          'Request for an exam',
+        );
+        expect(document.title).to.equal(
+          'Request for an exam | Veterans Affairs',
+        );
       });
     },
   );

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -1228,6 +1228,45 @@ export const generateClaimTitle = (claim, placement, tab) => {
   }
 };
 
+export const getDisplayFriendlyName = item => {
+  if (!evidenceDictionary[item.displayName]?.isProperNoun) {
+    let updatedFriendlyName = item.friendlyName;
+    updatedFriendlyName =
+      updatedFriendlyName.charAt(0).toLowerCase() +
+      updatedFriendlyName.slice(1);
+    return updatedFriendlyName;
+  }
+  return item.friendlyName;
+};
+
+export const getLabel = (toggleValue, trackedItem) => {
+  if (isAutomated5103Notice(trackedItem?.displayName)) {
+    return trackedItem?.displayName;
+  }
+  if (toggleValue) {
+    if (
+      trackedItem?.friendlyName &&
+      trackedItem?.status === 'NEEDED_FROM_YOU'
+    ) {
+      return trackedItem.friendlyName;
+    }
+    if (
+      !trackedItem?.friendlyName &&
+      trackedItem?.status === 'NEEDED_FROM_YOU'
+    ) {
+      return 'Request for evidence';
+    }
+    if (trackedItem?.displayName.toLowerCase().includes('dbq')) {
+      return 'Request for an exam';
+    }
+    if (trackedItem?.friendlyName) {
+      return `Your ${getDisplayFriendlyName(trackedItem)}`;
+    }
+    return 'Request for evidence outside VA';
+  }
+  return trackedItem?.displayName;
+};
+
 // Use this function to set the Document Request Page Title, Page Tab and Page Breadcrumb Title
 // It is also used to set the Document Request Page breadcrumb text
 export function setDocumentRequestPageTitle(displayName) {
@@ -1241,10 +1280,10 @@ export function setTabDocumentTitle(claim, tabName) {
   setDocumentTitle(generateClaimTitle(claim, 'document', tabName));
 }
 
-export const setPageTitle = trackedItem => {
+export const setPageTitle = (trackedItem, toggleValue) => {
   if (trackedItem) {
     const pageTitle = setDocumentRequestPageTitle(
-      trackedItem.friendlyName || trackedItem.displayName,
+      getLabel(toggleValue, trackedItem),
     );
     setDocumentTitle(pageTitle);
   } else {
@@ -1287,17 +1326,6 @@ export const getTrackedItemDateFromStatus = item => {
     default:
       return item.requestedDate;
   }
-};
-
-export const getDisplayFriendlyName = item => {
-  if (!evidenceDictionary[item.displayName]?.isProperNoun) {
-    let updatedFriendlyName = item.friendlyName;
-    updatedFriendlyName =
-      updatedFriendlyName.charAt(0).toLowerCase() +
-      updatedFriendlyName.slice(1);
-    return updatedFriendlyName;
-  }
-  return item.friendlyName;
 };
 
 export const renderDefaultThirdPartyMessage = displayName => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update breadcrumb and document title to match H1 in evidence request

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

testing locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |   
<img width="866" height="272" alt="Screenshot 2025-07-11 at 11 47 04 AM" src="https://github.com/user-attachments/assets/711520ac-3c2a-4c90-be90-b85edf8b8672" />
<img width="562" height="80" alt="Screenshot 2025-07-11 at 11 47 15 AM" src="https://github.com/user-attachments/assets/a12a0053-7a58-4d04-ae65-3be1dbfa77a8" />
<img width="610" height="202" alt="Screenshot 2025-07-11 at 11 47 56 AM" src="https://github.com/user-attachments/assets/ff29a9ef-0d5b-48db-a2af-a220b7717b4d" />
<img width="558" height="70" alt="Screenshot 2025-07-11 at 11 48 33 AM" src="https://github.com/user-attachments/assets/ac8d5378-9090-47f7-b98b-685ce0c49ed8" />
<img width="610" height="276" alt="Screenshot 2025-07-11 at 11 49 01 AM" src="https://github.com/user-attachments/assets/03c346c2-6540-41a7-86ef-fec77107fbb4" />
<img width="497" height="57" alt="Screenshot 2025-07-11 at 11 49 11 AM" src="https://github.com/user-attachments/assets/29474b27-c2bb-4138-8e2b-bb03a5fedd62" />
<img width="609" height="210" alt="Screenshot 2025-07-11 at 11 49 28 AM" src="https://github.com/user-attachments/assets/902c44e3-6f17-4ca0-9b01-615f1d232fb3" />
<img width="556" height="61" alt="Screenshot 2025-07-11 at 11 49 39 AM" src="https://github.com/user-attachments/assets/2589d985-afec-4633-b482-66f690dc2837" />
<img width="575" height="184" alt="Screenshot 2025-07-11 at 11 51 12 AM" src="https://github.com/user-attachments/assets/9a119d4d-41c8-4692-8b52-2fd81ea2e299" />
<img width="400" height="86" alt="Screenshot 2025-07-11 at 11 51 18 AM" src="https://github.com/user-attachments/assets/97af05d2-9e38-4abd-ac75-554a0ab69067" />


    |

## What areas of the site does it impact?

CST

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
