### PR TITLE
arp/fix_content_on_arp_supporting_evidence_file_size

### DIFF
--- a/src/applications/representative-form-upload/pages/upload.jsx
+++ b/src/applications/representative-form-upload/pages/upload.jsx
@@ -85,7 +85,7 @@ export const uploadPage = {
             Select supporting documents to upload.
           </p>
           <p className="form-686c__upload-hint">
-            You can upload one file at a time no larger than 25MB.
+            You can upload one file at a time no larger than 100MB.
             <br />
             Your file can be .pdf, .png, or .jpg.
           </p>


### PR DESCRIPTION
 raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No


## Summary

- Our supporting evidence upload has a size limit of 100mb. The content should reflect that instead of 25mb. Demonstrated in the ticket with screenshots

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1471/views/6?sliceBy%5Bvalue%5D=Sprint+Backlog&pane=issue&itemId=120794848&issue=department-of-veterans-affairs%7Cva.gov-team%7C114780

## Testing done

- Tested locally

## Screenshots
<img width="465" height="131" alt="Screenshot 2025-08-04 at 10 31 47 AM" src="https://github.com/user-attachments/assets/28e6e3ec-0562-4c0b-b55c-5adea57611f4" />

## What areas of the site does it impact?

representative/representative-form-upload


### Error Handling

- [ ] Browser console contains no warnings or errors.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user