### PR TITLE
114839 results page content

### DIFF
--- a/src/applications/appeals/onramp/constants/results-content/cards.jsx
+++ b/src/applications/appeals/onramp/constants/results-content/cards.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export const DISABILITY_COMP_CARD = explanation => (
+  <va-card>
+    <h2 className="vads-u-margin-top--0">Disability Compensation Claim</h2>
+    <p>{explanation}</p>
+    <va-link
+      external
+      class="vads-u-display--block vads-u-margin-bottom--2"
+      href="/disability/how-to-file-claim"
+      text="Learn more about Disability Benefits"
+    />
+    <va-link-action
+      href="/disability/file-disability-claim-form-21-526ez/introduction"
+      text="Start disability compensation application"
+    />
+  </va-card>
+);
+
+export const CLAIM_FOR_INCREASE_CARD = (
+  <va-card>
+    <h2 className="vads-u-margin-top--0">Claim for increase</h2>
+    <p>
+      This may be a good fit because your condition has worsened since the
+      decision on your initial claim.
+    </p>
+    <p>
+      <strong>Note:</strong> You’ll need to submit evidence with your claim.
+    </p>
+    <va-link
+      external
+      class="vads-u-display--block vads-u-margin-bottom--2"
+      href="/disability/how-to-file-claim/evidence-needed/#what-should-the-evidence-show-"
+      text="Learn more about evidence for a claim for increase"
+    />
+    <va-link-action
+      href="/disability/file-disability-claim-form-21-526ez/introduction"
+      text="Start disability compensation application"
+    />
+  </va-card>
+);

--- a/src/applications/appeals/onramp/constants/results-content/common.jsx
+++ b/src/applications/appeals/onramp/constants/results-content/common.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import manifest from '../../manifest.json';
+
+const HORIZ_RULE = <hr className="vads-u-margin-y--4" />;
+export const NON_DR_HEADING = `Your available options`;
+export const DR_HEADING = `Your decision review options`;
+
+export const PRINT_OR_RESTART = (
+  <>
+    <h2 className="vads-u-margin-bottom--3">Print your results</h2>
+    <p>
+      You can print this page to keep a summary of your answers and the options
+      that may apply to you.
+    </p>
+    <va-button
+      class="vads-u-width--full"
+      onClick={window.print}
+      text="Print this page"
+    />
+    {HORIZ_RULE}
+    <h2 className="vads-u-margin-bottom--3">Want to explore other pathways?</h2>
+    <p className="vads-u-margin-bottom--3">
+      We showed decision review options based on your responses. If your
+      situation changes—or you want to see other options for a different
+      reason—you can restart the guide.
+    </p>
+    <va-link-action href={manifest.rootUrl} text="Restart the guide" />
+  </>
+);
+
+export const DIVIDED_BENES = (
+  <>
+    <h2 className="vads-u-margin-top--3">
+      If you’re requesting a change to how benefits are divided
+    </h2>
+    <p>
+      Some contested claims—like apportionments—may follow a different process.
+    </p>
+    <va-link
+      external
+      href="/find-forms/about-form-21-0788"
+      text="Learn how to apply to receive an Apportionment of Beneficiary's Award"
+    />
+  </>
+);

