### PR TITLE
0969 | Recurring income – Unassociated recurring income name collection updates

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -461,8 +461,28 @@ const nonVeteranIncomeRecipientPage = {
 /** @returns {PageSchema} */
 const recipientNamePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Recurring income recipient'),
-    recipientName: fullNameNoSuffixUI(title => `Income recipient’s ${title}`),
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Recurring income recipient',
+    ),
+    recipientName: showUpdatedContent()
+      ? {
+          ...fullNameNoSuffixUI,
+          first: {
+            ...fullNameNoSuffixUI.first,
+            'ui:title': 'First or given name',
+          },
+          middle: {
+            ...fullNameNoSuffixUI.middle,
+            'ui:title': 'Middle name',
+          },
+          last: {
+            ...fullNameNoSuffixUI.last,
+            'ui:title': 'Last or family name',
+          },
+        }
+      : fullNameNoSuffixUI(title => `Income recipient’s ${title}`),
   },
   schema: {
     type: 'object',
@@ -558,7 +578,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     unassociatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
-      title: 'Recurring income recipient',
+      title: showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Recurring income recipient',
       path: 'recurring-income/:index/veteran-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'VETERAN',
@@ -566,7 +588,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: veteranIncomeRecipientPage.schema,
     }),
     unassociatedIncomeSpouseRecipientPage: pageBuilder.itemPage({
-      title: 'Recurring income recipient',
+      title: showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Recurring income recipient',
       path: 'recurring-income/:index/spouse-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'SPOUSE',
@@ -574,7 +598,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: spouseIncomeRecipientPage.schema,
     }),
     unassociatedIncomeCustodianRecipientPage: pageBuilder.itemPage({
-      title: 'Recurring income recipient',
+      title: showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Recurring income recipient',
       path: 'recurring-income/:index/custodian-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
@@ -582,7 +608,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: custodianIncomeRecipientPage.schema,
     }),
     unassociatedIncomeParentRecipientPage: pageBuilder.itemPage({
-      title: 'Recurring income recipient',
+      title: showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Recurring income recipient',
       path: 'recurring-income/:index/parent-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'PARENT',
@@ -590,7 +618,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: parentIncomeRecipientPage.schema,
     }),
     unassociatedIncomeNonVeteranRecipientPage: pageBuilder.itemPage({
-      title: 'Recurring income recipient',
+      title: showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Recurring income recipient',
       path: 'recurring-income/:index/income-recipient',
       depends: formData =>
         !showUpdatedContent() ||
@@ -599,7 +629,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: nonVeteranIncomeRecipientPage.schema,
     }),
     unassociatedIncomeRecipientNamePage: pageBuilder.itemPage({
-      title: 'Recurring income recipient name',
+      title: showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Recurring income recipient',
       path: 'recurring-income/:index/recipient-name',
       depends: (formData, index) =>
         recipientNameRequired(formData, index, 'unassociatedIncomes'),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated the **Recurring income** list-and-loop chapter’s **Income recipient** page in the Income and Asset Statement form (VA Form 21P-0969) when the `claimantType` is not `"VETERAN"` and the `incomeAndAssetsContentUpdates` feature toggle is enabled. This enhancement updates the language to be more plain language.

## Related issue(s)

[0969 | Recurring Income - Name of income recipient page #111461](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111461)

## Design References
- [Figma link – Recurring Income chapter](https://www.figma.com/design/tJhSwyQorlgdVPC2UKx1fQ/WIP---21P-0969-Income-and-Asset?node-id=1113-43439&t=v7LhGIAt7hQYqPyv-4)

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`
4. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969/` in your browser

## How to verify
1. Begin a new 0969 application
2. Ensure `claimantType` is set to anything but `"VETERAN"`
3. Navigate to the **Recurring income** section
4. On the **Income recipient** page:
   - Confirm that content is tailored for a Veteran applicant
   - Confirm that relationship options are appropriately limited or adjusted
   - Ensure schema updates validate data correctly
5. Disable the feature toggle and verify that the original content renders instead

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Before - `incomeAndAssetsContentUpdates` disabled
<img width="514" height="530" alt="Screenshot 2025-08-06 at 17 58 44" src="https://github.com/user-attachments/assets/49aa1c20-c4cc-4685-b0cc-2c4edace32bb" />

After - `incomeAndAssetsContentUpdates` enabled
<img width="498" height="570" alt="Screenshot 2025-08-06 at 17 58 19" src="https://github.com/user-attachments/assets/20ef60b5-0eba-48d1-9869-4c7b2bb9eaef" />

## What areas of the site does it impact?

n/a

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

