### PR TITLE
VEBT-2805: 22-10297 - Incorporate updates into Confirmation page

### DIFF
--- a/src/applications/edu-benefits/10297/containers/App.jsx
+++ b/src/applications/edu-benefits/10297/containers/App.jsx
@@ -30,7 +30,7 @@ export default function App({ location, children }) {
     [userLoggedIn, location],
   );
   return (
-    <div className="form-22-1919-container row">
+    <div className="form-22-10297-container row">
       <div className="vads-u-padding-left--0">
         <Breadcrumbs />
       </div>

--- a/src/applications/edu-benefits/10297/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/10297/containers/ConfirmationPage.jsx
@@ -4,8 +4,7 @@ import { useSelector } from 'react-redux';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import {
   ConfirmationGoBackLink,
-  ConfirmationPrintThisPage,
-  ConfirmationSubmissionAlert,
+  ConfirmationHowToContact,
   ConfirmationWhatsNextProcessList,
 } from '../helpers';
 
@@ -20,14 +19,14 @@ export const ConfirmationPage = props => {
       formConfig={props.route?.formConfig}
       submitDate={submitDate}
       confirmationNumber={confirmationNumber}
+      pdfUrl={submission?.response?.pdfUrl}
     >
-      <ConfirmationView.SubmissionAlert
-        title="You’ve submitted your application for the High Technology Program"
-        content={<ConfirmationSubmissionAlert />}
-        actions=""
-      />
-      <ConfirmationPrintThisPage data={form.data} submitDate={submitDate} />
+      <ConfirmationView.SubmissionAlert actions={null} />
+      <ConfirmationView.SavePdfDownload />
+      <ConfirmationView.ChapterSectionCollection />
+      <ConfirmationView.PrintThisPage />
       <ConfirmationWhatsNextProcessList />
+      <ConfirmationView.HowToContact content={<ConfirmationHowToContact />} />
       <ConfirmationGoBackLink />
     </ConfirmationView>
   );

--- a/src/applications/edu-benefits/10297/helpers.js
+++ b/src/applications/edu-benefits/10297/helpers.js
@@ -1,51 +1,7 @@
 import React from 'react';
 
 import classNames from 'classnames';
-import { format, isValid } from 'date-fns';
 import PropTypes from 'prop-types';
-
-const getFullName = fullName => {
-  if (!fullName) return null;
-
-  const first = (fullName?.first || '').trim();
-  const middle = (fullName?.middle || '').trim();
-  const last = (fullName?.last || '').trim();
-
-  return [first, middle, last].filter(Boolean).join(' ');
-};
-
-const onPrintPageClick = () => {
-  window.print();
-};
-
-export const ConfirmationSubmissionAlert = () => (
-  <p className="vads-u-margin-bottom--0">
-    We’ve received your application. We’ll review it and email you a decision
-    soon.
-  </p>
-);
-
-export const ConfirmationPrintThisPage = ({ data, submitDate }) => (
-  <va-summary-box>
-    <h3 slot="headline">Your application information</h3>
-    <h4 className="vads-u-margin-top--1p5">Who submitted this form</h4>
-    <p data-testid="full-name">{getFullName(data.fullName) || '---'}</p>
-    <h4 className="vads-u-margin-top--1">Date submitted</h4>
-    <p data-testid="data-submitted">
-      {isValid(submitDate) ? format(submitDate, 'MMM d, yyyy') : '---'}
-    </p>
-    <h4 className="vads-u-margin-top--1">Confirmation for your recrods</h4>
-    <p className="vads-u-padding-bottom--3">
-      You can print this confirmation page for your records.
-    </p>
-    <va-button onClick={onPrintPageClick} text="Print this page" />
-  </va-summary-box>
-);
-
-ConfirmationPrintThisPage.propTypes = {
-  data: PropTypes.object,
-  submitDate: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-};
 
 export const ConfirmationWhatsNextProcessList = () => (
   <>
@@ -76,6 +32,13 @@ export const ConfirmationWhatsNextProcessList = () => (
   </>
 );
 
+export const ConfirmationHowToContact = () => (
+  <p>
+    If you have questions about this form or need help, you can submit a request
+    through <va-link external href="https://ask.va.gov/" text="Ask VA" />
+  </p>
+);
+
 export const ConfirmationGoBackLink = () => (
   <div
     className={classNames(
@@ -84,7 +47,7 @@ export const ConfirmationGoBackLink = () => (
       'vads-u-margin-top--2',
     )}
   >
-    <va-link-action href="/" text="Go back to VA.gov" type="primary" />
+    <va-link-action href="/" text="Go back to VA.gov homepage" type="primary" />
   </div>
 );
 

--- a/src/applications/edu-benefits/10297/sass/10297-edu-benefits.scss
+++ b/src/applications/edu-benefits/10297/sass/10297-edu-benefits.scss
@@ -16,11 +16,11 @@
     }
   }
 }