--- a/src/applications/appeals/onramp/constants/results-data-map.js
+++ b/src/applications/appeals/onramp/constants/results-data-map.js
@@ -1,3 +1,16 @@
+import React from 'react';
+import manifest from '../manifest.json';
+import {
+  DISABILITY_COMP_CARD,
+  CLAIM_FOR_INCREASE_CARD,
+} from './results-content/cards';
+import {
+  DIVIDED_BENES,
+  DR_HEADING,
+  NON_DR_HEADING,
+  PRINT_OR_RESTART,
+} from './results-content/common';
+
 export const RESULTS_NAME_MAP = Object.freeze({
   RESULTS_1_1B: 'RESULTS_1_1B',
   RESULTS_1_1C: 'RESULTS_1_1C',
@@ -9,4 +22,146 @@ export const RESULTS_NAME_MAP = Object.freeze({
   RESULTS_BOARD_EVIDENCE: 'RESULTS_BOARD_EVIDENCE',
   RESULTS_BOARD_HEARING: 'RESULTS_BOARD_HEARING',
   RESULTS_BOARD_DIRECT: 'RESULTS_BOARD_DIRECT',
+});
+
+export const RESULTS_CONTENT = Object.freeze({
+  RESULTS_1_1B: {
+    h1: NON_DR_HEADING,
+    bodyContent: (
+      <>
+        <p>
+          Based on your answers, a decision review may not be available because
+          you haven’t filed an initial claim for this condition.
+        </p>
+        <p className="vads-u-margin-bottom--3">
+          VA can only review decisions that have already been made. To move
+          forward, you’ll need to file an initial claim first.
+        </p>
+        {DISABILITY_COMP_CARD(
+          `This may be a good fit because you haven’t filed a claim yet.`,
+        )}
+        {PRINT_OR_RESTART}
+      </>
+    ),
+  },
+  RESULTS_1_1C: {
+    h1: NON_DR_HEADING,
+    bodyContent: (
+      <>
+        <p>
+          Based on your answers, a decision review may not be available because:
+        </p>
+        <ul>
+          <li>
+            You’ve submitted a claim, <strong>and</strong>
+          </li>
+          <li>You haven’t received a decision</li>
+        </ul>
+        <p>
+          Once you get your decision letter, you’ll be able to request a
+          decision review.
+        </p>
+        <va-link-action
+          href="/claim-or-appeal-status"
+          text="Check status in Claim Status Tool"
+        />
+        <p>
+          You can still use this guide to learn about your options and see what
+          might apply once you get your decision letter.
+        </p>
+        <va-link href={manifest.rootUrl} text="Restart the guide" />
+        {DIVIDED_BENES}
+        {PRINT_OR_RESTART}
+      </>
+    ),
+  },
+  RESULTS_1_3B: {
+    h1: NON_DR_HEADING,
+    bodyContent: (
+      <>
+        <p>
+          Based on your answers, a decision review may not be available because:
+        </p>
+        <ul>
+          <li>
+            Your claim is contested, <strong>and</strong>
+          </li>
+          <li>It’s been more than 60 days since your decision</li>
+        </ul>
+        <p>But you may have other options, depending on your situation:</p>
+        {DIVIDED_BENES}
+        <h2 className="vads-u-margin-top--3">
+          If you’re seeking benefits related to a deceased Veteran
+        </h2>
+        <p>You may need to apply for a different benefit, such as:</p>
+        <ul>
+          <li>Dependency and Indemnity Compensation (DIC)</li>
+          <li>Substitution of claimant</li>
+          <li>Death pension</li>
+          <li>Burial or memorial benefits</li>
+        </ul>
+        <p>Each of these benefit types follows a different process.</p>
+        <va-link
+          href="/family-and-caregiver-benefits/survivor-compensation/dependency-indemnity-compensation"
+          text="Learn how to apply for survivor and dependent compensation"
+        />
+        {PRINT_OR_RESTART}
+      </>
+    ),
+  },
+  RESULTS_1_2_C1: {
+    h1: NON_DR_HEADING,
+    bodyContent: (
+      <>
+        <p>
+          Based on your answers, your claim is no longer eligible for a decision
+          review because:
+        </p>
+        <ul>
+          <li>
+            You don’t have any new and relevant evidence, <strong>and</strong>
+          </li>
+          <li>VA made a decision on your claim more than 1 year ago</li>
+        </ul>
+        <p>But you may have other options, depending on your situation:</p>
+        {DISABILITY_COMP_CARD(
+          `This may be a good fit because your claim is no longer eligible for a decision review.`,
+        )}
+        {PRINT_OR_RESTART}
+      </>
+    ),
+  },
+  RESULTS_2_IS_3: {
+    h1: NON_DR_HEADING,
+    bodyContent: (
+      <>
+        <p>
+          Based on your answers, you may be eligible to apply for more
+          disability compensation.
+        </p>
+        {CLAIM_FOR_INCREASE_CARD}
+        {PRINT_OR_RESTART}
+      </>
+    ),
+  },
+  RESULTS_HLR: {
+    h1: DR_HEADING,
+    bodyContent: <></>,
+  },
+  RESULTS_SC: {
+    h1: DR_HEADING,
+    bodyContent: <></>,
+  },
+  RESULTS_BOARD_EVIDENCE: {
+    h1: DR_HEADING,
+    bodyContent: <></>,
+  },
+  RESULTS_BOARD_HEARING: {
+    h1: DR_HEADING,
+    bodyContent: <></>,
+  },
+  RESULTS_BOARD_DIRECT: {
+    h1: DR_HEADING,
+    bodyContent: <></>,
+  },
 });

--- a/src/applications/appeals/onramp/containers/ResultsTemplate.jsx
+++ b/src/applications/appeals/onramp/containers/ResultsTemplate.jsx
@@ -19,7 +19,7 @@ const ResultsTemplate = ({ resultPage, router, viewedIntroPage }) => {
   if (h1 && bodyContent) {
     return (
       <>
-        <h1 data-testid="onramp-results-header">{h1}</h1>
+        <h1 data-testid={`onramp-results-header-${resultPage}`}>{h1}</h1>
         {bodyContent}
       </>
     );

--- a/src/applications/appeals/onramp/containers/ResultsTemplate.jsx
+++ b/src/applications/appeals/onramp/containers/ResultsTemplate.jsx
@@ -2,8 +2,11 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { ROUTES } from '../constants';
+import { RESULTS_CONTENT } from '../constants/results-data-map';
 
 const ResultsTemplate = ({ resultPage, router, viewedIntroPage }) => {
+  const { h1, bodyContent } = RESULTS_CONTENT?.[resultPage] || {};
+
   useEffect(
     () => {
       if (!viewedIntroPage) {
@@ -13,7 +16,16 @@ const ResultsTemplate = ({ resultPage, router, viewedIntroPage }) => {
     [router, viewedIntroPage],
   );
 
-  return <h1 data-testid="onramp-results-header">{resultPage}</h1>;
+  if (h1 && bodyContent) {
+    return (
+      <>
+        <h1 data-testid="onramp-results-header">{h1}</h1>
+        {bodyContent}
+      </>
+    );
+  }
+
+  return null;
 };
 
 const mapStateToProps = state => ({

--- a/src/applications/appeals/onramp/tests/cypress/helpers.js
+++ b/src/applications/appeals/onramp/tests/cypress/helpers.js
@@ -1,4 +1,8 @@
 import manifest from '../../manifest.json';
+import {
+  DR_HEADING,
+  NON_DR_HEADING,
+} from '../../constants/results-content/common';
 
 export const ROOT = manifest.rootUrl;
 export const START_LINK = 'onramp-start';
@@ -72,3 +76,15 @@ export const verifyText = (selector, expectedValue) =>
     .findByTestId(selector)
     .should('be.visible')
     .should('have.text', expectedValue);
+
+export const verifyNonDrResultsHeader = () =>
+  cy
+    .findByTestId(RESULTS_HEADER)
+    .should('be.visible')
+    .should('have.text', NON_DR_HEADING);
+
+export const verifyDrResultsHeader = () =>
+  cy
+    .findByTestId(RESULTS_HEADER)
+    .should('be.visible')
+    .should('have.text', DR_HEADING);

--- a/src/applications/appeals/onramp/tests/cypress/helpers.js
+++ b/src/applications/appeals/onramp/tests/cypress/helpers.js
@@ -77,14 +77,14 @@ export const verifyText = (selector, expectedValue) =>
     .should('be.visible')
     .should('have.text', expectedValue);
 
-export const verifyNonDrResultsHeader = () =>
+export const verifyNonDrResultsHeader = expectedPage =>
   cy
-    .findByTestId(RESULTS_HEADER)
+    .findByTestId(`${RESULTS_HEADER}-${expectedPage}`)
     .should('be.visible')
     .should('have.text', NON_DR_HEADING);
 
-export const verifyDrResultsHeader = () =>
+export const verifyDrResultsHeader = expectedPage =>
   cy
-    .findByTestId(RESULTS_HEADER)
+    .findByTestId(`${RESULTS_HEADER}-${expectedPage}`)
     .should('be.visible')
     .should('have.text', DR_HEADING);

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -12,7 +11,6 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2B_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
-const { RESULTS_BOARD_DIRECT } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Direct Review recommended
 // 1.1 - Yes
@@ -69,7 +67,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_BOARD_DIRECT);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_H_2B_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,6 +12,7 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2B_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
+const { RESULTS_BOARD_DIRECT } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Direct Review recommended
 // 1.1 - Yes
@@ -67,7 +69,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_BOARD_DIRECT);
       cy.go('back');
 
       // Q_2_H_2B_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-2.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,6 +11,7 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2B_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
+const { RESULTS_BOARD_DIRECT } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Direct Review recommended
 // 1.1 - Yes
@@ -60,7 +62,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_BOARD_DIRECT);
       cy.go('back');
 
       // Q_2_H_2B_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-2.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,7 +10,6 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2B_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
-const { RESULTS_BOARD_DIRECT } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Direct Review recommended
 // 1.1 - Yes
@@ -62,7 +60,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_BOARD_DIRECT);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_H_2B_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -12,7 +11,6 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2A_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
-const { RESULTS_BOARD_EVIDENCE } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Evidence Submission recommended
 // 1.1 - Yes
@@ -69,7 +67,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_BOARD_EVIDENCE);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_H_2A_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,6 +12,7 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2A_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
+const { RESULTS_BOARD_EVIDENCE } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Evidence Submission recommended
 // 1.1 - Yes
@@ -67,7 +69,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_BOARD_EVIDENCE);
       cy.go('back');
 
       // Q_2_H_2A_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,7 +10,6 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2A_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
-const { RESULTS_BOARD_EVIDENCE } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Evidence Submission recommended
 // 1.1 - Yes
@@ -62,7 +60,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_BOARD_EVIDENCE);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_H_2A_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,6 +11,7 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2A_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
+const { RESULTS_BOARD_EVIDENCE } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Evidence Submission recommended
 // 1.1 - Yes
@@ -60,7 +62,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_BOARD_EVIDENCE);
       cy.go('back');
 
       // Q_2_H_2A_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,6 +12,7 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2A_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
+const { RESULTS_BOARD_HEARING } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Hearing Request recommended
 // 1.1 - Yes
@@ -67,7 +69,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_BOARD_HEARING);
       cy.go('back');
 
       // Q_2_H_2A_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -12,7 +11,6 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2A_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
