### PR TITLE
Dependents + DV | Address UI validation and graduation date validation

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/674/addStudentsArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/674/addStudentsArrayPages.js
@@ -583,7 +583,10 @@ export const studentTermDatesPage = {
             properties: {
               officialSchoolStartDate: currentOrPastDateSchema,
               expectedStudentStartDate: currentOrPastDateSchema,
-              expectedGraduationDate: currentOrPastDateSchema,
+              expectedGraduationDate: {
+                type: 'string',
+                pattern: '^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$',
+              },
             },
           },
         },

--- a/src/applications/dependents/686c-674/config/chapters/674/addStudentsArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/674/addStudentsArrayPages.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import {
   titleUI,
   textUI,
@@ -207,12 +206,32 @@ export const studentIncomePage = {
 export const studentAddressPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(() => 'Student’s address'),
-    address: addressUI({
-      labels: {
-        militaryCheckbox:
-          'The student receives mail outside of the United States on a U.S. military base.',
+    address: {
+      ...addressUI({
+        title: '',
+        labels: {
+          militaryCheckbox:
+            'The student receives mail outside of the United States on a U.S. military base.',
+        },
+      }),
+      city: {
+        ...addressUI().city,
+        'ui:validations': [
+          (errors, city, formData) => {
+            const address = formData?.address;
+            const cityStr = city?.trim().toUpperCase();
+
+            if (
+              address &&
+              ['APO', 'FPO', 'DPO'].includes(cityStr) &&
+              address.isMilitary !== true
+            ) {
+              errors.addError('Enter a valid city name');
+            }
+          },
+        ],
       },
-    }),
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformation.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformation.js
@@ -21,11 +21,29 @@ export const uiSchema = {
   doesLiveWithSpouse: {
     address: {
       ...addressUI({
+        title: '',
         labels: {
           militaryCheckbox:
             'Spouse receives mail outside of the United States on a U.S. military base.',
         },
       }),
+      city: {
+        ...addressUI().city,
+        'ui:validations': [
+          (errors, city, formData) => {
+            const address = formData?.doesLiveWithSpouse?.address;
+            const cityStr = city?.trim().toUpperCase();
+
+            if (
+              address &&
+              ['APO', 'FPO', 'DPO'].includes(cityStr) &&
+              address.isMilitary !== true
+            ) {
+              errors.addError('Enter a valid city name');
+            }
+          },
+        ],
+      },
     },
   },
 };

--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/childAddressPartOne.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/childAddressPartOne.js
@@ -10,7 +10,30 @@ export const childAddressPartOne = {
       title: 'Child’s address',
     }),
     address: {
-      ...addressUI(),
+      ...addressUI({
+        title: '',
+        labels: {
+          militaryCheckbox:
+            'This child lives on a United States military base outside of the U.S.',
+        },
+      }),
+      city: {
+        ...addressUI().city,
+        'ui:validations': [
+          (errors, city, formData) => {
+            const address = formData?.address;
+            const cityStr = city?.trim().toUpperCase();
+
+            if (
+              address &&
+              ['APO', 'FPO', 'DPO'].includes(cityStr) &&
+              address.isMilitary !== true
+            ) {
+              errors.addError('Enter a valid city name');
+            }
+          },
+        ],
+      },
     },
     'ui:options': {
       updateSchema: (formData, formSchema, _uiSchema, index) => {

--- a/src/applications/dependents/686c-674/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.js
+++ b/src/applications/dependents/686c-674/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.js
@@ -196,11 +196,29 @@ export const childAddressPage = {
     ...arrayBuilderItemSubsequentPageTitleUI(() => 'Stepchild’s address'),
     address: {
       ...addressUI({
+        title: '',
         labels: {
           militaryCheckbox:
             'This child lives on a United States military base outside of the U.S.',
         },
       }),
+      city: {
+        ...addressUI().city,
+        'ui:validations': [
+          (errors, city, formData) => {
+            const address = formData?.address;
+            const cityStr = city?.trim().toUpperCase();
+
+            if (
+              address &&
+              ['APO', 'FPO', 'DPO'].includes(cityStr) &&
+              address.isMilitary !== true
+            ) {
+              errors.addError('Enter a valid city name');
+            }
+          },
+        ],
+      },
     },
   },
   schema: {

--- a/src/applications/dependents/686c-674/config/chapters/veteran-information/veteran-address/veteran-address.js
+++ b/src/applications/dependents/686c-674/config/chapters/veteran-information/veteran-address/veteran-address.js
@@ -15,6 +15,23 @@ export const uiSchema = {
             'I live on a United States military base outside of the U.S.',
         },
       }),
+      city: {
+        ...addressUI().city,
+        'ui:validations': [
+          (errors, city, formData) => {
+            const address = formData?.veteranContactInformation?.veteranAddress;
+            const cityStr = city?.trim().toUpperCase();
+
+            if (
+              address &&
+              ['APO', 'FPO', 'DPO'].includes(cityStr) &&
+              address.isMilitary !== true
+            ) {
+              errors.addError('Enter a valid city name');
+            }
+          },
+        ],
+      },
     },
   },
 };

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/currentMarriageInformation.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/currentMarriageInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
-import { render } from '@testing-library/react';
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
-import React from 'react';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { $$ } from 'platform/forms-system/src/js/utilities/ui';
@@ -72,6 +72,36 @@ describe('686 current marriage information: Spouse address', () => {
     expect($$('va-text-input', container).length).to.equal(4);
     expect($$('va-select', container).length).to.equal(1);
     expect($$('va-radio-option', container).length).to.equal(6);
+  });
+
+  it('should render custom city error', async () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            doesLiveWithSpouse: {
+              address: { city: 'APO', isMilitary: false },
+            },
+          }}
+        />
+      </Provider>,
+    );
+
+    const form = container?.querySelector('form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      const cityInput = container.querySelector(
+        'va-text-input[name="root_doesLiveWithSpouse_address_city"]',
+      );
+      expect(cityInput).to.exist;
+      expect(cityInput.getAttribute('error')).to.equal(
+        'Enter a valid city name',
+      );
+    });
   });
 });
 

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/childAddressPartOne.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/childAddressPartOne.unit.spec.jsx
@@ -1,7 +1,7 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { expect } from 'chai';
-import React from 'react';
+import { expect, fireEvent, waitFor } from 'chai';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import {
   DefinitionTester,
@@ -39,5 +39,41 @@ describe('686 add child child address part one', () => {
 
     const formDOM = getFormDOM(form);
     expect(formDOM.querySelectorAll('va-text-input').length).to.eq(6);
+  });
+
+  it('should render custom city error', async () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            'view:selectable686Options': { addChild: true },
+            childrenToAdd: [
+              {
+                doesChildLiveWithYou: false,
+                address: { city: 'APO', isMilitary: false },
+              },
+            ],
+          }}
+          arrayPath="childrenToAdd"
+          pagePerItemIndex={0}
+        />
+      </Provider>,
+    );
+
+    const form = container?.querySelector('form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      const cityInput = container.querySelector(
+        'va-text-input[name*="_address_city"]',
+      );
+      expect(cityInput).to.exist;
+      expect(cityInput.getAttribute('error')).to.equal(
+        'Enter a valid city name',
+      );
+    });
   });
 });

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/childAddressPartOne.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-child/childAddressPartOne.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { expect, fireEvent, waitFor } from 'chai';
+import { expect } from 'chai';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import {
   DefinitionTester,

--- a/src/applications/dependents/686c-674/tests/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/stepchild-no-longer-part-of-household/removeChildHouseholdArrayPages.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
@@ -298,6 +298,39 @@ describe('686 Remove child no longer in household: Stepchild’s address', () =>
     expect($$('va-checkbox', container).length).to.equal(1);
     expect($$('va-text-input', container).length).to.equal(6);
     expect($$('va-select', container).length).to.equal(1);
+  });
+
+  it('should render custom city error', async () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            'view:selectable686Options': {
+              reportStepchildNotInHousehold: true,
+            },
+            stepChildren: [{ address: { city: 'APO', isMilitary: false } }],
+          }}
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
+        />
+      </Provider>,
+    );
+
+    const form = container?.querySelector('form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      const cityInput = container.querySelector(
+        'va-text-input[name*="_address_city"]',
+      );
+      expect(cityInput).to.exist;
+      expect(cityInput.getAttribute('error')).to.equal(
+        'Enter a valid city name',
+      );
+    });
   });
 });
 

