### PR TITLE
[WIP] Dbex test confirmation view plus

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -48,8 +48,7 @@ export default class ConfirmationPage extends React.Component {
         fullName={props.fullName}
         isSubmittingBDD={props.isSubmittingBDD}
       />
-      {/* Testing confirmation component - with accordion */}
-      {/* <ConfirmationView.ChapterSectionCollection /> */}
+      <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList
         item1Header="We’ll send you an email to confirm your submission"
@@ -63,9 +62,6 @@ export default class ConfirmationPage extends React.Component {
       {dependentsAdditionalBenefits}
       <ConfirmationView.GoBackLink />
       <ConfirmationView.NeedHelp />
-
-      {/* Testing confirmation component - bottom of page, no accordion */}
-      <ConfirmationView.ChapterSectionCollection collapsible={false} />
     </ConfirmationView>
   );
 

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -48,6 +48,8 @@ export default class ConfirmationPage extends React.Component {
         fullName={props.fullName}
         isSubmittingBDD={props.isSubmittingBDD}
       />
+      {/* Testing confirmation component - with accordion */}
+      {/* <ConfirmationView.ChapterSectionCollection /> */}
       <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList
         item1Header="We’ll send you an email to confirm your submission"
@@ -62,8 +64,8 @@ export default class ConfirmationPage extends React.Component {
       <ConfirmationView.GoBackLink />
       <ConfirmationView.NeedHelp />
 
-      {/* Testing confirmation accordion */}
-      <ConfirmationView.ChapterSectionCollection />
+      {/* Testing confirmation component - bottom of page, no accordion */}
+      <ConfirmationView.ChapterSectionCollection collapsible={false} />
     </ConfirmationView>
   );
 

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/combined-maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/combined-maximal-test.json
@@ -5,6 +5,7 @@
       "view:claimingNew": true
     },
     "standardClaim": true,
+    "view:isBddData": true,
     "view:fdcWarning": {},
     "isVaEmployee": true,
     "homelessOrAtRisk": "homeless",
@@ -130,6 +131,16 @@
       "view:hasOtherEvidence": true
     },
     "view:evidenceTypeHelp": {},
+    "view:uploadServiceTreatmentRecordsQualifier": {
+      "view:hasServiceTreatmentRecordsToUpload": true
+    },
+    "serviceTreatmentRecordsAttachments": [
+      {
+        "name": "STR.pdf",
+        "confirmationCode": "abcdef00-a42f-4bbc-88f3-873c5bea6c00",
+        "attachmentId": "L451"
+      }
+    ],
     "view:unemployable": false,
     "view:aidAndAttendance": true,
     "view:modifyingHome": true,
@@ -259,6 +270,10 @@
         {
           "from": "2016-01-01",
           "to": "2017-01-01"
+        },
+        {
+          "from": "2017-01-06",
+          "to": "2017-04-01"
         }
       ],
       "powDisabilities": {
@@ -351,6 +366,10 @@
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": false,
+        "title10Activation": {
+          "title10ActivationDate": "2015-01-01",
+          "anticipatedSeparationDate": "2120-01-01"
+        },
         "obligationTermOfServiceDateRange": {
           "from": "2007-05-22",
           "to": "2008-06-05"
@@ -366,6 +385,12 @@
           }
         },
         {
+          "serviceBranch": "Air Force Reserves",
+          "dateRange": {
+            "from": "2014-07-22"
+          }
+        },
+        {
           "serviceBranch": "Air National Guard",
           "dateRange": {
             "from": "2015-01-01",
@@ -373,7 +398,11 @@
           }
         }
       ],
