### PR TITLE
Refactor createReferral redux actions to RTK postReferral

### DIFF
--- a/src/applications/vaos/redux/api/vaosApi.js
+++ b/src/applications/vaos/redux/api/vaosApi.js
@@ -65,6 +65,36 @@ export const vaosApi = createApi({
         }
       },
     }),
+    postReferralAppointment: builder.mutation({
+      async queryFn({
+        draftApppointmentId,
+        referralNumber,
+        slotId,
+        networkId,
+        providerServiceId,
+      }) {
+        try {
+          return await apiRequestWithUrl(`/vaos/v2/appointments/submit`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              id: draftApppointmentId,
+              referralNumber,
+              slotId,
+              networkId,
+              providerServiceId,
+            }),
+          });
+        } catch (error) {
+          captureError(error, false, 'post referral appointment');
+          return {
+            error: { status: error.status || 500, message: error?.message },
+          };
+        }
+      },
+    }),
   }),
 });
 
@@ -72,4 +102,5 @@ export const {
   useGetReferralByIdQuery,
   useGetPatientReferralsQuery,
   usePostDraftReferralAppointmentMutation,
+  usePostReferralAppointmentMutation,
 } = vaosApi;

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
@@ -7,11 +7,11 @@ import {
   getAppointmentCreateStatus,
   getSelectedSlotStartTime,
 } from './redux/selectors';
-import { setFormCurrentPage, setSelectedSlotStartTime } from './redux/actions';
 import {
   POST_DRAFT_REFERRAL_APPOINTMENT_CACHE,
   POST_REFERRAL_REQUEST_CACHE,
 } from '../utils/constants';
