### PR TITLE
Add international phones opt-in param for forms using Profile contact info

### DIFF
--- a/src/applications/personalization/profile/mocks/endpoints/user/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/user/index.js
@@ -1682,6 +1682,12 @@ const loa3UserWithInternationalMobilePhoneNumber = set(
   },
 );
 
+const loa3UserWithIntlMobilePhoneAndNoEmail = set(
+  cloneDeep(loa3UserWithInternationalMobilePhoneNumber),
+  'data.attributes.vet360ContactInformation.email',
+  null,
+);
+
 const responses = {
   ...baseUserResponses,
   ...mockErrorResponses,
@@ -1703,6 +1709,7 @@ const responses = {
   loa3UserWithoutMailingAddress,
   loa3UserWithoutLighthouseServiceAvailable,
   loa3UserWithInternationalMobilePhoneNumber,
+  loa3UserWithIntlMobilePhoneAndNoEmail,
 };
 
 // handler that can be used to customize the user data returned

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -145,6 +145,7 @@ const responses = {
     // return res.json(user.loa3UserWithNoHomeAddress); // home address is null
     // return res.json(user.loa3UserWithoutMailingAddress); // user with no mailing address
     // return res.json(user.loa3UserWithInternationalMobilePhoneNumber); // international mobile phone number
+    // return res.json(user.loa3UserWithIntlMobilePhoneAndNoEmail); // user with international mobile phone number and no email
     // data claim users
     // return res.json(user.loa3UserWithNoRatingInfoClaim);
     // return res.json(user.loa3UserWithNoMilitaryHistoryClaim);

--- a/src/applications/personalization/review-information/config/form.js
+++ b/src/applications/personalization/review-information/config/form.js
@@ -28,6 +28,7 @@ const profileContactInfoPage = profileContactInfo({
   contactInfoUiSchema: {},
   contactSectionHeadingLevel: 'h2',
   editContactInfoHeadingLevel: 'h2',
+  allowInternationalPhones: true,
 });
 
 content.title = '';

--- a/src/applications/personalization/review-information/tests/utils.js
+++ b/src/applications/personalization/review-information/tests/utils.js
@@ -10,7 +10,7 @@ import mockProfilePhone from './fixtures/mocks/profile-phone.json';
 // import mockProfileAddress from './fixtures/mocks/profile-address.json';
 // import mockProfileAddressValidation from './fixtures/mocks/profile-address-validation.json';
 
-export const cypressSetup = () => {
+export const cypressSetup = ({ internationalPhonesEnabled = false } = {}) => {
   Cypress.config({ scrollBehavior: 'nearest' });
 
   cy.intercept('/v0/in_progress_forms/WELCOME_VA_SETUP_REVIEW_INFORMATION', {
@@ -18,9 +18,28 @@ export const cypressSetup = () => {
     body: mockPrefill,
   });
 
-  cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles).as(
-    'features',
-  );
+  if (internationalPhonesEnabled) {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          {
+            name: 'profile_international_phone_numbers',
+            value: true,
+          },
+          {
+            name: 'profileInternationalPhoneNumbers',
+            value: true,
+          },
+        ],
+      },
+    });
+  } else {
+    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles).as(
+      'features',
+    );
+  }
+
   cy.intercept('GET', '/v0/maintenance_windows', []).as('maintenanceWindows');
   cy.intercept('GET', '/data/cms/vamc-ehr.json', mockVamc).as('mockVamc');
 

