### PR TITLE
Resolve Chapter 4 bug fixes

### DIFF
--- a/src/applications/accreditation/21a/config/submit-transformer.js
+++ b/src/applications/accreditation/21a/config/submit-transformer.js
@@ -148,7 +148,7 @@ const build21aPayload = data => {
       data.educationalInstitutions?.map(e => ({
         name: e.name,
         startDate: `${e.dateRange?.from}-01`, // adding a day here since GCLAWS requires it
-        endDate: `${e.dateRange?.to}-01` || null, // adding a day here since GCLAWS requires it
+        endDate: e.dateRange?.to ? `${e.dateRange.to}-01` : null, // adding a day here since GCLAWS requires it
         wasDegreeReceived: !!e.degreeReceived,
         major: e.major,
         degreeTypeId: DEGREE_TYPE_ENUM[e.degree],

--- a/src/applications/accreditation/21a/config/submit-transformer.js
+++ b/src/applications/accreditation/21a/config/submit-transformer.js
@@ -119,7 +119,7 @@ const build21aPayload = data => {
         addressCountry: e.address?.country || null,
         phoneTypeId: PHONE_TYPE_ENUM.WORK,
         phoneNumber: `${e.phone.callingCode}${e.phone.contact}`,
-        phoneExtension: null,
+        phoneExtension: e.extension,
         startDate: `${e.dateRange?.from}-01`, // adding a day here since GCLAWS requires it
         // Not using `currentlyEmployed` so if it exists we set `endDate` to null
         // Adding a day here since GCLAWS requires it

--- a/src/applications/accreditation/21a/pages/02-military-service-chapter/militaryServicePages.js
+++ b/src/applications/accreditation/21a/pages/02-military-service-chapter/militaryServicePages.js
@@ -72,8 +72,8 @@ const branchAndDateRangePage = {
       currentLabel:
         'I am currently serving in this military service experience.',
       currentKey: 'currentlyServing',
-      isCurrentChecked: (formData, index) =>
-        formData?.militaryServiceExperiences?.[index]?.currentlyServing,
+      isCurrentChecked: (fullData, index) =>
+        fullData?.militaryServiceExperiences?.[index]?.currentlyServing,
     }),
   },
   schema: {

--- a/src/applications/accreditation/21a/pages/02-military-service-chapter/militaryServicePages.js
+++ b/src/applications/accreditation/21a/pages/02-military-service-chapter/militaryServicePages.js
@@ -72,8 +72,15 @@ const branchAndDateRangePage = {
       currentLabel:
         'I am currently serving in this military service experience.',
       currentKey: 'currentlyServing',
-      isCurrentChecked: (fullData, index) =>
-        fullData?.militaryServiceExperiences?.[index]?.currentlyServing,
+      isCurrentChecked: (formData, index, fullData) => {
+        // Adding a check for formData and fullData since formData is sometimes undefined on load
+        // and we cant rely on fullData for testing
+        const militaryServiceExperiences =
+          formData.militaryServiceExperiences ??
+          fullData.militaryServiceExperiences;
+        const militaryServiceExperience = militaryServiceExperiences?.[index];
+        return militaryServiceExperience?.currentlyServing === true;
+      },
     }),
   },
   schema: {

--- a/src/applications/accreditation/21a/pages/03-employment-information-chapter/employersPages.js
+++ b/src/applications/accreditation/21a/pages/03-employment-information-chapter/employersPages.js
@@ -184,8 +184,8 @@ const dateRangePage = {
       toLabel: 'Employment end date',
       currentLabel: 'I still work here.',
       currentKey: 'currentlyEmployed',
-      isCurrentChecked: (formData, index) =>
-        formData?.employers?.[index]?.currentlyEmployed,
+      isCurrentChecked: (fullData, index) =>
+        fullData?.employers?.[index]?.currentlyEmployed,
     }),
   },
   schema: {

--- a/src/applications/accreditation/21a/pages/03-employment-information-chapter/employersPages.js
+++ b/src/applications/accreditation/21a/pages/03-employment-information-chapter/employersPages.js
@@ -184,8 +184,14 @@ const dateRangePage = {
       toLabel: 'Employment end date',
       currentLabel: 'I still work here.',
       currentKey: 'currentlyEmployed',
-      isCurrentChecked: (fullData, index) =>
-        fullData?.employers?.[index]?.currentlyEmployed,
+      isCurrentChecked: (formData, index, fullData) => {
+        // Adding a check for formData and fullData since formData is sometimes undefined on load
+        // and we cant rely on fullData for testing
+        const employers = formData.employers ?? fullData.employers;
+        const employer = employers?.[index];
+
+        return employer?.currentlyEmployed === true;
+      },
     }),
   },
   schema: {

--- a/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
+++ b/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
@@ -79,7 +79,6 @@ const institutionAndDegreePage = {
           fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;
 
         return currentlyEnrolled === true;
-        // return fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;
       },
     }),
     institution: selectUI('Institution type'),
