### PR TITLE
Update recurring income recipient pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -117,6 +117,13 @@ const yesNoOptionsMore = {
   },
 };
 
+const sharedRecipientRelationshipBase = {
+  title: 'Who receives this income?',
+  hint: 'You’ll be able to add individual incomes separately',
+  labelHeaderLevel: '2',
+  labelHeaderLevelStyle: '3',
+};
+
 /**
  * Cards are populated on this page above the uiSchema if items are present
  *
@@ -221,9 +228,7 @@ const veteranIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      title: 'Who receives this income?',
-      labelHeaderLevel: '2',
-      labelHeaderLevelStyle: '3',
+      ...sharedRecipientRelationshipBase,
       labels: Object.fromEntries(
         Object.entries(relationshipLabels).filter(
           ([key]) => key !== 'PARENT' && key !== 'CUSTODIAN',
@@ -268,10 +273,7 @@ const spouseIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      title: 'What’s the income recipient’s relationship to the Veteran?',
-      hint: 'You’ll be able to add individual incomes separately',
-      labelHeaderLevel: '2',
-      labelHeaderLevelStyle: '3',
+      ...sharedRecipientRelationshipBase,
       labels: Object.fromEntries(
         Object.entries(relationshipLabels)
           .filter(
@@ -326,9 +328,7 @@ const custodianIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      title: 'What’s the income recipient’s relationship to the Veteran?',
-      labelHeaderLevel: '2',
-      labelHeaderLevelStyle: '3',
+      ...sharedRecipientRelationshipBase,
       labels: Object.fromEntries(
         Object.entries(relationshipLabels)
           .filter(
@@ -384,9 +384,7 @@ const parentIncomeRecipientPage = {
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
-      title: 'What’s the income recipient’s relationship to the Veteran?',
-      labelHeaderLevel: '2',
-      labelHeaderLevelStyle: '3',
+      ...sharedRecipientRelationshipBase,
       labels: Object.fromEntries(
         Object.entries(relationshipLabels)
           .filter(


### PR DESCRIPTION
## Summary
Made updates to the **Recipient relationship** pages throughout the Income and Asset Statement form (VA Form 21P-0969) based on feedback from Design QA. These changes include refinements to content, hint text, and label alignment for clarity and consistency across different claimant types.

## Issue
- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/111459](https://github.com/department-of-veterans-affairs/va.gov-team/issues/111459)

## Related issue(s)
- Follows work on recurring income recipient flow and content toggle features

## Associated Pull Request(s)
- N/A

## How to run in local environment
1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Enable the feature flag:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`
4. Visit:  
   `http://localhost:3001/income-and-asset-statement-form-21p-0969/`

## How to verify
1. Navigate to pages where the recipient relationship is selected (e.g., in **Recurring income** or **Other assets** sections)
2. Confirm that:
   - Content aligns with the latest Design QA guidance
   - Updated labels and hint text render correctly for different `claimantType` values
   - There are no layout, validation, or accessibility regressions
3. Run through a few different claimantType scenarios (Veteran, Spouse, Parent, Custodian)

## What areas of the site does it impact?
Income and Asset Statement Application — recipient relationship pages across asset and income sections

## Screenshots
| Before | After |
|--------|-------|
| Older label styles and inconsistent hint text | Updated language and formatting based on Design QA |

### Quality Assurance & Testing
- [ ] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Console is clear of errors or warnings
- [x] Dynamic rendering and conditional content behave as expected
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and test different authenticated states

## Milestone
- 0969 Post-MVP content and design QA — gated behind `incomeAndAssetsContentUpdates` flipper

## Requested Feedback
Please review the updated relationship pages for content accuracy and design alignment. Let me know if there are any discrepancies with the Figma design references or additional claimantType-specific content needed.
