### PR TITLE
added slack IDs and modified the dispatch step to add slack_channel t…

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2076,10 +2076,11 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/dispatches \
-          -d "$(jq -n --arg sha "${{ github.sha }}" \
-          --arg ref "${{ github.ref }}" \
-          --arg entry "${{ needs.build.outputs.entry_names }}" \
-          '{event_type: "cd-production-deploy", client_payload: {github_sha: $sha, github_ref: $ref, entry_app: $entry}}')"
+          -d "$(jq -n --arg sha \"${{ github.sha }}\" \
+          --arg ref \"${{ github.ref }}\" \
+          --arg entry \"${{ needs.build.outputs.entry_names }}\" \
+          --arg slack_channel \"${{ steps.determine-channel.outputs.channel }}\" \
+          '{event_type: \"cd-production-deploy\", client_payload: {github_sha: $sha, github_ref: $ref, entry_app: $entry, slack_channel: $slack_channel}}')"
                          
   notify-failure:
     name: Notify Failure

--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -2,7 +2,8 @@
   "apps": [
     {
       "rootFolder": "dependents",
-      "slackGroup": "<@U055VBGMWD9> <@U059ATZPRUZ> <@UN2J9UE1L>"
+      "slackGroup": "<@U055VBGMWD9> <@U059ATZPRUZ> <@UN2J9UE1L>",
+      "slackChannel": "C063YELFVLM"
     },
     {
       "rootFolder": "accreditation",
@@ -14,7 +15,8 @@
     },
     {
       "rootFolder": "appeals",
-      "slackGroup": "@benefits-decision-reviews-team"
+      "slackGroup": "@benefits-decision-reviews-team",
+      "slackChannel": "C5AGLBNRK"
     },
     {
       "rootFolder": "ask-a-question",
@@ -26,7 +28,8 @@
     },
     {
       "rootFolder": "auth",
-      "slackGroup": "<@U05TSDR2NAF> <@U04M52Y7VFU>"
+      "slackGroup": "<@U05TSDR2NAF> <@U04M52Y7VFU>",
+      "slackChannel": "C02SBFQ22RL"
     },
     {
       "rootFolder": "avs",
@@ -38,11 +41,13 @@
     },
     {
       "rootFolder": "burials-ez",
-      "slackGroup": "<@U05UWBJ0LC8> <@U02JAL36LG3> <@UN2J9UE1L>"
+      "slackGroup": "<@U05UWBJ0LC8> <@U02JAL36LG3> <@UN2J9UE1L>",
+      "slackChannel": "C090C6NNZGS"
     },
     {
       "rootFolder": "caregivers",
-      "slackGroup": "@1010-fe-dev"
+      "slackGroup": "@1010-fe-dev",
+      "slackChannel": "C05Q6411HPF"
     },
     {
       "rootFolder": "check-in",
@@ -50,7 +55,8 @@
     },
     {
       "rootFolder": "claims-status",
-      "slackGroup": "@benefits-management-tools-team-2 @benefits-management-tools-team-1"
+      "slackGroup": "@benefits-management-tools-team-2 @benefits-management-tools-team-1",
+      "slackChannel": "C090ZRQHRL5"
     },
     {
       "rootFolder": "combined-debt-portal",
@@ -67,7 +73,8 @@
     {
       "rootFolder": "disability-benefits",
       "slackGroup": "<@U08Q9EMQATV> <@U053MKBJE1H> <@U04L7TKUJQL>",
-      "continuousDeployment": false
+      "continuousDeployment": false,
+      "slackChannel": "C05URMLM09Z"
     },
     {
       "rootFolder": "discharge-wizard",
@@ -107,7 +114,8 @@
     },
     {
       "rootFolder": "ezr",
-      "slackGroup": "@1010-fe-dev"
+      "slackGroup": "@1010-fe-dev",
+      "slackChannel": "C05Q6411HPF"
     },
     {
       "rootFolder": "facility-locator",
@@ -127,23 +135,28 @@
     },
     {
       "rootFolder": "hca",
-      "slackGroup": "@1010-fe-dev"
+      "slackGroup": "@1010-fe-dev",
+      "slackChannel": "C05Q6411HPF"
     },
     {
       "rootFolder": "health-care-supply-reordering",
-      "slackGroup": "<@C05DFSM57FW>"
+      "slackGroup": "<@C05DFSM57FW>",
+      "slackChannel": "C05DFSM57FW"
     },
     {
       "rootFolder": "income-and-asset-statement",
-      "slackGroup": "<@U05UWBJ0LC8> <@U02JAL36LG3> <@UN2J9UE1L>"
+      "slackGroup": "<@U05UWBJ0LC8> <@U02JAL36LG3> <@UN2J9UE1L>",
+      "slackChannel": "C0909A2S57F"
     },
     {
       "rootFolder": "ivc-champva",
-      "slackGroup": "<@U074HNVJ7TQ> <@U066MEYGKDX> <@U02R5NVRJEP> <@U063V879TEX>"
+      "slackGroup": "<@U074HNVJ7TQ> <@U066MEYGKDX> <@U02R5NVRJEP> <@U063V879TEX>",
+      "slackChannel": "C068Y3ZFKNJ"
     },
     {
       "rootFolder": "letters",
-      "slackGroup": "@benefits-management-tools-team-2 @benefits-management-tools-team-1"
+      "slackGroup": "@benefits-management-tools-team-2 @benefits-management-tools-team-1",
+      "slackChannel": "C090ZRQHRL5"
     },
     {
       "rootFolder": "lgy",
@@ -151,15 +164,18 @@
     },
     {
       "rootFolder": "login",
-      "slackGroup": "<@U05TSDR2NAF> <@U03MR6MK08Z>"
+      "slackGroup": "<@U05TSDR2NAF> <@U03MR6MK08Z>",
+      "slackChannel": "C02SBFQ22RL"
     },
     {
       "rootFolder": "medallions",
-      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>"
+      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>",
+      "slackChannel": "C06C6CAG3DG"
     },
     {
       "rootFolder": "medallions2",
-      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>"
+      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>",
+      "slackChannel": "C06C6CAG3DG"
     },
     {
       "rootFolder": "messages",
@@ -167,7 +183,8 @@
     },
     {
       "rootFolder": "mhv-landing-page",
-      "slackGroup": "@mhv-vagov-dev"
+      "slackGroup": "@mhv-vagov-dev",
+      "slackChannel": "C0581MN69TJ"
     },
     {
       "rootFolder": "mhv-medical-records",
@@ -175,11 +192,13 @@
     },
     {
       "rootFolder": "mhv-medications",
-      "slackGroup": "<@U05J06WJNUE> <@U03R3CJ3N3D> <@U063FU5526B>"
+      "slackGroup": "<@U05J06WJNUE> <@U03R3CJ3N3D> <@U063FU5526B>",
+      "slackChannel": "C08VD854EF5"
     },
     {
       "rootFolder": "mhv-secure-messaging",
-      "slackGroup": "<@U03FYHMUG9K> <@U02EVE4RX8W>"
+      "slackGroup": "<@U03FYHMUG9K> <@U02EVE4RX8W>",
+      "slackChannel": "C03T8JY2DM2"
     },
     {
       "rootFolder": "mhv",
@@ -187,7 +206,8 @@
     },
     {
       "rootFolder": "mhv-supply-reordering",
-      "slackGroup": "@mhv-vagov-dev"
+      "slackGroup": "@mhv-vagov-dev",
+      "slackChannel": "C05DFSM57FW"
     },
     {
       "rootFolder": "_mock-form",
@@ -215,7 +235,8 @@
     },
     {
       "rootFolder": "pensions",
-      "slackGroup": "<@U05UWBJ0LC8> <@U02JAL36LG3> <@UN2J9UE1L>"
+      "slackGroup": "<@U05UWBJ0LC8> <@U02JAL36LG3> <@UN2J9UE1L>",
+      "slackChannel": "C090CFCVATW"
     },
     {
       "rootFolder": "personalization",
@@ -228,11 +249,13 @@
     },
     {
       "rootFolder": "pre-need",
-      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>"
+      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>",
+      "slackChannel": "C06C6CAG3DG"
     },
     {
       "rootFolder": "pre-need-integration",
-      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>"
+      "slackGroup": "<@UJBTZN4RG> <@U04LYEY3B9C>",
+      "slackChannel": "C06C6CAG3DG"
     },
     {
       "rootFolder": "proxy-rewrite",
@@ -244,7 +267,8 @@
     },
     {
       "rootFolder": "rated-disabilities",
-      "slackGroup": "@benefits-management-tools-team-2 @benefits-management-tools-team-1"
+      "slackGroup": "@benefits-management-tools-team-2 @benefits-management-tools-team-1",
+      "slackChannel": "C090ZRQHRL5"
     },
     {
       "rootFolder": "representative-appoint",
@@ -292,7 +316,8 @@
     },
     {
       "rootFolder": "terms-of-use",
-      "slackGroup": "<@U018M85FA2K> <@U04M52Y7VFU>"
+      "slackGroup": "<@U018M85FA2K> <@U04M52Y7VFU>",
+      "slackChannel": "C02SBFQ22RL"
     },
     {
       "rootFolder": "toe",
@@ -300,7 +325,8 @@
     },
     {
       "rootFolder": "travel-pay",
-      "slackGroup": "<@U01NU8D1Q5B> <@U0894STJS9F> <@U06059URY69>"
+      "slackGroup": "<@U01NU8D1Q5B> <@U0894STJS9F> <@U06059URY69>",
+      "slackChannel": "C05UTPZRZFY"
     },
     {
       "rootFolder": "user-testing",
@@ -312,7 +338,8 @@
     },
     {
       "rootFolder": "verify",
-      "slackGroup": "<@U03MR6MK08Z> <@U018M85FA2K>"
+      "slackGroup": "<@U03MR6MK08Z> <@U018M85FA2K>",
+      "slackChannel": "C02SBFQ22RL"
     },
     {
       "rootFolder": "verify-your-enrollment",
@@ -324,7 +351,8 @@
     },
     {
       "rootFolder": "virtual-agent",
-      "slackGroup": "<@U022GNYPJ1L>"
+      "slackGroup": "<@U022GNYPJ1L>",
+      "slackChannel": "C088VHR0GTS"
     },
     {
       "rootFolder": "vre",


### PR DESCRIPTION
…o the client payload

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

**Added slackChannel entries for these apps in config/changed-apps-build.json:**
- ivc-champva → #ivc-forms-engineering
- appeals → #benefits-decision-reviews
- caregivers, ezr, hca → # 1010-dev-team
- claims-status, letters, rated-disabilities → #benefits-management-tools-deployments
- disability-benefits → #benefits-disability-notifications
- dependents → #benefits-dependents-management-notifications
- health-care-supply-reordering, mhv-supply-reordering → #vagov-supply-reordering-alerts
- income-and-asset-statement → #benefits-income-and-assets-notifications
- login, verify, sign-in-changes, auth, terms-of-use → #va-identity-alerts
- medallions, medallions2, pre-need, pre-need-integration → #va-gov-mbs-notifications
- mhv-landing-page → #mhv-on-vagov-cartography-team
- mhv-secure-messaging → #mhv-sm-redesign-devs
- mhv-medications → #mhv-medications-deployment-alerts
- travel-pay → #beneficiary-travel-team
- virtual-agent → #chatbot-platform-monitor

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
