### PR TITLE
Update data missing alert to use correct name

### DIFF
--- a/src/applications/appeals/shared/components/NeedsMissingInfoAlert.jsx
+++ b/src/applications/appeals/shared/components/NeedsMissingInfoAlert.jsx
@@ -6,8 +6,20 @@ import recordEvent from 'platform/monitoring/record-event';
 
 export const heading = 'We’re missing some of your personal information';
 
-const NeedsMissingInfoAlert = ({ missing }) => {
+// Helper function to get form name based on formId
+const getFormName = formId => {
+  const formNames = {
+    '10182': 'Board Appeal',
+    '20-0995': 'Supplemental Claim',
+    '20-0996': 'Higher-Level Review',
+  };
+
+  return formNames[formId] || 'appeal';
+};
+
+const NeedsMissingInfoAlert = ({ missing, formId }) => {
   const alertRef = useRef(null);
+  const formName = getFormName(formId);
 
   useEffect(
     () => {
@@ -34,10 +46,10 @@ const NeedsMissingInfoAlert = ({ missing }) => {
       <h2 slot="headline">{heading}</h2>
       <p>
         You’ll need to provide us with the missing information before you can
-        fill out a Supplemental Claim request. Call the Defense Manpower Data
-        Center (DMDC) support office at <va-telephone contact="8005389552" /> to
-        make sure we have your {missing}. They’re open Monday through Friday,
-        8:00 a.m. to 8:00 p.m.{' '}
+        fill out a {formName} request. Call the Defense Manpower Data Center
+        (DMDC) support office at <va-telephone contact="8005389552" /> to make
+        sure we have your {missing}. They’re open Monday through Friday, 8:00
+        a.m. to 8:00 p.m.{' '}
         <dfn>
           <abbr title="Eastern Time">ET</abbr>
         </dfn>
@@ -49,6 +61,7 @@ const NeedsMissingInfoAlert = ({ missing }) => {
 };
 
 NeedsMissingInfoAlert.propTypes = {
+  formId: PropTypes.string,
   missing: PropTypes.string,
 };
 

--- a/src/applications/appeals/shared/components/NeedsMissingInfoAlert.jsx
+++ b/src/applications/appeals/shared/components/NeedsMissingInfoAlert.jsx
@@ -14,7 +14,7 @@ const getFormName = formId => {
     '20-0996': 'Higher-Level Review',
   };
 
-  return formNames[formId] || 'appeal';
+  return formNames[formId] ? `a ${formNames[formId]}` : `an appeal`;
 };
 
 const NeedsMissingInfoAlert = ({ missing, formId }) => {
@@ -46,7 +46,7 @@ const NeedsMissingInfoAlert = ({ missing, formId }) => {
       <h2 slot="headline">{heading}</h2>
       <p>
         You’ll need to provide us with the missing information before you can
-        fill out a {formName} request. Call the Defense Manpower Data Center
+        fill out {formName} request. Call the Defense Manpower Data Center
         (DMDC) support office at <va-telephone contact="8005389552" /> to make
         sure we have your {missing}. They’re open Monday through Friday, 8:00
         a.m. to 8:00 p.m.{' '}

--- a/src/applications/appeals/shared/components/ShowAlertOrSip.jsx
+++ b/src/applications/appeals/shared/components/ShowAlertOrSip.jsx
@@ -57,7 +57,7 @@ const ShowAlertOrSip = ({ basename, sipOptions, bottom }) => {
     return bottom ? (
       <div className={classes} />
     ) : (
-      <NeedsMissingInfoAlert missing={missing} />
+      <NeedsMissingInfoAlert missing={missing} formId={sipOptions?.formId} />
     );
   }
 
@@ -71,7 +71,9 @@ const ShowAlertOrSip = ({ basename, sipOptions, bottom }) => {
 ShowAlertOrSip.propTypes = {
   basename: PropTypes.string,
   bottom: PropTypes.bool,
-  sipOptions: PropTypes.shape({}),
+  sipOptions: PropTypes.shape({
+    formId: PropTypes.string.isRequired,
+  }),
 };
 
 export default ShowAlertOrSip;

--- a/src/applications/appeals/shared/tests/components/NeedsMissingInfoAlert.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/NeedsMissingInfoAlert.unit.spec.jsx
@@ -33,7 +33,7 @@ describe('<NeedsMissingInfoAlert>', () => {
       'make sure we have your date of birth.',
     );
     expect($('p', container).textContent).to.contain(
-      'fill out a appeal request.', // Default fallback
+      'fill out an appeal request.', // Default fallback
     );
   });
 

--- a/src/applications/appeals/shared/tests/components/NeedsMissingInfoAlert.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/NeedsMissingInfoAlert.unit.spec.jsx
@@ -9,10 +9,10 @@ import NeedsMissingInfoAlert, {
 } from '../../components/NeedsMissingInfoAlert';
 
 describe('<NeedsMissingInfoAlert>', () => {
-  const setup = missing => {
+  const setup = (missing, formId) => {
     return (
       <div>
-        <NeedsMissingInfoAlert missing={missing} />
+        <NeedsMissingInfoAlert missing={missing} formId={formId} />
       </div>
     );
   };
@@ -22,6 +22,46 @@ describe('<NeedsMissingInfoAlert>', () => {
     expect($('h2', container).textContent).to.eq(heading);
     expect($('p', container).textContent).to.contain(
       'make sure we have your date of birth.',
+    );
+  });
+
+  it('should render with default form name when no formId provided', () => {
+    const { container } = render(setup('date of birth'));
+    expect($('va-alert', container)).to.exist;
+    expect($('h2', container).textContent).to.eq(heading);
+    expect($('p', container).textContent).to.contain(
+      'make sure we have your date of birth.',
+    );
+    expect($('p', container).textContent).to.contain(
+      'fill out a appeal request.', // Default fallback
+    );
+  });
+
+  it('should render with Board Appeal form name for formId 10182', () => {
+    const { container } = render(setup('date of birth', '10182'));
+    expect($('va-alert', container)).to.exist;
+    expect($('h2', container).textContent).to.eq(heading);
+    expect($('p', container).textContent).to.contain(
+      'make sure we have your date of birth.',
+    );
+    expect($('p', container).textContent).to.contain(
+      'fill out a Board Appeal request.',
+    );
+  });
+
+  it('should render with Supplemental Claim form name for formId 20-0995', () => {
+    const { container } = render(setup('Social Security number', '20-0995'));
+    expect($('va-alert', container)).to.exist;
+    expect($('p', container).textContent).to.contain(
+      'fill out a Supplemental Claim request.',
+    );
+  });
+
+  it('should render with Higher-Level Review form name for formId 20-0996', () => {
+    const { container } = render(setup('full name', '20-0996'));
+    expect($('va-alert', container)).to.exist;
+    expect($('p', container).textContent).to.contain(
+      'fill out a Higher-Level Review request.',
     );
   });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updated the `NeedsMissingInfoAlert `component to display dynamic form names instead of always showing "Supplemental Claim request." The component now accepts a `formId` prop and uses a mapping function to show the correct form name: "Board Appeal request" for form 10182, "Supplemental Claim request" for 20-0995, and "Higher-Level Review request" for 20-0996.

Modified `ShowAlertOrSip` to pass the `formId` from `sipOptions` to the alert component, and updated the test spec to verify the new dynamic behavior works correctly for all form types while maintaining backwards compatibility.

## Related issue(s)

[Issue Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/112361)

## Testing done

Added tests to verify the dynamic form name functionality works correctly for each form ID: one test each for Board Appeal (10182), Supplemental Claim (20-0995), and Higher-Level Review (20-0996) to ensure they display their respective form names. We also added tests for edge cases including unknown form IDs and missing form IDs to verify the fallback behavior shows "appeal request."

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Mobile | Desktop |
| ------- | ------ | ----- |
| 10182  | <img width="361" height="434" alt="Screenshot 2025-08-07 at 10 41 40 AM" src="https://github.com/user-attachments/assets/ecf558ea-6b60-4d88-8211-721492fdc4c8" /> |  <img width="644" height="215" alt="Screenshot 2025-08-07 at 8 10 36 AM" src="https://github.com/user-attachments/assets/7bdbc0bd-6b2c-4cf1-8a70-609002b03986" /> |
| 20995 | <img width="361" height="434" alt="Screenshot 2025-08-07 at 10 41 19 AM" src="https://github.com/user-attachments/assets/6f05e4db-f0de-4db5-8fe7-95948acc9961" /> |  <img width="661" height="230" alt="Screenshot 2025-08-07 at 8 09 41 AM" src="https://github.com/user-attachments/assets/0d0343b9-7630-435c-a1ed-55b244dac6d0" /> |
| 20996 | <img width="361" height="434" alt="Screenshot 2025-08-07 at 10 41 30 AM" src="https://github.com/user-attachments/assets/5c60f6d4-62cb-44a7-8300-8b4954212c94" /> | <img width="644" height="215" alt="Screenshot 2025-08-07 at 8 10 15 AM" src="https://github.com/user-attachments/assets/b0d2afb6-9c1b-4926-868c-dbaaa946fba0" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
