### PR TITLE
10-10EZ | Update insurance v2 form config declaration

### DIFF
--- a/src/applications/hca/config/chapters/insuranceInformation/insurancePolicies.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/insurancePolicies.js
@@ -34,12 +34,14 @@ const healthInsurancePolicyPages = arrayBuilderPages(options, pagebuilder => ({
     path: 'insurance-information/health-insurance',
     uiSchema: summaryPageSchemas.uiSchema,
     schema: summaryPageSchemas.schema,
+    depends: formData => formData['view:isInsuranceV2Enabled'],
   }),
   healthInsurancePolicyInformation: pagebuilder.itemPage({
     title: content['insurance-info--policy-page-title'],
     path: 'insurance-information/health-insurance/:index/policy-information',
     uiSchema: policyPageSchemas.uiSchema,
     schema: policyPageSchemas.schema,
+    depends: formData => formData['view:isInsuranceV2Enabled'],
   }),
 }));
 

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -276,7 +276,7 @@ const formConfig = {
           path: 'va-benefits/benefits-package',
           title: 'VA benefits package',
           depends: includeRegOnlyGuestQuestions,
-          CustomPageReview: () => null,
+          CustomPageReview: null,
           uiSchema: benefitsPackage.uiSchema,
           schema: benefitsPackage.schema,
         },
@@ -573,14 +573,7 @@ const formConfig = {
           uiSchema: general.uiSchema,
           schema: general.schema,
         },
-        healthInsurancePolicySummary: {
-          ...insurancePolicyPages.healthInsurancePolicySummary,
-          depends: formData => formData['view:isInsuranceV2Enabled'],
-        },
-        healthInsurancePolicyInformation: {
-          ...insurancePolicyPages.healthInsurancePolicyInformation,
-          depends: formData => formData['view:isInsuranceV2Enabled'],
-        },
+        ...insurancePolicyPages,
         vaFacility: {
           path: 'insurance-information/va-facility',
           title: 'VA Facility',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the declaration of the insurance v2 edits, which utilize the updated ArrayBuilder pattern from the product forms group. The updates eliminates the need of redeclaring the ArrayBuilder pages in the form config, by moving the `depends` declaration into their page configs.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#35230

## Acceptance criteria

- Conditional dependencies work as intended when declared inside the ArrayBuilder config

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution