### PR TITLE
Update CODEOWNERS for 10-10 apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,16 +152,14 @@ src/applications/static-pages/facilities @department-of-veterans-affairs/vfs-fac
 src/applications/static-pages/tests/facilities @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/situation-updates-banner @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 
-# Caregiver
+# 10-10 Health Apps
 
 src/applications/caregivers @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
-
-# Health Care Applications
-
 src/applications/hca @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/ezr @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/hca-performance-warning @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/ezr-submission-options @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/ivc-champv @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Healthcare Experience
 
@@ -280,6 +278,5 @@ src/applications/third-party-app-directory @department-of-veterans-affairs/va-pl
 src/applications/static-pages/analytics @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/download-1095b @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/benefit-eligibility-questionnaire @department-of-veterans-affairs/va-platform-cop-frontend
-src/applications/ivc-champv @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/office-directory @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/travel-pay @department-of-veterans-affairs/va-platform-cop-frontend


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the CODEOWNERS for 10-10 health apps. An upcoming recompete merges the IVC portfolio with the Health Enrollment portfolio. This PR adds the 1010 FE group as a code owner to the IVC product portfolio.

## Acceptance criteria

- IVC products can be approved by all 1010 engineers

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution