### PR TITLE
Removed forward slash from State Veterans' Benefits link

### DIFF
--- a/src/applications/discover-your-benefits/constants/urls.js
+++ b/src/applications/discover-your-benefits/constants/urls.js
@@ -40,5 +40,5 @@ export const URLS = Object.freeze({
     'https://www.va.gov/education/transfer-post-9-11-gi-bill-benefits/',
   DCU_LEARN: 'https://www.va.gov/discharge-upgrade-instructions/',
   SVB_LEARN:
-    'https://discover.va.gov/external-resources/?_resource_type=state-veterans-affairs-office/',
+    'https://discover.va.gov/external-resources/?_resource_type=state-veterans-affairs-office',
 });


### PR DESCRIPTION
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- _Remove a forward slash from the end of state veterans' affairs link._
- _Click on the url labeled SVB_LEARN in `constants/urls`_