### PR TITLE
113830: Fix skipped cypress test

### DIFF
--- a/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
@@ -372,7 +372,6 @@ describe('VAOS Referral API Error Handling', () => {
       });
     });
 
-    // TODO: This test is flaky and needs to be corrected using fixed dates
     it('should display an error when appointment remains in proposed state and times out', () => {
       // Mock appointment details to always return proposed status (never transitions to booked)
       const proposedAppointmentResponse = new MockReferralAppointmentDetailsResponse(

--- a/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
@@ -212,6 +212,9 @@ describe('VAOS Referral API Error Handling', () => {
 
     errorCases.forEach(({ errorType, responseCode }) => {
       it(`should display an error message when submit appointment returns ${responseCode}`, () => {
+        // Use cy.clock() to control time and ensure consistent appointment slot dates
+        cy.clock(new Date('2025-06-02T12:00:00Z'), ['Date']);
+
         // Mock error response
         const submitAppointmentResponse = new MockReferralSubmitAppointmentResponse(
           {
@@ -310,6 +313,9 @@ describe('VAOS Referral API Error Handling', () => {
 
     errorCases.forEach(({ errorType, responseCode }) => {
       it(`should display an error message when appointment details returns ${responseCode}`, () => {
+        // Use cy.clock() to control time and ensure consistent appointment slot dates
+        cy.clock(new Date('2025-06-02T12:00:00Z'), ['Date']);
+
         // Mock error response
         const appointmentDetailsResponse = new MockReferralAppointmentDetailsResponse(
           {
@@ -367,7 +373,7 @@ describe('VAOS Referral API Error Handling', () => {
     });
 
     // TODO: This test is flaky and needs to be corrected using fixed dates
-    it.skip('should display an error when appointment remains in proposed state and times out', () => {
+    it('should display an error when appointment remains in proposed state and times out', () => {
       // Mock appointment details to always return proposed status (never transitions to booked)
       const proposedAppointmentResponse = new MockReferralAppointmentDetailsResponse(
         {

--- a/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
@@ -25,6 +25,7 @@ import scheduleReferral from '../../referrals/page-objects/ScheduleReferral';
 import chooseDateAndTime from '../../referrals/page-objects/ChooseDateAndTime';
 import reviewAndConfirm from '../../referrals/page-objects/ReviewAndConfirm';
 import completeReferral from '../../referrals/page-objects/CompleteReferral';
+import { mockToday } from '../../../mocks/constants';
 
 describe('VAOS Referral API Error Handling', () => {
   // Common error cases for all API tests
@@ -213,7 +214,7 @@ describe('VAOS Referral API Error Handling', () => {
     errorCases.forEach(({ errorType, responseCode }) => {
       it(`should display an error message when submit appointment returns ${responseCode}`, () => {
         // Use cy.clock() to control time and ensure consistent appointment slot dates
-        cy.clock(new Date('2025-06-02T12:00:00Z'), ['Date']);
+        cy.clock(mockToday, ['Date']);
 
         // Mock error response
         const submitAppointmentResponse = new MockReferralSubmitAppointmentResponse(
@@ -314,7 +315,7 @@ describe('VAOS Referral API Error Handling', () => {
     errorCases.forEach(({ errorType, responseCode }) => {
       it(`should display an error message when appointment details returns ${responseCode}`, () => {
         // Use cy.clock() to control time and ensure consistent appointment slot dates
-        cy.clock(new Date('2025-06-02T12:00:00Z'), ['Date']);
+        cy.clock(mockToday, ['Date']);
 
         // Mock error response
         const appointmentDetailsResponse = new MockReferralAppointmentDetailsResponse(
@@ -392,7 +393,7 @@ describe('VAOS Referral API Error Handling', () => {
       });
 
       // Use cy.clock() to control time and speed up the polling timeout test
-      cy.clock(new Date('2025-06-02T12:00:00Z'), ['Date']);
+      cy.clock(mockToday, ['Date']);
 
       // Navigate to the Referrals and Requests page
       appointmentList.navigateToReferralsAndRequests();

--- a/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-appointments.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-appointments.cypress.spec.js
@@ -156,6 +156,9 @@ describe('VAOS Referral Appointments', () => {
     });
 
     it('should navigate through the referral scheduling flow', () => {
+      // Use cy.clock() to control time and ensure consistent appointment slot dates
+      cy.clock(new Date('2025-06-02T12:00:00Z'), ['Date']);
+
       // Navigate to the Referrals and Requests page
       appointmentList.navigateToReferralsAndRequests();
 

--- a/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-appointments.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-appointments.cypress.spec.js
@@ -26,6 +26,7 @@ import chooseDateAndTime from '../../referrals/page-objects/ChooseDateAndTime';
 import reviewAndConfirm from '../../referrals/page-objects/ReviewAndConfirm';
 import completeReferral from '../../referrals/page-objects/CompleteReferral';
 import epsAppointmentDetails from '../../referrals/page-objects/EpsAppointmentDetails';
+import { mockToday } from '../../../mocks/constants';
 
 describe('VAOS Referral Appointments', () => {
   beforeEach(() => {
@@ -157,7 +158,7 @@ describe('VAOS Referral Appointments', () => {
 
     it('should navigate through the referral scheduling flow', () => {
       // Use cy.clock() to control time and ensure consistent appointment slot dates
-      cy.clock(new Date('2025-06-02T12:00:00Z'), ['Date']);
+      cy.clock(mockToday, ['Date']);
 
       // Navigate to the Referrals and Requests page
       appointmentList.navigateToReferralsAndRequests();

--- a/src/applications/vaos/tests/fixtures/MockReferralDraftAppointmentResponse.js
+++ b/src/applications/vaos/tests/fixtures/MockReferralDraftAppointmentResponse.js
@@ -1,4 +1,5 @@
 import { addDays, addMonths, setDate } from 'date-fns';
+import { mockToday } from '../mocks/constants';
 
 /**
  * Class to create mock draft referral appointment responses for Cypress tests.
@@ -242,7 +243,6 @@ class MockReferralDraftAppointmentResponse {
 
     // Get first day of next month
     // Use a fixed date instead of new Date() to avoid flaky tests
-    const mockToday = new Date('2025-06-02T12:00:00Z');
     const firstDayNextMonth = addMonths(setDate(mockToday, 1), 1);
 
     for (let i = 0; i < numberOfSlots; i++) {

--- a/src/applications/vaos/tests/fixtures/MockReferralDraftAppointmentResponse.js
+++ b/src/applications/vaos/tests/fixtures/MockReferralDraftAppointmentResponse.js
@@ -241,8 +241,9 @@ class MockReferralDraftAppointmentResponse {
     const startHour = 14; // Starting at 2 PM UTC
 
     // Get first day of next month
-    const today = new Date();
-    const firstDayNextMonth = addMonths(setDate(today, 1), 1);
+    // Use a fixed date instead of new Date() to avoid flaky tests
+    const mockToday = new Date('2025-06-02T12:00:00Z');
+    const firstDayNextMonth = addMonths(setDate(mockToday, 1), 1);
 
     for (let i = 0; i < numberOfSlots; i++) {
       // Create slots on consecutive days starting from the first day of next month

--- a/src/applications/vaos/tests/mocks/constants.js
+++ b/src/applications/vaos/tests/mocks/constants.js
@@ -1,0 +1,1 @@
+export const mockToday = new Date('2025-06-02T12:00:00Z');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

A single test was being skipped due to flaky results based on a mix of dynamic and static dates. The dynamic date has been change to static. The resulting failing tests were updated to use the new `mockToday` value.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113830

## Testing done

- Ran the vao cypress tests and confirmed the once-skipped test still fails.
- Changed dynamic date to be static.
- Tested the vao suite of tests with the new variable and fixed the resulting failing tests.

## What areas of the site does it impact?
vaos testing suite

## Acceptance criteria

The e2e tests are passing.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

The new static date relies on applying a magic date-string in a few places. I'd like to move this into a constant file somewhere but not sure where to put it.
