### PR TITLE
DV | Update exit page to match design

### DIFF
--- a/src/applications/dependents/dependents-verification/components/ExitForm.jsx
+++ b/src/applications/dependents/dependents-verification/components/ExitForm.jsx
@@ -3,15 +3,18 @@ import PropTypes from 'prop-types';
 
 import { getAppUrl } from 'platform/utilities/registry-helpers';
 import { scrollAndFocus } from 'platform/utilities/scroll';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { deleteInProgressForm } from '../util';
 
 export const form686Url = getAppUrl('686C-674');
 
-export const ExitForm = ({ goBack }) => {
+export const ExitForm = ({
+  goBack,
+  contentBeforeButtons,
+  contentAfterButtons,
+}) => {
   useEffect(() => {
-    scrollAndFocus('h1');
+    scrollAndFocus('h1.page-title');
   }, []);
 
   const handlers = {
@@ -26,10 +29,12 @@ export const ExitForm = ({ goBack }) => {
 
   return (
     <>
-      <FormTitle
-        title="Update your dependents in a different form"
-        subTitle="VA Forms 21-686c and 21-674"
-      />
+      <div className="schemaform-title internal-page-title">
+        <h1 className="page-title">
+          Update your dependents in a different form
+        </h1>
+        <div className="schemaform-subtitle">VA Forms 21-686c and 21-674</div>
+      </div>
       <p>
         Because you told us you need to update your dependents, we need you to
         use a different online form. This form will help you add or remove
@@ -45,6 +50,7 @@ export const ExitForm = ({ goBack }) => {
         After you get your decision letter for the dependents you updated, come
         back here to verify all your dependents.
       </p>
+      {contentBeforeButtons}
       <div className="vads-u-margin-y--2 vads-u-display--flex">
         <va-button
           back
@@ -58,11 +64,16 @@ export const ExitForm = ({ goBack }) => {
           text="Go to add or remove dependents form"
         />
       </div>
+      {contentAfterButtons}
+      <div className="vads-u-margin-bottom--4" />
     </>
   );
 };
 
 ExitForm.propTypes = {
+  contentAfterButtons: PropTypes.node.isRequired,
+  contentBeforeButtons: PropTypes.node.isRequired,
+  goBack: PropTypes.func.isRequired,
   router: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,

--- a/src/applications/dependents/dependents-verification/containers/App.jsx
+++ b/src/applications/dependents/dependents-verification/containers/App.jsx
@@ -15,8 +15,9 @@ export default function App({ location, children }) {
     state => state?.externalServiceStatus?.loading,
   );
   const hasSession = JSON.parse(localStorage.getItem('hasSession'));
-
   const isIntroPage = location?.pathname?.endsWith('/introduction');
+  const { pathname } = location || {};
+  const pageUrl = pathname?.slice(1);
 
   const breadcrumbs = [
     {
@@ -30,7 +31,10 @@ export default function App({ location, children }) {
     {
       href:
         '/view-change-dependents/verify-dependents-form-21-0538/introduction',
-      label: 'Verify your dependents for disability benefits',
+      label:
+        pageUrl === 'exit-form'
+          ? 'Update your dependents in a different form'
+          : 'Verify your dependents for disability benefits',
     },
   ];
 
@@ -62,7 +66,7 @@ export default function App({ location, children }) {
   }
 
   return (
-    <article>
+    <article id="form-0538" data-location={pageUrl}>
       <div className="row">
         <div className="columns">
           <va-breadcrumbs breadcrumb-list={rawBreadcrumbs} wrapping />

--- a/src/applications/dependents/dependents-verification/sass/0538-dependents-verification.scss
+++ b/src/applications/dependents/dependents-verification/sass/0538-dependents-verification.scss
@@ -25,6 +25,10 @@
   }
 }
 
+/* Hide 0538 H1 & progress bar on exit-form page */
+article[data-location="exit-form"] .schemaform-title:not(.internal-page-title),
+article[data-location="exit-form"] va-segmented-progress-bar,
+
 /* hide SSN input on Vet info page */
 #root_veteranInformation_ssnLastFour-label,
 #root_veteranInformation_ssnLastFour-label + div {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Updated breadcrumb to match H1
  > - Hid 0538-specific H1 & subtitle
  > - Hid form progress bar
  > - Add content above (finish this form later link) & below (last save success alert) form navigation buttons
  > - Add space above need help section
  > - Updated unit tests
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/116088

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Exit page | <img width="500" alt="exit page with focus on segmented progress bar. H1 above the progress bar refers to the 0538 form and H1 below the progress bar refers to updating dependents in a different form. Missing finish this application later link" src="https://github.com/user-attachments/assets/82c54846-5895-4662-a9db-64436facea0d" /> | <img width="500" alt="exit page with a single H1 regarding updating dependents in a separate form, no segmented progress bar, and has finish this application later link" src="https://github.com/user-attachments/assets/68162294-c206-415e-b952-5d4f2fb22dc9" /> |

## What areas of the site does it impact?

Dependents Verification Form (21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
