### PR TITLE
Conditionally set referralNumber on CC mock error requests

### DIFF
--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -81,7 +81,6 @@ const createDraftAppointmentInfo = (
 ) => {
   const tomorrow = dateFns.addDays(dateFns.startOfDay(new Date()), 1);
   const draftApppointmentInfo = createDefaultDraftAppointment();
-
   if (referralNumber === 'draft-no-slots-error') {
     return draftApppointmentInfo;
   }

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -81,6 +81,7 @@ const createDraftAppointmentInfo = (
 ) => {
   const tomorrow = dateFns.addDays(dateFns.startOfDay(new Date()), 1);
   const draftApppointmentInfo = createDefaultDraftAppointment();
+
   if (referralNumber === 'draft-no-slots-error') {
     return draftApppointmentInfo;
   }

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -98,7 +98,7 @@ const createReferralById = (
       stationId: '659BY',
       expirationDate:
         expirationDate || format(addMonths(relativeDate, 6), mydFormat),
-      referralNumber: 'VA0000007241',
+      referralNumber: uuid.includes('error') ? uuid : 'VA0000007241',
       categoryOfCare,
       referralConsultId: '984_646907',
       hasAppointments: false,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Change hardcoded referral number to be conditionally set if mock referral id contains the word error.
- On the referral list page, the referrals after the not in station error, should now show their error referral number on the details page and then trigger the error as expected. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114785

## Testing done

- Manual testing of the mocked error referrals on localhost.
- This was only effecting tests, as most unit tests mocked their own results. 

## Screenshots

N/A only changes to mock server requests. 

## What areas of the site does it impact?

The error state referrals on localhost.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A
