### PR TITLE
Proof of concept - submissions url root

### DIFF
--- a/src/applications/accredited-representative-portal/containers/SubmissionsPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/SubmissionsPage.jsx
@@ -86,7 +86,7 @@ const SubmissionsPage = title => {
             The form will be processed by VA Centralized Mail after you submit
             it.
             <va-link-action
-              href="/representative/representative-form-upload/21-686c"
+              href="/representative/submissions/21-686c"
               text="Upload and submit VA Form 21-686c"
             />
           </p>

--- a/src/applications/manifest-catalog.json
+++ b/src/applications/manifest-catalog.json
@@ -571,7 +571,7 @@
       "directoryPath": "src/applications/representative-form-upload",
       "appName": "Representative Form Upload",
       "entryName": "representative-form-upload",
-      "rootUrl": "/representative/representative-form-upload"
+      "rootUrl": "/representative/submissions"
     },
     {
       "directoryPath": "src/applications/representative-search",

--- a/src/applications/representative-form-upload/helpers/index.js
+++ b/src/applications/representative-form-upload/helpers/index.js
@@ -17,7 +17,7 @@ const formMappings = {
 
 export const getFormNumber = (pathname = null) => {
   const path = pathname || window?.location?.pathname;
-  const regex = /upload\/([^/]+)/;
+  const regex = /submissions\/([^/]+)/;
   const match = path.match(regex)?.[1];
   return (
     Object.keys(formMappings).find(key => key.toLowerCase() === match) || ''

--- a/src/applications/representative-form-upload/manifest.json
+++ b/src/applications/representative-form-upload/manifest.json
@@ -2,5 +2,5 @@
   "appName": "Representative Form Upload",
   "entryFile": "./app-entry.jsx",
   "entryName": "representative-form-upload",
-  "rootUrl": "/representative/representative-form-upload"
+  "rootUrl": "/representative/submissions"
 }

--- a/src/applications/representative-form-upload/utilities/constants.js
+++ b/src/applications/representative-form-upload/utilities/constants.js
@@ -22,10 +22,7 @@ export const getSignInUrl = ({ __returnUrl } = {}) => {
   url.searchParams.set(USIP_QUERY_PARAMS.application, USIP_APPLICATIONS.ARP);
   url.searchParams.set(USIP_QUERY_PARAMS.OAuth, true);
 
-  url.searchParams.set(
-    USIP_QUERY_PARAMS.to,
-    `/representative-form-upload/${formNumber}`,
-  );
+  url.searchParams.set(USIP_QUERY_PARAMS.to, `/submissions/${formNumber}`);
 
   return url;
 };


### PR DESCRIPTION
- Simply moved all representative-form-upload routes and config to submissions.
- Submissions page works when visited from ARP navbar, but not when entered directly into URL or from representative-form-upload pages.
- 21-686c form upload works without issues

