### PR TITLE
Intent to File - Add disableAutoFocus prop

### DIFF
--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -71,11 +71,10 @@ export default function PensionEntry({ location, children }) {
     return <NoFormPage />;
   }
 
-  // Hide ITF until backend feature is ready
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {pensionItfShowAlert && (
-        <IntentToFile itfType="pension" location={location} />
+        <IntentToFile itfType="pension" location={location} disableAutoFocus />
       )}
       {children}
     </RoutedSavableApp>

--- a/src/platform/shared/itf/IntentToFile.jsx
+++ b/src/platform/shared/itf/IntentToFile.jsx
@@ -82,6 +82,7 @@ const IntentToFile = ({
   location = window.location,
   WrapAlert = WrapContent,
   WrapPage = WrapPageWithButtons, // required if customizing page replacement
+  disableAutoFocus = false,
 } = {}) => {
   const loggedIn = useSelector(state => isLoggedIn(state));
 
@@ -96,6 +97,7 @@ const IntentToFile = ({
   const apiUrl = `${environment.API_URL}${itfApi}/${itfType}`;
 
   const focusAlertHeader = () => {
+    if (disableAutoFocus) return;
     const header = children ? 'h2' : 'va-alert';
     setTimeout(() => {
       scrollTo('topContentElement');
@@ -225,6 +227,7 @@ IntentToFile.propTypes = {
   WrapPage: PropTypes.func,
   baseUrl: PropTypes.string,
   children: PropTypes.any,
+  disableAutoFocus: PropTypes.bool,
   itfApi: PropTypes.string,
   itfCreated: PropTypes.func,
   itfCreating: PropTypes.func,

--- a/src/platform/shared/itf/tests/IntentToFile.unit.spec.jsx
+++ b/src/platform/shared/itf/tests/IntentToFile.unit.spec.jsx
@@ -54,11 +54,11 @@ describe('IntentToFile', () => {
       </div>,
     );
 
-  it('should render searching for ITF loading indicator', () => {
+  it('should render searching for ITF loading indicator', async () => {
     mockApiRequest({});
     const { container } = renderPage(getData());
 
-    waitFor(() => {
+    await waitFor(() => {
       expect($('.itf-wrapper', container)).to.exist;
       expect(
         $('va-loading-indicator', container).getAttribute('message'),
@@ -66,11 +66,11 @@ describe('IntentToFile', () => {
     });
   });
 
-  it('should render ITF found alert', () => {
+  it('should render ITF found alert', async () => {
     mockApiRequest(mockItfData(activeItf));
     const { container } = renderPage(getData());
 
-    waitFor(() => {
+    await waitFor(() => {
       expect($('va-alert[status="success"]', container).textContent).to.include(
         'We have your intent to file',
       );
@@ -78,11 +78,11 @@ describe('IntentToFile', () => {
     });
   });
 
-  it('should render ITF created alert', () => {
+  it('should render ITF created alert', async () => {
     mockApiRequest(mockItfData(nonActiveItf));
     const { container } = renderPage(getData());
 
-    waitFor(() => {
+    await waitFor(() => {
       expect($('va-alert[status="success"]', container).textContent).to.include(
         'We recorded your intent to file',
       );
@@ -90,12 +90,12 @@ describe('IntentToFile', () => {
     });
   });
 
-  it('should render ITF failed alert', () => {
+  it('should render ITF failed alert', async () => {
     mockApiRequest(mockItfData(), false);
     const { container } = renderPage(getData());
 
-    waitFor(() => {
-      expect($('va-alert[status="success"]', container).textContent).to.include(
+    await waitFor(() => {
+      expect($('va-alert[status="warning"]', container).textContent).to.include(
         'We’re sorry. We can’t find a record of your intent to file',
       );
       expect(document.activeElement?.tagName).to.equal('VA-ALERT');
@@ -152,6 +152,52 @@ describe('IntentToFile', () => {
     }).then(() => {
       expect($('.itf-wrapper', container)).to.not.exist;
       expect($('#test', container)).to.exist;
+    });
+  });
+
+  it('should not autofocus success alert when disableAutoFocus is true and ITF exists', async () => {
+    mockApiRequest(mockItfData(activeItf));
+    const { props, mockStore } = getData();
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntentToFile {...props} disableAutoFocus />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect($('va-alert[status="success"]', container).textContent).to.include(
+        'We have your intent to file',
+      );
+      expect(document.activeElement?.tagName).to.not.equal('VA-ALERT');
+    });
+  });
+
+  it('should not autofocus ITF created alert when disableAutoFocus is true and new ITF is created', async () => {
+    mockApiRequest(mockItfData(nonActiveItf));
+    const { props, mockStore } = getData();
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntentToFile {...props} disableAutoFocus />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect($('va-alert[status="success"]', container).textContent).to.include(
+        'We recorded your intent to file',
+      );
+      expect(document.activeElement?.tagName).to.not.equal('VA-ALERT');
+    });
+  });
+
+  it('should not autofocus ITF failed alert when disableAutoFocus is true and ITF lookup fails', () => {
+    mockApiRequest(mockItfData(), false);
+    const { container } = renderPage(getData());
+
+    waitFor(() => {
+      expect($('va-alert[status="success"]', container).textContent).to.include(
+        'We’re sorry. We can’t find a record of your intent to file',
+      );
+      expect(document.activeElement?.tagName).to.not.equal('VA-ALERT');
     });
   });
 });


### PR DESCRIPTION
## Summary
Added the `disableAutoFocus` prop to the `IntentToFile` component in the Pension Benefits form (VA Form 21P-527EZ) to improve accessibility and screen reader behavior. This change ensures that the ITF alert can be included in the natural DOM flow and avoid interrupting the natural focus behavior of page load.

Unlike other VA.gov forms, the Pension Benefits form focuses the segmented progress bar instead of the main page heading (`<h3>`), which means the ITF alert is in the natural screen reader order. This update prevents premature focus shifts triggered by the `IntentToFile` component itself.

## Issue
- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/115278](https://github.com/department-of-veterans-affairs/va.gov-team/issues/115278)

## How to run in local environment
1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Visit: `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`

## How to verify
1. Navigate to the form as an authenticated user
2. Confirm that the Intent to File alert appears at the top of the page
3. Verify that it is included in the natural screen reader flow and is no longer automatically focused on initial load
4. Ensure that the progress bar remains the first focused element and the alert follows in logical DOM order

## What areas of the site does it impact?
Pension Benefits Application — IntentToFile behavior and page focus management

## Screenshots
| Before (Focus flow) | After (Focus flow) |
|---------------------|--------------------|
| ITF alert focused by screen readers after async load | ITF alert included in natural focus order below automatically focused segmented progress bar |

### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] No console warnings or unexpected focus shifts occur
- [x] Alert visibility and form load behavior remain stable
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify behavior with a test user

## Requested Feedback
Please confirm that this update meets accessibility expectations for screen reader navigation and resolves the focus-related issue without introducing regressions to the ITF logic.