### PR TITLE
Pensions | Fix more imposter components

### DIFF
--- a/src/applications/pensions/components/MarriageCount.jsx
+++ b/src/applications/pensions/components/MarriageCount.jsx
@@ -100,6 +100,7 @@ const MarriageCount = props => {
       buttonText="Update page"
       buttonClass="usa-button-primary"
       ariaLabel="Update marriage information"
+      useWebComponents
     />
   );
 
@@ -110,6 +111,7 @@ const MarriageCount = props => {
           <Title title="Marriage history" />
         </legend>
         <va-text-input
+          class="vads-u-margin-bottom--4"
           label="How many times have you been married?"
           inputmode="numeric"
           id="root_marriage_count_value"

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -553,24 +553,28 @@ export default class ArrayField extends React.Component {
           {/* Only show the 'Add another ..' button when another item can be added. This approach helps
            improve accessibility by removing unnecessary elements from the DOM when they are not relevant
            or interactable. */}
-          {showAddAnotherButton && useWebComponents ? (
-            <VaButton
-              secondary
-              class="va-growable-add-btn"
-              onClick={this.handleAdd}
-              text={`Add another ${uiItemName}`}
-            />
-          ) : (
-            <button
-              type="button"
-              className={classNames(
-                'usa-button-secondary',
-                'va-growable-add-btn',
+          {showAddAnotherButton && (
+            <>
+              {useWebComponents ? (
+                <VaButton
+                  secondary
+                  class="va-growable-add-btn"
+                  onClick={this.handleAdd}
+                  text={`Add another ${uiItemName}`}
+                />
+              ) : (
+                <button
+                  type="button"
+                  className={classNames(
+                    'usa-button-secondary',
+                    'va-growable-add-btn',
+                  )}
+                  onClick={this.handleAdd}
+                >
+                  Add another {uiItemName}
+                </button>
               )}
-              onClick={this.handleAdd}
-            >
-              Add another {uiItemName}
-            </button>
+            </>
           )}
           {/* Show an alert when no more items can be added */}
           {!showAddAnotherButton && (

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -365,6 +365,9 @@ export default class ArrayField extends React.Component {
       'rjsf-array-field': true,
     });
 
+    const useWebComponents = this.props.formContext?.formOptions
+      ?.useWebComponentForNavigation;
+
     return (
       <div className={containerClassNames}>
         {hasTitleOrDescription && (
@@ -550,7 +553,14 @@ export default class ArrayField extends React.Component {
           {/* Only show the 'Add another ..' button when another item can be added. This approach helps
            improve accessibility by removing unnecessary elements from the DOM when they are not relevant
            or interactable. */}
-          {showAddAnotherButton && (
+          {showAddAnotherButton && useWebComponents ? (
+            <VaButton
+              secondary
+              class="va-growable-add-btn"
+              onClick={this.handleAdd}
+              text={`Add another ${uiItemName}`}
+            />
+          ) : (
             <button
               type="button"
               className={classNames(
@@ -577,15 +587,17 @@ export default class ArrayField extends React.Component {
 }
 
 ArrayField.propTypes = {
+  formContext: PropTypes.shape({
+    formOptions: PropTypes.shape({
+      useWebComponentForNavigation: PropTypes.bool,
+    }),
+  }).isRequired,
   schema: PropTypes.object.isRequired,
-  uiSchema: PropTypes.object,
-  errorSchema: PropTypes.object,
-  requiredSchema: PropTypes.object,
-  idSchema: PropTypes.object,
   onChange: PropTypes.func.isRequired,
-  onBlur: PropTypes.func,
-  formData: PropTypes.array,
   disabled: PropTypes.bool,
+  errorSchema: PropTypes.object,
+  formData: PropTypes.array,
+  idSchema: PropTypes.object,
   readonly: PropTypes.bool,
   registry: PropTypes.shape({
     widgets: PropTypes.objectOf(
@@ -593,6 +605,8 @@ ArrayField.propTypes = {
     ).isRequired,
     fields: PropTypes.objectOf(PropTypes.func).isRequired,
     definitions: PropTypes.object.isRequired,
-    formContext: PropTypes.object.isRequired,
   }),
+  requiredSchema: PropTypes.object,
+  uiSchema: PropTypes.object,
+  onBlur: PropTypes.func,
 };

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -340,45 +340,31 @@ class ArrayField extends React.Component {
                             )}
                           </div>
                           <div className="small-6 right columns">
-                            {showReviewButton && useWebComponents ? (
-                              <va-button
-                                secondary
-                                class="edit-btn float-right"
-                                onClick={() => this.handleEdit(index, false)}
-                                aria-label={`Review ${itemName}`}
-                                text="Review"
-                              />
-                            ) : (
-                              <button
-                                type="button"
-                                className="edit-btn float-right"
-                                aria-label={`Review ${itemName}`}
-                                onClick={() => this.handleEdit(index, false)}
-                              >
-                                Review
-                              </button>
-                            )}
-                            {useWebComponents ? (
-                              <va-button
-                                secondary
-                                class="float-right"
-                                aria-label={`Remove ${itemName}`}
-                                text="Remove"
-                                onClick={() =>
-                                  this.handleRemove(index, fieldName)
-                                }
-                              />
-                            ) : (
-                              <button
-                                type="button"
-                                className="usa-button-secondary float-right"
-                                aria-label={`Remove ${itemName}`}
-                                onClick={() =>
-                                  this.handleRemove(index, fieldName)
-                                }
-                              >
-                                Remove
-                              </button>
+                            {showReviewButton && (
+                              <>
+                                {useWebComponents ? (
+                                  <va-button
+                                    secondary
+                                    class="float-right"
+                                    aria-label={`Remove ${itemName}`}
+                                    text="Remove"
+                                    onClick={() =>
+                                      this.handleRemove(index, fieldName)
+                                    }
+                                  />
+                                ) : (
+                                  <button
+                                    type="button"
+                                    className="usa-button-secondary float-right"
+                                    aria-label={`Remove ${itemName}`}
+                                    onClick={() =>
+                                      this.handleRemove(index, fieldName)
+                                    }
+                                  >
+                                    Remove
+                                  </button>
+                                )}
+                              </>
                             )}
                           </div>
                         </div>

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -243,6 +243,8 @@ class ArrayField extends React.Component {
       : this.state.items;
     const itemsNeeded = (schema.minItems || 0) > 0 && items.length === 0;
     const addAnotherDisabled = items.length >= (schema.maxItems || Infinity);
+    const useWebComponents =
+      formContext?.formOptions?.useWebComponentForNavigation;
 
     return (
       <div
@@ -320,16 +322,53 @@ class ArrayField extends React.Component {
                       >
                         <div className="row small-collapse">
                           <div className="small-6 left columns">
-                            <button
-                              type="submit"
-                              className="float-left"
-                              aria-label={`Update ${itemName}`}
-                            >
-                              Update
-                            </button>
+                            {useWebComponents ? (
+                              <va-button
+                                submit="prevent"
+                                class="float-left"
+                                aria-label={`Update ${itemName}`}
+                                text="Update"
+                              />
+                            ) : (
+                              <button
+                                type="submit"
+                                className="float-left"
+                                aria-label={`Update ${itemName}`}
+                              >
+                                Update
+                              </button>
+                            )}
                           </div>
                           <div className="small-6 right columns">
-                            {showReviewButton && (
+                            {showReviewButton && useWebComponents ? (
+                              <va-button
+                                secondary
+                                class="edit-btn float-right"
+                                onClick={() => this.handleEdit(index, false)}
+                                aria-label={`Review ${itemName}`}
+                                text="Review"
+                              />
+                            ) : (
+                              <button
+                                type="button"
+                                className="edit-btn float-right"
+                                aria-label={`Review ${itemName}`}
+                                onClick={() => this.handleEdit(index, false)}
+                              >
+                                Review
+                              </button>
+                            )}
+                            {useWebComponents ? (
+                              <va-button
+                                secondary
+                                class="float-right"
+                                aria-label={`Remove ${itemName}`}
+                                text="Remove"
+                                onClick={() =>
+                                  this.handleRemove(index, fieldName)
+                                }
+                              />
+                            ) : (
                               <button
                                 type="button"
                                 className="usa-button-secondary float-right"
@@ -387,17 +426,32 @@ class ArrayField extends React.Component {
           {title &&
             !itemCountLocked && (
               <>
-                <button
-                  type="button"
-                  name={`add-another-${fieldName}`}
-                  disabled={addAnotherDisabled}
-                  className="add-btn primary-outline"
-                  onClick={() => this.handleAdd()}
-                >
-                  {uiOptions.itemName
-                    ? `Add another ${uiOptions.itemName}`
-                    : 'Add another'}
-                </button>
+                {useWebComponents ? (
+                  <va-button
+                    secondary
+                    name={`add-another-${fieldName}`}
+                    disabled={addAnotherDisabled}
+                    class="add-btn"
+                    onClick={() => this.handleAdd()}
+                    text={
+                      uiOptions.itemName
+                        ? `Add another ${uiOptions.itemName}`
+                        : 'Add another'
+                    }
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    name={`add-another-${fieldName}`}
+                    disabled={addAnotherDisabled}
+                    className="add-btn primary-outline"
+                    onClick={() => this.handleAdd()}
+                  >
+                    {uiOptions.itemName
+                      ? `Add another ${uiOptions.itemName}`
+                      : 'Add another'}
+                  </button>
+                )}
                 <div>
                   {addAnotherDisabled &&
                     `You’ve entered the maximum number of items allowed.`}
@@ -413,13 +467,19 @@ class ArrayField extends React.Component {
 export default ArrayField;
 
 ArrayField.propTypes = {
-  schema: PropTypes.object.isRequired,
-  uiSchema: PropTypes.object,
-  trackingPrefix: PropTypes.string.isRequired,
   pageKey: PropTypes.string.isRequired,
   path: PropTypes.array.isRequired,
-  formData: PropTypes.object,
-  arrayData: PropTypes.array,
+  schema: PropTypes.object.isRequired,
+  trackingPrefix: PropTypes.string.isRequired,
   appStateData: PropTypes.object,
+  arrayData: PropTypes.array,
+  formContext: PropTypes.shape({
+    formOptions: PropTypes.shape({
+      useWebComponentForNavigation: PropTypes.bool,
+    }),
+    onReviewPage: PropTypes.bool,
+  }),
+  formData: PropTypes.object,
   pageTitle: PropTypes.string,
+  uiSchema: PropTypes.object,
 };

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -94,6 +94,7 @@ class ReviewChapters extends React.Component {
             hasUnviewedPages={chapter.hasUnviewedPages}
             uploadFile={this.props.uploadFile}
             viewedPages={viewedPages}
+            formOptions={formConfig?.formOptions}
           />
         ))}
       </VaAccordion>

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -213,6 +213,7 @@ class ReviewCollapsibleChapter extends React.Component {
     const ariaText =
       typeof labelTitle === 'function' ? labelTitle(pageData) : labelTitle;
     const ariaLabel = `Update ${ariaText || 'page'}`;
+    const formOptions = this.props.formOptions || {};
 
     const visibleFields =
       pageSchema &&
@@ -269,7 +270,7 @@ class ReviewCollapsibleChapter extends React.Component {
           }
           uploadFile={this.props.uploadFile}
           reviewMode={!editing}
-          formContext={formContext}
+          formContext={{ ...formContext, formOptions }}
           editModeOnReviewPage={page.editModeOnReviewPage}
         >
           {!editing ? (
@@ -288,6 +289,9 @@ class ReviewCollapsibleChapter extends React.Component {
               buttonText="Update page"
               buttonClass="usa-button-primary"
               ariaLabel={ariaLabel}
+              useWebComponents={
+                this.props.formOptions?.useWebComponentForNavigation
+              }
             />
           )}
         </SchemaForm>
@@ -299,7 +303,7 @@ class ReviewCollapsibleChapter extends React.Component {
               arrayData={get(arrayField.path, form.data)}
               formData={form.data}
               appStateData={page.appStateData}
-              formContext={formContext}
+              formContext={{ ...formContext, formOptions }}
               pageConfig={page}
               onBlur={this.props.onBlur}
               schema={arrayField.schema}
@@ -482,6 +486,9 @@ ReviewCollapsibleChapter.propTypes = {
   setData: PropTypes.func.isRequired,
   setFormErrors: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
+  formOptions: PropTypes.shape({
+    useWebComponentForNavigation: PropTypes.bool,
+  }),
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Fix marriage count custom review page
  > - Fix _all_ update page buttons on review page
  > - Fix original array view on review page to render web components
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/113476#issuecomment-3122093562

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Pensions: marriage count | <img width="690" height="238" alt="before-marriage-count" src="https://github.com/user-attachments/assets/89ded565-61a3-4715-bc59-473fc3ad39b8" /> | <img width="676" height="249" alt="after-marriage-count" src="https://github.com/user-attachments/assets/1dccb670-63b3-4164-943a-b7159e70e733" /> |
| Global: Update page button | <img width="674" height="281" alt="before-update-page" src="https://github.com/user-attachments/assets/45092b08-9b72-4f2e-a22b-99f5897d49cd" /> | <img width="685" height="248" alt="after-update-page" src="https://github.com/user-attachments/assets/f7110f0f-3ccf-4830-bb4a-8a5856a72733" /> |
| Global: classic array add button | <img width="691" height="259" alt="before-array-view" src="https://github.com/user-attachments/assets/c07f23cd-61e9-46a5-9cce-5ba7180d8e62" /> | <img width="689" height="221" alt="after-array-view" src="https://github.com/user-attachments/assets/a436c9cf-53fa-4fb0-b1d4-92dac24468ba" /> |

## What areas of the site does it impact?

Pensions & all other apps that set the `useWebComponentForNavigation` form config `formOptions`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
