### PR TITLE
Update yarn.lock after unpinning claims-status component library

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,18 +2858,6 @@
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.0.tgz#8c7e8028a5fc22ad102fa542b0a446c956830455"
   integrity sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew==
 
-"@department-of-veterans-affairs/component-library@43.0.2":
-  version "43.0.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-43.0.2.tgz#5dc260fc3da4c541da810bbea0d28a7151f25016"
-  integrity sha512-v8uM7Xw9ud9pwCvFS73a1Mf/6eskUNVpcCQhC35/INzrReX2aqD/TN2IFBr3WfH7aFkJA7CyAwy1YNGiJpHyxQ==
-  dependencies:
-    "@department-of-veterans-affairs/react-components" "28.1.0"
-    "@department-of-veterans-affairs/web-components" "11.2.9"
-    i18next "^21.6.14"
-    i18next-browser-languagedetector "^6.1.4"
-    react-focus-on "^3.5.1"
-    react-transition-group "^1.0.0"
-
 "@department-of-veterans-affairs/component-library@51.4.0":
   version "51.4.0"
   resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-51.4.0.tgz#b444bf7f75e3b66b7932e1ea0d332990f281ec5f"
@@ -2889,15 +2877,6 @@
   dependencies:
     "@divriots/style-dictionary-to-figma" "^0.4.0"
     "@uswds/uswds" "^3.9.0"
-    rimraf "^5.0.5"
-
-"@department-of-veterans-affairs/css-library@^0.8.1":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/css-library/-/css-library-0.8.8.tgz#f86fa4f126148c5d187831618446c520a639fdd6"
-  integrity sha512-9XjIppvFrmACoD/m1BssWkA/eXTRhszSxWnPFNSb38cYaVs35HcTEAF2vbPdeipkT5KKUC4Ns6MDxMZMqLv2hg==
-  dependencies:
-    "@divriots/style-dictionary-to-figma" "^0.4.0"
-    "@uswds/uswds" "^3.8.1"
     rimraf "^5.0.5"
 
 "@department-of-veterans-affairs/eslint-plugin@^1.18.2":
@@ -2956,19 +2935,6 @@
   integrity sha512-FpMWFknWkRZ5uSv4Qr5cfZ3Ad1uTuYAZkt/FxZbY1IP5/I3p6IrOJ8NTgoS69lUoHsrZ4vZ774d/Obo2OseRLg==
   dependencies:
     minimist "^1.2.6"
-
-"@department-of-veterans-affairs/web-components@11.2.9":
-  version "11.2.9"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-11.2.9.tgz#10f4ec73f5d177c1864a116386334748c2e39bcb"
-  integrity sha512-Kl7zCoxuheC/EYdM0D3N2X4cC7Kjd1eq6ZaX525BAiRJlxKhIpqhZzJfbXkQw0SrX8voLrA0Ab74KFcZjgRV3A==
-  dependencies:
-    "@department-of-veterans-affairs/css-library" "^0.8.1"
-    "@stencil/core" "^2.19.2"
-    aria-hidden "^1.1.3"
-    body-scroll-lock "^4.0.0-beta.0"
-    chromatic "^11.0.4"
-    classnames "^2.3.1"
-    intersection-observer "^0.12.0"
 
 "@department-of-veterans-affairs/web-components@19.4.0":
   version "19.4.0"
@@ -4396,11 +4362,6 @@
   resolved "https://registry.npmjs.org/@stencil/core/-/core-4.20.0.tgz#221f2b36ab999891560449b02d6915862c435f49"
   integrity sha512-WPrTHFngvN081RY+dJPneKQLwnOFD60OMCOQGmmSHfCW0f4ujPMzzhwWU1gcSwXPWXz5O+8cBiiCaxAbJU7kAg==
 
-"@stencil/core@^2.19.2":
-  version "2.22.3"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.22.3.tgz#83987e20bba855c450f6d6780e3a20192603f13f"
-  integrity sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==
-
 "@stylelint/postcss-css-in-js@^0.37.2":
   version "0.37.2"
   resolved "https://registry.yarnpkg.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz#7e5a84ad181f4234a2480803422a47b8749af3d2"
@@ -5151,14 +5112,6 @@
   integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   dependencies:
     "@types/node" "*"
-
-"@uswds/uswds@^3.8.1":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@uswds/uswds/-/uswds-3.10.0.tgz#f78ab69e26dec0080a92845b3dd1d9ddab26e6e9"
-  integrity sha512-LWFTQzp4e3kqtnD/Wsyfx9uGTkn5GEpzhscNWJMIsdWBGKtiu96QT99oRJUmcsB6HbGhR0Th0FtlK/Zzx2WghA==
-  dependencies:
-    receptor "1.0.0"
-    resolve-id-refs "0.1.0"
 
 "@uswds/uswds@^3.9.0":
   version "3.9.0"


### PR DESCRIPTION
Removed yarn.lock change from [Migrate from 43.0.2 to latest version of component library including File Input #36920](https://github.com/department-of-veterans-affairs/vets-website/pull/36920) so I can use Staged Continuous Deployment on that PR. This PR cannot be deployed using Staged Continuous Deployment and thus will be merged in the Daily Deployment the day after the aforementioned PR is merged.

## Summary
- Updates yarn.lock to remove component-library v43.0.2 dependencies
- This change is needed after unpinning the claims-status application from that specific version
- Separated from the main feature PR to allow use of Staged Continuous Deployment

## Context
The claims-status application was previously pinned to component-library v43.0.2. The main feature PR removes this pinning, but including the yarn.lock changes would prevent using Staged Continuous Deployment. This PR contains only the yarn.lock updates that result from removing the pinned version.

## Test plan
- This PR contains only yarn.lock changes
- The changes remove 47 lines of dependencies that are no longer needed
- Should be deployed through the normal daily deployment process