### PR TITLE
switches order of login buttons

### DIFF
--- a/src/applications/sign-in-changes/components/AccountSwitch.jsx
+++ b/src/applications/sign-in-changes/components/AccountSwitch.jsx
@@ -30,15 +30,15 @@ export default function AccountSwitch({ userEmails }) {
       <h2 className="vads-u-margin-y--0" id="accountSwitchH2">
         {headingText}
       </h2>
+      {userHasIdme && (
+        <CspDisplay csp="idme" email={userEmails.idme} name="ID.me" />
+      )}
       {userHasLogingov && (
         <CspDisplay
           csp="logingov"
           email={userEmails.logingov}
           name="Login.gov"
         />
-      )}
-      {userHasIdme && (
-        <CspDisplay csp="idme" email={userEmails.idme} name="ID.me" />
       )}
     </div>
   );

--- a/src/applications/sign-in-changes/components/CreateAccount.jsx
+++ b/src/applications/sign-in-changes/components/CreateAccount.jsx
@@ -3,7 +3,7 @@ import { VerifyButton } from '~/platform/user/exportsFile';
 import { VaLink } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 export default function CreateAccount() {
-  const cspInfo = ['logingov', 'idme'];
+  const cspInfo = ['idme', 'logingov'];
   return (
     <div
       className="vads-u-display--flex vads-u-flex-direction--column"
@@ -13,8 +13,8 @@ export default function CreateAccount() {
         Create a different account now
       </h2>
       <p id="createAccountP">
-        Create an identity-verified <strong>Login.gov</strong> or{' '}
-        <strong>ID.me</strong> account now, so you're ready for the change.
+        Create an identity-verified <strong>ID.me</strong> or{' '}
+        <strong>Login.gov</strong> account now, so you're ready for the change.
       </p>
       <VaLink
         text="Learn about why we are making changes to sign in"

--- a/src/applications/static-pages/cta-widget/components/messages/SignInOtherAccount.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/SignInOtherAccount.jsx
@@ -11,11 +11,11 @@ import { VerifyButton } from 'platform/user/authentication/components/VerifyButt
 const SignInOtherAccount = ({ headerLevel }) => {
   return (
     <VaAlertSignIn variant="signInEither" visible headingLevel={headerLevel}>
-      <span slot="LoginGovSignInButton">
-        <VerifyButton csp="logingov" />
-      </span>
       <span slot="IdMeSignInButton">
         <VerifyButton csp="idme" />
+      </span>
+      <span slot="LoginGovSignInButton">
+        <VerifyButton csp="logingov" />
       </span>
     </VaAlertSignIn>
   );

--- a/src/applications/static-pages/cta-widget/components/messages/Verify.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/Verify.jsx
@@ -16,19 +16,19 @@ import {
 const Verify = ({ signInService, headerLevel }) => {
   const { variant, spanSlot } =
     {
-      logingov: {
-        variant: 'verifyLoginGov',
-        spanSlot: (
-          <span slot="LoginGovVerifyButton">
-            <VerifyLogingovButton />
-          </span>
-        ),
-      },
       idme: {
         variant: 'verifyIdMe',
         spanSlot: (
           <span slot="IdMeVerifyButton">
             <VerifyIdmeButton />
+          </span>
+        ),
+      },
+      logingov: {
+        variant: 'verifyLoginGov',
+        spanSlot: (
+          <span slot="LoginGovVerifyButton">
+            <VerifyLogingovButton />
           </span>
         ),
       },

--- a/src/applications/static-pages/download-1095b/components/App/index.js
+++ b/src/applications/static-pages/download-1095b/components/App/index.js
@@ -120,11 +120,11 @@ export const App = ({ toggleLoginModal }) => {
         }
         return (
           <VaAlertSignIn variant="signInEither" visible headingLevel={4}>
-            <span slot="LoginGovSignInButton">
-              <VerifyLogingovButton />
-            </span>
             <span slot="IdMeSignInButton">
               <VerifyIdmeButton />
+            </span>
+            <span slot="LoginGovSignInButton">
+              <VerifyLogingovButton />
             </span>
           </VaAlertSignIn>
         );

--- a/src/applications/verify/components/UnifiedVerify.jsx
+++ b/src/applications/verify/components/UnifiedVerify.jsx
@@ -25,7 +25,7 @@ export default function Verify() {
   } else {
     renderServiceNames = (
       <>
-        <strong>Login.gov</strong> or <strong>ID.me</strong>
+        <strong>ID.me</strong> or <strong>Login.gov</strong>
       </>
     );
   }

--- a/src/applications/verify/components/UnifiedVerify.jsx
+++ b/src/applications/verify/components/UnifiedVerify.jsx
@@ -49,11 +49,11 @@ export default function Verify() {
   } else {
     buttonContent = (
       <>
-        <VerifyLogingovButton
+        <VerifyIdmeButton
           useOAuth
           queryParams={{ operation: 'verify_page_unauthenticated' }}
         />
-        <VerifyIdmeButton
+        <VerifyLogingovButton
           useOAuth
           queryParams={{ operation: 'verify_page_unauthenticated' }}
         />

--- a/src/platform/user/authentication/config/constants.js
+++ b/src/platform/user/authentication/config/constants.js
@@ -3,8 +3,8 @@ import { CLIENT_IDS } from '../../../utilities/oauth/constants';
 import { EXTERNAL_APPS } from '../constants';
 
 export const defaultSignInProviders = {
-  logingov: true,
   idme: true,
+  logingov: true,
 };
 
 export const legacySignInProviders = {

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -45,13 +45,6 @@ export const CSP_IDS = {
 };
 
 export const SERVICE_PROVIDERS = {
-  [CSP_IDS.LOGIN_GOV]: {
-    label: 'Login.gov',
-    link: 'https://secure.login.gov/account',
-    image: <img src="/img/logingov.svg" alt="Login.gov" />,
-    policy: 'logingov',
-    className: `logingov-button`,
-  },
   [CSP_IDS.ID_ME]: {
     label: 'ID.me',
     link: 'https://wallet.id.me/settings',
@@ -59,6 +52,13 @@ export const SERVICE_PROVIDERS = {
     altImage: <img src="/img/idme.svg" alt="ID.me" />,
     policy: 'idme',
     className: 'idme-button',
+  },
+  [CSP_IDS.LOGIN_GOV]: {
+    label: 'Login.gov',
+    link: 'https://secure.login.gov/account',
+    image: <img src="/img/logingov.svg" alt="Login.gov" />,
+    policy: 'logingov',
+    className: `logingov-button`,
   },
   [CSP_IDS.DS_LOGON]: {
     label: 'DS Logon',

--- a/src/platform/user/authorization/components/VerifyAlert.jsx
+++ b/src/platform/user/authorization/components/VerifyAlert.jsx
@@ -24,13 +24,13 @@ export default function VerifyAlert({ headingLevel = 2, dataTestId }) {
         headingLevel={headingLevel}
         data-testid={dataTestId}
       >
-        <span slot="LoginGovSignInButton">
-          <VerifyLogingovButton
+        <span slot="IdMeSignInButton">
+          <VerifyIdmeButton
             queryParams={{ operation: 'verify_cta_authenticated' }}
           />
         </span>
-        <span slot="IdMeSignInButton">
-          <VerifyIdmeButton
+        <span slot="LoginGovSignInButton">
+          <VerifyLogingovButton
             queryParams={{ operation: 'verify_cta_authenticated' }}
           />
         </span>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates the login modal, sign in page, verify page/CTAs, and interstitial application to have the ID.me button above the Login.gov button and content updates to mention ID.me accounts first.

## Related issue(s)

[Ticket link](https://github.com/department-of-veterans-affairs/identity-documentation/issues/576)

## Testing done

- unit test and end to end test pass

## Screenshots
<img width="1266" height="597" alt="Screenshot 2025-08-04 at 7 56 06 AM" src="https://github.com/user-attachments/assets/590de0fc-cb7f-4b4d-9a12-7eacea087133" />

<img width="1266" height="597" alt="Screenshot 2025-08-04 at 7 55 50 AM" src="https://github.com/user-attachments/assets/ecad8532-2136-4016-99b2-19361e49183c" />

<img width="1266" height="795" alt="Screenshot 2025-08-04 at 8 03 11 AM" src="https://github.com/user-attachments/assets/c93a699d-a15a-4d40-8ba7-631de11ac990" />

## What areas of the site does it impact?

- [/verify](va.gov/verify)
- [/sign-in](va.gov/sign-in)
- [-sign-in-changes-reminder](va.gov/sign-in-changes-reminder)

## Acceptance criteria
- ID.me is mentioned before Login.gov in our content
- ID.me button is shown above Login.gov button on our applications

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
