### PR TITLE
DV | Move exit page inside form flow

### DIFF
--- a/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
@@ -224,11 +224,7 @@ DependentsInformation.propTypes = {
   data: PropTypes.shape({
     dependents: PropTypes.arrayOf(
       PropTypes.shape({
-        fullName: PropTypes.shape({
-          first: PropTypes.string,
-          middle: PropTypes.string,
-          last: PropTypes.string,
-        }),
+        fullName: PropTypes.string,
         relationship: PropTypes.string,
         dob: PropTypes.string,
         age: PropTypes.number,

--- a/src/applications/dependents/dependents-verification/components/ExitForm.jsx
+++ b/src/applications/dependents/dependents-verification/components/ExitForm.jsx
@@ -7,14 +7,14 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 
 export const form686Url = getAppUrl('686C-674');
 
-export const ExitForm = ({ router }) => {
+export const ExitForm = ({ goBack }) => {
   useEffect(() => {
     scrollAndFocus('h1');
   }, []);
 
   const handlers = {
     goBack: () => {
-      router.push('/dependents');
+      goBack();
     },
     goTo686: () => {
       window.location.assign(form686Url);

--- a/src/applications/dependents/dependents-verification/config/form.js
+++ b/src/applications/dependents/dependents-verification/config/form.js
@@ -77,14 +77,6 @@ const formConfig = {
   title: TITLE,
   subTitle: SUBTITLE,
   defaultDefinitions: {},
-  additionalRoutes: [
-    {
-      path: 'exit-form',
-      component: ExitForm,
-      pageKey: 'exitForm',
-      depends: () => false,
-    },
-  ],
   chapters: {
     veteranInformation: {
       title: 'Review your personal information',
@@ -129,6 +121,14 @@ const formConfig = {
           CustomPageReview: DependentsInformationReview,
           uiSchema: dependents.uiSchema,
           schema: dependents.schema,
+        },
+        exitForm: {
+          path: 'exit-form',
+          CustomPage: ExitForm,
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+          depends: data => data.hasDependentsStatusChanged === 'Y',
         },
       },
     },

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -24,11 +24,11 @@ describe('ExitForm', () => {
   });
 
   it('should push url to router when back button is clicked', async () => {
-    const router = { push: sinon.spy() };
-    const { container } = render(<ExitForm router={router} />);
+    const goBackSpy = sinon.spy();
+    const { container } = render(<ExitForm goBack={goBackSpy} />);
 
     fireEvent.click($('va-button[back]', container));
-    await expect(router.push.calledWith('/dependents')).to.be.true;
+    await expect(goBackSpy.called).to.be.true;
   });
 
   it('should call redirect to 686c-674 when Go to button is clicked', async () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Having the exit form page added inside `additionalRoutes` was setting up that page as one that exists _outside_ of the form flow. So after navigating to the page, clicking on any link in the header or footer was not making the browser open a browser unload (leave the form) modal. After moving the page into a chapter, the browser unload modal now shows, except when the "Go to" 686c-674 button is clicked.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/115719

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

<img width="500" alt="clicking on a breadcrumb link now shows the browser unload modal" src="https://github.com/user-attachments/assets/0db59963-ccd7-4a26-bbfe-45d2d37b161f" />

## What areas of the site does it impact?

Dependents Verificiation (21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
