### PR TITLE
Update review page links to use labels instead of aria-labels

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/PreferredLanguageSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/PreferredLanguageSection.jsx
@@ -39,7 +39,7 @@ export default function PreferredLanguageSection({ data }) {
           <va-link
             href={ccLanguage.url}
             onClick={handleClick(history, home, ccLanguage)}
-            aria-label="Edit preferred language"
+            label="Edit preferred language"
             text="Edit"
             data-testid="edit-preferred-language"
           />

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/SchedulingFacilitySection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/SchedulingFacilitySection.jsx
@@ -53,7 +53,7 @@ export default function SchedulingFacilitySection({ facility }) {
           <va-link
             href={ccClosestCity.url}
             onClick={handleClick(history, home, ccClosestCity)}
-            aria-label="Edit facility preference"
+            label="Edit facility preference"
             text="Edit"
             data-testid="edit-new-appointment"
           />

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ContactDetailSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ContactDetailSection.jsx
@@ -89,7 +89,7 @@ export default function ContactDetailSection({ data }) {
           <div>
             <va-link
               href={contactInfo.url}
-              aria-label="Edit your contact information"
+              label="Edit your contact information"
               text="Edit"
               data-testid="edit-new-appointment"
               onClick={handleClick(history, home, contactInfo)}

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDatesSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDatesSection.jsx
@@ -55,7 +55,7 @@ export default function PreferredDatesSection(props) {
           <div>
             <va-link
               href={`../${url}`}
-              aria-label="Edit preferred date"
+              label="Edit preferred date"
               text="Edit"
               data-testid="edit-new-appointment"
               onClick={handleClick(history, home, url)}

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
@@ -59,7 +59,7 @@ export default function ReasonForAppointmentSection({ data }) {
           <div>
             <va-link
               href={reason.url}
-              aria-label="Edit details you’d like to share with your provider"
+              label="Edit details you’d like to share with your provider"
               text="Edit"
               data-testid="edit-new-appointment"
               onClick={handleClick(history, home, reason)}

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/VAAppointmentSection/TypeOfVisitSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/VAAppointmentSection/TypeOfVisitSection.jsx
@@ -52,7 +52,7 @@ export default function TypeOfVisitSection({ data }) {
             href={visitType.url}
             onClick={handleClick(history, home, visitType)}
             text="Edit"
-            aria-label="Edit how you want to attend"
+            label="Edit how you want to attend"
           />
         </div>
       </div>

--- a/src/applications/vaos/new-appointment/components/ReviewPage/SelectedProviderSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/SelectedProviderSection.jsx
@@ -78,7 +78,7 @@ export default function SelectedProviderSection({ data, vaCityState }) {
           <va-link
             href={ccPreferences.url}
             onClick={handleClick(history, home, ccPreferences)}
-            aria-label="Edit provider preference"
+            label="Edit provider preference"
             text="Edit"
             data-testid="edit-new-appointment"
           />

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -178,8 +178,8 @@ describe('VAOS Page: ReviewPage direct scheduling', () => {
     const editLinks = screen.getAllByTestId('edit-new-appointment');
     const uniqueLinks = new Set();
     editLinks.forEach(link => {
-      expect(link).to.have.attribute('aria-label');
-      uniqueLinks.add(link.getAttribute('aria-label'));
+      expect(link).to.have.attribute('label');
+      uniqueLinks.add(link.getAttribute('label'));
     });
     expect(uniqueLinks.size).to.equal(editLinks.length);
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The current links use `aria-label` which are not read correctly by all screen readers. To ensure more consistent behaviors among screen readers we will update the edit links on all review pages to use `label` instead.
- UAE Orion
- This is not behind a Flipper

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/111662

## Testing done

- Tested locally using VoiceOver

## Screenshots

Note that different screen readers behave differently but here's the content that was read out by VoiceOver on Mac, note the duplicate "Edit, Edit your contact information":

| Before | After |
| ------ | ----- |
|    <img width="632" height="134" alt="image" src="https://github.com/user-attachments/assets/21708779-ab10-40de-8f5b-f957c1b45089" />    |   <img width="651" height="153" alt="image" src="https://github.com/user-attachments/assets/688627bb-4da2-4517-a8b9-8a038aca1114" />    |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user