### PR TITLE
10-10d Extended | Add Sponsor email field

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/sponsorInformation.js
@@ -6,6 +6,8 @@ import {
   dateOfBirthSchema,
   dateOfDeathSchema,
   dateOfDeathUI,
+  emailUI,
+  emailSchema,
   fullNameUI,
   fullNameSchema,
   phoneUI,
@@ -196,6 +198,9 @@ export const sponsorContactInfo = {
       ...phoneUI(),
       'ui:required': () => true,
     },
+    sponsorEmail: {
+      ...emailUI(),
+    },
   },
   schema: {
     type: 'object',
@@ -203,6 +208,7 @@ export const sponsorContactInfo = {
     properties: {
       titleSchema,
       sponsorPhone: phoneSchema,
+      sponsorEmail: emailSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/data/maximal-test.json
@@ -106,6 +106,7 @@
       "postalCode": "12312"
     },
     "sponsorPhone": "5552223333",
+    "sponsorEmail": "sponsor@email.gov",
     "sponsorIsDeceased": true,
     "sponsorDOD": "2001-01-01",
     "sponsorDeathConditions": false,

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/pages/combinedPageTests.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/pages/combinedPageTests.unit.spec.jsx
@@ -98,7 +98,7 @@ testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.sponsorInformation.pages.page11.schema,
   formConfig.chapters.sponsorInformation.pages.page11.uiSchema,
-  1,
+  2,
   'Sponsor Information - Contact info',
   {},
 );
@@ -106,7 +106,7 @@ testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.sponsorInformation.pages.page11.schema,
   formConfig.chapters.sponsorInformation.pages.page11.uiSchema,
-  1,
+  2,
   'Sponsor Information - Contact info (role: sponsor)',
   { certifierRole: 'sponsor' },
 );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds an email field for the 10-10d's sponsor contact information page. This is a newer field on the paper form, so we are adding this to match that paper form update.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#116866

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Base | Valid | Invalid |
| ------- | ------ | ----- |
| <img width="547" height="404" alt="Screenshot 2025-08-18 at 12 46 18" src="https://github.com/user-attachments/assets/867f8b06-af8c-468c-82db-77702e4efae3" /> | <img width="547" height="404" alt="Screenshot 2025-08-18 at 12 46 09" src="https://github.com/user-attachments/assets/5cbb94a2-2392-4e96-b154-9ca04ed79037" /> | <img width="547" height="465" alt="Screenshot 2025-08-18 at 12 45 54" src="https://github.com/user-attachments/assets/c018b59c-fb3b-45ac-bdf9-e0890b25a7f2" /> |

## Acceptance criteria

- Field is available for input and included in payload for consumption

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution