### PR TITLE
Updated MHV Landing Page header text and links

### DIFF
--- a/src/applications/mhv-landing-page/components/HeaderLayout.jsx
+++ b/src/applications/mhv-landing-page/components/HeaderLayout.jsx
@@ -42,17 +42,13 @@ const HeaderLayout = ({ showWelcomeMessage = false, isCerner = false }) => (
           </div>
         </div>
         <div>
-          <p className="vads-u-font-family--serif vads-u-line-height--5 medium-screen:vads-u-font-size--lg medium-screen:vads-u-line-height--6">
+          <p className="vads-u-font-family--serif vads-u-line-height--5 medium-screen:vads-u-font-size--lg medium-screen:vads-u-line-height--6 vads-u-margin-bottom--2">
             {ledeContent}
-          </p>
-          <p className="vads-u-font-family--serif vads-u-line-height--5 medium-screen:vads-u-font-size--lg medium-screen:vads-u-line-height--6">
-            Want to learn more about what’s new? <VaLink {...learnMoreLink} />
           </p>
         </div>
         {isCerner && (
-          <p>
-            If your facility uses My VA Health, go to the My VA Health portal to
-            manage your care.
+          <p className="vads-u-font-family--serif vads-u-line-height--5 medium-screen:vads-u-font-size--lg medium-screen:vads-u-line-height--6 vads-u-margin-y--2">
+            Does your facility use the My VA Health portal?
             <br />
             <a
               onClick={() => {
@@ -65,6 +61,7 @@ const HeaderLayout = ({ showWelcomeMessage = false, isCerner = false }) => (
                   'link-origin': window.location.href,
                 });
               }}
+              className="vads-u-font-family--serif medium-screen:vads-u-font-size--lg"
               data-testid="mhv-go-back-1"
               href={myVAHealthPortalLink}
             >
@@ -72,6 +69,11 @@ const HeaderLayout = ({ showWelcomeMessage = false, isCerner = false }) => (
             </a>
           </p>
         )}
+        <div>
+          <p className="vads-u-margin-y--2">
+            Want to learn more about what’s new? <VaLink {...learnMoreLink} />
+          </p>
+        </div>
       </div>
       <div
         className={classnames(

--- a/src/applications/mhv-landing-page/components/HeaderLayout.jsx
+++ b/src/applications/mhv-landing-page/components/HeaderLayout.jsx
@@ -42,7 +42,7 @@ const HeaderLayout = ({ showWelcomeMessage = false, isCerner = false }) => (
           </div>
         </div>
         <div>
-          <p className="vads-u-font-family--serif vads-u-line-height--5 medium-screen:vads-u-font-size--lg medium-screen:vads-u-line-height--6 vads-u-margin-bottom--2">
+          <p className="vads-u-font-family--serif vads-u-line-height--5 medium-screen:vads-u-font-size--lg medium-screen:vads-u-line-height--6 vads-u-margin-top--1 vads-u-margin-bottom--2">
             {ledeContent}
           </p>
         </div>

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -2,7 +2,7 @@ import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utiliti
 import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
 import {
   environment,
-  cernerEnvPrefixes,
+  getCernerURL,
 } from '@department-of-veterans-affairs/platform-utilities/exports';
 // Links to MHV subdomain need to use `mhvUrl`. Va.gov links can just be paths
 import { HEALTH_TOOL_HEADINGS, HEALTH_TOOL_LINKS } from '../../constants';
@@ -36,9 +36,7 @@ const resolveSHMDLink = environment.isProduction()
   : 'https://veteran.apps-staging.va.gov/smhdWeb';
 
 // Oracle Health 'My VA Health' Portal
-const myVAHealthPortalLink = `https://${
-  cernerEnvPrefixes[environment.BUILDTYPE]
-}patientportal.myhealth.va.gov/pages/home`;
+const myVAHealthPortalLink = getCernerURL('/pages/home', true);
 
 const resolveLandingPageLinks = (
   authdWithSSOe = false,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update text order and links for header.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/115650

## Testing done
- Existing unit tests

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="1290" height="2796" alt="localhost_3001_my-health_(iPhone 14 Pro Max) (1)" src="https://github.com/user-attachments/assets/454ca2ab-fd07-416f-9fad-72aef4a31d8f" />     |   <img width="1290" height="2796" alt="localhost_3001_my-health_(iPhone 14 Pro Max) (2)" src="https://github.com/user-attachments/assets/5dc681b3-61e7-4c89-ba62-092bc43bedd4" />    |
| Desktop |  <img width="2748" height="1958" alt="localhost_3001_my-health_ (3)" src="https://github.com/user-attachments/assets/b6ff73ec-2d25-4836-aeb1-7dd7e4eb0ad2" />      |  <img width="2748" height="1958" alt="localhost_3001_my-health_ (4)" src="https://github.com/user-attachments/assets/ca3555ca-bf1f-4324-a616-686d8b99cb48" />     |

## What areas of the site does it impact?
MHV Landing Page

## Acceptance criteria
- The My VA Health portal link text (and the line of text it is included in) remains conditional and is only visible to users with at least one OH facility in their profile
- The link text for the My VA Health portal now has a ?authenticated=true parameter added
- The placement of this link is above the "Want to learn more about what's new?" line
- The font is now the same as lede / subtitle - font: Bitter / size: 20
- The "Want to learn more about what's new?" line is given the standard font treatment (Source pro sans / 16.9 px)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

