### PR TITLE
Support for international phone numbers for DR confirmation page

### DIFF
--- a/src/applications/appeals/shared/components/ConfirmationVeteranContact.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationVeteranContact.jsx
@@ -27,6 +27,9 @@ export const ConfirmationVeteranContact = ({
           >
             <va-telephone
               contact={getPhoneString(homePhone)}
+              country-code={
+                homePhone?.isInternational ? homePhone?.countryCode : undefined
+              }
               extension={homePhone?.extension}
               not-clickable
             />
@@ -43,6 +46,9 @@ export const ConfirmationVeteranContact = ({
         >
           <va-telephone
             contact={getPhoneString(phone)}
+            country-code={
+              phone?.isInternational ? phone?.countryCode : undefined
+            }
             extension={phone?.extension}
             not-clickable
           />

--- a/src/applications/appeals/shared/tests/components/ConfirmationVeteranContact.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationVeteranContact.unit.spec.jsx
@@ -46,4 +46,47 @@ describe('ConfirmationVeteranContact', () => {
       '123 Main StNew York, NY 30012',
     ]);
   });
+
+  it('should render international phone numbers with country code', () => {
+    const testVeteran = {
+      ...veteran(),
+      phone: {
+        countryCode: '44',
+        areaCode: '20',
+        phoneNumber: '12345678',
+        isInternational: true,
+      },
+    };
+
+    const { container } = render(
+      <ConfirmationVeteranContact veteran={testVeteran} />,
+    );
+
+    const telephoneElement = container.querySelector('va-telephone');
+    expect(telephoneElement).to.exist;
+    expect(telephoneElement.getAttribute('country-code')).to.equal('44');
+    expect(telephoneElement.getAttribute('not-clickable')).to.equal('true');
+  });
+
+  it('should not render country-code attribute for domestic numbers', () => {
+    const testVeteran = {
+      ...veteran(),
+      phone: {
+        countryCode: '1',
+        areaCode: '555',
+        phoneNumber: '8001111',
+        extension: '123',
+        isInternational: false,
+      },
+    };
+
+    const { container } = render(
+      <ConfirmationVeteranContact veteran={testVeteran} />,
+    );
+
+    const telephoneElement = container.querySelector('va-telephone');
+    expect(telephoneElement).to.exist;
+    expect(telephoneElement.getAttribute('country-code')).to.be.null;
+    expect(telephoneElement.getAttribute('extension')).to.equal('123');
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated ConfirmationVeteranContact component to handle international phone number rendering

- Added conditional logic to only pass the country-code attribute to va-telephone when the phone number is marked as international

- The va-telephone component does not support displaying extension numbers for international phone numbers. I had a [discussion](https://dsva.slack.com/archives/C08P5UMPBKN/p1753211737744649) in Slack with other teams and created this [issue](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4557) for the platform to support it. In the meantime, we can display it without the extension, and be sure to circle back once the platform adds support.

## Related issue(s)

[Issue Ticket](https://github.com/orgs/department-of-veterans-affairs/projects/1434/views/3?pane=issue&itemId=116841014&issue=department-of-veterans-affairs%7Cva.gov-team%7C112752)

## Testing done

### International phone number rendering tests

- Verifies country-code attribute is passed correctly
- Tests both domestic and international numbers
-  Run Spec `yarn test src/applications/appeals/shared/tests/components/ConfirmationVeteranContact.unit.spec.jsx`

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Domestic | Domestic W/ Ext |  International  |
| ------- | ------ | ----- | ----- | 
| 00995  |  <img width="202" height="141" alt="image" src="https://github.com/user-attachments/assets/a74ad4f0-59b6-4146-b0c2-aa93ae218bff" /> | <img width="202" height="141" alt="image" src="https://github.com/user-attachments/assets/a437534d-f396-4ec5-a704-c3f637625a20" /> | <img width="202" height="141" alt="image" src="https://github.com/user-attachments/assets/c51e0df6-9f4d-4a92-af81-521c5c97ffa8" /> |
| 00996 | <img width="214" height="94" alt="image" src="https://github.com/user-attachments/assets/45189b23-59d1-4066-89fb-b5925f9757ca" /> | <img width="214" height="94" alt="image" src="https://github.com/user-attachments/assets/a914c112-306d-401a-9f30-71f8d22c0a9c" /> | <img width="214" height="94" alt="image" src="https://github.com/user-attachments/assets/7ca37e48-b337-4b7f-8c12-e8c19ad3b1e3" /> |
| 10182 | <img width="193" height="88" alt="image" src="https://github.com/user-attachments/assets/a09aeb68-b18f-46fc-8b25-623af15f138d" /> | <img width="214" height="94" alt="image" src="https://github.com/user-attachments/assets/bbbabde3-6e2e-4da0-8c9a-bc419a031c28" />| <img width="202" height="88" alt="image" src="https://github.com/user-attachments/assets/1ae114bc-1421-4e82-8f43-dd41a7b6e076" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user