### PR TITLE
[art/114395] - updating awaiting receipt icon

### DIFF
--- a/src/applications/accredited-representative-portal/components/SubmissionCard.jsx
+++ b/src/applications/accredited-representative-portal/components/SubmissionCard.jsx
@@ -36,7 +36,7 @@ const formatStatus = submission => {
         <span className="submissions__awaiting">
           <va-icon
             class="submissions__inline-status-icon submissions__card-check"
-            icon="check_circle"
+            icon="loop"
             size="3"
           />
           <span>Awaiting receipt</span>

--- a/src/applications/accredited-representative-portal/sass/SubmissionsPage.scss
+++ b/src/applications/accredited-representative-portal/sass/SubmissionsPage.scss
@@ -63,6 +63,10 @@
   &__awaiting {
     display: flex;
     padding: 0 !important;
+
+    .submissions__inline-status-icon.submissions__card-check {
+      color: $vads-color-base;
+    }
   }
 }
 .submission {


### PR DESCRIPTION
updating icon for "awaiting receipt" on submissions page, see [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114395) 

<img width="654" height="207" alt="Screenshot 2025-07-16 at 2 51 42 PM" src="https://github.com/user-attachments/assets/1400e636-23a8-4c41-8cb4-1550b8499626" />