-const { RESULTS_BOARD_HEARING } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Hearing Request recommended
 // 1.1 - Yes
@@ -69,7 +67,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_BOARD_HEARING);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_H_2A_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,6 +11,7 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2B_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
+const { RESULTS_BOARD_HEARING } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Hearing Request recommended
 // 1.1 - Yes
@@ -60,7 +62,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_BOARD_HEARING);
       cy.go('back');
 
       // Q_2_H_2B_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,7 +10,6 @@ const {
   Q_2_H_2_NEW_EVIDENCE,
   Q_2_H_2B_JUDGE_HEARING,
 } = SHORT_NAME_MAP;
-const { RESULTS_BOARD_HEARING } = RESULTS_NAME_MAP;
 
 // Results Board Appeal: Hearing Request recommended
 // 1.1 - Yes
@@ -62,7 +60,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_BOARD_HEARING);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_H_2B_JUDGE_HEARING

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -13,7 +12,6 @@ const {
   Q_2_IS_1A_LAW_POLICY_CHANGE,
   Q_2_IS_1B_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
-const { RESULTS_HLR } = RESULTS_NAME_MAP;
 
 // Results HLR: Higher-Level Review recommended
 // 1.1 - Yes
@@ -76,7 +74,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_HLR);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_IS_1B_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -12,6 +13,7 @@ const {
   Q_2_IS_1A_LAW_POLICY_CHANGE,
   Q_2_IS_1B_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
+const { RESULTS_HLR } = RESULTS_NAME_MAP;
 
 // Results HLR: Higher-Level Review recommended
 // 1.1 - Yes
@@ -74,7 +76,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_HLR);
       cy.go('back');
 
       // Q_2_IS_1B_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,6 +12,7 @@ const {
   Q_2_IS_1A_LAW_POLICY_CHANGE,
   Q_2_IS_1B_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
