### PR TITLE
Fix calendar widget initial day offset error

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarRow.jsx
+++ b/src/applications/vaos/components/calendar/CalendarRow.jsx
@@ -104,7 +104,6 @@ CalendarRow.propTypes = {
   handleSelectOption: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   rowNumber: PropTypes.number.isRequired,
-  timezone: PropTypes.string.isRequired,
   availableSlots: PropTypes.arrayOf(
     PropTypes.shape({
       start: PropTypes.string,
@@ -122,4 +121,5 @@ CalendarRow.propTypes = {
   renderSelectedLabel: PropTypes.func,
   selectedDates: PropTypes.arrayOf(PropTypes.string),
   showWeekends: PropTypes.bool,
+  timezone: PropTypes.string,
 };

--- a/src/applications/vaos/components/calendar/utils.js
+++ b/src/applications/vaos/components/calendar/utils.js
@@ -103,7 +103,7 @@ export function pad(num, size) {
  * @returns {number} A number of the first day of the month
  */
 export function getFirstDayOfMonth(date) {
-  return Number(format(startOfMonth(date), 'd'));
+  return Number(format(startOfMonth(date), 'i'));
 }
 
 /**


### PR DESCRIPTION
The first day of the month is now correctly aligned to the day of the week

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We noticed that as part of our migration from moment.js to date-fns, we accidentally stopped resolving the first day of the month's day of the week correctly. This led to an issue where the first day of the month is always assumed to be a Monday, see screenshot below. For example, Aug 1, 2025 is a Friday, not Monday.
- This can be reproduced by visiting the date selection page of any scheduling flow (DS, Requests), see below for an example
- Resolve the day of the week correctly via the format string `i` instead of `d`
- Appointments FE Team
- This is not behind a Flipper.

## Related issue(s)

- The original work item where this bug was introduced: https://github.com/department-of-veterans-affairs/va.gov-team/issues/112925
- Ticket tracking this bug: https://github.com/department-of-veterans-affairs/va.gov-team/issues/115374

## Testing done

- Tested locally, see screenshot
- We'll work on adding tests at a later time to expedite this fix for production

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    <img width="850" height="5138" alt="image" src="https://github.com/user-attachments/assets/8965bb7a-9cf3-4bc8-aefc-76903fe755cb" />   |  <img width="850" height="5236" alt="image" src="https://github.com/user-attachments/assets/9e62401c-e553-4af0-8d63-988f7feb14b4" />    |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

