### PR TITLE
FMP1 Address Bug

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
@@ -7,9 +7,8 @@ import { concatStreets } from '../../shared/utilities';
 // Take an address object and turn it into a string with line breaks
 function stringifyAddress(addr) {
   return addr
-    ? `${concatStreets(addr, true).streetCombined}${addr.city}, ${
-        addr.state
-      }\n${addr.postalCode}`
+    ? `${concatStreets(addr, true).streetCombined}${addr.city}, ${addr.state ||
+        ''},\n${addr.postalCode}`
     : '';
 }
 
@@ -47,18 +46,18 @@ export default function transformForSubmit(formConfig, form) {
       physical_address: transformedData.sameMailingAddress
         ? transformedData.veteranAddress
         : transformedData.physicalAddress || {
-            country: 'NA',
-            street: 'NA',
-            city: 'NA',
-            state: 'NA',
-            postalCode: 'NA',
+            country: ' ',
+            street: ' ',
+            city: ' ',
+            state: ' ',
+            postalCode: ' ',
           },
       mailing_address: transformedData.veteranAddress || {
-        country: 'NA',
-        street: 'NA',
-        city: 'NA',
-        state: 'NA',
-        postalCode: 'NA',
+        country: ' ',
+        street: ' ',
+        city: ' ',
+        state: ' ',
+        postalCode: ' ',
       },
       ssn: transformedData?.veteranSocialSecurityNumber?.ssn,
       vaClaimNumber: transformedData?.veteranSocialSecurityNumber?.vaFileNumber,


### PR DESCRIPTION
…ft blank

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR makes the state a blank string instead of undefined if it is left blank

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/115315

## Testing done
e2e
unit

## Screenshots
<img width="776" height="280" alt="Screenshot 2025-08-07 at 12 15 28 PM" src="https://github.com/user-attachments/assets/bfac0aa1-37e5-41e2-b730-f972a920e33e" />

## What areas of the site does it impact?
Jut this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
