### PR TITLE
Use dynamic net worth value

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
@@ -38,14 +38,15 @@ export const whatAreAssets = (
   </>
 );
 
-export const netWorthTitle = ({ netWorthLimit, featureFlag }) => {
+export const netWorthTitle = ({ netWorthLimit, featureFlag } = {}) => {
   if (!featureFlag) {
     return `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`;
   }
 
-  const number = `${netWorthLimit}` || NETWORTH_VALUE;
-  const formattedNumber = parseInt(number.replace(/,/g, ''), 10).toLocaleString(
-    'en-US',
-  );
+  const number = netWorthLimit || NETWORTH_VALUE;
+  const formattedNumber = parseInt(
+    `${number}`.replace(/,/g, ''),
+    10,
+  ).toLocaleString('en-US');
   return `Did the household have a net worth greater than $${formattedNumber} in the last tax year?`;
 };

--- a/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
@@ -38,12 +38,12 @@ export const whatAreAssets = (
   </>
 );
 
-export const netWorthTitle = ({ networthValue, featureFlag }) => {
+export const netWorthTitle = ({ netWorthLimit, featureFlag }) => {
   if (!featureFlag) {
     return `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`;
   }
 
-  const number = `${networthValue}` || NETWORTH_VALUE;
+  const number = `${netWorthLimit}` || NETWORTH_VALUE;
   const formattedNumber = parseInt(number.replace(/,/g, ''), 10).toLocaleString(
     'en-US',
   );

--- a/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
@@ -38,4 +38,10 @@ export const whatAreAssets = (
   </>
 );
 
-export const netWorthTitle = `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`;
+export const netWorthTitle = networthValue => {
+  const number = `${networthValue}` || NETWORTH_VALUE;
+  const formattedNumber = parseInt(number.replace(/,/g, ''), 10).toLocaleString(
+    'en-US',
+  );
+  return `Did the household have a net worth greater than $${formattedNumber} in the last tax year?`;
+};

--- a/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/helpers.js
@@ -38,7 +38,11 @@ export const whatAreAssets = (
   </>
 );
 
-export const netWorthTitle = networthValue => {
+export const netWorthTitle = ({ networthValue, featureFlag }) => {
+  if (!featureFlag) {
+    return `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`;
+  }
+
   const number = `${networthValue}` || NETWORTH_VALUE;
   const formattedNumber = parseInt(number.replace(/,/g, ''), 10).toLocaleString(
     'en-US',

--- a/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
@@ -19,7 +19,7 @@ export const uiSchema = {
   ),
   'ui:description': whatAreAssets,
   householdIncome: yesNoUI({
-    title: netWorthTitle({}),
+    title: netWorthTitle(),
     enableAnalytics: true,
     updateUiSchema: formData => ({
       'ui:title': netWorthTitle({

--- a/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
@@ -19,7 +19,10 @@ export const uiSchema = {
   ),
   'ui:description': whatAreAssets,
   householdIncome: yesNoUI({
-    title: netWorthTitle,
+    title: netWorthTitle(),
     enableAnalytics: true,
+    updateUiSchema: formData => ({
+      'ui:title': netWorthTitle(formData?.netWorthLimit),
+    }),
   }),
 };

--- a/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
@@ -19,11 +19,11 @@ export const uiSchema = {
   ),
   'ui:description': whatAreAssets,
   householdIncome: yesNoUI({
-    title: netWorthTitle(),
+    title: netWorthTitle({}),
     enableAnalytics: true,
     updateUiSchema: formData => ({
       'ui:title': netWorthTitle({
-        netWorthValue: formData?.netWorthLimit,
+        netWorthLimit: formData?.netWorthLimit,
         featureFlag: formData?.vaDependentsNetWorthAndPension,
       }),
     }),

--- a/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/dependents/686c-674/config/chapters/household-income/householdIncome.js
@@ -22,7 +22,10 @@ export const uiSchema = {
     title: netWorthTitle(),
     enableAnalytics: true,
     updateUiSchema: formData => ({
-      'ui:title': netWorthTitle(formData?.netWorthLimit),
+      'ui:title': netWorthTitle({
+        netWorthValue: formData?.netWorthLimit,
+        featureFlag: formData?.vaDependentsNetWorthAndPension,
+      }),
     }),
   }),
 };

--- a/src/applications/dependents/686c-674/config/prefill-transformer.js
+++ b/src/applications/dependents/686c-674/config/prefill-transformer.js
@@ -1,6 +1,11 @@
+import { NETWORTH_VALUE } from './constants';
+
 export default function prefillTransformer(pages, formData, metadata) {
-  const { veteranSsnLastFour = '', veteranVaFileNumberLastFour = '' } =
-    formData?.nonPrefill || {};
+  const {
+    veteranSsnLastFour = '',
+    veteranVaFileNumberLastFour = '',
+    netWorthLimit = NETWORTH_VALUE,
+  } = formData?.nonPrefill || {};
   const contact = formData?.veteranContactInformation || {};
   const address = contact.veteranAddress || {};
   const isMilitary =
@@ -30,6 +35,7 @@ export default function prefillTransformer(pages, formData, metadata) {
         emailAddress: contact.emailAddress || null,
       },
       useV2: true,
+      netWorthLimit,
       daysTillExpires: 365,
     },
     metadata,

--- a/src/applications/dependents/686c-674/containers/App.jsx
+++ b/src/applications/dependents/686c-674/containers/App.jsx
@@ -43,13 +43,7 @@ function App({
   });
 
   const { useFormFeatureToggleSync } = useFeatureToggle();
-  useFormFeatureToggleSync([
-    'featureToggleNameAndDataKey',
-    {
-      toggleName: 'vaDependentsNetWorthAndPension',
-      formKey: 'vaDependentsNetWorthAndPension',
-    },
-  ]);
+  useFormFeatureToggleSync(['vaDependentsNetWorthAndPension']);
 
   // Handle loading
   if (isLoading) {

--- a/src/applications/dependents/686c-674/containers/App.jsx
+++ b/src/applications/dependents/686c-674/containers/App.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { useBrowserMonitoring } from 'platform/monitoring/Datadog/';
 import environment from 'platform/utilities/environment';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 
 import manifest from '../manifest.json';
 import formConfig from '../config/form';
@@ -40,6 +41,15 @@ function App({
       environment.vspEnvironment() === 'staging' ? 100 : 20,
     sessionSampleRate: 50,
   });
+
+  const { useFormFeatureToggleSync } = useFeatureToggle();
+  useFormFeatureToggleSync([
+    'featureToggleNameAndDataKey',
+    {
+      toggleName: 'vaDependentsNetWorthAndPension',
+      formKey: 'vaDependentsNetWorthAndPension',
+    },
+  ]);
 
   // Handle loading
   if (isLoading) {

--- a/src/applications/dependents/686c-674/tests/config/chapters/household-income/helpers.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/household-income/helpers.unit.spec.jsx
@@ -1,0 +1,177 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import {
+  whatAreAssets,
+  netWorthTitle,
+} from '../../../../config/chapters/household-income/helpers';
+import { NETWORTH_VALUE } from '../../../../config/constants';
+
+describe('household income helpers', () => {
+  describe('whatAreAssets', () => {
+    it('should render the assets accordion with correct structure', () => {
+      const { container } = render(whatAreAssets);
+
+      const accordion = container.querySelector('va-accordion');
+      expect(accordion).to.not.be.null;
+      expect(accordion.getAttribute('open-single')).to.equal('true');
+    });
+
+    it('should render the accordion item with correct attributes', () => {
+      const { container } = render(whatAreAssets);
+
+      const accordionItem = container.querySelector('va-accordion-item');
+      expect(accordionItem).to.not.be.null;
+      expect(accordionItem.getAttribute('id')).to.equal(
+        'what-we-count-as-assets',
+      );
+      expect(accordionItem.getAttribute('header')).to.equal(
+        'What we count as assets',
+      );
+      expect(accordionItem.getAttribute('bordered')).to.equal('true');
+      expect(accordionItem.getAttribute('level')).to.equal('4');
+    });
+
+    it('should contain the correct content about assets', () => {
+      const { container } = render(whatAreAssets);
+
+      const content = container.textContent;
+      expect(content).to.include('Assets include the fair market value');
+      expect(content).to.include('Investments (like stocks and bonds)');
+      expect(content).to.include('Furniture');
+      expect(content).to.include('Boats');
+    });
+
+    it('should contain the correct content about excluded items', () => {
+      const { container } = render(whatAreAssets);
+
+      const content = container.textContent;
+      expect(content).to.include('include the value of these items:');
+      expect(content).to.include('Your primary residence');
+      expect(content).to.include('Your car');
+      expect(content).to.include('Basic home items like appliances');
+    });
+
+    it('should have two unordered lists', () => {
+      const { container } = render(whatAreAssets);
+
+      const lists = container.querySelectorAll('ul');
+      expect(lists).to.have.lengthOf(2);
+    });
+
+    it('should have the correct number of list items', () => {
+      const { container } = render(whatAreAssets);
+
+      const listItems = container.querySelectorAll('li');
+      expect(listItems).to.have.lengthOf(6); // 3 in first list + 3 in second list
+    });
+  });
+
+  describe('netWorthTitle', () => {
+    it('should return default title when feature flag is false', () => {
+      const result = netWorthTitle({ featureFlag: false });
+
+      expect(result).to.equal(
+        `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`,
+      );
+    });
+
+    it('should return default title when feature flag is undefined', () => {
+      const result = netWorthTitle({});
+
+      expect(result).to.equal(
+        `Did the household have a net worth greater than $${NETWORTH_VALUE} in the last tax year?`,
+      );
+    });
+
+    it('should return formatted title when feature flag is true and netWorthLimit is provided', () => {
+      const result = netWorthTitle({
+        featureFlag: true,
+        netWorthLimit: '200000',
+      });
+
+      expect(result).to.equal(
+        'Did the household have a net worth greater than $200,000 in the last tax year?',
+      );
+    });
+
+    it('should handle netWorthLimit with commas', () => {
+      const result = netWorthTitle({
+        featureFlag: true,
+        netWorthLimit: '1,500,000',
+      });
+
+      expect(result).to.equal(
+        'Did the household have a net worth greater than $1,500,000 in the last tax year?',
+      );
+    });
+
+    it('should use default NETWORTH_VALUE when netWorthLimit is not provided and feature flag is true', () => {
+      const result = netWorthTitle({
+        featureFlag: true,
+      });
+
+      // When netWorthLimit is undefined, it falls back to NETWORTH_VALUE
+      const expectedValue = parseInt(
+        NETWORTH_VALUE.replace(/,/g, ''),
+        10,
+      ).toLocaleString('en-US');
+      expect(result).to.equal(
+        `Did the household have a net worth greater than $${expectedValue} in the last tax year?`,
+      );
+    });
+
+    it('should handle empty string netWorthLimit', () => {
+      const result = netWorthTitle({
+        featureFlag: true,
+        netWorthLimit: '',
+      });
+
+      // Empty string falls back to NETWORTH_VALUE
+      const expectedValue = parseInt(
+        NETWORTH_VALUE.replace(/,/g, ''),
+        10,
+      ).toLocaleString('en-US');
+      expect(result).to.equal(
+        `Did the household have a net worth greater than $${expectedValue} in the last tax year?`,
+      );
+    });
+
+    it('should handle null netWorthLimit', () => {
+      const result = netWorthTitle({
+        featureFlag: true,
+        netWorthLimit: null,
+      });
+
+      // When netWorthLimit is null, it falls back to NETWORTH_VALUE
+      const expectedValue = parseInt(
+        NETWORTH_VALUE.replace(/,/g, ''),
+        10,
+      ).toLocaleString('en-US');
+      expect(result).to.equal(
+        `Did the household have a net worth greater than $${expectedValue} in the last tax year?`,
+      );
+    });
+
+    it('should format large numbers correctly', () => {
+      const result = netWorthTitle({
+        featureFlag: true,
+        netWorthLimit: '12345678',
+      });
+
+      expect(result).to.equal(
+        'Did the household have a net worth greater than $12,345,678 in the last tax year?',
+      );
+    });
+
+    it('should handle small numbers correctly', () => {
+      const result = netWorthTitle({
+        featureFlag: true,
+        netWorthLimit: '100',
+      });
+
+      expect(result).to.equal(
+        'Did the household have a net worth greater than $100 in the last tax year?',
+      );
+    });
+  });
+});

--- a/src/applications/dependents/686c-674/tests/config/prefill-transformer.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/prefill-transformer.unit.spec.jsx
@@ -7,12 +7,14 @@ const buildData = ({
   city = 'Decatur',
   useV2 = true,
   daysTillExpires = 365,
+  netWorthLimit = '159,240',
 }) => ({
   prefill: {
     data: {},
     nonPrefill: {
       veteranSsnLastFour: ssnLastFour,
       veteranVaFileNumberLastFour: vaFileLastFour,
+      netWorthLimit,
     },
     veteranContactInformation: {
       veteranAddress: {
@@ -31,6 +33,7 @@ const buildData = ({
   result: {
     useV2,
     daysTillExpires,
+    netWorthLimit,
     veteranInformation: {
       ssnLastFour,
       vaFileLastFour,
@@ -72,6 +75,7 @@ describe('NOD prefill transformer', () => {
       formData: {
         useV2: true,
         daysTillExpires: 365,
+        netWorthLimit: '159,240',
         veteranInformation: {
           ssnLastFour: '',
           vaFileLastFour: '',
@@ -111,6 +115,34 @@ describe('NOD prefill transformer', () => {
 
   describe('prefill contact info with military address', () => {
     it('should transform contact info when present', () => {
+      const { pages, metadata } = noTransformData;
+      const data = buildData({
+        ssnLastFour: '9876',
+        vaFileLastFour: '7654',
+        city: 'APO',
+      });
+      const transformedData = prefillTransformer(pages, data.prefill, metadata)
+        .formData;
+
+      expect(transformedData).to.deep.equal(data.result);
+    });
+  });
+
+  describe('prefill with netWorthValue', () => {
+    it('should use netWorthValue when present', () => {
+      const { pages, metadata } = noTransformData;
+      const data = buildData({
+        ssnLastFour: '9876',
+        vaFileLastFour: '7654',
+        city: 'APO',
+        netWorthLimit: '200,000',
+      });
+      const transformedData = prefillTransformer(pages, data.prefill, metadata)
+        .formData;
+
+      expect(transformedData).to.deep.equal(data.result);
+    });
+    it('should use default value for netWorthValue when absent', () => {
       const { pages, metadata } = noTransformData;
       const data = buildData({
         ssnLastFour: '9876',

--- a/src/applications/dependents/686c-674/tests/config/prefill-transformer.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/prefill-transformer.unit.spec.jsx
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import prefillTransformer from '../../config/prefill-transformer';
+import { NETWORTH_VALUE } from '../../config/constants';
 
 const buildData = ({
   ssnLastFour = '',
@@ -7,7 +8,7 @@ const buildData = ({
   city = 'Decatur',
   useV2 = true,
   daysTillExpires = 365,
-  netWorthLimit = '159,240',
+  netWorthLimit = NETWORTH_VALUE,
 }) => ({
   prefill: {
     data: {},
@@ -75,7 +76,7 @@ describe('NOD prefill transformer', () => {
       formData: {
         useV2: true,
         daysTillExpires: 365,
-        netWorthLimit: '159,240',
+        netWorthLimit: NETWORTH_VALUE,
         veteranInformation: {
           ssnLastFour: '',
           vaFileLastFour: '',
@@ -153,6 +154,7 @@ describe('NOD prefill transformer', () => {
         .formData;
 
       expect(transformedData).to.deep.equal(data.result);
+      expect(transformedData.netWorthLimit).to.equal(NETWORTH_VALUE);
     });
   });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -300,6 +300,7 @@
   "travelPayClaimsManagementDecisionReason": "travel_pay_claims_management_decision_reason",
   "useFacilitiesApiV2ForCernerCTA": "use_facilities_api_v2_for_cerner_cta",
   "useLighthouseFormsSearchLogic": "new_va_forms_search",
+  "vaDependentsNetWorthAndPension": "va_dependents_net_worth_and_pension",
   "vaDependentsVerification": "va_dependents_verification",
   "vaDependentsV2": "va_dependents_v2",
   "vaDependentsV2Banner": "va_dependents_v2_banner",


### PR DESCRIPTION
## Summary
This pull request updates the way the net worth question is displayed and handled in the dependents application form. The main improvement is that the net worth threshold shown to users is now dynamically formatted and can be customized based on form data, rather than being a static string. Additionally, the prefill logic is updated to ensure the net worth limit is available throughout the form.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/96876

## Testing done

- Updated tests
- Verified the default value is shown when the value is not returned in prefill
- Verified the updated value is shown when the value is returned in prefill

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    <img width="577" height="349" alt="Before" src="https://github.com/user-attachments/assets/4c9cb99e-ff11-4071-8b80-00615e3b8d35" /> |   <img width="546" height="363" alt="After" src="https://github.com/user-attachments/assets/29b09851-7911-4464-90b8-d1239d30dffb" />    |

## What areas of the site does it impact?

Dependents

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
