### PR TITLE
Bugfix api call rate limit fix for ci deploy job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1887,6 +1887,7 @@ jobs:
         run: node ./script/github-actions/check-deployability.js
         env:
           BUILDTYPE: ${{ matrix.environment }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials (1)
         if: steps.check-deployability.outputs.is_deployable == 'true'

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -105,3 +105,7 @@ va-textarea::part(input-type-textarea) {
   outline: 2px solid var(--vads-color-action-focus-on-light);
   outline-offset: 2px;
 }
+// dummy class
+.vaos-does-not-match-anything-existing {
+  font-size: 24px;
+}

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -105,7 +105,3 @@ va-textarea::part(input-type-textarea) {
   outline: 2px solid var(--vads-color-action-focus-on-light);
   outline-offset: 2px;
 }
-// dummy class
-.vaos-does-not-match-anything-existing {
-  font-size: 24px;
-}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Github has a rate limit for unauthenticated API calls.  This can affect Github Actions workflows that rely on API calls to perform certain tasks, such as initiating deployments from the main vets-website branch to our staging environment.

The rate limit on a runner is 60 unauthenticated API calls per hour.  The authenticated call rate limit is 5,000.


## Related issue(s)

- _[Platform SRE Ticket link](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114830)_

