### PR TITLE
Sanitized error being thrown in date-parsing function

### DIFF
--- a/src/applications/mhv-medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv-medical-records/containers/Vaccines.jsx
@@ -8,7 +8,6 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import {
   updatePageTitle,
   generatePdfScaffold,
@@ -143,7 +142,6 @@ const Vaccines = props => {
     pageTitles.VACCINES_PAGE_TITLE,
     user.userFullName,
     user.dob,
-    formatDateLong,
     updatePageTitle,
   );
 

--- a/src/platform/utilities/date/index.js
+++ b/src/platform/utilities/date/index.js
@@ -59,7 +59,7 @@ export function parseStringOrDate(date) {
   }
 
   throw new Error(
-    `Could not parse date string: ${date}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+    `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
   );
 }
 

--- a/src/platform/utilities/date/index.js
+++ b/src/platform/utilities/date/index.js
@@ -59,6 +59,7 @@ export function parseStringOrDate(date) {
   }
 
   throw new Error(
+    // `Could not parse date string: ${date}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
     `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
   );
 }

--- a/src/platform/utilities/date/index.js
+++ b/src/platform/utilities/date/index.js
@@ -58,9 +58,17 @@ export function parseStringOrDate(date) {
     }
   }
 
+  const sanitizedDate = inputDate => {
+    if (inputDate == null) return String(inputDate); // handles null & undefined
+    return String(inputDate)
+      .replace(/[A-Za-z]/g, 'A')
+      .replace(/\d/g, '1');
+  };
+
   throw new Error(
-    // `Could not parse date string: ${date}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
-    `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+    `Could not parse date string (sanitized): ${sanitizedDate(
+      date,
+    )}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
   );
 }
 

--- a/src/platform/utilities/tests/date.unit.spec.jsx
+++ b/src/platform/utilities/tests/date.unit.spec.jsx
@@ -302,35 +302,40 @@ describe('Helpers unit tests', () => {
     it('should throw an error when given an invalid date string', () => {
       const invalidDateString = 'invalid-date';
       expect(() => parseStringOrDate(invalidDateString)).to.throw(
-        `Could not parse date string: ${invalidDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        // `Could not parse date string: ${invalidDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given a date in an invalid format', () => {
       const nonDateString = 'Sun Jun 11 2012 00:00:00 GMT-0700 (PDT)';
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given a non-date string', () => {
       const nonDateString = 'not-a-date';
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given null', () => {
       const nonDateString = null;
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given a non-date string', () => {
       const nonDateString = undefined;
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
   });

--- a/src/platform/utilities/tests/date.unit.spec.jsx
+++ b/src/platform/utilities/tests/date.unit.spec.jsx
@@ -302,40 +302,35 @@ describe('Helpers unit tests', () => {
     it('should throw an error when given an invalid date string', () => {
       const invalidDateString = 'invalid-date';
       expect(() => parseStringOrDate(invalidDateString)).to.throw(
-        // `Could not parse date string: ${invalidDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
-        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string (sanitized): AAAAAAA-AAAA. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given a date in an invalid format', () => {
       const nonDateString = 'Sun Jun 11 2012 00:00:00 GMT-0700 (PDT)';
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
-        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string (sanitized): AAA AAA 11 1111 11:11:11 AAA-1111 (AAA). Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given a non-date string', () => {
       const nonDateString = 'not-a-date';
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
-        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string (sanitized): AAA-A-AAAA. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given null', () => {
       const nonDateString = null;
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
-        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string (sanitized): null. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
 
     it('should throw an error when given a non-date string', () => {
       const nonDateString = undefined;
       expect(() => parseStringOrDate(nonDateString)).to.throw(
-        // `Could not parse date string: ${nonDateString}. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
-        `Could not parse date string. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
+        `Could not parse date string (sanitized): undefined. Please ensure that you provide a Date object, Unix timestamp with milliseconds, or ISO 8601 date string.`,
       );
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- User PII was being printed in DD logs
- Until the exact chain of events can be determined that printed user data, I am removing the statement that prints the data.
- Also fixed the root-cause of the PII leak, which was an extraneous function argument causing a non-date string to be passed into a date parsing function.

## Related issue(s)

See these Slack threads for details:
- https://dsva.slack.com/archives/C03Q2UQL1AS/p1754333561196429
- https://dsva.slack.com/archives/CBU0KDSB1/p1754334860335389

## Testing done

- One-word change to a comment. Tested locally to ensure the data is no longer printed

## Screenshots

Note that the error message no longer contains a user name or DOB, but is instead redacted:

<img width="600" height="268" alt="image" src="https://github.com/user-attachments/assets/443f0fa7-a7fc-422c-bda7-9867967caa46" />


## What areas of the site does it impact?

This change will alter the comment for anywhere `parseStringOrDate` is used, which is site-wide.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
