### PR TITLE
Letter: update aria live region for edit address to be less intrusive

### DIFF
--- a/src/applications/letters/containers/NewAddressSection.jsx
+++ b/src/applications/letters/containers/NewAddressSection.jsx
@@ -88,8 +88,14 @@ export function NewAddressSection({ success }) {
             </va-alert>
           )}
           <va-card className="vads-u-justify-content--space-between">
-            <div aria-live="polite" aria-relevant="all" className="sr-only">
-              {isEditing && 'Edit address mode is active.'}
+            <div
+              aria-live="polite"
+              aria-relevant="all"
+              aria-atomic="true"
+              className="sr-only"
+              tabIndex={-1}
+            >
+              {isEditing ? 'Edit address mode is active.' : ''}
             </div>
             <ProfileInformationFieldController
               fieldName={FIELD_NAMES.MAILING_ADDRESS}

--- a/src/applications/letters/containers/NewAddressSection.jsx
+++ b/src/applications/letters/containers/NewAddressSection.jsx
@@ -84,7 +84,7 @@ export function NewAddressSection({ success }) {
           } else {
             checkbox.focus();
           }
-        }, 100);
+        }, 300);
       };
 
       // Attach the event listener

--- a/src/applications/letters/containers/NewAddressSection.jsx
+++ b/src/applications/letters/containers/NewAddressSection.jsx
@@ -88,11 +88,9 @@ export function NewAddressSection({ success }) {
             </va-alert>
           )}
           <va-card className="vads-u-justify-content--space-between">
-            {isEditing && (
-              <div aria-live="polite" aria-relevant="all" className="sr-only">
-                Edit address mode is active.
-              </div>
-            )}
+            <div aria-live="polite" aria-relevant="all" className="sr-only">
+              {isEditing && 'Edit address mode is active.'}
+            </div>
             <ProfileInformationFieldController
               fieldName={FIELD_NAMES.MAILING_ADDRESS}
               ariaDescribedBy={`described-by-${FIELD_NAMES.MAILING_ADDRESS}`}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request enhances accessibility for the address editing experience by introducing an `aria-live` region and managing focus behavior for checkboxes in the `NewAddressSection` component. It also adds a unit test to verify the new accessibility features.

**Accessibility improvements:**

* Added an `aria-live` region to the `NewAddressSection` component to announce when edit mode is active, improving screen reader support. The region is visually hidden with the `sr-only` class and dynamically updates its content based on editing state.
* Implemented logic using a `MutationObserver` to detect when the user enters or exits address edit mode by monitoring the presence of the edit button, updating the `isEditing` state accordingly.
* Enhanced keyboard navigation by intercepting focus events on the first checkbox during edit mode: when focused, the `aria-live` region receives focus first to provide context, then focus returns to the checkbox input.

**Testing:**

* Added a unit test to verify that the `aria-live` region is rendered and updates its content appropriately when entering edit mode.

**Code maintenance:**

* Updated imports to include `useState` and added new refs and state variables to support the accessibility features. [[1]](diffhunk://#diff-3369f372b00c6d0f2f3a2b09b98006623ff6798bb5fb126a5239b012c3a3df1cL1-R1) [[2]](diffhunk://#diff-3369f372b00c6d0f2f3a2b09b98006623ff6798bb5fb126a5239b012c3a3df1cR12-R15)

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#116266

## Testing done

- Tested locally using user +54
- Tested by both canceling and submitting after opening the edit panel
- Used mock API responses to validate behavior with submission

## Screenshots

Video demo:

https://github.com/user-attachments/assets/f20f8757-3f87-44f4-9c33-fde379c9afc1

## What areas of the site does it impact?

Letters page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable). (n/a)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary) (n/a)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (n/a)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
