### PR TITLE
SC 115414: Fix treatment date error for year only

### DIFF
--- a/src/applications/appeals/995/utils/submit/evidence.js
+++ b/src/applications/appeals/995/utils/submit/evidence.js
@@ -40,11 +40,15 @@ export const getTreatmentDate = (type, showNewFormContent, location) => {
   if (showNewFormContent && noDate) {
     return '';
   }
+
+  const validTreatmentDate =
+    treatmentDate.length === 4 || treatmentDate.length === 7;
+
   const date =
-    showNewFormContent && treatmentDate.length === 7
+    showNewFormContent && validTreatmentDate
       ? `${treatmentDate}-01`
       : evidenceDates[type] || '';
-  return fixDateFormat(date);
+  return fixDateFormat(date, treatmentDate.length === 4);
 };
 
 export const hasDuplicateLocation = (

--- a/src/applications/appeals/shared/utils/replace.js
+++ b/src/applications/appeals/shared/utils/replace.js
@@ -93,11 +93,20 @@ export const replaceSubmittedData = text =>
  * @param {String} dateString YYYY-M-D or YYYY-MM-DD date string
  * @returns {String} YYYY-MM-DD date string
  */
-export const fixDateFormat = date => {
+export const fixDateFormat = (date, yearOnly = false) => {
   const dateString = coerceStringValue(date).replace(REGEXP.WHITESPACE, '');
+
   if (dateString.length === 10 || dateString === '') {
     return dateString;
   }
+
+  // Stopgap solution to properly format a year only when provided for a VA treatment date "before 2005"
+  // Coming into this function it will have a format of {year}-01. Here we'll add a day of 01
+  // Remove this when the new date components are implemented and the fields are required
+  if (yearOnly) {
+    return `${dateString}-01`;
+  }
+
   const { day, month, year } = parseISODate(dateString);
   return `${year}-${addLeadingZero(month)}-${addLeadingZero(day)}`;
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In Supplemental Claims, we have a utility file ([evidence.js](https://github.com/department-of-veterans-affairs/vets-website/blob/cab8f254158b472abdeedfb4fc6d31835891d391/src/applications/appeals/995/utils/submit/evidence.js#L44)) that is transforming the treatment date for VA locations into evidence dates for Lighthouse processing. When showScNewForm is true, we get the month/year selection (the one for "before 2005" but is actually required no matter what year). If you only fill out the year and not the month, this logic will send an empty string for your evidence dates, but the UI will not fail your submission and it'll get to Lighthouse with empty evidence dates instead, where it'll fail down the line.

This PR creates a stopgap solution to allow a treatment date of only a year to succeed through submission. Once we implement the new date component solution and have required fields, this problem will solve itself.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/115414

## Testing done & Screenshots

### Year Only

<img width="500" alt="Screenshot 2025-07-29 at 9 13 02 AM" src="https://github.com/user-attachments/assets/0699e138-1bfc-4b52-9287-c7ba583a0081" />

<img width="500" alt="Screenshot 2025-07-29 at 9 20 52 AM" src="https://github.com/user-attachments/assets/8a390d8f-1577-4b28-9e1e-d29505a1ca2e" />

#### FE payload to BE

<img width="400" alt="Screenshot 2025-07-29 at 9 13 29 AM" src="https://github.com/user-attachments/assets/2fa6d59c-b7c5-480b-b802-d7edd07b6b40" />

#### `SavedClaim` data (Rails console)

<img width="300"  alt="Screenshot 2025-07-29 at 9 55 20 AM" src="https://github.com/user-attachments/assets/8071c01d-a865-4ea3-8dd0-60e89008830f" />

### Year and Month

<img width="500" alt="Screenshot 2025-07-29 at 9 15 00 AM" src="https://github.com/user-attachments/assets/0a4556c1-9307-4799-9c9a-1fb58a3c6fe3" />

<img width="500" alt="Screenshot 2025-07-29 at 9 20 52 AM" src="https://github.com/user-attachments/assets/8a390d8f-1577-4b28-9e1e-d29505a1ca2e" />

#### FE payload to BE

<img width="400" alt="Screenshot 2025-07-29 at 9 15 21 AM" src="https://github.com/user-attachments/assets/0466b51c-a2ec-40b6-9b3a-b7830388418e" />

#### `SavedClaim` data (Rails console)

<img width="300" alt="Screenshot 2025-07-29 at 9 57 42 AM" src="https://github.com/user-attachments/assets/ee80a729-94a4-4754-89ce-c440f2636814" />

### No Date

<img width="500" alt="Screenshot 2025-07-29 at 9 16 06 AM" src="https://github.com/user-attachments/assets/ac547531-d704-478a-a87d-1d999cfb36dd" />

<img width="500" alt="Screenshot 2025-07-29 at 9 20 52 AM" src="https://github.com/user-attachments/assets/8a390d8f-1577-4b28-9e1e-d29505a1ca2e" />

#### FE payload to BE

<img width="400" alt="Screenshot 2025-07-29 at 9 17 10 AM" src="https://github.com/user-attachments/assets/fab69bbc-d08b-4c3c-9cdc-a3d5150fa68d" />

#### `SavedClaim` data (Rails console)

<img width="300" alt="Screenshot 2025-07-29 at 9 59 43 AM" src="https://github.com/user-attachments/assets/6812e2cf-5518-4331-a832-d20ddfc466b0" />
