### PR TITLE
Form 21A Chapter 1 unit tests and component updates

### DIFF
--- a/src/applications/accreditation/21a/config/submit-transformer.js
+++ b/src/applications/accreditation/21a/config/submit-transformer.js
@@ -44,7 +44,7 @@ const build21aPayload = data => {
     birthCountry: data.placeOfBirth?.country,
 
     // Chapter 1 - Contact Info
-    homePhone: data.phone,
+    homePhone: `${data.phone.callingCode}${data.phone.contact}`,
     homePhoneTypeId: PHONE_TYPE_ENUM[data.typeOfPhone?.toUpperCase()],
     canReceiveTexts: !!data.canReceiveTexts,
     homeEmail: data.email,

--- a/src/applications/accreditation/21a/pages/01-personal-information-chapter/contactInformation.js
+++ b/src/applications/accreditation/21a/pages/01-personal-information-chapter/contactInformation.js
@@ -7,12 +7,12 @@ import {
   yesNoSchema,
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-
-import { typeOfPhoneOptions } from '../../constants/options';
 import {
   internationalPhoneSchema,
   internationalPhoneUI,
-} from '../helpers/internationalPhonePatterns';
+} from 'platform/forms-system/src/js/web-component-patterns/internationalPhonePattern';
+
+import { typeOfPhoneOptions } from '../../constants/options';
 
 /** @type {PageSchema} */
 export default {
@@ -34,7 +34,7 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      phone: internationalPhoneSchema,
+      phone: internationalPhoneSchema(),
       typeOfPhone: radioSchema(Object.keys(typeOfPhoneOptions)),
       canReceiveTexts: yesNoSchema,
       email: emailSchema,

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/contactInformation.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/contactInformation.unit.spec.jsx
@@ -13,7 +13,11 @@ describe('Contact information page', () => {
         schema={contactInformationPage.schema}
         uiSchema={contactInformationPage.uiSchema}
         data={{
-          phone: '206-555-0100',
+          phone: {
+            callingCode: 1,
+            countryCode: 'US',
+            contact: '206-555-0100',
+          },
           typeOfPhone: 'CELL',
           canReceiveTexts: true,
           email: 'test@example.com',
@@ -25,10 +29,9 @@ describe('Contact information page', () => {
 
     expect(getByText('Contact information')).to.exist;
 
-    const vaPhoneInput = container.querySelector(
-      'va-text-input[label="Primary phone number"]',
-    );
+    const vaPhoneInput = container.querySelector('va-telephone-input');
     expect(vaPhoneInput).to.exist;
+    expect(vaPhoneInput.getAttribute('label')).to.equal('Primary phone number');
 
     const vaRadio = container.querySelector('va-radio');
     expect(vaRadio).to.exist;

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/contactInformation.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/contactInformation.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import contactInformationPage from '../../../../pages/01-personal-information-chapter/contactInformation';
+
+describe('Contact information page', () => {
+  it('renders the title, phone field, type of phone options, and all radio options', () => {
+    const { container, getByText } = render(
+      <SchemaForm
+        name="contactInformation"
+        title={contactInformationPage.title}
+        schema={contactInformationPage.schema}
+        uiSchema={contactInformationPage.uiSchema}
+        data={{
+          phone: '206-555-0100',
+          typeOfPhone: 'CELL',
+          canReceiveTexts: true,
+          email: 'test@example.com',
+        }}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(getByText('Contact information')).to.exist;
+
+    const vaPhoneInput = container.querySelector(
+      'va-text-input[label="Primary phone number"]',
+    );
+    expect(vaPhoneInput).to.exist;
+
+    const vaRadio = container.querySelector('va-radio');
+    expect(vaRadio).to.exist;
+    expect(vaRadio.getAttribute('label')).to.equal('Type of phone');
+
+    const html = container.innerHTML;
+    expect(html).to.include('Cell');
+    expect(html).to.include('Home');
+    expect(html).to.include('Work');
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/homeAddress.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/homeAddress.unit.spec.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import homeAddressPage from '../../../../pages/01-personal-information-chapter/homeAddress';
+
+describe('Home address page', () => {
+  it('renders the title and home address fields', () => {
+    const { container, getByText } = render(
+      <SchemaForm
+        name="homeAddress"
+        title={homeAddressPage.title}
+        schema={homeAddressPage.schema}
+        uiSchema={homeAddressPage.uiSchema}
+        data={{
+          homeAddress: {
+            street: '123 Main St',
+            city: 'Springfield',
+            state: 'IL',
+            postalCode: '12345',
+            country: 'United States',
+          },
+        }}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(getByText('Primary home address')).to.exist;
+    const html = container.innerHTML;
+    expect(html).to.include('label="Street address"');
+    expect(html).to.include('label="city"');
+    expect(html).to.include('label="state"');
+    expect(html).to.include('label="Postal code"');
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/lawLicense.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/lawLicense.unit.spec.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import lawLicensePage from '../../../../pages/01-personal-information-chapter/lawLicense';
+
+describe('Law license page', () => {
+  it('renders the law license question and yes/no options', () => {
+    const { container } = render(
+      <SchemaForm
+        name="lawLicense"
+        title={lawLicensePage.title}
+        schema={lawLicensePage.schema}
+        uiSchema={lawLicensePage.uiSchema}
+        data={{}}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    const vaRadio = container.querySelector('va-radio');
+    expect(vaRadio).to.exist;
+    expect(vaRadio.getAttribute('label')).to.equal(
+      'Are you currently an active member in good standing of the bar of the highest court of a state or territory of the United States?',
+    );
+
+    const options = container.querySelectorAll('va-radio-option');
+    expect(options.length).to.equal(2);
+    expect(options[0].getAttribute('label')).to.equal('Yes');
+    expect(options[1].getAttribute('label')).to.equal('No');
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/nameDateOfBirth.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/nameDateOfBirth.unit.spec.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import nameDateOfBirthPage from '../../../../pages/01-personal-information-chapter/nameDateOfBirth';
+
+describe('Name and date of birth page', () => {
+  it('renders the title, subtitle, full name, and date of birth fields', () => {
+    const { container, getByText } = render(
+      <SchemaForm
+        name="nameDateOfBirth"
+        title={nameDateOfBirthPage.title}
+        schema={nameDateOfBirthPage.schema}
+        uiSchema={nameDateOfBirthPage.uiSchema}
+        data={{}}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(getByText('Name and date of birth')).to.exist;
+    expect(
+      getByText(
+        'Use your legal name as it appears on your government documentation.',
+      ),
+    ).to.exist;
+
+    const firstNameInput = container.querySelector(
+      'va-text-input[label="First name"]',
+    );
+    const lastNameInput = container.querySelector(
+      'va-text-input[label="Last name"]',
+    );
+    const middleNameInput = container.querySelector(
+      'va-text-input[label="Middle name"]',
+    );
+    const suffixSelect = container.querySelector('va-select[label="Suffix"]');
+    expect(firstNameInput).to.exist;
+    expect(lastNameInput).to.exist;
+    expect(middleNameInput).to.exist;
+    expect(suffixSelect).to.exist;
+
+    const dobInput = container.querySelector(
+      'va-memorable-date[label="Date of birth"]',
+    );
+    expect(dobInput).to.exist;
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/notInGoodStanding.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/notInGoodStanding.unit.spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import NotInGoodStanding from '../../../../components/01-personal-information-chapter/NotInGoodStanding';
+
+describe('NotInGoodStanding', () => {
+  it('renders the alert headline, message, and navigation buttons', () => {
+    const { getByText, container } = render(
+      <NotInGoodStanding goToPath={() => {}} />,
+    );
+
+    expect(
+      getByText(
+        'You must be in good standing with the bar to become accredited.',
+      ),
+    ).to.exist;
+    expect(
+      getByText(
+        /In order to be accredited by VA as an attorney, an individual must be a member in good standing of the bar of the highest court of a state or territory of the United States\./,
+        { exact: false },
+      ),
+    ).to.exist;
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).to.be.greaterThan(0);
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/otherAddress.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/otherAddress.unit.spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import otherAddressPage from '../../../../pages/01-personal-information-chapter/otherAddress';
+
+describe('Other address page', () => {
+  it('renders the title, subtitle, and address fields', () => {
+    const { container, getByText } = render(
+      <SchemaForm
+        name="otherAddress"
+        title={otherAddressPage.title}
+        schema={otherAddressPage.schema}
+        uiSchema={otherAddressPage.uiSchema}
+        data={{
+          otherAddress: {
+            country: 'United States',
+            street: '123 Main St',
+            city: 'Springfield',
+            state: 'IL',
+            postalCode: '12345',
+          },
+        }}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(getByText('Other address')).to.exist;
+    expect(
+      getByText('We will send information about your form to this address.'),
+    ).to.exist;
+
+    const vaCheckbox = container.querySelector('va-checkbox');
+    expect(vaCheckbox).to.exist;
+    expect(vaCheckbox.getAttribute('label')).to.include('military base');
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/personalInformationIntro.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/personalInformationIntro.unit.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import PersonalInformationIntro from '../../../../components/01-personal-information-chapter/PersonalInformationIntro';
+
+describe('PersonalInformationIntro', () => {
+  it('renders the intro paragraph and all list items', () => {
+    const { getByText, getAllByRole } = render(<PersonalInformationIntro />);
+
+    expect(
+      getByText(
+        /Over the next few pages, we will ask you for some personal information.\s*You will need to provide the following:/,
+      ),
+    ).to.exist;
+
+    const items = [
+      'Whether you are applying to become an accredited attorney or claims agent',
+      'Whether you currently hold a license to practice law',
+      'Name, date of birth, and place of birth',
+      'Contact information',
+    ];
+    const listItems = getAllByRole('listitem');
+    expect(listItems.length).to.equal(items.length);
+    items.forEach((text, idx) => {
+      expect(listItems[idx].textContent).to.equal(text);
+    });
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/placeOfBirth.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/placeOfBirth.unit.spec.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import placeOfBirthPage from '../../../../pages/01-personal-information-chapter/placeOfBirth';
+
+describe('Place of birth page', () => {
+  it('renders the title and place of birth fields', () => {
+    const { container, getByText } = render(
+      <SchemaForm
+        name="placeOfBirth"
+        title={placeOfBirthPage.title}
+        schema={placeOfBirthPage.schema}
+        uiSchema={placeOfBirthPage.uiSchema}
+        data={{
+          placeOfBirth: {
+            city: 'Springfield',
+            state: 'IL',
+            country: 'United States',
+          },
+        }}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(getByText('Place of birth')).to.exist;
+    const html = container.innerHTML;
+    expect(html).to.include('label="city"');
+    expect(html).to.include('label="state"');
+    expect(html).to.include('label="Country"');
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/primaryMailingAddress.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/primaryMailingAddress.unit.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import primaryMailingAddressPage from '../../../../pages/01-personal-information-chapter/primaryMailingAddress';
+
+describe('Primary mailing address page', () => {
+  it('renders the title, question, and all radio options', () => {
+    const { container, getByText } = render(
+      <SchemaForm
+        name="primaryMailingAddress"
+        title={primaryMailingAddressPage.title}
+        schema={primaryMailingAddressPage.schema}
+        uiSchema={primaryMailingAddressPage.uiSchema}
+        data={{ primaryMailingAddress: 'HOME' }}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    expect(getByText('Primary mailing address')).to.exist;
+
+    const vaRadio = container.querySelector('va-radio');
+    expect(vaRadio).to.exist;
+    expect(vaRadio.getAttribute('label')).to.equal(
+      'What address would you like to receive communication from the Office of General Counsel (OGC)?',
+    );
+
+    const html = container.innerHTML;
+    expect(html).to.include('Home');
+    expect(html).to.include('Work');
+    expect(html).to.include('Other');
+  });
+});

--- a/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/role.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/01-personal-information-chapter/role.unit.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import rolePage from '../../../../pages/01-personal-information-chapter/role';
+
+describe('Role page', () => {
+  it('renders the role question, description, and options', () => {
+    const { container, getByText } = render(
+      <SchemaForm
+        name="role"
+        title={rolePage.title}
+        schema={rolePage.schema}
+        uiSchema={rolePage.uiSchema}
+        data={{}}
+        onChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    const vaRadio = container.querySelector('va-radio');
+    expect(vaRadio).to.exist;
+    expect(vaRadio.getAttribute('label')).to.equal(
+      'Which role are you applying for?',
+    );
+
+    expect(
+      getByText(
+        /To be accredited as an attorney, you must be active and in good standing with a state bar. To be accredited as a claims agent, you must pass a written examination administered by VA./,
+        { exact: false },
+      ),
+    ).to.exist;
+
+    const options = container.querySelectorAll('va-radio-option');
+    expect(options.length).to.equal(2);
+    expect(options[0].getAttribute('label')).to.equal('Attorney');
+    expect(options[1].getAttribute('label')).to.equal(
+      'Claims agent (non-attorney representative)',
+    );
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added unit tests for form 21a chapter 1
- Updated contact-information component to make use of forms library internationalPhoneSchema and UI 

For all address fields, we'll continue to make use of the forms library schema and ui schema for maintainability/simplicity. As a result, this chapter does not contain any updated imports from the 21A vets-json-schema file. 

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112530

## Testing done

- Test coverage for chapter 1

## Screenshots

<img width="717" height="664" alt="image" src="https://github.com/user-attachments/assets/71b0072f-e6c6-4e09-89f1-cef26d99d895" />


## What areas of the site does it impact?

Non-prod-enabled Form 21A app

