### PR TITLE
Rename isInCCPilot to sInPilotUserStation

### DIFF
--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -2,7 +2,7 @@ import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/Pag
 import React from 'react';
 import { Route, Switch, Redirect, useLocation } from 'react-router-dom';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
-import { useIsInCCPilot } from '../referral-appointments/hooks/useIsInCCPilot';
+import { useIsInPilotUserStations } from '../referral-appointments/hooks/useIsInPilotUserStations';
 import ReferralsAndRequests from '../referral-appointments/ReferralsAndRequests';
 import UpcomingAppointmentsDetailsPage from './pages/UpcomingAppointmentsDetailsPage';
 import EpsAppointmentDetailsPage from '../referral-appointments/EpsAppointmentDetailsPage';
@@ -12,7 +12,7 @@ import RequestedAppointmentDetailsPage from './pages/RequestedAppointmentDetails
 function AppointmentListSection() {
   useManualScrollRestoration();
 
-  const { isInCCPilot } = useIsInCCPilot();
+  const { isInPilotUserStations } = useIsInPilotUserStations();
   const location = useLocation();
 
   // Parse the query parameters
@@ -27,14 +27,18 @@ function AppointmentListSection() {
           component={RequestedAppointmentDetailsPage}
         />
 
-        {isInCCPilot && <Redirect from="/pending" to="/referrals-requests" />}
-        {!isInCCPilot && <Redirect from="/referrals-requests" to="/pending" />}
+        {isInPilotUserStations && (
+          <Redirect from="/pending" to="/referrals-requests" />
+        )}
+        {!isInPilotUserStations && (
+          <Redirect from="/referrals-requests" to="/pending" />
+        )}
 
         <Route path="/pending" component={AppointmentsPage} />
-        {isInCCPilot &&
+        {isInPilotUserStations &&
           eps && <Route path="/:id" component={EpsAppointmentDetailsPage} />}
 
-        {isInCCPilot && (
+        {isInPilotUserStations && (
           <Route path="/referrals-requests" component={ReferralsAndRequests} />
         )}
         <Route path="/past/:id" component={UpcomingAppointmentsDetailsPage} />

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.jsx
@@ -16,7 +16,7 @@ import RequestedAppointmentsPage from '../RequestedAppointmentsPage/RequestedApp
 // import { selectPatientFacilities } from '~/platform/user/cerner-dsot/selectors';
 // import ReferralTaskCardWithReferral from '../../../referral-appointments/components/ReferralTaskCardWithReferral';
 import { routeToCCPage } from '../../../referral-appointments/flow';
-import { useIsInCCPilot } from '../../../referral-appointments/hooks/useIsInCCPilot';
+import { useIsInPilotUserStations } from '../../../referral-appointments/hooks/useIsInPilotUserStations';
 import { setFormCurrentPage } from '../../../referral-appointments/redux/actions';
 import AppointmentListNavigation from '../../components/AppointmentListNavigation';
 import PageLayout from '../../components/PageLayout';
@@ -45,7 +45,7 @@ export default function AppointmentsPage() {
   const dispatch = useDispatch();
   const [hasTypeChanged, setHasTypeChanged] = useState(false);
   let [pageTitle] = useState('VA appointments');
-  const { isInCCPilot } = useIsInCCPilot();
+  const { isInPilotUserStations } = useIsInPilotUserStations();
 
   const pendingAppointments = useSelector(state =>
     selectPendingAppointments(state),
@@ -153,7 +153,7 @@ export default function AppointmentsPage() {
       referral id in the url sent to the veteran  */}
       {/* {isInCCPilot && <ReferralTaskCardWithReferral />} */}
 
-      {isInCCPilot && (
+      {isInPilotUserStations && (
         <div
           className={classNames(
             'vads-u-padding-y--3',
@@ -175,7 +175,7 @@ export default function AppointmentsPage() {
         </div>
       )}
       <AppointmentListNavigation
-        hidePendingTab={isInCCPilot}
+        hidePendingTab={isInPilotUserStations}
         count={count}
         callback={setHasTypeChanged}
       />

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -36,7 +36,7 @@ import {
   STARTED_NEW_APPOINTMENT_FLOW,
   STARTED_NEW_VACCINE_FLOW,
 } from '../../redux/sitewide';
-import { getIsInCCPilot } from '../../referral-appointments/utils/pilot';
+import { getIsInPilotUserStations } from '../../referral-appointments/utils/pilot';
 import { fetchHealthcareServiceById } from '../../services/healthcare-service';
 import {
   captureError,
@@ -90,7 +90,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
     const patientFacilities = selectPatientFacilities(state);
 
-    const includeEPS = getIsInCCPilot(
+    const includeEPS = getIsInPilotUserStations(
       featureCCDirectScheduling,
       patientFacilities || [],
     );
@@ -240,7 +240,7 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
     const state = getState();
     const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
     const patientFacilities = selectPatientFacilities(state);
-    const includeEPS = getIsInCCPilot(
+    const includeEPS = getIsInPilotUserStations(
       featureCCDirectScheduling,
       patientFacilities || [],
     );

--- a/src/applications/vaos/redux/actions.js
+++ b/src/applications/vaos/redux/actions.js
@@ -2,7 +2,7 @@
 import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
 import { selectPatientFacilities } from '@department-of-veterans-affairs/platform-user/cerner-dsot/selectors';
 import { addDays, subDays } from 'date-fns';
-import { getIsInCCPilot } from '../referral-appointments/utils/pilot';
+import { getIsInPilotUserStations } from '../referral-appointments/utils/pilot';
 import { getAppointmentRequests } from '../services/appointment';
 import { GA_PREFIX } from '../utils/constants';
 import { captureError } from '../utils/error';
@@ -40,7 +40,7 @@ export function fetchPendingAppointments() {
       const state = getState();
       const featureCCDirectScheduling = selectFeatureCCDirectScheduling(state);
       const patientFacilities = selectPatientFacilities(state);
-      const includeEPS = getIsInCCPilot(
+      const includeEPS = getIsInPilotUserStations(
         featureCCDirectScheduling,
         patientFacilities || [],
       );

--- a/src/applications/vaos/referral-appointments/hooks/useIsInPilotUserStations.jsx
+++ b/src/applications/vaos/referral-appointments/hooks/useIsInPilotUserStations.jsx
@@ -1,22 +1,22 @@
 import { useSelector } from 'react-redux';
 import { selectPatientFacilities } from '@department-of-veterans-affairs/platform-user/cerner-dsot/selectors';
 import { selectFeatureCCDirectScheduling } from '../../redux/selectors';
-import { getIsInCCPilot } from '../utils/pilot';
+import { getIsInPilotUserStations } from '../utils/pilot';
 
 const emptyPatientFacilities = [];
 
-const useIsInCCPilot = () => {
+const useIsInPilotUserStations = () => {
   const featureCCDirectScheduling = useSelector(
     selectFeatureCCDirectScheduling,
   );
   const patientFacilities = useSelector(selectPatientFacilities);
 
   return {
-    isInCCPilot: getIsInCCPilot(
+    isInPilotUserStations: getIsInPilotUserStations(
       featureCCDirectScheduling,
       patientFacilities || emptyPatientFacilities,
     ),
   };
 };
 
-export { useIsInCCPilot };
+export { useIsInPilotUserStations };

--- a/src/applications/vaos/referral-appointments/index.jsx
+++ b/src/applications/vaos/referral-appointments/index.jsx
@@ -10,7 +10,7 @@ import ScheduleReferral from './ScheduleReferral';
 import ReviewAndConfirm from './ReviewAndConfirm';
 import ChooseDateAndTime from './ChooseDateAndTime';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
-import { useIsInCCPilot } from './hooks/useIsInCCPilot';
+import { useIsInPilotUserStations } from './hooks/useIsInPilotUserStations';
 import CompleteReferral from './CompleteReferral';
 import ReferralLayout from './components/ReferralLayout';
 import { useGetReferralByIdQuery } from '../redux/api/vaosApi';
@@ -18,7 +18,7 @@ import { useGetReferralByIdQuery } from '../redux/api/vaosApi';
 export default function ReferralAppointments() {
   useManualScrollRestoration();
   const basePath = useRouteMatch();
-  const { isInCCPilot } = useIsInCCPilot();
+  const { isInPilotUserStations } = useIsInPilotUserStations();
   const { search } = useLocation();
   const params = new URLSearchParams(search);
   const id = params.get('id');
@@ -30,7 +30,7 @@ export default function ReferralAppointments() {
     return <Redirect to="/referrals-requests" />;
   }
 
-  if (!isInCCPilot) {
+  if (!isInPilotUserStations) {
     return <Redirect from={basePath.url} to="/" />;
   }
 

--- a/src/applications/vaos/referral-appointments/index.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/index.unit.spec.jsx
@@ -8,7 +8,7 @@ import { renderWithStoreAndRouter } from '../tests/mocks/setup';
 import { FETCH_STATUS } from '../utils/constants';
 import { createReferrals, createReferralById } from './utils/referrals';
 import * as useManualScrollRestoration from '../hooks/useManualScrollRestoration';
-import * as useIsInCCPilot from './hooks/useIsInCCPilot';
+import * as useIsInPilotUserStations from './hooks/useIsInPilotUserStations';
 import * as vaosApi from '../redux/api/vaosApi';
 
 const initialStateVAOSService = {
@@ -31,8 +31,8 @@ describe('ReferralAppointments', () => {
       isLoading: false,
     });
     sandbox.stub(useManualScrollRestoration, 'default');
-    sandbox.stub(useIsInCCPilot, 'useIsInCCPilot').returns({
-      isInCCPilot: true,
+    sandbox.stub(useIsInPilotUserStations, 'useIsInPilotUserStations').returns({
+      isInPilotUserStations: true,
     });
   });
 

--- a/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/TestComponent.jsx
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/TestComponent.jsx
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 import React from 'react';
-import { useIsInCCPilot } from '../../../hooks/useIsInCCPilot';
+import { useIsInPilotUserStations } from '../../../hooks/useIsInPilotUserStations';
 
 export default function TestComponent() {
-  const { isInCCPilot } = useIsInCCPilot();
+  const { isInPilotUserStations } = useIsInPilotUserStations();
   return (
     <div>
       <p>Test component</p>
-      <p data-testid="pilot-value">{isInCCPilot.toString()}</p>
+      <p data-testid="pilot-value">{isInPilotUserStations.toString()}</p>
     </div>
   );
 }

--- a/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/useIsInPilotUserStations.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/tests/hooks/useIsInCCPilot/useIsInPilotUserStations.unit.spec.jsx
@@ -7,20 +7,20 @@ import * as pilotUtils from '../../../utils/pilot';
 import TestComponent from './TestComponent';
 
 describe('Community Care Referrals', () => {
-  describe('useIsInCCPilot hook', () => {
+  describe('useIsInPilotUserStations hook', () => {
     const sandbox = sinon.createSandbox();
 
     afterEach(() => {
       sandbox.restore();
     });
 
-    it('Returns true when getIsInCCPilot is true', () => {
-      sandbox.stub(pilotUtils, 'getIsInCCPilot').returns(true);
+    it('Returns true when getIsInPilotUserStations is true', () => {
+      sandbox.stub(pilotUtils, 'getIsInPilotUserStations').returns(true);
       const screen = renderWithStoreAndRouter(<TestComponent />, {});
       expect(screen.getByTestId('pilot-value')).to.have.text('true');
     });
-    it('Returns false when getIsInCCPilot is false', () => {
-      sandbox.stub(pilotUtils, 'getIsInCCPilot').returns(false);
+    it('Returns false when getIsInPilotUserStations is false', () => {
+      sandbox.stub(pilotUtils, 'getIsInPilotUserStations').returns(false);
       const screen = renderWithStoreAndRouter(<TestComponent />, {});
       expect(screen.getByTestId('pilot-value')).to.have.text('false');
     });

--- a/src/applications/vaos/referral-appointments/tests/utils/pilot.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/tests/utils/pilot.unit.spec.jsx
@@ -1,27 +1,36 @@
 import { expect } from 'chai';
-import { getIsInCCPilot } from '../../utils/pilot';
+import { getIsInPilotUserStations } from '../../utils/pilot';
 
 describe('VAOS CC pilot utils', () => {
-  describe('getIsInCCPilot', () => {
+  describe('getIsInPilotUserStations', () => {
     it('Returns false when the user has a facility within the pilot list but the feature is off', () => {
-      expect(getIsInCCPilot(false)).to.be.false;
+      expect(getIsInPilotUserStations(false)).to.be.false;
     });
     it('should return false if patientFacilities is empty', () => {
-      expect(getIsInCCPilot(true, [])).to.be.false;
+      expect(getIsInPilotUserStations(true, [])).to.be.false;
     });
     it('Returns false when the user has no facilities in the pilot list', () => {
       expect(
-        getIsInCCPilot(true, [{ facilityId: '123' }, { facilityId: '456' }]),
+        getIsInPilotUserStations(true, [
+          { facilityId: '123' },
+          { facilityId: '456' },
+        ]),
       ).to.be.false;
     });
     it('Returns true when the user has a facility within the pilot list', () => {
       expect(
-        getIsInCCPilot(true, [{ facilityId: '123' }, { facilityId: '984' }]),
+        getIsInPilotUserStations(true, [
+          { facilityId: '123' },
+          { facilityId: '984' },
+        ]),
       ).to.be.true;
     });
     it('Returns true when the user has a facility within the pilot list as well as some outside', () => {
       expect(
-        getIsInCCPilot(true, [{ facilityId: '659' }, { facilityId: '400' }]),
+        getIsInPilotUserStations(true, [
+          { facilityId: '659' },
+          { facilityId: '400' },
+        ]),
       ).to.be.true;
     });
   });

--- a/src/applications/vaos/referral-appointments/utils/pilot.js
+++ b/src/applications/vaos/referral-appointments/utils/pilot.js
@@ -1,11 +1,14 @@
 /**
- * Determines if a patient is in the Community Care (CC) pilot program.
+ * Determines if a patient is in the Community Care (CC) pilot program user station.
  *
  * @param {boolean} featureCCDirectScheduling - Flag indicating if the CC direct scheduling feature is enabled.
  * @param {Array<{ facilityId: string }>} patientFacilities - Array of patient facilities with their IDs.
- * @returns {boolean} - Returns true if the patient is in the CC pilot program, otherwise false.
+ * @returns {boolean} - Returns true if the patient is in the CC pilot program user station, otherwise false.
  */
-const getIsInCCPilot = (featureCCDirectScheduling, patientFacilities = []) => {
+const getIsInPilotUserStations = (
+  featureCCDirectScheduling,
+  patientFacilities = [],
+) => {
   const stagingStations = ['984', '983'];
   const prodStations = ['659', '657'];
   const pilotStations = [...stagingStations, ...prodStations];
@@ -39,4 +42,4 @@ const getIsInPilotReferralStation = referral => {
   return validStationIds.includes(referral.stationId);
 };
 
-export { getIsInCCPilot, getIsInPilotReferralStation };
+export { getIsInPilotUserStations, getIsInPilotReferralStation };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Changes isInCCPilot to isInPilotUserStation functions and hooks.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114602

## Testing done

- Updated tests to use the new function names.
- Reran tests to make sure everything still worked. 


## Screenshots

N/A just renaming functions.

## What areas of the site does it impact?

Vaos referral section of the site.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A