### PR TITLE
Fix time display for appointment details view

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentDateTime.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentDateTime.jsx
@@ -31,11 +31,15 @@ export function AppointmentTime({
   const { abbreviation, description } = getAppointmentTimezone(appointment);
   return (
     <>
-      <span data-dd-privacy="mask">
+      <span data-dd-privacy="mask" data-testid="appointment-time">
         {formatInTimeZone(appointment.start, timezone, format)}{' '}
       </span>
-      <span aria-hidden="true">{abbreviation}</span>
-      <span className="sr-only">{description}</span>
+      <span aria-hidden="true" data-testid="appointment-time-abbreviation">
+        {abbreviation}
+      </span>
+      <span className="sr-only" data-testid="appointment-time-description">
+        {description}
+      </span>
     </>
   );
 }

--- a/src/applications/vaos/components/AppointmentDate.jsx
+++ b/src/applications/vaos/components/AppointmentDate.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { format } from 'date-fns';
+
+/**
+ * Component for displaying appointment date in a consistent format
+ */
+export default function AppointmentDate({ date }) {
+  const formattedDate = format(new Date(date), 'EEEE, MMMM do, yyyy');
+
+  return (
+    <span data-dd-privacy="mask" data-testid="appointment-date">
+      {formattedDate}
+    </span>
+  );
+}
+
+AppointmentDate.propTypes = {
+  date: PropTypes.string.isRequired,
+};

--- a/src/applications/vaos/components/AppointmentDate.unit.spec.jsx
+++ b/src/applications/vaos/components/AppointmentDate.unit.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import AppointmentDate from './AppointmentDate';
+
+describe('AppointmentDate', () => {
+  const sampleDate = '2024-11-18T18:30:00Z';
+
+  it('should render date with default format', () => {
+    const { getByTestId } = render(<AppointmentDate date={sampleDate} />);
+
+    const dateElement = getByTestId('appointment-date');
+    expect(dateElement).to.exist;
+    expect(dateElement.textContent).to.include('Monday, November 18th, 2024');
+  });
+
+  it('should have data-dd-privacy mask attribute', () => {
+    const { getByTestId } = render(<AppointmentDate date={sampleDate} />);
+
+    const dateElement = getByTestId('appointment-date');
+    expect(dateElement).to.exist;
+    expect(dateElement.getAttribute('data-dd-privacy')).to.equal('mask');
+  });
+});

--- a/src/applications/vaos/components/AppointmentTime.jsx
+++ b/src/applications/vaos/components/AppointmentTime.jsx
@@ -23,7 +23,7 @@ export default function AppointmentTime({ date, timezone }) {
         {timezoneAbbreviation}
       </span>
       <span className="sr-only" data-testid="appointment-time-description">
-        {formattedTime} {timezoneAbbreviation}
+        {`${formattedTime} ${timezoneAbbreviation}`}
         {`Appointment time in ${timezoneDescription}`}
       </span>
     </div>

--- a/src/applications/vaos/components/AppointmentTime.jsx
+++ b/src/applications/vaos/components/AppointmentTime.jsx
@@ -18,7 +18,7 @@ export default function AppointmentTime({ date, timezone }) {
   );
   return (
     <div data-dd-privacy="mask" data-testid="appointment-time">
-      {formattedTime}
+      {`${formattedTime} `}
       <span aria-hidden="true" data-testid="appointment-time-abbreviation">
         {timezoneAbbreviation}
       </span>

--- a/src/applications/vaos/components/AppointmentTime.jsx
+++ b/src/applications/vaos/components/AppointmentTime.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { formatInTimeZone } from 'date-fns-tz';
-import { stripDST } from '../utils/timezone';
+import { stripDST, getFormattedTimezoneAbbr } from '../utils/timezone';
 
 /**
  * Component for displaying appointment time in a consistent format with timezone
  */
 export default function AppointmentTime({ date, timezone }) {
   const formattedTime = formatInTimeZone(new Date(date), timezone, 'h:mm aaaa');
-  const timezoneAbbreviation = stripDST(
-    formatInTimeZone(new Date(date), timezone, 'zzz'),
-  );
+  const timezoneAbbreviation = getFormattedTimezoneAbbr(date, timezone);
   const timezoneDescription = stripDST(
     formatInTimeZone(new Date(date), timezone, 'zzzz'),
   );

--- a/src/applications/vaos/components/AppointmentTime.jsx
+++ b/src/applications/vaos/components/AppointmentTime.jsx
@@ -7,9 +7,7 @@ import { stripDST } from '../utils/timezone';
  * Component for displaying appointment time in a consistent format with timezone
  */
 export default function AppointmentTime({ date, timezone }) {
-  const formattedTime = stripDST(
-    formatInTimeZone(new Date(date), timezone, 'h:mm aaaa'),
-  );
+  const formattedTime = formatInTimeZone(new Date(date), timezone, 'h:mm aaaa');
   const timezoneAbbreviation = stripDST(
     formatInTimeZone(new Date(date), timezone, 'zzz'),
   );

--- a/src/applications/vaos/components/AppointmentTime.jsx
+++ b/src/applications/vaos/components/AppointmentTime.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { formatInTimeZone } from 'date-fns-tz';
+import { stripDST } from '../utils/timezone';
+
+/**
+ * Component for displaying appointment time in a consistent format with timezone
+ */
+export default function AppointmentTime({ date, timezone }) {
+  const formattedTime = stripDST(
+    formatInTimeZone(new Date(date), timezone, 'h:mm aaaa'),
+  );
+  const timezoneAbbreviation = stripDST(
+    formatInTimeZone(new Date(date), timezone, 'zzz'),
+  );
+  const timezoneDescription = stripDST(
+    formatInTimeZone(new Date(date), timezone, 'zzzz'),
+  );
+  return (
+    <div data-dd-privacy="mask" data-testid="appointment-time">
+      {formattedTime}
+      <span aria-hidden="true" data-testid="appointment-time-abbreviation">
+        {timezoneAbbreviation}
+      </span>
+      <span className="sr-only" data-testid="appointment-time-description">
+        {formattedTime} {timezoneAbbreviation}
+        {`Appointment time in ${timezoneDescription}`}
+      </span>
+    </div>
+  );
+}
+
+AppointmentTime.propTypes = {
+  date: PropTypes.string.isRequired,
+  timezone: PropTypes.string.isRequired,
+};

--- a/src/applications/vaos/components/AppointmentTime.unit.spec.jsx
+++ b/src/applications/vaos/components/AppointmentTime.unit.spec.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import AppointmentTime from './AppointmentTime';
+
+describe('AppointmentTime', () => {
+  const sampleDate = '2024-11-18T18:30:00Z';
+  const timezone = 'America/New_York';
+
+  it('should render time with timezone conversion', () => {
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={timezone} />,
+    );
+
+    const timeElement = getByTestId('appointment-time');
+    expect(timeElement).to.exist;
+
+    // Should show either 1:30 PM or 2:30 PM depending on DST
+    const timeText = timeElement.textContent;
+    const hasCorrectTime =
+      timeText.includes('1:30') || timeText.includes('2:30');
+    expect(hasCorrectTime).to.be.true;
+
+    // Should include p.m.
+    const hasPM = timeText.includes('p.m.');
+    expect(hasPM).to.be.true;
+  });
+
+  it('should strip DST from timezone', () => {
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={timezone} />,
+    );
+
+    const timeElement = getByTestId('appointment-time');
+    const timeText = timeElement.textContent;
+
+    // Should include ET (stripped DST) rather than EST/EDT
+    expect(timeText).to.include('ET');
+  });
+
+  it('should have data-dd-privacy mask attribute', () => {
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={timezone} />,
+    );
+
+    const timeElement = getByTestId('appointment-time');
+    expect(timeElement).to.exist;
+    expect(timeElement.getAttribute('data-dd-privacy')).to.equal('mask');
+  });
+
+  it('should handle different timezones correctly', () => {
+    const pacificTimezone = 'America/Los_Angeles';
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={pacificTimezone} />,
+    );
+
+    const timeElement = getByTestId('appointment-time');
+    const timeText = timeElement.textContent;
+
+    // Should show either 10:30 AM or 11:30 AM for Pacific time
+    const hasCorrectTime =
+      timeText.includes('10:30') || timeText.includes('11:30');
+    expect(hasCorrectTime).to.be.true;
+
+    // Should include a.m.
+    const hasAM = timeText.includes('a.m.');
+    expect(hasAM).to.be.true;
+  });
+
+  it('should render separate timezone abbreviation element', () => {
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={timezone} />,
+    );
+
+    const timezoneElement = getByTestId('appointment-time-abbreviation');
+    expect(timezoneElement).to.exist;
+    expect(timezoneElement.getAttribute('aria-hidden')).to.equal('true');
+    expect(timezoneElement.textContent).to.include('ET');
+  });
+
+  it('should render screen reader description', () => {
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={timezone} />,
+    );
+
+    const descriptionElement = getByTestId('appointment-time-description');
+    expect(descriptionElement).to.exist;
+    expect(descriptionElement.className).to.include('sr-only');
+
+    const descriptionText = descriptionElement.textContent;
+    expect(descriptionText).to.include('p.m.');
+    expect(descriptionText).to.include('ET');
+    expect(descriptionText).to.include('Appointment time in Eastern');
+  });
+
+  it('should have proper accessibility structure', () => {
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={timezone} />,
+    );
+
+    const mainElement = getByTestId('appointment-time');
+    const timezoneElement = getByTestId('appointment-time-abbreviation');
+    const descriptionElement = getByTestId('appointment-time-description');
+
+    // Main element should have data-dd-privacy
+    expect(mainElement.getAttribute('data-dd-privacy')).to.equal('mask');
+
+    // Timezone should be aria-hidden
+    expect(timezoneElement.getAttribute('aria-hidden')).to.equal('true');
+
+    // Description should be screen reader only
+    expect(descriptionElement.className).to.include('sr-only');
+  });
+
+  it('should format Pacific timezone correctly with abbreviation', () => {
+    const pacificTimezone = 'America/Los_Angeles';
+    const { getByTestId } = render(
+      <AppointmentTime date={sampleDate} timezone={pacificTimezone} />,
+    );
+
+    const timezoneElement = getByTestId('appointment-time-abbreviation');
+    expect(timezoneElement.textContent).to.include('PT');
+
+    const descriptionElement = getByTestId('appointment-time-description');
+    const descriptionText = descriptionElement.textContent;
+    expect(descriptionText).to.include('PT');
+    expect(descriptionText).to.include('Appointment time in Pacific');
+  });
+});

