### PR TITLE
Global | Make finish this application later link tabbable

### DIFF
--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -81,13 +81,12 @@ class SaveFormLink extends React.Component {
             {savedStatus === SAVE_STATUSES.noAuth && (
               <span>
                 Sorry, you’re signed out. Please{' '}
-                <button
-                  type="button"
-                  className="va-button-link"
+                <va-link
+                  class="sign-in-link"
                   onClick={this.openLoginModal}
-                >
-                  sign in
-                </button>{' '}
+                  text="sign in"
+                  href="#"
+                />{' '}
                 again to save your {appType}.
               </span>
             )}
@@ -97,6 +96,7 @@ class SaveFormLink extends React.Component {
           <div className="vads-u-display--flex vads-u-margin-top--2">
             {useWebComponentForNavigation ? (
               <va-link
+                href={`${formConfig.rootUrl}/form-saved`}
                 onClick={this.handleSave}
                 class="schemaform-sip-save-link"
                 text={this.props.children || `Finish this ${appType} later`}
@@ -134,6 +134,7 @@ SaveFormLink.propTypes = {
   user: PropTypes.object.isRequired,
   children: PropTypes.any,
   formConfig: PropTypes.shape({
+    rootUrl: PropTypes.string,
     formOptions: PropTypes.shape({
       useWebComponentForNavigation: PropTypes.bool,
     }),

--- a/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
@@ -22,178 +22,375 @@ describe('Schemaform <SaveFormLink>', () => {
     },
   };
 
-  const props = ({
-    data = {},
-    savedStatus = SAVE_STATUSES.notAttempted,
-    saveAndRedirectToReturnUrl = () => {},
-    saveInProgressForm = () => {},
-    user = loggedInUser,
-  } = {}) => ({
-    user,
-    form: {
-      formId: 'test',
-      version: 1,
-      data,
-      trackingPrefix: 'test-',
-      savedStatus,
-      submission: {},
-      locationPathname: '/test',
-    },
-    formConfig: {
-      rootUrl: '',
-    },
-    saveAndRedirectToReturnUrl,
-    saveInProgressForm,
-    toggleLoginModal: () => {},
-  });
-
-  it('should not render save message when not logged in', () => {
-    const { container } = render(
-      <SaveFormLink {...props({ user: loggedOutUser })} />,
-    );
-    expect(container.textContent).to.be.empty;
-  });
-
-  it('should render finish message when logged in', () => {
-    const { container } = render(<SaveFormLink {...props()} />);
-    expect(container.textContent).to.contain('Finish this application later');
-  });
-
-  it('should render overridden save message when prop is passed', () => {
-    const { container } = render(
-      <SaveFormLink {...props()}>Test</SaveFormLink>,
-    );
-    expect(container.textContent).to.contain('Test');
-  });
-
-  it('should show error message', () => {
-    const { container } = render(
-      <SaveFormLink {...props({ savedStatus: SAVE_STATUSES.failure })} />,
-    );
-    expect(container.textContent).to.contain('Something went wrong');
-    expect($('.schemaform-sip-save-link', container).textContent).to.contain(
-      'Finish this application later',
-    );
-  });
-
-  it('should show client error message', () => {
-    const { container } = render(
-      <SaveFormLink {...props({ savedStatus: SAVE_STATUSES.clientFailure })} />,
-    );
-
-    expect(container.textContent).to.contain('unable to connect');
-    expect($('.schemaform-sip-save-link', container).textContent).to.contain(
-      'Finish this application later',
-    );
-  });
-
-  it('should render expired message with noAuth status', () => {
-    const { container } = render(
-      <SaveFormLink {...props({ savedStatus: SAVE_STATUSES.noAuth })} />,
-    );
-
-    const signInButton = $('.va-button-link', container);
-
-    expect(container.textContent).to.contain('Sorry, you’re signed out.');
-    expect(signInButton).to.exist;
-    expect(signInButton.textContent).to.contain('sign in');
-  });
-
-  it('should call saveAndRedirectToReturnUrl and include returnUrl from page config if logged in', () => {
-    const saveAndRedirectToReturnUrl = sinon.spy();
-    const route = {
-      pageConfig: {
-        pageKey: 'testPage',
-        schema: {},
-        uiSchema: {},
-        errorMessages: {},
-        title: '',
-        returnUrl: '/testing2',
+  context('Renders button that looks like a link', () => {
+    const props = ({
+      data = {},
+      savedStatus = SAVE_STATUSES.notAttempted,
+      saveAndRedirectToReturnUrl = () => {},
+      saveInProgressForm = () => {},
+      user = loggedInUser,
+    } = {}) => ({
+      user,
+      form: {
+        formId: 'test',
+        version: 1,
+        data,
+        trackingPrefix: 'test-',
+        savedStatus,
+        submission: {},
+        locationPathname: '/test',
       },
-      pageList: [
-        {
-          path: 'testing',
-        },
-      ],
-    };
-    const { container } = render(
-      <div>
-        <SaveFormLink
-          {...props({ saveAndRedirectToReturnUrl })}
-          route={route}
-        />
-      </div>,
-    );
-
-    // "Save" the form
-    fireEvent.click($('.schemaform-sip-save-link', container));
-
-    expect(saveAndRedirectToReturnUrl.called);
-    expect(saveAndRedirectToReturnUrl.args[0][3]).to.eq('/testing2');
-  });
-
-  it('should call pageConfig and formConfig onFormExit callbacks before redirecting', () => {
-    const saveAndRedirectToReturnUrl = sinon.spy();
-    const exitSpy = sinon.spy();
-    const exitCallback = data => {
-      const alteredData = { ...data, testIndex: data.testIndex + 1 };
-      exitSpy(alteredData);
-      return alteredData;
-    };
-    const route = {
-      pageConfig: {
-        pageKey: 'testPage',
-        schema: {},
-        uiSchema: {},
-        errorMessages: {},
-        title: '',
-        returnUrl: '/testing2',
-        onFormExit: exitCallback,
+      formConfig: {
+        rootUrl: '',
       },
-      pageList: [
-        {
-          path: 'testing',
-        },
-      ],
-    };
-    render(
-      <div>
+      saveAndRedirectToReturnUrl,
+      saveInProgressForm,
+      toggleLoginModal: () => {},
+    });
+
+    it('should not render save message when not logged in', () => {
+      const { container } = render(
+        <SaveFormLink {...props({ user: loggedOutUser })} />,
+      );
+      expect(container.textContent).to.be.empty;
+    });
+
+    it('should render finish message when logged in', () => {
+      const { container } = render(<SaveFormLink {...props()} />);
+      expect(container.textContent).to.contain('Finish this application later');
+    });
+
+    it('should render overridden save message when prop is passed', () => {
+      const { container } = render(
+        <SaveFormLink {...props()}>Test</SaveFormLink>,
+      );
+      expect(container.textContent).to.contain('Test');
+    });
+
+    it('should show error message', () => {
+      const { container } = render(
+        <SaveFormLink {...props({ savedStatus: SAVE_STATUSES.failure })} />,
+      );
+      expect(container.textContent).to.contain('Something went wrong');
+      expect($('.schemaform-sip-save-link', container).textContent).to.contain(
+        'Finish this application later',
+      );
+    });
+
+    it('should show client error message', () => {
+      const { container } = render(
         <SaveFormLink
-          {...props({
-            data: { testIndex: 0 },
-            saveAndRedirectToReturnUrl,
-          })}
-          route={route}
-          formConfig={{ rootUrl: '', onFormExit: exitCallback }}
-        />
-      </div>,
-    );
+          {...props({ savedStatus: SAVE_STATUSES.clientFailure })}
+        />,
+      );
 
-    // "Save" the form
-    fireEvent.click($('.schemaform-sip-save-link'));
+      expect(container.textContent).to.contain('unable to connect');
+      expect($('.schemaform-sip-save-link', container).textContent).to.contain(
+        'Finish this application later',
+      );
+    });
 
-    expect(exitSpy.firstCall.args[0]).to.deep.equal({ testIndex: 1 });
-    expect(exitSpy.secondCall.args[0]).to.deep.equal({ testIndex: 2 });
+    it('should render expired message with noAuth status', () => {
+      const { container } = render(
+        <SaveFormLink {...props({ savedStatus: SAVE_STATUSES.noAuth })} />,
+      );
+      const signInButton = $('va-link.sign-in-link', container);
 
-    expect(saveAndRedirectToReturnUrl.called);
-    expect(saveAndRedirectToReturnUrl.args[0][1]).to.deep.equal({
-      testIndex: 2,
+      expect(container.textContent).to.contain('Sorry, you’re signed out.');
+      expect(signInButton).to.exist;
+      expect(signInButton.getAttribute('text')).to.contain('sign in');
+    });
+
+    it('should call saveAndRedirectToReturnUrl and include returnUrl from page config if logged in', () => {
+      const saveAndRedirectToReturnUrl = sinon.spy();
+      const route = {
+        pageConfig: {
+          pageKey: 'testPage',
+          schema: {},
+          uiSchema: {},
+          errorMessages: {},
+          title: '',
+          returnUrl: '/testing2',
+        },
+        pageList: [
+          {
+            path: 'testing',
+          },
+        ],
+      };
+      const { container } = render(
+        <div>
+          <SaveFormLink
+            {...props({ saveAndRedirectToReturnUrl })}
+            route={route}
+          />
+        </div>,
+      );
+
+      // "Save" the form
+      fireEvent.click($('.schemaform-sip-save-link', container));
+
+      expect(saveAndRedirectToReturnUrl.called);
+      expect(saveAndRedirectToReturnUrl.args[0][3]).to.eq('/testing2');
+    });
+
+    it('should call pageConfig and formConfig onFormExit callbacks before redirecting', () => {
+      const saveAndRedirectToReturnUrl = sinon.spy();
+      const exitSpy = sinon.spy();
+      const exitCallback = data => {
+        const alteredData = { ...data, testIndex: data.testIndex + 1 };
+        exitSpy(alteredData);
+        return alteredData;
+      };
+      const route = {
+        pageConfig: {
+          pageKey: 'testPage',
+          schema: {},
+          uiSchema: {},
+          errorMessages: {},
+          title: '',
+          returnUrl: '/testing2',
+          onFormExit: exitCallback,
+        },
+        pageList: [
+          {
+            path: 'testing',
+          },
+        ],
+      };
+      render(
+        <div>
+          <SaveFormLink
+            {...props({
+              data: { testIndex: 0 },
+              saveAndRedirectToReturnUrl,
+            })}
+            route={route}
+            formConfig={{ rootUrl: '', onFormExit: exitCallback }}
+          />
+        </div>,
+      );
+
+      // "Save" the form
+      fireEvent.click($('.schemaform-sip-save-link'));
+
+      expect(exitSpy.firstCall.args[0]).to.deep.equal({ testIndex: 1 });
+      expect(exitSpy.secondCall.args[0]).to.deep.equal({ testIndex: 2 });
+
+      expect(saveAndRedirectToReturnUrl.called);
+      expect(saveAndRedirectToReturnUrl.args[0][1]).to.deep.equal({
+        testIndex: 2,
+      });
+    });
+
+    it('should call saveInProgressForm if logged in', () => {
+      const saveInProgressForm = sinon.spy();
+      const { container } = render(
+        // Wrapped in a div because I SaveFormLink only returns an anchor and I
+        //  didn't want to just .click() the tree (if that would even work).
+        <div>
+          <SaveFormLink {...props({ saveInProgressForm })} />
+        </div>,
+      );
+
+      // "Save" the form
+      fireEvent.click($('.schemaform-sip-save-link', container));
+
+      expect(saveInProgressForm.called);
     });
   });
 
-  it('should call saveInProgressForm if logged in', () => {
-    const saveInProgressForm = sinon.spy();
-    const { container } = render(
-      // Wrapped in a div because I SaveFormLink only returns an anchor and I
-      //  didn't want to just .click() the tree (if that would even work).
-      <div>
-        <SaveFormLink {...props({ saveInProgressForm })} />
-      </div>,
-    );
+  context('render va-link web component', () => {
+    const props = ({
+      data = {},
+      savedStatus = SAVE_STATUSES.notAttempted,
+      saveAndRedirectToReturnUrl = () => {},
+      saveInProgressForm = () => {},
+      user = loggedInUser,
+    } = {}) => ({
+      user,
+      form: {
+        formId: 'test',
+        version: 1,
+        data,
+        trackingPrefix: 'test-',
+        savedStatus,
+        submission: {},
+        locationPathname: '/test',
+      },
+      formConfig: {
+        rootUrl: '',
+        formOptions: {
+          useWebComponentForNavigation: true,
+        },
+      },
+      saveAndRedirectToReturnUrl,
+      saveInProgressForm,
+      toggleLoginModal: () => {},
+    });
+    it('should not render save message when not logged in', () => {
+      const { container } = render(
+        <SaveFormLink {...props({ user: loggedOutUser })} />,
+      );
+      expect($('va-link.schemaform-sip-save-link', container)).to.not.exist;
+    });
 
-    // "Save" the form
-    fireEvent.click($('.schemaform-sip-save-link', container));
+    it('should render finish message when logged in', () => {
+      const { container } = render(<SaveFormLink {...props()} />);
+      const saveLink = $('va-link.schemaform-sip-save-link', container);
+      expect(saveLink.getAttribute('text')).to.contain(
+        'Finish this application later',
+      );
+      // href needed to make the internal link tabbable
+      expect(saveLink.getAttribute('href')).to.contain('/form-saved');
+    });
 
-    expect(saveInProgressForm.called);
+    it('should render overridden save message when prop is passed', () => {
+      const { container } = render(
+        <SaveFormLink {...props()}>Test</SaveFormLink>,
+      );
+      expect(
+        $('va-link.schemaform-sip-save-link', container).getAttribute('text'),
+      ).to.contain('Test');
+    });
+
+    it('should show error message', () => {
+      const { container } = render(
+        <SaveFormLink {...props({ savedStatus: SAVE_STATUSES.failure })} />,
+      );
+      expect(container.textContent).to.contain('Something went wrong');
+      expect(
+        $('va-link.schemaform-sip-save-link', container).getAttribute('text'),
+      ).to.contain('Finish this application later');
+    });
+
+    it('should show client error message', () => {
+      const { container } = render(
+        <SaveFormLink
+          {...props({ savedStatus: SAVE_STATUSES.clientFailure })}
+        />,
+      );
+
+      expect(container.textContent).to.contain('unable to connect');
+      expect(
+        $('va-link.schemaform-sip-save-link', container).getAttribute('text'),
+      ).to.contain('Finish this application later');
+    });
+
+    it('should render expired message with noAuth status', () => {
+      const { container } = render(
+        <SaveFormLink {...props({ savedStatus: SAVE_STATUSES.noAuth })} />,
+      );
+
+      const signInButton = $('va-link.sign-in-link', container);
+
+      expect(container.textContent).to.contain('Sorry, you’re signed out.');
+      expect(signInButton).to.exist;
+      expect(signInButton.getAttribute('text')).to.contain('sign in');
+    });
+
+    it('should call saveAndRedirectToReturnUrl and include returnUrl from page config if logged in', () => {
+      const saveAndRedirectToReturnUrl = sinon.spy();
+      const route = {
+        pageConfig: {
+          pageKey: 'testPage',
+          schema: {},
+          uiSchema: {},
+          errorMessages: {},
+          title: '',
+          returnUrl: '/testing2',
+        },
+        pageList: [
+          {
+            path: 'testing',
+          },
+        ],
+      };
+      const { container } = render(
+        <div>
+          <SaveFormLink
+            {...props({ saveAndRedirectToReturnUrl })}
+            route={route}
+          />
+        </div>,
+      );
+
+      // "Save" the form
+      fireEvent.click($('va-link.schemaform-sip-save-link', container));
+
+      expect(saveAndRedirectToReturnUrl.called);
+      expect(saveAndRedirectToReturnUrl.args[0][3]).to.eq('/testing2');
+    });
+
+    it('should call pageConfig and formConfig onFormExit callbacks before redirecting', () => {
+      const saveAndRedirectToReturnUrl = sinon.spy();
+      const exitSpy = sinon.spy();
+      const exitCallback = data => {
+        const alteredData = { ...data, testIndex: data.testIndex + 1 };
+        exitSpy(alteredData);
+        return alteredData;
+      };
+      const route = {
+        pageConfig: {
+          pageKey: 'testPage',
+          schema: {},
+          uiSchema: {},
+          errorMessages: {},
+          title: '',
+          returnUrl: '/testing2',
+          onFormExit: exitCallback,
+        },
+        pageList: [
+          {
+            path: 'testing',
+          },
+        ],
+      };
+      const linkProps = props({
+        data: { testIndex: 0 },
+        saveAndRedirectToReturnUrl,
+      });
+
+      render(
+        <div>
+          <SaveFormLink
+            {...linkProps}
+            route={route}
+            formConfig={{
+              rootUrl: '',
+              onFormExit: exitCallback,
+              ...linkProps.formConfig,
+            }}
+          />
+        </div>,
+      );
+
+      // "Save" the form
+      fireEvent.click($('va-link.schemaform-sip-save-link'));
+
+      expect(exitSpy.firstCall.args[0]).to.deep.equal({ testIndex: 1 });
+      expect(exitSpy.secondCall.args[0]).to.deep.equal({ testIndex: 2 });
+
+      expect(saveAndRedirectToReturnUrl.called);
+      expect(saveAndRedirectToReturnUrl.args[0][1]).to.deep.equal({
+        testIndex: 2,
+      });
+    });
+
+    it('should call saveInProgressForm if logged in', () => {
+      const saveInProgressForm = sinon.spy();
+      const { container } = render(
+        // Wrapped in a div because I SaveFormLink only returns an anchor and I
+        //  didn't want to just .click() the tree (if that would even work).
+        <div>
+          <SaveFormLink {...props({ saveInProgressForm })} />
+        </div>,
+      );
+
+      // "Save" the form
+      fireEvent.click($('va-link.schemaform-sip-save-link', container));
+
+      expect(saveInProgressForm.called);
+    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > During a staging review, it was discovered that the "Finish this application later" link is not keyboard accessible (you can't tab to it). This was due to a recent change that updated the "Finish this application later" button (that was styled as a link) into a `va-link` web component. The `href` on the `va-link` wasn't included thus making the internal link invisible to keyboard navigation. This PR adds the appropriate `href` to the `va-link` and unit tests.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/115280

## Testing done

- _Describe what the old behavior was prior to the change_
  > Tabbing through the page would skip over the "Finish this application later" link
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Added unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A - no visual changes

## What areas of the site does it impact?

All forms with `useWebComponentForNavigation` set to `true` in the form config `formOptions`:
- 686c-674 (v2)
- Dependency Verification (21-0538)
- Pensions (21-527EZ)
- Burials (21-530EZ)
- Income and assets (21P-0969)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
