### PR TITLE
109708c - Update custom pages to use new nav button component - IVC CHAMPVA

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/SelectHealthcareParticipantsPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/SelectHealthcareParticipantsPage.jsx
@@ -9,7 +9,7 @@ import {
   checkboxGroupUI,
   arrayBuilderItemSubsequentPageTitleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import { CustomPageNavButtons } from '../../shared/components/CustomPageNavButtons';
 import { toHash, nameWording } from '../../shared/utilities';
 
 // This is the original schema that will be dynamically overrulled as soon
@@ -95,6 +95,10 @@ export function selectHealthcareParticipantsOnGoForward(props) {
 /** @type {CustomPageType} */
 export function SelectHealthcareParticipantsPage(props) {
   const sch = dynamicSchema(props?.fullData, props?.data);
+  const navButtons = CustomPageNavButtons({
+    ...props,
+    onContinue: () => selectHealthcareParticipantsOnGoForward(props),
+  });
 
   return (
     <SchemaForm
@@ -113,11 +117,7 @@ export function SelectHealthcareParticipantsPage(props) {
       <>
         {/* contentBeforeButtons = save-in-progress links */}
         {props.contentBeforeButtons}
-        <FormNavButtons
-          goBack={props.goBack}
-          goForward={() => selectHealthcareParticipantsOnGoForward(props)}
-          submitToContinue
-        />
+        {navButtons}
         {props.contentAfterButtons}
       </>
     </SchemaForm>

--- a/src/applications/ivc-champva/10-10d-extended/chapters/SelectMedicareParticipantsPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/SelectMedicareParticipantsPage.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/sort-prop-types */
 import PropTypes from 'prop-types';
 import React from 'react';
-import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import {
   arrayBuilderItemSubsequentPageTitleUI,
@@ -9,6 +8,7 @@ import {
   radioUI,
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import { CustomPageNavButtons } from '../../shared/components/CustomPageNavButtons';
 import { nameWording, toHash } from '../../shared/utilities';
 
 // similar to `toSpliced`, but simpler and actually works in testing framework
@@ -137,6 +137,12 @@ export function selectMedicareParticipantOnGoForward(props) {
 
 /** @type {CustomPageType} */
 export function SelectMedicareParticipantPage(props) {
+  const navButtons = CustomPageNavButtons({
+    ...props,
+    onContinue: () => {
+      return selectMedicareParticipantOnGoForward(props);
+    },
+  });
   return (
     <SchemaForm
       name={props.name}
@@ -157,11 +163,7 @@ export function SelectMedicareParticipantPage(props) {
     >
       <>
         {props.contentBeforeButtons}
-        <FormNavButtons
-          goBack={props.goBack}
-          goForward={() => selectMedicareParticipantOnGoForward(props)}
-          submitToContinue
-        />
+        {navButtons}
         {props.contentAfterButtons}
       </>
     </SchemaForm>

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -751,9 +751,7 @@ export const applicantPages = arrayBuilderPages(
       path: 'applicant-address-selection/:index',
       title: 'Address selection',
       ...applicantAddressSelectionPage,
-      CustomPage: props => {
-        return ApplicantAddressCopyPage(props);
-      },
+      CustomPage: ApplicantAddressCopyPage,
       depends: (formData, index) => page15aDepends(formData, index),
     }),
     page15: pageBuilder.itemPage({

--- a/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
@@ -20,7 +20,7 @@ import {
 import React from 'react';
 import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
-import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import { CustomPageNavButtons } from '../../shared/components/CustomPageNavButtons';
 import { populateFirstApplicant } from '../helpers/utilities';
 import manifest from '../manifest.json';
 
@@ -174,6 +174,11 @@ export function SignerContactInfoPage(props) {
     </button>
   );
 
+  const navButtons = CustomPageNavButtons({
+    ...props,
+    onContinue: () => signerContactOnGoForward(props),
+  });
+
   return (
     <SchemaForm
       name={props.name}
@@ -191,15 +196,7 @@ export function SignerContactInfoPage(props) {
       <>
         {/* contentBeforeButtons = save-in-progress links */}
         {props.contentBeforeButtons}
-        {props.onReviewPage ? (
-          updateButton
-        ) : (
-          <FormNavButtons
-            goBack={props.goBack}
-            goForward={() => signerContactOnGoForward(props)}
-            submitToContinue
-          />
-        )}
+        {props.onReviewPage ? updateButton : navButtons}
         {props.contentAfterButtons}
       </>
     </SchemaForm>

--- a/src/applications/ivc-champva/10-10d-extended/tests/components/customArrayBuilderButtonPair.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/components/customArrayBuilderButtonPair.unit.spec.jsx
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { getProps } from '../../../shared/tests/pages/pageTests.spec';
+import CustomArrayBuilderButtonPair from '../../../shared/components/CustomArrayBuilderButtonPair';
+
+function stubWindowLocation(url, search) {
+  const originalLocation = window.location;
+
+  // Use defineProperty instead of direct assignment
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { href: url ?? originalLocation, search: search ?? '?add=true' },
+  });
+
+  return () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  };
+}
+
+describe('CustomArrayBuilderButtonPair', () => {
+  it('should call goForward when "continue" clicked', async () => {
+    const restoreLocation = stubWindowLocation();
+    const goFwdSpy = sinon.spy();
+    const component = (
+      <CustomArrayBuilderButtonPair
+        contentBeforeButtons={<></>}
+        contentAfterButtons={<></>}
+        setFormData={() => {}}
+        goBack={() => {}}
+        onContinue={goFwdSpy}
+        updatePage={() => {}}
+        arrayPath="applicants"
+        summaryRoute="/summaryRoute"
+        introRoute="/introRoute"
+        reviewRoute="/reviewRoute"
+        required={() => false}
+        getText={() => {}}
+      />
+    );
+    const { mockStore } = getProps();
+    const { container } = render(
+      <Provider store={mockStore}>{component}</Provider>,
+    );
+
+    const continueButton = $('.usa-button-primary', container);
+    expect(continueButton).to.contain.text('Continue');
+    fireEvent.click(continueButton);
+    await waitFor(() => {
+      expect(goFwdSpy.called).to.be.true;
+    });
+    restoreLocation();
+  });
+  it('should use custom text when on edit flow', async () => {
+    const restoreLocation = stubWindowLocation(
+      'localhost:3001/ivc-champva/10-10d-extended/applicant-name-dob/0',
+      '?edit=true',
+    );
+    const goFwdSpy = sinon.spy();
+    const component = (
+      <CustomArrayBuilderButtonPair
+        contentBeforeButtons={<></>}
+        contentAfterButtons={<></>}
+        setFormData={() => {}}
+        goBack={() => {}}
+        onContinue={goFwdSpy}
+        updatePage={() => {}}
+        arrayPath="applicants"
+        summaryRoute="/summaryRoute"
+        introRoute="/introRoute"
+        reviewRoute="/reviewRoute"
+        required={() => false}
+        getText={_prop => {
+          return 'Custom text';
+        }}
+      />
+    );
+    const { mockStore } = getProps();
+    const { container } = render(
+      <Provider store={mockStore}>{component}</Provider>,
+    );
+
+    const continueButton = $('va-button', container);
+    expect(continueButton).to.exist;
+    expect(continueButton.text).to.eq('Custom text');
+    restoreLocation();
+  });
+});

--- a/src/applications/ivc-champva/10-10d-extended/tests/components/customArrayBuilderButtonPair.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/components/customArrayBuilderButtonPair.unit.spec.jsx
@@ -62,14 +62,13 @@ describe('CustomArrayBuilderButtonPair', () => {
       'localhost:3001/ivc-champva/10-10d-extended/applicant-name-dob/0',
       '?edit=true',
     );
-    const goFwdSpy = sinon.spy();
     const component = (
       <CustomArrayBuilderButtonPair
         contentBeforeButtons={<></>}
         contentAfterButtons={<></>}
         setFormData={() => {}}
         goBack={() => {}}
-        onContinue={goFwdSpy}
+        onContinue={() => {}}
         updatePage={() => {}}
         arrayPath="applicants"
         summaryRoute="/summaryRoute"

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/components/customPageNavButtons.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/components/customPageNavButtons.unit.spec.jsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for shared CustomPageNavButtons component
+ */
+import { expect } from 'chai';
+import React from 'react';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+
+import { CustomPageNavButtons } from '../../../../shared/components/CustomPageNavButtons';
+
+const mockStore = state => createStore(() => state);
+
+function stubWindowLocation(url, pathname, search) {
+  const originalLocation = window.location;
+
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { href: url, pathname, search },
+  });
+
+  return () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  };
+}
+
+describe('CustomPageNavButtons', () => {
+  const arrayBuilderProps = {
+    arrayPath: 'applicants',
+    summaryRoute: '/summaryRoute',
+    introRoute: '/introRoute',
+    reviewRoute: '/review-and-submit',
+    getText: () => {
+      'Save and continue';
+    },
+    required: () => false,
+  };
+
+  describe('when in an array builder edit page', () => {
+    it('should have va button with submit set to prevent', () => {
+      const restoreLocation = stubWindowLocation(
+        'http://localhost:3001/form/applicants/0?edit=true',
+        '/form/applicants/0?edit=true',
+        '?edit=true',
+      );
+      const props = {
+        contentAfterButtons: <></>,
+        goBack: () => {},
+        onContinue: () => {},
+        arrayBuilder: arrayBuilderProps,
+      };
+      const minimalStore = mockStore({
+        form: {
+          data: {
+            applicants: [{ firstName: 'test first' }],
+          },
+        },
+      });
+      const { container } = render(
+        <Provider store={minimalStore}>
+          <CustomPageNavButtons {...props} />
+        </Provider>,
+      );
+
+      // We expect a cancel and continue button to exists
+      expect($('va-button[data-action="cancel"]', container)).to.exist;
+      // continue button has a submit="prevent" property in this configuration
+      expect($('va-button[continue="true"]', container)).to.exist;
+      restoreLocation();
+    });
+  });
+
+  describe('when in an array builder add page', () => {
+    it('should have va button to cancel', () => {
+      const restoreLocation = stubWindowLocation(
+        'http://localhost:3001/form/applicants/0?add=true',
+        '/form/applicants/0?add=true',
+        '?add=true',
+      );
+      const props = {
+        contentAfterButtons: <></>,
+        goBack: () => {},
+        onContinue: () => {},
+        arrayBuilder: arrayBuilderProps,
+        formConfig: { useTopBackLink: true },
+      };
+      const minimalStore = mockStore({
+        form: {
+          data: {
+            applicants: [{ firstName: 'test first' }],
+          },
+        },
+      });
+      const { container } = render(
+        <Provider store={minimalStore}>
+          <CustomPageNavButtons {...props} />,
+        </Provider>,
+      );
+
+      // We expect a cancel and continue button to exists
+      expect($('va-button', container)['data-action']).to.eq('cancel');
+      expect($('button.usa-button-primary', container)).to.have.text(
+        'Continue',
+      );
+      restoreLocation();
+    });
+  });
+
+  describe('when in a non-array custom page', () => {
+    it('should have back/continue buttons', () => {
+      const restoreLocation = stubWindowLocation(
+        'http://localhost:3001/form/somepath',
+        '/form/somepath',
+      );
+      const props = {
+        contentAfterButtons: <></>,
+        goBack: () => {},
+        onContinue: () => {},
+      };
+      const minimalStore = mockStore({
+        form: {
+          data: {},
+        },
+      });
+      const { container } = render(
+        <Provider store={minimalStore}>
+          <CustomPageNavButtons {...props} />,
+        </Provider>,
+      );
+
+      expect($('button.usa-button-secondary', container)).to.have.text('Back');
+      expect($('button.usa-button-primary', container)).to.have.text(
+        'Continue',
+      );
+      restoreLocation();
+    });
+  });
+});

--- a/src/applications/ivc-champva/shared/components/CustomApplicantSSNPage.jsx
+++ b/src/applications/ivc-champva/shared/components/CustomApplicantSSNPage.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
-import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import { CustomPageNavButtons } from './CustomPageNavButtons';
 
 /*
 The purpose of this component is to wrap the applicant SSN input page
@@ -20,6 +20,8 @@ export function CustomApplicantSSNPage(props) {
     </button>
   );
 
+  const navButtons = CustomPageNavButtons(props);
+
   const customSetFormData = args => {
     // Update current applicant without losing all form data
     const newData = { ...props.data };
@@ -31,9 +33,13 @@ export function CustomApplicantSSNPage(props) {
 
   // Depending on if we're in the form flow or on review page this value
   // should be different:
-  let pageData = props.data.applicants
-    ? props.data.applicants?.[props?.pagePerItemIndex]
+  let pageData = props.data?.applicants
+    ? props.data?.applicants?.[props?.pagePerItemIndex]
     : props.data;
+
+  // If pageData is undefined just use empty object to prevent
+  // array builder error when clicking "cancel" on first applicant
+  if (!pageData) pageData = {};
 
   // Add some view values useful in the validator func (since full form
   // data isn't available within validator funcs in list loop V1)
@@ -63,11 +69,7 @@ export function CustomApplicantSSNPage(props) {
       <>
         {/* contentBeforeButtons = save-in-progress links */}
         {props.contentBeforeButtons}
-        {props.onReviewPage ? (
-          updateButton
-        ) : (
-          <FormNavButtons goBack={props.goBack} submitToContinue />
-        )}
+        {props.onReviewPage ? updateButton : navButtons}
         {props.contentAfterButtons}
       </>
     </SchemaForm>

--- a/src/applications/ivc-champva/shared/components/CustomArrayBuilderButtonPair.jsx
+++ b/src/applications/ivc-champva/shared/components/CustomArrayBuilderButtonPair.jsx
@@ -1,0 +1,114 @@
+/* eslint-disable react/sort-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import ArrayBuilderCancelButton from 'platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCancelButton';
+import { getArrayUrlSearchParams } from 'platform/forms-system/src/js/patterns/array-builder';
+
+/**
+ * Array builder cancel/save and continue buttons. May be used
+ * as standalone components within a user-defined CustomPage within an
+ * array builder. Ideally this would be moved inside the array builder
+ * itself and provided as a prop that could be accessed, but for now
+ * going with this approach locally so our form looks consistent.
+ * @param {{
+ *   arrayPath: string,
+ *   summaryRoute: string,
+ *   introRoute?: string,
+ *   required: (formData) => boolean,
+ *   reviewRoute: string,
+ *   getText: import('platform/forms-system/src/js/patterns/array-builder/arrayBuilderText').ArrayBuilderGetText,
+ * }} props
+ */
+export default function CustomArrayBuilderButtonPair(props) {
+  /*
+  These are supplied via the array builder + passed to any
+  custom pages that override the normal array builder page via the
+  `arrayBuilder` prop (see CustomPage logic in arrayBuilder.jsx).
+  */
+  const {
+    arrayPath,
+    summaryRoute,
+    introRoute,
+    reviewRoute,
+    getText,
+    required,
+  } = props;
+  const searchParams = getArrayUrlSearchParams();
+  const isEdit = !!searchParams.get('edit');
+  const isAdd = !!searchParams.get('add');
+
+  const NavButtons = props.NavButtons || FormNavButtons;
+
+  return (
+    <>
+      {isAdd && (
+        <>
+          <ArrayBuilderCancelButton
+            goToPath={props.goToPath}
+            arrayPath={arrayPath}
+            summaryRoute={summaryRoute}
+            introRoute={introRoute}
+            reviewRoute={reviewRoute}
+            getText={getText}
+            required={required}
+          />
+          {/* save-in-progress link, etc */}
+          {props.pageContentBeforeButtons}
+          {props.contentBeforeButtons}
+          <NavButtons
+            goBack={props.goBack}
+            goForward={props.onContinue}
+            submitToContinue
+            useWebComponents={props.formOptions?.useWebComponentForNavigation}
+          />
+        </>
+      )}
+      {isEdit && (
+        <div className="vads-u-display--flex">
+          <div className="vads-u-margin-right--2">
+            <ArrayBuilderCancelButton
+              goToPath={props.goToPath}
+              arrayPath={arrayPath}
+              summaryRoute={summaryRoute}
+              introRoute={introRoute}
+              reviewRoute={reviewRoute}
+              getText={getText}
+              required={required}
+              className="vads-u-margin-0"
+            />
+          </div>
+          <div>
+            <VaButton
+              continue
+              submit="prevent"
+              text={getText('editSaveButtonText')}
+            />
+          </div>
+        </div>
+      )}
+
+      {props.contentAfterButtons}
+    </>
+  );
+}
+
+CustomArrayBuilderButtonPair.propTypes = {
+  arrayPath: PropTypes.string.isRequired,
+  summaryRoute: PropTypes.string.isRequired,
+  required: PropTypes.func.isRequired,
+  introRoute: PropTypes.string,
+  reviewRoute: PropTypes.string.isRequired,
+  getText: PropTypes.func.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+  formContext: PropTypes.object,
+  formOptions: PropTypes.object,
+  goBack: PropTypes.func,
+  goToPath: PropTypes.func,
+  onContinue: PropTypes.func,
+  pageContentBeforeButtons: PropTypes.node,
+  NavButtons: PropTypes.func,
+  props: PropTypes.object,
+};

--- a/src/applications/ivc-champva/shared/components/CustomArrayBuilderButtonPair.jsx
+++ b/src/applications/ivc-champva/shared/components/CustomArrayBuilderButtonPair.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/sort-prop-types */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
@@ -41,6 +41,22 @@ export default function CustomArrayBuilderButtonPair(props) {
 
   const NavButtons = props.NavButtons || FormNavButtons;
 
+  // This ref allows us to listen for the "Continue" VaButton's onclick, which
+  // lets us run consistent onclick logic (e.g., the same props.onContinue that
+  // the normal NavButtons component uses)
+  const contBtn = useRef(null);
+
+  // Attach click listener (works for enter key and spacebar as well) to
+  // the VaButton used to continue on edit pages.
+  useEffect(() => {
+    const handleContClick = _e => {
+      props.onContinue(props);
+    };
+    if (contBtn.current) {
+      contBtn.current.addEventListener('click', handleContClick);
+    }
+  }, []);
+
   return (
     <>
       {isAdd && (
@@ -81,6 +97,7 @@ export default function CustomArrayBuilderButtonPair(props) {
           </div>
           <div>
             <VaButton
+              ref={contBtn} // Allows us to call `props.onContinue`
               continue
               submit="prevent"
               text={getText('editSaveButtonText')}

--- a/src/applications/ivc-champva/shared/components/CustomPageNavButtons.jsx
+++ b/src/applications/ivc-champva/shared/components/CustomPageNavButtons.jsx
@@ -12,7 +12,7 @@ import CustomArrayBuilderButtonPair from './CustomArrayBuilderButtonPair';
  * @returns JSX
  */
 export function CustomPageNavButtons(props) {
-  const { contentAfterButtons, arrayBuilder, goBack } = props;
+  const { contentAfterButtons, arrayBuilder, goBack, onContinue } = props;
 
   const searchParams = getArrayUrlSearchParams();
   const isEdit = !!searchParams.get('edit');
@@ -25,19 +25,22 @@ export function CustomPageNavButtons(props) {
 
   /*
   Three possible button configs:
-  1. useTopbackLink: show top back link + a wide Continue button (this aligns with minimal header styling)
-  2. useTopbackLink && arrayBuilder: show top back link + custom array builder continue/cancel buttons
+  1. arrayBuilder (with or without topBackLink): custom array builder continue/cancel buttons
+  2. useTopbackLink: show top back link + a wide Continue button (this aligns with minimal header styling)
   3. no useTopBackLink: standard Continue/Back buttons
   */
-  if (useTopBackLink) {
-    navButtons =
-      arrayBuilder && (isEdit || isAdd) ? (
-        <CustomArrayBuilderButtonPair {...props} {...arrayBuilder} />
-      ) : (
-        <FormNavButtonContinue submitToContinue />
-      );
+  if (arrayBuilder && (isEdit || isAdd)) {
+    navButtons = <CustomArrayBuilderButtonPair {...props} {...arrayBuilder} />;
   } else {
-    navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
+    navButtons = useTopBackLink ? (
+      <FormNavButtonContinue
+        submitToContinue
+        goBack={goBack}
+        goForward={onContinue}
+      />
+    ) : (
+      <FormNavButtons goBack={goBack} submitToContinue />
+    );
   }
 
   return navButtons;

--- a/src/applications/ivc-champva/shared/components/CustomPageNavButtons.jsx
+++ b/src/applications/ivc-champva/shared/components/CustomPageNavButtons.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import FormNavButtons, {
+  FormNavButtonContinue,
+} from 'platform/forms-system/src/js/components/FormNavButtons';
+import CustomArrayBuilderButtonPair from './CustomArrayBuilderButtonPair';
+
+/**
+ * This wrapper handles showing the appropriate form navigation buttons based
+ * on the props provided.
+ * @param {object} props The standard props object provided to a custom page
+ * @returns JSX
+ */
+export function CustomPageNavButtons(props) {
+  const { contentAfterButtons, arrayBuilder, goBack } = props;
+
+  const useTopBackLink =
+    contentAfterButtons?.props?.formConfig?.useTopBackLink ?? false;
+
+  let navButtons;
+
+  /*
+  Three possible button configs:
+  1. useTopbackLink: show top back link + a wide Continue button (this aligns with minimal header styling)
+  2. useTopbackLink && arrayBuilder: show top back link + custom array builder continue/cancel buttons
+  3. no useTopBackLink: standard Continue/Back buttons
+  */
+  if (useTopBackLink) {
+    navButtons = arrayBuilder ? (
+      <CustomArrayBuilderButtonPair {...props} {...arrayBuilder} />
+    ) : (
+      <FormNavButtonContinue submitToContinue />
+    );
+  } else {
+    navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
+  }
+
+  return navButtons;
+}

--- a/src/applications/ivc-champva/shared/components/CustomPageNavButtons.jsx
+++ b/src/applications/ivc-champva/shared/components/CustomPageNavButtons.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import FormNavButtons, {
   FormNavButtonContinue,
 } from 'platform/forms-system/src/js/components/FormNavButtons';
+import { getArrayUrlSearchParams } from 'platform/forms-system/src/js/patterns/array-builder';
 import CustomArrayBuilderButtonPair from './CustomArrayBuilderButtonPair';
 
 /**
@@ -12,6 +13,10 @@ import CustomArrayBuilderButtonPair from './CustomArrayBuilderButtonPair';
  */
 export function CustomPageNavButtons(props) {
   const { contentAfterButtons, arrayBuilder, goBack } = props;
+
+  const searchParams = getArrayUrlSearchParams();
+  const isEdit = !!searchParams.get('edit');
+  const isAdd = !!searchParams.get('add');
 
   const useTopBackLink =
     contentAfterButtons?.props?.formConfig?.useTopBackLink ?? false;
@@ -25,11 +30,12 @@ export function CustomPageNavButtons(props) {
   3. no useTopBackLink: standard Continue/Back buttons
   */
   if (useTopBackLink) {
-    navButtons = arrayBuilder ? (
-      <CustomArrayBuilderButtonPair {...props} {...arrayBuilder} />
-    ) : (
-      <FormNavButtonContinue submitToContinue />
-    );
+    navButtons =
+      arrayBuilder && (isEdit || isAdd) ? (
+        <CustomArrayBuilderButtonPair {...props} {...arrayBuilder} />
+      ) : (
+        <FormNavButtonContinue submitToContinue />
+      );
   } else {
     navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
   }

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
@@ -1,53 +1,50 @@
 import React, { useState, useEffect } from 'react';
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
-import FormNavButtons, {
-  FormNavButtonContinue,
-} from 'platform/forms-system/src/js/components/FormNavButtons';
 import PropTypes from 'prop-types';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { CustomPageNavButtons } from '../CustomPageNavButtons';
 import { applicantWording } from '../../utilities';
 
-export function ApplicantAddressCopyPage({
-  contentBeforeButtons,
-  contentAfterButtons,
-  customAddressKey, // optional override of `applicantAddress` so we can target arbitrary addresses in the form
-  data,
-  fullData,
-  setFormData,
-  goBack,
-  goForward,
-  pagePerItemIndex,
-  updatePage,
-  onReviewPage,
-  customTitle,
-  customDescription,
-  customSelectText,
-  positivePrefix,
-  negativePrefix,
-}) {
+export function ApplicantAddressCopyPage(props) {
+  const {
+    contentBeforeButtons,
+    contentAfterButtons,
+    customAddressKey, // optional override of `applicantAddress` so we can target arbitrary addresses in the form
+    data,
+    fullData,
+    setFormData,
+    goForward,
+    pagePerItemIndex,
+    updatePage,
+    onReviewPage,
+    customTitle,
+    customDescription,
+    customSelectText,
+    positivePrefix,
+    negativePrefix,
+  } = props;
   const addressKey = customAddressKey ?? 'applicantAddress';
   // Get the current applicant from list, OR if we don't have a list of
   // applicants, just treat the whole form data object as a single applicant
-  const currentApp =
+  let currentApp =
     pagePerItemIndex && data?.applicants
       ? data?.applicants?.[pagePerItemIndex]
       : data;
+
+  // If currentApp is undefined just use empty object to prevent
+  // array builder error when clicking "cancel" on first applicant
+  if (!currentApp) currentApp = {};
+
   const [selectValue, setSelectValue] = useState(currentApp?.sharesAddressWith);
   const [address, setAddress] = useState(
-    data[addressKey] ?? currentApp?.[addressKey],
+    data?.[addressKey] ?? currentApp?.[addressKey],
   );
   // const [radioError, setRadioError] = useState(undefined);
   const [selectError, setSelectError] = useState(undefined);
   const [dirty, setDirty] = useState(false);
 
-  const useTopBackLink =
-    contentAfterButtons?.props?.formConfig?.useTopBackLink ?? false;
-  const navButtons = useTopBackLink ? (
-    <FormNavButtonContinue submitToContinue />
-  ) : (
-    <FormNavButtons goBack={goBack} submitToContinue />
-  );
+  const navButtons = CustomPageNavButtons(props);
 
   // eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component
   const updateButton = <button type="submit">Update page</button>;
@@ -254,6 +251,7 @@ export function ApplicantAddressCopyPage({
 }
 
 ApplicantAddressCopyPage.propTypes = {
+  arrayBuilder: PropTypes.object,
   contentAfterButtons: PropTypes.element,
   contentBeforeButtons: PropTypes.element,
   customAddressKey: PropTypes.string,
@@ -263,7 +261,6 @@ ApplicantAddressCopyPage.propTypes = {
   data: PropTypes.object,
   fullData: PropTypes.object,
   genOp: PropTypes.func,
-  goBack: PropTypes.func,
   goForward: PropTypes.func,
   keyname: PropTypes.string,
   negativePrefix: PropTypes.string,

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
@@ -5,10 +5,8 @@ import {
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
-import FormNavButtons, {
-  FormNavButtonContinue,
-} from 'platform/forms-system/src/js/components/FormNavButtons';
 import PropTypes from 'prop-types';
+import { CustomPageNavButtons } from '../CustomPageNavButtons';
 
 import { ADDITIONAL_FILES_HINT } from '../../constants';
 import { applicantWording } from '../../utilities';
@@ -158,22 +156,22 @@ export function ApplicantRelationshipReviewPage(props) {
   ) : null;
 }
 
-export default function ApplicantRelationshipPage({
-  contentAfterButtons,
-  data,
-  fullData,
-  genOp,
-  setFormData,
-  goBack,
-  goForward,
-  keyname = KEYNAME,
-  primary = PRIMARY,
-  secondary = SECONDARY,
-  pagePerItemIndex,
-  updatePage,
-  onReviewPage,
-  customWording,
-}) {
+export default function ApplicantRelationshipPage(props) {
+  const {
+    data,
+    fullData,
+    genOp,
+    setFormData,
+    goForward,
+    keyname = KEYNAME,
+    primary = PRIMARY,
+    secondary = SECONDARY,
+    pagePerItemIndex,
+    updatePage,
+    onReviewPage,
+    customWording,
+  } = props;
+
   // fulldata is present in array builder pages:
   const fullOrItemData = fullData ?? data;
   const relationshipStructure = {
@@ -190,13 +188,8 @@ export default function ApplicantRelationshipPage({
 
   const radioRef = useRef(null); // Used to set focus when in error state
 
-  const useTopBackLink =
-    contentAfterButtons?.props?.formConfig?.useTopBackLink ?? false;
-  const navButtons = useTopBackLink ? (
-    <FormNavButtonContinue submitToContinue />
-  ) : (
-    <FormNavButtons goBack={goBack} submitToContinue />
-  );
+  const navButtons = CustomPageNavButtons(props);
+
   // eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component
   const updateButton = <button type="submit">Update page</button>;
   const genOps = genOp || generateOptions;

--- a/src/applications/ivc-champva/shared/components/fileUploads/FileUpload.jsx
+++ b/src/applications/ivc-champva/shared/components/fileUploads/FileUpload.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
+import { CustomPageNavButtons } from '../CustomPageNavButtons';
 import MissingFileOverview, { hasReq } from './MissingFileOverview';
 
 export function FileFieldCustom(props) {
@@ -81,7 +81,7 @@ export function FileFieldCustom(props) {
     }
   }
 
-  const navButtons = <FormNavButtons goBack={onGoBack} submitToContinue />;
+  const navButtons = CustomPageNavButtons({ ...props, goBack: onGoBack });
 
   return (
     <>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the custom pages used by multiple IVC forms to point to a new shared set of nav buttons. The new nav button component makes use of the custom array builder back/continue buttons added in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/37946).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/109708

## Testing done

- Manual
- Unit

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Signer info (custom page, **outside** array builder, using top back link). Before, was showing a back button when the top back link was present, which goes against minimal header convention. |<img width="711" height="609" alt="Screenshot 2025-07-28 at 09 19 25" src="https://github.com/user-attachments/assets/f573d0e4-f71c-42ce-b1b0-1f25d7f80e55" />|<img width="700" height="621" alt="Screenshot 2025-07-28 at 09 23 20" src="https://github.com/user-attachments/assets/374f6f9a-1343-4fe3-89a0-ceff806e2295" />|
|Applicant relationship (custom page, **inside** array builder, using top back link). Before, was showing a single "continue" button, which goes against array builder convention.|<img width="686" height="549" alt="Screenshot 2025-07-28 at 09 20 36" src="https://github.com/user-attachments/assets/dcf1f444-210a-4a38-abd4-f63d329a82fe" />|<img width="693" height="560" alt="Screenshot 2025-07-28 at 09 24 39" src="https://github.com/user-attachments/assets/783ad6eb-e149-4bc0-8112-05918807acc4" />|

## What areas of the site does it impact?

IVC CHAMPVA forms with custom pages that use the new button component (10-10d, 10-10d-extended, 10-7959c, 10-7959a)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