+const { RESULTS_HLR } = RESULTS_NAME_MAP;
 
 // Results HLR: Higher-Level Review recommended
 // 1.1 - Yes
@@ -67,7 +69,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_HLR);
       cy.go('back');
 
       // Q_2_IS_1B_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -12,7 +11,6 @@ const {
   Q_2_IS_1A_LAW_POLICY_CHANGE,
   Q_2_IS_1B_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
-const { RESULTS_HLR } = RESULTS_NAME_MAP;
 
 // Results HLR: Higher-Level Review recommended
 // 1.1 - Yes
@@ -69,7 +67,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_HLR);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_IS_1B_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -9,6 +10,7 @@ const {
   Q_2_0_CLAIM_TYPE,
   Q_2_S_1_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
+const { RESULTS_HLR } = RESULTS_NAME_MAP;
 
 // Results HLR: Higher-Level Review recommended
 // 1.1 - Yes
@@ -53,7 +55,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_HLR);
       cy.go('back');
 
       // Q_2_S_1_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,7 +9,6 @@ const {
   Q_2_0_CLAIM_TYPE,
   Q_2_S_1_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
-const { RESULTS_HLR } = RESULTS_NAME_MAP;
 
 // Results HLR: Higher-Level Review recommended
 // 1.1 - Yes
@@ -55,7 +53,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_HLR);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_S_1_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -8,6 +9,7 @@ const {
   Q_1_2A_CONDITION_WORSENED,
   Q_1_2B_LAW_POLICY_CHANGE,
 } = SHORT_NAME_MAP;
+const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -46,7 +48,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_SC);
       cy.go('back');
 
       // Q_1_2B_LAW_POLICY_CHANGE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -9,7 +8,6 @@ const {
   Q_1_2A_CONDITION_WORSENED,
   Q_1_2B_LAW_POLICY_CHANGE,
 } = SHORT_NAME_MAP;
