### PR TITLE
Dbex(526): Fix import/extensions warnings

### DIFF
--- a/src/applications/disability-benefits/all-claims/migrations/02-convert-country-code.js
+++ b/src/applications/disability-benefits/all-claims/migrations/02-convert-country-code.js
@@ -1,4 +1,4 @@
-import { countries } from 'platform/forms/address/index.js';
+import { countries } from 'platform/forms/address/index';
 import _ from 'platform/utilities/data';
 
 /**

--- a/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.jsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockApiRequest } from 'platform/testing/unit/helpers.js';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 
 import {
   fetchITF,

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -105,7 +105,7 @@ describe('<IntroductionPage/>', () => {
 
   it('should render 2 SiP intros', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
-    const sipIntro = wrapper.find('Connect(SaveInProgressIntro)');
+    const sipIntro = wrapper.find('Connect(withRouter(SaveInProgressIntro))');
     expect(sipIntro.length).to.equal(2);
     expect(sipIntro.first().props().startText).to.equal(START_TEXT.ALL);
     wrapper.unmount();
@@ -119,7 +119,7 @@ describe('<IntroductionPage/>', () => {
         .format('YYYY-MM-DD'),
     );
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
-    const sipIntro = wrapper.find('Connect(SaveInProgressIntro)');
+    const sipIntro = wrapper.find('Connect(withRouter(SaveInProgressIntro))');
     expect(sipIntro.length).to.equal(2);
     expect(sipIntro.first().props().startText).to.equal(START_TEXT.BDD);
     wrapper.unmount();

--- a/src/applications/disability-benefits/all-claims/tests/pages/adaptiveBenefits.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/adaptiveBenefits.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
@@ -5,9 +5,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import moment from 'moment';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
-import {
-  DefinitionTester, // selectCheckbox
-} from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import { createStore } from 'redux';
 import { render } from '@testing-library/react';
 import { waitFor } from '@testing-library/dom';

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalRemarks781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalRemarks781.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/aidAndAttendance.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/aidAndAttendance.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
@@ -8,9 +8,9 @@ import {
   $$,
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 
 describe('Disability benefits 718 PTSD type', () => {
   const {

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -10,13 +10,13 @@ import { combineReducers, createStore } from 'redux';
 
 import {
   DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import {
   STATE_VALUES,
   MILITARY_STATE_VALUES,
 } from 'applications/disability-benefits/all-claims/constants';
 import { commonReducer } from 'platform/startup/store';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 import reducers from '../../reducers';
 
 // const NEXT_YEAR = moment()

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -8,9 +8,7 @@ import { waitFor } from '@testing-library/dom';
 import { Provider } from 'react-redux';
 import { combineReducers, createStore } from 'redux';
 
-import {
-  DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import {
   STATE_VALUES,
   MILITARY_STATE_VALUES,

--- a/src/applications/disability-benefits/all-claims/tests/pages/finalIncident.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/finalIncident.unit.spec.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { ERR_MSG_CSS_CLASS } from '../../constants';
-
 import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils';
+
+import { ERR_MSG_CSS_CLASS } from '../../constants';
+
 import formConfig from '../../config/form';
 
 describe('781 last incident details', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 const yesLabel = 'Yes, I have uploaded all my supporting documents.';

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentLocation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/individualUnemployability.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/individualUnemployability.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/mentalHealthChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/mentalHealthChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
@@ -5,7 +5,7 @@ import {
   DefinitionTester,
   selectRadio,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormIntro.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormIntro.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 
 describe('Disability benefits 4192', () => {
   const {

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
@@ -5,9 +5,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
-import {
-  DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
@@ -7,9 +7,9 @@ import { Provider } from 'react-redux';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('4192 form upload', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import { waitFor } from '@testing-library/dom';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 
 const {
   schema,

--- a/src/applications/disability-benefits/all-claims/tests/pages/physicalHealthChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/physicalHealthChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -5,7 +5,7 @@ import {
   DefinitionTester,
   fillDate,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
@@ -7,9 +7,9 @@ import {
   $,
   $$,
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 
 describe('526 All Claims Private medical records', () => {
   const page =

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsAttachments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsAttachments.unit.spec.jsx
@@ -5,9 +5,9 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 
 describe('526 All Claims Private medical records', () => {
   const errorClass = '.usa-input-error-message';

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
-import formConfig from '../../config/form.js';
-import initialData from '../schema/initialData.js';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+import initialData from '../schema/initialData';
 
 describe('781 choice screen', () => {
   const page = formConfig.chapters.disabilities.pages.ptsdWalkthroughChoice781;

--- a/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
@@ -3,11 +3,11 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
-import initialData from '../initialData.js';
-import { NULL_CONDITION_STRING } from '../../constants.js';
+import formConfig from '../../config/form';
+import initialData from '../initialData';
+import { NULL_CONDITION_STRING } from '../../constants';
 
 describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
   const {

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPayWaiver.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPayWaiver.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentLocation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSourcesHelp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSourcesHelp.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/separationLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/separationLocation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import moment from 'moment';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/socialBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/socialBehaviorChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/supplementalBenefits.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/supplementalBenefits.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityAdditionalInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityAdditionalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   fillDate,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.unit.spec.jsx
@@ -6,12 +6,12 @@ import sinon from 'sinon';
 import { Provider } from 'react-redux';
 import { combineReducers, createStore } from 'redux';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { commonReducer } from 'platform/startup/store';
 
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
-import initialData from '../initialData.js';
+import formConfig from '../../config/form';
+import initialData from '../initialData';
 import reducers from '../../reducers';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDoctorCare.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDoctorCare.unit.spec.jsx
@@ -6,10 +6,10 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
-import initialData from '../initialData.js';
+import formConfig from '../../config/form';
+import initialData from '../initialData';
 
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormIntro.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormIntro.unit.spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
@@ -5,9 +5,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
-import {
-  DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
@@ -7,9 +7,9 @@ import { Provider } from 'react-redux';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('8940 form upload', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
@@ -5,9 +5,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
-import {
-  DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
@@ -7,9 +7,9 @@ import { Provider } from 'react-redux';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('781 record upload', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
@@ -5,9 +5,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
-import {
-  DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
@@ -7,9 +7,9 @@ import { Provider } from 'react-redux';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('781a record upload', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
@@ -5,9 +5,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
-import {
-  DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
@@ -7,9 +7,9 @@ import { Provider } from 'react-redux';
 import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import {
   DefinitionTester, // selectCheckbox
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils';
 import { waitFor } from '@testing-library/dom';
-import formConfig from '../../config/form.js';
+import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('8940 supporting documents upload', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/workBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/workBehaviorChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Changes were made to unit tests and a handful of other files that had the `js` or `jsx` extension on file names.
- The solution is to remove the extensions, as React now natively assumes the filetypes. 
- This work is done on behalf of Team 2 of the Disability Benefits Team.

## Related issue(s)

- (https://github.com/department-of-veterans-affairs/va.gov-team/issues/112776)

## Testing done

- The old behavior after running `yarn eslint src/applications/disability-benefits/all-claims` was that there would be a number of errors related to the file extension, cluttering up CI.
- Ran the test suite after each change, along with cypress, and then ran the script again to make sure that the problem had been addressed.
- Ran the testing suite, as well as running the above script to make sure the error is removed from the stack.

## Screenshots

Not needed as these are lintr related changes and aren't customer facing.

## What areas of the site does it impact?

It touches almost all of `all-claims` in regards that the files were scanned and changes were made to files within all-claims that may have had this error.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

