### PR TITLE
[#113822] Travel Pay, Add tool name to useSetPageTitle

### DIFF
--- a/src/applications/travel-pay/hooks/useSetPageTitle.js
+++ b/src/applications/travel-pay/hooks/useSetPageTitle.js
@@ -4,7 +4,7 @@ const useSetPageTitle = title => {
   useEffect(
     () => {
       if (title) {
-        document.title = `${title} | Veterans Affairs`;
+        document.title = `${title} - Travel Pay | Veterans Affairs`;
       }
     },
     [title],

--- a/src/applications/travel-pay/tests/hooks/useSetPageTitle.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/hooks/useSetPageTitle.unit.spec.jsx
@@ -4,7 +4,7 @@ import useSetPageTitle from '../../hooks/useSetPageTitle';
 
 const originalTitle = document.title;
 
-const appendTitle = title => `${title} | Veterans Affairs`;
+const appendTitle = title => `${title} - Travel Pay | Veterans Affairs`;
 
 describe('useSetPageTitle', () => {
   afterEach(() => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding the application name to the hook the Travel Pay team uses to dynamically update the page title based on headings.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/113822

## Testing done

Updated unit tests and local verification of new page title

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1153" height="664" alt="Screenshot 2025-07-17 at 6 57 14 AM" src="https://github.com/user-attachments/assets/c010caec-25ae-4ee1-9456-68a76ea7ef5a" /> | <img width="1167" height="747" alt="Screenshot 2025-07-17 at 6 33 10 AM" src="https://github.com/user-attachments/assets/144f50d1-c7f6-4b85-b92f-e96c974ffd20" /> |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user