### PR TITLE
arp/user_refresh_pop_up

### DIFF
--- a/src/applications/representative-form-upload/containers/App.jsx
+++ b/src/applications/representative-form-upload/containers/App.jsx
@@ -45,6 +45,23 @@ const App = ({ children }) => {
   const dispatch = useDispatch();
   useEffect(() => dispatch(fetchUser()), [dispatch]);
 
+  useEffect(() => {
+    const handleBeforeUnload = e => {
+      const event = e || window.event;
+      const isIncomplete =
+        sessionStorage.getItem('formIncompleteARP') === 'true';
+      if (isIncomplete) {
+        event.preventDefault();
+        event.returnValue = ''; // Required for most browsers
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   if (isAppToggleLoading) {
     return (
       <div className="vads-u-margin-y--5">

--- a/src/applications/representative-form-upload/containers/ConfirmationPage.jsx
+++ b/src/applications/representative-form-upload/containers/ConfirmationPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { ConfirmationPageView } from '../components/ConfirmationPageView';
@@ -18,6 +18,10 @@ const ConfirmationPage = () => {
   const confirmationNumber = submission.response?.confirmationNumber;
 
   const { formNumber } = getFormContent();
+
+  useEffect(() => {
+    sessionStorage.removeItem('formIncompleteARP');
+  }, []);
 
   return (
     <ConfirmationPageView

--- a/src/applications/representative-form-upload/containers/IntroductionPage.jsx
+++ b/src/applications/representative-form-upload/containers/IntroductionPage.jsx
@@ -28,6 +28,7 @@ const IntroductionPage = ({ route, router }) => {
   const startBtn = useMemo(
     () => {
       const startForm = () => {
+        sessionStorage.setItem('formIncompleteARP', 'true');
         recordEvent({ event: `${formNumber}-start-form` });
         return router.push(route.pageList[1].path);
       };

--- a/src/applications/representative-form-upload/tests/e2e/form-upload.cypress.spec.js
+++ b/src/applications/representative-form-upload/tests/e2e/form-upload.cypress.spec.js
@@ -68,6 +68,19 @@ describe('Representative Form Upload', () => {
       );
     });
 
+    it('sets sessionStorage flag when "Start form" is clicked', () => {
+      cy.visit('/representative/representative-form-upload/21-686c');
+
+      cy.get('a[href="#start"]')
+        .contains('Start form')
+        .click();
+
+      cy.window().then(win => {
+        const flag = win.sessionStorage.getItem('formIncompleteARP');
+        expect(flag).to.equal('true');
+      });
+    });
+
     it('allows veteran claimant submission', () => {
       cy.visit('/representative/representative-form-upload/21-686c');
       cy.location('pathname').should(

--- a/src/applications/representative-form-upload/tests/unit/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/containers/IntroductionPage.unit.spec.jsx
@@ -138,4 +138,27 @@ describe('IntroductionPage', () => {
     expect(openSpy.calledOnce).to.be.true;
     openSpy.restore();
   });
+
+  it('sets sessionStorage flag when start form link is clicked', () => {
+    const routerSpy = { push: sinon.spy() };
+    const setItemSpy = sinon.spy(Storage.prototype, 'setItem');
+
+    const { container } = render(
+      <Provider store={mockStore(true)}>
+        <IntroductionPage {...props} router={routerSpy} />
+      </Provider>,
+    );
+
+    const link = container.querySelector('va-link-action');
+    expect(link).to.exist;
+
+    link.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+
+    expect(setItemSpy.calledWith('formIncompleteARP', 'true')).to.be.true;
+    expect(routerSpy.push.calledOnce).to.be.true;
+
+    setItemSpy.restore();
+  });
 });


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No

## Summary

- Because we removed In Progress Forms, refreshing in the middle of the form causes unintended behavior. Navigating away mid flow loses all inputted info. We want a way to alert the user that these actions might have consequences. This is our MVP using in built in browser pop ups

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/6?sliceBy%5Bvalue%5D=In+Progress&pane=issue&itemId=119207141&issue=department-of-veterans-affairs%7Cva.gov-team%7C113874

## Testing done

- Walked through locally, added e2e test and unit test

## Screenshots
<img width="2968" height="952" alt="Screenshot 2025-07-24 at 4 47 24 PM (1)" src="https://github.com/user-attachments/assets/1c6dff5c-0f5b-4fc3-b8fd-c0340d7fd972" />

<img width="2504" height="1496" alt="Screenshot 2025-07-25 at 9 03 16 AM (1)" src="https://github.com/user-attachments/assets/fcda2dfe-0711-44af-9081-9c2477dc6957" />

## What areas of the site does it impact?

representative/representative-form-upload

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
