### PR TITLE
ArrayBuilder | Call autoSave action on remove

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
@@ -8,7 +8,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { setData } from 'platform/forms-system/src/js/actions';
 import get from 'platform/utilities/data/get';
 import set from 'platform/utilities/data/set';
 import { focusElement, scrollTo } from 'platform/utilities/ui';
@@ -82,7 +81,6 @@ const ArrayBuilderCards = ({
   arrayPath,
   isIncomplete = () => false,
   getEditItemPathUrl,
-  setFormData,
   formData,
   nounSingular,
   titleHeaderLevel = '3',
@@ -91,7 +89,6 @@ const ArrayBuilderCards = ({
   onRemove,
   required,
   isReview,
-  forceRerender,
 }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(null);
@@ -158,15 +155,10 @@ const ArrayBuilderCards = ({
     if (!required(newData) && !arrayWithRemovedItem?.length) {
       delete newData[arrayPath];
     }
-    setFormData(newData);
     hideRemoveConfirmationModal({
       focusRemoveButton: false,
     });
-    onRemove(removedIndex, removedItem);
-    // forceRerender should happen BEFORE onRemoveAll because
-    // we should handle any data manipulation before a potential
-    // change of URL
-    forceRerender(newData);
+    onRemove(removedIndex, removedItem, newData);
     if (arrayWithRemovedItem.length === 0) {
       onRemoveAll(newData);
     }
@@ -307,13 +299,8 @@ const mapStateToProps = state => ({
   pageList: state.form.pages,
 });
 
-const mapDispatchToProps = {
-  setFormData: setData,
-};
-
 ArrayBuilderCards.propTypes = {
   arrayPath: PropTypes.string.isRequired,
-  forceRerender: PropTypes.func.isRequired,
   formData: PropTypes.object.isRequired,
   getEditItemPathUrl: PropTypes.func.isRequired,
   getText: PropTypes.func.isRequired,
@@ -321,7 +308,6 @@ ArrayBuilderCards.propTypes = {
   isReview: PropTypes.bool.isRequired,
   nounSingular: PropTypes.string.isRequired,
   required: PropTypes.func.isRequired,
-  setFormData: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onRemoveAll: PropTypes.func.isRequired,
   cardDescription: PropTypes.oneOfType([
@@ -332,7 +318,4 @@ ArrayBuilderCards.propTypes = {
   titleHeaderLevel: PropTypes.string,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ArrayBuilderCards);
+export default connect(mapStateToProps)(ArrayBuilderCards);

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -338,7 +338,8 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
       forceRerender();
     }
 
-    function onRemoveItem(index, item) {
+    function onRemoveItem(index, item, newFormData) {
+      props.onChange(newFormData);
       // updated alert may be from initial state (URL path)
       // so we can go ahead and remove it if there is a new
       // alert
@@ -487,7 +488,6 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
         onRemoveAll={onRemoveAllItems}
         onRemove={onRemoveItem}
         isReview={isReviewPage}
-        forceRerender={forceRerender}
         titleHeaderLevel={headingLevel}
       />
     );
@@ -694,7 +694,6 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
     recalculateErrors: PropTypes.func,
     reviewErrors: PropTypes.object,
     setData: PropTypes.func, // available regardless of review page or not
-    setFormData: PropTypes.func, // not available on review page
     title: PropTypes.string,
     trackingPrefix: PropTypes.string,
     NavButtons: PropTypes.func,

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -124,6 +124,7 @@ describe('ArrayBuilderSummaryPage', () => {
     const setFormData = sinon.spy();
     const goToPath = sinon.spy();
     const onContinue = sinon.spy();
+    const onChange = sinon.spy();
     let getText = helpers.initGetText({
       getItemName: item => item?.name,
       nounPlural: 'employers',
@@ -143,6 +144,7 @@ describe('ArrayBuilderSummaryPage', () => {
     const { mockStore } = mockRedux({
       formData: data,
       setFormData,
+      onChange,
       formErrors: reviewErrors,
     });
 
@@ -206,7 +208,7 @@ describe('ArrayBuilderSummaryPage', () => {
           schema={processedSchema}
           uiSchema={processedUiSchema}
           data={processedData}
-          onChange={() => {}}
+          onChange={onChange}
           onContinue={onContinue}
           onSubmit={() => {}}
           onReviewPage={false}
@@ -222,37 +224,14 @@ describe('ArrayBuilderSummaryPage', () => {
 
     const { container, getByText } = renderResult;
 
-    function rerenderWithNewData(newData) {
-      renderResult.rerender(
-        <Provider store={mockStore}>
-          <CustomPage
-            schema={processedSchema}
-            uiSchema={processedUiSchema}
-            data={newData}
-            setFormData={setFormData}
-            onChange={() => {}}
-            onContinue={onContinue}
-            onSubmit={() => {}}
-            onReviewPage={false}
-            goToPath={goToPath}
-            name={title}
-            title={title}
-            appStateData={{}}
-            formContext={{}}
-            formOptions={{ useWebComponentForNavigation: useWebComponent }}
-          />
-        </Provider>,
-      );
-    }
-
     return {
       setFormData,
       goToPath,
       getText,
       container,
       getByText,
-      rerenderWithNewData,
       onContinue,
+      onChange,
     };
   }
 
@@ -329,13 +308,7 @@ describe('ArrayBuilderSummaryPage', () => {
   });
 
   it('should remove all appropriately', () => {
-    const {
-      getText,
-      container,
-      goToPath,
-      getByText,
-      setFormData,
-    } = setupArrayBuilderSummaryPage({
+    const { container, goToPath, onChange } = setupArrayBuilderSummaryPage({
       arrayData: [{ name: 'Test' }],
       urlParams: '',
       maxItems: 5,
@@ -348,8 +321,8 @@ describe('ArrayBuilderSummaryPage', () => {
     const $modal = container.querySelector('va-modal');
     expect($modal.getAttribute('visible')).to.eq('true');
     $modal.__events.primaryButtonClick();
-    expect(setFormData.called).to.be.true;
-    expect(setFormData.args[0][0].employers).to.eql([]);
+    sinon.assert.calledOnce(onChange);
+    sinon.assert.calledWithExactly(onChange, { employers: [] });
     expect(goToPath.args[0][0]).to.eql(
       '/first-item/0?add=true&removedAllWarn=true',
     );
@@ -587,11 +560,7 @@ describe('ArrayBuilderSummaryPage', () => {
   });
 
   it('should display a removed item alert from 1 -> 0 items', async () => {
-    const {
-      container,
-      setFormData,
-      rerenderWithNewData,
-    } = setupArrayBuilderSummaryPage({
+    const { container, onChange } = setupArrayBuilderSummaryPage({
       arrayData: [{ name: 'Test' }],
       urlParams: '',
       maxItems: 5,
@@ -605,20 +574,15 @@ describe('ArrayBuilderSummaryPage', () => {
     expect(modal).to.have.attribute('visible');
     modal.__events.primaryButtonClick();
     await waitFor(() => {
-      sinon.assert.calledWith(setFormData, {});
-      rerenderWithNewData({});
+      sinon.assert.calledOnce(onChange);
+      sinon.assert.calledWithExactly(onChange, {});
       const alert = container.querySelector('va-alert');
       expect(alert).to.include.text('has been deleted');
-      expect(setFormData.args[0][0]).to.eql({});
     });
   });
 
   it('should display a removed item alert from 2 -> 1 items', async () => {
-    const {
-      container,
-      setFormData,
-      rerenderWithNewData,
-    } = setupArrayBuilderSummaryPage({
+    const { container, onChange } = setupArrayBuilderSummaryPage({
       arrayData: [{ name: 'Test' }, { name: 'Test 2' }],
       urlParams: '',
       maxItems: 5,
@@ -632,15 +596,12 @@ describe('ArrayBuilderSummaryPage', () => {
     expect(modal).to.have.attribute('visible');
     modal.__events.primaryButtonClick();
     await waitFor(() => {
-      sinon.assert.calledWith(setFormData, {
-        employers: [{ name: 'Test 2' }],
-      });
-      rerenderWithNewData({
+      sinon.assert.calledOnce(onChange);
+      sinon.assert.calledWithExactly(onChange, {
         employers: [{ name: 'Test 2' }],
       });
       const alert = container.querySelector('va-alert');
       expect(alert).to.include.text('has been deleted');
-      expect(setFormData.args[0][0].employers).to.have.lengthOf(1);
     });
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

During some general QA on the ArrayBuilder pattern, it was discovered that on remove of a item in the array, the `SET_DATA` action is being dispatched to update the Redux data, but the `SET_AUTO_SAVE_FORM_STATUS` action is not being dispatched to update in-progress form data when logged in and the form has save-in-progress enabled. This PR updates the `onRemove` action to call the default `onChange` method, which calls both actions by default.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#116030

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/4794febf-034c-436d-8faf-56798db0ec4f |       |

## Acceptance criteria

- SET_DATA remains being called to save form data to Redux
- SET_AUTO_SAVE_FORM_STATUS is called when logged in and SIP is enabled for the form
- All recursive testing passes without issue

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