-const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -48,7 +46,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_SC);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_1_2B_LAW_POLICY_CHANGE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,7 +9,6 @@ const {
   Q_1_2B_LAW_POLICY_CHANGE,
   Q_1_2C_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
-const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -55,7 +53,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_SC);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_1_2C_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -9,6 +10,7 @@ const {
   Q_1_2B_LAW_POLICY_CHANGE,
   Q_1_2C_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
+const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -53,7 +55,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_SC);
       cy.go('back');
 
       // Q_1_2C_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,7 +10,6 @@ const {
   Q_2_IS_1_SERVICE_CONNECTED,
   Q_2_IS_1A_LAW_POLICY_CHANGE,
 } = SHORT_NAME_MAP;
-const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -62,7 +60,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_SC);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_IS_1A_LAW_POLICY_CHANGE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,6 +11,7 @@ const {
   Q_2_IS_1_SERVICE_CONNECTED,
   Q_2_IS_1A_LAW_POLICY_CHANGE,
 } = SHORT_NAME_MAP;
+const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -60,7 +62,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_SC);
       cy.go('back');
 
       // Q_2_IS_1A_LAW_POLICY_CHANGE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -12,7 +11,6 @@ const {
   Q_2_IS_1A_LAW_POLICY_CHANGE,
   Q_2_IS_1B_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
-const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -69,7 +67,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_SC);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_IS_1B_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,6 +12,7 @@ const {
   Q_2_IS_1A_LAW_POLICY_CHANGE,
   Q_2_IS_1B_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
+const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -67,7 +69,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_SC);
       cy.go('back');
 
       // Q_2_IS_1B_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -9,6 +10,7 @@ const {
   Q_2_0_CLAIM_TYPE,
   Q_2_S_1_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
+const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -53,7 +55,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_SC);
       cy.go('back');
 
       // Q_2_S_1_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,7 +9,6 @@ const {
   Q_2_0_CLAIM_TYPE,
   Q_2_S_1_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
-const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -55,7 +53,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_SC);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_S_1_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -9,6 +10,7 @@ const {
   Q_2_0_CLAIM_TYPE,
   Q_2_H_1_EXISTING_BOARD_APPEAL,
 } = SHORT_NAME_MAP;
+const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -53,7 +55,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyDrResultsHeader();
+      h.verifyDrResultsHeader(RESULTS_SC);
       cy.go('back');
 
       // Q_2_H_1_EXISTING_BOARD_APPEAL

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,7 +9,6 @@ const {
   Q_2_0_CLAIM_TYPE,
   Q_2_H_1_EXISTING_BOARD_APPEAL,
 } = SHORT_NAME_MAP;
-const { RESULTS_SC } = RESULTS_NAME_MAP;
 
 // Results SC: Supplemental Claim recommended
 // 1.1 - Yes
@@ -55,7 +53,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_SC);
+      h.verifyDrResultsHeader();
       cy.go('back');
 
       // Q_2_H_1_EXISTING_BOARD_APPEAL

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-1.cypress.spec.js
@@ -1,14 +1,12 @@
 import * as h from '../../helpers';
 import { ROUTES } from '../../../../constants';
 import { SHORT_NAME_MAP } from '../../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
   Q_1_2_CLAIM_DECISION,
   Q_1_2A_CONDITION_WORSENED,
 } = SHORT_NAME_MAP;
-const { RESULTS_2_IS_3 } = RESULTS_NAME_MAP;
 
 // Results 2.IS3: Condition has worsened, you may be eligible for more
 // 1.1 - Yes
@@ -41,7 +39,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_2_IS_3);
+      h.verifyNonDrResultsHeader();
       cy.go('back');
 
       // Q_1_2A_CONDITION_WORSENED

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-1.cypress.spec.js
@@ -1,12 +1,14 @@
 import * as h from '../../helpers';
 import { ROUTES } from '../../../../constants';
 import { SHORT_NAME_MAP } from '../../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
   Q_1_2_CLAIM_DECISION,
   Q_1_2A_CONDITION_WORSENED,
 } = SHORT_NAME_MAP;
+const { RESULTS_2_IS_3 } = RESULTS_NAME_MAP;
 
 // Results 2.IS3: Condition has worsened, you may be eligible for more
 // 1.1 - Yes
@@ -39,7 +41,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyNonDrResultsHeader();
+      h.verifyNonDrResultsHeader(RESULTS_2_IS_3);
       cy.go('back');
 
       // Q_1_2A_CONDITION_WORSENED

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-2.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../../helpers';
 import { ROUTES } from '../../../../constants';
 import { SHORT_NAME_MAP } from '../../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,7 +10,6 @@ const {
   Q_2_IS_1_SERVICE_CONNECTED,
   Q_2_IS_2_CONDITION_WORSENED,
 } = SHORT_NAME_MAP;
-const { RESULTS_2_IS_3 } = RESULTS_NAME_MAP;
 
 // Results 2.IS3: Condition has worsened, you may be eligible for more
 // 1.1 - Yes