--- a/src/applications/personalization/review-information/tests/welcome-va-setup-review-information.cypress.spec.js
+++ b/src/applications/personalization/review-information/tests/welcome-va-setup-review-information.cypress.spec.js
@@ -15,6 +15,23 @@ describe('Welcome to My VA Review Contact Information form', () => {
     cy.findByTestId('save-edit-button').click();
   };
 
+  // Uses the VaTelephoneInput component when the profileInternationalPhoneNumbers flag is ON
+  const editMobileNumberWithVaTelephoneInput = () => {
+    cy.get('#edit-mobile-phone').click();
+    cy.location('pathname').should('include', '/edit-mobile-phone');
+    cy.axeCheck();
+
+    cy.get('va-telephone-input')
+      .shadow()
+      .find('va-text-input')
+      .shadow()
+      .find('input')
+      .clear()
+      .type('1234567890', { force: true });
+
+    cy.findByTestId('save-edit-button').click();
+  };
+
   const editEmailAddress = () => {
     cy.get('#edit-email').click();
     cy.location('pathname').should('include', '/edit-email');
@@ -85,6 +102,30 @@ describe('Welcome to My VA Review Contact Information form', () => {
       cy.get('[name="header-mobile-phone"]').should('exist');
 
       editMobileNumber();
+      editEmailAddress();
+      editMailingAddress();
+      checkConfirmationPage();
+    });
+  });
+
+  context('when signed in and profileInternationalPhoneNumbers is ON', () => {
+    beforeEach(() => {
+      cypressSetup({ internationalPhonesEnabled: true });
+      cy.login(mockUser);
+      cy.visit(formURL);
+      cy.wait(['@mockUser', '@mockVamc']);
+    });
+
+    it('should be completable', () => {
+      cy.location('pathname').should('match', /\/contact-information$/);
+
+      cy.injectAxe();
+      cy.axeCheck();
+
+      cy.get('h1[data-testid="form-title"]').should('exist');
+      cy.get('[name="header-mobile-phone"]').should('exist');
+
+      editMobileNumberWithVaTelephoneInput();
       editEmailAddress();
       editMailingAddress();
       checkConfirmationPage();

--- a/src/platform/forms-system/src/js/components/EditContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/EditContactInfo.jsx
@@ -28,6 +28,7 @@ export const BuildPage = ({
   goToPath,
   contactPath,
   editContactInfoHeadingLevel,
+  allowInternationalPhones = false,
 }) => {
   const Heading = editContactInfoHeadingLevel || 'h3';
   const headerRef = useRef(null);
@@ -92,6 +93,7 @@ export const BuildPage = ({
           cancelCallback={handlers.cancel}
           successCallback={handlers.success}
           saveButtonText="Update"
+          allowInternationalPhones={allowInternationalPhones}
         />
       </InitializeVAPServiceID>
     </div>
@@ -99,6 +101,7 @@ export const BuildPage = ({
 };
 
 BuildPage.propTypes = {
+  allowInternationalPhones: PropTypes.bool,
   contactPath: PropTypes.string,
   editContactInfoHeadingLevel: PropTypes.string,
   field: PropTypes.string,

--- a/src/platform/forms-system/src/js/definitions/profileContactInfo.js
+++ b/src/platform/forms-system/src/js/definitions/profileContactInfo.js
@@ -67,6 +67,8 @@ const profileContactInfo = ({
   emailSchema,
   phoneSchema,
 
+  allowInternationalPhones = false,
+
   // keys to use in form data
   wrapperKey = 'veteran',
   addressKey = 'mailingAddress',
@@ -132,6 +134,7 @@ const profileContactInfo = ({
           content,
           contactPath,
           editContactInfoHeadingLevel,
+          allowInternationalPhones,
         }),
       CustomPageReview: null, // not shown on review & submit
       depends: () => false, // accessed from contact info page
@@ -153,6 +156,7 @@ const profileContactInfo = ({
           content,
           contactPath,
           editContactInfoHeadingLevel,
+          allowInternationalPhones,
         }),
       CustomPageReview: null, // not shown on review & submit
       depends: () => false, // accessed from contact info page

--- a/src/platform/forms-system/src/js/utilities/data/profile.js
+++ b/src/platform/forms-system/src/js/utilities/data/profile.js
@@ -311,7 +311,7 @@ export const validatePhone = (content, phoneObject) => {
   if (!processedPhoneString) {
     return content.missingPhoneError;
   }
-  if (!isValidPhone(processedPhoneString)) {
+  if (!phoneObject.isInternational && !isValidPhone(processedPhoneString)) {
     return content.invalidPhone;
   }
   return '';
@@ -371,10 +371,15 @@ export const getMissingInfo = ({ data, keys, content, requiredKeys = [] }) => {
     requiredKeys.includes(phones.join('')) ||
     requiredKeys.includes(phones.reverse().join(''));
 
-  const isValidHomePhone = isValidPhone(getPhoneString(data[keys.homePhone]));
-  const isValidMobilePhone = isValidPhone(
-    getPhoneString(data[keys.mobilePhone]),
-  );
+  const homePhoneObj = data[keys.homePhone] || {};
+  const mobilePhoneObj = data[keys.mobilePhone] || {};
+
+  const isValidHomePhone =
+    homePhoneObj.isInternational || isValidPhone(getPhoneString(homePhoneObj));
+
+  const isValidMobilePhone =
+    mobilePhoneObj.isInternational ||
+    isValidPhone(getPhoneString(mobilePhoneObj));
 
   if (keys.homePhone && keys.mobilePhone && eitherPhone) {
     missingInfo.push(

--- a/src/platform/forms-system/src/js/utilities/data/profile.js
+++ b/src/platform/forms-system/src/js/utilities/data/profile.js
@@ -250,9 +250,9 @@ export const profileAddressSchema = {
 /**
  * @typedef phoneObject
  * @type {Object}
- * @property {String} countryCode - country code (1 digit, usually)
- * @property {String} areaCode - area code (3 digits)
- * @property {String} phoneNumber - phone number (7 digits)
+ * @property {String} countryCode - country code (1-3 digits)
+ * @property {String} areaCode - area code (3 digits for domestic, null for international)
+ * @property {String} phoneNumber - phone number (7 digits for domestic, up to 14 for international)
  * @property {String} phoneNumberExt - extension
  * @returns
  */
@@ -274,6 +274,9 @@ export const renderTelephone = (phoneObject = {}) => {
   return phoneString ? (
     <va-telephone
       contact={phoneString}
+      country-code={
+        phoneObject?.isInternational ? phoneObject?.countryCode : null
+      }
       extension={phoneObject?.extension}
       not-clickable
     />

--- a/src/platform/forms-system/test/js/components/EditContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/EditContactInfo.unit.spec.jsx
@@ -101,5 +101,75 @@ describe('EditContactInfo', () => {
 
       expect(getReturnState()).to.eq('home-phone,canceled');
     });
+
+    describe('profileInternationalPhoneNumbers flag', () => {
+      it('should render VaTelephoneInput fields when allowInternationalPhones is true', () => {
+        const { getByText, getByTestId, container } = renderInReduxProvider(
+          <EditHomePhone {...props} allowInternationalPhones />,
+          {
+            initialState: {
+              vapProfile,
+              featureToggles: { profileInternationalPhoneNumbers: true },
+            },
+            reducers: { vapService },
+          },
+        );
+
+        expect(getByText(content.editHomePhone)).to.exist;
+
+        // The international phone input component should render
+        const vaTelephoneInput = $(
+          'va-telephone-input[label^="Home phone number"]',
+          container,
+        );
+        expect(vaTelephoneInput).to.exist;
+        expect(vaTelephoneInput.required).to.be.true;
+
+        // We assume the country selector dropdown and phone number inputs also exist
+        // but can't test as they are in the web component's shadow DOM
+
+        const extension = $('va-text-input[label^="Extension"]', container);
+        expect(extension).to.exist;
+
+        expect(getByTestId('save-edit-button')).to.exist;
+        expect(getByTestId('cancel-edit-button')).to.exist;
+      });
+
+      it('should not render VaTelephoneInput fields when allowInternationalPhones is false', () => {
+        const { getByText, getByTestId, container } = renderInReduxProvider(
+          <EditHomePhone {...props} allowInternationalPhones={false} />,
+          {
+            initialState: {
+              vapProfile,
+              featureToggles: { profileInternationalPhoneNumbers: true },
+            },
+            reducers: { vapService },
+          },
+        );
+
+        expect(getByText(content.editHomePhone)).to.exist;
+
+        // The international phone input component should not render
+        const vaTelephoneInput = $(
+          'va-telephone-input[label^="Home phone number"]',
+          container,
+        );
+        expect(vaTelephoneInput).to.not.exist;
+
+        // The legacy phone input component should render
+        const phoneNumber = $(
+          'va-text-input[label^="Home phone number"]',
+          container,
+        );
+        expect(phoneNumber).to.exist;
+        expect(phoneNumber.required).to.be.true;
+
+        const extension = $('va-text-input[label^="Extension"]', container);
+        expect(extension).to.exist;
+
+        expect(getByTestId('save-edit-button')).to.exist;
+        expect(getByTestId('cancel-edit-button')).to.exist;
+      });
+    });
   });
 });

--- a/src/platform/forms-system/test/js/utilities/profile.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/utilities/profile.unit.spec.jsx
@@ -105,6 +105,19 @@ describe('profile utilities', () => {
       expect(vaPhone.getAttribute('extension')).to.eq('45678');
       expect(vaPhone.getAttribute('not-clickable')).to.eq('true');
     });
+    it('should return international telephone object', () => {
+      const phoneObj = {
+        countryCode: '44',
+        phoneNumber: '2045675000',
+        isInternational: true,
+      };
+      const { container } = render(<div>{renderTelephone(phoneObj)}</div>);
+      const vaPhone = $('va-telephone', container);
+      expect(vaPhone.getAttribute('country-code')).to.eq('44');
+      expect(vaPhone.getAttribute('contact')).to.eq('2045675000');
+      expect(vaPhone.getAttribute('extension')).to.be.null;
+      expect(vaPhone.getAttribute('not-clickable')).to.eq('true');
+    });
   });
 
   describe('getMissingInfo', () => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds the `allowInternationalPhones` parameter so forms teams and others relying on Profile contact info can opt in to using the new `VaTelephoneInput` component to support international phone numbers. The param defaults to false and is passed through `profileContactInfo` to `EditContactInfo`, and finally to the `ProfileInformationFieldController`. It only has an effect when the `profileInternationalPhoneNumbers` flag is enabled.

This PR skips validating international phone numbers in contact info review flows, because international numbers are validated by the VaTelephoneInput component and normalized to number strings before being saved to VA Profile.

- Adds the `allowInternationalPhones` param to [profileContactInfo.js](https://github.com/department-of-veterans-affairs/vets-website/pull/38031/files#diff-979b598b8813a352e3ec410b3f80e0f0a3568ad8fc6f6b5eb484c8fd2d5591fd) and [EditContactInfo.jsx](https://github.com/department-of-veterans-affairs/vets-website/pull/38031/files#diff-dab4ffa7c935e985dc06a129ade6b2064dd8bff3ff4496a83333b36a4349239f)
- [profile.js](https://github.com/department-of-veterans-affairs/vets-website/pull/38031/files#diff-a55da7c59f7ca12c807193b373923deebf59b95561714efbce986902ae0d5abc)
  - Updates the `renderTelephone` utility  to use the `country-code` attribute for international numbers
  - Skips phone validation for international numbers in `getMissingInfo` and `validatePhone`
- Sets `allowInternationalPhones` to true in [review-information/config/form.js](https://github.com/department-of-veterans-affairs/vets-website/pull/38031/files#diff-6fec70a5aa3a6d596ba854aabc3c4c1f9079b47d8d0b33d0e0f5d942ad8cd1b3)
- Adds a mock user with an international mobile phone number and no email address

Team: Authenticated Experience
Flipper: `profileInternationalPhoneNumbers`

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/113535

## Testing done
Added unit & e2e tests for flag on/off scenarios.


To test locally:
- Checkout this branch
- In src/applications/personalization/profile/mocks/server.js
  - [Set the flag value to true](https://github.com/department-of-veterans-affairs/vets-website/blob/1ea37e33a95d2af14e5127aa99f7cfe67b6e36ca/src/applications/personalization/profile/mocks/server.js#L99)
    `profileInternationalPhoneNumbers: true,`
  - [Comment out this line](https://github.com/department-of-veterans-affairs/vets-website/blob/1ea37e33a95d2af14e5127aa99f7cfe67b6e36ca/src/applications/personalization/profile/mocks/server.js#L131)
    `// return res.json(user.loa3User72); // default user LOA3 w/id.me (success)`
  - [Uncomment this line](https://github.com/department-of-veterans-affairs/vets-website/blob/1ea37e33a95d2af14e5127aa99f7cfe67b6e36ca/src/applications/personalization/profile/mocks/server.js#L148)
    `return res.json(user.loa3UserWithIntlMobilePhoneAndNoEmail); // user with international mobile phone number and no email`
- Run `yarn watch --env entry=welcome-va-setup-review-information` in a terminal
- Run `yarn mock-api --responses src/applications/personalization/profile/mocks/server.js` in a separate terminal 
- Open http://127.0.0.1:3001
  - Enter `localStorage.setItem('hasSession', true)` in the browser console 
- Navigate to http://127.0.0.1:3001/my-va/welcome-va-setup/contact-information
  - Confirm the international number `+93 20 123 4567` is displayed
  - Click to edit the mobile number
  - Confirm the new telephone input component appears

## Screenshots
| Before | After |
| ----- | ----- |
| <img alt="image" src="https://github.com/user-attachments/assets/26415e31-360b-4f7c-8339-8381c0ddf8c6" /> | <img  alt="image" src="https://github.com/user-attachments/assets/99412c89-c54b-4326-af6d-5f46da7865be" /> |
| <img alt="image" src="https://github.com/user-attachments/assets/f47e0ba1-9b67-4ecc-a959-988ac4bedfa2" /> | <img alt="image" src="https://github.com/user-attachments/assets/341926ae-8f4f-4f98-af6d-a5199e3e2a47" /> |

## What areas of the site does it impact?

Contact Info [review & submit form flow](https://github.com/department-of-veterans-affairs/vets-website/pull/26426)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