+
 .need-help-container {
   width: 642px;
   @media (max-width: $small-screen) {
     width: 100%;
-    padding-inline: 8px !important;
   }
 }
 
@@ -38,4 +38,24 @@
 
 .eligibility-summary .eligibility-ul {
   list-style-type: none;
+}
+
+@media (max-width: $small-screen) {
+  .form-22-10297-container {
+    padding-inline: 0.5rem;
+  }
+
+  .form-22-10297-container .schemaform-buttons,
+  .form-22-10297-container .form-progress-buttons {
+    display: flex;
+    flex-direction: column !important;
+
+    div {
+      width: 100%;
+    }
+
+    div:first-of-type {
+      order: 2;
+    }
+  }
 }

--- a/src/applications/edu-benefits/10297/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/10297/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -7,6 +7,7 @@ import { createInitialState } from '@department-of-veterans-affairs/platform-for
 
 import formConfig from '../../config/form';
 import ConfirmationPage from '../../containers/ConfirmationPage';
+import * as maximalJson from '../fixtures/data/maximal-test.json';
 
 const mockStore = state => createStore(() => state);
 
@@ -21,6 +22,7 @@ const getPage = submission =>
         form: {
           ...createInitialState(formConfig),
           submission,
+          data: { ...maximalJson.data },
         },
       })}
     >
