### PR TITLE
Letters: set focus on title when letters list loads

### DIFF
--- a/src/applications/letters/containers/LetterList.jsx
+++ b/src/applications/letters/containers/LetterList.jsx
@@ -35,8 +35,8 @@ export class LetterList extends React.Component {
   }
 
   componentDidMount() {
-    const { shouldUseLighthouse } = this.props;
-    focusElement('h2#nav-form-header');
+    const { lettersNewDesign, shouldUseLighthouse } = this.props;
+    focusElement(lettersNewDesign ? '#letters-title-id' : 'h2#nav-form-header');
     this.setState({
       // eslint-disable-next-line -- LH_MIGRATION
       LH_MIGRATION__options: LH_MIGRATION__getOptions(shouldUseLighthouse),

--- a/src/applications/letters/tests/containers/LetterList.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/LetterList.unit.spec.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom-v5-compat';
 
+import * as focusUtils from '~/platform/utilities/ui/focus';
 import { LetterList } from '../../containers/LetterList';
 import {
   AVAILABILITY_STATUSES,
@@ -64,6 +66,50 @@ const getStore = (lettersPageNewDesign = false) =>
   }));
 
 describe('<LetterList>', () => {
+  describe('focus setting tests', () => {
+    let focusElementSpy;
+
+    beforeEach(() => {
+      focusElementSpy = sinon.spy(focusUtils, 'focusElement');
+    });
+
+    afterEach(() => {
+      focusElementSpy.restore();
+    });
+
+    it('sets focus to h2 when lettersNewDesign is false', () => {
+      render(
+        <Provider store={getStore()}>
+          <MemoryRouter>
+            <LetterList {...defaultProps} lettersNewDesign={false} />
+          </MemoryRouter>
+        </Provider>,
+      );
+
+      // Check that focusElement was called
+      expect(focusElementSpy.callCount).to.equal(1);
+      // Check what it was called with - when lettersNewDesign is false, it should call with nav header
+      const lastCall = focusElementSpy.getCall(0);
+      expect(lastCall.args[0]).to.equal('h2#nav-form-header');
+    });
+
+    it('sets focus to letters title when lettersNewDesign is true', () => {
+      render(
+        <Provider store={getStore(true)}>
+          <MemoryRouter>
+            <LetterList {...defaultProps} lettersNewDesign />
+          </MemoryRouter>
+        </Provider>,
+      );
+
+      // Check that focusElement was called
+      expect(focusElementSpy.callCount).to.equal(1);
+      // Check what it was called with
+      const lastCall = focusElementSpy.getCall(0);
+      expect(lastCall.args[0]).to.equal('#letters-title-id');
+    });
+  });
+
   it('renders', () => {
     const tree = SkinDeep.shallowRender(<LetterList {...defaultProps} />);
     expect(tree.type).to.equal('div');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request updates the focus behavior in the `LetterList` component to better support the new letters design. Now, when the component mounts, it will focus on a different element based on whether the new design is enabled.

This component is owned by the BMT teams.

The flipper should be deprecated in late August/early September, at which point it will no longer be required for choosing which element should be set as focused.

### Steps to reproduce:

1. Log in as [user +54](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/dc5e9a840bef9ecdab3cf56988f1f88169e5ef2a/Administrative/vagov-users/mvi-staging-users.csv#L56)
2. Navigate to https://staging.va.gov/records/download-va-letters/letters

**Expected**: When the page loads, focus will be set to the H1 and the visual focus indicator will appear around the focused element.

**Actual**: When the page loads, focus is not set and there is no visual indicator of where focus is meant to be.

### Problem

In the code, there was a manual focus being set onto an element that does not exist in the new version of the page.  Therefore, the focus was not being properly directed to the appropriate heading.

### Solution

Checking for the version of the page being rendered and conditionally setting focus to the element that exists on this version of the page corrects this issue and ensures that the heading is focused correctly when the page is loaded.

### Accessibility and UI improvements

* Updated the `componentDidMount` method in `LetterList.jsx` to focus on `#letters-title-id` if the `lettersNewDesign` prop is true; otherwise, it falls back to the previous header selector.

## Related issue(s)

- Resolves department-of-veterans-affairs/va.gov-team#116270

## Testing done

- Prior to the change, loading the page would fail to set focus, and no element on the page was highlighted after load completed.
- After the change, loading the page sets focus to the heading.
- This was tested locally with the feature flag on and off to ensure the correct behavior was observed in both scenarios.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="1328" height="950" alt="image" src="https://github.com/user-attachments/assets/d77b5f56-2555-45a0-a3bf-296d99f2a982" /> | <img width="1272" height="944" alt="image" src="https://github.com/user-attachments/assets/0ced1c48-2246-4edf-9d0d-48104cb65faa" /> |
| Desktop | <img width="820" height="916" alt="image" src="https://github.com/user-attachments/assets/2d4d8df3-95f6-4953-a218-bc96dfa31e86" /><br /><img width="265" height="161" alt="image" src="https://github.com/user-attachments/assets/312ba837-0269-46de-9f53-87eba64f565a" /> | <img width="844" height="790" alt="image" src="https://github.com/user-attachments/assets/16b8a563-d552-4df3-a4ac-ad497313cb51" /><br /><img width="241" height="138" alt="image" src="https://github.com/user-attachments/assets/c2a0fa8a-cb33-46cc-82b6-f4d075f0c38f" /> |

## What areas of the site does it impact?

- This only affects the letters listing page.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary) (n/a)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (n/a)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
