### PR TITLE
10-7959a | Update content for PDI/Control number clarification

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
@@ -18,10 +18,68 @@ import { nameWording, privWrapper } from '../../shared/utilities';
 import { CHAMPVA_PHONE_NUMBER } from '../../shared/constants';
 import { validFieldCharsOnly } from '../../shared/validations';
 
-export const claimIdentifyingNumberOptions = [
-  'PDI number',
-  'Claim control number',
-];
+export const claimIdentifyingNumberOptions = ['PDI number', 'Control number'];
+
+const additionalInfoDescription = (
+  <div className="vads-u-margin-top--4">
+    <p>
+      <strong>For PDI numbers</strong> you don’t need to include the date in the
+      beginning of the PDI number. Enter the 2 letters and the all of the
+      numbers following it.
+    </p>
+    <p>
+      <strong>For control numbers</strong> include all of the numbers listed
+      under “Control Number” on the CHAMPVA Explanation of benefits.
+    </p>
+
+    <va-additional-info
+      trigger="Where to find the PDI number"
+      class="vads-u-margin-y--3"
+    >
+      <span>
+        <p className="vads-u-margin-top--0">
+          The PDI number is located at the bottom of the letter we mailed you.
+          It begins with a date, followed by 2 letters (VA, PG, FX and CM) and a
+          series of numbers (example: 02/26/2025-VA1753294097390-001).
+        </p>
+        <p className="vads-u-margin-bottom--0">
+          If you can’t find the PDI number, call us at{' '}
+          <va-telephone contact={CHAMPVA_PHONE_NUMBER} />{' '}
+          <va-telephone contact="711" tty />
+          {'. '}
+          We’re here Monday through Friday, 8:05a.m. to 7:30 p.m.{' '}
+          <dfn>
+            <abbr title="Eastern Time">ET</abbr>
+          </dfn>
+          .
+        </p>
+      </span>
+    </va-additional-info>
+    <va-additional-info
+      trigger="Where to find the control number"
+      class="vads-u-margin-y--3"
+    >
+      <span>
+        <p className="vads-u-margin-top--0">
+          The control number is located on the CHAMPVA Explanation of Benefits
+          we mailed you. It is a 12-digit code or may begin with a the letter
+          “M” followed by an 11-digit code (example: M00001234567).
+        </p>
+        <p className="vads-u-margin-bottom--0">
+          If you can’t find the control number, call us at{' '}
+          <va-telephone contact={CHAMPVA_PHONE_NUMBER} />
+          <va-telephone contact="711" tty />
+          {'. '}
+          We’re here Monday through Friday, 8:05a.m. to 7:30 p.m.{' '}
+          <dfn>
+            <abbr title="Eastern Time">ET</abbr>
+          </dfn>
+          .
+        </p>
+      </span>
+    </va-additional-info>
+  </div>
+);
 
 const additionalNotesClaims = formData => {
   const nameCap = privWrapper(
@@ -55,53 +113,20 @@ export const claimIdentifyingNumber = {
         `${
           formData?.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
         } claim identification number`,
-      `We'll use the Program Document Identifier (PDI) or claim control number to identify the original claim that was submitted. These can be found on the letter you received from CHAMPVA requesting further action on your claim.`,
+      `We’ll use the Program Document Identifier (PDI) or control number to identify the original claim that was submitted. These can be found on the letter you received from CHAMPVA requesting further action on your claim.`,
     ),
     pdiOrClaimNumber: selectUI({
-      title: 'Is this a PDI or claim control number?',
+      title: 'Is this a PDI number or control number?',
     }),
     identifyingNumber: {
-      ...textUI('PDI number or claim identification number'),
+      ...textUI('Claim identification number'),
     },
     'ui:validations': [
       (errors, formData) =>
         validFieldCharsOnly(errors, null, formData, 'identifyingNumber'),
     ],
     'view:adtlInfo': {
-      'ui:description': (
-        <div>
-          <va-additional-info trigger="Where to find the PDI number">
-            <p>
-              The PDI number is located at the bottom of the letter we mailed
-              you. It begins with the letters "VA" and includes an 8-digit code
-              (example: VA12345678).
-            </p>
-            <br />
-            <p>
-              If you can’t find the PDI number, call us at{' '}
-              <va-telephone contact={CHAMPVA_PHONE_NUMBER} />{' '}
-              <va-telephone contact="711" tty="true" />
-              {'. '}
-              We’re here Monday through Friday, 8:05a.m. to 7:30 p.m. ET.
-            </p>
-          </va-additional-info>
-          <va-additional-info trigger="Where to find the claim control number">
-            <p>
-              The claim control number is located on the CHAMPVA Explanation of
-              Benefits we mailed you. It begins with a letter followed by an
-              11-digit code (example: M00001234567).
-            </p>
-            <br />
-            <p>
-              If you can’t find the claim control number, call us at{' '}
-              <va-telephone contact={CHAMPVA_PHONE_NUMBER} />
-              <va-telephone contact="711" tty="true" />
-              {'. '}
-              We’re here Monday through Friday, 8:05a.m. to 7:30 p.m. ET.
-            </p>
-          </va-additional-info>
-        </div>
-      ),
+      'ui:description': additionalInfoDescription,
     },
   },
   schema: {

--- a/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/resubmission.js
@@ -24,8 +24,8 @@ const additionalInfoDescription = (
   <div className="vads-u-margin-top--4">
     <p>
       <strong>For PDI numbers</strong> you don’t need to include the date in the
-      beginning of the PDI number. Enter the 2 letters and the all of the
-      numbers following it.
+      beginning of the PDI number. Enter the 2 letters and all of the numbers
+      following it.
     </p>
     <p>
       <strong>For control numbers</strong> include all of the numbers listed
@@ -62,8 +62,8 @@ const additionalInfoDescription = (
       <span>
         <p className="vads-u-margin-top--0">
           The control number is located on the CHAMPVA Explanation of Benefits
-          we mailed you. It is a 12-digit code or may begin with a the letter
-          “M” followed by an 11-digit code (example: M00001234567).
+          we mailed you. It is a 12-digit code or may begin with the letter “M”
+          followed by an 11-digit code (example: M00001234567).
         </p>
         <p className="vads-u-margin-bottom--0">
           If you can’t find the control number, call us at{' '}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates content for the PID/Control number section of the 10-7959a application. The content edits are for better clarification between the two numbers.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#115616

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1600" height="2483" alt="screencapture-localhost-3001-family-and-caregiver-benefits-health-and-disability-file-champva-claim-10-7959a-resubmission-claim-number-2025-08-01-12_08_49" src="https://github.com/user-attachments/assets/5bcadce6-2dbd-494e-900c-863db296b27c" /> | <img width="1600" height="2640" alt="screencapture-localhost-3001-family-and-caregiver-benefits-health-and-disability-file-champva-claim-10-7959a-resubmission-claim-number-2025-08-01-11_59_53" src="https://github.com/user-attachments/assets/08400c6a-bbdc-48de-8fcf-d3cf94246850" /> | 

## Acceptance criteria

 - Content better-clarifies the differences and provides clear direction to the user

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution