### PR TITLE
ArrayBuilder | Fix review page heading levels for a11y

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/chapterSelect.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/chapterSelect.js
@@ -16,7 +16,7 @@ const DeselectAll = ({ formData, setFormData }) => {
   return <va-button text="Deselect all" onClick={onClick} uswds />;
 };
 
-/** @type {PageSchema} */
+/** @type {PageSchema}  */
 export default {
   ContentBeforeButtons: DeselectAll,
   uiSchema: {

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -71,7 +71,7 @@ function getYesNoReviewErrorMessage(reviewErrors, hasItemsKey) {
   return error?.message;
 }
 
-const useHeadingLevels = (userHeaderLevel, isReviewPage) => {
+export const useHeadingLevels = (userHeaderLevel, isReviewPage) => {
   const isMinimalHeader = useRef(null);
   if (isMinimalHeader.current === null) {
     // only check once

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -79,10 +79,12 @@ export const useHeadingLevels = (userHeaderLevel, isReviewPage) => {
   }
   const headingLevel =
     userHeaderLevel || (isMinimalHeader.current && !isReviewPage ? '1' : '3');
+  const reviewHeadingLevel =
+    userHeaderLevel || (isMinimalHeader.current ? '3' : '4');
   const headingStyle =
     isMinimalHeader.current && !isReviewPage ? ' vads-u-font-size--h2' : '';
 
-  return { headingLevel, headingStyle };
+  return { headingLevel, headingStyle, reviewHeadingLevel };
 };
 
 /**

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react/sort-prop-types */
-import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui/focus';
 import { scrollAndFocus } from 'platform/utilities/scroll';
@@ -72,19 +72,20 @@ function getYesNoReviewErrorMessage(reviewErrors, hasItemsKey) {
 }
 
 export const useHeadingLevels = (userHeaderLevel, isReviewPage) => {
-  const isMinimalHeader = useRef(null);
-  if (isMinimalHeader.current === null) {
-    // only check once
-    isMinimalHeader.current = isMinimalHeaderPath();
-  }
-  const headingLevel =
-    userHeaderLevel || (isMinimalHeader.current && !isReviewPage ? '1' : '3');
-  const reviewHeadingLevel =
-    userHeaderLevel || (isMinimalHeader.current ? '3' : '4');
-  const headingStyle =
-    isMinimalHeader.current && !isReviewPage ? ' vads-u-font-size--h2' : '';
+  const isMinimalHeader = useMemo(() => isMinimalHeaderPath(), []);
+  let defaultLevel;
 
-  return { headingLevel, headingStyle, reviewHeadingLevel };
+  if (isMinimalHeader) {
+    defaultLevel = isReviewPage ? '3' : '1';
+  } else {
+    defaultLevel = isReviewPage ? '4' : '3';
+  }
+
+  const headingLevel = userHeaderLevel ?? defaultLevel;
+  const headingStyle =
+    isMinimalHeader && !isReviewPage ? 'vads-u-font-size--h2' : '';
+
+  return { headingLevel, headingStyle };
 };
 
 /**

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react/sort-prop-types */
+import classNames from 'classnames';
 import React, { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui/focus';
@@ -82,8 +83,9 @@ export const useHeadingLevels = (userHeaderLevel, isReviewPage) => {
   }
 
   const headingLevel = userHeaderLevel ?? defaultLevel;
-  const headingStyle =
-    isMinimalHeader && !isReviewPage ? 'vads-u-font-size--h2' : '';
+  const headingStyle = {
+    'vads-u-font-size--h2': isMinimalHeader && !isReviewPage,
+  };
 
   return { headingLevel, headingStyle };
 };
@@ -374,10 +376,10 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
 
     const Title = ({ textType }) => {
       const text = getText(textType, updatedItemData, props.data);
-
+      const baseClasses = ['vads-u-color--gray-dark', 'vads-u-margin-top--0'];
       return text ? (
         <Heading
-          className={`vads-u-color--gray-dark vads-u-margin-top--0${headingStyle}`}
+          className={classNames(baseClasses, headingStyle)}
           data-title-for-noun-singular={nounSingular}
         >
           {text}

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
@@ -14,11 +14,8 @@ const ArrayBuilderSummaryReviewPage = ({
   hideAdd,
 }) => {
   const { reviewPanelHeadingLevel } = arrayBuilderOptions;
-  const { reviewHeadingLevel } = useHeadingLevels(
-    reviewPanelHeadingLevel,
-    true,
-  );
-  const Header = `h${reviewHeadingLevel}`;
+  const { headingLevel } = useHeadingLevels(reviewPanelHeadingLevel, true);
+  const Header = `h${headingLevel}`;
   return (
     <>
       {arrayData?.length ? (

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
@@ -13,7 +13,7 @@ const ArrayBuilderSummaryReviewPage = ({
   Title,
   hideAdd,
 }) => {
-  const { reviewPanelHeadingLevel } = arrayBuilderOptions;
+  const { reviewPanelHeadingLevel = '4' } = arrayBuilderOptions;
   const { headingLevel } = useHeadingLevels(reviewPanelHeadingLevel, true);
   const Header = `h${headingLevel}`;
   return (

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useHeadingLevels } from './ArrayBuilderSummaryPage';
 
 const ArrayBuilderSummaryReviewPage = ({
   customPageProps,
@@ -13,11 +14,7 @@ const ArrayBuilderSummaryReviewPage = ({
   hideAdd,
 }) => {
   const { reviewPanelHeadingLevel } = arrayBuilderOptions;
-  const headingLevel = ['1', '2', '3', '4', '5', '6'].includes(
-    String(reviewPanelHeadingLevel),
-  )
-    ? reviewPanelHeadingLevel
-    : '4';
+  const { headingLevel } = useHeadingLevels(reviewPanelHeadingLevel, true);
   const Header = `h${headingLevel}`;
   return (
     <>

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
@@ -12,6 +12,13 @@ const ArrayBuilderSummaryReviewPage = ({
   Title,
   hideAdd,
 }) => {
+  const { reviewPanelHeadingLevel } = arrayBuilderOptions;
+  const headingLevel = ['1', '2', '3', '4', '5', '6'].includes(
+    String(reviewPanelHeadingLevel),
+  )
+    ? reviewPanelHeadingLevel
+    : '4';
+  const Header = `h${headingLevel}`;
   return (
     <>
       {arrayData?.length ? (
@@ -19,7 +26,7 @@ const ArrayBuilderSummaryReviewPage = ({
       ) : (
         <>
           <div className="form-review-panel-page-header-row">
-            <h4
+            <Header
               className="form-review-panel-page-header vads-u-font-size--h5"
               data-title-for-noun-singular={`${
                 arrayBuilderOptions.nounSingular
@@ -30,7 +37,7 @@ const ArrayBuilderSummaryReviewPage = ({
                 updatedItemData,
                 customPageProps.data,
               )}
-            </h4>
+            </Header>
           </div>
           <dl className="review">
             <div className="review-row">

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryReviewPage.jsx
@@ -13,9 +13,12 @@ const ArrayBuilderSummaryReviewPage = ({
   Title,
   hideAdd,
 }) => {
-  const { reviewPanelHeadingLevel = '4' } = arrayBuilderOptions;
-  const { headingLevel } = useHeadingLevels(reviewPanelHeadingLevel, true);
-  const Header = `h${headingLevel}`;
+  const { reviewPanelHeadingLevel } = arrayBuilderOptions;
+  const { reviewHeadingLevel } = useHeadingLevels(
+    reviewPanelHeadingLevel,
+    true,
+  );
+  const Header = `h${reviewHeadingLevel}`;
   return (
     <>
       {arrayData?.length ? (

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryReviewPage.unit.spec.jsx
@@ -103,7 +103,7 @@ describe('ArrayBuilderSummaryReviewPage', () => {
       });
 
       expect(queryByTestId('title')).to.not.exist;
-      expect(getByRole('heading', { level: 3, name: summaryTitle })).to.exist;
+      expect(getByRole('heading', { level: 4, name: summaryTitle })).to.exist;
       expect(container.querySelector('dl.review')).to.exist;
       expect(container.querySelector('dt')).to.include.text(reviewQuestion);
       expect(container.querySelector('dd span')).to.include.text('No');
@@ -117,12 +117,12 @@ describe('ArrayBuilderSummaryReviewPage', () => {
         arrayData: [],
         arrayBuilderOptions: {
           getText,
-          reviewPanelHeadingLevel: '2',
+          reviewPanelHeadingLevel: '3',
         },
       });
 
-      expect(getByRole('heading', { level: 2, name: summaryTitle })).to.exist;
-      expect(queryByRole('heading', { level: 3 })).to.not.exist;
+      expect(getByRole('heading', { level: 3, name: summaryTitle })).to.exist;
+      expect(queryByRole('heading', { level: 4 })).to.not.exist;
     });
 
     it('should call `getText` with correct parameters', () => {
@@ -216,7 +216,7 @@ describe('ArrayBuilderSummaryReviewPage', () => {
         },
       });
 
-      const headerEl = container.querySelector('h3');
+      const headerEl = container.querySelector('h4');
       expect(headerEl.getAttribute('data-title-for-noun-singular')).to.equal(
         'employer',
       );

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryReviewPage.unit.spec.jsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent } from '@testing-library/react';
+import sinon from 'sinon-v20';
+import ArrayBuilderSummaryReviewPage from '../ArrayBuilderSummaryReviewPage';
+
+describe('ArrayBuilderSummaryReviewPage', () => {
+  const defaultProps = {
+    customPageProps: { data: { employers: [] } },
+    arrayBuilderOptions: {
+      nounSingular: 'employer',
+      nounPlural: 'employers',
+      getText: sinon.stub(),
+    },
+    arrayData: [],
+    hideAdd: false,
+    updatedItemData: null,
+    addAnotherItemButtonClick: sinon.stub(),
+    Alerts: sinon.stub().returns(<div data-testid="alerts" />),
+    Cards: sinon.stub().returns(<div data-testid="cards" />),
+    Title: sinon.stub().returns(<div data-testid="title" />),
+  };
+
+  const createGetTextStub = (map = {}) => {
+    const stub = sinon.stub();
+    Object.entries(map).forEach(([key, val]) => {
+      stub.withArgs(key).returns(val);
+    });
+    return stub;
+  };
+
+  const renderComponent = (overrides = {}) => {
+    const props = {
+      ...defaultProps,
+      ...overrides,
+      arrayBuilderOptions: {
+        ...defaultProps.arrayBuilderOptions,
+        ...(overrides.arrayBuilderOptions || {}),
+      },
+    };
+    const utils = render(<ArrayBuilderSummaryReviewPage {...props} />);
+    return { ...utils, props };
+  };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  context('when array is populated', () => {
+    it('should render Title component', () => {
+      const { props, getByTestId, queryByRole } = renderComponent({
+        arrayData: [{ name: 'Test employer' }],
+      });
+      expect(getByTestId('title')).to.exist;
+      expect(queryByRole('definition')).to.not.exist;
+      sinon.assert.calledWith(props.Title, { textType: 'summaryTitle' });
+    });
+
+    it('should render summary description when `getText` returns content', () => {
+      const summaryDescription = 'This is a description';
+      const getText = createGetTextStub({
+        summaryDescription,
+        summaryTitle: 'Review your employers',
+      });
+
+      const { getByText } = renderComponent({
+        arrayData: [{ name: 'Test' }],
+        arrayBuilderOptions: { getText },
+      });
+
+      const desc = getByText(summaryDescription);
+      expect(desc).to.exist;
+      expect(desc.className).to.include('vads-u-font-family--sans');
+    });
+
+    it('should not render summary description when `getText` returns falsy', () => {
+      const getText = createGetTextStub({
+        summaryDescription: '',
+        summaryTitle: 'Review your employers',
+      });
+
+      const { queryByText } = renderComponent({
+        arrayData: [{ name: 'Test' }],
+        arrayBuilderOptions: { getText },
+      });
+
+      expect(queryByText('This is a description')).to.not.exist;
+    });
+  });
+
+  context('when array is empty', () => {
+    it('should render Header and review structure', () => {
+      const summaryTitle = 'Review your employers';
+      const reviewQuestion = 'Do you have any employers?';
+      const getText = createGetTextStub({
+        summaryTitle,
+        yesNoBlankReviewQuestion: reviewQuestion,
+      });
+
+      const { container, getByRole, queryByTestId } = renderComponent({
+        arrayData: [],
+        arrayBuilderOptions: { getText },
+      });
+
+      expect(queryByTestId('title')).to.not.exist;
+      expect(getByRole('heading', { level: 3, name: summaryTitle })).to.exist;
+      expect(container.querySelector('dl.review')).to.exist;
+      expect(container.querySelector('dt')).to.include.text(reviewQuestion);
+      expect(container.querySelector('dd span')).to.include.text('No');
+    });
+
+    it('should use correct heading level from `useHeadingLevels` hook', () => {
+      const summaryTitle = 'Review your employers';
+      const getText = createGetTextStub({ summaryTitle });
+
+      const { getByRole, queryByRole } = renderComponent({
+        arrayData: [],
+        arrayBuilderOptions: {
+          getText,
+          reviewPanelHeadingLevel: '2',
+        },
+      });
+
+      expect(getByRole('heading', { level: 2, name: summaryTitle })).to.exist;
+      expect(queryByRole('heading', { level: 3 })).to.not.exist;
+    });
+
+    it('should call `getText` with correct parameters', () => {
+      const getText = createGetTextStub({
+        summaryTitle: 'Review your employers',
+        yesNoBlankReviewQuestion: 'Do you have any employers?',
+      });
+
+      const customPageProps = { data: { test: 'data' } };
+      const updatedItemData = { name: 'Updated' };
+
+      renderComponent({
+        arrayData: [],
+        customPageProps,
+        updatedItemData,
+        arrayBuilderOptions: { getText },
+      });
+
+      expect(
+        getText.calledWith(
+          'summaryTitle',
+          updatedItemData,
+          customPageProps.data,
+        ),
+      ).to.be.true;
+
+      expect(
+        getText.calledWith(
+          'yesNoBlankReviewQuestion',
+          null,
+          customPageProps.data,
+        ),
+      ).to.be.true;
+    });
+  });
+
+  context('buttons and subcomponents', () => {
+    it('should render add button when `hideAdd` prop is `false`', () => {
+      const buttonText = 'Add another employer';
+      const getText = createGetTextStub({ reviewAddButtonText: buttonText });
+
+      const { container } = renderComponent({
+        hideAdd: false,
+        arrayBuilderOptions: { getText },
+      });
+
+      const addButton = container.querySelector('va-button[data-action="add"]');
+      expect(addButton).to.exist;
+      expect(addButton.getAttribute('text')).to.equal(buttonText);
+      expect(addButton.getAttribute('name')).to.equal('employersAddButton');
+    });
+
+    it('should not render add button when `hideAdd` prop is `true`', () => {
+      const { container } = renderComponent({ hideAdd: true });
+      const addButton = container.querySelector('va-button[data-action="add"]');
+      expect(addButton).to.not.exist;
+    });
+
+    it('should call `addAnotherItemButtonClick` when add button is clicked', () => {
+      const getText = createGetTextStub({
+        reviewAddButtonText: 'Add another employer',
+      });
+      const addAnotherItemButtonClick = sinon.stub();
+
+      const { container } = renderComponent({
+        addAnotherItemButtonClick,
+        arrayBuilderOptions: { getText },
+      });
+
+      const addButton = container.querySelector('va-button[data-action="add"]');
+      fireEvent.click(addButton);
+      sinon.assert.calledOnce(addAnotherItemButtonClick);
+    });
+
+    it('should render Alerts and Cards components', () => {
+      const { getByTestId } = renderComponent();
+      expect(getByTestId('alerts')).to.exist;
+      expect(getByTestId('cards')).to.exist;
+    });
+
+    it('should pass correct data attributes to Header element', () => {
+      const getText = createGetTextStub({
+        summaryTitle: 'Review your employers',
+      });
+
+      const { container } = renderComponent({
+        arrayData: [],
+        arrayBuilderOptions: {
+          nounSingular: 'employer',
+          getText,
+        },
+      });
+
+      const headerEl = container.querySelector('h3');
+      expect(headerEl.getAttribute('data-title-for-noun-singular')).to.equal(
+        'employer',
+      );
+      expect(headerEl.classList.contains('form-review-panel-page-header')).to.be
+        .true;
+      expect(headerEl.classList.contains('vads-u-font-size--h5')).to.be.true;
+    });
+  });
+});

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -465,6 +465,7 @@
  * @property {number} [maxItems] The maximum number of items allowed in the array. Omit to allow unlimited items.
  * @property {boolean} required This determines the flow type of the array builder. Required starts with an intro page, optional starts with the yes/no question (summary page).
  * @property {string} [reviewPath] Defaults to `'review-and-submit'` if not provided.
+ * @property {string} [reviewPanelHeadingLevel] The heading level for the summary title on the review page.
  * @property {ArrayBuilderText} [text] Override any default text used in the array builder pattern
  * @property {boolean} [useLinkInsteadOfYesNo]
  * @property {boolean} [useButtonInsteadOfYesNo]


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the heading level on the ArrayBuilder review page to fix issues found with an Axe checks failing for apps using the minimal header. For the minimal header, the review panel titles need to be H3s, but they're hard-coded as H4s.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#116800

## Acceptance criteria

 - Axe check passes with the correct heading levels

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution