### PR TITLE
Income and asset unassociated income pages updates

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -578,9 +578,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     unassociatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
-      title: showUpdatedContent()
-        ? 'Person who receives this income'
-        : 'Recurring income recipient',
+      title: 'Recurring income recipient',
       path: 'recurring-income/:index/veteran-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'VETERAN',
@@ -588,9 +586,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: veteranIncomeRecipientPage.schema,
     }),
     unassociatedIncomeSpouseRecipientPage: pageBuilder.itemPage({
-      title: showUpdatedContent()
-        ? 'Person who receives this income'
-        : 'Recurring income recipient',
+      title: 'Recurring income recipient',
       path: 'recurring-income/:index/spouse-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'SPOUSE',
@@ -598,9 +594,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: spouseIncomeRecipientPage.schema,
     }),
     unassociatedIncomeCustodianRecipientPage: pageBuilder.itemPage({
-      title: showUpdatedContent()
-        ? 'Person who receives this income'
-        : 'Recurring income recipient',
+      title: 'Recurring income recipient',
       path: 'recurring-income/:index/custodian-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
@@ -608,9 +602,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: custodianIncomeRecipientPage.schema,
     }),
     unassociatedIncomeParentRecipientPage: pageBuilder.itemPage({
-      title: showUpdatedContent()
-        ? 'Person who receives this income'
-        : 'Recurring income recipient',
+      title: 'Recurring income recipient',
       path: 'recurring-income/:index/parent-income-recipient',
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'PARENT',
@@ -618,9 +610,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: parentIncomeRecipientPage.schema,
     }),
     unassociatedIncomeNonVeteranRecipientPage: pageBuilder.itemPage({
-      title: showUpdatedContent()
-        ? 'Person who receives this income'
-        : 'Recurring income recipient',
+      title: 'Recurring income recipient',
       path: 'recurring-income/:index/income-recipient',
       depends: formData =>
         !showUpdatedContent() ||
@@ -629,9 +619,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: nonVeteranIncomeRecipientPage.schema,
     }),
     unassociatedIncomeRecipientNamePage: pageBuilder.itemPage({
-      title: showUpdatedContent()
-        ? 'Person who receives this income'
-        : 'Recurring income recipient',
+      title: 'Recurring income recipient',
       path: 'recurring-income/:index/recipient-name',
       depends: (formData, index) =>
         recipientNameRequired(formData, index, 'unassociatedIncomes'),

--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -222,6 +222,8 @@ const veteranIncomeRecipientPage = {
     }),
     recipientRelationship: radioUI({
       title: 'Who receives this income?',
+      labelHeaderLevel: '2',
+      labelHeaderLevelStyle: '3',
       labels: Object.fromEntries(
         Object.entries(relationshipLabels).filter(
           ([key]) => key !== 'PARENT' && key !== 'CUSTODIAN',
@@ -267,6 +269,8 @@ const spouseIncomeRecipientPage = {
     }),
     recipientRelationship: radioUI({
       title: 'What’s the income recipient’s relationship to the Veteran?',
+      labelHeaderLevel: '2',
+      labelHeaderLevelStyle: '3',
       labels: Object.fromEntries(
         Object.entries(relationshipLabels)
           .filter(
@@ -322,6 +326,8 @@ const custodianIncomeRecipientPage = {
     }),
     recipientRelationship: radioUI({
       title: 'What’s the income recipient’s relationship to the Veteran?',
+      labelHeaderLevel: '2',
+      labelHeaderLevelStyle: '3',
       labels: Object.fromEntries(
         Object.entries(relationshipLabels)
           .filter(
@@ -378,6 +384,8 @@ const parentIncomeRecipientPage = {
     }),
     recipientRelationship: radioUI({
       title: 'What’s the income recipient’s relationship to the Veteran?',
+      labelHeaderLevel: '2',
+      labelHeaderLevelStyle: '3',
       labels: Object.fromEntries(
         Object.entries(relationshipLabels)
           .filter(
@@ -431,6 +439,8 @@ const nonVeteranIncomeRecipientPage = {
     }),
     recipientRelationship: radioUI({
       title: 'Who receives the income?',
+      labelHeaderLevel: '2',
+      labelHeaderLevelStyle: '3',
       labels: relationshipLabels,
     }),
     otherRecipientRelationshipType: {


### PR DESCRIPTION
## Summary
Made a series of small content updates to the **Recurring income** chapter in the Income and Asset Statement form (VA Form 21P-0969). These updates include adjustments to static titles, header text, and form label/question text header hierarchy updates on the **Income recipient** pages.

## Issue
n/a

## Related issue(s)
- Part of ongoing 0969 post-MVP refinements

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Visit: `http://localhost:3001/income-and-asset-statement-form-21p-0969/`  
4. Navigate to the **Recurring income** chapter

## How to verify
1. Navigate to the **Income recipient** page
   - Confirm that the question text header have been updated
   - Ensure content matches current plain language and design guidance
2. Continue through the chapter and verify:
   - Page titles and summary headings are clear and consistent
   - Layout is preserved and screen reader behavior is unaffected

## What areas of the site does it impact?
Income and Asset Statement Application — Recurring income chapter (static content, labels, and titles)

## Screenshots
| Before                            | After                               |
|-----------------------------------|--------------------------------------|
|<img width="601" height="660" alt="Screenshot 2025-08-08 at 12 56 13 PM" src="https://github.com/user-attachments/assets/0eee6a7b-db0f-4c03-91a5-34ef4fd7779b" />|<img width="547" height="665" alt="Screenshot 2025-08-08 at 12 56 46 PM" src="https://github.com/user-attachments/assets/50c41656-6bb1-4b33-af24-d112bdeb3d3f" />


### Quality Assurance & Testing
- [ ] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in log
