### PR TITLE
add paperless unavailable alert

### DIFF
--- a/src/applications/personalization/profile/components/paperless-delivery/Documents.jsx
+++ b/src/applications/personalization/profile/components/paperless-delivery/Documents.jsx
@@ -1,14 +1,19 @@
 import React from 'react';
+import { shallowEqual, useSelector } from 'react-redux';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { selectPatientFacilities } from '~/platform/user/cerner-dsot/selectors';
 import { useNotificationSettingsUtils } from '@@profile/hooks';
 import { Document } from './Document';
 
 export const Documents = () => {
+  const facilities = useSelector(selectPatientFacilities, shallowEqual);
   const { usePaperlessDeliveryGroup } = useNotificationSettingsUtils();
   const group = usePaperlessDeliveryGroup();
   const documents = group?.[0]?.items;
+  const notEnrolled = !facilities?.length;
+  const hasDocuments = !!documents?.length;
 
-  if (!group?.length || !documents?.length) {
+  if (notEnrolled) {
     return (
       <VaAlert status="info" visible>
         <h2 slot="headline">Paperless delivery not available yet</h2>
@@ -32,9 +37,13 @@ export const Documents = () => {
             change this at any time.
           </h3>
         </legend>
-        {documents.map(id => (
-          <Document key={id} document={id} />
-        ))}
+        {hasDocuments && (
+          <>
+            {documents.map(id => (
+              <Document key={id} document={id} />
+            ))}
+          </>
+        )}
       </fieldset>
     </>
   );

--- a/src/applications/personalization/profile/tests/components/paperless-delivery/Documents.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/paperless-delivery/Documents.unit.spec.jsx
@@ -1,33 +1,37 @@
 import React from 'react';
+import * as redux from 'react-redux';
 import { cleanup } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon-v20';
 import { renderWithStoreAndRouter as render } from '~/platform/testing/unit/react-testing-library-helpers';
+import { selectPatientFacilities } from '~/platform/user/cerner-dsot/selectors';
 import * as useNotificationSettingsUtils from '@@profile/hooks/useNotificationSettingsUtils';
-import * as MockDocument from '../../../components/paperless-delivery/Document';
+import * as Document from '../../../components/paperless-delivery/Document';
 import { Documents } from '../../../components/paperless-delivery/Documents';
 
 describe('Documents', () => {
+  let sandbox;
+  let facilities;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(redux, 'useSelector').callsFake(selector => {
+      if (selector === selectPatientFacilities) {
+        return facilities;
+      }
+      return undefined;
+    });
+    sandbox.stub(Document, 'Document').callsFake(() => <div />);
+  });
+
   afterEach(() => {
     cleanup();
-    sinon.restore();
+    sandbox.restore();
   });
 
-  it('should render alert', () => {
-    sinon
-      .stub(useNotificationSettingsUtils, 'useNotificationSettingsUtils')
-      .returns({
-        usePaperlessDeliveryGroup: () => [],
-      });
-    const { getByText } = render(<Documents />, {
-      initialState: {},
-    });
-    expect(getByText(/Paperless delivery not available yet/)).to.exist;
-  });
-
-  it('should render', () => {
-    sinon.stub(MockDocument, 'Document').callsFake(() => <div />);
-    sinon
+  it('should render alert when missing facilities', () => {
+    facilities = [];
+    sandbox
       .stub(useNotificationSettingsUtils, 'useNotificationSettingsUtils')
       .returns({
         usePaperlessDeliveryGroup: () => [
@@ -40,9 +44,26 @@ describe('Documents', () => {
           },
         ],
       });
-    const { getByRole } = render(<Documents />, {
-      initialState: {},
-    });
+    const { getByText } = render(<Documents />, {});
+    expect(getByText(/Paperless delivery not available yet/)).to.exist;
+  });
+
+  it('should render documents', () => {
+    facilities = ['a-facility'];
+    sandbox
+      .stub(useNotificationSettingsUtils, 'useNotificationSettingsUtils')
+      .returns({
+        usePaperlessDeliveryGroup: () => [
+          {
+            name: 'Digital Delivery - Health Care',
+            description:
+              'Digital Delivery settings for health care related items',
+            items: ['item15'],
+            id: 'group6',
+          },
+        ],
+      });
+    const { getByRole } = render(<Documents />, {});
     const heading = getByRole('heading', { level: 2 });
     expect(heading).to.exist;
     expect(heading).to.have.text('Documents available for paperless delivery');


### PR DESCRIPTION
## Summary

- _Users not enrolled in health care will not be displayed paperless delivery options_

## Related issue(s)

- _[IIR-1895](https://github.com/department-of-veterans-affairs/va-iir/issues/1895)_

## Testing done

- _Added unit tests_

## What areas of the site does it impact?

Profile -> Paperless Delivery

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
