### PR TITLE
Set default `attachmentId` properties for file uploads - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/claimInformation.js
@@ -242,6 +242,7 @@ export const medicalClaimUploadSchema = {
     medicalUpload: fileUploadUI({
       label: 'Upload supporting document',
       attachmentName: true,
+      attachmentId: 'medical invoice', // hard-set for LLM verification
     }),
   },
   schema: {
@@ -346,6 +347,7 @@ export const eobUploadSchema = isPrimary => {
       [keyName]: fileUploadUI({
         label: 'Upload explanation of benefits',
         attachmentName: true,
+        attachmentId: 'EOB', // hard-set for LLM verification
       }),
     },
     schema: {
@@ -441,6 +443,7 @@ export const pharmacyClaimUploadSchema = {
     pharmacyUpload: fileUploadUI({
       label: 'Upload supporting document',
       attachmentName: true,
+      attachmentId: 'pharmacy invoice', // hard-set for LLM verification
     }),
   },
   schema: {

--- a/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
@@ -300,6 +300,7 @@ export const pharmacyClaimUploadDocs = {
     pharmacyUpload: fileUploadUI({
       label: 'Upload supporting document',
       attachmentName: true,
+      attachmentId: 'pharmacy invoice', // hard-set for LLM verification
     }),
   },
   schema: {

--- a/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
@@ -32,7 +32,7 @@ export default function transformForSubmit(formConfig, form) {
   copyOfData.primaryContactInfo = getPrimaryContact(copyOfData);
 
   // ---
-  // Add type/category info to file uploads:
+  // Add type/category info to file uploads for Pega/DOCMP ingestion:
   const pharmacyUpload = copyOfData?.pharmacyUpload?.map(el => {
     return { ...el, attachmentId: 'MEDDOCS' };
   });

--- a/src/applications/ivc-champva/shared/components/fileUploads/upload.js
+++ b/src/applications/ivc-champva/shared/components/fileUploads/upload.js
@@ -10,14 +10,19 @@ const uploadUrl = `${
   environment.API_URL
 }/ivc_champva/v1/forms/submit_supporting_documents`;
 
-export function createPayload(file, _formId, password) {
+export function createPayload(
+  file,
+  _formId,
+  password,
+  attachmentId = undefined,
+) {
   const payload = new FormData();
   payload.append('file', file);
   payload.append('form_id', _formId);
+  // For hard-coded attachment IDs (needed for LLM validation)
+  if (attachmentId) payload.append('attachment_id', attachmentId);
   // password for encrypted PDFs
-  if (password) {
-    payload.append('password', password);
-  }
+  if (password) payload.append('password', password);
 
   return payload;
 }
@@ -65,7 +70,8 @@ export const fileUploadUi = content => {
     addAnotherLabel,
     buttonText: content.buttonText || 'Upload file',
     fileTypes,
-    createPayload,
+    createPayload: (file, _formId, password) =>
+      createPayload(file, _formId, password, content.attachmentId),
     parseResponse: (response, file) => {
       setTimeout(() => {
         // Get the host element that contains our upload/delete buttons.


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the upload inputs on form 10-7959a to have default `attachmentId` values when initially uploaded to the backend. This is so that our LLM integration can have an expectation for the type of document it is receiving, which gives us something to ground the inspection in.

On final submission of the form, the attachmenIds are re-set back to the `MEDDOC` or `EOB` values they currently use.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114015

## Testing done

- Manual

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|description|upload screen| attachment id at time of upload|
|-|-|-|
|Pharmacy (new claim)|<img width="594" height="1014" alt="Image" src="https://github.com/user-attachments/assets/bb43a330-c9ca-467c-b83c-ac32e2187b99" />|<img width="482" height="126" alt="Image" src="https://github.com/user-attachments/assets/5b972820-2eb0-42f4-a827-ec8bf7efff50" />|
|Pharmacy (resubmission)|<img width="598" height="582" alt="Image" src="https://github.com/user-attachments/assets/d318a14e-3f09-4f30-9237-db9794b248e7" />|<img width="451" height="148" alt="Image" src="https://github.com/user-attachments/assets/8df3c8be-b6a3-4efb-b020-5ea8babecfd4" />|
|Medical EOB (new claim)|<img width="590" height="932" alt="Image" src="https://github.com/user-attachments/assets/d1858f98-302b-425f-abdf-9ca350d61dea" />|<img width="440" height="100" alt="Image" src="https://github.com/user-attachments/assets/f8910b0b-b39f-44a0-a2ce-3fc629edcb91" />|
|Medical Supporting doc (new claim)|<img width="616" height="1275" alt="Image" src="https://github.com/user-attachments/assets/59031bc2-79bb-4619-b4e1-054335e6b814" />|<img width="491" height="141" alt="Image" src="https://github.com/user-attachments/assets/27e0a0d9-18ac-4e18-85b9-44ec6a096f29" />|
|Medical catch-all (resubmission) |<img width="714" height="982" alt="Image" src="https://github.com/user-attachments/assets/045c6c6e-2518-4972-a9da-71b9a49b3334" />|<img width="523" height="129" alt="Image" src="https://github.com/user-attachments/assets/2e18424b-8fbc-4f3f-9aba-7d76ed5099eb" />|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA