### PR TITLE
SC: Treatment date fix

### DIFF
--- a/src/applications/appeals/995/tests/utils/submit-evidence.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/utils/submit-evidence.unit.spec.jsx
@@ -16,51 +16,97 @@ import {
 } from '../../utils/submit';
 
 describe('getTreatmentDate', () => {
-  const setup = ({
-    toggle = true,
-    type = '',
-    date = '',
-    from = '2000-02-02',
-    to = '2020-03-04',
-    noDate,
-  }) => {
-    return getTreatmentDate(type, toggle, {
-      treatmentDate: date,
-      evidenceDates: { from, to },
-      noDate,
+  describe('showNewFormContent is false', () => {
+    it('should return empty when the proper data is not given', () => {
+      const location = {
+        evidenceDates: {
+          from: '',
+        },
+      };
+
+      expect(getTreatmentDate('to', false, location)).to.eq('');
+      expect(getTreatmentDate('from', false, location)).to.eq('');
+      expect(getTreatmentDate('', false, location)).to.eq('');
+      expect(getTreatmentDate('to', false, {})).to.eq('');
+      expect(getTreatmentDate('to', null, {})).to.eq('');
     });
-  };
 
-  it('should return an empty string', () => {
-    expect(getTreatmentDate('', true, {})).to.eq('');
+    it('should return a properly formatted date when the proper data is given', () => {
+      const location = {
+        evidenceDates: {
+          from: '2020-03-04',
+          to: '2020-03-04',
+        },
+      };
+
+      expect(getTreatmentDate('to', false, location)).to.eq('2020-03-04');
+      expect(getTreatmentDate('from', false, location)).to.eq('2020-03-04');
+    });
   });
 
-  it('should return treatment date', () => {
-    expect(setup({ date: '2020-02' })).to.eq('2020-02-01');
-  });
+  describe('showNewFormContent is true', () => {
+    it('should return empty when the proper data is not given', () => {
+      const location = {
+        treatmentDate: '1-01',
+      };
 
-  it('should return empty string', () => {
-    expect(setup({ noDate: true })).to.eq('');
-    expect(setup({ type: '' })).to.eq('');
-    expect(setup({ type: '' })).to.eq('');
-  });
+      expect(getTreatmentDate('to', true, location)).to.eq('');
+      expect(getTreatmentDate('from', true, location)).to.eq('');
+    });
 
-  it('should return from date', () => {
-    expect(setup({ type: 'from' })).to.eq('2000-02-02');
-    expect(setup({ type: 'from', toggle: false })).to.eq('2000-02-02');
-    // expecting YYYY-MM format for treatement date
-    expect(setup({ type: 'from', date: '2010-05-06' })).to.eq('2000-02-02');
-  });
+    it('should return empty when the proper data is not given', () => {
+      const location = {
+        treatmentDate: '01-01',
+      };
 
-  it('should return to date', () => {
-    expect(setup({ type: 'to' })).to.eq('2020-03-04');
-    expect(setup({ type: 'to', toggle: false })).to.eq('2020-03-04');
-    // expecting YYYY-MM format for treatement date
-    expect(setup({ type: 'to', date: '2010-05-06' })).to.eq('2020-03-04');
-  });
+      expect(getTreatmentDate('to', true, location)).to.eq('');
+      expect(getTreatmentDate('from', true, location)).to.eq('');
+    });
 
-  it('should return treatment date', () => {
-    expect(setup({ date: '2010-05' })).to.eq('2010-05-01');
+    it('should return empty when the proper data is not given', () => {
+      const location = {
+        treatmentDate: '1',
+      };
+
+      expect(getTreatmentDate('to', true, location)).to.eq('');
+      expect(getTreatmentDate('from', true, location)).to.eq('');
+    });
+
+    it('should return empty when the proper data is not given', () => {
+      const location = {
+        treatmentDate: '1923',
+      };
+
+      expect(getTreatmentDate('to', true, location)).to.eq('');
+      expect(getTreatmentDate('from', true, location)).to.eq('');
+    });
+
+    it('should return empty when the proper data is not given', () => {
+      const location = {
+        treatmentDate: '101-01',
+      };
+
+      expect(getTreatmentDate('to', true, location)).to.eq('');
+      expect(getTreatmentDate('from', true, location)).to.eq('');
+    });
+
+    it('should return the date when a proper data is given', () => {
+      const location = {
+        treatmentDate: '1926-01',
+      };
+
+      expect(getTreatmentDate('to', true, location)).to.eq('1926-01-01');
+      expect(getTreatmentDate('from', true, location)).to.eq('1926-01-01');
+    });
+
+    it('should return the date when a proper data is given', () => {
+      const location = {
+        treatmentDate: '2001-01',
+      };
+
+      expect(getTreatmentDate('to', true, location)).to.eq('2001-01-01');
+      expect(getTreatmentDate('from', true, location)).to.eq('2001-01-01');
+    });
   });
 });
 

--- a/src/applications/appeals/995/tests/utils/submit-evidence.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/utils/submit-evidence.unit.spec.jsx
@@ -335,11 +335,46 @@ describe('getEvidence', () => {
     expect(getEvidence(evidence.data)).to.deep.equal(evidence.result());
   });
 
-  // TODO: Replace this test once Lighthouse provides an endpoint for the new
-  // form data
-  it('should temporarily process VA evidence treatment dates into an evidence date range', () => {
-    const evidence = getData({ showScNewForm: true });
-    expect(getEvidence(evidence.data)).to.deep.equal(evidence.result(true));
+  describe('when showScNewForm is true', () => {
+    // TODO: Replace this test once Lighthouse provides an endpoint for the new
+    // form data
+    it('should temporarily process VA evidence treatment dates into an evidence date range', () => {
+      const evidence = getData({ showScNewForm: true });
+      expect(getEvidence(evidence.data)).to.deep.equal(evidence.result(true));
+    });
+
+    it('should send noTreatmentDates as true when no date is provided', () => {
+      const evidence = {
+        [EVIDENCE_VA]: true,
+        showScNewForm: true,
+        form5103Acknowledged: true,
+        locations: [
+          {
+            locationAndName: 'test 1',
+            issues: ['1', '2'],
+            evidenceDates: { from: '', to: '' },
+            treatmentDate: '',
+            noDate: false,
+          },
+        ],
+      };
+
+      expect(getEvidence(evidence)).to.deep.equal({
+        evidenceSubmission: {
+          evidenceType: ['retrieval'],
+          retrieveFrom: [
+            {
+              attributes: {
+                locationAndName: 'test 1',
+                noTreatmentDates: true,
+              },
+              type: 'retrievalEvidence',
+            },
+          ],
+        },
+        form5103Acknowledged: true,
+      });
+    });
   });
 });
 

--- a/src/applications/appeals/995/utils/submit/evidence.js
+++ b/src/applications/appeals/995/utils/submit/evidence.js
@@ -194,11 +194,14 @@ export const getEvidence = formData => {
           if (showNewFormContent) {
             // Only startDate (from) is required, remove evidenceDates if
             // undefined
-            if (location.noDate || !from) {
+            const noTreatmentDates = location.noDate || !from;
+
+            if (noTreatmentDates) {
               delete entry.attributes.evidenceDates;
             }
+
             // noDate can be undefined; so fallback to false due to LH schema
-            entry.attributes.noTreatmentDates = location.noDate || false;
+            entry.attributes.noTreatmentDates = noTreatmentDates || false;
           }
           list.push(entry);
         }

--- a/src/applications/appeals/995/utils/submit/evidence.js
+++ b/src/applications/appeals/995/utils/submit/evidence.js
@@ -37,17 +37,19 @@ import { fixDateFormat } from '../../../shared/utils/replace';
  */
 export const getTreatmentDate = (type, showNewFormContent, location) => {
   const { treatmentDate = '', evidenceDates = {}, noDate } = location;
+
   if (showNewFormContent && noDate) {
     return '';
   }
 
-  const validTreatmentDate =
-    treatmentDate.length === 4 || treatmentDate.length === 7;
+  const isYearOnly = treatmentDate.replace('-', '').length === 4;
+  const validTreatmentDate = isYearOnly || treatmentDate.length === 7;
 
   const date =
     showNewFormContent && validTreatmentDate
       ? `${treatmentDate}-01`
       : evidenceDates[type] || '';
+
   return fixDateFormat(date, treatmentDate.length === 4);
 };
 

--- a/src/applications/appeals/995/utils/submit/evidence.js
+++ b/src/applications/appeals/995/utils/submit/evidence.js
@@ -37,18 +37,19 @@ import { fixDateFormat } from '../../../shared/utils/replace';
  */
 export const getTreatmentDate = (type, showNewFormContent, location) => {
   const { treatmentDate = '', evidenceDates = {}, noDate } = location;
+  const yearRegex = /^(19[2-9][6-9]|20[0-1][0-9]|202[0-5])$/;
+  const isValidYear = showNewFormContent && yearRegex.test(treatmentDate);
 
-  if (showNewFormContent && noDate) {
+  if (
+    (showNewFormContent && noDate) ||
+    (showNewFormContent && treatmentDate.length < 7 && !isValidYear)
+  ) {
     return '';
   }
 
-  const isYearOnly = treatmentDate.replace('-', '').length === 4;
-  const validTreatmentDate = isYearOnly || treatmentDate.length === 7;
-
-  const date =
-    showNewFormContent && validTreatmentDate
-      ? `${treatmentDate}-01`
-      : evidenceDates[type] || '';
+  const date = showNewFormContent
+    ? `${treatmentDate}-01`
+    : evidenceDates[type] || '';
 
   return fixDateFormat(date, treatmentDate.length === 4);
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This is another bandaid fix for the `treatmentDate` month/year experience for VA providers. If someone enters a month (January) and an invalid year (`1`), it formats as `1-01` behind the scenes, which comes out as `1-01-01-01` after all the formatting and submit utilities, which gives a 422 on the front end and fails the submission.

I added some regex to check that the year is a valid year: 4 digits and between 1926 and 2025 per the rules of the input. It didn't make sense to further refine this because this should be temporary code.

That combined with the `showNewFormContent` flag being true means we're being given a valid year only for this flow. 

In the function, we're also checking that in the new flow (`showNewFormContent` = `true`), when the `noDate` checkbox is checked, we return empty string. Also, in the new flow, when the `treatmentDate` length is less than 7 (e.g. `2020-01` is 7 characters, so anything less would be invalid) and **not** a valid year per the earlier check, we return an empty string. This should hopefully catch all the weird edge cases that people are finding.

I emphasize - this should be short-lived code until we get the new date component work in place.

This PR also includes a fix to send `noTreatmentDates: true` when the dates are not being sent to the BE.

## Screenshots

### Before

| Context | Screenshot |
| --- | --- |
| User enters a month and invalid year on the VA providers page | <img width="400" alt="Screenshot 2025-08-08 at 11 04 30 AM" src="https://github.com/user-attachments/assets/7a5cef1b-31a7-4a71-8ea3-7bdd3b6ec6a2" /> |
| In Redux, this is how we're storing the date for later | <img width="400" alt="Screenshot 2025-08-08 at 11 04 40 AM" src="https://github.com/user-attachments/assets/83e96e04-ca3f-43bc-b6fd-cf34813f47c6" /> |
| On the evidence review page, this is what the user sees | <img width="400" alt="Screenshot 2025-08-08 at 11 07 18 AM" src="https://github.com/user-attachments/assets/442635f2-ab64-42b8-b587-cb08596f29d1" /> |
| When the user tries to submit, this is what they see | <img width="400" alt="Screenshot 2025-08-08 at 11 07 28 AM" src="https://github.com/user-attachments/assets/af360f29-ff1b-411f-bf58-3ddd07a712c0" /> |
| This is what we send to the BE in the SC payload | <img width="400" alt="Screenshot 2025-08-08 at 11 11 29 AM" src="https://github.com/user-attachments/assets/a1b6c1bb-d4e3-4b17-964d-46933edb61dc" /> |

### After

| Context | Screenshot |
| --- | --- |
| User enters a month and invalid year on the VA providers page | <img width="400"  alt="Screenshot 2025-08-08 at 12 13 22 PM" src="https://github.com/user-attachments/assets/cff5bef8-cb04-45fe-8777-d6a7edc639a5" /> |
| In Redux, this is how we're storing the date for later | <img width="400" alt="Screenshot 2025-08-08 at 11 04 40 AM" src="https://github.com/user-attachments/assets/83e96e04-ca3f-43bc-b6fd-cf34813f47c6" /> |
| On the evidence review page, this is what the user sees | <img width="400" alt="Screenshot 2025-08-08 at 12 13 35 PM" src="https://github.com/user-attachments/assets/9213cddd-d899-4d9f-92cf-319a58901de5" /> |
| When the user tries to submit, this is what they see | <img width="723" height="488" alt="Screenshot 2025-08-08 at 12 13 43 PM" src="https://github.com/user-attachments/assets/45fbb8e7-6f3f-4afd-8427-9425b0c63bdb" /> |
| This is what we send to the BE in the SC payload | <img width="490" height="135" alt="Screenshot 2025-08-08 at 1 07 10 PM" src="https://github.com/user-attachments/assets/d2ed079f-6b3e-4d67-bd35-060f96221163" /> |
| This is what we see in the Rails console in the BE | <img width="878" height="117" alt="Screenshot 2025-08-08 at 1 08 25 PM" src="https://github.com/user-attachments/assets/37552085-cb1a-4a11-8242-f25138b5cb0b" /><img width="880" height="214" alt="Screenshot 2025-08-08 at 1 08 39 PM" src="https://github.com/user-attachments/assets/42940d5d-b4db-4e97-939e-89dbb3db3b10" /> |

### Related test case - entering only a month for the treatment date

| Context | Screenshot |
| --- | --- |
| This is what we send to the BE in the SC payload | <img width="493" height="184" alt="Screenshot 2025-08-08 at 1 10 25 PM" src="https://github.com/user-attachments/assets/dfc63a47-1cca-48a5-a9d3-8c43847741ba" /> |
| Submission succeeds | <img width="542" height="576" alt="Screenshot 2025-08-08 at 1 10 32 PM" src="https://github.com/user-attachments/assets/25a4bf34-1ce0-42ac-b951-a0b40330e6ea" /> |
| Rails console output | <img width="883" height="322" alt="Screenshot 2025-08-08 at 1 10 47 PM" src="https://github.com/user-attachments/assets/5325cce2-956c-4ccd-b544-ca7ccd74e5f7" /> |

### Related test case - entering only a year for the treatment date

| Context | Screenshot |
| --- | --- |
| This is what we send to the BE in the SC payload | <img width="501" height="203" alt="Screenshot 2025-08-08 at 1 14 42 PM" src="https://github.com/user-attachments/assets/44fb0752-3061-4091-bf8d-97d4ce3c4d9c" /> |
| Submission succeeds | <img width="542" height="576" alt="Screenshot 2025-08-08 at 1 10 32 PM" src="https://github.com/user-attachments/assets/25a4bf34-1ce0-42ac-b951-a0b40330e6ea" /> |
| Rails console output | <img width="877" height="324" alt="Screenshot 2025-08-08 at 1 13 52 PM" src="https://github.com/user-attachments/assets/c47c1162-0a71-4578-9917-3aec2160e8db" /> |
