### PR TITLE
113732 - Fix optional file overview titles showing up on 10-10d confirmation page - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -10,7 +10,7 @@ import {
   VaLinkAction,
   VaTelephone,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { REQUIRED_FILES, OPTIONAL_FILES } from '../config/constants';
+import { REQUIRED_FILES } from '../config/constants';
 import MissingFileOverview from '../../shared/components/fileUploads/MissingFileOverview';
 import {
   ConfirmationPagePropTypes,
@@ -39,13 +39,6 @@ const requiredWarningHeading = (
       We can’t review your application until we receive copies of these
       documents.
     </p>
-  </>
-);
-
-const optionalWarningHeading = (
-  <>
-    {heading}
-    <p>You can still send us these optional documents for faster processing:</p>
   </>
 );
 
@@ -80,13 +73,13 @@ export function ConfirmationPage(props) {
     heading,
     showRequirementHeaders: false,
     requiredDescription: '',
-    optionalWarningHeading: <>{optionalWarningHeading}</>,
     requiredWarningHeading: <>{requiredWarningHeading}</>,
+    dropUploaded: true,
     showMail: true,
     mailPreamble,
     faxNum: CHAMPVA_FAX_NUMBER,
     allPages: form.pages,
-    fileNameMap: { ...REQUIRED_FILES, ...OPTIONAL_FILES },
+    fileNameMap: { ...REQUIRED_FILES },
     requiredFiles: REQUIRED_FILES,
   });
 

--- a/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
+++ b/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
@@ -166,6 +166,7 @@ export function checkFlags(pages, person, newListOfMissingFiles) {
  * @param {JSX.Element} param0.mailPreamble - Optional content to display above mailing address
  * @param {string} param0.officeName - Name of office to mail documents to
  * @param {string} param0.faxNum - Number where documents can be faxed
+ * @param {boolean} param0.dropUploaded- (optional) passed to hasReq to ignore files where uploaded=true. If not present, value of `showConsent` is passed to hasReq as analogue for `dropUploaded`.
  * @param {boolean} param0.showConsent - control whether the "Consent to Mail Missing Documents" checkbox is added to the page
  * @param {object} param0.allPages - all formConfig page objects (if not provided, we fall back to form page data stored in `contentAfterButtons`)
  * @param {object} param0.fileNameMap - object with formConfig keys for all possible files (required and optional) mapped to a user-friendly string (e.g., `{schoolCert: 'School Certificate'}`). This should be a superset containing `requiredFiles`
@@ -194,6 +195,7 @@ export default function MissingFileOverview({
   officeName,
   requiredDescription,
   faxNum,
+  dropUploaded,
   showConsent,
   allPages,
   fileNameMap,
@@ -208,6 +210,10 @@ export default function MissingFileOverview({
   const [isChecked, setIsChecked] = useState(
     data?.consentToMailMissingRequiredFiles || false,
   );
+  // preserve backwards compat with existing usage of `showConsent` as an
+  // analogue for `dropUploaded`, while now allowing explicit usage of
+  // dropUploaded in main config.
+  const drop = dropUploaded ?? showConsent;
   const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
   const chapters = contentAfterButtons?.props?.formConfig?.chapters;
   const verifier = new SupportingDocsVerification(requiredFiles);
@@ -266,11 +272,11 @@ export default function MissingFileOverview({
   };
 
   const requiredFilesStillMissing =
-    hasReq(sponsorMiss, true, showConsent) ||
-    hasReq(applicantsWithMissingFiles, true, showConsent);
+    hasReq(sponsorMiss, true, drop) ||
+    hasReq(applicantsWithMissingFiles, true, drop);
 
   const optionalFilesStillMissing =
-    hasReq(sponsorMiss, false, showConsent) || hasReq(apps, false, showConsent);
+    hasReq(sponsorMiss, false, drop) || hasReq(apps, false, drop);
 
   const filesAreMissing =
     requiredFilesStillMissing || optionalFilesStillMissing;
@@ -336,7 +342,7 @@ export default function MissingFileOverview({
 
       {filesAreMissing ? (
         <>
-          {hasReq(sponsorMiss, true, showConsent) ? (
+          {hasReq(sponsorMiss, true, drop) ? (
             <MissingFileList
               data={sponsorMiss}
               nameKey={nonListNameKey ?? 'name'}
@@ -349,7 +355,7 @@ export default function MissingFileOverview({
               showFileBullets={sfb}
             />
           ) : null}
-          {hasReq(apps, true, showConsent) ? (
+          {hasReq(apps, true, drop) ? (
             <MissingFileList
               data={apps}
               nameKey={listNameKey ?? 'applicantName'}
@@ -404,6 +410,7 @@ MissingFileOverview.propTypes = {
   contentAfterButtons: PropTypes.object,
   data: PropTypes.object,
   disableLinks: PropTypes.bool,
+  dropUploaded: PropTypes.bool,
   faxNum: PropTypes.string,
   fileNameMap: PropTypes.object,
   goBack: PropTypes.func,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes a visual bug where the missing file overview component was displaying applicant names (typically accompanied by a list of files still needed) on the confirmation page despite there not being any files left to upload.

This bug came from a poor configuration design in the component itself. The fix was to introduce a boolean that explicitly controls this portion of the display (previously it was relying on another parameter that wasn't directly meant to be responsible for controlling this behavior, so it introduced an edge case on the confirmation page). More in this [comment](https://github.com/department-of-veterans-affairs/vets-website/pull/37814#discussion_r2216358687).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113732

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="1974" height="1582" alt="before" src="https://github.com/user-attachments/assets/5cb05cfd-1ae9-4a0c-9a9c-58df8a99065d" />|<img width="760" height="576" alt="Screenshot 2025-07-17 at 21 57 37" src="https://github.com/user-attachments/assets/79b1ef5a-2087-41f6-a2b9-8c8069a781e1" />|

## What areas of the site does it impact?

IVC CHAMPVA form 10-10d

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
