### PR TITLE
MHV-70286: Metric name fix

### DIFF
--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -373,6 +373,6 @@ export const postRecordDatadogAction = async (metric, tags = []) => {
   return apiRequest(`${environment.API_URL}/v0/datadog_action`, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ metric, tags }),
+    body: JSON.stringify({ metric: `mr.${metric}`, tags }),
   });
 };

--- a/src/applications/mhv-medical-records/tests/api/MrApi.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/api/MrApi.unit.spec.jsx
@@ -52,6 +52,7 @@ import {
   getAcceleratedLabsAndTests,
   getAcceleratedImmunizations,
   getAcceleratedImmunization,
+  postRecordDatadogAction,
 } from '../../api/MrApi';
 
 describe('Get labs and tests api call', () => {
@@ -443,5 +444,53 @@ describe('Accelerated OH API calls', () => {
         expect(res.mock).to.equal('data');
       });
     });
+  });
+});
+
+describe('postRecordDatadogAction', () => {
+  const endpoint = `${environment.API_URL}/v0/datadog_action`;
+
+  it('should make an api call to record datadog action and return the response', () => {
+    const mockData = { status: 'ok' };
+    mockApiRequest(mockData);
+
+    return postRecordDatadogAction('TestAction', ['tag1', 'tag2']).then(res => {
+      expect(res.status).to.equal('ok');
+    });
+  });
+
+  it('should call the correct endpoint with correct method, headers, and body, including the "mr." prefix', async () => {
+    const fetchStub = Sinon.stub(global, 'fetch');
+    const mockResponse = new Response(JSON.stringify({ result: 'done' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    fetchStub.resolves(mockResponse);
+
+    const metricName = 'MyMetric';
+    const result = await postRecordDatadogAction(metricName, ['foo', 'bar']);
+
+    // ensure we hit the right URL once
+    expect(fetchStub.calledOnce, 'fetch was called once').to.be.true;
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).to.equal(endpoint);
+
+    // verify it includes the Content-Type we set
+    expect(options.headers).to.have.property(
+      'Content-Type',
+      'application/json',
+    );
+
+    // verify body payload
+    const parsed = JSON.parse(options.body);
+    // explicit check for "mr." prefix
+    expect(parsed.metric).to.equal(`mr.${metricName}`);
+    expect(parsed.metric.startsWith('mr.')).to.be.true;
+    expect(parsed.tags).to.deep.equal(['foo', 'bar']);
+
+    // and that apiRequest returns the parsed JSON
+    expect(result.result).to.equal('done');
+
+    fetchStub.restore();
   });
 });


### PR DESCRIPTION
## Summary
Fix for the metric name to add the 'mr.' prefix. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-70286

> ### Milestone 2: Logging to be fixed so the MR DataDog metrics are accurate
> Description
> Logging to be fixed so the MR DataDog metrics are accurate
> 
> Note: Work with Mike and Stephen to get details. We should create custom DD StatsD metrics in vets-api by using, e.g., a parameter passed down from the client. A good use case for this is Allergies, which can be triggered by the Veteran or by medications app.

## Testing done
Unit tests written for API call ensuring 'mr' prefix is present. 

## Screenshots
No UI changes. 

## What areas of the site does it impact?
MHV medical records

## Acceptance criteria
Front end metrics being tracked by Datadog StatsD

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
