### PR TITLE
Add format possessive string helper

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -18,6 +18,7 @@ import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fie
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import {
   formatCurrency,
+  formatPossessiveString,
   generateDeleteDescription,
   isDefined,
   isIncomeTypeInfoIncomplete,
@@ -46,7 +47,8 @@ export const options = {
         return undefined;
       }
       const fullName = resolveRecipientFullName(item, formData);
-      return `${fullName}’s income from ${item.payer}`;
+      const possessiveName = formatPossessiveString(fullName);
+      return `${possessiveName} income from ${item.payer}`;
     },
     cardDescription: item =>
       isDefined(item?.grossMonthlyIncome) && (

--- a/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
@@ -18,6 +18,7 @@ import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fie
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import {
   formatCurrency,
+  formatPossessiveString,
   generateDeleteDescription,
   isDefined,
   isIncomeTypeInfoIncomplete,
@@ -47,7 +48,8 @@ export const options = {
         return undefined;
       }
       const fullName = resolveRecipientFullName(item, formData);
-      return `${fullName}’s income from ${item.payer}`;
+      const possessiveName = formatPossessiveString(fullName);
+      return `${possessiveName} income from ${item.payer}`;
     },
     cardDescription: item =>
       isDefined(item?.grossMonthlyIncome) && (

--- a/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
@@ -17,6 +17,7 @@ import {
 import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 import {
   formatCurrency,
+  formatPossessiveString,
   generateDeleteDescription,
   isDefined,
   isRecipientInfoIncomplete,
@@ -48,7 +49,8 @@ export const options = {
         return undefined;
       }
       const fullName = resolveRecipientFullName(item, formData);
-      return `${fullName}’s income from a ${lowercase(
+      const possessiveName = formatPossessiveString(fullName);
+      return `${possessiveName} income from a ${lowercase(
         ownedAssetTypeLabels[item.assetType],
       )}`;
     },

--- a/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
@@ -20,6 +20,7 @@ import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fie
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import {
   formatCurrency,
+  formatPossessiveString,
   generateDeleteDescription,
   isDefined,
   isRecipientInfoIncomplete,
@@ -48,7 +49,8 @@ export const options = {
         return undefined;
       }
       const fullName = resolveRecipientFullName(item, formData);
-      return `${fullName}’s income`;
+      const possessiveName = formatPossessiveString(fullName);
+      return `${possessiveName} income`;
     },
     cardDescription: item =>
       isDefined(item?.grossMonthlyIncome) &&

--- a/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/10-discontinued-incomes/discontinuedIncomePages.js
@@ -20,6 +20,7 @@ import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fie
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import {
   formatCurrency,
+  formatPossessiveString,
   generateDeleteDescription,
   isDefined,
   isIncomeTypeInfoIncomplete,
@@ -49,7 +50,8 @@ export const options = {
         return undefined;
       }
       const fullName = resolveRecipientFullName(item, formData);
-      return `${fullName}’s income from ${item.payer}`;
+      const possessiveName = formatPossessiveString(fullName);
+      return `${possessiveName} income from ${item.payer}`;
     },
     cardDescription: item =>
       isDefined(item?.grossAnnualAmount) && (

--- a/src/applications/income-and-asset-statement/config/chapters/11-income-receipt-waivers/incomeReceiptWaiverPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/11-income-receipt-waivers/incomeReceiptWaiverPages.js
@@ -23,6 +23,7 @@ import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fie
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import {
   formatCurrency,
+  formatPossessiveString,
   generateDeleteDescription,
   isDefined,
   isRecipientInfoIncomplete,
@@ -48,7 +49,8 @@ export const options = {
         return undefined;
       }
       const fullName = resolveRecipientFullName(item, formData);
-      return `${fullName}’s waived income`;
+      const possessiveName = formatPossessiveString(fullName);
+      return `${possessiveName} waived income`;
     },
     cardDescription: item =>
       isDefined(item?.waivedGrossMonthlyIncome) && (

--- a/src/applications/income-and-asset-statement/helpers.js
+++ b/src/applications/income-and-asset-statement/helpers.js
@@ -38,6 +38,21 @@ export const formatFullNameNoSuffix = name => {
   return [first, middleInitial, last].filter(Boolean).join(' ');
 };
 
+/**
+ * Converts any string (e.g., a person's name or noun) to its possessive form.
+ * - "Johnson" -> "Johnson’s"
+ * - "Williams" -> "Williams’"
+ * - "Business" -> "Business’"
+ * - "Emma Lee" -> "Emma Lee’s"
+ *
+ * @param {string} str - The string to convert (e.g., full name or label)
+ * @returns {string} - Possessive form of the string
+ */
+export const formatPossessiveString = str => {
+  if (!str || typeof str !== 'string') return '';
+  return str.endsWith('s') ? `${str}’` : `${str}’s`;
+};
+
 export const isDefined = value => {
   return value !== '' && typeof value !== 'undefined' && value !== null;
 };

--- a/src/applications/income-and-asset-statement/tests/unit/helpers.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/helpers.unit.spec.jsx
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import {
   formatFullNameNoSuffix,
+  formatPossessiveString,
   isDefined,
   isReviewAndSubmitPage,
   resolveRecipientFullName,
@@ -157,5 +158,37 @@ describe('resolveRecipientFullName', () => {
     const formData = { isLoggedIn: true };
 
     expect(resolveRecipientFullName(item, formData)).to.equal('');
+  });
+});
+
+describe('formatPossessiveString', () => {
+  it("should append ’s to strings not ending in 's'", () => {
+    expect(formatPossessiveString('Johnson')).to.equal('Johnson’s');
+    expect(formatPossessiveString('Emma')).to.equal('Emma’s');
+    expect(formatPossessiveString('Emma Lee')).to.equal('Emma Lee’s');
+  });
+
+  it("should append just ’ to strings ending in 's'", () => {
+    expect(formatPossessiveString('Williams')).to.equal('Williams’');
+    expect(formatPossessiveString('Ross')).to.equal('Ross’');
+    expect(formatPossessiveString('Business')).to.equal('Business’');
+    expect(formatPossessiveString('Ed Harris')).to.equal('Ed Harris’');
+  });
+
+  it('should return empty string for null, undefined, or non-string input', () => {
+    expect(formatPossessiveString(null)).to.equal('');
+    expect(formatPossessiveString(undefined)).to.equal('');
+    expect(formatPossessiveString(123)).to.equal('');
+    expect(formatPossessiveString({})).to.equal('');
+  });
+
+  it('should handle empty string input', () => {
+    expect(formatPossessiveString('')).to.equal('');
+  });
+
+  it("should use typographic apostrophe (’) not straight quote (')", () => {
+    const result = formatPossessiveString('Jones');
+    expect(result).to.include('’');
+    expect(result).to.not.include("'");
   });
 });


### PR DESCRIPTION
## Summary
Added a helper function `formatPossessiveString` to handle possessive apostrophe logic used in list-and-loop card titles on the Income and Asset Statement form (VA Form 21P-0969). This ensures names are formatted correctly with `'s` or `'` depending on whether they end in “s” (e.g., “James’ annuity” vs. “Maria’s annuity”), improving readability and grammatical correctness across dynamic card titles.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109543

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969/` in your browser

## How to verify
1. Navigate to any list-and-loop section where an income recipient name is used in the card title (e.g., annuities, income, property)
2. Add an entry with a non-veteran relationship name ending in “s” (e.g., “James”) and one without (e.g., “Maria”)
3. Confirm that titles are correctly rendered as:
   - “James’ annuity”
   - “Maria’s annuity”
4. Ensure no visual or content regressions on cards

## What areas of the site does it impact?
Income and Asset Statement Application — List-and-loop card titles in sections such as Annuities, Income, and Property

## Screenshots
| Before                    | After                     |
|---------------------------|---------------------------|
|<img width="587" height="689" alt="Screenshot 2025-07-22 at 11 52 21 AM" src="https://github.com/user-attachments/assets/c511d4ec-1be4-484a-8ada-09b070671f41" />|<img width="575" height="689" alt="Screenshot 2025-07-22 at 10 24 28 AM" src="https://github.com/user-attachments/assets/aa7d0d83-8512-4b36-bfed-c586f8b71a5b" />|

### Quality Assurance & Testing
- [x] New unit tests (for `formatPossessiveString`)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors
- [x] Card titles display consistently across edge cases
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify authenticated/unauthenticated user flows

## Requested Feedback
Please confirm that the possessive formatting is working as expected for common name edge cases, and let me know if you spot any inconsistencies in the card title rendering.
