### PR TITLE
updates content for ServiceProviders components

### DIFF
--- a/src/platform/user/authentication/components/ServiceProvidersList.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersList.jsx
@@ -5,10 +5,10 @@ const ServiceProvidersList = React.memo(() => {
     <>
       <ul>
         <li>
-          A verified <strong>Login.gov</strong> account, <strong>or</strong>
+          A verified <strong>ID.me</strong> account, <strong>or</strong>
         </li>
         <li>
-          A verified <strong>ID.me</strong> account, <strong>or</strong>
+          A verified <strong>Login.gov</strong> account, <strong>or</strong>
         </li>
         <li>
           A Premium <strong>DS Logon</strong> account, <strong>or</strong>
@@ -16,7 +16,7 @@ const ServiceProvidersList = React.memo(() => {
       </ul>
       <p>
         If you don’t have one of these accounts, you can create a free{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account.
+        <strong>ID.me</strong> or <strong>Login.gov</strong> account.
       </p>
     </>
   );

--- a/src/platform/user/authentication/components/ServiceProvidersList.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersList.jsx
@@ -10,9 +10,6 @@ const ServiceProvidersList = React.memo(() => {
         <li>
           A verified <strong>Login.gov</strong> account, <strong>or</strong>
         </li>
-        <li>
-          A Premium <strong>DS Logon</strong> account, <strong>or</strong>
-        </li>
       </ul>
       <p>
         If you don’t have one of these accounts, you can create a free{' '}

--- a/src/platform/user/authentication/components/ServiceProvidersText.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersText.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const ServiceProviders = React.memo(({ isBold }) => {
-  const serviceProviders = ['ID.me', 'Login.gov', 'DS Logon'];
+  const serviceProviders = ['ID.me', 'Login.gov'];
 
   return new Intl.ListFormat('en', { style: 'long', type: 'disjunction' })
     .formatToParts(serviceProviders)

--- a/src/platform/user/authentication/components/ServiceProvidersText.jsx
+++ b/src/platform/user/authentication/components/ServiceProvidersText.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const ServiceProviders = React.memo(({ isBold }) => {
-  const serviceProviders = ['Login.gov', 'ID.me', 'DS Logon'];
+  const serviceProviders = ['ID.me', 'Login.gov', 'DS Logon'];
 
   return new Intl.ListFormat('en', { style: 'long', type: 'disjunction' })
     .formatToParts(serviceProviders)
@@ -23,7 +23,7 @@ export const ServiceProvidersTextCreateAcct = React.memo(
       <>
         If you {isFormComponent}
         don’t have any of these accounts, you can create a free{' '}
-        <strong>Login.gov</strong> or <strong>ID.me</strong> account now.
+        <strong>ID.me</strong> or <strong>Login.gov</strong> account now.
         {showExtraTodo}
       </>
     );

--- a/src/platform/user/tests/authentication/components/ServiceProvidersText.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/ServiceProvidersText.unit.spec.jsx
@@ -8,7 +8,7 @@ import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
 
-const serviceProviders = ['Login.gov', 'ID.me', 'DS Logon', 'My HealtheVet'];
+const serviceProviders = ['ID.me', 'Login.gov', 'DS Logon', 'My HealtheVet'];
 const mockStore = configureMockStore();
 
 const getServiceProvidersTextData = ({ propsIsBold = false }) => {

--- a/src/platform/user/tests/authentication/components/ServiceProvidersText.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/components/ServiceProvidersText.unit.spec.jsx
@@ -8,7 +8,7 @@ import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
 
-const serviceProviders = ['ID.me', 'Login.gov', 'DS Logon', 'My HealtheVet'];
+const serviceProviders = ['ID.me', 'Login.gov'];
 const mockStore = configureMockStore();
 
 const getServiceProvidersTextData = ({ propsIsBold = false }) => {
@@ -38,7 +38,7 @@ describe('ServiceProvidersText', () => {
     const { wrapper } = getServiceProvidersTextData({
       propsIsBold: true,
     });
-    expect(wrapper.find('strong').length).to.eql(3);
+    expect(wrapper.find('strong').length).to.eql(2);
     wrapper.unmount();
   });
   it('should display normal if `isBold` is falsy', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates content to switch the order of ID.me and Login.gov per IDme's request

## Related issue(s)

[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Frontend/button-placement-audit.md)

## Testing done

- unit test updated and passing

## What areas of the site does it impact?

- authentication/identity

## Acceptance criteria

- ID.me should appear before Login.gov across all site wide content. Teams update owned applications accordingly.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