-      "view:militaryHistoryNote": {}
+      "view:militaryHistoryNote": {},
+      "separationLocation": {
+        "id": "98283",
+        "label": "AF Academy"
+      }
     },
     "view:selectablePtsdTypes": {
       "view:combatPtsdType": true
@@ -457,7 +486,6 @@
       "view:recordsInfo": {},
       "view:unemployabilityDatesDesc": {},
       "view:grossIncomeAdditionalInfo": {},
-      "view:supplementalBenefitsHelp": {},
       "view:substantiallyGainfulEmploymentInfo": {},
       "view:statementsAreTrue": {},
       "view:informOfReturnToWork": {}

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/combined-maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/combined-maximal-test.json
@@ -1,0 +1,498 @@
+{
+  "data": {
+    "view:claimType": {
+      "view:claimingIncrease": false,
+      "view:claimingNew": true
+    },
+    "standardClaim": true,
+    "view:fdcWarning": {},
+    "isVaEmployee": true,
+    "homelessOrAtRisk": "homeless",
+    "none": false,
+    "view:isHomeless": {
+      "homelessHousingSituation": "other",
+      "otherHomelessHousing": "Under a bridge",
+      "needToLeaveHousing": true
+    },
+    "homelessnessContact": {
+      "name": "Name Here, and invalid chars `~-- with email test@email.com",
+      "phoneNumber": "1231231234"
+    },
+    "view:bankAccount": {
+      "bankAccountType": "Checking",
+      "bankAccountNumber": "1233",
+      "bankRoutingNumber": "123123123",
+      "bankName": "Bigbank Co."
+    },
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "view:livesOnMilitaryBase": false,
+      "type": "MILITARY",
+      "militaryPostOfficeTypeCode": "APO",
+      "militaryStateCode": "AA",
+      "zipFirstFive": "27103",
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "view:hasForwardingAddress": true,
+    "forwardingAddress": {
+      "country": "USA",
+      "addressLine1": "321 Secondary",
+      "city": "Smallcity",
+      "state": "NY",
+      "zipCode": "54321",
+      "effectiveDate": {
+        "from": "2099-12-01",
+        "to": "2100-01-01"
+      }
+    },
+    "view:contactInfoDescription": {},
+    "additionalDocuments": [
+      {
+        "name": "lolwut.png",
+        "confirmationCode": "552067b2-9c5d-4bd8-bcd8-bc621b51a145",
+        "attachmentId": "L015"
+      },
+      {
+        "name": "image (1).png",
+        "confirmationCode": "0496e5c2-0675-4a43-83d6-e1eeabd4ea0e",
+        "attachmentId": "L070"
+      },
+      {
+        "name": "Success.jpg",
+        "confirmationCode": "de89492d-2d3f-4486-a73d-1fa4868aa49d",
+        "attachmentId": "L023"
+      }
+    ],
+    "view:uploadPrivateRecordsQualifier": {
+      "view:aboutPrivateMedicalRecords": {},
+      "view:hasPrivateRecordsToUpload": true,
+      "view:privateRecordsChoiceHelp": {}
+    },
+    "privateMedicalRecordAttachments": [
+      {
+        "name": "AngleSettingJig_9_25_15.pdf",
+        "confirmationCode": "544f14cc-4e51-4661-b8f4-d79f71567491",
+        "attachmentId": "L107"
+      },
+      {
+        "name": "image.png",
+        "confirmationCode": "fa0c0f47-a42f-4bbc-88f3-873c5bea6ce7",
+        "attachmentId": "L023"
+      }
+    ],
+    "view:vaMedicalRecordsIntro": {},
+    "vaTreatmentFacilities": [
+      {
+        "treatmentCenterName": "Treatment Center the First",
+        "treatmentDateRange": {
+          "from": "2008-01-XX"
+        },
+        "treatmentCenterAddress": {
+          "country": "USA",
+          "city": "Bigcity",
+          "state": "AK"
+        },
+        "treatedDisabilityNames": {
+          "diabetesmellitus0": true,
+          "diabetesmellitus1": true,
+          "heartattackmyocardialinfarction": true
+        },
+        "treatmentLocation0781Related": true
+      },
+      {
+        "treatmentCenterName": "Treatment Center the Second",
+        "treatmentDateRange": {
+          "from": "2010-01-XX"
+        },
+        "treatmentCenterAddress": {
+          "country": "Uganda",
+          "city": "Ugandan City"
+        },
+        "treatedDisabilityNames": {
+          "asthma": true,
+          "heartattackmyocardialinfarction": true,
+          "ankylosisinkneebilateral": true
+        },
+        "treatmentLocation0781Related": false
+      }
+    ],
+    "view:hasEvidence": true,
+    "view:selectableEvidenceTypes": {
+      "view:hasVaMedicalRecords": true,
+      "view:hasPrivateMedicalRecords": true,
+      "view:hasOtherEvidence": true
+    },
+    "view:evidenceTypeHelp": {},
+    "view:unemployable": false,
+    "view:aidAndAttendance": true,
+    "view:modifyingHome": true,
+    "view:modifyingCar": true,
+    "view:needsCarHelp": {
+      "view:alreadyClaimedVehicleAllowance": false
+    },
+    "toxicExposure": {
+      "conditions": {
+        "asthma": true,
+        "heartattackmyocardialinfarction": true
+      },
+      "gulfWar1990": {
+        "afghanistan": true,
+        "iraq": true,
+        "airspace": true
+      },
+      "gulfWar1990Details": {
+        "afghanistan": {
+          "startDate": "1990-01-01",
+          "endDate": "1990-12-31"
+        },
+        "bahrain": {},
+        "egypt": {},
+        "iraq": {
+          "startDate": "1991-02-01",
+          "endDate": "1992-12-15"
+        },
+        "israel": {},
+        "jordan": {},
+        "kuwait": {},
+        "neutralzone": {},
+        "oman": {},
+        "qatar": {},
+        "saudiarabia": {},
+        "somalia": {},
+        "syria": {},
+        "uae": {},
+        "turkey": {},
+        "waters": {},
+        "airspace": {
+          "startDate": "1991-03-01",
+          "endDate": "1991-04-01"
+        }
+      },
+      "view:gulfWar1990AdditionalInfo": {},
+      "gulfWar2001": {
+        "yemen": true,
+        "airspace": false
+      },
+      "gulfWar2001Details": {
+        "djibouti": {},
+        "lebanon": {},
+        "uzbekistan": {},
+        "yemen": {
+          "startDate": "2002-01-01",
+          "endDate": "2002-12-31"
+        },
+        "airspace": {}
+      },
+      "view:gulfWar2001AdditionalInfo": {},
+      "herbicide": {
+        "guam": true,
+        "laos": true,
+        "c123": true
+      },
+      "otherHerbicideLocations": {
+        "description": "Test location 1",
+        "startDate": "1968-01-01",
+        "endDate": "1969-01-01"
+      },
+      "herbicideDetails": {
+        "cambodia": {},
+        "guam": {
+          "startDate": "1967-01-01",
+          "endDate": "1967-12-31"
+        },
+        "koreandemilitarizedzone": {},
+        "johnston": {},
+        "laos": {
+          "startDate": "1965-01-01",
+          "endDate": "1965-12-31"
+        },
+        "c123": {
+          "startDate": "1966-01-01",
+          "endDate": "1966-02-20"
+        },
+        "thailand": {},
+        "vietnam": {
+          "view:notSure": true
+        }
+      },
+      "view:herbicideAdditionalInfo": {},
+      "otherExposures": {
+        "asbestos": true,
+        "mos": true,
+        "radiation": true,
+        "notsure": true
+      },
+      "specifyOtherExposures": {
+        "startDate": "2000-03-20",
+        "endDate": "2001-03-01",
+        "description": "Test substance 1, Test Substance 2, Test Substance 3"
+      },
+      "view:additionalExposuresAdditionalInfo": {},
+      "otherExposuresDetails": {
+        "asbestos": {
+          "startDate": "2000-01-01",
+          "endDate": "2000-12-31"
+        },
+        "chemical": {},
+        "water": {},
+        "mos": {
+          "startDate": "2001-01-08",
+          "endDate": "2001-12-31"
+        },
+        "mustardgas": {},
+        "radiation": {
+          "startDate": "2005-01-01",
+          "endDate": "2005-05-30"
+        }
+      }
+    },
+    "view:powStatus": true,
+    "view:isPow": {
+      "confinements": [
+        {
+          "from": "2016-01-01",
+          "to": "2017-01-01"
+        }
+      ],
+      "powDisabilities": {
+        "ankylosisinkneebilateral": true,
+        "heartattackmyocardialinfarction": true
+      }
+    },
+    "newDisabilities": [
+      {
+        "cause": "NEW",
+        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "condition": "asthma",
+        "view:descriptionInfo": {}
+      },
+      {
+        "cause": "SECONDARY",
+        "view:secondaryFollowUp": {
+          "causedByDisability": "Diabetes Mellitus0",
+          "causedByDisabilityDescription": "Again, this doesn't really make sense."
+        },
+        "condition": "Cranial nerve paralysis or cranial neuritis (inflammation of cranial nerves)",
+        "view:descriptionInfo": {}
+      },
+      {
+        "cause": "WORSENED",
+        "view:worsenedFollowUp": {
+          "worsenedDescription": "My knee was strained in the service",
+          "worsenedEffects": "It wasn't great before, but it got bad enough I needed a replacement. Now I have to take medication for it. I think. That makes sense, right?"
+        },
+        "condition": "ankylosis in knee, bilateral",
+        "view:descriptionInfo": {}
+      },
+      {
+        "cause": "VA",
+        "view:vaFollowUp": {
+          "vaMistreatmentDescription": "A thing happened.",
+          "vaMistreatmentLocation": "Somewhereville",
+          "vaMistreatmentDate": "A while ago"
+        },
+        "condition": "heart attack (myocardial infarction)",
+        "view:descriptionInfo": {}
+      }
+    ],
+    "ratedDisabilities": [
+      {
+        "name": "Diabetes mellitus0",
+        "ratedDisabilityId": "0",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE",
+        "view:selected": true
+      },
+      {
+        "name": "Diabetes mellitus1",
+        "ratedDisabilityId": "1",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE",
+        "view:selected": true
+      },
+      {
+        "name": "De-selected",
+        "ratedDisabilityId": "2",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE",
+        "view:selected": false
+      },
+      {
+        "name": "Not selected",
+        "ratedDisabilityId": "3",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE"
+      }
+    ],
+    "view:disabilitiesClarification": {},
+    "serviceInformation": {
+      "reservesNationalGuardService": {
+        "view:isTitle10Activated": false,
+        "obligationTermOfServiceDateRange": {
+          "from": "2007-05-22",
+          "to": "2008-06-05"
+        },
+        "unitName": "Seal Team Six"
+      },
+      "servicePeriods": [
+        {
+          "serviceBranch": "Air Force",
+          "dateRange": {
+            "from": "2001-03-21",
+            "to": "2014-07-21"
+          }
+        },
+        {
+          "serviceBranch": "Air National Guard",
+          "dateRange": {
+            "from": "2015-01-01",
+            "to": "2017-05-13"
+          }
+        }
+      ],
+      "view:militaryHistoryNote": {}
+    },
+    "view:selectablePtsdTypes": {
+      "view:combatPtsdType": true
+    },
+    "view:ptsdTypeHelp": {},
+    "view:upload781ChoiceHelp": {},
+    "skip781ForCombatReason": false,
+    "view:ptsdCombatBypassAdditionalInfo": {},
+    "view:mentalHealthSupportAlert": {},
+    "mentalHealthWorkflowChoice": "optForOnlineForm0781",
+    "eventTypes": {
+      "combat": true,
+      "mst": true,
+      "nonMst": true,
+      "other": true
+    },
+    "view:traumaticEventsInfo": {},
+    "events": [
+      {
+        "details": "Briefly describe what happened during your traumatic event in the military.",
+        "view:eventExamplesAdditionalInfo": {},
+        "location": "Where did the event happen?",
+        "otherReports": "Other official report type not listed here",
+        "timing": "When did the event happen?",
+        "view:mentalHealthSupportAlert": {},
+        "reports": {
+          "restricted": true,
+          "unrestricted": true,
+          "police": true,
+          "none": true
+        },
+        "agency": "Name of the agency that issued the report",
+        "city": "report city",
+        "state": "report state",
+        "township": "report township",
+        "country": "USA"
+      }
+    ],
+    "workBehaviors": {
+      "absences": true,
+      "performance": true,
+      "reassignment": true
+    },
+    "healthBehaviors": {
+      "appetite": true,
+      "consultations": true,
+      "episodes": true,
+      "medications": true,
+      "pregnancy": true,
+      "screenings": true,
+      "selfMedication": true,
+      "substances": true
+    },
+    "otherBehaviors": {
+      "misconduct": true,
+      "relationships": true,
+      "socialEconomic": true,
+      "unlisted": true
+    },
+    "noBehavioralChange": {
+      "noChange": false
+    },
+    "treatmentReceivedNonVaProvider": {
+      "nonVa": true,
+      "vaCenters": true
+    },
+    "treatmentReceivedVaProvider": {
+      "medicalCenter": true,
+      "communityOutpatient": true,
+      "vaPaid": true,
+      "dod": true
+    },
+    "treatmentNoneCheckbox": {
+      "none": false
+    },
+    "optionIndicator": "yes",
+    "additionalInformation": "Is there anything else you want to tell us about your mental health conditions, or related traumatic events and behavioral changes?",
+    "view:ancillaryFormsWizardIntro": {},
+    "view:unemployabilityHelp": {},
+    "unemployability": {
+      "view:recordsInfo": {},
+      "view:unemployabilityDatesDesc": {},
+      "view:grossIncomeAdditionalInfo": {},
+      "view:supplementalBenefitsHelp": {},
+      "view:substantiallyGainfulEmploymentInfo": {},
+      "view:statementsAreTrue": {},
+      "view:informOfReturnToWork": {}
+    },
+    "view:privateMedicalFacility": {},
+    "view:upload4192Choice": {},
+    "view:downloadInfo": {},
+    "view:privateRecordsChoiceHelp": {},
+    "view:faqAccordion": {},
+    "view:originalBankAccount": {
+      "view:bankAccountType": "Checking",
+      "view:bankAccountNumber": "*********1234",
+      "view:bankRoutingNumber": "*****2115",
+      "view:bankName": "Comerica"
+    },
+    "supportingEvidenceReports": {
+      "police": true
+    },
+    "supportingEvidenceRecords": {
+      "physicians": true,
+      "counseling": true,
+      "crisis": true
+    },
+    "supportingEvidenceWitness": {
+      "family": true,
+      "faculty": false,
+      "service": false,
+      "clergy": true
+    },
+    "supportingEvidenceOther": {
+      "personal": false
+    },
+    "supportingEvidenceUnlisted": "unlisted document",
+    "supportingEvidenceNoneCheckbox": {
+      "none": false
+    }
+  }
+}

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/combined-maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/combined-maximal-test.json
@@ -16,14 +16,15 @@
       "needToLeaveHousing": true
     },
     "homelessnessContact": {
-      "name": "Name Here, and invalid chars `~-- with email test@email.com",
+      "name": "Name Here, and invalid chars è æ á with email test@email.com",
       "phoneNumber": "1231231234"
     },
     "view:bankAccount": {
       "bankAccountType": "Checking",
       "bankAccountNumber": "1233",
       "bankRoutingNumber": "123123123",
-      "bankName": "Bigbank Co."
+      "bankName": "Bigbank Co.",
+      "view:newAccountAlert": {}
     },
     "phoneAndEmail": {
       "primaryPhone": "4445551212",
@@ -39,7 +40,8 @@
       "addressLine1": "123 Main",
       "city": "Bigcity",
       "state": "AK",
-      "zipCode": "12345"
+      "zipCode": "12345",
+      "view:livesOnMilitaryBaseInfo": {}
     },
     "view:hasForwardingAddress": true,
     "forwardingAddress": {
@@ -69,6 +71,12 @@
         "name": "Success.jpg",
         "confirmationCode": "de89492d-2d3f-4486-a73d-1fa4868aa49d",
         "attachmentId": "L023"
+      },
+      {
+        "name": "Screenshot 2025-07-31 at 5.07.24 PM.png",
+        "confirmationCode": "6525e785-23e5-4c30-8cc7-2e3eb3e82d43",
+        "attachmentId": "L015",
+        "isEncrypted": false
       }
     ],
     "view:uploadPrivateRecordsQualifier": {
@@ -146,7 +154,8 @@
     "view:modifyingHome": true,
     "view:modifyingCar": true,
     "view:needsCarHelp": {
-      "view:alreadyClaimedVehicleAllowance": false
+      "view:alreadyClaimedVehicleAllowance": false,
+      "view:doubleAllowanceAlert": {}
     },
     "toxicExposure": {
       "conditions": {
@@ -156,7 +165,8 @@
       "gulfWar1990": {
         "afghanistan": true,
         "iraq": true,
-        "airspace": true
+        "airspace": true,
+        "jordan": true
       },
       "gulfWar1990Details": {
         "afghanistan": {
@@ -170,7 +180,10 @@
           "endDate": "1992-12-15"
         },
         "israel": {},
-        "jordan": {},
+        "jordan": {
+          "startDate": "2003-02-01",
+          "endDate": "2004-02-01"
+        },
         "kuwait": {},
         "neutralzone": {},
         "oman": {},
@@ -199,7 +212,10 @@
           "startDate": "2002-01-01",
           "endDate": "2002-12-31"
         },
-        "airspace": {}
+        "airspace": {
+          "startDate": "2000-01-12",
+          "endDate": "2002-01-24"
+        }
       },
       "view:gulfWar2001AdditionalInfo": {},
       "herbicide": {
@@ -210,10 +226,11 @@
       "otherHerbicideLocations": {
         "description": "Test location 1",
         "startDate": "1968-01-01",
-        "endDate": "1969-01-01"
+        "endDate": "1969-01-01",
+        "view:notSure": true
       },
       "herbicideDetails": {
-        "cambodia": {},
+        "cambodia": false,
         "guam": {
           "startDate": "1967-01-01",
           "endDate": "1967-12-31"
@@ -249,9 +266,14 @@
       "otherExposuresDetails": {
         "asbestos": {
           "startDate": "2000-01-01",
-          "endDate": "2000-12-31"
+          "endDate": "2000-12-31",
+          "view:notSure": false
         },
-        "chemical": {},
+        "chemical": {
+          "startDate": "2002-02-04",
+          "endDate": "2003-02-04",
+          "view:notSure": true
+        },
         "water": {},
         "mos": {
           "startDate": "2001-01-08",
@@ -284,7 +306,7 @@
     "newDisabilities": [
       {
         "cause": "NEW",
-        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "primaryDescription": "This description is for the first listed new condition (asthma).",
         "condition": "asthma",
         "view:descriptionInfo": {}
       },
@@ -292,7 +314,7 @@
         "cause": "SECONDARY",
         "view:secondaryFollowUp": {
           "causedByDisability": "Diabetes Mellitus0",
-          "causedByDisabilityDescription": "Again, this doesn't really make sense."
+          "causedByDisabilityDescription": "This is the causedByDisabilityDescription field for (Diabetes Mellitus0)."
         },
         "condition": "Cranial nerve paralysis or cranial neuritis (inflammation of cranial nerves)",
         "view:descriptionInfo": {}
@@ -396,9 +418,17 @@
             "from": "2015-01-01",
             "to": "2017-05-13"
           }
+        },
+        {
+          "serviceBranch": "Army",
+          "dateRange": {
+            "from": "2000-01-01",
+            "to": "2004-01-01"
+          }
         }
       ],
       "view:militaryHistoryNote": {},
+      "view:separationLocation": {},
       "separationLocation": {
         "id": "98283",
         "label": "AF Academy"
@@ -439,6 +469,31 @@
         "state": "report state",
         "township": "report township",
         "country": "USA"
+      },
+      {
+        "agency": "Name of the agency that issued the report",
+        "city": "report city",
+        "state": "report state",
+        "township": "report township",
+        "country": "USA",
+        "view:mentalHealthSupportAlert": {},
+        "militaryReports": { "restricted": false, "unrestricted": false, "pre2005": false },
+        "otherReports": { "police": true, "unsure": true },
+        "noReport": {},
+        "details": "first event",
+        "view:eventExamplesAdditionalInfo": {},
+        "location": "asdf",
+        "timing": "asdf"
+      },
+      {
+        "militaryReports": { "restricted": false, "unrestricted": false, "pre2005": false },
+        "otherReports": {},
+        "noReport": {},
+        "view:mentalHealthSupportAlert": {},
+        "details": "second event",
+        "view:eventExamplesAdditionalInfo": {},
+        "location": "asf",
+        "timing": "asdfasdf"
       }
     ],
     "workBehaviors": {
@@ -479,7 +534,7 @@
       "none": false
     },
     "optionIndicator": "yes",
-    "additionalInformation": "Is there anything else you want to tell us about your mental health conditions, or related traumatic events and behavioral changes?",
+    "additionalInformation": "Test string that includes a mix of potentially invalid characters — “consectètur” ædípíscíng élít; ‘sed’ do ámet… Curly “quotes” and ‘apostrophes’, en–dash –, em—dash —, ellipsis …, plus symbols § © ™.",
     "view:ancillaryFormsWizardIntro": {},
     "view:unemployabilityHelp": {},
     "unemployability": {
@@ -521,6 +576,38 @@
     "supportingEvidenceUnlisted": "unlisted document",
     "supportingEvidenceNoneCheckbox": {
       "none": false
+    },
+    "behaviorsDetails": {},
+    "waiveTrainingPay": true,
+    "view:waiveRetirementPayDescription": {},
+    "waiveRetirementPay": true,
+    "view:limitedConsent": true,
+    "limitedConsent": "asdf",
+    "view:patientAcknowledgement": { "view:acknowledgement": true },
+    "view:patientAcknowledgmentHelp": {},
+    "view:conflictingResponseAlert": {},
+    "view:ancillaryFormsWizard": false,
+    "view:behaviorAdditionalInformation": {},
+    "view:serviceTreatmentRecordsSubmitLater": {},
+    "view:evidenceSubmitLater": {},
+    "syncModern0781Flow": true,
+    "view:selectedMentalHealthWorkflowChoice": "optOutOfForm0781",
+    "view:previousMentalHealthWorkflowChoice": "optForOnlineForm0781",
+    "undefined": false,
+    "statementOfTruthCertified": true,
+    "statementOfTruthSignature": "Greg A Anderson",
+    "metadata": { "eventsForceRenderTimestamp": 1754003631751 },
+    "answerCombatBehaviorQuestions": "false",
+    "startedFormVersion": "2022",
+    "view:ratedDisabilitiesAlert": {},
+    "hasTrainingPay": true,
+    "view:hasMilitaryRetiredPay": true,
+    "militaryRetiredPayBranch": "Army",
+    "hasSeparationPay": true,
+    "view:separationPayDetails": {
+      "view:separationPayDetailsDescription": {},
+      "separationPayDate": "2006",
+      "separationPayBranch": "Army"
     }
   }
 }


### PR DESCRIPTION
## Summary
This is an experimental branch, to test adding page title subheaders to the confirmation view accordion.

- (Which team do you work for, does your team own the maintenance of this component?)
Disability Benefits Core Team (team one)

- (If using a flipper, what is the end date of the flipper being required/success criteria being targeted)
This new section of the 526 confirmation page will be behind a flipper and rolled out incrementally.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[https://github.com/department-of-veterans-affairs/va.gov-team/issues/115133](Copy of submission - ~Build experimental component~ pivit eng implementation research  va.gov-team#115133)
- _Link to epic if not included in ticket_
Super Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/107258

## Testing done

- _Describe what the old behavior was prior to the change_
The page titles were not included previously

Describe the tests completed and the results
- _Describe the steps required to verify your changes are working as expected_
Click through the 526 form, successfully submit the form, and verify the confirmation accordion at the bottom of the page.

- _Describe the tests completed and the results_
TODO! This was a quick proof of concept with only some manual testing of the 526 form locally. I tried a couple mockdata json forms with the dev setup, as well as clicking through several 526 pathways and viewing the results manually.

- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="330" height="672" alt="Screenshot 2025-08-07 at 12 37 14 PM" src="https://github.com/user-attachments/assets/bfb9986a-1181-4493-94ea-6e1e1c761f2d" /> | <img width="337" height="689" alt="Screenshot 2025-08-07 at 12 16 12 PM" src="https://github.com/user-attachments/assets/5fcbda1e-7cf2-465d-9b4b-38bdf4947d90" />|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
TODO! If the changes stay in this component, it will affect other forms that use the confirmation view.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