@@ -62,7 +60,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_2_IS_3);
+      h.verifyNonDrResultsHeader();
       cy.go('back');
 
       // Q_2_IS_2_CONDITION_WORSENED

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-2.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../../helpers';
 import { ROUTES } from '../../../../constants';
 import { SHORT_NAME_MAP } from '../../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,6 +11,7 @@ const {
   Q_2_IS_1_SERVICE_CONNECTED,
   Q_2_IS_2_CONDITION_WORSENED,
 } = SHORT_NAME_MAP;
+const { RESULTS_2_IS_3 } = RESULTS_NAME_MAP;
 
 // Results 2.IS3: Condition has worsened, you may be eligible for more
 // 1.1 - Yes
@@ -60,7 +62,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyNonDrResultsHeader();
+      h.verifyNonDrResultsHeader(RESULTS_2_IS_3);
       cy.go('back');
 
       // Q_2_IS_2_CONDITION_WORSENED

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-3.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../../helpers';
 import { ROUTES } from '../../../../constants';
 import { SHORT_NAME_MAP } from '../../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -11,7 +10,6 @@ const {
   Q_2_IS_1_SERVICE_CONNECTED,
   Q_2_IS_2_CONDITION_WORSENED,
 } = SHORT_NAME_MAP;
-const { RESULTS_2_IS_3 } = RESULTS_NAME_MAP;
 
 // Results 2.IS3: Condition has worsened, you may be eligible for more
 // 1.1 - Yes
@@ -62,7 +60,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_2_IS_3);
+      h.verifyNonDrResultsHeader();
       cy.go('back');
 
       // Q_2_IS_2_CONDITION_WORSENED

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/2-IS3/results-2-IS3-path-3.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../../helpers';
 import { ROUTES } from '../../../../constants';
 import { SHORT_NAME_MAP } from '../../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,6 +11,7 @@ const {
   Q_2_IS_1_SERVICE_CONNECTED,
   Q_2_IS_2_CONDITION_WORSENED,
 } = SHORT_NAME_MAP;
+const { RESULTS_2_IS_3 } = RESULTS_NAME_MAP;
 
 // Results 2.IS3: Condition has worsened, you may be eligible for more
 // 1.1 - Yes
@@ -60,7 +62,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyNonDrResultsHeader();
+      h.verifyNonDrResultsHeader(RESULTS_2_IS_3);
       cy.go('back');
 
       // Q_2_IS_2_CONDITION_WORSENED

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1B.cypress.spec.js
@@ -1,10 +1,8 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const { Q_1_1_CLAIM_DECISION, Q_1_1A_SUBMITTED_526 } = SHORT_NAME_MAP;
-const { RESULTS_1_1B } = RESULTS_NAME_MAP;
 
 // Results 1.1B: File an initial claim before you request a review
 // 1.1 - No
@@ -31,7 +29,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_1_1B);
+      h.verifyNonDrResultsHeader();
       cy.go('back');
 
       // Q_1_1A_SUBMITTED_526

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1B.cypress.spec.js
@@ -1,8 +1,10 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const { Q_1_1_CLAIM_DECISION, Q_1_1A_SUBMITTED_526 } = SHORT_NAME_MAP;
+const { RESULTS_1_1B } = RESULTS_NAME_MAP;
 
 // Results 1.1B: File an initial claim before you request a review
 // 1.1 - No
@@ -29,7 +31,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyNonDrResultsHeader();
+      h.verifyNonDrResultsHeader(RESULTS_1_1B);
       cy.go('back');
 
       // Q_1_1A_SUBMITTED_526

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1C.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1C.cypress.spec.js
@@ -1,8 +1,10 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const { Q_1_1_CLAIM_DECISION, Q_1_1A_SUBMITTED_526 } = SHORT_NAME_MAP;
+const { RESULTS_1_1C } = RESULTS_NAME_MAP;
 
 // Results 1.1C: You can't request a review yet
 // 1.1 - No
@@ -29,7 +31,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyNonDrResultsHeader();
+      h.verifyNonDrResultsHeader(RESULTS_1_1C);
       cy.go('back');
 
       // Q_1_1A_SUBMITTED_526

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1C.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-1C.cypress.spec.js
@@ -1,10 +1,8 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const { Q_1_1_CLAIM_DECISION, Q_1_1A_SUBMITTED_526 } = SHORT_NAME_MAP;
-const { RESULTS_1_1C } = RESULTS_NAME_MAP;
 
 // Results 1.1C: You can't request a review yet
 // 1.1 - No
