### PR TITLE
Node 22 Bug Bash - Updated `burials-ez` Tests for Node 22 Upgrade

### DIFF
--- a/src/applications/burials-ez/tests/BurialsApp.unit.spec.jsx
+++ b/src/applications/burials-ez/tests/BurialsApp.unit.spec.jsx
@@ -66,8 +66,7 @@ describe('BurialsApp', () => {
         <BurialsApp location={{ ...burialsLocation, pathname: 'test' }} />
       </Provider>,
     );
-    expect(window.location.href).to.eq(
-      '/burials-memorials/veterans-burial-allowance/',
-    );
+    const location = window.location.pathname || window.location.href;
+    expect(location).to.eq('/burials-memorials/veterans-burial-allowance/');
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated `burials-ez` tests so that all tests pass in both Node 14 and Node 22.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/504)

## Testing done
- Updated `BurialsApp.unit.spec.jsx` and ran tests locally on both the `main` and `node-22-bug-bash-testing` branches.
- Can be replicated by running `yarn test:unit:summary --apps=burials-ez`.

## What areas of the site does it impact?
This only impacts `BurialsApp.unit.spec.jsx`.

## Acceptance criteria
- [x] `burials-ez` tests pass on Node 22
- [x] `burials-ez` tests continue to pass on Node 14