### PR TITLE
Dependents | Add V2 submission flags to transformForSubmit

### DIFF
--- a/src/applications/dependents/686c-674/config/form.js
+++ b/src/applications/dependents/686c-674/config/form.js
@@ -198,6 +198,11 @@ export const formConfig = {
           path: 'options-selection',
           uiSchema: addOrRemoveDependents.uiSchema,
           schema: addOrRemoveDependents.schema,
+          initialData: {
+            // Set in prefill, but included here because we're seeing v2
+            // submissions without it
+            useV2: true,
+          },
         },
         addDependentOptions: {
           title: 'Add a dependent',

--- a/src/applications/dependents/686c-674/config/form.js
+++ b/src/applications/dependents/686c-674/config/form.js
@@ -198,11 +198,6 @@ export const formConfig = {
           path: 'options-selection',
           uiSchema: addOrRemoveDependents.uiSchema,
           schema: addOrRemoveDependents.schema,
-          initialData: {
-            // Set in prefill, but included here because we're seeing v2
-            // submissions without it
-            useV2: true,
-          },
         },
         addDependentOptions: {
           title: 'Add a dependent',

--- a/src/applications/dependents/686c-674/config/prefill-transformer.js
+++ b/src/applications/dependents/686c-674/config/prefill-transformer.js
@@ -1,9 +1,3 @@
-/* vets-api/config/form_profile_mappings/10182.yml
-nonPrefill:
-  veteranSsnLastFour:
-  veteranVaFileNumberLastFour:
-*/
-
 export default function prefillTransformer(pages, formData, metadata) {
   const { veteranSsnLastFour = '', veteranVaFileNumberLastFour = '' } =
     formData?.nonPrefill || {};
@@ -35,8 +29,6 @@ export default function prefillTransformer(pages, formData, metadata) {
         phoneNumber: contact.phoneNumber || '',
         emailAddress: contact.emailAddress || '',
       },
-      useV2: true,
-      daysTillExpires: 365,
     },
     metadata,
   };

--- a/src/applications/dependents/686c-674/config/prefill-transformer.js
+++ b/src/applications/dependents/686c-674/config/prefill-transformer.js
@@ -29,6 +29,8 @@ export default function prefillTransformer(pages, formData, metadata) {
         phoneNumber: contact.phoneNumber || '',
         emailAddress: contact.emailAddress || '',
       },
+      useV2: true,
+      daysTillExpires: 365,
     },
     metadata,
   };

--- a/src/applications/dependents/686c-674/config/utilities.js
+++ b/src/applications/dependents/686c-674/config/utilities.js
@@ -116,8 +116,6 @@ export function customTransformForSubmit(formConfig, form) {
   }
   payload.data.useV2 = true;
   payload.data.daysTillExpires = 365;
-  // manually delete view:confirmEmail, since in our case we actually want the other view fields
-  // delete payload.data.veteranContactInformation['view:confirmEmail'];
   const expandedPages = expandArrayPages(
     createFormPageList(formConfig),
     payload.data,

--- a/src/applications/dependents/686c-674/config/utilities.js
+++ b/src/applications/dependents/686c-674/config/utilities.js
@@ -111,6 +111,11 @@ export {
 
 export function customTransformForSubmit(formConfig, form) {
   const payload = cloneDeep(form);
+  if (!payload.data) {
+    payload.data = {};
+  }
+  payload.data.useV2 = true;
+  payload.data.daysTillExpires = 365;
   // manually delete view:confirmEmail, since in our case we actually want the other view fields
   // delete payload.data.veteranContactInformation['view:confirmEmail'];
   const expandedPages = expandArrayPages(


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Moves the needed submission flags to the submission handler

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116071

## Testing done

- Manual / Unit / E2E

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
