### PR TITLE
fix: update Dockerfile to use archive repositories for Debian Buster EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN groupadd -g $userid vets-website \
 ENV YARN_VERSION 1.19.1
 ENV NODE_ENV production
 
+# Fix for Debian Buster EOL - use archive repositories
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
+    echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks
+
 RUN apt-get update
 
 # Install specific version of Chrome to match ChromeDriver installation.


### PR DESCRIPTION
## Summary
- Fixes Docker build failures caused by Debian Buster end-of-life
- Updates Dockerfile to use archive.debian.org repositories
- Disables validity checks for archived repositories

## Problem
[Jenkins builds were failing](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/dd%2F113211%2Fversion2/1/pipeline/) with 404 errors when running `apt-get update` because Debian Buster repositories moved to archive after reaching EOL.

## Solution
Added archive repository configuration before apt-get update to redirect to archive.debian.org and disable validity checks.

## Test plan
- [x] Verified fix works by testing base image with archive repositories
- [x] Confirmed original error reproduced without fix
- [ ] Jenkins build should now pass Docker build step