### PR TITLE
Clear in progress 0538 form when user chooses to update 686c

### DIFF
--- a/src/applications/dependents/dependents-verification/components/ExitForm.jsx
+++ b/src/applications/dependents/dependents-verification/components/ExitForm.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { getAppUrl } from 'platform/utilities/registry-helpers';
 import { scrollAndFocus } from 'platform/utilities/scroll';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import { VA_FORM_IDS } from 'platform/forms/constants';
+import { deleteInProgressForm } from '../util';
 
 export const form686Url = getAppUrl('686C-674');
 
@@ -16,7 +18,8 @@ export const ExitForm = ({ router }) => {
     goBack: () => {
       router.push('/dependents');
     },
-    goTo686: () => {
+    goTo686: async () => {
+      await deleteInProgressForm(VA_FORM_IDS.FORM_21_0538);
       window.location.assign(form686Url);
     },
   };

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinon from 'sinon-v20';
 
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
-
+import { VA_FORM_IDS } from 'platform/forms/constants';
+import * as utils from '../../../util';
 import { form686Url, ExitForm } from '../../../components/ExitForm';
 
 describe('ExitForm', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should render the exit form with correct title and subtitle', () => {
     const { container } = render(<ExitForm />);
 
@@ -32,12 +37,20 @@ describe('ExitForm', () => {
   });
 
   it('should call redirect to 686c-674 when Go to button is clicked', async () => {
+    const deleteInProgressFormStub = sinon
+      .stub(utils, 'deleteInProgressForm')
+      .resolves();
     const { container } = render(<ExitForm />);
     const assignSpy = sinon.spy();
     global.window = window;
     global.window.location = { assign: assignSpy };
 
     fireEvent.click($('va-button[continue]', container));
-    await expect(assignSpy.calledWith(form686Url)).to.be.true;
+
+    await waitFor(() => {
+      expect(deleteInProgressFormStub.calledWith(VA_FORM_IDS.FORM_21_0538)).to
+        .be.true;
+      expect(assignSpy.calledWith(form686Url)).to.be.true;
+    });
   });
 });

--- a/src/applications/dependents/dependents-verification/util.js
+++ b/src/applications/dependents/dependents-verification/util.js
@@ -2,6 +2,21 @@ import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 import recordEvent from 'platform/monitoring/record-event';
+import { removeFormApi } from 'platform/forms/save-in-progress/api';
+
+export async function deleteInProgressForm(formId) {
+  return removeFormApi(formId)
+    .then(() => {
+      recordEvent({
+        event: 'dependents-verification-delete-in-progress-form-success',
+      });
+    })
+    .catch(() => {
+      recordEvent({
+        event: 'dependents-verification-delete-in-progress-form-failure',
+      });
+    });
+}
 
 export function transform(formConfig, form) {
   const formData = transformForSubmit(formConfig, form);


### PR DESCRIPTION


## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _Clears in-progress 21-0538 form when user chooses that they need to update dependents through 686c-674_

## Related issue(s)

- _https://github.com/department-of-veterans-affairs/va.gov-team/issues/114196_

## Testing done

- _Added unit test coverage for removal of 0538 in progress form within the `ExitForm` component_
- _Tested manually by starting a 0538 form, confirming it was "in progress", choosing to update dependents, and confirming 0538 in progress form was deleted_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*Dependency Verification (21-0538)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
