### PR TITLE
Fix array builder being able to skip yes/no validation

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-depends.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-depends.cypress.spec.js
@@ -33,6 +33,15 @@ State change: ${state.value}
   }
 }
 
+function attemptContinueWithoutSelectingYesNo() {
+  cy.findByText(/continue/i, { selector: 'button' }).click();
+  cy.get('va-radio[name="root_view:hasEmployment"]').should(
+    'have.attr',
+    'error',
+    'Select yes if you have a employer to add',
+  );
+}
+
 function summaryAddMore(hasEmployment) {
   cy.selectYesNoVaRadioOption('root_view:hasEmployment', hasEmployment);
   cy.axeCheck();
@@ -136,6 +145,7 @@ const testConfig = createTestConfig(
           cy.get('@testData').then(() => {
             switch (nextState) {
               case 'SKIP_SUMMARY_NO_ITEMS':
+                attemptContinueWithoutSelectingYesNo();
                 summaryAddMore(false);
                 break;
               case 'ADDING_ITEM_1_NO_DEPENDS':

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -633,7 +633,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
       );
     }
 
-    const onContinue = () => {
+    const onSubmit = (...args) => {
       const isValid = validateIncompleteItems({
         arrayData: get(arrayPath, props.data),
         isItemIncomplete,
@@ -643,7 +643,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
       });
 
       if (isValid) {
-        props.onContinue();
+        props.onSubmit(...args);
       }
     };
 
@@ -659,7 +659,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
         formContext={props.formContext}
         trackingPrefix={props.trackingPrefix}
         onChange={props.onChange}
-        onSubmit={props.onSubmit}
+        onSubmit={onSubmit}
         formOptions={props.formOptions}
       >
         <>
@@ -668,7 +668,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
           {props.contentBeforeButtons}
           <NavButtons
             goBack={props.goBack}
-            goForward={onContinue}
+            goForward={props.onContinue}
             submitToContinue
             useWebComponents={props.formOptions?.useWebComponentForNavigation}
           />

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -633,7 +633,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
       );
     }
 
-    const onNavForward = () => {
+    const onContinue = () => {
       const isValid = validateIncompleteItems({
         arrayData: get(arrayPath, props.data),
         isItemIncomplete,
@@ -644,7 +644,6 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
 
       if (isValid) {
         props.onContinue();
-        props.onSubmit(props.data);
       }
     };
 
@@ -660,7 +659,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
         formContext={props.formContext}
         trackingPrefix={props.trackingPrefix}
         onChange={props.onChange}
-        onSubmit={onNavForward}
+        onSubmit={props.onSubmit}
         formOptions={props.formOptions}
       >
         <>
@@ -669,7 +668,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
           {props.contentBeforeButtons}
           <NavButtons
             goBack={props.goBack}
-            goForward={onNavForward}
+            goForward={onContinue}
             submitToContinue
             useWebComponents={props.formOptions?.useWebComponentForNavigation}
           />

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -417,57 +417,6 @@ describe('ArrayBuilderSummaryPage', () => {
     expect($errorAlert).to.not.exist;
   });
 
-  it('should show an error alert on the summary page and prevent navigation', async () => {
-    const { container, onContinue } = setupArrayBuilderSummaryPage({
-      arrayData: [{ name: 'Test' }, {}],
-      radioData: 'N',
-      useWebComponent: true,
-    });
-    const $errorAlert = container.querySelector('va-alert');
-    expect($errorAlert).to.include.text(
-      'This employer is missing information.',
-    );
-
-    fireEvent.click(container.querySelector('va-button[continue]'));
-    await expect(onContinue.called).to.be.false;
-  });
-
-  it('should show an error alert on the summary page and prevent navigation even if schema is set as required', async () => {
-    const { container, onContinue } = setupArrayBuilderSummaryPage({
-      arrayData: [{ name: 'Test' }, {}],
-      radioData: 'N',
-      urlParams: '',
-      schema: {
-        type: 'object',
-        properties: {
-          'view:hasOption': arrayBuilderYesNoSchema,
-        },
-      },
-      useWebComponent: true,
-    });
-    const $errorAlert = container.querySelector('va-alert');
-    expect($errorAlert).to.include.text(
-      'This employer is missing information.',
-    );
-
-    fireEvent.click(container.querySelector('va-button[continue]'));
-
-    await expect(onContinue.called).to.be.false;
-  });
-
-  it('should show an error alert on the summary page and prevent navigation even if schema is set as required', async () => {
-    const { container, onContinue } = setupArrayBuilderSummaryPage({
-      arrayData: [{ name: 'Test' }, { name: 'Test 2' }],
-      radioData: 'N',
-      urlParams: '',
-      useWebComponent: true,
-    });
-    expect(container.querySelector('va-alert')).to.not.exist;
-
-    fireEvent.click(container.querySelector('va-button[continue]'));
-    await expect(onContinue.called).to.be.true;
-  });
-
   it('should display summaryTitleWithoutItems and summaryDescriptionWithoutItems text override when array is empty', () => {
     const { container } = setupArrayBuilderSummaryPage({
       arrayData: [],


### PR DESCRIPTION
## Summary

- Fix array builder being able to skip yes/no validation

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4617
https://github.com/department-of-veterans-affairs/vets-website/pull/37899

## Testing done

- browser, e2e

## Screenshots

<img width="533" height="592" alt="image" src="https://github.com/user-attachments/assets/295ac5b4-5a4d-468e-8461-959d3f3a395c" />
<img width="498" height="345" alt="image" src="https://github.com/user-attachments/assets/ebf2d4cf-a1a0-4e70-ad75-ddb5b62b262c" />
<img width="543" height="519" alt="image" src="https://github.com/user-attachments/assets/fe6a58dc-f858-430a-95f4-06785e117ff7" />

## What areas of the site does it impact?

array builder

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