@@ -31,7 +29,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_1_1C);
+      h.verifyNonDrResultsHeader();
       cy.go('back');
 
       // Q_1_1A_SUBMITTED_526

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-2-C1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-2-C1.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -9,6 +10,7 @@ const {
   Q_1_2B_LAW_POLICY_CHANGE,
   Q_1_2C_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
+const { RESULTS_1_2_C1 } = RESULTS_NAME_MAP;
 
 // Results 1.2.C1: You need to file a new claim because you have no new evidence
 // and you are outside of the 1-year deadline
@@ -54,7 +56,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyNonDrResultsHeader();
+      h.verifyNonDrResultsHeader(RESULTS_1_2_C1);
       cy.go('back');
 
       // Q_1_2C_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-2-C1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-2-C1.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -10,7 +9,6 @@ const {
   Q_1_2B_LAW_POLICY_CHANGE,
   Q_1_2C_NEW_EVIDENCE,
 } = SHORT_NAME_MAP;
-const { RESULTS_1_2_C1 } = RESULTS_NAME_MAP;
 
 // Results 1.2.C1: You need to file a new claim because you have no new evidence
 // and you are outside of the 1-year deadline
@@ -56,7 +54,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_1_2_C1);
+      h.verifyNonDrResultsHeader();
       cy.go('back');
 
       // Q_1_2C_NEW_EVIDENCE

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-3B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-3B.cypress.spec.js
@@ -1,7 +1,6 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
-import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -9,7 +8,6 @@ const {
   Q_1_3_CLAIM_CONTESTED,
   Q_1_3A_FEWER_60_DAYS,
 } = SHORT_NAME_MAP;
-const { RESULTS_1_3B } = RESULTS_NAME_MAP;
 
 // Results 1.3B: Contested claims, more than 60 days after decision
 // 1.1 - Yes
@@ -48,7 +46,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyText(h.RESULTS_HEADER, RESULTS_1_3B);
+      h.verifyNonDrResultsHeader();
       cy.go('back');
 
       // Q_1_3A_FEWER_60_DAYS

--- a/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-3B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-shortcuts/results-1-3B.cypress.spec.js
@@ -1,6 +1,7 @@
 import * as h from '../helpers';
 import { ROUTES } from '../../../constants';
 import { SHORT_NAME_MAP } from '../../../constants/question-data-map';
