### PR TITLE
DV | General cleanup

### DIFF
--- a/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
@@ -95,7 +95,7 @@ export const DependentsInformationReview = ({ data, goToPath }) => {
 
       <div className="form-review-panel-page-header-row vads-u-margin-top--4">
         <h4 className="form-review-panel-page-header vads-u-font-size--h5 vads-u-margin--0">
-          Status of dependents
+          Has the status of your dependents changed?
         </h4>
         <va-button
           secondary

--- a/src/applications/dependents/dependents-verification/components/Gateway.jsx
+++ b/src/applications/dependents/dependents-verification/components/Gateway.jsx
@@ -106,6 +106,7 @@ const Gateway = ({ route, top = false }) => {
           messages={formConfig.savedFormMessages}
           pageList={pageList}
           startText="Start your disability benefits dependents verification"
+          formConfig={formConfig}
         />
       );
   }

--- a/src/applications/dependents/dependents-verification/components/Gateway.jsx
+++ b/src/applications/dependents/dependents-verification/components/Gateway.jsx
@@ -77,9 +77,9 @@ const Gateway = ({ route, top = false }) => {
     case 'no-dependents':
       return top ? (
         <va-alert status="info" visible>
-          <h3 slot="headline">
+          <h2 slot="headline">
             We don’t have any dependents information on file for you
-          </h3>
+          </h2>
           <p>We can’t find any dependents added to your disability award.</p>
           <va-link
             href="/view-change-dependents"
@@ -90,7 +90,7 @@ const Gateway = ({ route, top = false }) => {
     case 'error':
       return top ? (
         <va-alert status="error" visible>
-          <h3 slot="headline">Error Loading Dependents</h3>
+          <h2 slot="headline">Error Loading Dependents</h2>
           <p>
             There was an error loading your dependents. Please try again later
             or contact support.

--- a/src/applications/dependents/dependents-verification/components/VeteranContactInformationReviewPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranContactInformationReviewPage.jsx
@@ -195,7 +195,7 @@ const VeteranContactInformationReviewPage = ({ data, goToPath }) => {
           </dd>
         </div>
         <div className="review-row">
-          <dt>Email address</dt>
+          <dt>Electronic correspondence agreement</dt>
           <dd className="dd-privacy-hidden" data-dd-action-name="email address">
             <strong>
               {electronicCorrespondenceMessage(electronicCorrespondence)}

--- a/src/applications/dependents/dependents-verification/components/VeteranInformationComponent.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranInformationComponent.jsx
@@ -28,7 +28,7 @@ export const VeteranInformation = ({ formData }) => {
       <h3>Your personal information</h3>
       <p>
         This is part of the information we’ll submit on your behalf for your
-        verification of dependents (VA Form 21-0538)
+        verification of dependents (VA Form 21-0538).
       </p>
       <va-card>
         <h4 className="vads-u-font-size--h3 vads-u-margin-top--1">

--- a/src/applications/dependents/dependents-verification/containers/IntroductionPage.jsx
+++ b/src/applications/dependents/dependents-verification/containers/IntroductionPage.jsx
@@ -23,7 +23,7 @@ const ProcessList = () => {
         </p>
       </va-process-list-item>
       <va-process-list-item header="Review your active dependents and your information">
-        <p>Here’s what you will need to review:</p>
+        <p>Here’s what you’ll need to review:</p>
         <ul>
           <li>
             Your active VA dependents currently listed under your disability
@@ -73,7 +73,7 @@ export const IntroductionPage = props => {
     <article className="schemaform-intro">
       <FormTitle title={TITLE} subTitle={SUBTITLE} />
       <Gateway route={route} top />
-      <p className="vads-u-font-family--serif vads-u-font-size--md vads-u-margin-top--neg2 vads-u-margin-bottom--neg1 va-introtext">
+      <p className="va-introtext">
         Use our online tool to submit your dependent verification form for VA
         disability benefits.
       </p>

--- a/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
@@ -29,7 +29,7 @@ describe('DependentsInformationReview', () => {
     expect($$('h4', container).map(h4 => h4.textContent)).to.deep.equal([
       'Morty Smith',
       'Summer Smith',
-      'Status of dependents',
+      'Has the status of your dependents changed?',
     ]);
     const text = $$('.review-row', container).map(row => row.textContent);
     expect(text).to.deep.equal([

--- a/src/applications/dependents/dependents-verification/tests/unit/components/Gateway.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/Gateway.unit.spec.jsx
@@ -84,7 +84,7 @@ describe('Gateway', () => {
       expect(global.fetch.args[0][0]).to.contain('/show');
       const alert = $('va-alert[status="info"]', container);
       expect(alert).to.exist;
-      expect($('h3', alert).textContent).to.eq(
+      expect($('h2', alert).textContent).to.eq(
         'We don’t have any dependents information on file for you',
       );
     });
@@ -101,7 +101,7 @@ describe('Gateway', () => {
       expect(global.fetch.args[0][0]).to.contain('/show');
       const alert = $('va-alert[status="error"]', container);
       expect(alert).to.exist;
-      expect($('h3', alert).textContent).to.eq('Error Loading Dependents');
+      expect($('h2', alert).textContent).to.eq('Error Loading Dependents');
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Updating introduction page:
  > - Remove negative margins and duplicate classes from intro text
  > - Fix alert heading levels
  > - Update content to include contraction
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116035
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116041
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116111

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Intro page  | <img width="754" alt="negative margins causing overlap of no dependents alert, and step 2 shows 'you will' instead of a contraction" src="https://github.com/user-attachments/assets/027e4a39-a49b-4f2b-8352-e3175998de13" /> | <img width="768" alt="Remove negative margins adds appropriate spacing around alert, and step 2 includes a you’ll contraction" src="https://github.com/user-attachments/assets/df8d20c0-bea0-46a5-9887-5ac920d55b8c" /> |
| Heading level | <img width="1097" alt="No dependents alert h3 showing a headings map extension panel with a jump from h1 to h3" src="https://github.com/user-attachments/assets/ae4aa03c-c8ce-4240-bdd5-9bb6efed4749" /> | <img width="1082" alt="Headings map extension showing the alert with an h2 heading and appropriate heading levels" src="https://github.com/user-attachments/assets/3f2d627d-7c37-456a-8007-5dd96325c354" /> |
| In progress message | <img width="747" alt="Your application is in progress" src="https://github.com/user-attachments/assets/c04cdcb0-e012-42be-af8e-ec085f2da916" /> | <img width="745" alt="Your dependent-benefits form is in progress" src="https://github.com/user-attachments/assets/c2984785-8526-4537-a2bf-0db6ff999174" /> |
| Veteran info (period) | <img width="580" height="134" alt="Missing period at end of sentence" src="https://github.com/user-attachments/assets/d53214ce-9245-4da1-bb7f-46265af6fa8c" /> | <img width="573" height="145" alt="sentence ending with a period" src="https://github.com/user-attachments/assets/667a1415-da3a-47ee-8efd-896d9800ddc8" /> |
| Review email | <img width="744" alt="email address labeled twice for address and agreement checkbox" src="https://github.com/user-attachments/assets/bbc0cb9d-107e-4283-b41e-ca631847ad7e" /> | <img width="734" alt="email address label for address and electronic correspondence agreement label for checkbox" src="https://github.com/user-attachments/assets/efe695b2-46d8-4d5b-ac86-402c63ea8b23" /> |
| Status of dependents title | <img width="739" alt="Status of dependents page title" src="https://github.com/user-attachments/assets/b6a4b94f-b731-4ecc-8e45-8a41dc12a91b" /> | <img width="738" alt="Status of dependents page title changed to 'has the status of your dependents changed?'" src="https://github.com/user-attachments/assets/31df62a8-eb1b-4ee6-b3af-b0d7a219e1a3" /> | 

## What areas of the site does it impact?

Dependents Verification Form (21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
