### PR TITLE
EZR: Consolidates contacts feature flags into one flag

### DIFF
--- a/src/applications/ezr/config/form.js
+++ b/src/applications/ezr/config/form.js
@@ -22,7 +22,6 @@ import {
   includeOtherExposureDates,
   includeOtherExposureDetails,
   isEmergencyContactsEnabled,
-  isNextOfKinEnabled,
   showFinancialStatusAlert,
   spouseDidNotCohabitateWithVeteran,
   spouseAddressDoesNotMatchVeterans,
@@ -227,15 +226,15 @@ const formConfig = {
         },
         nextOfKinSummary: {
           ...nextOfKinPages.nextOfKinSummary,
-          depends: isNextOfKinEnabled,
+          depends: isEmergencyContactsEnabled,
         },
         nextOfKinPage: {
           ...nextOfKinPages.nextOfKinPage,
-          depends: isNextOfKinEnabled,
+          depends: isEmergencyContactsEnabled,
         },
         nextOfKinAddressPage: {
           ...nextOfKinPages.nextOfKinAddressPage,
-          depends: isNextOfKinEnabled,
+          depends: isEmergencyContactsEnabled,
         },
         /** NOTE: this page needs to live in the "Veteran Info" section to avoid
          * having an empty/inactive "Household Info" accordion on the review page

--- a/src/applications/ezr/containers/App.jsx
+++ b/src/applications/ezr/containers/App.jsx
@@ -28,7 +28,6 @@ const App = props => {
     loading: isLoadingFeatures,
     isProdEnabled,
     isEmergencyContactsEnabled,
-    isNextOfKinEnabled,
     isProvidersAndDependentsPrefillEnabled,
     isDownloadPdfEnabled,
   } = features;
@@ -69,7 +68,6 @@ const App = props => {
           'view:userDob': parseVeteranDob(veteranDateOfBirth),
           'view:householdEnabled': !!canSubmitFinancialInfo,
           'view:isEmergencyContactsEnabled': !!isEmergencyContactsEnabled,
-          'view:isNextOfKinEnabled': !!isNextOfKinEnabled,
           'view:isProvidersAndDependentsPrefillEnabled': !!isProvidersAndDependentsPrefillEnabled,
           'view:isDownloadPdfEnabled': !!isDownloadPdfEnabled,
         };
@@ -124,7 +122,6 @@ const mapStateToProps = state => ({
     isProdEnabled: state.featureToggles.ezrProdEnabled,
     isEmergencyContactsEnabled:
       state.featureToggles.ezrEmergencyContactsEnabled,
-    isNextOfKinEnabled: state.featureToggles.ezrNextOfKinEnabled,
     isProvidersAndDependentsPrefillEnabled:
       state.featureToggles.ezrProvidersAndDependentsPrefillEnabled,
     isDownloadPdfEnabled: state.featureToggles.ezrDownloadPdfEnabled,

--- a/src/applications/ezr/tests/unit/utils/selectors/feature-toggles.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/utils/selectors/feature-toggles.unit.spec.jsx
@@ -7,8 +7,7 @@ describe('ezr FeatureToggles selector', () => {
       /* eslint-disable camelcase */
       hca_browser_monitoring_enabled: true,
       ezr_upload_enabled: true,
-      ezr_emergency_contacts_enabled: true,
-      ezr_next_of_kin_enabled: true,
+      ezr_associations_api_enabled: true,
       loading: false,
     },
   };

--- a/src/applications/ezr/tests/unit/utils/selectors/feature-toggles.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/utils/selectors/feature-toggles.unit.spec.jsx
@@ -7,7 +7,7 @@ describe('ezr FeatureToggles selector', () => {
       /* eslint-disable camelcase */
       hca_browser_monitoring_enabled: true,
       ezr_upload_enabled: true,
-      ezr_associations_api_enabled: true,
+      ezr_emergency_contacts_enabled: true,
       loading: false,
     },
   };
@@ -20,7 +20,6 @@ describe('ezr FeatureToggles selector', () => {
         isBrowserMonitoringEnabled: true,
         isUploadEnabled: true,
         isEmergencyContactsEnabled: true,
-        isNextOfKinEnabled: true,
       });
     });
   });

--- a/src/applications/ezr/utils/helpers/form-config.js
+++ b/src/applications/ezr/utils/helpers/form-config.js
@@ -29,15 +29,6 @@ export function isEmergencyContactsEnabled(formData) {
 }
 
 /**
- * Helper that determines if next of kin is enabled
- * @param {Object} formData - the current data object passed from the form
- * @returns {Boolean} - true if the viewfield is empty
- */
-export function isNextOfKinEnabled(formData) {
-  return formData['view:isNextOfKinEnabled'];
-}
-
-/**
  * Helper that determines if the Veteran's home and mailing address are the same
  * @param {Object} formData - the current data object passed from the form
  * @returns {Boolean} - true if the viewfield is set to `false`

--- a/src/applications/ezr/utils/selectors/feature-toggles.js
+++ b/src/applications/ezr/utils/selectors/feature-toggles.js
@@ -10,10 +10,10 @@ const selectFeatureToggles = createSelector(
     ],
     isUploadEnabled: toggleValues(state)[FEATURE_FLAG_NAMES.ezrUploadEnabled],
     isEmergencyContactsEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.ezrEmergencyContactsEnabled
+      FEATURE_FLAG_NAMES.ezrAssociationsApiEnabled
     ],
     isNextOfKinEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.ezrNextOfKinEnabled
+      FEATURE_FLAG_NAMES.ezrAssociationsApiEnabled
     ],
   }),
   toggles => toggles,

--- a/src/applications/ezr/utils/selectors/feature-toggles.js
+++ b/src/applications/ezr/utils/selectors/feature-toggles.js
@@ -10,10 +10,7 @@ const selectFeatureToggles = createSelector(
     ],
     isUploadEnabled: toggleValues(state)[FEATURE_FLAG_NAMES.ezrUploadEnabled],
     isEmergencyContactsEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.ezrAssociationsApiEnabled
-    ],
-    isNextOfKinEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.ezrAssociationsApiEnabled
+      FEATURE_FLAG_NAMES.ezrEmergencyContactsEnabled
     ],
   }),
   toggles => toggles,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Consolidated the 4 feature flags into one flag `ezr_emergency_contacts_enabled`

## Related issue(s)

department-of-veterans-affairs/va.gov-team#113267

## Testing done

Unit and e2e specs pass

## What areas of the site does it impact?

Form 10-10 EZR

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

The emergency contacts and next of kin feature will be controlled by one flag `ezr_emergency_contacts_enabled`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
