### PR TITLE
114834 Onramp tool: connect questions

### DIFF
--- a/src/applications/appeals/onramp/components/RadioQuestion.jsx
+++ b/src/applications/appeals/onramp/components/RadioQuestion.jsx
@@ -41,15 +41,13 @@ const RadioQuestion = ({
     if (!formResponse) {
       setFormError(true);
       focusElement(radioRef.current);
+
+      return;
     }
 
     if (valueHasChanged) {
       // Remove answers from the Redux store if the display path ahead has changed
       cleanUpAnswers(allQuestionShortNames, updateCleanedFormStore, shortName);
-    }
-
-    if (formError) {
-      setFormError(false);
     }
 
     navigateForward(allQuestionShortNames, shortName, formResponses, router);
@@ -116,6 +114,7 @@ const RadioQuestion = ({
         <VaRadio
           class="vads-u-margin-top--0"
           data-testid={shortName}
+          error={formError ? 'Placeholder error message' : null}
           hint={hintText}
           id="onramp-radio"
           label={questionText}

--- a/src/applications/appeals/onramp/components/RadioQuestion.jsx
+++ b/src/applications/appeals/onramp/components/RadioQuestion.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
@@ -6,13 +6,24 @@ import {
   VaRadio,
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { QUESTION_CONTENT } from '../constants/question-data-map';
+import { updateFormStore, updateQuestionValue } from '../actions';
+import { cleanUpAnswers } from '../utilities/answer-storage';
+import { navigateForward } from '../utilities/page-navigation';
 
 /**
  * Produces a set of 2-3 radio options
  * @param {string} shortName - Question short name (SNAKE_CASE)
  */
-const RadioQuestion = ({ shortName }) => {
+const RadioQuestion = ({
+  allQuestionShortNames,
+  formResponses,
+  router,
+  setQuestionValue,
+  shortName,
+  updateCleanedFormStore,
+}) => {
   const {
     descriptionText,
     h1,
@@ -20,23 +31,40 @@ const RadioQuestion = ({ shortName }) => {
     questionText,
     responses,
   } = QUESTION_CONTENT[shortName];
+  const [formError, setFormError] = useState(false);
+  const [valueHasChanged, setValueHasChanged] = useState(false);
+  const radioRef = useRef(null);
+  const formResponse = formResponses?.[shortName];
   let radios;
-  const [isChecked, setIsChecked] = useState(false);
-
-  const setValueIsChecked = value => {
-    setIsChecked(value);
-  };
 
   const onContinueClick = () => {
-    // TODO
+    if (!formResponse) {
+      setFormError(true);
+      focusElement(radioRef.current);
+    }
+
+    if (valueHasChanged) {
+      // Remove answers from the Redux store if the display path ahead has changed
+      cleanUpAnswers(allQuestionShortNames, updateCleanedFormStore, shortName);
+    }
+
+    if (formError) {
+      setFormError(false);
+    }
+
+    navigateForward(allQuestionShortNames, shortName, formResponses, router);
   };
 
-  const onBackClick = () => {
-    // TODO
-  };
+  const onValueChange = value => {
+    setQuestionValue(shortName, value);
 
-  const onValueChange = () => {
-    // TODO
+    if (formResponse && formResponse !== value) {
+      setValueHasChanged(true);
+    }
+
+    if (value && formError) {
+      setFormError(false);
+    }
   };
 
   const renderRadioOptions = () => {
@@ -46,7 +74,7 @@ const RadioQuestion = ({ shortName }) => {
       return (
         <VaRadioOption
           key={index}
-          checked={isChecked === shortAnswer}
+          checked={formResponse === shortAnswer}
           data-testid="va-radio-option"
           description={longAnswer}
           label={shortAnswer}
@@ -64,17 +92,13 @@ const RadioQuestion = ({ shortName }) => {
         <VaRadio
           class="vads-u-margin-top--0"
           data-testid={shortName}
+          error={formError ? 'Placeholder error message' : null}
           form-heading={h1}
           form-heading-level={1}
           hint={hintText}
           id="onramp-radio"
           label={questionText}
-          onVaValueChange={e => {
-            // The below function is temporary; once data is connected to the Redux store,
-            // we can use only the onValueChange function.
-            setValueIsChecked(e.detail.value);
-            onValueChange(e.detail.value);
-          }}
+          onVaValueChange={e => onValueChange(e.detail.value)}
           required
           use-forms-pattern="single"
         >
@@ -95,12 +119,7 @@ const RadioQuestion = ({ shortName }) => {
           hint={hintText}
           id="onramp-radio"
           label={questionText}
-          onVaValueChange={e => {
-            // The below function is temporary; once data is connected to the Redux store,
-            // we can use only the onValueChange function.
-            setValueIsChecked(e.detail.value);
-            onValueChange(e.detail.value);
-          }}
+          onVaValueChange={e => onValueChange(e.detail.value)}
           required
         >
           {renderRadioOptions()}
@@ -116,20 +135,39 @@ const RadioQuestion = ({ shortName }) => {
         class="vads-u-margin-top--2"
         data-testid="onramp-buttonPair"
         onPrimaryClick={onContinueClick}
-        onSecondaryClick={onBackClick}
+        onSecondaryClick={router.goBack}
         continue
       />
     </>
   );
 };
 
+const mapStateToProps = state => ({
+  allQuestionShortNames: state?.decisionReviewsGuide?.allQuestionShortNames,
+  formResponses: state?.decisionReviewsGuide?.form,
+});
+
+const mapDispatchToProps = {
+  setQuestionValue: updateQuestionValue,
+  updateCleanedFormStore: updateFormStore,
+};
+
 RadioQuestion.propTypes = {
-  h1: PropTypes.string.isRequired,
+  allQuestionShortNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  formResponses: PropTypes.object.isRequired,
+  router: PropTypes.shape({
+    goBack: PropTypes.func,
+    push: PropTypes.func,
+  }).isRequired,
+  setQuestionValue: PropTypes.func.isRequired,
   shortName: PropTypes.string.isRequired,
-  testId: PropTypes.string.isRequired,
+  updateCleanedFormStore: PropTypes.func.isRequired,
   descriptionText: PropTypes.string,
   hintText: PropTypes.string,
   useSinglePattern: PropTypes.bool,
 };
 
-export default connect(null)(RadioQuestion);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(RadioQuestion);

--- a/src/applications/appeals/onramp/constants/display-conditions/README.md
+++ b/src/applications/appeals/onramp/constants/display-conditions/README.md
@@ -93,6 +93,16 @@ It is expected that the same condition (e.g. key:value pair) is repeated across 
 
 Additionally, repetition ensures that scenarios like splits in logic paths are covered. If you don't find explicit display conditions for questions that can be reached multiple ways, those conditions are listed on a traditional question in another part of the code. For instance, all questions in path A will make up the full logic through path A, and all questions in path B will make up the full logic through path B, but it is not necessary for one question to make up the full logic for both paths.
 
+## Order of Questions
+
+The display conditions code (the keys in the objects) are expected to flow in the same order that they would appear in the browser flow. If Question 1 has a subquestion, Question 1A, that can be reached by both Question 1 and Question 2, the keys in the display conditions should go in this order:
+
+1. Question 1
+2. Question 2
+3. Question 1A
+
+The utility functions that consume the display conditions always look **ahead** of the current question only to see what could come next, so there would never be a scenario where Question 2 would be checking Question 1's display conditions to see what's next.
+
 ## Display Conditions (Review Screens)
 
 TODO

--- a/src/applications/appeals/onramp/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/onramp/containers/IntroductionPage.jsx
@@ -39,6 +39,7 @@ const IntroductionPage = ({ router, setIntroPageViewed }) => {
       </p>
       <va-button
         class="vads-u-width--full"
+        data-testid="onramp-start"
         onClick={startTool}
         text="Start the tool"
       />

--- a/src/applications/appeals/onramp/containers/QuestionTemplate.jsx
+++ b/src/applications/appeals/onramp/containers/QuestionTemplate.jsx
@@ -1,16 +1,29 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import RadioQuestion from '../components/RadioQuestion';
 import { ROUTES } from '../constants';
 
-const QuestionTemplate = props => {
-  const route = props?.location?.pathname.replace('/', '');
+const QuestionTemplate = ({ location, router, viewedIntroPage }) => {
+  const route = location?.pathname.replace('/', '');
   const shortName =
     Object.keys(ROUTES).find(key => ROUTES[key] === route) || '';
 
-  return <RadioQuestion router={props.router} shortName={shortName} />;
+  useEffect(
+    () => {
+      if (!viewedIntroPage) {
+        router.push(ROUTES.HOME);
+      }
+    },
+    [router, viewedIntroPage],
+  );
+
+  return <RadioQuestion router={router} shortName={shortName} />;
 };
+
+const mapStateToProps = state => ({
+  viewedIntroPage: state?.decisionReviewsGuide?.viewedIntroPage,
+});
 
 QuestionTemplate.propTypes = {
   location: PropTypes.shape({
@@ -19,6 +32,7 @@ QuestionTemplate.propTypes = {
   router: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
+  viewedIntroPage: PropTypes.bool.isRequired,
 };
 
-export default connect()(QuestionTemplate);
+export default connect(mapStateToProps)(QuestionTemplate);

--- a/src/applications/appeals/onramp/containers/QuestionTemplate.jsx
+++ b/src/applications/appeals/onramp/containers/QuestionTemplate.jsx
@@ -9,13 +9,16 @@ const QuestionTemplate = props => {
   const shortName =
     Object.keys(ROUTES).find(key => ROUTES[key] === route) || '';
 
-  return <RadioQuestion shortName={shortName} />;
+  return <RadioQuestion router={props.router} shortName={shortName} />;
 };
 
 QuestionTemplate.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
-  }),
+  }).isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
 };
 
 export default connect()(QuestionTemplate);

--- a/src/applications/appeals/onramp/reducers/index.js
+++ b/src/applications/appeals/onramp/reducers/index.js
@@ -6,7 +6,10 @@ import {
 } from '../utilities/answer-storage';
 import { ALL_QUESTIONS } from '../constants';
 
-const { ONRAMP_VIEWED_INTRO_PAGE } = FORM_ACTION_TYPES;
+const {
+  ONRAMP_UPDATE_FORM_STORE,
+  ONRAMP_VIEWED_INTRO_PAGE,
+} = FORM_ACTION_TYPES;
 
 export const initialState = {
   allQuestionShortNames: ALL_QUESTIONS,
@@ -23,6 +26,16 @@ const decisionReviewsGuide = (state = initialState, action) => {
     return {
       ...state,
       viewedIntroPage: action.payload,
+    };
+  }
+
+  if (action.type === ONRAMP_UPDATE_FORM_STORE) {
+    return {
+      ...state,
+      form: {
+        ...state.form,
+        ...action.payload,
+      },
     };
   }
 

--- a/src/applications/appeals/onramp/tests/cypress/README.md
+++ b/src/applications/appeals/onramp/tests/cypress/README.md
@@ -1,0 +1,27 @@
+# Cypress Test Approach
+
+Refer to this [Figma](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=148-12838&t=YIDFuLZ1yrDtIsh8-0) for a complete diagram of all question flows.
+
+We want to use automated tests for as many flows as reasonable to ensure the display logic is functioning as expected. This includes navigation between questions and to and from the introduction page and results pages.
+
+We also recognize that we are limited in our ability to comprehensively test our components and end-to-end flow from our unit tests due to shadow DOM limitations. Cypress tests help us cover expected flows and gain confidence that our decision tree and utility functions are working correctly.
+
+## Cypress testing structure
+
+### Parent folders
+
+There are a number of `results-` parent folders. If the decision tree has a line to a results screen, there is a test file for it.
+
+`results-shortcuts` are the "shortcut" results screens that are not necessarily Decision Review pathway recommendations. They are represented by black ovals on the decision tree.
+
+If there are multiple lines leading to a particular results screen, there is a test to represent each of those lines.
+
+If there's a path split (`ONE_OF` in the decision tree logic) scenario that leads to a results screen, we cover all of the splits leading to that results screen with an individual test file each.
+
+The answers to the questions for each file (what the "path" is) are described in brief in the comments above the main `describe` block near the top of the file.
+
+## Cypress test performance
+
+There are many tests, but the idea is to keep their runs short and concise. Our CI is set up to run Cypress tests in parallel and performance should not be a major concern as long as the individual tests take on average a few seconds to run each.
+
+Additionally, because we are covering what our unit tests cannot (clicks on web components and thus answer validation and navigation between questions), that necessitates more end-to-end tests for now.

--- a/src/applications/appeals/onramp/tests/cypress/answer-clearing.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/answer-clearing.cypress.spec.js
@@ -1,0 +1,75 @@
+import * as h from './helpers';
+import { ROUTES } from '../../constants';
+import { SHORT_NAME_MAP } from '../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+} = SHORT_NAME_MAP;
+
+// Answer Clearing Check - make sure that when an answer is changed, all answers ahead of it are cleared
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results Board (path 1)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 1);
+      h.clickContinue();
+
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.validateRadioIsNotSelected(Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.validateRadioIsNotSelected(Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/deep-linking.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/deep-linking.cypress.spec.js
@@ -1,0 +1,19 @@
+import * as h from './helpers';
+import { ROUTES } from '../../constants';
+
+// TODO: This test won't work properly until we get this PR merged
+// https://github.com/department-of-veterans-affairs/vsp-platform-revproxy/pull/983
+// which is waiting on a finalized DR onramp URL
+xdescribe('Decision Reviews Onramp', () => {
+  describe('deep linking', () => {
+    it('redirects to home when a question page is loaded without the right criteria', () => {
+      cy.visit(`${h.ROOT}/${ROUTES.Q_1_1_CLAIM_DECISION}`);
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/form-validation.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/form-validation.cypress.spec.js
@@ -1,0 +1,35 @@
+import * as h from './helpers';
+import { ROUTES } from '../../constants';
+import { SHORT_NAME_MAP } from '../../constants/question-data-map';
+
+const { Q_1_1_CLAIM_DECISION } = SHORT_NAME_MAP;
+
+// TODO add more questions to this validation check if we end up with a split
+// structure in the types of radio buttons we use (with and without descriptionText)
+// We'll revisit this when design comps are final
+describe('Decision Reviews Onramp', () => {
+  describe('Form validation', () => {
+    it('displays the correct error text when no response is selected', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION -------------------------------
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.verifyFormErrorDoesNotExist(Q_1_1_CLAIM_DECISION);
+
+      h.clickContinue();
+      h.checkFormAlertText(
+        Q_1_1_CLAIM_DECISION,
+        'Error Placeholder error message',
+      );
+
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.verifyFormErrorDoesNotExist(Q_1_1_CLAIM_DECISION);
+      h.clickContinue();
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/helpers.js
+++ b/src/applications/appeals/onramp/tests/cypress/helpers.js
@@ -1,0 +1,73 @@
+import manifest from '../../manifest.json';
+
+export const ROOT = manifest.rootUrl;
+export const START_LINK = 'onramp-start';
+
+export const clickStart = () =>
+  cy
+    .findByTestId(START_LINK)
+    .should('be.visible')
+    .click();
+
+export const verifyUrl = link => cy.url().should('contain', `${ROOT}/${link}`);
+
+export const verifyElement = selector =>
+  cy.findByTestId(selector).should('exist');
+
+export const selectRadio = (selector, index) =>
+  cy
+    .findByTestId(selector)
+    .should('exist')
+    .get('[data-testid=va-radio-option]')
+    .eq(index)
+    .click();
+
+export const validateRadioIsNotSelected = selector =>
+  cy
+    .findByTestId(selector)
+    .should('exist')
+    .get('[data-testid=va-radio-option]')
+    .should('not.be.checked');
+
+export const clickBack = () =>
+  cy
+    .findByTestId('onramp-buttonPair')
+    .shadow()
+    .get('va-button')
+    .first()
+    .should('be.visible')
+    .click();
+
+export const clickContinue = () =>
+  cy
+    .findByTestId('onramp-buttonPair')
+    .shadow()
+    .get('va-button')
+    .eq(1)
+    .should('be.visible')
+    .click();
+
+export const verifyFormErrorNotShown = selector =>
+  cy
+    .findByTestId(selector)
+    .get('span[role="alert"]')
+    .should('have.text', '');
+
+export const verifyFormErrorDoesNotExist = selector =>
+  cy
+    .findByTestId(selector)
+    .get('span[role="alert"]')
+    .should('not.exist');
+
+export const checkFormAlertText = (selector, expectedValue) =>
+  cy
+    .findByTestId(selector)
+    .get('span[role="alert"]')
+    .should('be.visible')
+    .should('have.text', expectedValue);
+
+export const verifyText = (selector, expectedValue) =>
+  cy
+    .findByTestId(selector)
+    .should('be.visible')
+    .should('have.text', expectedValue);

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
@@ -1,0 +1,102 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_H_1_EXISTING_BOARD_APPEAL,
+  Q_2_H_2_NEW_EVIDENCE,
+  Q_2_H_2B_JUDGE_HEARING,
+} = SHORT_NAME_MAP;
+
+// Results Board Appeal: Direct Review recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - HLR
+// 2.H.1 - No
+// 2.H.2 - No
+// 2.H.2B - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results Board (path 1)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 2);
+      h.clickContinue();
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.selectRadio(Q_2_H_1_EXISTING_BOARD_APPEAL, 1);
+      h.clickContinue();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.selectRadio(Q_2_H_2_NEW_EVIDENCE, 1);
+      h.clickContinue();
+
+      // Q_2_H_2B_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2B_JUDGE_HEARING);
+      h.selectRadio(Q_2_H_2B_JUDGE_HEARING, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_H_2B_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2B_JUDGE_HEARING);
+      h.clickBack();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
@@ -1,0 +1,102 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_H_1_EXISTING_BOARD_APPEAL,
+  Q_2_H_2_NEW_EVIDENCE,
+  Q_2_H_2A_JUDGE_HEARING,
+} = SHORT_NAME_MAP;
+
+// Results Board Appeal: Evidence Submission recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - HLR
+// 2.H.1 - No
+// 2.H.2 - Yes
+// 2.H.2A - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results Board (path 1)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 2);
+      h.clickContinue();
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.selectRadio(Q_2_H_1_EXISTING_BOARD_APPEAL, 1);
+      h.clickContinue();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.selectRadio(Q_2_H_2_NEW_EVIDENCE, 0);
+      h.clickContinue();
+
+      // Q_2_H_2A_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2A_JUDGE_HEARING);
+      h.selectRadio(Q_2_H_2A_JUDGE_HEARING, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_H_2A_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2A_JUDGE_HEARING);
+      h.clickBack();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
@@ -1,0 +1,91 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_1_3A_FEWER_60_DAYS,
+  Q_2_H_2_NEW_EVIDENCE,
+  Q_2_H_2A_JUDGE_HEARING,
+} = SHORT_NAME_MAP;
+
+// Results Board Appeal: Evidence Submission recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - Yes
+// 1.3A - Yes
+// 2.H.2 - Yes
+// 2.H.2A - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results Board (path 2)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 0);
+      h.clickContinue();
+
+      // Q_1_3A_FEWER_60_DAYS
+      h.verifyUrl(ROUTES.Q_1_3A_FEWER_60_DAYS);
+      h.selectRadio(Q_1_3A_FEWER_60_DAYS, 0);
+      h.clickContinue();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.selectRadio(Q_2_H_2_NEW_EVIDENCE, 0);
+      h.clickContinue();
+
+      // Q_2_H_2A_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2A_JUDGE_HEARING);
+      h.selectRadio(Q_2_H_2A_JUDGE_HEARING, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_H_2A_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2A_JUDGE_HEARING);
+      h.clickBack();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_1_3A_FEWER_60_DAYS
+      h.verifyUrl(ROUTES.Q_1_3A_FEWER_60_DAYS);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
@@ -1,0 +1,102 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_H_1_EXISTING_BOARD_APPEAL,
+  Q_2_H_2_NEW_EVIDENCE,
+  Q_2_H_2A_JUDGE_HEARING,
+} = SHORT_NAME_MAP;
+
+// Results Board Appeal: Hearing Request recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - HLR
+// 2.H.1 - No
+// 2.H.2 - Yes
+// 2.H.2A - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results Board (path 1)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 2);
+      h.clickContinue();
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.selectRadio(Q_2_H_1_EXISTING_BOARD_APPEAL, 1);
+      h.clickContinue();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.selectRadio(Q_2_H_2_NEW_EVIDENCE, 0);
+      h.clickContinue();
+
+      // Q_2_H_2A_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2A_JUDGE_HEARING);
+      h.selectRadio(Q_2_H_2A_JUDGE_HEARING, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_H_2A_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2A_JUDGE_HEARING);
+      h.clickBack();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
@@ -1,0 +1,91 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_1_3A_FEWER_60_DAYS,
+  Q_2_H_2_NEW_EVIDENCE,
+  Q_2_H_2B_JUDGE_HEARING,
+} = SHORT_NAME_MAP;
+
+// Results Board Appeal: Hearing Request recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - Yes
+// 1.3A - Yes
+// 2.H.2 - No
+// 2.H.2B - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results Board (path 1)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 0);
+      h.clickContinue();
+
+      // Q_1_3A_FEWER_60_DAYS
+      h.verifyUrl(ROUTES.Q_1_3A_FEWER_60_DAYS);
+      h.selectRadio(Q_1_3A_FEWER_60_DAYS, 0);
+      h.clickContinue();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.selectRadio(Q_2_H_2_NEW_EVIDENCE, 1);
+      h.clickContinue();
+
+      // Q_2_H_2B_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2B_JUDGE_HEARING);
+      h.selectRadio(Q_2_H_2B_JUDGE_HEARING, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_H_2B_JUDGE_HEARING
+      h.verifyUrl(ROUTES.Q_2_H_2B_JUDGE_HEARING);
+      h.clickBack();
+
+      // Q_2_H_2_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_H_2_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_1_3A_FEWER_60_DAYS
+      h.verifyUrl(ROUTES.Q_1_3A_FEWER_60_DAYS);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
@@ -1,0 +1,102 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_IS_1_SERVICE_CONNECTED,
+  Q_2_IS_2_CONDITION_WORSENED,
+  Q_2_IS_1A_LAW_POLICY_CHANGE,
+} = SHORT_NAME_MAP;
+
+// Results HLR: Higher-Level Review recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - Initial
+// 2.IS.1 - Yes
+// 2.IS.2 - No
+// 2.IS.1A - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results HLR (path 1)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 0);
+      h.clickContinue();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.selectRadio(Q_2_IS_1_SERVICE_CONNECTED, 0);
+      h.clickContinue();
+
+      // Q_2_IS_2_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_2_IS_2_CONDITION_WORSENED);
+      h.selectRadio(Q_2_IS_2_CONDITION_WORSENED, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.selectRadio(Q_2_IS_1A_LAW_POLICY_CHANGE, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.clickBack();
+
+      // Q_2_IS_2_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_2_IS_2_CONDITION_WORSENED);
+      h.clickBack();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
@@ -1,0 +1,101 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_IS_1_SERVICE_CONNECTED,
+  Q_2_IS_1A_LAW_POLICY_CHANGE,
+  Q_2_IS_1B_NEW_EVIDENCE,
+} = SHORT_NAME_MAP;
+
+// Results HLR: Higher-Level Review recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - Supplemental
+// 2.IS.1 - No
+// 2.IS.1A - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results HLR (path 2)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.selectRadio(Q_2_IS_1_SERVICE_CONNECTED, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.selectRadio(Q_2_IS_1A_LAW_POLICY_CHANGE, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1B_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_IS_1B_NEW_EVIDENCE);
+      h.selectRadio(Q_2_IS_1B_NEW_EVIDENCE, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_IS_1B_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_IS_1B_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.clickBack();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
@@ -1,0 +1,80 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_S_1_NEW_EVIDENCE,
+} = SHORT_NAME_MAP;
+
+// Results HLR: Higher-Level Review recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - Board Appeal
+// 2.S.1 - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results HLR (path 3)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 3);
+      h.clickContinue();
+
+      // Q_2_S_1_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_S_1_NEW_EVIDENCE);
+      h.selectRadio(Q_2_S_1_NEW_EVIDENCE, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_S_1_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_S_1_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
@@ -1,0 +1,69 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_2A_CONDITION_WORSENED,
+  Q_1_2B_LAW_POLICY_CHANGE,
+} = SHORT_NAME_MAP;
+
+// Results SC: Supplemental Claim recommended
+// 1.1 - Yes
+// 1.2 - No
+// 1.2A - No
+// 1.2B - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results SC (path 1)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 1);
+      h.clickContinue();
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.selectRadio(Q_1_2A_CONDITION_WORSENED, 1);
+      h.clickContinue();
+
+      // Q_1_2B_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_1_2B_LAW_POLICY_CHANGE);
+      h.selectRadio(Q_1_2B_LAW_POLICY_CHANGE, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_1_2B_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_1_2B_LAW_POLICY_CHANGE);
+      h.clickBack();
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
@@ -1,0 +1,80 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_2A_CONDITION_WORSENED,
+  Q_1_2B_LAW_POLICY_CHANGE,
+  Q_1_2C_NEW_EVIDENCE,
+} = SHORT_NAME_MAP;
+
+// Results SC: Supplemental Claim recommended
+// 1.1 - Yes
+// 1.2 - No
+// 1.2A - No
+// 1.2B - No
+// 1.2C - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results SC (path 2)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 1);
+      h.clickContinue();
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.selectRadio(Q_1_2A_CONDITION_WORSENED, 1);
+      h.clickContinue();
+
+      // Q_1_2B_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_1_2B_LAW_POLICY_CHANGE);
+      h.selectRadio(Q_1_2B_LAW_POLICY_CHANGE, 1);
+      h.clickContinue();
+
+      // Q_1_2C_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_1_2C_NEW_EVIDENCE);
+      h.selectRadio(Q_1_2C_NEW_EVIDENCE, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_1_2C_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_1_2C_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_1_2B_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_1_2B_LAW_POLICY_CHANGE);
+      h.clickBack();
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
@@ -1,0 +1,91 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_IS_1_SERVICE_CONNECTED,
+  Q_2_IS_1A_LAW_POLICY_CHANGE,
+} = SHORT_NAME_MAP;
+
+// Results SC: Supplemental Claim recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - Initial
+// 2.IS.1 - No
+// 2.IS.1A - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results SC (path 3)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 0);
+      h.clickContinue();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.selectRadio(Q_2_IS_1_SERVICE_CONNECTED, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.selectRadio(Q_2_IS_1A_LAW_POLICY_CHANGE, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.clickBack();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
@@ -1,0 +1,102 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_IS_1_SERVICE_CONNECTED,
+  Q_2_IS_1A_LAW_POLICY_CHANGE,
+  Q_2_IS_1B_NEW_EVIDENCE,
+} = SHORT_NAME_MAP;
+
+// Results SC: Supplemental Claim recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - Supplemental
+// 2.IS.1 - No
+// 2.IS.1A - No
+// 2.IS.1B - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results SC (path 4)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.selectRadio(Q_2_IS_1_SERVICE_CONNECTED, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.selectRadio(Q_2_IS_1A_LAW_POLICY_CHANGE, 1);
+      h.clickContinue();
+
+      // Q_2_IS_1B_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_IS_1B_NEW_EVIDENCE);
+      h.selectRadio(Q_2_IS_1B_NEW_EVIDENCE, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_IS_1B_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_IS_1B_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_2_IS_1A_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_2_IS_1A_LAW_POLICY_CHANGE);
+      h.clickBack();
+
+      // Q_2_IS_1_SERVICE_CONNECTED
+      h.verifyUrl(ROUTES.Q_2_IS_1_SERVICE_CONNECTED);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
@@ -1,0 +1,80 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_S_1_NEW_EVIDENCE,
+} = SHORT_NAME_MAP;
+
+// Results SC: Supplemental Claim recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - Board Appeal
+// 2.S.1 - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results SC (path 5)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 3);
+      h.clickContinue();
+
+      // Q_2_S_1_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_S_1_NEW_EVIDENCE);
+      h.selectRadio(Q_2_S_1_NEW_EVIDENCE, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_S_1_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_2_S_1_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
@@ -1,0 +1,80 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_2_0_CLAIM_TYPE,
+  Q_2_H_1_EXISTING_BOARD_APPEAL,
+} = SHORT_NAME_MAP;
+
+// Results SC: Supplemental Claim recommended
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - No
+// 2.0 - HLR
+// 2.H.1 - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results SC (path 6)', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 1);
+      h.clickContinue();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.selectRadio(Q_2_0_CLAIM_TYPE, 2);
+      h.clickContinue();
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.selectRadio(Q_2_H_1_EXISTING_BOARD_APPEAL, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_2_H_1_EXISTING_BOARD_APPEAL
+      h.verifyUrl(ROUTES.Q_2_H_1_EXISTING_BOARD_APPEAL);
+      h.clickBack();
+
+      // Q_2_0_CLAIM_TYPE
+      h.verifyUrl(ROUTES.Q_2_0_CLAIM_TYPE);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1B.cypress.spec.js
@@ -1,0 +1,44 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const { Q_1_1_CLAIM_DECISION, Q_1_1A_SUBMITTED_526 } = SHORT_NAME_MAP;
+
+// Results 1.1B: File an initial claim before you request a review
+// 1.1 - No
+// 1.1A - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results 1.1B', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 1);
+      h.clickContinue();
+
+      // Q_1_1A_SUBMITTED_526
+      h.verifyUrl(ROUTES.Q_1_1A_SUBMITTED_526);
+      h.selectRadio(Q_1_1A_SUBMITTED_526, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_1_1A_SUBMITTED_526
+      h.verifyUrl(ROUTES.Q_1_1A_SUBMITTED_526);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1C.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1C.cypress.spec.js
@@ -1,0 +1,44 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const { Q_1_1_CLAIM_DECISION, Q_1_1A_SUBMITTED_526 } = SHORT_NAME_MAP;
+
+// Results 1.1C: You can't request a review yet
+// 1.1 - No
+// 1.1A - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results 1.1C', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 1);
+      h.clickContinue();
+
+      // Q_1_1A_SUBMITTED_526
+      h.verifyUrl(ROUTES.Q_1_1A_SUBMITTED_526);
+      h.selectRadio(Q_1_1A_SUBMITTED_526, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_1_1A_SUBMITTED_526
+      h.verifyUrl(ROUTES.Q_1_1A_SUBMITTED_526);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-2-C1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-2-C1.cypress.spec.js
@@ -1,0 +1,81 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_2A_CONDITION_WORSENED,
+  Q_1_2B_LAW_POLICY_CHANGE,
+  Q_1_2C_NEW_EVIDENCE,
+} = SHORT_NAME_MAP;
+
+// Results 1.2.C1: You need to file a new claim because you have no new evidence
+// and you are outside of the 1-year deadline
+// 1.1 - Yes
+// 1.2 - No
+// 1.2A - No
+// 1.2B - No
+// 1.2C - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results 1.2.C1', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 1);
+      h.clickContinue();
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.selectRadio(Q_1_2A_CONDITION_WORSENED, 1);
+      h.clickContinue();
+
+      // Q_1_2B_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_1_2B_LAW_POLICY_CHANGE);
+      h.selectRadio(Q_1_2B_LAW_POLICY_CHANGE, 1);
+      h.clickContinue();
+
+      // Q_1_2C_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_1_2C_NEW_EVIDENCE);
+      h.selectRadio(Q_1_2C_NEW_EVIDENCE, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_1_2C_NEW_EVIDENCE
+      h.verifyUrl(ROUTES.Q_1_2C_NEW_EVIDENCE);
+      h.clickBack();
+
+      // Q_1_2B_LAW_POLICY_CHANGE
+      h.verifyUrl(ROUTES.Q_1_2B_LAW_POLICY_CHANGE);
+      h.clickBack();
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-3B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-3B.cypress.spec.js
@@ -1,0 +1,69 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_3_CLAIM_CONTESTED,
+  Q_1_3A_FEWER_60_DAYS,
+} = SHORT_NAME_MAP;
+
+// Results 1.3B: Contested claims, more than 60 days after decision
+// 1.1 - Yes
+// 1.2 - Yes
+// 1.3 - Yes
+// 1.3A - No
+describe('Decision Reviews Onramp', () => {
+  describe('Results 1.3B', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.selectRadio(Q_1_3_CLAIM_CONTESTED, 0);
+      h.clickContinue();
+
+      // Q_1_3A_FEWER_60_DAYS
+      h.verifyUrl(ROUTES.Q_1_3A_FEWER_60_DAYS);
+      h.selectRadio(Q_1_3A_FEWER_60_DAYS, 1);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_1_3A_FEWER_60_DAYS
+      h.verifyUrl(ROUTES.Q_1_3A_FEWER_60_DAYS);
+      h.clickBack();
+
+      // Q_1_3_CLAIM_CONTESTED
+      h.verifyUrl(ROUTES.Q_1_3_CLAIM_CONTESTED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-2-IS3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-2-IS3.cypress.spec.js
@@ -1,0 +1,58 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+
+const {
+  Q_1_1_CLAIM_DECISION,
+  Q_1_2_CLAIM_DECISION,
+  Q_1_2A_CONDITION_WORSENED,
+} = SHORT_NAME_MAP;
+
+// Results 2.IS3: Condition has worsened, you may be eligible for more
+// 1.1 - Yes
+// 1.2 - No
+// 1.2A - Yes
+describe('Decision Reviews Onramp', () => {
+  describe('Results 2.IS3', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit(h.ROOT);
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.selectRadio(Q_1_1_CLAIM_DECISION, 0);
+      h.clickContinue();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.selectRadio(Q_1_2_CLAIM_DECISION, 1);
+      h.clickContinue();
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.selectRadio(Q_1_2A_CONDITION_WORSENED, 0);
+      h.clickContinue();
+
+      // TODO - Add results page check here
+
+      // Q_1_2A_CONDITION_WORSENED
+      h.verifyUrl(ROUTES.Q_1_2A_CONDITION_WORSENED);
+      h.clickBack();
+
+      // Q_1_2_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_2_CLAIM_DECISION);
+      h.clickBack();
+
+      // Q_1_1_CLAIM_DECISION
+      h.verifyUrl(ROUTES.Q_1_1_CLAIM_DECISION);
+      h.clickBack();
+
+      // INTRODUCTION
+      h.verifyUrl(ROUTES.INTRODUCTION);
+    });
+  });
+});

--- a/src/applications/appeals/onramp/utilities/page-navigation.js
+++ b/src/applications/appeals/onramp/utilities/page-navigation.js
@@ -43,7 +43,9 @@ export const navigateForward = (
 
   // We're looking for the next question that has display conditions met
   // so the loop helps us skip the ones that don't
-  for (let i = currentIndex + 1; i < endIndex; i++) {
+  // We allow one additional loop after we run out of questions
+  // to check if we're at a results page
+  for (let i = currentIndex + 1; i <= endIndex + 1; i++) {
     const nextShortName = allQuestionShortNames?.[nextIndex];
 
     if (nextIndex > endIndex) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Last PR for connecting the questions together via all of the navigation and answer storage work that has been merged in so far. In this PR, answers are stored into the Redux store and navigation between questions from start to end and back again is possible. Deep-diving is prevented. Until [this PR](https://github.com/department-of-veterans-affairs/vsp-platform-revproxy/pull/983) is merged, deep-diving will either 404 or show a blank page depending on the environment (404 vs. local) - I'm not sure what exactly will happen where.

The bulk of this PR is the addition of Cypress tests which check all of the routes to each of the results page. The "shortcut" results pages are the results pages other than SC, HLR and NOD where we need to give the user some other recommendation than one of our three flows. Those are indicated by black ovals on the [Figma](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=1-81&p=f&t=YIDFuLZ1yrDtIsh8-0).

Design & decision tree: https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=1-81&p=f&t=YIDFuLZ1yrDtIsh8-0

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/114834

## Testing done

The Cypress tests added here cover many of the available paths, but it's impossible to cover them all. We have a test for each results screen including the shortcut results screens.

## Video

### Navigation to a "shortcut" results screen

https://github.com/user-attachments/assets/9dfc9a1c-61d1-4a9d-83ea-ded2bc032ebf

### Forward and backward navigation, changing response to first question and verifying next questions have been cleared out

https://github.com/user-attachments/assets/1a8af685-69a5-4ce9-be30-68382567de35


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added