### PR TITLE
arp/replace-poa-search-with-claimant-search

### DIFF
--- a/src/applications/accreditation/21a/components/common/Header/Nav.jsx
+++ b/src/applications/accreditation/21a/components/common/Header/Nav.jsx
@@ -62,7 +62,7 @@ export const Nav = () => {
               <Toggler.Enabled>
                 <a
                   className="nav__btn desktop"
-                  href="/representative/poa-search"
+                  href="/representative/claimant-search"
                   data-testid="desktop-search-link"
                   data-eventname="nav-link-click"
                 >

--- a/src/applications/accreditation/21a/components/common/Header/UserNav.jsx
+++ b/src/applications/accreditation/21a/components/common/Header/UserNav.jsx
@@ -14,7 +14,7 @@ const UserHelpLinks = () => {
             <a
               data-testid="user-nav-poa-search-link"
               className="vads-u-color--white"
-              href="/representative/poa-search"
+              href="/representative/claimant-search"
               data-eventname="nav-link-click"
             >
               <va-icon icon="search" size={2} className="people-search-icon" />

--- a/src/applications/representative-form-upload/components/Header/Nav.jsx
+++ b/src/applications/representative-form-upload/components/Header/Nav.jsx
@@ -58,7 +58,7 @@ export const Nav = () => {
               <Toggler.Enabled>
                 <a
                   className="nav__btn desktop"
-                  href="/representative/poa-search"
+                  href="/representative/claimant-search"
                   data-testid="desktop-search-link"
                 >
                   <va-icon

--- a/src/applications/representative-form-upload/components/Header/UserNav.jsx
+++ b/src/applications/representative-form-upload/components/Header/UserNav.jsx
@@ -14,7 +14,7 @@ const UserHelpLinks = () => {
             <a
               data-testid="user-nav-poa-search-link"
               className="vads-u-color--white"
-              href="/representative/poa-search"
+              href="/representative/claimant-search"
             >
               <va-icon icon="search" size={2} className="people-search-icon" />
               Find Claimant


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No

## Summary

- Change links from poa-search (the old url) to claimant-search (the new url)

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/114142

## Testing done

- walked through locally

## Screenshots

n/a

## What areas of the site does it impact?

representative/

## Acceptance criteria


### Error Handling

- [ ] Browser console contains no warnings or errors.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
