### PR TITLE
Fix bug where international phone value was an object

### DIFF
--- a/src/applications/new-28-1900/config/submit-transformer.js
+++ b/src/applications/new-28-1900/config/submit-transformer.js
@@ -31,6 +31,8 @@ export default function transformForSubmit(formConfig, form) {
     },
   };
 
+  delete payload.checkBoxGroup;
+
   return JSON.stringify({
     veteranReadinessEmploymentClaim: {
       form: JSON.stringify(payload),

--- a/src/applications/new-28-1900/config/submit-transformer.js
+++ b/src/applications/new-28-1900/config/submit-transformer.js
@@ -18,10 +18,13 @@ export default function transformForSubmit(formConfig, form) {
     {},
   );
 
-  const { fullName, dob, ...otherFields } = normalizedData;
+  const { fullName, dob, internationalPhone, ...otherFields } = normalizedData;
 
   const payload = {
     ...otherFields,
+    internationalPhone: `${internationalPhone.callingCode}${
+      internationalPhone.contact
+    }`,
     veteranInformation: {
       fullName,
       dob,

--- a/src/applications/new-28-1900/config/submit-transformer.js
+++ b/src/applications/new-28-1900/config/submit-transformer.js
@@ -22,14 +22,17 @@ export default function transformForSubmit(formConfig, form) {
 
   const payload = {
     ...otherFields,
-    internationalPhone: `${internationalPhone.callingCode}${
-      internationalPhone.contact
-    }`,
     veteranInformation: {
       fullName,
       dob,
     },
   };
+
+  if (internationalPhone.contact) {
+    payload.internationalPhone = `${internationalPhone.callingCode}${
+      internationalPhone.contact
+    }`;
+  }
 
   delete payload.checkBoxGroup;
 

--- a/src/applications/new-28-1900/tests/unit/config/submit-transformer.unit.spec.jsx
+++ b/src/applications/new-28-1900/tests/unit/config/submit-transformer.unit.spec.jsx
@@ -4,7 +4,14 @@ import transformForSubmit from '../../../config/submit-transformer';
 const mockFormData = {
   mainPhone: '2125551234',
   cellPhone: '2125551234',
-  internationalPhone: '+12125551234',
+  internationalPhone: {
+    callingCode: 1,
+    countryCode: 'US',
+    contact: '2125551234',
+    _isValid: true,
+    _touched: true,
+    _required: false,
+  },
   email: 'email@test.com',
   newAddress: {
     country: 'USA',
@@ -49,6 +56,10 @@ describe('28-1900 submit-transformer', () => {
       fullName: mockFormData.fullName,
       dob: mockFormData.dob,
     });
+
+    // International phone should be a string with calling code and contact number concatenated
+    expect(result).to.have.property('internationalPhone');
+    expect(result.internationalPhone).to.equal('12125551234');
   });
 
   it('removes dashes from all phone fields', () => {
@@ -57,7 +68,6 @@ describe('28-1900 submit-transformer', () => {
         ...mockFormData,
         mainPhone: '212-555-1234',
         cellPhone: '212-555-5678',
-        internationalPhone: '+1-212-555-9999',
       },
     };
 
@@ -68,6 +78,5 @@ describe('28-1900 submit-transformer', () => {
 
     expect(result.mainPhone).to.equal('2125551234');
     expect(result.cellPhone).to.equal('2125555678');
-    expect(result.internationalPhone).to.equal('+12125559999');
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Fixes a bug where the international phone number was being submitted as an object rather than a string.
- I work for VA IIR and we own this form

To reproduce this bug, fill out the form with the network tab open, and take note of the submitted payload. It will include an object for `internationalPhone` with prperties like `callingCode`. Example:
```

  "veteranReadinessEmploymentClaim": {
    "form": "{\"internationalPhone\":{\"callingCode\":1,\"countryCode\":\"US\",\"contact\":\"7855561230\",\"_isValid\":true,\"_touched\":true,\"_required\":false},\"email\":\"n@n.com\",\"isMoving\":false,\"checkBoxGroup\":{\"checkForMailingAddress\":true},\"yearsOfEducation\":\"10\",\"AGREED\":true,\"veteranInformation\":{\"fullName\":{\"first\":\"N\",\"last\":\"S\"},\"dob\":\"2000-01-01\"}}"
  }
```

Now repeat the process on this PR branch. You should see that `internationalPhone` is now a string. Example:
```
"veteranReadinessEmploymentClaim": {
  "form":"{\"email\":\"n@n.com\",\"isMoving\":false,\"veteranAddress\":{\"country\":\"USA\",\"street\":\"1000 e st\",\"city\":\"Lawrence\",\"state\":\"KS\",\"postalCode\":\"66046\"},\"yearsOfEducation\":\"10\",\"AGREED\":true,\"internationalPhone\":\"17851234567\",\"veteranInformation\":{\"fullName\":{\"first\":\"N\",\"last\":\"S\"},\"dob\":\"2000-01-01\"}}"
}
```


## Related issue(s)
[VA IIR Ticket 1905](https://github.com/department-of-veterans-affairs/va-iir/issues/1905)

## Testing done
Updated unit tests. To check them, run the following command:
```
yarn test:unit src/applications/new-28-1900/tests/unit/config/submit-transformer.unit.spec.jsx
```

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
