### PR TITLE
Unskip tests and fix breadcrumb failed test

### DIFF
--- a/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.jsx
@@ -15,7 +15,7 @@ import * as flow from './flow';
 import { FETCH_STATUS } from '../utils/constants';
 import * as utils from '../services/utils';
 
-describe.skip('VAOS ChooseDateAndTime component', () => {
+describe('VAOS ChooseDateAndTime component', () => {
   const sandbox = sinon.createSandbox();
   const confirmed = [
     {

--- a/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/components/DateAndTimeContent.unit.spec.jsx
@@ -7,7 +7,7 @@ import { createReferralById, getReferralSlotKey } from '../utils/referrals';
 import { createDraftAppointmentInfo } from '../utils/provider';
 import { renderWithStoreAndRouter } from '../../tests/mocks/setup';
 
-describe.skip('VAOS Component: DateAndTimeContent', () => {
+describe('VAOS Component: DateAndTimeContent', () => {
   const initialState = {
     featureToggles: {
       vaOnlineSchedulingCCDirectScheduling: true,

--- a/src/applications/vaos/referral-appointments/components/ReferralBreadcrumbs.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/components/ReferralBreadcrumbs.unit.spec.jsx
@@ -17,7 +17,7 @@ const initialState = {
   },
 };
 
-describe.skip('VAOS Component: ReferralBreadcrumbs', () => {
+describe('VAOS Component: ReferralBreadcrumbs', () => {
   const sandbox = sinon.createSandbox();
 
   afterEach(() => {
@@ -25,21 +25,19 @@ describe.skip('VAOS Component: ReferralBreadcrumbs', () => {
   });
 
   it('should render Breadcrumbs component when breadcrumb does not start with "Back"', () => {
-    sandbox.stub(flow, 'getReferralUrlLabel').returns('Label');
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<ReferralBreadcrumbs />, {
       store,
     });
-
+    screen.history.push('/');
     const navigation = screen.getByTestId('vaos-breadcrumbs');
     expect(navigation).to.exist;
     const crumb =
       navigation.breadcrumbList[navigation.breadcrumbList.length - 1].label;
-    expect(crumb).to.equal('Label');
+    expect(crumb).to.equal('Appointments');
   });
 
   it('Should have Referrals and requests in breadcrumb', () => {
-    sandbox.stub(flow, 'getReferralUrlLabel').returns('Label');
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<ReferralBreadcrumbs />, {
       store,
@@ -48,7 +46,6 @@ describe.skip('VAOS Component: ReferralBreadcrumbs', () => {
     screen.history.push(
       '/schedule-referral?id=1234&referrer=referrals-requests',
     );
-
     const navigation = screen.getByTestId('vaos-breadcrumbs');
     expect(navigation).to.exist;
     const hasReferralBreadcrumbs = navigation.breadcrumbList.some(
@@ -59,9 +56,8 @@ describe.skip('VAOS Component: ReferralBreadcrumbs', () => {
   });
 
   it('should render back link correctly when breadcrumb starts with "Back"', () => {
-    sandbox.stub(flow, 'getReferralUrlLabel').returns('Back to previous page');
-
     const store = createTestStore(initialState);
+    initialState.referral.currentPage = 'complete';
     const screen = renderWithStoreAndRouter(<ReferralBreadcrumbs />, {
       store,
     });
@@ -70,17 +66,16 @@ describe.skip('VAOS Component: ReferralBreadcrumbs', () => {
     expect(navigation).to.exist;
     const backLink = screen.getByTestId('back-link');
     expect(backLink).to.exist;
-    expect(backLink).to.have.attribute('href', '#');
-    expect(backLink).to.have.attribute('text', 'Back to previous page');
+    expect(backLink).to.have.attribute('href', '/my-health/appointments');
+    expect(backLink).to.have.attribute('text', 'Back to appointments');
   });
 
   it('should call routeToPreviousReferralPage when back link is clicked', () => {
-    const routeToPreviousReferralPage = sandbox.stub(
+    const routeToPreviousReferralPage = sandbox.spy(
       flow,
       'routeToPreviousReferralPage',
     );
-    sandbox.stub(flow, 'getReferralUrlLabel').returns('Back to previous page');
-
+    initialState.referral.currentPage = 'complete';
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<ReferralBreadcrumbs />, {
       store,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Removed skip on some Referral tests.
- Fixed failing referral breadcrumb test when run with all tests
- Rewrote breadcrumb tests without stubs for better coverage.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115889
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115887

## Testing done

- Ran all unit tests isolated and with the entire suite.
- Made sure coverage tests ran and looked good.

## Screenshots

N/A

## What areas of the site does it impact?

Unit tests in the CC Referral app. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A