### PR TITLE
37648 update downtime dependencies in preperation for bep production outage

### DIFF
--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -84,6 +84,7 @@ function ClaimsStatusApp({
           appTitle="Claim Status"
           dependencies={[
             externalServices.evss,
+            externalServices.lighthouseBenefitsClaims,
             externalServices.global,
             externalServices.mvi,
             externalServices.vaProfile,

--- a/src/applications/letters/containers/App.jsx
+++ b/src/applications/letters/containers/App.jsx
@@ -21,7 +21,12 @@ export function App({ featureFlagsLoading, user }) {
       <AppContent featureFlagsLoading={featureFlagsLoading}>
         <DowntimeBanner
           appTitle="Letters Generator"
-          dependencies={[externalServices.evss]}
+          dependencies={[
+            externalServices.evss,
+            externalServices.lighthouseBenefitsClaims,
+            externalServices.vaProfile,
+            externalServices.global,
+          ]}
         />
         <Outlet />
       </AppContent>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_ 
    - Review/update the configuration for all our products: Letters, Claim Status Tool, Payment History, and Disability Rating.
         - Added lighthouseBenefitsClaims, vaProfile, & global dependencies to Letters `DowntimeBanner`.
         - Added lighthouseBenefitsClaims dependency to Claims Status `DowntimeNotification`.
         - No changes made to Payment History or Disability Rating.
- _(If bug, how to reproduce)_ n/a
- _(What is the solution, why is this the solution)_ n/a
- _(Which team do you work for, does your team own the maintenance of this component?)_ BMT1 / yes
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_ n/a

## Related issue(s)

- _Link to ticket created in va.gov-team repo_ [Update downtime dependencies in preparation for BEP Production Outage](https://github.com/department-of-veterans-affairs/vets-website/issues/37648)
- _Link to previous change of the code/bug (if applicable)_ n/a
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_ n/a one off task requested by Amy in preparation for outage scheduled from Friday, July 11 at 10 PM ET through Sunday, July 13 at 11:59 PM ET

## Testing done

- _Describe what the old behavior was prior to the change_  prior to the change dependency outages would not trigger user facing notifications. 
- _Describe the steps required to verify your changes are working as expected_  
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

### `DowntimeBanner`: Simple banner that keeps the original application content visible.
<img width="1705" height="851" alt="Image" src="https://github.com/user-attachments/assets/0c927038-a5aa-4e6a-8dcb-943bc3c6a20b" />

### `DowntimeNotificaiton`: Completely hides/replaces the application content.
<img width="1721" height="954" alt="Image" src="https://github.com/user-attachments/assets/3dc818ba-7746-4954-946c-a2b019429a9d" />

## What areas of the site does it impact?

Letters `DowntimeBanner` and `Claims Status DowntimeNotificaiton`

## Acceptance criteria

All existing functionality is preserved and no user experience regressions exist. 
DowntimeBanner or DowntimeNotification is triggered should one of the tracked dependencies go down. 


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable). n/a
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary) n/a
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed n/a

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
 
### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
