### PR TITLE
Remove fill button from meds card

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -79,7 +79,6 @@ const MedicationsListCard = ({ rx }) => {
           </p>
         )}
         {rx && <ExtraDetails {...rx} />}
-        {rx && <FillRefillButton {...rx} />}
       </>
     );
   };

--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsListCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
-import FillRefillButton from '../shared/FillRefillButton';
 import ExtraDetails from '../shared/ExtraDetails';
 import LastFilledInfo from '../shared/LastFilledInfo';
 import { dateFormat } from '../../util/helpers';


### PR DESCRIPTION
See Slack for context: https://dsva.slack.com/archives/C04PRFEJQTY/p1754491915313209?thread_ts=1754418360.818149&cid=C04PRFEJQTY

Fixes problem with inverted logic introduced to show the refill button on the medications list card in #37634 