### PR TITLE
update coverage script to read correct artifact and list all apps

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1321,7 +1321,18 @@ jobs:
    # --------------------------------------
       # | Publish Unit Test Coverage Report       |
       # -------------------------------------
+      - name: Generate full coverage on main
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: yarn test:unit:gha --full-suite --coverage --log-level verbose
+
+      - name: Prepare coverage artifact (main)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          mkdir -p qa-standards-dashboard-data/coverage
+          cp coverage/coverage-summary.json qa-standards-dashboard-data/coverage/coverage-summary.json
+
       - name: Download Unit Test coverage results
+        if: ${{ github.ref != 'refs/heads/main' }}
         uses: ./.github/workflows/download-artifact
         with:
           name: unit-test-coverage

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -98,10 +98,16 @@ const logCoverage = coverageResults => {
   const data = JSON.stringify(coverageResults, null, 4);
   console.log(data);
   // write coverageResults string to file
-  const outputFile = path.join(
+  const outputDir = path.join(
     __dirname,
-    '../qa-standards-dashboard-data/coverage/test-coverage-report.json',
+    '../qa-standards-dashboard-data/coverage',
   );
+
+  // Ensure the directory exists (local runs may not have it)
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const outputFile = path.join(outputDir, 'test-coverage-report.json');
+
   fs.writeFile(outputFile, data, err => {
     if (err) {
       throw err;
@@ -113,15 +119,39 @@ const logCoverage = coverageResults => {
 // Root directory of application folders
 const applicationDir = path.join(__dirname, '../src/applications/');
 
-// Check if coverage-summary.json exists before generating coverage
-if (fs.existsSync(path.join(__dirname, '../merged-coverage-report.json'))) {
-  const coverageSummaryJson = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '../merged-coverage-report.json')),
-  );
-  // Generate and print coverage
+// Determine which coverage summary to use (CI artifact first, then local, then legacy merged file)
+const qaCoveragePath = path.join(
+  __dirname,
+  '../qa-standards-dashboard-data/coverage/coverage-summary.json',
+);
+const localCoveragePath = path.join(
+  __dirname,
+  '../coverage/coverage-summary.json',
+);
+const legacyMergedCoveragePath = path.join(
+  __dirname,
+  '../merged-coverage-report.json',
+);
+
+let selectedCoveragePath = null;
+if (fs.existsSync(qaCoveragePath)) {
+  selectedCoveragePath = qaCoveragePath;
+} else if (fs.existsSync(localCoveragePath)) {
+  selectedCoveragePath = localCoveragePath;
+} else if (fs.existsSync(legacyMergedCoveragePath)) {
+  selectedCoveragePath = legacyMergedCoveragePath;
+}
+
+if (selectedCoveragePath) {
+  const coverageSummaryJson = JSON.parse(fs.readFileSync(selectedCoveragePath));
   const appCoverages = generateCoverage(applicationDir, coverageSummaryJson);
   logCoverage(appCoverages);
   printCoverage(appCoverages);
 } else {
-  console.log('./merged-coverage-report.json not found.');
+  console.log(
+    'No coverage summary found at expected locations. Checked: \n' +
+      ` - ${qaCoveragePath}\n` +
+      ` - ${localCoveragePath}\n` +
+      ` - ${legacyMergedCoveragePath}`,
+  );
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Root cause: Coverage script expected legacy file path; CI only ran changed-file tests, omitting apps whose tests didn't execute
- Solution: Updated script to read correct CI artifact with fallbacks, ensure all manifest apps are listed (0% if no coverage), and run full coverage suite on main branch

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

### Old behavior: 
Apps like 0538-dependents-verification were completely absent from coverage report when their tests weren't selected in CI run

### New behavior: All apps from src/applications manifests now appear in coverage report:
- Apps with tests show actual coverage percentages
- Apps without tests show 0% (instead of being omitted)
- Script handles missing directories gracefully
**Verification** steps:
1. Ran yarn test:unit:gha --full-suite --coverage locally
2. Generated coverage report: node script/app-coverage-report.js
3. Confirmed dependents/dependents-verification appears with ~96% coverage
4. Confirmed 22 apps with 0% coverage are now listed (previously missing)

### CI Testing
To verify in CI:
- Merge to main branch
- Monitor "Testing Reports - Unit Tests Coverage" job
- Verify it runs full coverage suite and publishes complete report
- Check dashboard shows all apps including 0538-dependents-verification
- For PRs: confirm selective test runs still work but don't update platform coverage

**Expected** outcome: 
Platform coverage report includes every app from manifests, with accurate percentages or 0% where no tests exist.


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
