### PR TITLE
109708 - Extract back/continue buttons from array builder to separate component

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderButtonPair.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderButtonPair.jsx
@@ -1,0 +1,119 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/sort-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import ArrayBuilderCancelButton from './ArrayBuilderCancelButton';
+import { getArrayUrlSearchParams } from './helpers';
+
+/**
+ * Array builder cancel/save and continue buttons. May be used
+ * as standalone components within a user-defined CustomPage within an
+ * array builder.
+ * @param {{
+ *   arrayPath: string,
+ *   nounPlural: string,
+ *   nounSingular: string,
+ *   summaryRoute: string,
+ *   introRoute?: string,
+ *   required: (formData) => boolean,
+ *   reviewRoute: string,
+ *   getText: import('./arrayBuilderText').ArrayBuilderGetText,
+ *   props: object
+ * }} props
+ */
+export default function ArrayBuilderButtonPair(props) {
+  /*
+  These are supplied via the array builder + passed to any
+  custom pages that override the normal array builder page via the
+  `arrayBuilder` prop (see CustomPage logic in arrayBuilder.jsx).
+  */
+  const {
+    arrayPath,
+    summaryRoute,
+    introRoute,
+    reviewRoute,
+    getText,
+    required,
+  } = props;
+  const searchParams = getArrayUrlSearchParams();
+  const isEdit = !!searchParams.get('edit');
+  const isAdd = !!searchParams.get('add');
+
+  const NavButtons = props.NavButtons || FormNavButtons;
+
+  return (
+    <>
+      {isAdd && (
+        <>
+          <ArrayBuilderCancelButton
+            goToPath={props.goToPath}
+            arrayPath={arrayPath}
+            summaryRoute={summaryRoute}
+            introRoute={introRoute}
+            reviewRoute={reviewRoute}
+            getText={getText}
+            required={required}
+          />
+          {/* save-in-progress link, etc */}
+          {props.pageContentBeforeButtons}
+          {props.contentBeforeButtons}
+          <NavButtons
+            goBack={props.goBack}
+            goForward={props.onContinue}
+            submitToContinue
+            useWebComponents={props.formOptions?.useWebComponentForNavigation}
+          />
+        </>
+      )}
+      {isEdit && (
+        <div className="vads-u-display--flex">
+          <div className="vads-u-margin-right--2">
+            <ArrayBuilderCancelButton
+              goToPath={props.goToPath}
+              arrayPath={arrayPath}
+              summaryRoute={summaryRoute}
+              introRoute={introRoute}
+              reviewRoute={reviewRoute}
+              getText={getText}
+              required={required}
+              className="vads-u-margin-0"
+            />
+          </div>
+          <div>
+            <VaButton
+              continue
+              submit="prevent"
+              // "Continue" will display instead of `text`
+              // prop until this is fixed:
+              // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2733
+              text={getText('editSaveButtonText')}
+            />
+          </div>
+        </div>
+      )}
+
+      {props.contentAfterButtons}
+    </>
+  );
+}
+
+ArrayBuilderButtonPair.propTypes = {
+  arrayPath: PropTypes.string.isRequired,
+  summaryRoute: PropTypes.string.isRequired,
+  required: PropTypes.func.isRequired,
+  introRoute: PropTypes.string,
+  reviewRoute: PropTypes.string.isRequired,
+  getText: PropTypes.func.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+  formContext: PropTypes.object,
+  formOptions: PropTypes.object,
+  goBack: PropTypes.func,
+  goToPath: PropTypes.func,
+  onContinue: PropTypes.func,
+  pageContentBeforeButtons: PropTypes.node,
+  NavButtons: PropTypes.func,
+  props: PropTypes.object,
+};

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
@@ -3,12 +3,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
-import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import navigationState from 'platform/forms-system/src/js/utilities/navigation/navigationState';
 import { useEditOrAddForm } from './useEditOrAddForm';
-import ArrayBuilderCancelButton from './ArrayBuilderCancelButton';
 import { getArrayUrlSearchParams } from './helpers';
+import ArrayBuilderButtonPair from './ArrayBuilderButtonPair';
 
 /**
  * @param {{
@@ -94,60 +93,15 @@ export default function ArrayBuilderItemPage({
         onChange={onChange}
         onSubmit={onSubmit}
       >
-        <>
-          {isAdd && (
-            <>
-              <ArrayBuilderCancelButton
-                goToPath={props.goToPath}
-                arrayPath={arrayPath}
-                summaryRoute={summaryRoute}
-                introRoute={introRoute}
-                reviewRoute={reviewRoute}
-                getText={getText}
-                required={required}
-              />
-              {/* save-in-progress link, etc */}
-              {props.pageContentBeforeButtons}
-              {props.contentBeforeButtons}
-              <NavButtons
-                goBack={props.goBack}
-                goForward={props.onContinue}
-                submitToContinue
-                useWebComponents={
-                  props.formOptions?.useWebComponentForNavigation
-                }
-              />
-            </>
-          )}
-          {isEdit && (
-            <div className="vads-u-display--flex">
-              <div className="vads-u-margin-right--2">
-                <ArrayBuilderCancelButton
-                  goToPath={props.goToPath}
-                  arrayPath={arrayPath}
-                  summaryRoute={summaryRoute}
-                  introRoute={introRoute}
-                  reviewRoute={reviewRoute}
-                  getText={getText}
-                  required={required}
-                  className="vads-u-margin-0"
-                />
-              </div>
-              <div>
-                <VaButton
-                  continue
-                  submit="prevent"
-                  // "Continue" will display instead of `text`
-                  // prop until this is fixed:
-                  // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2733
-                  text={getText('editSaveButtonText')}
-                />
-              </div>
-            </div>
-          )}
-
-          {props.contentAfterButtons}
-        </>
+        <ArrayBuilderButtonPair
+          arrayPath={arrayPath}
+          summaryRoute={summaryRoute}
+          introRoute={introRoute}
+          reviewRoute={reviewRoute}
+          getText={getText}
+          required={required}
+          {...props}
+        />
       </SchemaForm>
     );
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR pulls the back/cancel & continue buttons out of the array builder page component into a separate component so that when array builder consumers supply a custom page, they can ensure the back/continue buttons behave the same without having to duplicate navigation buttons in their custom pages.

This change should be backwards compatible as nothing has been changed in the button logic, it's just been extracted for individual usage.

## Related issue(s)

- 

## Testing done

- Manual

## Screenshots

|         | Before (using custom buttons) | After (using array builder buttons)|
| ------- | ------ | ----- |
| Desktop |<img width="760" height="517" alt="Screenshot 2025-07-22 at 17 16 51" src="https://github.com/user-attachments/assets/9efde2d0-beb6-451c-bba4-0b34f088d9f6" />|<img width="646" height="430" alt="Screenshot 2025-07-22 at 17 15 37" src="https://github.com/user-attachments/assets/41866fe2-418a-4934-9fd1-c1b389dc3cba" />|

## What areas of the site does it impact?

forms that use the array builder

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
