### PR TITLE
Dependents | Fix edit page button width

### DIFF
--- a/src/applications/dependents/dependents-verification/components/EditPageButtons.jsx
+++ b/src/applications/dependents/dependents-verification/components/EditPageButtons.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 
 export default function EditPageButtons(props) {
   return (
-    <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--3">
+    <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--3 ">
       <div className="small-6 medium-5 columns">
         <va-button
           text="Update"
           message-aria-describedby={`Update ${props.pageName.toLowerCase()}`}
           submit="prevent"
+          full-width
         />
       </div>
       <div className="small-6 medium-5 end columns">
@@ -18,6 +19,7 @@ export default function EditPageButtons(props) {
           onClick={props.handlers.onCancel}
           secondary
           submit="prevent"
+          full-width
         />
       </div>
     </div>

--- a/src/applications/dependents/dependents-verification/tests/mock-api-full-data.js
+++ b/src/applications/dependents/dependents-verification/tests/mock-api-full-data.js
@@ -34,7 +34,7 @@ const submission = {
 };
 
 const mockSipGet = {
-  formData: mockMaxData.data,
+  formData: mockMaxData,
   metadata: {
     version: 1,
     prefill: true,

--- a/src/applications/dependents/dependents-verification/tests/unit/util.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/util.unit.spec.jsx
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as apiModule from 'platform/utilities/api';
+// import * as recordEventModule from 'platform/monitoring/record-event';
+import * as helpers from 'platform/forms-system/src/js/helpers';
+import * as utils from '../../util'; // <-- Adjust path as needed
+
+describe('dependents/686c-674 util', () => {
+  let stubs = [];
+
+  afterEach(() => {
+    stubs.forEach(stub => stub.restore && stub.restore());
+    stubs = [];
+    sinon.restore && sinon.restore();
+  });
+
+  it('should call transformForSubmit and return stringified payload', () => {
+    const fakeFormConfig = { foo: 'bar' };
+    const fakeForm = { baz: 'qux' };
+    const fakeResult = { formData: 'transformed' };
+    const transformStub = sinon
+      .stub(helpers, 'transformForSubmit')
+      .returns(fakeResult);
+    stubs.push(transformStub);
+
+    const result = utils.transform(fakeFormConfig, fakeForm);
+
+    expect(transformStub.calledWith(fakeFormConfig, fakeForm)).to.be.true;
+    expect(result).to.equal(
+      JSON.stringify({ dependentsVerificationClaim: { form: fakeResult } }),
+    );
+  });
+
+  //   it('ensureValidCSRFToken calls fetchNewCSRFToken if no token in storage', async () => {
+
+  //     sinon
+  //       .stub(localStorage, 'getItem')
+  //       .withArgs('csrfToken')
+  //       .returns(null);
+  //     const fetchStub = sinon.stub(utils, 'fetchNewCSRFToken').resolves();
+  //     stubs.push(localStorage.getItem, fetchStub);
+
+  //     await utils.ensureValidCSRFToken();
+
+  //     expect(fetchStub.called).to.be.true;
+  //   });
+
+  //   it('ensureValidCSRFToken logs present token', async () => {
+  //     sinon
+  //       .stub(localStorage, 'getItem')
+  //       .withArgs('csrfToken')
+  //       .returns('abc');
+  //     const recordStub = sinon.stub(recordEventModule, 'default');
+  //     stubs.push(localStorage.getItem, recordStub);
+
+  //     await utils.ensureValidCSRFToken();
+
+  //     expect(recordStub.calledWithMatch({ event: /present/ })).to.be.true;
+  //   });
+
+  it('submit - successful request', async () => {
+    sinon.stub(utils, 'ensureValidCSRFToken').resolves();
+    const apiStub = sinon
+      .stub(apiModule, 'apiRequest')
+      .resolves({ data: { attributes: { test: 123 } } });
+    stubs.push(utils.ensureValidCSRFToken, apiStub);
+
+    window.dataLayer = [];
+    const fakeFormConfig = { trackingPrefix: 'test' };
+    const fakeForm = {};
+
+    const result = await utils.submit(fakeForm, fakeFormConfig);
+
+    expect(result).to.deep.equal({ test: 123 });
+    expect(window.dataLayer.some(e => e.event === 'test-submission-successful'))
+      .to.be.true;
+  });
+
+  it('submit - CSRF failure retries then fails', async () => {
+    sinon.stub(utils, 'ensureValidCSRFToken').resolves();
+    const fakeResponse = {
+      errors: [{ status: '403', detail: 'Invalid Authenticity Token' }],
+    };
+    const apiStub = sinon.stub(apiModule, 'apiRequest');
+    apiStub
+      .onFirstCall()
+      .rejects(fakeResponse)
+      .onSecondCall()
+      .resolves({ data: { attributes: { foo: 'bar' } } });
+    stubs.push(utils.ensureValidCSRFToken, apiStub);
+
+    window.dataLayer = [];
+    const fakeFormConfig = { trackingPrefix: 'again' };
+    const fakeForm = {};
+
+    const result = await utils.submit(fakeForm, fakeFormConfig);
+
+    expect(result).to.deep.equal({ foo: 'bar' });
+  });
+
+  it('submit - onFailure for 429 response', async () => {
+    sinon.stub(utils, 'ensureValidCSRFToken').resolves();
+
+    const fakeResp = new Response(null, { status: 429 });
+    fakeResp.headers.set('x-ratelimit-reset', '123');
+    const apiStub = sinon.stub(apiModule, 'apiRequest').rejects(fakeResp);
+    stubs.push(utils.ensureValidCSRFToken, apiStub);
+
+    const fakeFormConfig = { trackingPrefix: 'rate' };
+    const fakeForm = {};
+
+    try {
+      await utils.submit(fakeForm, fakeFormConfig);
+      throw new Error('Should have thrown!');
+    } catch (err) {
+      expect(err.message).to.equal(
+        'vets_throttled_error_dependents_verification',
+      );
+      expect(err.extra).to.equal(123);
+    }
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- adds `full-width` prop to custom component for Edit page buttons

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114245

## Testing done

- Manual / Unit / E2E

## Screenshots

<img width="669" height="394" alt="image" src="https://github.com/user-attachments/assets/942c141c-ed6e-4dda-aa26-5b8baa80511d" />

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
