### PR TITLE
Update constants for myVA 0538 in progress/draft card

### DIFF
--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -716,8 +716,8 @@ export const MY_VA_SIP_FORMS = [
   {
     id: VA_FORM_IDS.FORM_21_0538,
     benefit: 'verifying your dependents for disability benefits',
-    title: '21-0538 Dependents Verification',
-    description: 'dependent-benefits',
+    title: 'verifying your dependents for disability benefits (21-0538)',
+    description: 'verifying your dependents for disability benefits (21-0538)',
     trackingPrefix: '0538-dependents-verification-',
   },
   {

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -191,7 +191,9 @@ export const getAllFormLinks = getAppUrlImpl => {
     [VA_FORM_IDS.FORM_1330M]: `${tryGetAppUrl('1330M')}/`,
     [VA_FORM_IDS.FORM_22_10216]: `${tryGetAppUrl('10216-edu-benefits')}/`,
     [VA_FORM_IDS.FORM_10_10D_EXTENDED]: `${tryGetAppUrl('10-10D-EXTENDED')}/`,
-    [VA_FORM_IDS.FORM_21_0538]: `${tryGetAppUrl('21-0538')}/`,
+    [VA_FORM_IDS.FORM_21_0538]: `${tryGetAppUrl(
+      '0538-dependents-verification',
+    )}/`,
     [VA_FORM_IDS.FORM_22_10297]: `${tryGetAppUrl('22-10297')}/`,
   };
 };
@@ -713,8 +715,8 @@ export const MY_VA_SIP_FORMS = [
   },
   {
     id: VA_FORM_IDS.FORM_21_0538,
-    benefit: 'dependent-benefits',
-    title: '21-0538 Dependents verification',
+    benefit: 'verifying your dependents for disability benefits',
+    title: '21-0538 Dependents Verification',
     description: 'dependent-benefits',
     trackingPrefix: '0538-dependents-verification-',
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
 > Updated 21-0538 constants for MyVA profile 'draft'/'in-progress' card for router link and title
- _(If bug, how to reproduce)_
 > Start a 21-0538 form, navigate to MyVA profile, click 'Continue Your Application'
- _(What is the solution, why is this the solution)_
 > Needed to update to correct `entryName` per dependents verification `manifest.json` so that [registry_helper](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/utilities/registry-helpers.js#L13) can correctly locate the url
- _(Which team do you work for, does your team own the maintenance of this component?)_
 > Benefits Lifestages / Dependents Management
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113270

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| MyVA Card | <img width="680" height="255" alt="before-myVA-profile-card" src="https://github.com/user-attachments/assets/319aa8c7-13a6-49e2-940d-1d534b8c8b88" /> | <img width="680" height="255" alt="Screenshot 2025-07-17 at 3 00 27 PM" src="https://github.com/user-attachments/assets/8391aaeb-2a6b-4e9c-97e5-dde1fa350678" /> |


## What areas of the site does it impact?

Dependents Verification Form (21-0538) 'draft' card on MyVA profile

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

