### PR TITLE
Added downtime nofication and unit test

### DIFF
--- a/src/applications/vaos/referral-appointments/components/ReferralList.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralList.jsx
@@ -1,8 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 import PendingReferralCard from './PendingReferralCard';
 import InfoAlert from '../../components/InfoAlert';
 import NewTabAnchor from '../../components/NewTabAnchor';
+
+const renderDowntimeMessage = () => {
+  return (
+    <InfoAlert
+      status="warning"
+      headline="We’re working on community care referrals right now"
+    >
+      <p>
+        You can’t access community care referrals right now. Check back soon, or
+        call your provider for help scheduling an appointment.
+      </p>
+      <p>
+        <NewTabAnchor href="/find-locations">
+          Find your community care provider’s phone number
+        </NewTabAnchor>
+      </p>
+    </InfoAlert>
+  );
+};
 
 const ReferralList = ({ referrals, referralsError }) => {
   if (referralsError) {
@@ -16,37 +38,58 @@ const ReferralList = ({ referrals, referralsError }) => {
       </InfoAlert>
     );
   }
-  if (referrals.length === 0) {
+
+  const referralListContent = () => {
+    if (referrals.length === 0) {
+      return (
+        <div
+          data-testid="no-referral-content"
+          className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-y--3"
+        >
+          <h2 className="vads-u-margin--0 vads-u-margin-bottom--2p5 vads-u-font-size--md">
+            You don’t have any referrals
+          </h2>
+          <p className="vads-u-margin-bottom--0">
+            If you think you should have referrals here, call your{' '}
+            <NewTabAnchor href="/find-locations">
+              VA health facility
+            </NewTabAnchor>
+          </p>
+        </div>
+      );
+    }
     return (
-      <div
-        data-testid="no-referral-content"
-        className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-y--3"
+      <ul
+        className="usa-unstyled-list vaos-appts__list"
+        data-testid="referral-list"
       >
-        <h2 className="vads-u-margin--0 vads-u-margin-bottom--2p5 vads-u-font-size--md">
-          You don’t have any referrals
-        </h2>
-        <p className="vads-u-margin-bottom--0">
-          If you think you should have referrals here, call your{' '}
-          <NewTabAnchor href="/find-locations">VA health facility</NewTabAnchor>
-        </p>
-      </div>
+        {referrals.map((referral, index) => {
+          return (
+            <PendingReferralCard
+              key={index}
+              index={index}
+              referral={referral.attributes}
+            />
+          );
+        })}
+      </ul>
     );
-  }
+  };
+
   return (
-    <ul
-      className="usa-unstyled-list vaos-appts__list"
-      data-testid="referral-list"
+    <DowntimeNotification
+      appTitle="community care referrals"
+      dependencies={[externalServices.communityCareDS]}
+      render={(props, children) => {
+        // eslint-disable-next-line react/prop-types
+        if (props.status === 'down') {
+          return renderDowntimeMessage();
+        }
+        return children;
+      }}
     >
-      {referrals.map((referral, index) => {
-        return (
-          <PendingReferralCard
-            key={index}
-            index={index}
-            referral={referral.attributes}
-          />
-        );
-      })}
-    </ul>
+      {referralListContent()}
+    </DowntimeNotification>
   );
 };
 

--- a/src/applications/vaos/referral-appointments/components/ReferralList.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralList.unit.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import { expect } from 'chai';
+import { format, subDays, addDays } from 'date-fns';
+import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
+import { renderWithStoreAndRouter } from '../../tests/mocks/setup';
 import ReferralList from './ReferralList';
 import { createReferrals } from '../utils/referrals';
 
@@ -9,8 +11,18 @@ describe('VAOS Component: ReferralList', () => {
   const emptyReferrals = [];
 
   it('should render the referral list with referrals', () => {
-    const screen = render(
+    const initialState = {
+      scheduledDowntime: {
+        globalDowntime: null,
+        isReady: true,
+        isPending: false,
+        serviceMap: new Map(),
+        dismissedDowntimeWarnings: [],
+      },
+    };
+    const screen = renderWithStoreAndRouter(
       <ReferralList referrals={referrals} referralsError={false} />,
+      { initialState },
     );
 
     expect(screen.getByTestId('referral-list')).to.exist;
@@ -19,17 +31,73 @@ describe('VAOS Component: ReferralList', () => {
   });
 
   it('should render the no referral content when referrals are empty', () => {
-    const screen = render(
+    const initialState = {
+      scheduledDowntime: {
+        globalDowntime: null,
+        isReady: true,
+        isPending: false,
+        serviceMap: new Map(),
+        dismissedDowntimeWarnings: [],
+      },
+    };
+    const screen = renderWithStoreAndRouter(
       <ReferralList referrals={emptyReferrals} referralsError={false} />,
+      { initialState },
     );
 
     expect(screen.getByTestId('no-referral-content')).to.exist;
   });
   it('should render an error when there is a referral error', () => {
-    const screen = render(
+    const initialState = {
+      scheduledDowntime: {
+        globalDowntime: null,
+        isReady: true,
+        isPending: false,
+        serviceMap: new Map(),
+        dismissedDowntimeWarnings: [],
+      },
+    };
+    const screen = renderWithStoreAndRouter(
       <ReferralList referrals={emptyReferrals} referralsError />,
+      { initialState },
     );
 
     expect(screen.getByText('We’re sorry. We’ve run into a problem')).to.exist;
+  });
+
+  it('should render downtime notification when community care service is down', () => {
+    const serviceMap = createServiceMap([
+      {
+        attributes: {
+          externalService: 'community_care_ds',
+          status: 'down',
+          startTime: format(subDays(new Date(), 1), "yyyy-LL-dd'T'HH:mm:ss"),
+          endTime: format(addDays(new Date(), 1), "yyyy-LL-dd'T'HH:mm:ss"),
+        },
+      },
+    ]);
+
+    const initialState = {
+      scheduledDowntime: {
+        globalDowntime: null,
+        isReady: true,
+        isPending: false,
+        serviceMap,
+        dismissedDowntimeWarnings: [],
+      },
+    };
+    const screen = renderWithStoreAndRouter(
+      <ReferralList referrals={emptyReferrals} referralsError={false} />,
+      { initialState },
+    );
+
+    expect(
+      screen.getByText('We’re working on community care referrals right now'),
+    ).to.exist;
+    expect(
+      screen.getByText(
+        'You can’t access community care referrals right now. Check back soon, or call your provider for help scheduling an appointment.',
+      ),
+    ).to.exist;
   });
 });

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -84,6 +84,8 @@ export default {
   pcie: 'pcie',
   // Travel claim
   tc: 'tc',
+  // Community Care Direct Scheduling
+  communityCareDS: 'community_care_ds',
   // MDOT/ROES/DLC
   mdot: 'mdot',
   // stagingMdot: 'staging_mdot', // unnecessary


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds an inline downtime notification to the CC feature
- Connected to the Community care direct scheduling service in pagerduty

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/114784

## Testing done

- Unit tests that set redux state as if the maintenance window is in place
- Will test on staging once it is merged

## Screenshots

<img width="669" height="2335" alt="image" src="https://github.com/user-attachments/assets/9144d901-f270-4efd-a853-cd811d3acb32" />

## What areas of the site does it impact?

CC direct scheduling referrals and requests page

## Acceptance criteria

- [ ] Shows an alert in place of the referral list when a maintenance window is triggered

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
