### PR TITLE
Node 22 upgrade preneed

### DIFF
--- a/src/applications/ask-va/tests/components/YourPersonalInformationAuthenticated.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/YourPersonalInformationAuthenticated.unit.spec.jsx
@@ -121,7 +121,7 @@ describe('YourPersonalInformationAuthenticated', () => {
       </Provider>,
     );
 
-    expect(getByText('Date of birth: None provided')).to.exist;
+    expect(getByText('Date of birth: Not provided')).to.exist;
   });
 
   it('should redirect if not logged in', () => {

--- a/src/applications/ask-va/tests/components/YourPersonalInformationAuthenticated.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/YourPersonalInformationAuthenticated.unit.spec.jsx
@@ -121,7 +121,7 @@ describe('YourPersonalInformationAuthenticated', () => {
       </Provider>,
     );
 
-    expect(getByText('Date of birth: Not provided')).to.exist;
+    expect(getByText('Date of birth: None provided')).to.exist;
   });
 
   it('should redirect if not logged in', () => {

--- a/src/applications/pre-need/containers/ConfirmationPage.jsx
+++ b/src/applications/pre-need/containers/ConfirmationPage.jsx
@@ -16,7 +16,7 @@ class ConfirmationPage extends React.Component {
 
     return (
       <div>
-        <h3>Your claim has been submitted.</h3>
+        <h2>Your claim has been submitted.</h2>
         <p>
           We’ll let you know by mail or phone if we need more information.
           <br />

--- a/src/applications/pre-need/tests/components/Phone.unit.spec.jsx
+++ b/src/applications/pre-need/tests/components/Phone.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
-import Form from '@department-of-veterans-affairs/react-jsonschema-form';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import definitions from 'vets-json-schema/dist/definitions.json';
@@ -39,23 +39,22 @@ describe('Preneed Schemaform definition phone', () => {
 
     expect(formDOM.querySelector('label').textContent).to.equal('My phone');
   });
-  it('should render minLength phone error', () => {
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={definitions.phone} uiSchema={uiSchema()} />,
+  it('should render minLength phone error', async () => {
+    const { container } = render(
+      <DefinitionTester
+        schema={definitions.phone}
+        uiSchema={uiSchema()}
+        data={{}}
+      />,
     );
 
-    const formDOM = findDOMNode(form);
-    ReactTestUtils.Simulate.change(formDOM.querySelector('input'), {
-      target: {
-        value: '1asdf',
-      },
-    });
-    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
-      preventDefault: f => f,
-    });
+    const input = container.querySelector('input');
+    fireEvent.change(input, { target: { value: '1asdf' } });
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(
-      formDOM.querySelector('.usa-input-error-message').textContent,
-    ).to.include('Phone number should be between 10-15 digits long');
+    await waitFor(() => {
+      const errorElement = container.querySelector('.usa-input-error-message');
+      expect(errorElement).to.exist;
+    });
   });
 });

--- a/src/applications/pre-need/tests/config/applicantDemographics.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/applicantDemographics.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -30,9 +31,9 @@ describe('Pre-need applicant demographics', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -41,11 +42,13 @@ describe('Pre-need applicant demographics', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(3);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(3);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/applicantMilitaryName.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/applicantMilitaryName.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -28,9 +29,9 @@ describe('Pre-need applicant military name', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -39,11 +40,13 @@ describe('Pre-need applicant military name', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required fields filled in', () => {

--- a/src/applications/pre-need/tests/config/applicantRelationshipToVet.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/applicantRelationshipToVet.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -32,9 +33,9 @@ describe('Pre-need applicant relationship to vet', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -42,12 +43,13 @@ describe('Pre-need applicant relationship to vet', () => {
         uiSchema={uiSchema}
       />,
     );
+    fireEvent.submit(container.querySelector('form'));
 
-    form.find('form').simulate('submit');
-
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { mockFetch } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
@@ -64,9 +65,9 @@ describe('Pre-need burial benefits', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <Provider store={store}>
         <DefinitionTester
           schema={schema}
@@ -77,11 +78,13 @@ describe('Pre-need burial benefits', () => {
       </Provider>,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should fill in desired cemetery', done => {

--- a/src/applications/pre-need/tests/config/contactInformation.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/contactInformation.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 
@@ -50,9 +51,9 @@ describe('Pre-need applicant contact information', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <Provider store={store}>
         <DefinitionTester
           schema={schema}
@@ -62,12 +63,13 @@ describe('Pre-need applicant contact information', () => {
         />
       </Provider>,
     );
+    fireEvent.submit(container.querySelector('form'));
 
-    form.find('form').simulate('submit');
-
-    expect(form.find('.usa-input-error').length).to.equal(5);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(5);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with valid data', () => {

--- a/src/applications/pre-need/tests/config/currentlyBuried.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/currentlyBuried.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import {
@@ -69,9 +70,9 @@ describe('Pre-need burial benefits', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <Provider store={store}>
         <DefinitionTester
           schema={schema}
@@ -82,11 +83,13 @@ describe('Pre-need burial benefits', () => {
       </Provider>,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(2);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(2);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/documents.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/documents.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   DefinitionTester,
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import formConfig from '../../config/form';
 
 describe('Pre-need attachments', () => {
@@ -55,9 +55,9 @@ describe('Pre-need attachments', () => {
     expect(onSubmit.called).to.be.true;
   });
 
-  it('should not submit without attachment id', () => {
+  it('should not submit without attachment id', async () => {
     const onSubmit = sinon.spy();
-    const form = render(
+    const { container } = render(
       <Provider store={uploadStore}>
         <DefinitionTester
           schema={schema}
@@ -77,16 +77,18 @@ describe('Pre-need attachments', () => {
       </Provider>,
     );
 
-    const formDOM = getFormDOM(form);
+    fireEvent.submit(container.querySelector('form'));
 
-    formDOM.submitForm();
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
-  it('should not submit without required fields', () => {
+  it('should not submit without required fields', async () => {
     const onSubmit = sinon.spy();
-    const form = render(
+    const { container } = render(
       <Provider store={uploadStore}>
         <DefinitionTester
           schema={schema}
@@ -106,11 +108,13 @@ describe('Pre-need attachments', () => {
       </Provider>,
     );
 
-    const formDOM = getFormDOM(form);
+    fireEvent.submit(container.querySelector('form'));
 
-    formDOM.submitForm();
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
   it('should submit with valid data', () => {
     const onSubmit = sinon.spy();

--- a/src/applications/pre-need/tests/config/militaryDetails.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/militaryDetails.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -29,9 +30,9 @@ describe('Pre-need military details', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -39,12 +40,13 @@ describe('Pre-need military details', () => {
         uiSchema={uiSchema}
       />,
     );
+    fireEvent.submit(container.querySelector('form'));
 
-    form.find('form').simulate('submit');
-
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/nonVeteranApplicantDetails.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/nonVeteranApplicantDetails.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -33,9 +34,9 @@ describe('Pre-need applicant non veteran applicant details', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -43,12 +44,13 @@ describe('Pre-need applicant non veteran applicant details', () => {
         uiSchema={uiSchema}
       />,
     );
+    fireEvent.submit(container.querySelector('form'));
 
-    form.find('form').simulate('submit');
-
-    expect(form.find('.usa-input-error').length).to.equal(4);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(4);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/preparer.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/preparer.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
@@ -24,9 +25,9 @@ describe('Pre-need preparer info', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -35,10 +36,12 @@ describe('Pre-need preparer info', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 });

--- a/src/applications/pre-need/tests/config/preparerDetails.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/preparerDetails.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -28,12 +29,12 @@ describe('Pre-need preparer Details info', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
     uiSchema.application.applicant.name.first['ui:required'] = () => true;
     uiSchema.application.applicant.name.last['ui:required'] = () => true;
 
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -41,11 +42,13 @@ describe('Pre-need preparer Details info', () => {
         uiSchema={uiSchema}
       />,
     );
+    fireEvent.submit(container.querySelector('form'));
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(2);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(2);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required fields filled in', () => {

--- a/src/applications/pre-need/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/servicePeriods.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -25,9 +26,9 @@ describe('Pre-need service periods', () => {
       form.unmount();
     });
 
-    it('should not submit empty form', () => {
+    it('should not submit empty form', async () => {
       const onSubmit = sinon.spy();
-      const form = mount(
+      const { container } = render(
         <DefinitionTester
           schema={schema}
           definitions={formConfig.defaultDefinitions}
@@ -36,11 +37,13 @@ describe('Pre-need service periods', () => {
         />,
       );
 
-      form.find('form').simulate('submit');
+      fireEvent.submit(container.querySelector('form'));
 
-      expect(form.find('.usa-input-error').length).to.equal(1);
-      expect(onSubmit.called).to.be.false;
-      form.unmount();
+      await waitFor(() => {
+        const errorElements = container.querySelectorAll('.usa-input-error');
+        expect(errorElements.length).to.equal(1);
+        expect(onSubmit.called).to.be.false;
+      });
     });
 
     it('should add another service period', () => {
@@ -120,10 +123,10 @@ describe('Pre-need service periods', () => {
     });
   }
 
-  const sponsorMilitaryHistory =
-    formConfig.chapters.militaryHistory.pages.sponsorMilitaryHistory;
-  const applicantMilitaryHistory =
-    formConfig.chapters.militaryHistory.pages.applicantMilitaryHistory;
+  const { sponsorMilitaryHistory } = formConfig.chapters.militaryHistory.pages;
+  const {
+    applicantMilitaryHistory,
+  } = formConfig.chapters.militaryHistory.pages;
 
   describe('sponsor', () => {
     servicePeriodsTests(sponsorMilitaryHistory);

--- a/src/applications/pre-need/tests/config/sponsorDeceased.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorDeceased.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -28,9 +29,9 @@ describe('Pre-need sponsor is deceased', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -39,11 +40,13 @@ describe('Pre-need sponsor is deceased', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/sponsorDemographics.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorDemographics.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -29,9 +30,9 @@ describe('Pre-need sponsor demogrpahics', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -40,11 +41,13 @@ describe('Pre-need sponsor demogrpahics', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(3);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(3);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/sponsorDetails.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorDetails.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -29,9 +30,9 @@ describe('Pre-need sponsor details', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -40,11 +41,13 @@ describe('Pre-need sponsor details', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(3);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(3);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/sponsorMilitaryDetails.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorMilitaryDetails.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -29,9 +30,9 @@ describe('Pre-need sponsor military details', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -40,11 +41,13 @@ describe('Pre-need sponsor military details', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/sponsorMilitaryHistory.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorMilitaryHistory.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import {
   DefinitionTester,
@@ -29,9 +30,9 @@ describe('Pre-need sponsor military history', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -40,11 +41,13 @@ describe('Pre-need sponsor military history', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {

--- a/src/applications/pre-need/tests/config/sponsorMilitaryName.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorMilitaryName.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -28,9 +29,9 @@ describe('Pre-need sponsor military name', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -39,11 +40,13 @@ describe('Pre-need sponsor military name', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(1);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required fields filled in', () => {

--- a/src/applications/pre-need/tests/config/veteranApplicantDetails.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/veteranApplicantDetails.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -33,9 +34,9 @@ describe('Pre-need applicant veteran applicant details', () => {
     form.unmount();
   });
 
-  it('should not submit empty form', () => {
+  it('should not submit empty form', async () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { container } = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -44,11 +45,13 @@ describe('Pre-need applicant veteran applicant details', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    fireEvent.submit(container.querySelector('form'));
 
-    expect(form.find('.usa-input-error').length).to.equal(5);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
+    await waitFor(() => {
+      const errorElements = container.querySelectorAll('.usa-input-error');
+      expect(errorElements.length).to.equal(5);
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should submit with required information', () => {


### PR DESCRIPTION
**Upgrade tests to support Node 18+ and Node 22**

This PR updates unit test files to use async form submission and assertions with React Testing Library. The changes replace synchronous Enzyme mount and .simulate('submit') patterns with render, fireEvent, and waitFor to properly handle asynchronous state updates and validation errors in modern React and Node (18+). All updated tests now pass under Node 22.  

[VA-IIR Ticket](https://github.com/department-of-veterans-affairs/va-iir/issues/1871)

