### PR TITLE
fix: react exhaustive-deps for DEBEX

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/workflowChoicePage.jsx
@@ -409,13 +409,7 @@ const WorkflowChoicePage = props => {
         goForward(data);
       }
     },
-
-    /**
-     * TODO: tech-debt(react-hooks/exhaustive-deps): Validate this rule exception is needed and why
-     * @see https://github.com/department-of-veterans-affairs/va.gov-team/issues/110539
-     */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data?.mentalHealthWorkflowChoice, shouldGoForward],
+    [data, goForward, selectedMentalHealthWorkflowChoice, shouldGoForward],
   );
 
   const missingSelectionErrorMessage =

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -105,7 +105,7 @@ describe('<IntroductionPage/>', () => {
 
   it('should render 2 SiP intros', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
-    const sipIntro = wrapper.find('Connect(SaveInProgressIntro)');
+    const sipIntro = wrapper.find('Connect(withRouter(SaveInProgressIntro))');
     expect(sipIntro.length).to.equal(2);
     expect(sipIntro.first().props().startText).to.equal(START_TEXT.ALL);
     wrapper.unmount();

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -119,7 +119,7 @@ describe('<IntroductionPage/>', () => {
         .format('YYYY-MM-DD'),
     );
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
-    const sipIntro = wrapper.find('Connect(SaveInProgressIntro)');
+    const sipIntro = wrapper.find('Connect(withRouter(SaveInProgressIntro))');
     expect(sipIntro.length).to.equal(2);
     expect(sipIntro.first().props().startText).to.equal(START_TEXT.BDD);
     wrapper.unmount();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fix for the `react exhaustive-deps` warning that occurs when linting

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/110539
## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/110539

## Testing done

- Ran `yarn eslint src/applications/disability-benefits/all-claims` to ensure warning is NOT present

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
