### PR TITLE
Creating a cookie-based AuthBroker selector

### DIFF
--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -1,5 +1,7 @@
 import appendQuery from 'append-query';
 
+import { determineAuthBroker } from 'platform/user/authentication/utilities';
+
 export const TOGGLE_FORM_SIGN_IN_MODAL = 'TOGGLE_FORM_SIGN_IN_MODAL';
 export const TOGGLE_LOGIN_MODAL = 'TOGGLE_LOGIN_MODAL';
 export const UPDATE_SEARCH_HELP_USER_MENU = 'UPDATE_SEARCH_HELP_USER_MENU';
@@ -15,15 +17,23 @@ export function toggleLoginModal(
   forceVerification = false,
 ) {
   return async (dispatch, getState) => {
-    const { signInServiceEnabled } = getState()?.featureToggles;
+    const {
+      signInServiceEnabled,
+      cernerNonEligibleSisEnabled,
+    } = getState()?.featureToggles;
 
     const nextParam = new URLSearchParams(window?.location?.search)?.get(
       'next',
     );
+    const authBrokerCookieSelector = determineAuthBroker(
+      cernerNonEligibleSisEnabled,
+    );
+
     const nextQuery = {
       next: nextParam ?? 'loginModal',
       ...(signInServiceEnabled && { oauth: true }),
       ...(forceVerification && { verification: 'required' }),
+      ...(authBrokerCookieSelector && { oauth: true }),
     };
 
     const url = isOpen

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -452,24 +452,37 @@ export const logoutUrl = () => {
   return sessionTypeUrl({ type: POLICY_TYPES.SLO, version: API_VERSION });
 };
 
+/**
+ * @description See https://github.com/department-of-veterans-affairs/identity-documentation/issues/260 for technical diagram
+ * @param {Boolean} cernerNonEligibleSisEnabled feature toggle that controls logic
+ * @returns {Boolean} Returns a boolean to determine AuthBroker
+ */
 export const determineAuthBroker = featureFlagEnabled => {
   if (featureFlagEnabled) {
     const cookieValue = Cookies.get('CERNER_ELIGIBLE');
     const rawCookie = cookieValue?.split('--')[0];
 
-    // If there isn't a rawCookie value
+    /**
+     * @returns false if cookie doesn't exist or if cookie does exist with no value
+     */
     if (!cookieValue || !rawCookie) return false;
 
     const parsedJson = JSON.parse(atob(rawCookie));
     const message = parsedJson?._rails?.message;
 
-    // If there isn't a value in the `message` field
-    if (!['T', 'F']?.includes(message)) return false;
+    /**
+     * @returns false when no message or malformed
+     */
+    if (!message) return false;
 
     const secondDecode = atob(message);
     const parsedCookie = secondDecode?.charAt(2);
 
-    // Refer to: https://github.com/department-of-veterans-affairs/identity-documentation/issues/260
+    /**
+     * @returns false if parsed cookie contains a value other than `T` or `F`
+     */
+    if (!['T', 'F']?.includes(parsedCookie)) return false;
+
     return parsedCookie === 'F';
   }
   return false;

--- a/src/platform/user/tests/authentication/utilities.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.jsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import appendQuery from 'append-query';
-
+import Cookies from 'js-cookie';
 import {
   getLoginAttempted,
   removeLoginAttempted,
@@ -739,6 +739,34 @@ describe('Authentication Utilities', () => {
       expect(() => API_SESSION_URL({})).to.throw(
         'Attempted to call API_SESSION_URL without a type',
       );
+    });
+  });
+
+  describe('determineAuthBroker', () => {
+    const parsedCookieT = `eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaFUiLCJleHAiOiIyMDQ1LTA3LTE2VDE2OjEwOjM0LjY2NFoiLCJwdXIiOiJjb29raWUuQ0VSTkVSX0VMSUdJQkxFIn19--TRUE`;
+    const parsedCookieF = `eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEciLCJleHAiOiIyMDQ1LTA3LTE2VDE2OjAwOjU5LjAxN1oiLCJwdXIiOiJjb29raWUuQ0VSTkVSX0VMSUdJQkxFIn19--FALSE`;
+
+    afterEach(() => {
+      document.cookie = '';
+    });
+
+    it('should return false by default', () => {
+      expect(authUtilities.determineAuthBroker()).to.be.false;
+      expect(authUtilities.determineAuthBroker(false)).to.be.false;
+    });
+
+    it('should return `false` when no cookie is found', () => {
+      expect(authUtilities.determineAuthBroker(true)).to.be.false;
+    });
+
+    it('should return `false` when parsed cookie is `T`', () => {
+      Cookies.set('CERNER_ELIGIBLE', parsedCookieT);
+      expect(authUtilities.determineAuthBroker(true)).to.be.false;
+    });
+
+    it('should return `true` when parsed cookie is `F`', () => {
+      Cookies.set('CERNER_ELIGIBLE', parsedCookieF);
+      expect(authUtilities.determineAuthBroker(true)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR encapsulates the body of work regarding the cookie-based AuthBroker selection. It essentially reads a cookie (created by `vets-api`) that when enabled determines which AuthBroker to use. This will speed up authentication for the wider majority of non-Oracle Health users.

## Related issue(s)

- department-of-veterans-affairs/identity-documentation#524

## Testing done
- Unit testing

## Screenshots
n/a

## What areas of the site does it impact?
This will impact site-wide authentication when the feature toggle is enabled

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
Instructions to test locally
`vets-api`
1. Start up `vets-api`
2. Disable the `sign_in_service_enabled` feature toggle (to mimic production current value)
3. Enable the `cerner_non_eligible_sis_enabled` feature toggle

`vets-website` (there are 2 sets of instructions for simple and real usage)
1. Run `yarn watch`
2. (Simple) Open Chrome DevTools > Application (tab) > Cookies
4. Use the table below to simulate the expected outcome

| Name | Value | Outcome |
| --- | --- | --- |
| `CERNER_ELIGIBLE` | `eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaFUiLCJleHAiOiIyMDQ1LTA3LTE2VDE2OjEwOjM0LjY2NFoiLCJwdXIiOiJjb29raWUuQ0VSTkVSX0VMSUdJQkxFIn19--TRUE` | When I open the Sign-in Modal `oauth=true` IS NOT in the URL bar |
| `CERNER_ELIGIBLE` | `eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEciLCJleHAiOiIyMDQ1LTA3LTE2VDE2OjAwOjU5LjAxN1oiLCJwdXIiOiJjb29raWUuQ0VSTkVSX0VMSUdJQkxFIn19--FALSE` | When I open the Sign-in Modal `oauth=true` IS in the URL bar |
| - | - | When `CERNER_ELIGIBLE` cookie is missing/deleted default to normal non-cookie-based AuthBroker auth mechanism |

5. When `oauth=true` and I click on a credential I see the URL contain `v0/sign_in/authorize`
6. When no `oauth` query parameter and I click on a credential I see the URL contain `v1/sessions/<csp>/new`

(Real)
If you don't feel like pasting in cookie values and want to test for "real" you can update some code in `vets-api` to simulate the full flow

(SSOe check)
1. Start by modifying the [`eligible` variable](https://github.com/department-of-veterans-affairs/vets-api/blob/c1be6ea313bcb1313238288c68814bb92f04e66c/app/controllers/concerns/authentication_and_sso_concerns.rb#L112) to `true` in the `vets-api` repo and start up the Rails server
2. Start up `vets-website` by running `yarn watch` > Navigate to `localhost:3001` > Open Chrome DevTools and delete any `CERNER_ELIGIBLE` cookie that exists
3. With `localhost:3001` up > Click Sign in button to open the modal > Select a credential to authenticate with (ID.me or Login.gov)
4. After you finish authenticating and land back on VA.gov (`localhost:3001`) > Check DevTools to ensure `CERNER_ELIGIBLE` cookie value is present and has a value
5. Logout
6. Open the sign-in modal > Confirm `oauth` query parameter is not present in the URL bar > Try to re-authenticate > Confirm `v1/sessions/<csp>/new` is in the redirect URL

(SiS check)
1. Start by modifying the [`eligible` variable](https://github.com/department-of-veterans-affairs/vets-api/blob/c1be6ea313bcb1313238288c68814bb92f04e66c/app/controllers/concerns/authentication_and_sso_concerns.rb#L112) to `false` in the `vets-api` repo and start up the Rails server
2. Start up `vets-website` by running `yarn watch` > Navigate to `localhost:3001` > Open Chrome DevTools and delete any `CERNER_ELIGIBLE` cookie that exists
3. With `localhost:3001` up > Click Sign in button to open the modal > Select a credential to authenticate with (ID.me or Login.gov)
4. After you finish authenticating and land back on VA.gov (`localhost:3001`) > Check DevTools to ensure `CERNER_ELIGIBLE` cookie value is present and has a value
5. Logout
6. Open the sign-in modal > Confirm `oauth=true` is in the URL bar > Try to re-authenticate > Confirm `v0/sign_in/authorize` is in the redirect URL
