### PR TITLE
Fix FileField encryption breaking

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -616,7 +616,7 @@ const FileField = props => {
                 const passwordInput = $(`[name="get_password_${index}"]`);
                 if (passwordInput) {
                   focusElement('input', {}, passwordInput?.shadowRoot);
-                  scrollTo(`get_password_${index}"]`);
+                  scrollTo(getFileListId(index));
                 }
               }, 100);
             }


### PR DESCRIPTION
## Summary

- When uploading an encrypted file, FileField would break, because it was trying to scroll to an invalid css selector
- Fix the scrolling issue

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4552

## Testing done

- Test scrolling works correctly

## Screenshots
Before:
<img width="1638" height="850" alt="image" src="https://github.com/user-attachments/assets/74552b33-8fbe-4785-a73e-cd138c59af51" />

After:
<img width="528" height="402" alt="image" src="https://github.com/user-attachments/assets/d599f969-ae89-4c1e-a271-52278a5c4aad" />

## What areas of the site does it impact?

FileField

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
