### PR TITLE
Remove outdated BGS dependency in Decision Review configs

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -73,7 +73,6 @@ const formConfig = {
     requiredForPrefill: true,
     dependencies: [
       services.vaProfile, // for contact info
-      services.bgs, // submission
       services.mvi, // contestable issues
       services.appeals, // LOA3 & SSN
     ],

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -132,7 +132,6 @@ const formConfig = {
     requiredForPrefill: true,
     dependencies: [
       services.vaProfile, // for contact info
-      services.bgs, // submission
       services.mvi, // contestable issues
       services.appeals, // LOA3 & SSN
     ],

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -67,7 +67,6 @@ const formConfig = {
     requiredForPrefill: true,
     dependencies: [
       services.vaProfile, // for contact info
-      services.bgs, // submission
       services.mvi, // contestable issues
       services.appeals, // LOA3 & SSN
     ],

--- a/src/applications/appeals/testing/hlr/config/form.js
+++ b/src/applications/appeals/testing/hlr/config/form.js
@@ -58,7 +58,6 @@ const formConfig = {
     requiredForPrefill: true,
     dependencies: [
       services.vaProfile, // for contact info
-      services.bgs, // submission
       services.mvi, // contestable issues
       services.appeals, // LOA3 & SSN
     ],

--- a/src/applications/appeals/testing/sc/config/form.js
+++ b/src/applications/appeals/testing/sc/config/form.js
@@ -124,7 +124,6 @@ const formConfig = {
     requiredForPrefill: true,
     dependencies: [
       services.vaProfile, // for contact info
-      services.bgs, // submission
       services.mvi, // contestable issues
       services.appeals, // LOA3 & SSN
     ],


### PR DESCRIPTION
### Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Since BGS is listed as a dependency that is required for prefill in our form configs, we will render a downtime notification window blocking any logged-in users without a saved in-progress form during the BEP/BGS maintenance window this weekend without any changes. However, since the original PR https://github.com/department-of-veterans-affairs/vets-website/pull/26738 mentioned this dependency was added to support the intent to file endpoint, and we have since made it so that a failure to fetch the ITF [no longer blocks the user from submitting](https://github.com/department-of-veterans-affairs/vets-website/pull/29644), this is no longer relevant.

Our [enablement team confirmed](https://dsva.slack.com/archives/C5AGLBNRK/p1752084078580749?thread_ts=1751407912.412079&cid=C5AGLBNRK) that we should remove this outdated dependency to prevent unnecessarily blocking some of our users from accessing the apps during the BEP/BGS migration.

## Related issue(s)

- Link to [spike](https://github.com/department-of-veterans-affairs/va.gov-team/issues/113847) with more details
- Link to [BEP/BGS migration announcement thread](https://dsva.slack.com/archives/CE4304QPK/p1748451888597769)

## Testing done + screenshots
- I ran vets-api locally to mock a current BGS maintenance window (using [the method I previously described here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/112300)) to see the current behavior. 
<img width="440" height="1008" alt="Screenshot 2025-07-11 at 11 39 25 AM" src="https://github.com/user-attachments/assets/e58b1355-c5b0-4d23-ad5f-85119f9005c4" />

### Previous/current behavior with an active BGS maintenance window (shows downtime notification window preventing logged in users without an In-Progress Form from accessing apps)
<img width="1110" height="759" alt="Screenshot 2025-07-11 at 11 15 19 AM" src="https://github.com/user-attachments/assets/af1a9846-75b3-4ac7-8d7a-b5483a316b30" />
<img width="917" height="845" alt="Screenshot 2025-07-11 at 11 15 26 AM" src="https://github.com/user-attachments/assets/e95a3c8d-56d5-4e75-aa5e-e7b9eb636004" />
<img width="1008" height="801" alt="Screenshot 2025-07-11 at 11 32 16 AM" src="https://github.com/user-attachments/assets/53c5fe31-e068-4d79-96ce-03e8d16c4942" />
<img width="865" height="740" alt="Screenshot 2025-07-11 at 11 32 22 AM" src="https://github.com/user-attachments/assets/49feace5-bfca-4732-9bd3-91a4c4dedc11" />
<img width="715" height="670" alt="Screenshot 2025-07-11 at 11 56 47 AM" src="https://github.com/user-attachments/assets/d3aed79e-5a8f-48f3-bdd0-b30fb97b3356" />
<img width="754" height="664" alt="Screenshot 2025-07-11 at 11 57 01 AM" src="https://github.com/user-attachments/assets/f4a76b29-7692-429a-8d2f-f47872e6be46" />
<img width="787" height="343" alt="Screenshot 2025-07-11 at 11 57 56 AM" src="https://github.com/user-attachments/assets/94f9d336-4eb3-4303-84b0-81ed338d418b" />

------------

### Previous/current behavior (also shows downtime notification window for all non-logged-in users)
<img width="754" height="664" alt="Screenshot 2025-07-11 at 11 57 01 AM" src="https://github.com/user-attachments/assets/70875f51-6c56-4968-a71c-925da47156e6" />
<img width="714" height="611" alt="Screenshot 2025-07-11 at 12 00 23 PM" src="https://github.com/user-attachments/assets/4907c035-8c70-4ff4-bb9d-09e0b06babc8" />
<img width="702" height="548" alt="Screenshot 2025-07-11 at 12 01 30 PM" src="https://github.com/user-attachments/assets/9568b4f9-a3a9-4520-bf93-c2e24a822d13" />

------------


### After removing the dependency, with the active BGS maintenance window (logged in users without IPFs can proceed to app):
<img width="705" height="632" alt="Screenshot 2025-07-11 at 11 37 50 AM" src="https://github.com/user-attachments/assets/96bf7714-db0b-4d9b-ad8d-bbd7e1442e9f" />
<img width="794" height="744" alt="Screenshot 2025-07-11 at 11 38 13 AM" src="https://github.com/user-attachments/assets/d975d1bc-9e88-44e1-90b7-e37643a49b71" />
<img width="769" height="531" alt="Screenshot 2025-07-11 at 11 38 29 AM" src="https://github.com/user-attachments/assets/6c200aa1-3c8e-411a-a96b-59d49f390a53" />

------------

### Non-logged in users will see the banner asking them to sign in:
 
<img width="768" height="730" alt="Screenshot 2025-07-11 at 12 03 02 PM" src="https://github.com/user-attachments/assets/c1fd60e7-b77d-4864-9ab3-b46ec5b9b81b" />
<img width="729" height="743" alt="Screenshot 2025-07-11 at 12 03 11 PM" src="https://github.com/user-attachments/assets/8ddd5cad-0022-4722-a6b0-22d2300bc280" />
<img width="698" height="672" alt="Screenshot 2025-07-11 at 12 03 22 PM" src="https://github.com/user-attachments/assets/44d11b3c-832a-4880-9adc-d3d868328c2d" />

## What areas of the site does it impact?
Decision Reviews Forms (995, 996, 10182)