### PR TITLE
Revert "Update CODEOWNERS for 10-10 apps"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,14 +152,16 @@ src/applications/static-pages/facilities @department-of-veterans-affairs/vfs-fac
 src/applications/static-pages/tests/facilities @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/situation-updates-banner @department-of-veterans-affairs/vfs-facilities-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 
-# 10-10 Health Apps
+# Caregiver
 
 src/applications/caregivers @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
+
+# Health Care Applications
+
 src/applications/hca @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/ezr @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/hca-performance-warning @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/ezr-submission-options @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
-src/applications/ivc-champv @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Healthcare Experience
 
@@ -278,5 +280,6 @@ src/applications/third-party-app-directory @department-of-veterans-affairs/va-pl
 src/applications/static-pages/analytics @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/download-1095b @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/benefit-eligibility-questionnaire @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/ivc-champv @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/office-directory @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/travel-pay @department-of-veterans-affairs/va-platform-cop-frontend


### PR DESCRIPTION
## Description

This PR reverts department-of-veterans-affairs/vets-website#37755. While there was team developer approval. It didnt get bubbled up the chain of command and the current team Delivery Manager would like this decoupled.