### PR TITLE
116002: Add RUM browser monitoring for 0969

### DIFF
--- a/src/applications/income-and-asset-statement/containers/App.jsx
+++ b/src/applications/income-and-asset-statement/containers/App.jsx
@@ -68,10 +68,9 @@ function App({ location, children, isLoggedIn }) {
 }
 
 const mapStateToProps = state => {
-  const { featureToggles, user } = state;
+  const { user } = state;
   return {
     isLoggedIn: user?.login?.currentlyLoggedIn,
-    featureToggles,
   };
 };
 

--- a/src/applications/income-and-asset-statement/containers/App.jsx
+++ b/src/applications/income-and-asset-statement/containers/App.jsx
@@ -3,10 +3,7 @@ import { connect, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import {
-  canInitDatadog,
-  useBrowserMonitoring,
-} from 'platform/monitoring/Datadog/';
+import { useBrowserMonitoring } from 'platform/monitoring/Datadog/';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import environment from 'platform/utilities/environment';
 import formConfig from '../config/form';
@@ -54,10 +51,6 @@ function App({ location, children, isLoggedIn }) {
     },
     [isLoadingFeatures, incomeAndAssetsContentUpdates],
   );
-
-  if (!canInitDatadog()) {
-    return <NoFormPage />;
-  }
 
   if (isLoadingFeatures) {
     return <va-loading-indicator message="Loading application..." />;

--- a/src/applications/income-and-asset-statement/containers/App.jsx
+++ b/src/applications/income-and-asset-statement/containers/App.jsx
@@ -1,13 +1,18 @@
 import React, { useEffect } from 'react';
+import { connect, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import {
+  canInitDatadog,
+  useBrowserMonitoring,
+} from 'platform/monitoring/Datadog/';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
+import environment from 'platform/utilities/environment';
 import formConfig from '../config/form';
 import { NoFormPage } from '../components/NoFormPage';
 
-export default function App({ location, children }) {
+function App({ location, children, isLoggedIn }) {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const incomeAndAssetsFormEnabled = useToggleValue(
     TOGGLE_NAMES.incomeAndAssetsFormEnabled,
@@ -21,6 +26,23 @@ export default function App({ location, children }) {
     state => state?.featureToggles?.loading ?? false,
   );
 
+  // Add Datadog UX monitoring to the application
+  useBrowserMonitoring({
+    loggedIn: isLoggedIn,
+    toggleName: 'incomeAndAssetsBrowserMonitoringEnabled',
+    applicationId: '58e7ffff-9710-46f0-bf72-bf1f7b0f1ba4',
+    clientToken: 'puba95e30e73b0bae094ea212fca3870ef3',
+    // `site` refers to the Datadog site parameter of your organization
+    // see https://docs.datadoghq.com/getting_started/site/
+    service: 'benefits-income-and-assets',
+    version: '1.0.0',
+    // record 100% of staging sessions, but only 20% of production
+    sessionReplaySampleRate:
+      environment.vspEnvironment() === 'staging' ? 100 : 20,
+    sessionSampleRate: 100,
+    defaultPrivacyLevel: 'mask-user-input',
+  });
+
   useEffect(
     () => {
       if (!isLoadingFeatures) {
@@ -32,6 +54,10 @@ export default function App({ location, children }) {
     },
     [isLoadingFeatures, incomeAndAssetsContentUpdates],
   );
+
+  if (!canInitDatadog()) {
+    return <NoFormPage />;
+  }
 
   if (isLoadingFeatures) {
     return <va-loading-indicator message="Loading application..." />;
@@ -48,7 +74,18 @@ export default function App({ location, children }) {
   );
 }
 
+const mapStateToProps = state => {
+  const { featureToggles, user } = state;
+  return {
+    isLoggedIn: user?.login?.currentlyLoggedIn,
+    featureToggles,
+  };
+};
+
 App.propTypes = {
   children: PropTypes.node.isRequired,
   location: PropTypes.object.isRequired,
+  isLoggedIn: PropTypes.bool,
 };
+
+export default connect(mapStateToProps)(App);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -126,6 +126,7 @@
   "hlrBrowserMonitoringEnabled": "hlr_browser_monitoring_enabled",
   "incomeAndAssetsFormEnabled": "income_and_assets_form_enabled",
   "incomeAndAssetsContentUpdates": "income_and_assets_content_updates",
+  "incomeAndAssetsBrowserMonitoringEnabled": "income_and_assets_browser_monitoring_enabled",
   "intentToFileLighthouseEnabled": "intent_to_file_lighthouse_enabled",
   "intentToFileSynchronousEnabled": "intent_to_file_synchronous_enabled",
   "lettersCheckDiscrepancies": "letters_check_discrepancies",


### PR DESCRIPTION
Added the RUM browser monitoring logic to the 0969 App.jsx This PR https://github.com/department-of-veterans-affairs/vets-api/pull/23497 needs to go up first

## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add feature flag
- Add logic for isLoggedIn
- Add logic for `useBrowserMonitoring`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116002