@@ -104,17 +103,45 @@ const degreeInformationPage = {
   uiSchema: {
     degree: selectUI({
       title: 'Type of degree',
-      hideIf: (formData, index, fullData) =>
-        !fullData?.educationalInstitutions?.[index]?.degreeReceived,
-      required: (formData, index, fullData) =>
-        fullData?.educationalInstitutions?.[index]?.degreeReceived,
+      hideIf: (formData, index, fullData) => {
+        // Adding a check for formData and fullData since formData is sometimes undefined on load
+        // and we cant rely on fullData for testing
+        const degreeReceived =
+          formData?.educationalInstitutions?.[index]?.degreeReceived ??
+          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+
+        return degreeReceived === false;
+      },
+      required: (formData, index, fullData) => {
+        // Adding a check for formData and fullData since formData is sometimes undefined on load
+        // and we cant rely on fullData for testing
+        const degreeReceived =
+          formData?.educationalInstitutions?.[index]?.degreeReceived ??
+          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+
+        return degreeReceived === true;
+      },
     }),
     reasonForNotCompleting: textareaUI({
       title: 'Explain why you did not complete this degree.',
-      hideIf: (formData, index, fullData) =>
-        !fullData?.educationalInstitutions?.[index]?.degreeReceived === false,
-      required: (formData, index, fullData) =>
-        fullData?.educationalInstitutions?.[index]?.degreeReceived === false,
+      hideIf: (formData, index, fullData) => {
+        // Adding a check for formData and fullData since formData is sometimes undefined on load
+        // and we cant rely on fullData for testing
+        const degreeReceived =
+          formData?.educationalInstitutions?.[index]?.degreeReceived ??
+          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+
+        return degreeReceived === true;
+      },
+      required: (formData, index, fullData) => {
+        // Adding a check for formData and fullData since formData is sometimes undefined on load
+        // and we cant rely on fullData for testing
+        const degreeReceived =
+          formData?.educationalInstitutions?.[index]?.degreeReceived ??
+          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+
+        return degreeReceived === false;
+      },
     }),
   },
   schema: {

--- a/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
+++ b/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
@@ -71,8 +71,15 @@ const institutionAndDegreePage = {
       toLabel: 'End date',
       currentLabel: 'I still go to school here.',
       currentKey: 'currentlyEnrolled',
-      isCurrentChecked: (fullData, index) => {
-        return fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;
+      isCurrentChecked: (formData, index, fullData) => {
+        // Adding a check for formData and fullData since formData is sometimes undefined on load
+        // and we cant rely on fullData for testing
+        const currentlyEnrolled =
+          formData?.educationalInstitutions?.[index]?.currentlyEnrolled ??
+          fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;
+
+        return currentlyEnrolled === true;
+        // return fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;
       },
     }),
     institution: selectUI('Institution type'),

--- a/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
+++ b/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
@@ -74,11 +74,11 @@ const institutionAndDegreePage = {
       isCurrentChecked: (formData, index, fullData) => {
         // Adding a check for formData and fullData since formData is sometimes undefined on load
         // and we cant rely on fullData for testing
-        const currentlyEnrolled =
-          formData?.educationalInstitutions?.[index]?.currentlyEnrolled ??
-          fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;
+        const institutions =
+          formData.educationalInstitutions ?? fullData.educationalInstitutions;
+        const institution = institutions?.[index];
 
-        return currentlyEnrolled === true;
+        return institution?.currentlyEnrolled === true;
       },
     }),
     institution: selectUI('Institution type'),
@@ -106,20 +106,20 @@ const degreeInformationPage = {
       hideIf: (formData, index, fullData) => {
         // Adding a check for formData and fullData since formData is sometimes undefined on load
         // and we cant rely on fullData for testing
-        const degreeReceived =
-          formData?.educationalInstitutions?.[index]?.degreeReceived ??
-          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+        const institutions =
+          formData.educationalInstitutions ?? fullData.educationalInstitutions;
+        const institution = institutions?.[index];
 
-        return degreeReceived === false;
+        return institution?.degreeReceived === false;
       },
       required: (formData, index, fullData) => {
         // Adding a check for formData and fullData since formData is sometimes undefined on load
         // and we cant rely on fullData for testing
-        const degreeReceived =
-          formData?.educationalInstitutions?.[index]?.degreeReceived ??
-          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+        const institutions =
+          formData.educationalInstitutions ?? fullData.educationalInstitutions;
+        const institution = institutions?.[index];
 
-        return degreeReceived === true;
+        return institution?.degreeReceived === true;
       },
     }),
     reasonForNotCompleting: textareaUI({
@@ -127,20 +127,20 @@ const degreeInformationPage = {
       hideIf: (formData, index, fullData) => {
         // Adding a check for formData and fullData since formData is sometimes undefined on load
         // and we cant rely on fullData for testing
-        const degreeReceived =
-          formData?.educationalInstitutions?.[index]?.degreeReceived ??
-          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+        const institutions =
+          formData.educationalInstitutions ?? fullData.educationalInstitutions;
+        const institution = institutions?.[index];
 
-        return degreeReceived === true;
+        return institution?.degreeReceived === true;
       },
       required: (formData, index, fullData) => {
         // Adding a check for formData and fullData since formData is sometimes undefined on load
         // and we cant rely on fullData for testing
-        const degreeReceived =
-          formData?.educationalInstitutions?.[index]?.degreeReceived ??
-          fullData?.educationalInstitutions?.[index]?.degreeReceived;
+        const institutions =
+          formData.educationalInstitutions ?? fullData.educationalInstitutions;
+        const institution = institutions?.[index];
 
-        return degreeReceived === false;
+        return institution?.degreeReceived === false;
       },
     }),
   },