@@ -34,26 +36,55 @@ describe('<ConfirmationPage />', () => {
   it('shows success alert', () => {
     const { container } = getPage({
       response: { confirmationNumber: '1234567890' },
-      timestamp: new Date().toISOString(),
+      timestamp: new Date(2025, 7, 1),
     });
+    const successAlert = container.querySelector('va-alert');
 
-    expect(container.querySelector('va-alert')).to.have.attribute(
-      'status',
-      'success',
-    );
+    expect(successAlert).to.have.attribute('status', 'success');
+    // Submission Date
+    expect(successAlert.innerHTML).to.include('August 1, 2025');
+    // Confirmation Number
+    expect(successAlert.innerHTML).to.include('1234567890');
   });
 
-  it('shows summary box with button to print page', () => {
+  it('shows save pdf section if response provides pdfUrl', () => {
+    const { container } = getPage({
+      response: { confirmationNumber: '1234567890', pdfUrl: '10297-download' },
+      timestamp: new Date(2025, 7, 1),
+    });
+    const savePdfSection = container.querySelector(
+      'div[class^="confirmation-save-pdf-download-section"]',
+    );
+
+    expect(savePdfSection).to.exist;
+    expect(savePdfSection.querySelector('va-link[filetype="PDF"]')).to.exist;
+  });
+
+  it('shows the chapter section collection/summary accordion', () => {
     const { container } = getPage({
       response: { confirmationNumber: '1234567890' },
       timestamp: new Date().toISOString(),
     });
+    const accordion = container.querySelector('va-accordion');
 
-    expect(container.querySelector('va-summary-box')).to.exist;
-    expect(container.querySelectorAll('va-summary-box h4').length).to.equal(3);
-    expect(container.querySelector('va-button')).to.have.attribute(
+    expect(accordion).to.exist;
+    expect(accordion.querySelectorAll('va-accordion-item').length).to.equal(1);
+    expect(accordion.querySelectorAll('h3').length).to.equal(4);
+  });
+
+  it('shows button to print page', () => {
+    const { container } = getPage({
+      response: { confirmationNumber: '1234567890' },
+      timestamp: new Date().toISOString(),
+    });
+    const printSection = container.querySelector(
+      'div[class^="confirmation-print-this-page-section"]',
+    );
+
+    expect(printSection).to.exist;
+    expect(printSection.querySelector('va-button')).to.have.attribute(
       'text',
-      'Print this page',
+      'Print this page for your records',
     );
   });
 
@@ -69,6 +100,19 @@ describe('<ConfirmationPage />', () => {
     );
   });
 
+  it('shows how to contact section with link', () => {
+    const { container } = getPage({
+      response: { confirmationNumber: '1234567890' },
+      timestamp: new Date().toISOString(),
+    });
+    const contactSection = container.querySelector(
+      'div[class="confirmation-how-to-contact-section"]',
+    );
+
+    expect(contactSection).to.exist;
+    expect(contactSection.querySelector('va-link[text="Ask VA"]')).to.exist;
+  });
+
   it('shows action link to return to VA.gov homepage', () => {
     const { container } = getPage({
       response: { confirmationNumber: '1234567890' },
@@ -77,7 +121,7 @@ describe('<ConfirmationPage />', () => {
 
     expect(container.querySelector('va-link-action')).to.have.attribute(
       'text',
-      'Go back to VA.gov',
+      'Go back to VA.gov homepage',
     );
   });
 
@@ -89,6 +133,6 @@ describe('<ConfirmationPage />', () => {
       'success',
     );
 
-    expect(queryByText(/\d{6,}/)).to.be.null;
+    expect(queryByText('Your confirmation number is')).to.be.null;
   });
 });

--- a/src/applications/edu-benefits/10297/tests/fixtures/data/maximal-test.json
+++ b/src/applications/edu-benefits/10297/tests/fixtures/data/maximal-test.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "highestLevelOfEducation": "BD",
+    "currentSalary": "fiftyToSeventyFive",
+    "technologyAreaOfFocus": "mediaApplication",
+    "isInTechnologyIndustry": true,
+    "isEmployed": true,
+    "bankAccount": {
+      "accountType": "checking",
+      "accountNumber": "12345",
+      "routingNumber": "121000248"
+    },
+    "hasCompletedActiveDuty": false,
+    "dateReleasedFromActiveDuty": "2025-09-07",
+    "ssn": "111223333",
+    "contactInfo": {
+      "mobilePhone": "1234567890",
+      "emailAddress": "email@address.com"
+    },
+    "mailingAddress": {
+      "country": "USA",
+      "street": "The Street",
+      "city": "City",
+      "state": "AL",
+      "postalCode": "12345"
+    },
+    "applicantFullName": { "first": "John", "last": "Doe" },
+    "dutyRequirement": "atLeast3Years",
+    "dateOfBirth": "2000-10-03",
+    "otherThanDishonorableDischarge": true,
+    "trainingProvider": [
+      {
+        "name": "Training Provider",
+        "address": {
+          "country": "USA",
+          "street": "Train Street",
+          "city": "Train City",
+          "state": "DE",
+          "postalCode": "54321"
+        }
+      }
+    ]
+  }
+}

--- a/src/applications/edu-benefits/10297/tests/helpers.unit.spec.jsx
+++ b/src/applications/edu-benefits/10297/tests/helpers.unit.spec.jsx
@@ -4,8 +4,6 @@ import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import {
   ConfirmationGoBackLink,
-  ConfirmationPrintThisPage,
-  ConfirmationSubmissionAlert,
   ConfirmationWhatsNextProcessList,
   getAgeInYears,
   getEligibilityStatus,
@@ -15,42 +13,6 @@ import {
 } from '../helpers';
 
 describe('10297 Helpers', () => {
-  describe('<ConfirmationSubmissionAlert />', () => {
-    it('should render the submission alert inner message', () => {
-      const { container } = render(<ConfirmationSubmissionAlert />);
-
-      expect(container.querySelector('p').innerHTML).to.contain(
-        'We’ve received your application. We’ll review it and email you a decision soon.',
-      );
-    });
-  });
-
-  describe('<ConfirmationPrintThisPage />', () => {
-    it('should handle rendering summary box when no details are provided', () => {
-      const data = { fullName: {} };
-      const submission = {};
-      const { getByTestId } = render(
-        <ConfirmationPrintThisPage data={data} submission={submission} />,
-      );
-
-      expect(getByTestId('full-name').innerHTML).to.contain('---');
-      expect(getByTestId('data-submitted').innerHTML).to.contain('---');
-    });
-
-    it('should render summary box with provided details', () => {
-      const data = { fullName: { first: 'John', middle: 'Test', last: 'Doe' } };
-      const submitDate = new Date('07/11/2025');
-      const { getByTestId } = render(
-        <ConfirmationPrintThisPage data={data} submitDate={submitDate} />,
-      );
-
-      expect(getByTestId('full-name').innerHTML).to.contain('John Test Doe');
-      expect(getByTestId('data-submitted').innerHTML).to.contain(
-        'Jul 11, 2025',
-      );
-    });
-  });
-
   describe('<ConfirmationWhatsNextProcessList />', () => {
     it('shows process list section', () => {
       const { container } = render(<ConfirmationWhatsNextProcessList />);
@@ -68,7 +30,7 @@ describe('10297 Helpers', () => {
 
       expect(container.querySelector('va-link-action')).to.have.attribute(
         'text',
-        'Go back to VA.gov',
+        'Go back to VA.gov homepage',
       );
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Updates the 22-10297 Confirmation page to match the latest design
- The `pdfUrl` is currently set to the BE response, which is currently empty and the Save PDF section should not be displayed
- Added container styling to the 22-10297 for spacing, Need Help component, and mobile buttons

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-2805

**As a...**

VEBT Developer

**I want…**

To incorporate the updates into the newly updated Confirmation page 

**So that…**

the FE matches the latest Figma file designs 

**Acceptance Criteria**
AC1 : The updates per Midpoint Review have been incorporated into the Confirmation page 

## Testing done

- Local testing with dummy data that all conditional fields are displayed accordingly
- `SubmissionAlert` displays submission date and confirmation number
- `SavePdfDownload` only displays if BE returns a `pdfUrl`
- `ChapterSectionCollection` displays submitted form fields in accordion
- Unit tests updated for each of these cases

<img width="953" height="234" alt="Unit Test Coverage - Part 1" src="https://github.com/user-attachments/assets/019c67cd-2f29-4940-9ee4-4867ba5ee701" />
<img width="955" height="275" alt="Unit Test Coverage - Part 2" src="https://github.com/user-attachments/assets/b6c0332b-6075-40cb-abd9-f63b005f3db8" />

## Screenshots

**Mobile:**

<img width="373" height="813" alt="Confirmation Page - Part 1 (Mobile)" src="https://github.com/user-attachments/assets/f697507c-3cd5-44e9-877a-8478f435600a" />
<img width="374" height="815" alt="Confirmation Page - Part 2 (Mobile)" src="https://github.com/user-attachments/assets/fc7d86d3-b916-40c3-8301-daaa25ab6c0a" />
<img width="373" height="814" alt="Confirmation Page - Part 3 (Mobile)" src="https://github.com/user-attachments/assets/21fe3df8-fdcf-43f4-a005-9399dce753a3" />
<img width="374" height="814" alt="Information Summary - Part 1 (Mobile)" src="https://github.com/user-attachments/assets/dc476c18-6436-41e0-b248-a12fa9950701" />
<img width="374" height="815" alt="Information Summary - Part 2 (Mobile)" src="https://github.com/user-attachments/assets/534db9d3-e331-404d-9a70-190e3efce96e" />
<img width="373" height="428" alt="Information Summary - Part 3 (Mobile)" src="https://github.com/user-attachments/assets/bd3533f3-535e-4696-9c60-3ec032bbc54f" />

**Desktop:**

<img width="747" height="817" alt="Confirmation Page - Part 1 (Desktop)" src="https://github.com/user-attachments/assets/6e2af00f-8a9c-4b04-9f00-c1b8884a53e7" />
<img width="748" height="823" alt="Confirmation Page - Part 2 (Desktop)" src="https://github.com/user-attachments/assets/7bce2bf9-b61b-4388-bb5a-13266388d170" />
<img width="491" height="902" alt="Information Summary - Part 1 (Desktop)" src="https://github.com/user-attachments/assets/22b4cb8a-548b-4e1b-8f68-e1f5f241d907" />
<img width="492" height="549" alt="Information Summary - Part 2 (Desktop)" src="https://github.com/user-attachments/assets/51ef6916-8403-4553-a8e7-31beee80086a" />

## What areas of the site does it impact?

- Form 22-10297 Confirmation page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
