### PR TITLE
Added New CTA-Widget Tests to Complete Code Coverage

### DIFF
--- a/src/applications/static-pages/cta-widget/components/CallToActionAlert.jsx
+++ b/src/applications/static-pages/cta-widget/components/CallToActionAlert.jsx
@@ -53,9 +53,3 @@ CallToActionAlert.propTypes = {
   secondaryButtonText: PropTypes.string,
   status: PropTypes.string,
 };
-
-CallToActionAlert.defaultProps = {
-  headerLevel: 3,
-  ariaDescribedby: null,
-  ariaLabel: null,
-};

--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -4,9 +4,9 @@ import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNa
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { getAppUrl } from '~/platform/utilities/registry-helpers';
 
-const viewDependentsUrl = getAppUrl('dependents-view-dependents');
+export const viewDependentsUrl = getAppUrl('dependents-view-dependents');
 
-const disabilityBenefitsUrls = {
+export const disabilityBenefitsUrls = {
   '686c': getAppUrl('686C-674'),
   'view-payments': getAppUrl('view-payments'),
 };
@@ -121,6 +121,30 @@ export const ctaWidgetsLookup = {
     mhvToolName: null,
     requiredServices: null,
     serviceDescription: 'view your VA disability rating',
+  },
+  [CTA_WIDGET_TYPES.EDUCATION_LETTERS]: {
+    id: CTA_WIDGET_TYPES.EDUCATION_LETTERS,
+    deriveToolUrlDetails: () => ({
+      url: 'education/download-letters',
+      redirect: false,
+    }),
+    hasRequiredMhvAccount: () => false,
+    isHealthTool: false,
+    mhvToolName: null,
+    requiredServices: null,
+    serviceDescription: 'check your VA education letter',
+  },
+  [CTA_WIDGET_TYPES.ENROLLMENT_VERIFICATION]: {
+    id: CTA_WIDGET_TYPES.ENROLLMENT_VERIFICATION,
+    deriveToolUrlDetails: () => ({
+      url: 'education/verify-school-enrollment',
+      redirect: false,
+    }),
+    hasRequiredMhvAccount: () => false,
+    isHealthTool: false,
+    mhvToolName: null,
+    requiredServices: null,
+    serviceDescription: 'verify your school enrollment',
   },
   [CTA_WIDGET_TYPES.GI_BILL_BENEFITS]: {
     id: CTA_WIDGET_TYPES.GI_BILL_BENEFITS,
@@ -267,29 +291,5 @@ export const ctaWidgetsLookup = {
     mhvToolName: null,
     requiredServices: null,
     serviceDescription: 'view your VA payment history',
-  },
-  [CTA_WIDGET_TYPES.EDUCATION_LETTERS]: {
-    id: CTA_WIDGET_TYPES.EDUCATION_LETTERS,
-    deriveToolUrlDetails: () => ({
-      url: 'education/download-letters',
-      redirect: false,
-    }),
-    hasRequiredMhvAccount: () => false,
-    isHealthTool: false,
-    mhvToolName: null,
-    requiredServices: null,
-    serviceDescription: 'check your VA education letter',
-  },
-  [CTA_WIDGET_TYPES.ENROLLMENT_VERIFICATION]: {
-    id: CTA_WIDGET_TYPES.ENROLLMENT_VERIFICATION,
-    deriveToolUrlDetails: () => ({
-      url: 'education/verify-school-enrollment',
-      redirect: false,
-    }),
-    hasRequiredMhvAccount: () => false,
-    isHealthTool: false,
-    mhvToolName: null,
-    requiredServices: null,
-    serviceDescription: 'verify your school enrollment',
   },
 };

--- a/src/applications/static-pages/cta-widget/tests/components/messages/ChangeAddress.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/components/messages/ChangeAddress.unit.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import sinon from 'sinon';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import ChangeAddress from '../../../components/messages/ChangeAddress';
+
+describe('ChangeAddress', () => {
+  it('should call dispatch on button click', () => {
+    const mockStore = {
+      dispatch: sinon.spy(),
+      getState: () => ({}),
+      subscribe: () => {},
+    };
+    const { container } = render(
+      <Provider store={mockStore}>
+        <ChangeAddress />
+      </Provider>,
+    );
+    const button = container.querySelector('va-button');
+    expect(button).to.exist;
+    userEvent.click(button);
+    expect(mockStore.dispatch.calledOnce).to.be.true;
+  });
+});

--- a/src/applications/static-pages/cta-widget/tests/components/messages/DirectDeposit.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/components/messages/DirectDeposit.unit.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import sinon from 'sinon';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import DirectDeposit from '../../../components/messages/DirectDeposit';
+
+describe('DirectDeposit', () => {
+  it('should call dispatch on button click', () => {
+    const mockStore = {
+      dispatch: sinon.spy(),
+      getState: () => ({}),
+      subscribe: () => {},
+    };
+    const { container } = render(
+      <Provider store={mockStore}>
+        <DirectDeposit />
+      </Provider>,
+    );
+    const button = container.querySelector('va-button');
+    expect(button).to.exist;
+    userEvent.click(button);
+    expect(mockStore.dispatch.calledOnce).to.be.true;
+  });
+});

--- a/src/applications/static-pages/cta-widget/tests/components/messages/DirectDeposit/Unauthed.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/components/messages/DirectDeposit/Unauthed.unit.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import sinon from 'sinon';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import Unauthed from '../../../../components/messages/DirectDeposit/Unauthed';
+
+describe('Unauthed', () => {
+  it('should dispatch on button click', () => {
+    const mockStore = {
+      dispatch: sinon.spy(),
+      getState: () => ({}),
+      subscribe: () => {},
+    };
+    const { container } = render(
+      <Provider store={mockStore}>
+        <Unauthed />
+      </Provider>,
+    );
+    const button = container.querySelector('va-button');
+    expect(button).to.exist;
+    userEvent.click(button);
+    expect(mockStore.dispatch.calledOnce).to.be.true;
+  });
+});

--- a/src/applications/static-pages/cta-widget/tests/components/messages/SignIn.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/components/messages/SignIn.unit.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import sinon from 'sinon';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import SignIn from '../../../components/messages/SignIn';
+
+describe('SignIn', () => {
+  it('should call dispatch on button click', () => {
+    const mockStore = {
+      dispatch: sinon.spy(),
+      getState: () => ({}),
+      subscribe: () => {},
+    };
+    const { container } = render(
+      <Provider store={mockStore}>
+        <SignIn />
+      </Provider>,
+    );
+    const button = container.querySelector('va-button');
+    expect(button).to.exist;
+    userEvent.click(button);
+    expect(mockStore.dispatch.calledOnce).to.be.true;
+  });
+});

--- a/src/applications/static-pages/cta-widget/tests/components/messages/VAOnlineScheduling.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/components/messages/VAOnlineScheduling.unit.spec.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import VAOnlineScheduling from '../../../components/messages/VAOnlineScheduling';
+
+describe('VAOnlineScheduling', () => {
+  it('should redirect to appointments on button click', () => {
+    const { container } = render(
+      <VAOnlineScheduling
+        featureToggles={{ vaOnlineSchedulingCommunityCare: true }}
+      />,
+    );
+    const button = container.querySelector('va-button');
+    expect(button).to.exist;
+    userEvent.click(button);
+    const location = window.location.href || window.location;
+    expect(location).to.include('/my-health/appointments');
+  });
+});

--- a/src/applications/static-pages/cta-widget/tests/components/messages/Verify.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/components/messages/Verify.unit.spec.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import Verify from '../../../components/messages/Verify';
+
+describe('Verify', () => {
+  it('should render VaAlertSignIn with a null variant when no props are passed', () => {
+    const { container } = render(<Verify />);
+    const alert = container.querySelector('va-alert-sign-in');
+    expect(alert).to.exist;
+    expect(alert.getAttribute('variant')).to.be.null;
+  });
+});

--- a/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.jsx
+++ b/src/applications/static-pages/cta-widget/tests/ctaWidgets.unit.spec.jsx
@@ -1,0 +1,202 @@
+import { expect } from 'chai';
+import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
+import {
+  CTA_WIDGET_TYPES,
+  ctaWidgetsLookup,
+  disabilityBenefitsUrls,
+  viewDependentsUrl,
+} from '../ctaWidgets';
+
+describe('ctaWidgetsLookup', () => {
+  it('should return the appropriate tool url and correct MHV account info for ADD_REMOVE_DEPENDENTS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.ADD_REMOVE_DEPENDENTS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: disabilityBenefitsUrls['686c'],
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for CHANGE_ADDRESS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.CHANGE_ADDRESS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/profile/contact-information',
+      redirect: true,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for CLAIMS_AND_APPEALS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.CLAIMS_AND_APPEALS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/track-claims/',
+      redirect: true,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for COMBINED_DEBT_PORTAL', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.COMBINED_DEBT_PORTAL];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/manage-va-debt/summary',
+      redirect: true,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for DIRECT_DEPOSIT', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.DIRECT_DEPOSIT];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/profile/direct-deposit',
+      redirect: true,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for DISABILITY_BENEFITS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.DISABILITY_BENEFITS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/disability/how-to-file-claim',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for DISABILITY_RATINGS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.DISABILITY_RATINGS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/disability/view-disability-rating/rating',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for GI_BILL_BENEFITS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.GI_BILL_BENEFITS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/education/check-remaining-post-9-11-gi-bill-benefits/status',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for HA_CPAP_SUPPLIES', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.HA_CPAP_SUPPLIES];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/health-care/order-hearing-aid-or-CPAP-supplies-form',
+      redirect: true,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for HEARING_AID_SUPPLIES', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.HEARING_AID_SUPPLIES];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/health-care/order-hearing-aid-or-CPAP-supplies-form',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for HOME_LOAN_COE_STATUS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.HOME_LOAN_COE_STATUS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/housing-assistance/home-loans/check-coe-status/your-coe/',
+      redirect: true,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for LETTERS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.LETTERS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/records/download-va-letters/letters',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for MANAGE_VA_DEBT', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.MANAGE_VA_DEBT];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/manage-va-debt/summary/debt-balances',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for SCHEDULE_APPOINTMENTS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.SCHEDULE_APPOINTMENTS];
+    expect(ctaWidget.deriveToolUrlDetails(true)).to.eql({
+      url: mhvUrl(true, 'appointments'),
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount('Premium')).to.be.true;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for UPDATE_HEALTH_BENEFITS_INFO', () => {
+    const ctaWidget =
+      ctaWidgetsLookup[CTA_WIDGET_TYPES.UPDATE_HEALTH_BENEFITS_INFO];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/my-health/update-benefits-information-form-10-10ezr',
+      redirect: true,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for VETERAN_ID_CARD', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.VETERAN_ID_CARD];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: '/records/get-veteran-id-cards/apply',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for VET_TEC', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.VET_TEC];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url:
+        '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for VIEW_DEPENDENTS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.VIEW_DEPENDENTS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: viewDependentsUrl,
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for VIEW_PAYMENT_HISTORY', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.VIEW_PAYMENT_HISTORY];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: disabilityBenefitsUrls['view-payments'],
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for EDUCATION_LETTERS', () => {
+    const ctaWidget = ctaWidgetsLookup[CTA_WIDGET_TYPES.EDUCATION_LETTERS];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: 'education/download-letters',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+
+  it('should return the appropriate tool url and correct MHV account info for ENROLLMENT_VERIFICATION', () => {
+    const ctaWidget =
+      ctaWidgetsLookup[CTA_WIDGET_TYPES.ENROLLMENT_VERIFICATION];
+    expect(ctaWidget.deriveToolUrlDetails()).to.eql({
+      url: 'education/verify-school-enrollment',
+      redirect: false,
+    });
+    expect(ctaWidget.hasRequiredMhvAccount()).to.be.false;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Added new CTA-Widget tests to meet minimum code coverage standards. Also updated `ctaWidgets.js` and `CallToActionAlert.jsx` to make testing easier.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/429)

## Testing done
- Updated and added tests. Ran tests locally to ensure proper code coverage and no breaking changes.
- Can be replicated by running `yarn test:coverage-app static-pages/cta-widget`.

## What areas of the site does it impact?
This only impacts the CTA-Widget and its related tests.

## Acceptance criteria
- [x] Test are added that bring code coverage to 80-100%
- [x] No breaking changes