### PR TITLE
10-10EZ | Invalid insurance record hotfix

### DIFF
--- a/src/applications/hca/config/migrations.js
+++ b/src/applications/hca/config/migrations.js
@@ -253,6 +253,22 @@ export default [
       newMetadata = set('returnUrl', returnUrl, newMetadata);
     }
 
+    // temp fix until we get insurance v2 enabled
+    (formData?.providers || []).forEach(policy => {
+      const isValid =
+        policy.insuranceName &&
+        policy.insurancePolicyHolderName &&
+        (policy.insurancePolicyNumber || policy.insuranceGroupCode);
+
+      if (!isValid) {
+        newMetadata = set(
+          'returnUrl',
+          'insurance-information/general',
+          newMetadata,
+        );
+      }
+    });
+
     return { formData, metadata: newMetadata };
   },
 ];

--- a/src/applications/hca/tests/unit/config/migrations.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/config/migrations.unit.spec.jsx
@@ -330,9 +330,19 @@ describe('hca migrations', () => {
     const migration = migrations[7];
 
     it('should update the `va-facility` return URL to remove the `-api` reference', () => {
-      const returnUrl = '/insurance-information/va-facility-api';
-      const desiredUrl = '/insurance-information/va-facility';
+      const returnUrl = 'insurance-information/va-facility-api';
+      const desiredUrl = 'insurance-information/va-facility';
       const data = { formData: {}, metadata: { returnUrl } };
+      const { metadata } = migration(data);
+      expect(metadata.returnUrl).to.eq(desiredUrl);
+    });
+
+    it('should update the return URL when invalid insurance values are present in the form data', () => {
+      const desiredUrl = 'insurance-information/general';
+      const data = {
+        formData: { providers: [{ insuranceName: 'Dave Jones' }] },
+        metadata: { returnUrl: '/review-and-submit' },
+      };
       const { metadata } = migration(data);
       expect(metadata.returnUrl).to.eq(desiredUrl);
     });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR creates a hotfix to take care of invalid insurance records that aren't being picked up by the review page validation.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#44427

## Acceptance criteria

- Users with invalid in-progress records are returned to the insurance page to correct the issue

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution