### PR TITLE
DV | Update review page email sections

### DIFF
--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/transformed-maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/transformed-maximal.json
@@ -1,0 +1,305 @@
+{
+  "view:addOrRemoveDependents": { "add": true, "remove": true },
+  "view:addDependentOptions": {
+    "addSpouse": true,
+    "addChild": true,
+    "report674": true,
+    "addDisabledChild": true
+  },
+  "view:removeDependentOptions": {
+    "reportDivorce": true,
+    "reportDeath": true,
+    "reportStepchildNotInHousehold": true,
+    "reportMarriageOfChildUnder18": true,
+    "reportChild18OrOlderIsNotAttendingSchool": true
+  },
+
+
+  "useV2": true,
+  "daysTillExpires": 365,
+  "veteranInformation": {
+    "fullName": { "first": "Pauline", "middle": "E", "last": "Foster" },
+    "ssn": "796330625",
+    "birthDate": "1976-06-09",
+    "ssnLastFour": "0625",
+    "vaFileLastFour": "0625"
+  },
+  "veteranContactInformation": {
+    "veteranAddress": {
+      "country": "AGO",
+      "street": "123 Fake st",
+      "street2": "Apt 1",
+      "street3": "Suite 100",
+      "city": "Fakesville",
+      "state": "Fakeland",
+      "postalCode": "987654321"
+    },
+    "phoneNumber": "8008885555",
+    "emailAddress": "nope@nope.com"
+  },
+
+  "spouseInformation": {
+    "ssn": "333445555",
+    "vaFileNumber": "987654321",
+    "serviceNumber": "W123456",
+    "birthDate": "1991-02-19",
+    "isVeteran": true,
+    "fullName": { "first": "Two-Names", "last": "Doe" }
+  },
+  "doesLiveWithSpouse": {
+    "spouseDoesLiveWithVeteran": false,
+    "spouseIncome": "NA",
+    "address": {
+      "country": "USA",
+      "street": "123 Fake st",
+      "city": "Fakesville",
+      "state": "NV",
+      "postalCode": "89131"
+    },
+    "currentSpouseReasonForSeparation": "Other",
+    "other": "Other reason"
+  },
+  "currentMarriageInformation": {
+    "typeOfMarriage": "CIVIL",
+    "location": { "city": "Fakesville", "state": "CA" },
+    "date": "1991-03-19"
+  },
+
+  "view:completedSpouseFormerMarriage": false,
+  "spouseMarriageHistory": [
+    {
+      "startLocation": {
+        "outsideUsa": true,
+        "location": { "city": "Fakesville", "country": "DZA" }
+      },
+      "endLocation": { "location": { "city": "Fakesville", "state": "CO" } },
+      "endDate": "2020-03-25",
+      "startDate": "2020-03-19",
+      "reasonMarriageEnded": "Other",
+      "otherReasonMarriageEnded": "other way",
+      "fullName": { "first": "John", "last": "Doe" }
+    }
+  ],
+
+
+
+  "spouseSupportingDocuments": [
+    {
+      "name": "Screenshot from 2025-04-23 13-28-43.png",
+      "confirmationCode": "0a6fc362-f125-4796-84c9-c13435363329",
+      "attachmentId": "",
+      "isEncrypted": false
+    },
+    {
+      "name": "Screenshot from 2025-04-23 13-28-59.png",
+      "confirmationCode": "9a267bd7-f459-47e5-903e-baab21953ffd",
+      "attachmentId": "",
+      "isEncrypted": false
+    }
+  ],
+  "childSupportingDocuments": [
+    {
+      "name": "Screenshot from 2025-04-21 12-47-33.png",
+      "confirmationCode": "e13a641a-23e0-4e08-aa0f-bfc1b3e61519",
+      "attachmentId": "",
+      "isEncrypted": false
+    }
+  ],
+  "householdIncome": false,
+
+  "reportDivorce": {
+    "spouseIncome": "NA",
+    "date": "2019-03-02",
+    "divorceLocation": {
+      "outsideUsa": true,
+      "location": { "city": "Fakesville", "state": "FM", "country": "BGD" }
+    },
+    "reasonMarriageEnded": "Other",
+    "explanationOfOther": "Other",
+    "fullName": { "first": "John", "last": "Doe" },
+    "birthDate": "1991-03-19"
+  },
+
+
+
+
+  "view:completedChildStoppedAttendingSchool": false,
+  "view:completedMarriedChild": false,
+  "view:completedDependent": false,
+  "view:completedHouseholdChild": false,
+  "view:completedStudent": false,
+  "view:completedVeteranFormerMarriage": false,
+
+
+
+
+  "view:completedAddChild": false,
+
+
+
+
+
+
+  "childrenToAdd": [
+    {
+      "incomeInLastYear": "NA",
+      "marriageEndDescription": "Other",
+      "marriageEndDate": "2021-08-18",
+      "marriageEndReason": "Other",
+      "doesChildLiveWithYou": true,
+      "hasChildEverBeenMarried": true,
+      "doesChildHaveDisability": false,
+      "isBiologicalChildOfSpouse": true,
+      "dateEnteredHousehold": "2021-05-19",
+      "biologicalParentName": { "first": "John", "last": "Doe" },
+      "biologicalParentSsn": "333444554",
+      "biologicalParentDob": "2014-09-19",
+      "relationshipToChild": { "adopted": true, "stepchild": true },
+      "isBiologicalChild": false,
+      "birthLocation": {
+        "location": {
+          "city": "Fakesville",
+          "state": "CA",
+          "postalCode": "12345"
+        }
+      },
+      "ssn": "333445555",
+      "fullName": { "first": "John", "last": "Doe" },
+      "birthDate": "2010-04-19"
+    }
+  ],
+  "view:selectable686Options": {
+    "addSpouse": true,
+    "addChild": true,
+    "report674": true,
+    "addDisabledChild": true,
+    "reportDivorce": true,
+    "reportDeath": true,
+    "reportStepchildNotInHousehold": true,
+    "reportMarriageOfChildUnder18": true,
+    "reportChild18OrOlderIsNotAttendingSchool": true
+  },
+
+  "privacyAgreementAccepted": true,
+  "studentInformation": [
+    {
+      "studentNetworthInformation": {
+        "savings": "6000",
+        "securities": "3455",
+        "realEstate": "43332",
+        "otherAssets": "3433",
+        "totalValue": "23455"
+      },
+      "studentExpectedEarningsNextYear": {
+        "earningsFromAllEmployment": "1",
+        "annualSocialSecurityPayments": "1",
+        "otherAnnuitiesIncome": "1",
+        "allOtherIncome": "1"
+      },
+      "studentEarningsFromSchoolYear": {
+        "earningsFromAllEmployment": "2000.00",
+        "annualSocialSecurityPayments": "40000",
+        "otherAnnuitiesIncome": "2000.86",
+        "allOtherIncome": "100"
+      },
+      "claimsOrReceivesPension": true,
+      "schoolInformation": {
+        "studentDidAttendSchoolLastTerm": false,
+        "dateFullTimeEnded": "2000-02-12",
+        "studentIsEnrolledFullTime": false,
+        "currentTermDates": {
+          "officialSchoolStartDate": "1991-02-19",
+          "expectedStudentStartDate": "2000-01-19",
+          "expectedGraduationDate": "2025-12-19"
+        },
+        "isSchoolAccredited": true,
+        "name": "Test"
+      },
+      "typeOfProgramOrBenefit": {
+        "ch35": true,
+        "fry": true,
+        "feca": true,
+        "other": true
+      },
+      "otherProgramOrBenefit": "Test",
+      "tuitionIsPaidByGovAgency": false,
+      "ssn": "333445555",
+      "isParent": false,
+      "wasMarried": false,
+      "address": {
+        "country": "USA",
+        "street": "123 Fake St.",
+        "city": "Fakesville",
+        "state": "AL",
+        "postalCode": "12345"
+      },
+      "remarks": "asdf",
+      "benefitPaymentDate": "2021-01-19",
+      "studentIncome": "NA",
+      "fullName": { "first": "John", "last": "Doe" },
+      "birthDate": "1991-04-19"
+    }
+  ],
+  "veteranMarriageHistory": [
+    {
+      "endLocation": { "location": { "city": "Fakesville", "state": "AZ" } },
+      "startLocation": { "location": { "city": "Fakesville", "state": "AZ" } },
+      "endDate": "1991-01-19",
+      "startDate": "1991-01-19",
+      "reasonMarriageEnded": "Other",
+      "otherReasonMarriageEnded": "other",
+      "fullName": { "first": "John", "last": "Doe" }
+    }
+  ],
+  "stepChildren": [
+    {
+      "whoDoesTheStepchildLiveWith": { "first": "John", "last": "Doe" },
+      "address": {
+        "country": "USA",
+        "street": "123 Fake St.",
+        "city": "Las Vegas",
+        "state": "NV",
+        "postalCode": "12345"
+      },
+      "livingExpensesPaid": "More than half",
+      "supportingStepchild": true,
+      "fullName": { "first": "John", "last": "Doe" },
+      "ssn": "333445555",
+      "birthDate": "2012-02-19"
+    }
+  ],
+  "deaths": [
+    {
+      "dependentDeathLocation": {
+        "outsideUsa": false,
+        "location": { "city": "Fakesville", "state": "CO" }
+      },
+      "deceasedDependentIncome": "NA",
+      "dependentDeathDate": "1991-05-19",
+      "dependentType": "SPOUSE",
+      "fullName": { "first": "John", "last": "Doe" },
+      "ssn": "333445555",
+      "birthDate": "1991-06-19"
+    }
+  ],
+  "childMarriage": [
+    {
+      "dependentIncome": "NA",
+      "dateMarried": "1991-01-19",
+      "fullName": { "first": "John", "last": "Doe" },
+      "ssn": "333445555",
+      "birthDate": "1991-02-19"
+    }
+  ],
+  "childStoppedAttendingSchool": [
+    {
+      "dependentIncome": "NA",
+      "dateChildLeftSchool": "1991-03-19",
+      "fullName": { "first": "John", "last": "Doe" },
+      "ssn": "333445555",
+      "birthDate": "1991-01-19"
+    }
+  ],
+  "statementOfTruthSignature": "Pauline E Foster",
+  "statementOfTruthCertified": true
+}

--- a/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
@@ -7,6 +7,7 @@ import { VaLink } from '@department-of-veterans-affairs/component-library/dist/r
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { scrollAndFocus } from 'platform/utilities/scroll';
 
+import { electronicCorrespondenceMessage } from '../config/chapters/veteran-contact-information/editEmailPage';
 import { isEmptyObject } from '../../shared/utils';
 
 const VeteranContactInformationPage = ({
@@ -171,10 +172,6 @@ const VeteranContactInformationPage = ({
     .join(' and ');
   const article = !email ? 'an' : 'a';
 
-  const agreementMessage = electronicCorrespondence
-    ? 'I agree to receive electronic correspondence from the VA about my claim at this email address'
-    : 'I do not agree to receive electronic correspondence from the VA about my claim at this email address';
-
   return (
     <>
       <h3 className="vads-u-margin-y--2">
@@ -294,7 +291,7 @@ const VeteranContactInformationPage = ({
                   className="dd-privacy-hidden"
                   data-dd-action-name="Electronic correspondence"
                 >
-                  {agreementMessage}
+                  {electronicCorrespondenceMessage(electronicCorrespondence)}
                 </div>
               </span>
             ) : (

--- a/src/applications/dependents/dependents-verification/components/VeteranContactInformationReviewPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranContactInformationReviewPage.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { electronicCorrespondenceMessage } from '../config/chapters/veteran-contact-information/editEmailPage';
+
 const VeteranContactInformationReviewPage = ({ data, goToPath }) => {
-  const { email, phone, address = {}, internationalPhone } = data || {};
+  const {
+    email,
+    electronicCorrespondence,
+    phone,
+    address = {},
+    internationalPhone,
+  } = data || {};
   sessionStorage.removeItem('onReviewPage');
 
   const goEditPath = path => {
@@ -128,6 +136,14 @@ const VeteranContactInformationReviewPage = ({ data, goToPath }) => {
           <dt>Email address</dt>
           <dd className="dd-privacy-hidden" data-dd-action-name="email address">
             <strong>{email ?? showError('Missing email address')}</strong>
+          </dd>
+        </div>
+        <div className="review-row">
+          <dt>Email address</dt>
+          <dd className="dd-privacy-hidden" data-dd-action-name="email address">
+            <strong>
+              {electronicCorrespondenceMessage(electronicCorrespondence)}
+            </strong>
           </dd>
         </div>
       </dl>

--- a/src/applications/dependents/dependents-verification/config/chapters/veteran-contact-information/editEmailPage.js
+++ b/src/applications/dependents/dependents-verification/config/chapters/veteran-contact-information/editEmailPage.js
@@ -5,6 +5,11 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import EditEmailPage from '../../../components/EditEmailPage';
 
+export const electronicCorrespondenceMessage = value =>
+  value
+    ? 'I agree to receive electronic correspondence from the VA about my claim at this email address'
+    : 'I do not agree to receive electronic correspondence from the VA about my claim at this email address';
+
 /** @type {PageSchema} */
 export default {
   title: 'Edit email address',
@@ -29,6 +34,7 @@ export default {
         'I agree to receive electronic correspondence from the VA about my claim.',
       'ui:webComponentField': VaCheckboxField,
       'ui:options': {
+        hideOnReview: true,
         classNames: 'custom-width',
       },
     },

--- a/src/applications/dependents/dependents-verification/tests/mock-api-full-data.js
+++ b/src/applications/dependents/dependents-verification/tests/mock-api-full-data.js
@@ -12,7 +12,7 @@ const mockMaxData = require('./e2e/fixtures/data/maximal-test.json');
 const mockDependents = require('../../shared/tests/fixtures/mocks/mock-dependents.json');
 const mockVaFileNumber = require('../../686c-674/tests/e2e/fixtures/va-file-number.json');
 
-const returnUrl = '/dependents';
+const returnUrl = '/review-and-submit';
 
 const submission = {
   data: {

--- a/src/applications/dependents/dependents-verification/tests/unit/components/VeteranContactInformationPage.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/VeteranContactInformationPage.unit.spec.jsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import VeteranContactInformationPage from '../../../components/VeteranContactInformationPage';
+import { electronicCorrespondenceMessage } from '../../../config/chapters/veteran-contact-information/editEmailPage';
 
 const defaultProfile = ({
   isInternationalHome = false,
@@ -103,9 +104,7 @@ describe('VeteranContactInformationPage (querySelector-only)', () => {
     const text = container.textContent;
     expect(text).to.include('Mailing address');
     expect(text).to.include('Email address');
-    expect(text).to.include(
-      'I do not agree to receive electronic correspondence',
-    );
+    expect(text).to.include(electronicCorrespondenceMessage(false));
     expect(text).to.include('phone number');
     expect(text).to.include('International phone number');
     expect(text).to.include('123 Main St');
@@ -266,7 +265,7 @@ describe('VeteranContactInformationPage (querySelector-only)', () => {
     const continueBtn = $('va-button[continue]', container);
     expect(continueBtn).to.not.be.null;
     expect(container.textContent).to.include(
-      'I agree to receive electronic correspondence',
+      electronicCorrespondenceMessage(true),
     );
 
     await waitFor(() => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > In the Dependents Verification:
  > - Hid the edit email page on the review & submit page
  > - Moved electronic correspondence choice to the review & submit email page 
  > - Updated unit tests
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/115817

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Review & submit page | <img width="500" alt="Before email page does not include electronic correspondent choice and an edit email page at the bottom does include the choice" src="https://github.com/user-attachments/assets/820b3301-97f6-4dcf-8f2e-feaf8187e044" /> | <img width="500" alt="After, removed edit email page and moved electronic correspondence choice to email page" src="https://github.com/user-attachments/assets/7c31e7a5-38b5-4c8d-a27c-c695ebb599fc" /> |

## What areas of the site does it impact?

Dependents Verification Form (21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