+import { setFormCurrentPage, setSelectedSlotStartTime } from './redux/actions';
 import {
   usePostDraftReferralAppointmentMutation,
   usePostReferralAppointmentMutation,
@@ -34,7 +34,7 @@ const ReviewAndConfirm = props => {
   const { attributes: currentReferral } = props.currentReferral;
   const dispatch = useDispatch();
   const history = useHistory();
-  const selectedSlotStartTime = useSelector(getSelectedSlotStartTime);
+  const selectedSlot = useSelector(state => getSelectedSlotStartTime(state));
   const [
     postDraftReferralAppointment,
     {
@@ -55,7 +55,7 @@ const ReviewAndConfirm = props => {
   const [createLoading, setCreateLoading] = useState(false);
   const slotDetails = getSlotByDate(
     draftAppointmentInfo?.attributes?.slots,
-    selectedSlotStartTime,
+    selectedSlot,
   );
   const savedSelectedSlot = sessionStorage.getItem(
     getReferralSlotKey(currentReferral.uuid),
@@ -79,20 +79,17 @@ const ReviewAndConfirm = props => {
   );
   useEffect(
     () => {
-      if (!selectedSlotStartTime && !savedSelectedSlot) {
+      if (!selectedSlot && !savedSelectedSlot) {
         routeToCCPage(history, 'scheduleReferral', currentReferral.uuid);
       }
     },
-    [currentReferral.uuid, history, savedSelectedSlot, selectedSlotStartTime],
+    [currentReferral.uuid, history, savedSelectedSlot, selectedSlot],
   );
 
   useEffect(
     () => {
       if (isDraftUninitialized) {
-        postDraftReferralAppointment({
-          referralNumber: currentReferral.referralNumber,
-          referralConsultId: currentReferral.referralConsultId,
-        });
+        postDraftReferralAppointment(currentReferral.referralNumber);
       } else if (isDraftSuccess) {
         setLoading(false);
       } else if (isDraftError) {
@@ -101,7 +98,7 @@ const ReviewAndConfirm = props => {
       }
     },
     [
-      currentReferral,
+      currentReferral.referralNumber,
       dispatch,
       isDraftError,
       isDraftSuccess,
@@ -112,7 +109,7 @@ const ReviewAndConfirm = props => {
 
   useEffect(
     () => {
-      if (!selectedSlotStartTime && savedSelectedSlot && isDraftSuccess) {
+      if (!selectedSlot && savedSelectedSlot && isDraftSuccess) {
         const savedSlot = getSlotByDate(
           draftAppointmentInfo?.attributes?.slots,
           savedSelectedSlot,
@@ -129,7 +126,7 @@ const ReviewAndConfirm = props => {
       savedSelectedSlot,
       draftAppointmentInfo,
       history,
-      selectedSlotStartTime,
+      selectedSlot,
       isDraftSuccess,
     ],
   );

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
@@ -7,17 +7,11 @@ import {
   getAppointmentCreateStatus,
   getSelectedSlotStartTime,
 } from './redux/selectors';
+import { setFormCurrentPage, setSelectedSlotStartTime } from './redux/actions';
 import {
   POST_DRAFT_REFERRAL_APPOINTMENT_CACHE,
+  POST_REFERRAL_REQUEST_CACHE,
 } from '../utils/constants';
-import {
-  setFormCurrentPage,
-  setSelectedSlotStartTime,
-} from './redux/actions';
-import { usePostDraftReferralAppointmentMutation } from '../redux/api/vaosApi';
-import { getAppointmentCreateStatus } from './redux/selectors';
-import { POST_DRAFT_REFERRAL_APPOINTMENT_CACHE } from '../utils/constants';
-import { setFormCurrentPage } from './redux/actions';
 import {
   usePostDraftReferralAppointmentMutation,
   usePostReferralAppointmentMutation,
@@ -68,9 +62,14 @@ const ReviewAndConfirm = props => {
   );
   const [
     postReferralAppointment,
-    { data: appointmentInfo, isError, isLoading, isSuccess },
+    {
+      data: appointmentInfo,
+      isError: isAppointmentError,
+      isLoading: isAppointmentLoading,
+      isSuccess: isAppointmentSuccess,
+    },
   ] = usePostReferralAppointmentMutation({
-    fixedCacheKey: 'postReferralAppointmentCache',
+    fixedCacheKey: POST_REFERRAL_REQUEST_CACHE,
   });
   useEffect(
     () => {
@@ -148,11 +147,11 @@ const ReviewAndConfirm = props => {
   // or show error message if the appointment creation failed
   useEffect(
     () => {
-      if (isLoading) {
+      if (isAppointmentLoading) {
         setCreateLoading(true);
         setCreateFailed(false);
       }
-      if (isSuccess && draftAppointmentInfo?.id) {
+      if (isAppointmentSuccess && draftAppointmentInfo?.id) {
         setCreateLoading(false);
         routeToNextReferralPage(
           history,
@@ -160,15 +159,19 @@ const ReviewAndConfirm = props => {
           currentReferral.uuid,
           draftAppointmentInfo.id,
         );
-      } else if (isError && draftAppointmentInfo?.id && isDraftSuccess) {
+      } else if (
+        isAppointmentError &&
+        draftAppointmentInfo?.id &&
+        isDraftSuccess
+      ) {
         setCreateLoading(false);
         setCreateFailed(true);
       }
     },
     [
-      isSuccess,
-      isLoading,
-      isError,
+      isAppointmentSuccess,
+      isAppointmentLoading,
+      isAppointmentError,
       appointmentCreateStatus,
       appointmentInfo?.id,
       draftAppointmentInfo?.id,
@@ -200,7 +203,7 @@ const ReviewAndConfirm = props => {
     >
       <div>
         <hr className="vads-u-margin-y--2" />
-        {isSuccess && <p data-testid="success-text">success</p>}
+        {isAppointmentSuccess && <p data-testid="success-text">success</p>}
         <div className=" vads-l-grid-container vads-u-padding--0">
           <div className="vads-l-row">
             <div className="vads-l-col">

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
@@ -152,9 +152,8 @@ const ReviewAndConfirm = props => {
         setCreateLoading(true);
         setCreateFailed(false);
       }
-      if (isSuccess && draftAppointmentInfo?.id === appointmentInfo?.id) {
+      if (isSuccess && draftAppointmentInfo?.id) {
         setCreateLoading(false);
-        // console.log('route');
         routeToNextReferralPage(
           history,
           'reviewAndConfirm',

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -234,7 +234,9 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     await screen.findByTestId('continue-button');
     expect(screen.getByTestId('continue-button')).to.exist;
     await userEvent.click(screen.getByTestId('continue-button'));
-    sandbox.assert.calledOnce(requestStub);
+    waitFor(() => {
+      sandbox.assert.calledOnce(requestStub);
+    });
     expect(screen.findByTestId('create-error-alert')).to.exist;
   });
 });

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
       vaOnlineSchedulingCCDirectScheduling: true,
     },
     referral: {
-      selectedSlot: '2024-09-09T16:00:00.000Z',
+      selectedSlotStartTime: '2024-09-09T16:00:00.000Z',
       currentPage: 'reviewAndConfirm',
       appointmentCreateStatus: FETCH_STATUS.notStarted,
       pollingRequestStart: null,
@@ -76,10 +76,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     const noSelectState = {
       ...initialFullState,
       ...{
-        referral: {
-          ...initialFullState.referral,
-          selectedSlotStartTime: '',
-        },
+        referral: { ...initialFullState.referral, selectedSlotStartTime: '' },
       },
     };
 
@@ -108,10 +105,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     const noSelectState = {
       ...initialFullState,
       ...{
-        referral: {
-          ...initialFullState.referral,
-          selectedSlotStartTime: '',
-        },
+        referral: { ...initialFullState.referral, selectedSlotStartTime: '' },
       },
     };
     const screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -27,7 +27,6 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     },
     referral: {
       selectedSlot: '2024-09-09T16:00:00.000Z',
-      draftAppointmentInfo,
       currentPage: 'reviewAndConfirm',
       appointmentCreateStatus: FETCH_STATUS.notStarted,
       pollingRequestStart: null,

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -26,9 +26,8 @@ describe('VAOS Component: ReviewAndConfirm', () => {
       vaOnlineSchedulingCCDirectScheduling: true,
     },
     referral: {
-      selectedSlot: '0',
+      selectedSlot: '2024-09-09T16:00:00.000Z',
       draftAppointmentInfo,
-      draftAppointmentCreateStatus: FETCH_STATUS.succeeded,
       currentPage: 'reviewAndConfirm',
       appointmentCreateStatus: FETCH_STATUS.notStarted,
       pollingRequestStart: null,
@@ -221,7 +220,6 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     requestStub.throws({
       error: { status: 500, message: 'Failed to create appointment' },
     });
-    // .rejects(new Error('Failed to create appointment'));
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
         currentReferral={createReferralById('2024-09-09', 'UUID')}
@@ -234,9 +232,17 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     await screen.findByTestId('continue-button');
     expect(screen.getByTestId('continue-button')).to.exist;
     await userEvent.click(screen.getByTestId('continue-button'));
-    waitFor(() => {
-      sandbox.assert.calledOnce(requestStub);
-    });
-    expect(screen.findByTestId('create-error-alert')).to.exist;
+    // Wait for the postReferralAppointment call to complete
+    waitFor(() =>
+      expect(screen.getByTestId('continue-button')).to.have.attribute(
+        'loading',
+        'false',
+      ),
+    );
+    await screen.findByTestId('create-error-alert');
+    expect(screen.getByTestId('create-error-alert')).to.contain.text(
+      'We couldn’t schedule this appointment',
+    );
+    sandbox.assert.calledOnce(requestStub);
   });
 });

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -1,20 +1,11 @@
 import { formatISO, differenceInMilliseconds } from 'date-fns';
 
 import { captureError } from '../../utils/error';
-import {
-  postReferralAppointment,
-  getProviderById,
-  getAppointmentInfo,
-} from '../../services/referral';
+import { getProviderById, getAppointmentInfo } from '../../services/referral';
 // import { filterReferrals } from '../utils/referrals';
 import { STARTED_NEW_APPOINTMENT_FLOW } from '../../redux/sitewide';
 
 export const SET_FORM_CURRENT_PAGE = 'SET_FORM_CURRENT_PAGE';
-export const CREATE_REFERRAL_APPOINTMENT = 'CREATE_REFERRAL_APPOINTMENT';
-export const CREATE_REFERRAL_APPOINTMENT_SUCCEEDED =
-  'CREATE_REFERRAL_APPOINTMENT_SUCCEEDED';
-export const CREATE_REFERRAL_APPOINTMENT_FAILED =
-  'CREATE_REFERRAL_APPOINTMENT_FAILED';
 export const FETCH_PROVIDER_DETAILS = 'FETCH_PROVIDER_DETAILS';
 export const FETCH_PROVIDER_DETAILS_SUCCEEDED =
   'FETCH_PROVIDER_DETAILS_SUCCEEDED';
@@ -154,40 +145,5 @@ export function setInitReferralFlow() {
 export function startNewAppointmentFlow() {
   return {
     type: STARTED_NEW_APPOINTMENT_FLOW,
-  };
-}
-
-export function createReferralAppointment({
-  draftApppointmentId,
-  referralNumber,
-  slotId,
-  networkId,
-  providerServiceId,
-}) {
-  return async dispatch => {
-    try {
-      dispatch({
-        type: CREATE_REFERRAL_APPOINTMENT,
-      });
-
-      const appointmentInfo = await postReferralAppointment({
-        draftApppointmentId,
-        referralNumber,
-        slotId,
-        networkId,
-        providerServiceId,
-      });
-
-      dispatch({
-        type: CREATE_REFERRAL_APPOINTMENT_SUCCEEDED,
-      });
-
-      return appointmentInfo;
-    } catch (error) {
-      dispatch({
-        type: CREATE_REFERRAL_APPOINTMENT_FAILED,
-      });
-      return captureError(error);
-    }
   };
 }

--- a/src/applications/vaos/referral-appointments/redux/actions.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/redux/actions.unit.spec.jsx
@@ -61,53 +61,6 @@ describe('referral actions', () => {
     });
   });
 
-  describe('createReferralAppointment', () => {
-    it('should dispatch success flow', async () => {
-      const mockAppointment = { confirmation: true };
-      sandbox
-        .stub(services, 'postReferralAppointment')
-        .resolves(mockAppointment);
-
-      const result = await actions.createReferralAppointment({
-        draftApppointmentId: 'd1',
-        referralNumber: 'r1',
-        slotId: 's1',
-        networkId: 'n1',
-        providerServiceId: 'p1',
-      })(dispatch);
-
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        actions.CREATE_REFERRAL_APPOINTMENT,
-      );
-      expect(dispatch.secondCall.args[0].type).to.equal(
-        actions.CREATE_REFERRAL_APPOINTMENT_SUCCEEDED,
-      );
-      expect(result).to.deep.equal(mockAppointment);
-    });
-
-    it('should dispatch failure flow', async () => {
-      const captureStub = sandbox.stub(errorUtils, 'captureError');
-      sandbox
-        .stub(services, 'postReferralAppointment')
-        .rejects(new Error('fail'));
-
-      await actions.createReferralAppointment({
-        draftApppointmentId: 'd1',
-        referralNumber: 'r1',
-        slotId: 's1',
-        networkId: 'n1',
-        providerServiceId: 'p1',
-      })(dispatch);
-
-      expect(
-        dispatch.calledWithMatch({
-          type: actions.CREATE_REFERRAL_APPOINTMENT_FAILED,
-        }),
-      ).to.be.true;
-      expect(captureStub.calledOnce).to.be.true;
-    });
-  });
-
   describe('pollFetchAppointmentInfo', () => {
     it('should retry if status is draft', async () => {
       const pollSpy = sandbox.spy(actions, 'pollFetchAppointmentInfo');

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -1,8 +1,5 @@
 import {
   SET_FORM_CURRENT_PAGE,
-  CREATE_REFERRAL_APPOINTMENT,
-  CREATE_REFERRAL_APPOINTMENT_FAILED,
-  CREATE_REFERRAL_APPOINTMENT_SUCCEEDED,
   FETCH_REFERRAL_APPOINTMENT_INFO,
   FETCH_REFERRAL_APPOINTMENT_INFO_FAILED,
   FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED,
@@ -34,21 +31,6 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         currentPage: action.payload,
-      };
-    case CREATE_REFERRAL_APPOINTMENT:
-      return {
-        ...state,
-        appointmentCreateStatus: FETCH_STATUS.loading,
-      };
-    case CREATE_REFERRAL_APPOINTMENT_SUCCEEDED:
-      return {
-        ...state,
-        appointmentCreateStatus: FETCH_STATUS.succeeded,
-      };
-    case CREATE_REFERRAL_APPOINTMENT_FAILED:
-      return {
-        ...state,
-        appointmentCreateStatus: FETCH_STATUS.failed,
       };
     case FETCH_REFERRAL_APPOINTMENT_INFO:
       return {

--- a/src/applications/vaos/referral-appointments/redux/reducers.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/redux/reducers.unit.spec.jsx
@@ -1,11 +1,7 @@
 import { expect } from 'chai';
 import reducer from './reducers';
-import { FETCH_STATUS } from '../../utils/constants';
 import {
   SET_FORM_CURRENT_PAGE,
-  CREATE_REFERRAL_APPOINTMENT,
-  CREATE_REFERRAL_APPOINTMENT_FAILED,
-  CREATE_REFERRAL_APPOINTMENT_SUCCEEDED,
   FETCH_REFERRAL_APPOINTMENT_INFO,
   FETCH_REFERRAL_APPOINTMENT_INFO_FAILED,
   FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED,
@@ -20,25 +16,6 @@ describe('ccAppointmentReducer', () => {
       payload: 'review',
     });
     expect(state.currentPage).to.equal('review');
-  });
-
-  it('should handle CREATE_REFERRAL_APPOINTMENT', () => {
-    const state = reducer(undefined, { type: CREATE_REFERRAL_APPOINTMENT });
-    expect(state.appointmentCreateStatus).to.equal(FETCH_STATUS.loading);
-  });
-
-  it('should handle CREATE_REFERRAL_APPOINTMENT_SUCCEEDED', () => {
-    const state = reducer(undefined, {
-      type: CREATE_REFERRAL_APPOINTMENT_SUCCEEDED,
-    });
-    expect(state.appointmentCreateStatus).to.equal(FETCH_STATUS.succeeded);
-  });
-
-  it('should handle CREATE_REFERRAL_APPOINTMENT_FAILED', () => {
-    const state = reducer(undefined, {
-      type: CREATE_REFERRAL_APPOINTMENT_FAILED,
-    });
-    expect(state.appointmentCreateStatus).to.equal(FETCH_STATUS.failed);
   });
 
   it('should handle FETCH_REFERRAL_APPOINTMENT_INFO', () => {

--- a/src/applications/vaos/services/referral/index.js
+++ b/src/applications/vaos/services/referral/index.js
@@ -17,29 +17,6 @@ export async function getProviderById(providerId) {
   return response.data;
 }
 
-export async function postReferralAppointment({
-  draftApppointmentId,
-  referralNumber,
-  slotId,
-  networkId,
-  providerServiceId,
-}) {
-  const response = await apiRequestWithUrl(`/vaos/v2/appointments/submit`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      id: draftApppointmentId,
-      referralNumber,
-      slotId,
-      networkId,
-      providerServiceId,
-    }),
-  });
-  return response.data;
-}
-
 export async function getAppointmentInfo(appointmentId) {
   const response = await apiRequestWithUrl(
     `/vaos/v2/eps_appointments/${appointmentId}`,

--- a/src/applications/vaos/services/referral/index.unit.spec.jsx
+++ b/src/applications/vaos/services/referral/index.unit.spec.jsx
@@ -44,37 +44,6 @@ describe('Referral Services', () => {
     expect(result).to.deep.equal({ name: 'Provider A' });
   });
 
-  it('postReferralAppointment sends the correct payload and returns data', async () => {
-    const input = {
-      draftApppointmentId: 'd1',
-      referralNumber: 'r1',
-      slotId: 's1',
-      networkId: 'n1',
-      providerServiceId: 'p1',
-    };
-    const expectedBody = JSON.stringify({
-      id: 'd1',
-      referralNumber: 'r1',
-      slotId: 's1',
-      networkId: 'n1',
-      providerServiceId: 'p1',
-    });
-
-    requestStub.resolves({ data: { success: true } });
-
-    const result = await services.postReferralAppointment(input);
-
-    expect(
-      requestStub.calledWith('/vaos/v2/appointments/submit', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: expectedBody,
-      }),
-    ).to.be.true;
-
-    expect(result).to.deep.equal({ success: true });
-  });
-
   it('getAppointmentInfo calls the correct endpoint and returns data', async () => {
     requestStub.resolves({ data: { appointment: { id: 'a1' } } });
 

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -490,3 +490,5 @@ export const DATE_FORMATS = {
 
 export const POST_DRAFT_REFERRAL_APPOINTMENT_CACHE =
   'postDraftReferralAppointmentCache';
+
+export const POST_REFERRAL_REQUEST_CACHE = 'postReferralAppointmentCache';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add postReferral to vaosApi RTK middleware
- Update tests
- Remove old redux actions

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111256

## Testing done

- Made sure all tests passed
- Manually walked through app to make sure it worked the same

## Screenshots

N/A just refactor of React logic. 

## What areas of the site does it impact?

The ReviewAndConfirm page of the pilot referral program. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A
