### PR TITLE
Global | Fix submit button loading state

### DIFF
--- a/src/platform/forms-system/src/js/components/PersonalInformation/PersonalInformation.jsx
+++ b/src/platform/forms-system/src/js/components/PersonalInformation/PersonalInformation.jsx
@@ -86,6 +86,7 @@ export const PersonalInformation = ({
   contentBeforeButtons,
   contentAfterButtons,
   errorMessage,
+  formOptions = {},
 }) => {
   const finalConfig = { ...defaultConfig, ...config };
 
@@ -231,7 +232,11 @@ export const PersonalInformation = ({
       {footer || null}
 
       {contentBeforeButtons || null}
-      <NavButtons goBack={goBack} goForward={goForward} />
+      <NavButtons
+        goBack={goBack}
+        goForward={goForward}
+        useWebComponents={formOptions.useWebComponentForNavigation}
+      />
       {contentAfterButtons || null}
     </>
   );
@@ -279,6 +284,9 @@ PersonalInformation.propTypes = {
       ssnLastFour: PropTypes.string,
       vaFileLastFour: PropTypes.string,
     }),
+  }),
+  formOptions: PropTypes.shape({
+    useWebComponentForNavigation: PropTypes.bool,
   }),
   goBack: PropTypes.func,
   goForward: PropTypes.func,

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -62,7 +62,7 @@ const ProgressButton = props => {
     }
   } else {
     // Remove class names that may interfere with the web component
-    const vaButtonClass = buttonClass
+    const vaButtonClass = (buttonClass || '')
       .replace('usa-button-primary', '')
       .replace('usa-button-secondary', '')
       .replace('vads-u-width--auto', '')
@@ -83,7 +83,7 @@ const ProgressButton = props => {
       onClick: handleClick,
       // The web component does not support onMouseDown
       // onMouseDown: preventOnBlur,
-      secondary: buttonClass.includes('usa-button-secondary') || null,
+      secondary: (buttonClass || '').includes('usa-button-secondary') || null,
       submit: submitButton ? 'prevent' : null,
       text: buttonText,
     };
@@ -98,7 +98,9 @@ const ProgressButton = props => {
     <button
       type={submitButton ? 'submit' : 'button'}
       disabled={disabled}
-      className={`${buttonClass}${disabled ? ' usa-button-disabled' : ''}`}
+      className={`${buttonClass || ''}${
+        disabled ? ' usa-button-disabled' : ''
+      }`}
       id={`${id}-continueButton`}
       onClick={handleClick}
       onMouseDown={preventOnBlur}

--- a/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
@@ -31,6 +31,7 @@ export default function Pending(props) {
                 onButtonClick={onSubmit}
                 buttonText="Sending..."
                 disabled
+                loading
                 buttonClass="usa-button-disabled"
                 useWebComponents={useWebComponents}
               />
@@ -50,6 +51,7 @@ export default function Pending(props) {
                 onButtonClick={onSubmit}
                 buttonText="Sending..."
                 disabled
+                loading
                 buttonClass="usa-button-disabled"
                 useWebComponents={useWebComponents}
               />

--- a/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
@@ -31,7 +31,7 @@ export default function Submitted(props) {
                 onButtonClick={onSubmit}
                 buttonText="Submitted"
                 disabled
-                buttonClass="form-button-green"
+                buttonClass=""
                 beforeText="&#10003;"
                 useWebComponents={useWebComponents}
               />
@@ -51,7 +51,7 @@ export default function Submitted(props) {
                 onButtonClick={onSubmit}
                 buttonText="Submitted"
                 disabled
-                buttonClass="form-button-green"
+                buttonClass=""
                 beforeText="&#10003;"
                 useWebComponents={useWebComponents}
               />

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { Link, withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import { fromUnixTime, isBefore } from 'date-fns';
 import { format } from 'date-fns-tz';
-import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaButton,
+  VaLink,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { getNextPagePath } from '~/platform/forms-system/src/js/routing';
 import {
@@ -200,6 +203,31 @@ class SaveInProgressIntro extends React.Component {
         unauthStartText,
       } = this.props;
       const CustomLink = this.props.customLink;
+      const unauthStartLink = this.props.formConfig?.formOptions
+        ?.useWebComponentForNavigation ? (
+        <p>
+          <VaLink
+            onClick={this.handleClickAndReroute}
+            href={this.getStartPage()}
+            className="schemaform-start-button"
+            aria-label={ariaLabel}
+            // aria-describedby={ariaDescribedby}
+            text={`Start your ${appType} without signing in`}
+          />
+        </p>
+      ) : (
+        <p>
+          <Link
+            onClick={this.handleClick}
+            to={this.getStartPage}
+            className="schemaform-start-button"
+            aria-label={ariaLabel}
+            aria-describedby={ariaDescribedby}
+          >
+            Start your {appType} without signing in
+          </Link>
+        </p>
+      );
       const unauthStartButton = CustomLink ? (
         <CustomLink
           href="#start"
@@ -222,19 +250,7 @@ class SaveInProgressIntro extends React.Component {
       alert = buttonOnly ? (
         <>
           {unauthStartButton}
-          {!this.props.hideUnauthedStartLink && (
-            <p>
-              <Link
-                onClick={this.handleClick}
-                to={this.getStartPage}
-                className="schemaform-start-button"
-                aria-label={ariaLabel}
-                aria-describedby={ariaDescribedby}
-              >
-                Start your {appType} without signing in
-              </Link>
-            </p>
-          )}
+          {!this.props.hideUnauthedStartLink && unauthStartLink}
         </>
       ) : (
         <va-alert-sign-in
@@ -250,19 +266,7 @@ class SaveInProgressIntro extends React.Component {
         >
           <span slot="SignInButton">
             {unauthStartButton}
-            {!this.props.hideUnauthedStartLink && (
-              <p>
-                <Link
-                  onClick={this.handleClick}
-                  to={this.getStartPage}
-                  className="schemaform-start-button"
-                  aria-label={ariaLabel}
-                  aria-describedby={ariaDescribedby}
-                >
-                  Start your {appType} without signing in
-                </Link>
-              </p>
-            )}
+            {!this.props.hideUnauthedStartLink && unauthStartLink}
           </span>
         </va-alert-sign-in>
       );
@@ -299,6 +303,12 @@ class SaveInProgressIntro extends React.Component {
 
   handleClick = () => {
     recordEvent({ event: 'no-login-start-form' });
+  };
+
+  handleClickAndReroute = event => {
+    event.preventDefault();
+    recordEvent({ event: 'no-login-start-form' });
+    this.props.router.push(this.getStartPage());
   };
 
   openLoginModal = () => {
@@ -442,6 +452,9 @@ SaveInProgressIntro.propTypes = {
       appContinuing: PropTypes.string,
     }),
     requiresVerifiedUser: PropTypes.bool,
+    formOptions: PropTypes.shape({
+      useWebComponentForNavigation: PropTypes.bool,
+    }),
   }),
   formData: PropTypes.object,
   gaStartEventName: PropTypes.string,
@@ -458,6 +471,9 @@ SaveInProgressIntro.propTypes = {
   retentionPeriod: PropTypes.string,
   retentionPeriodStart: PropTypes.string,
   returnUrl: PropTypes.string,
+  router: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }),
   startMessageOnly: PropTypes.bool,
   startText: PropTypes.string,
   unauthStartText: PropTypes.string,
@@ -551,6 +567,6 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(SaveInProgressIntro);
+)(withRouter(SaveInProgressIntro));
 
 export { SaveInProgressIntro };

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 // import moment from 'moment';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { fromUnixTime } from 'date-fns';
 import { format } from 'date-fns-tz';
+import sinon from 'sinon';
 
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
@@ -692,6 +693,92 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       'Custom message displayed to non-signed-in users',
     );
     expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.exist;
+    // expect($('a.schemaform-start-button', container)).to.exist;
+  });
+
+  it('should display an unauth start imposter link', () => {
+    const user = {
+      profile: {
+        savedForms: [],
+        prefillsAvailable: [],
+      },
+      login: {
+        currentlyLoggedIn: false,
+        loginUrls: {
+          idme: '/mockLoginUrl',
+        },
+      },
+    };
+
+    const { container } = render(
+      <SaveInProgressIntro
+        saveInProgress={{ formData: {} }}
+        pageList={pageList}
+        formId="1010ez"
+        user={user}
+        prefillEnabled
+        fetchInProgressForm={fetchInProgressForm}
+        removeInProgressForm={removeInProgressForm}
+        toggleLoginModal={toggleLoginModal}
+        startMessageOnly
+        unauthStartText="Custom message displayed to non-signed-in users"
+        formConfig={formConfig}
+      />,
+    );
+    expect($('va-button', container).outerHTML).to.contain(
+      'Custom message displayed to non-signed-in users',
+    );
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.not
+      .exist;
+    expect($('a.schemaform-start-button', container)).to.exist;
+  });
+
+  it('should display an unauth start va-link', () => {
+    const pushSpy = sinon.spy();
+    const router = {
+      push: pushSpy,
+    };
+    const user = {
+      profile: {
+        savedForms: [],
+        prefillsAvailable: [],
+      },
+      login: {
+        currentlyLoggedIn: false,
+        loginUrls: {
+          idme: '/mockLoginUrl',
+        },
+      },
+    };
+
+    const { container } = render(
+      <SaveInProgressIntro
+        saveInProgress={{ formData: {} }}
+        pageList={pageList}
+        formId="1010ez"
+        user={user}
+        prefillEnabled
+        fetchInProgressForm={fetchInProgressForm}
+        removeInProgressForm={removeInProgressForm}
+        toggleLoginModal={toggleLoginModal}
+        startMessageOnly
+        unauthStartText="Custom message displayed to non-signed-in users"
+        formConfig={{
+          ...formConfig,
+          formOptions: { useWebComponentForNavigation: true },
+        }}
+        router={router}
+      />,
+    );
+    expect($('va-button', container).outerHTML).to.contain(
+      'Custom message displayed to non-signed-in users',
+    );
+    expect($('va-alert-sign-in[variant="signInRequired"]', container)).to.not
+      .exist;
+    const unauthStart = $('va-link.schemaform-start-button', container);
+    expect(unauthStart).to.exist;
+    fireEvent.click(unauthStart);
+    expect(pushSpy.called).to.be.true;
   });
 
   it('should not render an inProgress message', () => {

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -184,7 +184,7 @@ Cypress.Commands.add('tabToGoBack', (forward = true) => {
 Cypress.Commands.add('tabToSubmitForm', () => {
   // Form submit button is a button type?
   cy.tabToElement(
-    'button[id$="continueButton"].usa-button-primary, va-button:not([secondary]',
+    'button[id$="continueButton"].usa-button-primary, va-button:not([secondary])',
   );
   cy.realPress('Space');
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Upon submitting a form, the submit button isn't showing an in-progress (loading) indicator.
  > - When starting a form without signing in, the start form link is an imposter
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/114349

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Submit button | <img width="494" height="116" alt="Sending static text on submission" src="https://github.com/user-attachments/assets/339a510f-2e9c-445e-9955-fdbed614b341" /> | <img width="461" height="108" alt="Sending static text with spinning icon on submission" src="https://github.com/user-attachments/assets/a5fc00b6-974a-4e4f-ae4e-17fd1fb4af8d" /> |
| Unauth start form | <img width="676" height="540" alt="before-start-unauth" src="https://github.com/user-attachments/assets/00fd4f5c-9c54-4741-b308-b3a8f7ad6c15" /> | <img width="674" height="541" alt="after-start-unauth" src="https://github.com/user-attachments/assets/f3e696cb-6dd9-429b-87a8-868482b4f599" /> |

<img alt="submit-spinner in action" width="500" src="https://github.com/user-attachments/assets/fc57e468-8ce7-4a60-aa05-89573a734a5e" />

## What areas of the site does it impact?

All forms with `useWebComponentForNavigation` set to `true` within the form config `formOptions`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