+import { RESULTS_NAME_MAP } from '../../../constants/results-data-map';
 
 const {
   Q_1_1_CLAIM_DECISION,
@@ -8,6 +9,7 @@ const {
   Q_1_3_CLAIM_CONTESTED,
   Q_1_3A_FEWER_60_DAYS,
 } = SHORT_NAME_MAP;
+const { RESULTS_1_3B } = RESULTS_NAME_MAP;
 
 // Results 1.3B: Contested claims, more than 60 days after decision
 // 1.1 - Yes
@@ -46,7 +48,7 @@ describe('Decision Reviews Onramp', () => {
 
       // RESULTS
       h.verifyUrl(ROUTES.RESULTS);
-      h.verifyNonDrResultsHeader();
+      h.verifyNonDrResultsHeader(RESULTS_1_3B);
       cy.go('back');
 
       // Q_1_3A_FEWER_60_DAYS

--- a/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/utils/scrollAndFocusTarget.unit.spec.jsx
@@ -168,7 +168,7 @@ describe('focusEvidence', () => {
     render(
       <div id="main">
         <h3>Title</h3>
-        {hasError ? <div error="true" /> : <div />}
+        {hasError ? <div role="alert" error="true" /> : <div />}
       </div>,
     );
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add non-DR summary screen content.

Note: we don't have a variant of the design system button that looks like the "Print this Page" button. The [button with icon](https://design.va.gov/components/button/button-icon) variant looks quite different. I'm working with UX on this one but I don't think it should block the merge of this chunk of work - I can resolve in the final results page PR.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/114839

## Testing done

✅ Manual navigation to each of these summary screens to ensure correct display conditions
✅ Visual comparison to Figma flows

## Screenshots

**Reminders**

- We are using the same fonts / default font sizes in the dev build, but things render a little bit differently in Figma with regard to spacing, weight of the fonts, etc.
- Results page content was the focus of this ticket. There may be mismatches in other things such as the introduction page, breadcrumbs, etc. We can update these later when that guidance is finalized in Figma
- Similarly, results page content is under active revision. There is a screenshot of what was in Figma at the time this PR was prepped for review. That should be used as the source of truth until the content is finalized.

### Results 1.1.B
<details><summary>Screenshots</summary>

| Dev - Mobile | Figma - Mobile |
| --- | --- |
| <img width="250" alt="Screenshot 2025-08-13 at 12 47 07 PM" src="https://github.com/user-attachments/assets/c6bd691e-7539-4bb0-8599-92f858c16651" /> | <img width="250" alt="Screenshot 2025-08-15 at 9 31 40 AM" src="https://github.com/user-attachments/assets/eafc1e85-bb1e-48b5-8ec7-6dc626ada175" /> |

#### Tablet & desktop
<img width="600" alt="Screenshot 2025-08-13 at 12 47 58 PM" src="https://github.com/user-attachments/assets/67fedb99-3b80-4dc3-9f1e-8f96af859b1d" />

<img width="800" alt="Screenshot 2025-08-13 at 12 48 09 PM" src="https://github.com/user-attachments/assets/3b0eb5cd-1236-4321-83f7-0c98773469c1" />

</details>

### Results 1.1.C
<details><summary>Screenshots</summary>

| Dev - Mobile | Figma - Mobile |
| --- | --- |
| <img width="250" alt="Screenshot 2025-08-13 at 1 12 35 PM" src="https://github.com/user-attachments/assets/2e772887-6c35-4423-ad4f-58a3a4a0adc5" /> | <img width="250" alt="Screenshot 2025-08-13 at 12 56 22 PM" src="https://github.com/user-attachments/assets/f96842ba-5fd1-4769-a9a1-e2321e0e6960" /> |

#### Tablet & desktop
<img width="600" alt="Screenshot 2025-08-13 at 1 12 48 PM" src="https://github.com/user-attachments/assets/10e30054-53a4-4113-b6d4-a13a6630832d" />

<img width="800" alt="Screenshot 2025-08-13 at 1 12 57 PM" src="https://github.com/user-attachments/assets/c3e655d2-44ef-42b0-be99-7b82a3e63f07" />

</details>


### Results 1.2.C
<details><summary>Screenshots</summary>

| Dev - Mobile | Figma - Mobile |
| --- | --- |
| <img width="250" alt="Screenshot 2025-08-13 at 1 20 57 PM" src="https://github.com/user-attachments/assets/460568df-b8f1-4844-a51d-b02bc8195e76" /> | <img width="250" alt="Screenshot 2025-08-13 at 1 15 16 PM" src="https://github.com/user-attachments/assets/987fc7fa-ead1-49dc-9fc9-e6f6dc5a6b90" /> |

#### Tablet & desktop
<img width="600" alt="Screenshot 2025-08-13 at 1 21 05 PM" src="https://github.com/user-attachments/assets/1deb06ab-e2a0-4437-8642-74b0ca0a0930" />

<img width="800" alt="Screenshot 2025-08-13 at 1 21 13 PM" src="https://github.com/user-attachments/assets/be291d81-802c-40dc-bf0b-52e68e17ffb4" />

</details>

### Results 2.IS.3
<details><summary>Screenshots</summary>

| Dev - Mobile | Figma - Mobile |
| --- | --- |
| <img width="250" alt="Screenshot 2025-08-13 at 1 24 58 PM" src="https://github.com/user-attachments/assets/4e1945b1-1281-4a63-ad34-8ba8cf2b395d" /> | <img width="250" alt="Screenshot 2025-08-13 at 1 25 25 PM" src="https://github.com/user-attachments/assets/4604f687-134d-4d77-97c6-3c215e5a41ec" /> |

#### Tablet & desktop
<img width="600" alt="Screenshot 2025-08-13 at 1 25 08 PM" src="https://github.com/user-attachments/assets/f7b5a37a-c53d-4283-8c47-f4ec9c3e036c" />

<img width="800" alt="Screenshot 2025-08-13 at 1 25 16 PM" src="https://github.com/user-attachments/assets/1201b3eb-86a5-4134-8187-5e1b672092de" />

</details>


### Results 1.3.B
<details><summary>Screenshots</summary>

| Dev - Mobile | Figma - Mobile |
| --- | --- |
| <img width="250" alt="Screenshot 2025-08-13 at 1 27 42 PM" src="https://github.com/user-attachments/assets/e030b817-766c-4a20-8633-19e43ad9395e" /> | <img width="250" alt="Screenshot 2025-08-13 at 1 28 22 PM" src="https://github.com/user-attachments/assets/a8d035e0-8b62-473b-bce6-53da1cbf0abf" /> |

#### Tablet & desktop
<img width="600" alt="Screenshot 2025-08-13 at 1 27 56 PM" src="https://github.com/user-attachments/assets/7910a2a0-0e4c-474c-b7c9-0e9b950a40f8" />

<img width="800" alt="Screenshot 2025-08-13 at 1 28 04 PM" src="https://github.com/user-attachments/assets/b42acb15-081b-4428-86b1-fee7eb49eb12" />

</details>

## Acceptance criteria

- [x] Build out all non-DR results screens' content