### PR TITLE
113428a - Validate applicant date of marriage not before date of birth in 10-10d/10-7959c merged form - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -58,6 +58,7 @@ import { ApplicantDependentStatusPage } from '../../10-10D/pages/ApplicantDepend
 
 import CustomPrefillMessage from '../components/CustomPrefillAlert';
 
+import { validateMarriageAfterDob } from '../helpers/validations';
 /*
 // TODO: re-add this custom validation + the same for normal text fields
 import { applicantAddressCleanValidation } from '../../shared/validations';
@@ -579,6 +580,7 @@ const applicantMarriageDatesPage = {
       false,
     ),
     dateOfMarriageToSponsor: currentOrPastDateUI('Date of marriage'),
+    'ui:validations': [validateMarriageAfterDob],
   },
   schema: {
     type: 'object',

--- a/src/applications/ivc-champva/10-10d-extended/helpers/validations.js
+++ b/src/applications/ivc-champva/10-10d-extended/helpers/validations.js
@@ -1,0 +1,16 @@
+/**
+ * Validates an applicant's date of marriage to sponsor is not before
+ * said applicant's date of birth.
+ * @param {Object} errors - The errors object for the current page
+ * @param {Object} page - The current page data
+ */
+export const validateMarriageAfterDob = (errors, page) => {
+  const difference =
+    Date.parse(page?.dateOfMarriageToSponsor) - Date.parse(page?.applicantDob);
+
+  if (difference !== undefined && difference <= 0) {
+    errors.dateOfMarriageToSponsor.addError(
+      "Date of marriage must be after applicant's date of birth",
+    );
+  }
+};

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/validations.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/helpers/validations.unit.spec.jsx
@@ -1,0 +1,65 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { validateMarriageAfterDob } from '../../../helpers/validations';
+
+describe('validateMarriageAfterDob', () => {
+  let errors;
+
+  beforeEach(() => {
+    errors = {
+      dateOfMarriageToSponsor: {
+        addError: sinon.spy(),
+      },
+    };
+  });
+
+  it('should add an error when applicant dob is after date of marriage', () => {
+    const page = {
+      applicantDob: '2000-01-01',
+      dateOfMarriageToSponsor: '1999-01-01',
+    };
+
+    validateMarriageAfterDob(errors, page);
+    expect(errors.dateOfMarriageToSponsor.addError.calledOnce).to.be.true;
+  });
+
+  it('should add an error when applicant dob is same as date of marriage', () => {
+    const page = {
+      applicantDob: '2000-01-01',
+      dateOfMarriageToSponsor: '2000-01-01',
+    };
+
+    validateMarriageAfterDob(errors, page);
+    expect(errors.dateOfMarriageToSponsor.addError.calledOnce).to.be.true;
+  });
+
+  it('should NOT add an error when applicant dob is before date of marriage', () => {
+    const page = {
+      applicantDob: '1995-01-01',
+      dateOfMarriageToSponsor: '2020-01-01',
+    };
+
+    validateMarriageAfterDob(errors, page);
+    expect(errors.dateOfMarriageToSponsor.addError.called).to.be.false;
+  });
+
+  it('should NOT add an error when date of marriage is undefined', () => {
+    const page = {
+      applicantDob: '1995-01-01',
+      dateOfMarriageToSponsor: undefined,
+    };
+
+    validateMarriageAfterDob(errors, page);
+    expect(errors.dateOfMarriageToSponsor.addError.called).to.be.false;
+  });
+
+  it('should NOT add an error when date of birth is undefined', () => {
+    const page = {
+      applicantDob: undefined,
+      dateOfMarriageToSponsor: '2000-01-01',
+    };
+
+    validateMarriageAfterDob(errors, page);
+    expect(errors.dateOfMarriageToSponsor.addError.called).to.be.false;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds a validation to check if the date of marriage entered on an applicant is before that same applicant's date of birth.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113428

## Testing done

- Unit

## Screenshots

|         | After |
| ------- | ----- |
| Error |<img width="628" height="473" alt="Screenshot 2025-07-22 at 09 02 10" src="https://github.com/user-attachments/assets/b1ed85c7-7750-40eb-9edd-d661749f5930" />|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA