### PR TITLE
fix broken confirmation page

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/uploadDocuments.jsx
+++ b/src/applications/income-and-asset-statement/config/chapters/12-supporting-documents/uploadDocuments.jsx
@@ -34,22 +34,28 @@ export default {
   uiSchema: {
     ...titleUI('Upload supporting documents'),
     'ui:description': Description,
-    files: fileUploadUI('', {
-      buttonText: 'Upload supporting document',
-      fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
-      maxSize: MAX_FILE_SIZE_BYTES,
-      fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
-      fileUploadNetworkErrorMessage:
-        'We’re sorry. There was problem with our system and we couldn’t upload your file. You can try again later.',
-      fileUploadNetworkErrorAlert: {
-        header: 'We couldn’t upload your file',
-        body: [
-          'We’re sorry. There was a problem with our system and we couldn’t upload your file. Try uploading your file again.',
-          'Or select Continue to fill out the rest of your form. And then follow the instructions at the end to learn how to submit your documents.',
-        ],
-      },
-      hideLabelText: true,
-    }),
+    files: {
+      ...fileUploadUI('', {
+        buttonText: 'Upload supporting document',
+        fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
+        maxSize: MAX_FILE_SIZE_BYTES,
+        fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
+        fileUploadNetworkErrorMessage:
+          'We’re sorry. There was problem with our system and we couldn’t upload your file. You can try again later.',
+        fileUploadNetworkErrorAlert: {
+          header: 'We couldn’t upload your file',
+          body: [
+            'We’re sorry. There was a problem with our system and we couldn’t upload your file. Try uploading your file again.',
+            'Or select Continue to fill out the rest of your form. And then follow the instructions at the end to learn how to submit your documents.',
+          ],
+        },
+        hideLabelText: true,
+      }),
+      'ui:confirmationField': ({ formData }) => ({
+        data: formData?.map(item => item.name || item.fileName),
+        label: 'Supporting documents',
+      }),
+    },
     'view:uploadMessage': {
       'ui:description': UploadMessage,
     },


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fix broken confirmation page by adding `ui:confirmationField` to files uiSchema.
- There's an issue currently with the `ConfirmationView.ChapterSectionCollection` component when trying to render list of uploaded files. The form systems team is aware and is actively in the process of rolling out a new file uploader component that will work with the `ConfirmationView.ChapterSectionCollection` component.
- Until that update is rolled out, they've suggested to override the default render logic by providing a confirmationField definition.
- Pension and burials team to own this change.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#114013

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        | <img width="814" height="602" alt="image" src="https://github.com/user-attachments/assets/530e4649-2f49-4cb3-89ed-429c194e2139" /> |
| Desktop |  | <img width="1362" height="460" alt="image" src="https://github.com/user-attachments/assets/df04e892-4e6e-4fbe-93f6-25ccafa663b0" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