--- a/src/applications/dependents/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
@@ -323,6 +323,39 @@ describe('674 Add students: Student address ', () => {
     expect($$('va-checkbox', container).length).to.equal(1);
     expect($$('va-select', container).length).to.equal(1);
     expect($$('va-text-input', container).length).to.equal(6);
+  });
+
+  it('should render custom city error', async () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            ...formData(),
+            address: { city: 'APO', isMilitary: undefined },
+          }}
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
+        />
+      </Provider>,
+    );
+
+    const form = container.querySelector('form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      const cityInput = container.querySelector(
+        'va-text-input[name*="address_city"]',
+      );
+      expect(cityInput).to.exist;
+      // Debug
+      // console.log('ERROR ATTR:', cityInput.getAttribute('error'));
+      expect(cityInput.getAttribute('error')).to.equal(
+        'Enter a valid city name',
+      );
+    });
   });
 });
 

--- a/src/applications/dependents/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/student-information/addStudentArrayPages.unit.spec.jsx
@@ -334,7 +334,11 @@ describe('674 Add students: Student address ', () => {
           uiSchema={uiSchema}
           data={{
             ...formData(),
-            address: { city: 'APO', isMilitary: undefined },
+            studentInformation: [
+              {
+                address: { city: 'APO', isMilitary: false },
+              },
+            ],
           }}
           arrayPath={arrayPath}
           pagePerItemIndex={0}
@@ -350,8 +354,6 @@ describe('674 Add students: Student address ', () => {
         'va-text-input[name*="address_city"]',
       );
       expect(cityInput).to.exist;
-      // Debug
-      // console.log('ERROR ATTR:', cityInput.getAttribute('error'));
       expect(cityInput.getAttribute('error')).to.equal(
         'Enter a valid city name',
       );

--- a/src/applications/dependents/686c-674/tests/config/chapters/veteran-information/veteranAddress.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/veteran-information/veteranAddress.unit.spec.jsx
@@ -1,8 +1,7 @@
-//
+import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { expect } from 'chai';
-import React from 'react';
+import { expect, fireEvent, waitFor } from 'chai';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import {
   DefinitionTester,
@@ -33,5 +32,35 @@ describe('Veteran Information', () => {
     const formDOM = getFormDOM(form);
 
     expect($$('va-text-input', formDOM).length).to.equal(6);
+  });
+
+  it('should render custom city error', async () => {
+    const { container } = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{
+            veteranContactInformation: {
+              veteranAddress: { city: 'APO', isMilitary: false },
+            },
+          }}
+        />
+      </Provider>,
+    );
+
+    const form = container?.querySelector('form');
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      const cityInput = container.querySelector(
+        'va-text-input[name="root_veteranContactInformation_veteranAddress_city"]',
+      );
+      expect(cityInput).to.exist;
+      expect(cityInput.getAttribute('error')).to.equal(
+        'Enter a valid city name',
+      );
+    });
   });
 });

