### PR TITLE
Calculate Slot End Times

### DIFF
--- a/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/PastAppointmentsPage/index.unit.spec.jsx
@@ -19,10 +19,8 @@ import {
   mockAppointmentsApi,
   mockFacilitiesApi,
 } from '../../../tests/mocks/mockApis';
-import {
-  getTestDate,
-  renderWithStoreAndRouter,
-} from '../../../tests/mocks/setup';
+import { renderWithStoreAndRouter } from '../../../tests/mocks/setup';
+import { mockToday } from '../../../tests/mocks/constants';
 import { APPOINTMENT_STATUS } from '../../../utils/constants';
 
 const initialState = {
@@ -30,14 +28,14 @@ const initialState = {
     vaOnlineSchedulingCancel: true,
   },
 };
-const now = startOfDay(new Date(), 'day');
+const now = startOfDay(mockToday, 'day');
 const start = subMonths(now, 3);
 const end = addMinutes(new Date(now).setMinutes(0), 30);
 
 describe('VAOS Page: PastAppointmentsList api', () => {
   beforeEach(() => {
     mockFetch();
-    MockDate.set(getTestDate());
+    MockDate.set(mockToday);
     mockFacilitiesApi({ response: [] });
   });
 
@@ -91,7 +89,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
   it('should update range on dropdown change', async () => {
     // Arrange
-    const pastDate = subMonths(new Date(), 4);
+    const pastDate = subMonths(mockToday, 4);
     const response = new MockAppointmentResponse({
       localStartTime: pastDate,
     }).setTypeOfCare(null);
@@ -131,7 +129,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
   it('should show information without facility name', async () => {
     // Arrange
-    const pastDate = subDays(new Date(), 3);
+    const pastDate = subDays(mockToday, 3);
     const response = new MockAppointmentResponse({
       past: true,
       localStartTime: pastDate,
@@ -186,7 +184,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
   it('should show information with facility name', async () => {
     // Arrange
-    const pastDate = subDays(new Date(), 3);
+    const pastDate = subDays(mockToday, 3);
     const response = new MockAppointmentResponse({
       localStartTime: pastDate,
     }).setLocation(new MockFacilityResponse());
@@ -241,7 +239,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
   it('should not display when over 2 years away', () => {
     // Arrange
-    const pastDate = subYears(new Date(), 2);
+    const pastDate = subYears(mockToday, 2);
 
     mockAppointmentsApi({
       start,
@@ -263,7 +261,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
   it('should show expected video information', async () => {
     // Arrange
-    const pastDate = subDays(new Date(), 3);
+    const pastDate = subDays(mockToday, 3);
     const responses = MockAppointmentResponse.createGfeResponses({
       localStartTime: pastDate,
       past: true,
@@ -330,7 +328,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
   it('should display past appointments using V2 api call', async () => {
     // Arrange
-    const yesterday = subDays(new Date(), 1);
+    const yesterday = subDays(mockToday, 1);
     const facility = new MockFacilityResponse();
     const response = new MockAppointmentResponse({
       localStartTime: yesterday,
@@ -370,7 +368,7 @@ describe('VAOS Page: PastAppointmentsList api', () => {
 
   it('should display past cancel appt', async () => {
     // Arrange
-    const yesterday = subDays(new Date(), 1);
+    const yesterday = subDays(mockToday, 1);
     const facility = new MockFacilityResponse();
     const response = new MockAppointmentResponse({
       localStartTime: yesterday,

--- a/src/applications/vaos/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.unit.spec.jsx
@@ -12,7 +12,7 @@ import { formatInTimeZone } from 'date-fns-tz';
 import MockDate from 'mockdate';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getAppointmentConflict } from './utils';
+import { getAppointmentConflict, parseDurationFromSlotId } from './utils';
 import { onCalendarChange } from '../../new-appointment/redux/actions';
 import {
   createTestStore,
@@ -554,6 +554,84 @@ describe('CalendarUtils: getAppointmentConflict', () => {
         availableSlots,
       ),
     ).to.be.true;
+  });
+});
+
+describe('CalendarUtils: parseDurationFromSlotId', () => {
+  describe('valid duration formats', () => {
+    it('should parse minutes only format', () => {
+      const slotId =
+        'practitioner|uuid|2025-08-06T13:00:00Z|30m0s|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(30);
+    });
+
+    it('should parse hours only without minutes/seconds', () => {
+      const slotId = 'practitioner|uuid|2025-08-06T13:00:00Z|1h|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(60);
+    });
+
+    it('should handle complex duration with hours, minutes, and seconds', () => {
+      const slotId =
+        'practitioner|uuid|2025-08-06T13:00:00Z|1h15m45s|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(76); // 60 + 15 + 1 (rounded up for seconds)
+    });
+
+    it('should handle 45-minute appointment', () => {
+      const slotId =
+        'practitioner|uuid|2025-08-06T13:00:00Z|45m0s|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(45);
+    });
+
+    it('should handle 2.5-hour appointment', () => {
+      const slotId =
+        'practitioner|uuid|2025-08-06T13:00:00Z|2h30m0s|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(150);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('should return default duration for null input', () => {
+      expect(parseDurationFromSlotId(null)).to.equal(30);
+    });
+
+    it('should return default duration for undefined input', () => {
+      expect(parseDurationFromSlotId(undefined)).to.equal(30);
+    });
+
+    it('should return default duration for empty string', () => {
+      expect(parseDurationFromSlotId('')).to.equal(30);
+    });
+
+    it('should return default duration for insufficient pipe-separated parts', () => {
+      expect(parseDurationFromSlotId('practitioner|uuid|timestamp')).to.equal(
+        30,
+      );
+      expect(parseDurationFromSlotId('practitioner')).to.equal(30);
+    });
+
+    it('should return default duration for empty duration part', () => {
+      const slotId = 'practitioner|uuid|2025-08-06T13:00:00Z||timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(30);
+    });
+
+    it('should return default duration for malformed duration', () => {
+      const slotId =
+        'practitioner|uuid|2025-08-06T13:00:00Z|abc123|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(30);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return default for zero duration calculation', () => {
+      const slotId =
+        'practitioner|uuid|2025-08-06T13:00:00Z|0h0m0s|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(30);
+    });
+
+    it('should handle duration with only seconds', () => {
+      const slotId = 'practitioner|uuid|2025-08-06T13:00:00Z|45s|timestamp|ov';
+      expect(parseDurationFromSlotId(slotId)).to.equal(1); // rounds up to 1 minute
+    });
   });
 });
 

--- a/src/applications/vaos/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.unit.spec.jsx
@@ -30,20 +30,12 @@ describe('VAOS Component: CalendarWidget', () => {
     const slot2 = addMinutes(nowUTC, 120);
     const availableSlots = [
       {
+        id: 'practitioner|uuid|2025-08-06T13:00:00Z|60m0s|timestamp|ov',
         start: formatInTimeZone(nowUTC, 'UTC', DATE_FORMATS.ISODateTimeLocal),
-        end: formatInTimeZone(
-          addMinutes(nowUTC, 60),
-          'UTC',
-          DATE_FORMATS.ISODateTimeLocal,
-        ),
       },
       {
+        id: 'practitioner|uuid|2025-08-06T13:00:00Z|60m0s|timestamp|ov',
         start: formatInTimeZone(slot2, 'UTC', DATE_FORMATS.ISODateTimeLocal),
-        end: formatInTimeZone(
-          addMinutes(slot2, 60),
-          'UTC',
-          DATE_FORMATS.ISODateTimeLocal,
-        ),
       },
     ];
     const startMonth = nowUTC;
@@ -140,12 +132,8 @@ describe('VAOS Component: CalendarWidget', () => {
     nowUTC.setHours(12, 0, 0, 0);
     const availableSlots = [
       {
+        id: 'practitioner|uuid|2025-08-06T13:00:00Z|60m0s|timestamp|ov',
         start: formatInTimeZone(nowUTC, 'UTC', DATE_FORMATS.ISODateTimeUTC),
-        end: formatInTimeZone(
-          addMinutes(nowUTC, 60),
-          'UTC',
-          DATE_FORMATS.ISODateTimeUTC,
-        ),
       },
     ];
     const startMonth = nowUTC;
@@ -232,20 +220,12 @@ describe('VAOS Component: CalendarWidget', () => {
     const slot2 = addDays(nowUTC, 1);
     const availableSlots = [
       {
+        id: 'practitioner|uuid|2025-08-06T13:00:00Z|60m0s|timestamp|ov',
         start: formatInTimeZone(nowUTC, 'UTC', DATE_FORMATS.ISODateTimeUTC),
-        end: formatInTimeZone(
-          addMinutes(nowUTC, 60),
-          'UTC',
-          DATE_FORMATS.ISODateTimeUTC,
-        ),
       },
       {
+        id: 'practitioner|uuid|2025-08-06T13:00:00Z|60m0s|timestamp|ov',
         start: formatInTimeZone(slot2, 'UTC', DATE_FORMATS.ISODateTimeUTC),
-        end: formatInTimeZone(
-          addMinutes(slot2, 60),
-          'UTC',
-          DATE_FORMATS.ISODateTimeUTC,
-        ),
       },
     ];
     const startMonth = nowUTC;
@@ -341,11 +321,7 @@ describe('VAOS Component: CalendarWidget', () => {
     const availableSlots = [
       {
         start: formatInTimeZone(nowUTC, 'UTC', DATE_FORMATS.ISODateTimeUTC),
-        end: formatInTimeZone(
-          addMinutes(nowUTC, 60),
-          'UTC',
-          DATE_FORMATS.ISODateTimeUTC,
-        ),
+        id: 'practitioner|uuid|2025-08-06T13:00:00Z|60m0s|timestamp|ov',
       },
       {
         start: formatInTimeZone(slot2, 'UTC', DATE_FORMATS.ISODateTimeUTC),

--- a/src/applications/vaos/components/calendar/utils.js
+++ b/src/applications/vaos/components/calendar/utils.js
@@ -85,6 +85,7 @@ export function parseDurationFromSlotId(slotId) {
  * @param {Object} upcomingAppointments - Object containing upcoming appointments organized by month key (YYYY-MM)
  * @param {Array<Object>} availableSlots - Array of available appointment slots
  * @param {string} availableSlots[].start - ISO date string for slot start time
+ * @param {string} availableSlots[].end? - ISO date string for slot end time (optional)
  * @param {string} availableSlots[].id - Slot ID containing duration information
  * @returns {boolean} True if there is a scheduling conflict, false otherwise
  */
@@ -101,8 +102,13 @@ export function getAppointmentConflict(
     );
     if (selectedSlot) {
       const selectedSlotStart = ensureDate(selectedSlot.start);
-      const durationMinutes = parseDurationFromSlotId(selectedSlot.id);
-      const selectedSlotEnd = addMinutes(selectedSlotStart, durationMinutes);
+      let selectedSlotEnd;
+      if (selectedSlot.end) {
+        selectedSlotEnd = ensureDate(selectedSlot.end);
+      } else {
+        const durationMinutes = parseDurationFromSlotId(selectedSlot.id);
+        selectedSlotEnd = addMinutes(selectedSlotStart, durationMinutes);
+      }
       const key = format(selectedSlotStart, DATE_FORMATS.yearMonth);
       const appointments = upcomingAppointments[key];
       hasConflict = appointments?.some(appointment => {

--- a/src/applications/vaos/components/calendar/utils.js
+++ b/src/applications/vaos/components/calendar/utils.js
@@ -25,6 +25,56 @@ function ensureDate(value) {
 }
 
 /**
+ * Parses duration from slot ID string and returns minutes
+ *
+ * Extracts duration from pipe-separated ID string. The duration is expected
+ * to be at index 3 in formats like "30m0s", "1h30m0s", or "2h0m0s".
+ * Returns 30 minutes as default if duration cannot be parsed.
+ *
+ * @param {string} slotId - Slot ID string separated by pipes
+ * @returns {number} Duration in minutes, defaults to 30 if not found
+ *
+ * @example
+ * // returns 30
+ * parseDurationFromSlotId("...2025-08-06T13:00:00Z|30m0s|...")
+ * // returns 90
+ * parseDurationFromSlotId("...2025-08-06T13:00:00Z|1h30m0s|...")
+ * // returns 120
+ * parseDurationFromSlotId("...2025-08-06T13:00:00Z|2h0m0s|...")
+ */
+export function parseDurationFromSlotId(slotId) {
+  if (!slotId || typeof slotId !== 'string') {
+    return 30;
+  }
+
+  const parts = slotId.split('|');
+  if (parts.length < 4) {
+    return 30;
+  }
+
+  const durationString = parts[3];
+  if (!durationString) {
+    return 30;
+  }
+
+  // Parse duration format like "1h30m0s", "30m0s", "2h0m0s", etc.
+  const match = durationString.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/);
+  if (match) {
+    const hours = match[1] ? parseInt(match[1], 10) : 0;
+    const minutes = match[2] ? parseInt(match[2], 10) : 0;
+    const seconds = match[3] ? parseInt(match[3], 10) : 0;
+
+    // Convert everything to total minutes, rounding up if there are seconds
+    const totalMinutes = hours * 60 + minutes + (seconds > 0 ? 1 : 0);
+
+    // Return at least 1 minute if we got a valid match but calculated 0
+    return totalMinutes > 0 ? totalMinutes : 30;
+  }
+
+  return 30;
+}
+
+/**
  * Checks if a selected appointment time conflicts with existing appointments
  *
  * This function determines whether the user's selected appointment slot overlaps
@@ -35,7 +85,7 @@ function ensureDate(value) {
  * @param {Object} upcomingAppointments - Object containing upcoming appointments organized by month key (YYYY-MM)
  * @param {Array<Object>} availableSlots - Array of available appointment slots
  * @param {string} availableSlots[].start - ISO date string for slot start time
- * @param {string} availableSlots[].end - ISO date string for slot end time
+ * @param {string} availableSlots[].id - Slot ID containing duration information
  * @returns {boolean} True if there is a scheduling conflict, false otherwise
  */
 
@@ -51,7 +101,8 @@ export function getAppointmentConflict(
     );
     if (selectedSlot) {
       const selectedSlotStart = ensureDate(selectedSlot.start);
-      const selectedSlotEnd = ensureDate(selectedSlot.end);
+      const durationMinutes = parseDurationFromSlotId(selectedSlot.id);
+      const selectedSlotEnd = addMinutes(selectedSlotStart, durationMinutes);
       const key = format(selectedSlotStart, DATE_FORMATS.yearMonth);
       const appointments = upcomingAppointments[key];
       hasConflict = appointments?.some(appointment => {

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -95,15 +95,9 @@ const createDraftAppointmentInfo = (
   let hourFromNow = 12;
   for (let i = 0; i < numberOfSlots; i++) {
     const startTime = dateFns.addHours(tomorrow, hourFromNow);
-    const endTime = dateFns.addMinutes(startTime, 30);
     draftApppointmentInfo.attributes.slots.push({
       id: `5vuTac8v-practitioner-1-role-2|e43a19a8-b0cb-4dcf-befa-8cc511c3999b|2025-01-02T15:30:00Z|30m0s|1736636444704|ov${i.toString()}`,
       start: startTime.toISOString(),
-      end: endTime.toISOString(),
-      status: 'free',
-      overbooked: false,
-      localStart: '2024-11-18T08:00:00-05:00',
-      localEnd: '2024-11-18T08:30:00-05:00',
     });
     hourFromNow++;
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The prior logic relied on endTime being available from Slots. Now the end time is calculated from the duration of the appointment that hides in the ID string.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115745

## Testing done

- Corrected local test data to represent the correct model.
- Create new tests for the parsing of appointment duration

## What areas of the site does it impact?

CC and new appointments

## Acceptance criteria

- [x] A slot can be selected when a confirmed appointment exists for that month.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