--- a/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
+++ b/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
@@ -68,11 +68,12 @@ const institutionAndDegreePage = {
     name: textUI('Name of school'),
     ...dateRangeWithCurrentCheckboxUI({
       fromLabel: 'Start date',
-      toLabel: 'End date',
       currentLabel: 'I still go to school here.',
+      toLabel: 'End date',
       currentKey: 'currentlyEnrolled',
-      isCurrentChecked: (formData, index) =>
-        formData?.educationalInstitutions?.[index]?.currentlyEnrolled,
+      isCurrentChecked: (fullData, index) => {
+        return fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;
+      },
     }),
     institution: selectUI('Institution type'),
     degreeReceived: yesNoUI('Degree received?'),
@@ -96,17 +97,17 @@ const degreeInformationPage = {
   uiSchema: {
     degree: selectUI({
       title: 'Type of degree',
-      hideIf: (formData, index) =>
-        !formData?.educationalInstitutions?.[index]?.degreeReceived,
-      required: (formData, index) =>
-        formData?.educationalInstitutions?.[index]?.degreeReceived,
+      hideIf: (formData, index, fullData) =>
+        !fullData?.educationalInstitutions?.[index]?.degreeReceived,
+      required: (formData, index, fullData) =>
+        fullData?.educationalInstitutions?.[index]?.degreeReceived,
     }),
     reasonForNotCompleting: textareaUI({
       title: 'Explain why you did not complete this degree.',
-      hideIf: (formData, index) =>
-        !formData?.educationalInstitutions?.[index]?.degreeReceived === false,
-      required: (formData, index) =>
-        formData?.educationalInstitutions?.[index]?.degreeReceived === false,
+      hideIf: (formData, index, fullData) =>
+        !fullData?.educationalInstitutions?.[index]?.degreeReceived === false,
+      required: (formData, index, fullData) =>
+        fullData?.educationalInstitutions?.[index]?.degreeReceived === false,
     }),
   },
   schema: {

--- a/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
+++ b/src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js
@@ -68,8 +68,8 @@ const institutionAndDegreePage = {
     name: textUI('Name of school'),
     ...dateRangeWithCurrentCheckboxUI({
       fromLabel: 'Start date',
-      currentLabel: 'I still go to school here.',
       toLabel: 'End date',
+      currentLabel: 'I still go to school here.',
       currentKey: 'currentlyEnrolled',
       isCurrentChecked: (fullData, index) => {
         return fullData?.educationalInstitutions?.[index]?.currentlyEnrolled;

--- a/src/applications/accreditation/21a/pages/helpers/dateRangeWithCurrentCheckboxPattern.js
+++ b/src/applications/accreditation/21a/pages/helpers/dateRangeWithCurrentCheckboxPattern.js
@@ -30,16 +30,18 @@ export const dateRangeWithCurrentCheckboxUI = ({
     {
       title: toLabel,
       hint: 'For example: January 2000',
-      hideIf: (formData, index) => isCurrentChecked(formData, index),
-      required: (formData, index) => !isCurrentChecked(formData, index),
+      hideIf: (formData, index, fullData) => isCurrentChecked(fullData, index),
+      required: (formData, index, fullData) =>
+        !isCurrentChecked(fullData, index),
     },
   ),
   'view:currentToLabel': {
     'ui:description': toLabel,
     'ui:options': {
-      hideIf: (formData, index) => !isCurrentChecked(formData, index),
+      hideIf: (formData, index, fullData) => !isCurrentChecked(fullData, index),
     },
   },
+  // TODO: At somepoint we should update this so that the checkbox is before the to date for accessibility.
   [currentKey]: {
     'ui:title': currentLabel,
     'ui:webComponentField': VaCheckboxField,

--- a/src/applications/accreditation/21a/pages/helpers/dateRangeWithCurrentCheckboxPattern.js
+++ b/src/applications/accreditation/21a/pages/helpers/dateRangeWithCurrentCheckboxPattern.js
@@ -30,15 +30,25 @@ export const dateRangeWithCurrentCheckboxUI = ({
     {
       title: toLabel,
       hint: 'For example: January 2000',
-      hideIf: (formData, index, fullData) => isCurrentChecked(fullData, index),
+      hideIf: (formData, index, fullData) =>
+        isCurrentChecked(formData, index, fullData),
       required: (formData, index, fullData) =>
-        !isCurrentChecked(fullData, index),
+        !isCurrentChecked(formData, index, fullData),
     },
   ),
+  to: {
+    'ui:title': 'End date',
+    'ui:widget': 'date',
+    'ui:options': {
+      hideIf: (formData, index, fullData) =>
+        isCurrentChecked(formData, index, fullData),
+    },
+  },
   'view:currentToLabel': {
     'ui:description': toLabel,
     'ui:options': {
-      hideIf: (formData, index, fullData) => !isCurrentChecked(fullData, index),
+      hideIf: (formData, index, fullData) =>
+        isCurrentChecked(formData, index, fullData),
     },
   },
   // TODO: At somepoint we should update this so that the checkbox is before the to date for accessibility.

--- a/src/applications/accreditation/21a/pages/helpers/dateRangeWithCurrentCheckboxPattern.js
+++ b/src/applications/accreditation/21a/pages/helpers/dateRangeWithCurrentCheckboxPattern.js
@@ -36,21 +36,6 @@ export const dateRangeWithCurrentCheckboxUI = ({
         !isCurrentChecked(formData, index, fullData),
     },
   ),
-  to: {
-    'ui:title': 'End date',
-    'ui:widget': 'date',
-    'ui:options': {
-      hideIf: (formData, index, fullData) =>
-        isCurrentChecked(formData, index, fullData),
-    },
-  },
-  'view:currentToLabel': {
-    'ui:description': toLabel,
-    'ui:options': {
-      hideIf: (formData, index, fullData) =>
-        isCurrentChecked(formData, index, fullData),
-    },
-  },
   // TODO: At somepoint we should update this so that the checkbox is before the to date for accessibility.
   [currentKey]: {
     'ui:title': currentLabel,

--- a/src/applications/accreditation/21a/tests/unit/pages/02-military-service-chapter/militaryServicePages.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/02-military-service-chapter/militaryServicePages.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
@@ -13,6 +13,15 @@ import { explanationRequired } from '../../../../constants/options';
 const pages = militaryServicePages;
 
 describe('Military Service Chapter Pages', () => {
+  const formData = {
+    militaryServiceExperiences: [
+      {
+        branch: 'Army',
+        dateRange: { from: '2020-01-01', to: '2021-01-01' },
+        currentlyServing: false,
+      },
+    ],
+  };
   context('Intro page', () => {
     it('renders the intro paragraph and all list items', () => {
       const { getByText, getAllByRole } = render(<MilitaryServiceIntro />);
@@ -96,57 +105,27 @@ describe('Military Service Chapter Pages', () => {
         <DefinitionTester
           schema={pages.militaryServiceExperienceBranchDateRangePage.schema}
           uiSchema={pages.militaryServiceExperienceBranchDateRangePage.uiSchema}
-          data={{
-            militaryServiceExperiences: [
-              {
-                branch: 'Army',
-                dateRange: { from: '2020-01-01', to: '2021-01-01' },
-                currentlyServing: false,
-              },
-            ],
-          }}
+          data={formData}
           arrayPath="militaryServiceExperiences"
           pagePerItemIndex={0}
         />,
       );
-      // service end date should be visible
+      // service dates and checkbox  should be visible
       expect($('va-date[label="Service start date"]', container)).to.exist;
       expect($('va-date[label="Service end date"]', container)).to.exist;
-
-      // check currently serving checkbox
-
       const currentlyServingCheckbox = $('va-checkbox', container);
-      expect(currentlyServingCheckbox.getAttribute('label')).to.eq(
-        'I am currently serving in this military service experience.',
+      expect(currentlyServingCheckbox).to.exist;
+      expect(currentlyServingCheckbox.getAttribute('checked')).to.equal(
+        'false',
       );
-      currentlyServingCheckbox.checked = true;
-      fireEvent.change(currentlyServingCheckbox, { target: { checked: true } });
 
-      if ($('va-date[label="Service end date"]', container)) {
-        const { container: updatedContainer } = render(
-          <DefinitionTester
-            schema={pages.militaryServiceExperienceBranchDateRangePage.schema}
-            uiSchema={
-              pages.militaryServiceExperienceBranchDateRangePage.uiSchema
-            }
-            data={{
-              militaryServiceExperiences: [
-                {
-                  branch: 'Army',
-                  dateRange: { from: '2020-01-01', to: '' },
-                  currentlyServing: true,
-                },
-              ],
-            }}
-            arrayPath="militaryServiceExperiences"
-            pagePerItemIndex={0}
-          />,
-        );
-        expect($('va-date[label="Service end date"]', updatedContainer)).to.not
-          .exist;
-      } else {
-        expect($('va-date[label="Service end date"]', container)).to.not.exist;
-      }
+      // check currently enrolled checkbox
+      $('va-checkbox', container).__events.vaChange({
+        target: { checked: true },
+      });
+      // end date is hidden and checkbox is checked
+      expect($('va-date[label="Service end date"]', container)).to.not.exist;
+      expect(currentlyServingCheckbox.getAttribute('checked')).to.equal('true');
     });
   });
 

--- a/src/applications/accreditation/21a/tests/unit/pages/04-education-history-chapter/educationalInstitutionsPages.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/04-education-history-chapter/educationalInstitutionsPages.unit.spec.jsx
@@ -79,7 +79,7 @@ describe('educationalInstitutionsPages', () => {
       );
       expect($('va-text-input[label="Major"]'), container).to.exist;
     });
-    it('hides end date when currentlyEnrolled is true', () => {
+    it('hides end date when currentlyEnrolled is true', async () => {
       const { container } = render(
         <DefinitionTester
           schema={educationalInstitutionInstitutionAndDegreePage.schema}

--- a/src/applications/accreditation/21a/tests/unit/pages/04-education-history-chapter/educationalInstitutionsPages.unit.spec.jsx
+++ b/src/applications/accreditation/21a/tests/unit/pages/04-education-history-chapter/educationalInstitutionsPages.unit.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
@@ -79,7 +78,7 @@ describe('educationalInstitutionsPages', () => {
       );
       expect($('va-text-input[label="Major"]'), container).to.exist;
     });
-    it('hides end date when currentlyEnrolled is true', async () => {
+    it('hides end date when currentlyEnrolled is true', () => {
       const { container } = render(
         <DefinitionTester
           schema={educationalInstitutionInstitutionAndDegreePage.schema}
@@ -91,17 +90,20 @@ describe('educationalInstitutionsPages', () => {
           pagePerItemIndex={0}
         />,
       );
+      // education dates and checkbox should be visible
+      expect($('va-date[label="Start date"]', container)).to.exist;
       expect($('va-date[label="End date"]', container)).to.exist;
       const currentlyEnrolled = $('va-checkbox', container);
       expect(currentlyEnrolled).to.exist;
       expect(currentlyEnrolled.getAttribute('checked')).to.equal('false');
+
+      // check currently enrolled checkbox
       $('va-checkbox', container).__events.vaChange({
         target: { checked: true },
       });
-      expect($('va-checkbox', container).getAttribute('checked')).to.equal(
-        'true',
-      );
+      // end date is hidden and checkbox is checked
       expect($('va-date[label="End date"]', container)).to.not.exist;
+      expect(currentlyEnrolled.getAttribute('checked')).to.equal('true');
     });
   });
 


### PR DESCRIPTION
## Summary

- Updated `https://github.com/department-of-veterans-affairs/va.gov-team/issues/112533` so that the `employers.extension` is being used to set the `employment.extension` in gclaws. Also resolved a bug where the education.endDate was being set to `undefined-01` when the endDate was not populated. Added logic so that this no longer occurs.
- Updated `src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js` so that the bugs around the date and currentDate no longer occur. Now if you edit the education card the dates will load correctly. Found that it was checking `formData?.educationalInstitutions?.[index]?.degreeReceived` and formData sometimes renders undefined. Updating the logic to check formData and if undefined to then check fullData resolved this issue as it always renders the same regardless of if you are adding to a form or editing a form.
- Updated `src/applications/accreditation/21a/pages/04-education-history-chapter/educationalInstitutionsPages.js` so that the bugs around the `degreeReceived` and the `reasonForNotCompleting` and `degree` no longer occur. Now if you edit the education card the data will load correctly. Found that it was checking `formData?.educationalInstitutions?.[index]?.degreeReceived === false` and formData sometimes renders undefined. Updating the logic to check formData and if undefined to then check fullData resolved this issue as it always renders the same regardless of if you are adding to a form or editing a form. So now when you toggle the radio buttons between having a degree and not having on you see the correct options.
- Updated `src/applications/accreditation/21a/pages/02-military-service-chapter/militaryServicePages.js` so that the bugs around the date and currentDate no longer occur. Now if you edit the military card the dates will load correctly. Found that it was checking `formData?. militaryServiceExperiences?.[index]?. currentlyServing ` and formData sometimes renders undefined. Updating the logic to check formData and if undefined to then check fullData resolved this issue as it always renders the same regardless of if you are adding to a form or editing a form.
- Updated `src/applications/accreditation/21a/pages/03-employment-information-chapter/employersPages.js` so that the bugs around the date and currentDate no longer occur. Now if you edit the military card the dates will load correctly. Found that it was checking `formData?. employers?.[index]?. currentlyEmployed ` and formData sometimes renders undefined. Updating the logic to check formData and if undefined to then check fullData resolved this issue as it always renders the same regardless of if you are adding to a form or editing a form.
- Updated `src/applications/accreditation/21a/pages/helpers/dateRangeWithCurrentCheckboxPattern.js` to fix the bugs noted above with the date and current date 
- Added/updated tests to `src/applications/accreditation/21a/tests/unit/pages/04-education-history-chapter/educationalInstitutionsPages.unit.spec.jsx` and `src/applications/accreditation/21a/tests/unit/pages/02-military-service-chapter/militaryServicePages.unit.spec.jsx` .  The `militaryServicePages.unit.spec.jsx` test was using a fireEvent and that doesnt work for va-checkboxes so updated this to instead using a vaChange event.

## Related issue(s)

- _Link to ticket created in va.gov-team - https://github.com/department-of-veterans-affairs/va.gov-team/issues/112533
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112532
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112531

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Chapter 2 - Military End Date/CurrentlyServing bug fixed  |  https://github.com/user-attachments/assets/556296fb-353d-42d4-845f-06296ced7cec      |   https://github.com/user-attachments/assets/75b387e2-d0a8-4139-b884-4dc53776877a    |
| Chapter 3 - Employment End Date/CurrentlyEmployed bug fixed |      https://github.com/user-attachments/assets/6e1d4b12-5cf0-47aa-9f75-f32778606e76  |   https://github.com/user-attachments/assets/b05aa3ce-8ceb-4b53-95a1-78b4d940ff0f  |
| Chapter 4 - Education End Date/CurrentlyAttending bug fixed |  https://github.com/user-attachments/assets/6ff63a2c-3597-4cd1-9ad8-f1ca70b95722      |   https://github.com/user-attachments/assets/90e1ec39-b245-401f-a718-f56b516b9acb    |
| Chapter 4 - Degree Received bug fixed |    https://github.com/user-attachments/assets/6ff63a2c-3597-4cd1-9ad8-f1ca70b95722      |    https://github.com/user-attachments/assets/f7546d17-27bf-4e29-b96a-7c8f5fc4b154   |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
