### PR TITLE
115279: Update 'EDT' to 'ET'

### DIFF
--- a/src/platform/forms/save-in-progress/FormSaved.jsx
+++ b/src/platform/forms/save-in-progress/FormSaved.jsx
@@ -65,7 +65,7 @@ const FormSaved = props => {
               <div className="saved-form-metadata-container">
                 <span className="saved-form-metadata">
                   We saved your application on{' '}
-                  {format(lastSavedDate, "MMMM d, yyyy', at' h:mm aaaa z")}.
+                  {format(lastSavedDate, "MMMM d, yyyy', at' h:mm aaaa 'ET'")}.
                 </span>
                 {expirationMessage || (
                   <p className="expires-container">

--- a/src/platform/forms/save-in-progress/FormSaved.jsx
+++ b/src/platform/forms/save-in-progress/FormSaved.jsx
@@ -67,7 +67,7 @@ const FormSaved = props => {
                 <span className="saved-form-metadata">
                   We saved your application on{' '}
                   {format(lastSavedDate, "MMMM d, yyyy', at' h:mm aaaa ")}
-                  {getTimezoneAbbreviation()}.
+                  {getTimezoneAbbreviation(format(lastSavedDate, 'z'))}.
                 </span>
                 {expirationMessage || (
                   <p className="expires-container">

--- a/src/platform/forms/save-in-progress/FormSaved.jsx
+++ b/src/platform/forms/save-in-progress/FormSaved.jsx
@@ -8,6 +8,7 @@ import { format } from 'date-fns-tz';
 import { scrollToTop } from 'platform/utilities/scroll';
 import { waitForRenderThenFocus } from '~/platform/utilities/ui';
 import { savedMessage } from '~/platform/forms-system/src/js/utilities/save-in-progress-messages';
+import { getTimezoneAbbreviation } from '~/platform/utilities/date/index';
 
 import { fetchInProgressForm, removeInProgressForm } from './actions';
 import FormStartControls from './FormStartControls';
@@ -65,7 +66,8 @@ const FormSaved = props => {
               <div className="saved-form-metadata-container">
                 <span className="saved-form-metadata">
                   We saved your application on{' '}
-                  {format(lastSavedDate, "MMMM d, yyyy', at' h:mm aaaa 'ET'")}.
+                  {format(lastSavedDate, "MMMM d, yyyy', at' h:mm aaaa ")}
+                  {getTimezoneAbbreviation()}.
                 </span>
                 {expirationMessage || (
                   <p className="expires-container">

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -118,7 +118,7 @@ class SaveInProgressIntro extends React.Component {
 
         if (!isExpired) {
           const lastSavedDateTime =
-            savedAt && format(savedAt, "MMMM d, yyyy', at' h:mm aaaa z");
+            savedAt && format(savedAt, "MMMM d, yyyy', at' h:mm aaaa 'ET'");
 
           const ContinueMsg = (
             <p>

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -120,6 +120,7 @@ class SaveInProgressIntro extends React.Component {
         if (!isExpired) {
           const lastSavedDateTime =
             savedAt && format(savedAt, "MMMM d, yyyy', at' h:mm aaaa");
+          const timezone = savedAt && format(savedAt, 'z');
 
           const ContinueMsg = (
             <p>
@@ -134,7 +135,7 @@ class SaveInProgressIntro extends React.Component {
             <va-alert status="info" uswds visible>
               <Header slot="headline">
                 {inProgressMessage} {savedAt && 'and was last saved on '}
-                {lastSavedDateTime} {getTimezoneAbbreviation()}
+                {lastSavedDateTime} {getTimezoneAbbreviation(timezone)}
               </Header>
               <div className="saved-form-metadata-container">
                 <div className="expires-container">

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -15,6 +15,7 @@ import {
   inProgressMessage as getInProgressMessage,
 } from '~/platform/forms-system/src/js/utilities/save-in-progress-messages';
 import environment from 'platform/utilities/environment';
+import { getTimezoneAbbreviation } from '~/platform/utilities/date/index';
 import recordEvent from '~/platform/monitoring/record-event';
 
 import { toggleLoginModal } from '~/platform/site-wide/user-nav/actions';
@@ -118,7 +119,7 @@ class SaveInProgressIntro extends React.Component {
 
         if (!isExpired) {
           const lastSavedDateTime =
-            savedAt && format(savedAt, "MMMM d, yyyy', at' h:mm aaaa 'ET'");
+            savedAt && format(savedAt, "MMMM d, yyyy', at' h:mm aaaa");
 
           const ContinueMsg = (
             <p>
@@ -133,7 +134,7 @@ class SaveInProgressIntro extends React.Component {
             <va-alert status="info" uswds visible>
               <Header slot="headline">
                 {inProgressMessage} {savedAt && 'and was last saved on '}
-                {lastSavedDateTime}
+                {lastSavedDateTime} {getTimezoneAbbreviation()}
               </Header>
               <div className="saved-form-metadata-container">
                 <div className="expires-container">

--- a/src/platform/utilities/date/index.js
+++ b/src/platform/utilities/date/index.js
@@ -229,16 +229,14 @@ export const formatDowntime = (dateTime, dayPattern = 'd') => {
 };
 
 /**
- * Returns the timezone abbreviation based on the user's current timezone.
- * @returns {string} The timezone abbreviation, e.g., 'ET', 'CT', 'MT', 'PT', or 'local time'.
+ * Returns the timezone abbreviation based on the provided timezone.
+ * @param {string} timezone - The timezone abbreviation (e.g., 'EDT', 'CDT', 'MDT', 'PDT')
+ * @returns {string} The timezone abbreviation, e.g., 'ET', 'CT', 'MT', 'PT', or original timezone.
  */
-export const getTimezoneAbbreviation = () => {
-  const { timeZone } = Intl.DateTimeFormat().resolvedOptions();
-  if (timeZone.includes('New_York') || timeZone.includes('Eastern'))
-    return 'ET';
-  if (timeZone.includes('Chicago') || timeZone.includes('Central')) return 'CT';
-  if (timeZone.includes('Denver') || timeZone.includes('Mountain')) return 'MT';
-  if (timeZone.includes('Los_Angeles') || timeZone.includes('Pacific'))
-    return 'PT';
-  return 'local time';
+export const getTimezoneAbbreviation = timezone => {
+  if (timezone.includes('E')) return 'ET'; // EDT, EST -> ET
+  if (timezone.includes('C')) return 'CT'; // CDT, CST -> CT
+  if (timezone.includes('M')) return 'MT'; // MDT, MST -> MT
+  if (timezone.includes('P')) return 'PT'; // PDT, PST -> PT
+  return timezone; // Return as-is if no match
 };

--- a/src/platform/utilities/date/index.js
+++ b/src/platform/utilities/date/index.js
@@ -227,3 +227,18 @@ export const formatDowntime = (dateTime, dayPattern = 'd') => {
     { timeZone },
   );
 };
+
+/**
+ * Returns the timezone abbreviation based on the user's current timezone.
+ * @returns {string} The timezone abbreviation, e.g., 'ET', 'CT', 'MT', 'PT', or 'local time'.
+ */
+export const getTimezoneAbbreviation = () => {
+  const { timeZone } = Intl.DateTimeFormat().resolvedOptions();
+  if (timeZone.includes('New_York') || timeZone.includes('Eastern'))
+    return 'ET';
+  if (timeZone.includes('Chicago') || timeZone.includes('Central')) return 'CT';
+  if (timeZone.includes('Denver') || timeZone.includes('Mountain')) return 'MT';
+  if (timeZone.includes('Los_Angeles') || timeZone.includes('Pacific'))
+    return 'PT';
+  return 'local time';
+};


### PR DESCRIPTION
Update the time format from 'EDT' to 'ET'

## Summary

- Update date format on save in progress intro
- Update date format on application status

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115279

## Testing done

- Manual

## Screenshots
Updated pieces with ET now
<img width="664" height="343" alt="Screenshot 2025-07-31 at 12 44 49 PM" src="https://github.com/user-attachments/assets/017a3a39-353d-4c03-b5d8-9bc4806ed511" />

<img width="674" height="397" alt="Screenshot 2025-07-31 at 12 41 45 PM" src="https://github.com/user-attachments/assets/534e4f08-0482-4302-acfc-616ed7247c08" />