--- a/src/applications/dependents/686c-674/tests/config/chapters/veteran-information/veteranAddress.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/veteran-information/veteranAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { expect, fireEvent, waitFor } from 'chai';
+import { expect } from 'chai';
 import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
 import {
   DefinitionTester,

--- a/src/applications/dependents/dependents-verification/config/chapters/veteran-contact-information/editAddressPage.js
+++ b/src/applications/dependents/dependents-verification/config/chapters/veteran-contact-information/editAddressPage.js
@@ -13,6 +13,23 @@ export default {
   uiSchema: {
     address: {
       ...addressUI(),
+      city: {
+        ...addressUI().city,
+        'ui:validations': [
+          (errors, city, formData) => {
+            const address = formData?.address;
+            const cityStr = city?.trim().toUpperCase();
+
+            if (
+              address &&
+              ['APO', 'FPO', 'DPO'].includes(cityStr) &&
+              address.isMilitary !== true
+            ) {
+              errors.addError('Enter a valid city name');
+            }
+          },
+        ],
+      },
       'ui:options': {
         hideOnReview: true,
       },

--- a/src/applications/dependents/dependents-verification/tests/unit/components/EditMailingAddress.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/EditMailingAddress.unit.spec.jsx
@@ -50,6 +50,8 @@ const mockData = {
   },
 };
 
+const store = createMockStore();
+
 describe('EditMailingAddressPage', () => {
   afterEach(() => {
     cleanup();
@@ -57,7 +59,6 @@ describe('EditMailingAddressPage', () => {
   });
 
   it('renders address inputs with correct labels and values', () => {
-    const store = createMockStore();
     const { container } = render(
       <Provider store={store}>
         <EditMailingAddress
@@ -92,7 +93,6 @@ describe('EditMailingAddressPage', () => {
   });
 
   it('renders Update and Cancel buttons', () => {
-    const store = createMockStore();
     const { container } = render(
       <Provider store={store}>
         <EditMailingAddress
@@ -120,7 +120,6 @@ describe('EditMailingAddressPage', () => {
 
   it('handler: onCancel navigates to review-and-submit if onReviewPage', async () => {
     sessionStorage.setItem('onReviewPage', true);
-    const store = createMockStore();
     const goToPathSpy = sinon.spy();
     const { container } = render(
       <Provider store={store}>
@@ -147,7 +146,6 @@ describe('EditMailingAddressPage', () => {
   });
 
   it('handler: onCancel navigates to contact-info if not onReviewPage', async () => {
-    const store = createMockStore();
     const goToPathSpy = sinon.spy();
     const { container } = render(
       <Provider store={store}>
@@ -175,7 +173,6 @@ describe('EditMailingAddressPage', () => {
 
   it('handler: onUpdate navigates to review-and-submit if onReviewPage, and setFormData is called on change', async () => {
     sessionStorage.setItem('onReviewPage', true);
-    const store = createMockStore();
     const goToPathSpy = sinon.spy();
     const setFormDataSpy = sinon.spy();
     const { container } = render(
@@ -209,7 +206,6 @@ describe('EditMailingAddressPage', () => {
   });
 
   it('topScrollElement is called', async () => {
-    const store = createMockStore();
     const { container } = render(
       <Provider store={store}>
         <div name="topScrollElement" />


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Supplements existing `adressUI` validation specifically for this form

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115687
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115685

## Testing done

-  Manual / Unit / E2E

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
