### PR TITLE
Improve Code Coverage For Representative Form Upload After Launch

### DIFF
--- a/src/applications/representative-form-upload/tests/unit/pages/UploadPage.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/pages/UploadPage.unit.spec.jsx
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { uploadPage, warningsPresent } from '../../../pages/upload';
 import { createPayload, parseResponse } from '../../../helpers';
 
@@ -51,6 +52,56 @@ describe('uploadPage', () => {
         'ui:title': 'Select a file to upload',
       });
     });
+
+    describe('ui:validations', () => {
+      const validationFn = uploadedFile['ui:validations'][0];
+
+      it('adds error if required fields are missing', () => {
+        const errors = { addError: sinon.spy() };
+        validationFn(errors, {});
+        expect(errors.addError.calledOnce).to.be.true;
+        expect(errors.addError.firstCall.args[0]).to.include(
+          'Upload a completed VA Form',
+        );
+      });
+
+      it('adds error if file extension is not pdf', () => {
+        const errors = { addError: sinon.spy() };
+        validationFn(errors, {
+          name: 'file.txt',
+          confirmationCode: 'abc',
+          size: 123,
+        });
+        expect(errors.addError.calledWith('Your file must be .pdf format')).to
+          .be.true;
+      });
+
+      it('does not add error if all required fields are present and file is a pdf', () => {
+        const errors = { addError: sinon.spy() };
+        validationFn(errors, {
+          name: 'file.pdf',
+          confirmationCode: 'abc',
+          size: 123,
+        });
+        expect(errors.addError.notCalled).to.be.true;
+      });
+
+      it('skips pdf extension validation in Cypress', () => {
+        const originalCypress = window.Cypress;
+        window.Cypress = true;
+
+        const errors = { addError: sinon.spy() };
+        validationFn(errors, {
+          name: 'file.jpg',
+          confirmationCode: 'abc',
+          size: 123,
+        });
+
+        expect(errors.addError.notCalled).to.be.true;
+
+        window.Cypress = originalCypress;
+      });
+    });
   });
 
   describe('supportingDocuments', () => {
@@ -61,11 +112,33 @@ describe('uploadPage', () => {
       expect(result.data).to.deep.equal(['doc1.pdf', 'doc2.pdf']);
       expect(result.label).to.exist;
     });
+
+    it('has a ui:field and ui:options for supportingDocuments', () => {
+      const sd = uiSchema.supportingDocuments;
+      expect(sd['ui:field']).to.exist;
+      expect(sd['ui:options']).to.be.an('object');
+    });
+
+    it('has a ui:title React element', () => {
+      const title = uiSchema.supportingDocuments['ui:title'];
+      expect(title).to.be.an('object');
+    });
   });
 
   describe('schema', () => {
     it('defines expected required field', () => {
       expect(schema.required).to.include('uploadedFile');
+    });
+
+    it('defines schema for supportingDocuments', () => {
+      const props = schema.properties.supportingDocuments.items.properties;
+      expect(props).to.have.all.keys(
+        'fileName',
+        'fileSize',
+        'confirmationNumber',
+        'errorMessage',
+        'uploading',
+      );
     });
   });
 });

--- a/src/applications/representative-form-upload/tests/unit/utilities/api.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/utilities/api.unit.spec.jsx
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import * as Sentry from '@sentry/browser';
 import api from '../../../utilities/api';
 
 describe('API utilities', () => {
@@ -28,6 +29,65 @@ describe('API utilities', () => {
       expect(fetchStub.called).to.be.true;
       const url = fetchStub.firstCall.args[0];
       expect(url).to.include('/user');
+    });
+
+    it('returns response when status is 304', async () => {
+      const response = new Response(null, { status: 304 });
+      fetchStub.resolves(response);
+
+      const result = await api.getUser();
+      expect(result.status).to.equal(304);
+    });
+
+    it('redirects on 401 when not on root path', async () => {
+      const response = new Response(null, { status: 401 });
+      fetchStub.resolves(response);
+
+      const getSignInUrlStub = sandbox.stub().returns('https://fake-login-url');
+      const originalLocation = window.location;
+
+      global.window = Object.create(window);
+      window.location = {
+        pathname: '/not-root',
+        href: 'https://current-page',
+      };
+
+      const constants = await import('../../../utilities/constants');
+      const old = constants.getSignInUrl;
+      constants.getSignInUrl = getSignInUrlStub;
+
+      const result = await api.getUser();
+      expect(result).to.be.null;
+      expect(getSignInUrlStub.called).to.be.true;
+
+      constants.getSignInUrl = old;
+      window.location = originalLocation;
+    });
+
+    it('returns null on 401 when on root path', async () => {
+      const response = new Response(null, { status: 401 });
+      fetchStub.resolves(response);
+
+      global.window = Object.create(window);
+      window.location = {
+        pathname: '/accredited-representative', // manifest.rootUrl
+        href: 'https://current-page',
+      };
+
+      const result = await api.getUser();
+      expect(result).to.equal(null);
+    });
+
+    it('logs to Sentry on network error', async () => {
+      const captureStub = sandbox.stub(Sentry, 'captureMessage');
+
+      fetchStub.rejects(new TypeError('Network failed'));
+
+      try {
+        await api.getUser();
+      } catch (err) {
+        expect(captureStub.calledOnce).to.be.true;
+      }
     });
   });
 });

--- a/src/applications/representative-form-upload/tests/unit/utilities/constants.unit.spec.jsx
+++ b/src/applications/representative-form-upload/tests/unit/utilities/constants.unit.spec.jsx
@@ -81,6 +81,20 @@ describe('wrapApiRequest', () => {
     getSignInUrlStub.restore();
   });
 
+  it('throws TypeError if location.pathname is undefined', async () => {
+    const fakeResponse = createMockResponse(401);
+    fetchStub.resolves(fakeResponse);
+
+    locationStub = sinon.stub(window, 'location').value({});
+
+    try {
+      await apiModule.default.getUser();
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).to.be.instanceOf(TypeError);
+    }
+  });
+
   it('does not redirect to login if pathname is root', async () => {
     const fakeResponse = createMockResponse(401);
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).


Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No


## Summary

-  Improve code coverage for representative form upload in ARP after launch
- 
## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/38?pane=issue&itemId=122359134&issue=department-of-veterans-affairs%7Cva.gov-team%7C115695

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115442

## Testing done

- added tests

Went from 
<img width="799" height="46" alt="Screenshot 2025-07-31 at 10 29 17 AM" src="https://github.com/user-attachments/assets/260a54e1-eb72-4680-98f0-ca591b86f356" />


to
<img width="772" height="34" alt="Screenshot 2025-07-31 at 10 46 53 AM" src="https://github.com/user-attachments/assets/f78dd930-f480-450d-9d79-9a21661d1c41" />

## Screenshots

n/a

## What areas of the site does it impact?

representative/representative-form-upload

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