--- a/src/applications/vaos/referral-appointments/CompleteReferral.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.jsx
@@ -2,13 +2,12 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useHistory } from 'react-router-dom';
-import { format } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import { titleCase } from '../utils/formatters';
-import { stripDST } from '../utils/timezone';
 import ReferralLayout from './components/ReferralLayout';
 import ProviderAddress from './components/ProviderAddress';
+import AppointmentDate from '../components/AppointmentDate';
+import AppointmentTime from '../components/AppointmentTime';
 import { routeToNextReferralPage } from './flow';
 import {
   pollFetchAppointmentInfo,
@@ -128,18 +127,6 @@ export const CompleteReferral = props => {
 
   const { attributes } = referralAppointmentInfo;
 
-  const appointmentDate = format(
-    new Date(attributes.start),
-    'EEEE, MMMM do, yyyy',
-  );
-
-  const appointmentTime = stripDST(
-    formatInTimeZone(
-      new Date(attributes.start),
-      attributes.provider.location.timezone,
-      'h:mm aaaa zzz',
-    ),
-  );
   return (
     <ReferralLayout
       hasEyebrow
@@ -163,15 +150,18 @@ export const CompleteReferral = props => {
           >
             <p
               className="vads-u-margin-bottom--0 vads-u-font-family--serif"
-              data-testid="appointment-date"
+              data-testid="appointment-date-container"
             >
-              <span data-dd-privacy="mask">{appointmentDate}</span>
+              <AppointmentDate date={attributes.start} />
             </p>
             <h2
               className="vads-u-margin-top--0 vads-u-margin-bottom-1"
-              data-testid="appointment-time"
+              data-testid="appointment-time-container"
             >
-              <span data-dd-privacy="mask">{appointmentTime}</span>
+              <AppointmentTime
+                date={attributes.start}
+                timezone={attributes.provider.location.timezone}
+              />
             </h2>
             <strong data-dd-privacy="mask" data-testid="appointment-type">
               {titleCase(currentReferral.categoryOfCare)} with{' '}

--- a/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
@@ -113,6 +113,14 @@ describe('CompleteReferral', () => {
     expect(getByTestId('appointment-date')).to.have.text(
       'Monday, November 18th, 2024',
     );
+
+    // Check that appointment time container exists and contains time elements
+    const timeContainer = getByTestId('appointment-time');
+    expect(timeContainer).to.exist;
+    expect(timeContainer.textContent).to.include('8:30');
+    expect(timeContainer.textContent).to.include('a.m.');
+    expect(timeContainer.textContent).to.include('ET');
+
     expect(getByTestId('appointment-type')).to.have.text(
       'Optometry with Dr. Moreen S. Rafa',
     );

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useHistory } from 'react-router-dom';
-import { format } from 'date-fns';
 
 import { fetchAppointmentInfo, setFormCurrentPage } from './redux/actions';
 // eslint-disable-next-line import/no-restricted-paths
@@ -11,8 +10,8 @@ import { getReferralAppointmentInfo } from './redux/selectors';
 import PageLayout from '../appointment-list/components/PageLayout';
 import FullWidthLayout from '../components/FullWidthLayout';
 import Section from '../components/Section';
-// eslint-disable-next-line import/no-restricted-paths
-import { AppointmentTime } from '../appointment-list/components/AppointmentDateTime';
+import AppointmentDate from '../components/AppointmentDate';
+import AppointmentTime from '../components/AppointmentTime';
 import ProviderAddress from './components/ProviderAddress';
 
 export default function EpsAppointmentDetailsPage() {
@@ -87,11 +86,6 @@ export default function EpsAppointmentDetailsPage() {
 
   const { attributes: appointment } = referralAppointmentInfo;
 
-  const appointmentDate = format(
-    new Date(appointment.start),
-    'EEEE, MMMM do, yyyy',
-  );
-
   return (
     <PageLayout>
       <div className="vaos-hide-for-print mobile:vads-u-margin-bottom--0 mobile-lg:vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--2">
@@ -125,11 +119,11 @@ export default function EpsAppointmentDetailsPage() {
           <span data-dd-privacy="mask">Community Care Appointment</span>
         </h1>
         <Section heading="When">
-          <span data-dd-privacy="mask">{appointmentDate}</span>
+          <AppointmentDate date={appointment.start} />
           <br />
           <AppointmentTime
-            appointment={appointment}
-            timezone={appointment.timezone}
+            date={appointment.start}
+            timezone={appointment.provider.location.timezone}
           />
         </Section>
         <Section heading="Provider">

--- a/src/applications/vaos/utils/timezone.js
+++ b/src/applications/vaos/utils/timezone.js
@@ -45,6 +45,20 @@ export function stripDST(stringWithAbbr) {
 }
 
 /**
+ * Function to map GMT timezone to abbreviation
+ *
+ * @export
+ * @param {string} abbreviation - Timezone abbreviation that may be GMT format
+ * @returns {string} - Mapped timezone abbreviation or original if not GMT
+ */
+export function mapGmtToAbbreviation(abbreviation) {
+  if (abbreviation?.startsWith('GMT')) {
+    return GMT_TABLE_MAPPING[abbreviation] || abbreviation;
+  }
+  return abbreviation;
+}
+
+/**
  * Function to return timezone.
  *
  * @export
@@ -76,9 +90,7 @@ export function getTimezoneAbbrFromApi(appointment) {
     ? formatInTimeZone(new Date(), appointmentTZ, 'z')
     : null;
 
-  if (timeZoneAbbr?.startsWith('GMT')) {
-    return GMT_TABLE_MAPPING[timeZoneAbbr];
-  }
+  timeZoneAbbr = mapGmtToAbbreviation(timeZoneAbbr);
 
   // Strip out middle char in abbreviation so we can ignore DST
   if (
@@ -105,7 +117,7 @@ export function getTimezoneAbbrByFacilityId(id) {
   }
 
   let abbreviation = formatInTimeZone(new Date(), matchingZone, 'z');
-  if (abbreviation?.startsWith('GMT')) return GMT_TABLE_MAPPING[abbreviation];
+  abbreviation = mapGmtToAbbreviation(abbreviation);
 
   // Strip out middle char in abbreviation so we can ignore DST
   if (matchingZone.includes('America') || matchingZone.includes('Pacific')) {
@@ -158,8 +170,21 @@ export function getTimezoneNameFromAbbr(abbreviation) {
  */
 export function getUserTimezoneAbbr() {
   let abbreviation = format(new Date(), 'z');
-  if (abbreviation.startsWith('GMT'))
-    abbreviation = GMT_TABLE_MAPPING[abbreviation];
+  abbreviation = mapGmtToAbbreviation(abbreviation);
 
   return abbreviation || format(new Date(), 'z');
+}
+
+/**
+ * Function to get formatted timezone abbreviation for a given date and timezone.
+ *
+ * @export
+ * @param {string|Date} date - The date to format.
+ * @param {string} timezone - The IANA timezone string (e.g., 'America/New_York').
+ * @returns {string} - The formatted timezone abbreviation with DST stripped and GMTs replaced.
+ */
+export function getFormattedTimezoneAbbr(date, timezone) {
+  return stripDST(
+    mapGmtToAbbreviation(formatInTimeZone(new Date(date), timezone, 'zzz')),
+  );
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixes timezone issue on details view
- Creates new simpler components that convert utc time string to a unified agreed upon format

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/113897

## Testing done

- The time was being converted improperly because the timezone wasn't being passed in to the time component
- Go through the CC flow and click the details link on the complete page.
- It should display the correct time given the utc time provided and the timezone

## Screenshots
<img width="693" height="606" alt="Screenshot 2025-08-18 at 11 43 40 AM" src="https://github.com/user-attachments/assets/82f08022-0ba3-41d4-ae04-6d45be327259" />

## What areas of the site does it impact?

CC Direct Scheduling

## Acceptance criteria

- [ ] Time is converted properly

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
