### PR TITLE
Refactor fetchReferralAppointment to use RTK

### DIFF
--- a/src/applications/vaos/redux/api/vaosApi.js
+++ b/src/applications/vaos/redux/api/vaosApi.js
@@ -45,6 +45,20 @@ export const vaosApi = createApi({
         dispatch(cacheDraftReferralAppointment({}));
       },
     }),
+    getAppointmentInfo: builder.query({
+      async queryFn(appointmentId) {
+        try {
+          return await apiRequestWithUrl(
+            `/vaos/v2/eps_appointments/${appointmentId}`,
+          );
+        } catch (error) {
+          captureError(error, false, 'poll fetch appointment info');
+          return {
+            error: { status: error.status || 500, message: error.message },
+          };
+        }
+      },
+    }),
     postDraftReferralAppointment: builder.mutation({
       async queryFn({ referralNumber, referralConsultId }) {
         try {
@@ -104,6 +118,7 @@ export const vaosApi = createApi({
 export const {
   useGetReferralByIdQuery,
   useGetPatientReferralsQuery,
+  useGetAppointmentInfoQuery,
   usePostDraftReferralAppointmentMutation,
   usePostReferralAppointmentMutation,
 } = vaosApi;

--- a/src/applications/vaos/referral-appointments/CompleteReferral.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.jsx
@@ -78,7 +78,7 @@ export const CompleteReferral = props => {
         setAppointmentInfoTimeout(true);
         setPollingInterval(0);
       } else {
-        requestInterval = setTimeout(() => {
+        requestInterval = setInterval(() => {
           setRequestTime(
             differenceInMilliseconds(
               new Date(),
@@ -87,7 +87,7 @@ export const CompleteReferral = props => {
           );
         }, pollingInterval);
       }
-      return () => clearTimeout(requestInterval);
+      return () => clearInterval(requestInterval);
     },
     [
       booked,

--- a/src/applications/vaos/referral-appointments/CompleteReferral.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.jsx
@@ -87,7 +87,7 @@ export const CompleteReferral = props => {
           );
         }, pollingInterval);
       }
-      return () => clearInterval(requestInterval);
+      return () => clearTimeout(requestInterval);
     },
     [
       booked,

--- a/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
@@ -94,7 +94,7 @@ describe('CompleteReferral', () => {
 
   it('should render warning alert when appointment info has timed out', () => {
     clock = sinon.useFakeTimers({
-      toFake: ['setTimeout', 'Date'],
+      toFake: ['setTimeout', 'clearTimeout', 'Date'],
     });
     requestStub.resolves({ data: referralDraftAppointmentInfo });
     const { getByTestId } = renderWithStoreAndRouter(
@@ -104,6 +104,10 @@ describe('CompleteReferral', () => {
       },
     );
     clock.tick(33000);
+    waitFor(() => {
+      expect(getByTestId('warning-alert')).to.exist;
+    });
+
     expect(getByTestId('warning-alert')).to.exist;
     clock.restore();
   });

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
@@ -1,10 +1,9 @@
 import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useLocation, useHistory } from 'react-router-dom';
-
-import { fetchAppointmentInfo, setFormCurrentPage } from './redux/actions';
+import { useGetAppointmentInfoQuery } from '../redux/api/vaosApi';
+import { setFormCurrentPage } from './redux/actions';
 // eslint-disable-next-line import/no-restricted-paths
-import { getReferralAppointmentInfo } from './redux/selectors';
 
 // eslint-disable-next-line import/no-restricted-paths
 import PageLayout from '../appointment-list/components/PageLayout';
@@ -21,36 +20,19 @@ export default function EpsAppointmentDetailsPage() {
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const {
-    appointmentInfoError,
-    appointmentInfoLoading,
-    referralAppointmentInfo,
-  } = useSelector(getReferralAppointmentInfo);
   useEffect(
     () => {
       dispatch(setFormCurrentPage('details'));
     },
     [dispatch],
   );
-  useEffect(
-    () => {
-      if (
-        !appointmentInfoError &&
-        !appointmentInfoLoading &&
-        !referralAppointmentInfo?.attributes
-      ) {
-        dispatch(fetchAppointmentInfo(appointmentId));
-      }
-    },
-    [
-      dispatch,
-      appointmentId,
-      appointmentInfoError,
-      appointmentInfoLoading,
-      referralAppointmentInfo,
-    ],
-  );
-  if (appointmentInfoError) {
+  const {
+    data: referralAppointmentInfo,
+    isError,
+    isLoading,
+  } = useGetAppointmentInfoQuery(appointmentId);
+
+  if (isError) {
     return (
       <PageLayout showNeedHelp>
         <br />
@@ -75,8 +57,7 @@ export default function EpsAppointmentDetailsPage() {
       </PageLayout>
     );
   }
-
-  if (appointmentInfoLoading || !referralAppointmentInfo?.attributes) {
+  if (isLoading || !referralAppointmentInfo?.attributes) {
     return (
       <FullWidthLayout>
         <va-loading-indicator set-focus message="Loading your appointment..." />

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
@@ -85,9 +85,6 @@ describe('EpsAppointmentDetailsPage', () => {
     sandbox
       .stub(actionsModule, 'setFormCurrentPage')
       .returns({ type: 'SET_FORM_CURRENT_PAGE' });
-    sandbox
-      .stub(actionsModule, 'fetchAppointmentInfo')
-      .returns(referralAppointmentInfo);
   });
 
   afterEach(() => {

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
@@ -250,7 +250,7 @@ describe('EpsAppointmentDetailsPage', () => {
     expect(getByTestId('provider-telephone')).to.exist;
   });
 
-  it('should display correct time with timezone conversion', () => {
+  it('should display correct time with timezone conversion', async () => {
     // Create appointment with specific UTC time and timezone
     const appointmentWithTimeZone = {
       ...referralAppointmentInfo,
@@ -266,19 +266,15 @@ describe('EpsAppointmentDetailsPage', () => {
         },
       },
     };
-
-    const stateWithTimeZone = {
-      referral: {
-        ...initialState.referral,
-        referralAppointmentInfo: appointmentWithTimeZone,
-      },
-    };
-
+    requestStub.resolves({ data: appointmentWithTimeZone });
     const container = renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(stateWithTimeZone),
+      store: createTestStore(initialState),
       path: `/${appointmentId}`,
     });
 
+    await waitFor(() => {
+      expect(container.getByTestId('appointment-time')).to.exist;
+    });
     // The AppointmentTime component should display the time in the provider's timezone
     // 18:30 UTC should convert to either:
     // - 1:30 PM EST (during standard time)

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
+import { waitFor } from '@testing-library/dom';
+import * as utils from 'applications/vaos/services/utils';
 import EpsAppointmentDetailsPage from './EpsAppointmentDetailsPage';
 import * as actionsModule from './redux/actions';
 import {
@@ -12,6 +13,7 @@ import { createMockEpsAppointment } from './utils/appointment';
 import * as epsAppointmentUtils from './utils/appointment';
 
 describe('EpsAppointmentDetailsPage', () => {
+  let requestStub;
   const appointmentId = 'test-appointment-id';
   const referralAppointmentInfo = createMockEpsAppointment(
     appointmentId,
@@ -26,6 +28,31 @@ describe('EpsAppointmentDetailsPage', () => {
       appointmentInfoError: false,
       appointmentInfoLoading: false,
       referralAppointmentInfo,
+    },
+  };
+
+  const preFetchedState = {
+    referral: {
+      appointmentInfoError: false,
+      appointmentInfoLoading: false,
+    },
+    appointmentApi: {
+      queries: {
+        'getAppointmentInfo("test-appointment-id")': {
+          status: 'fulfilled',
+          endpointName: 'getAppointmentInfo',
+          startedTimeStamp: 1755196851027,
+          fulfilledTimeStamp: 1755196851141,
+          data: referralAppointmentInfo,
+        },
+      },
+      subscriptions: {
+        'getAppointmentInfo("test-appointment-id")': {
+          thisIsThePreviousCache: {
+            pollingInterval: 0,
+          },
+        },
+      },
     },
   };
 
@@ -45,14 +72,6 @@ describe('EpsAppointmentDetailsPage', () => {
     },
   };
 
-  const errorState = {
-    referral: {
-      appointmentInfoError: true,
-      appointmentInfoLoading: false,
-      referralAppointmentInfo: null,
-    },
-  };
-
   const emptyAppointmentState = {
     referral: {
       appointmentInfoError: false,
@@ -62,6 +81,7 @@ describe('EpsAppointmentDetailsPage', () => {
   };
 
   beforeEach(() => {
+    requestStub = sandbox.stub(utils, 'apiRequestWithUrl');
     sandbox
       .stub(actionsModule, 'setFormCurrentPage')
       .returns({ type: 'SET_FORM_CURRENT_PAGE' });
@@ -74,52 +94,37 @@ describe('EpsAppointmentDetailsPage', () => {
     sandbox.restore();
   });
 
-  it('should set form current page to details on mount', () => {
-    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(initialState),
-      path: `/${appointmentId}`,
-    });
-    expect(actionsModule.setFormCurrentPage.calledWith('details')).to.be.true;
-  });
-
-  it('should fetch appointment info when referralAppointmentInfo is null', () => {
-    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+  it('should fetch appointment info when referralAppointmentInfo is null', async () => {
+    requestStub.resolves({ data: referralAppointmentInfo });
+    const screen = renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
       store: createTestStore(noAppointmentInfoState),
       path: `/${appointmentId}`,
     });
-
-    expect(actionsModule.fetchAppointmentInfo.calledWith(appointmentId)).to.be
-      .true;
+    await waitFor(() => {
+      expect(screen.getByTestId('appointment-card')).to.exist;
+    });
+    sandbox.assert.calledWith(
+      utils.apiRequestWithUrl,
+      `/vaos/v2/eps_appointments/${appointmentId}`,
+    );
   });
 
-  it('should fetch appointment info when referralAppointmentInfo exists but is empty', () => {
-    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(emptyAppointmentState),
+  it('should not fetch appointment info when there is existing appointment data', async () => {
+    requestStub.resolves({ data: referralAppointmentInfo });
+    const store = createTestStore(preFetchedState);
+    const screen = renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
+      store,
       path: `/${appointmentId}`,
     });
-
-    expect(actionsModule.fetchAppointmentInfo.called).to.be.true;
-  });
-
-  it('should not fetch appointment info when there is existing appointment data', () => {
-    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(initialState),
-      path: `/${appointmentId}`,
+    await waitFor(() => {
+      expect(screen.getByTestId('appointment-card')).to.exist;
     });
 
-    expect(actionsModule.fetchAppointmentInfo.called).to.be.false;
+    expect(utils.apiRequestWithUrl.called).to.be.false;
   });
 
-  it('should not fetch when appointment info is loading', () => {
-    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(loadingState),
-      path: `/${appointmentId}`,
-    });
-
-    expect(actionsModule.fetchAppointmentInfo.called).to.be.false;
-  });
-
-  it('should render loading indicator when appointment is loading', () => {
+  it('should render loading indicator when appointment is loading', async () => {
+    requestStub.resolves({ data: referralAppointmentInfo });
     const { container } = renderWithStoreAndRouter(
       <EpsAppointmentDetailsPage />,
       {
@@ -131,28 +136,23 @@ describe('EpsAppointmentDetailsPage', () => {
     expect(container.querySelector('va-loading-indicator')).to.exist;
   });
 
-  it('should not fetch when there is an error', () => {
-    renderWithStoreAndRouter(<EpsAppointmentDetailsPage />, {
-      store: createTestStore(errorState),
-      path: `/${appointmentId}`,
-    });
-
-    expect(actionsModule.fetchAppointmentInfo.called).to.be.false;
-  });
-
-  it('should render error alert when there is an error', () => {
+  it('should render error alert when there is an error', async () => {
+    requestStub.throws(() => new Error());
     const { getByTestId } = renderWithStoreAndRouter(
       <EpsAppointmentDetailsPage />,
       {
-        store: createTestStore(errorState),
+        store: createTestStore(initialState),
         path: `/${appointmentId}`,
       },
     );
-
+    await waitFor(() => {
+      expect(getByTestId('error-alert')).to.exist;
+    });
     expect(getByTestId('error-alert')).to.exist;
   });
 
-  it('should render appointment details when appointment is loaded', () => {
+  it('should render appointment details when appointment is loaded', async () => {
+    requestStub.resolves({ data: referralAppointmentInfo });
     const { container, getByText, getByTestId } = renderWithStoreAndRouter(
       <EpsAppointmentDetailsPage />,
       {
@@ -160,7 +160,9 @@ describe('EpsAppointmentDetailsPage', () => {
         path: `/${appointmentId}`,
       },
     );
-
+    await waitFor(() => {
+      expect(getByTestId('appointment-card')).to.exist;
+    });
     // Check that main container exists
     expect(getByTestId('appointment-card')).to.exist;
 
@@ -194,7 +196,7 @@ describe('EpsAppointmentDetailsPage', () => {
     ).to.exist;
   });
 
-  it('should render provider address and directions link when location is available', () => {
+  it('should render provider address and directions link when location is available', async () => {
     const appointmentWithLocation = {
       ...referralAppointmentInfo,
       attributes: {
@@ -210,27 +212,23 @@ describe('EpsAppointmentDetailsPage', () => {
         },
       },
     };
-
-    const stateWithLocation = {
-      referral: {
-        ...initialState.referral,
-        referralAppointmentInfo: appointmentWithLocation,
-      },
-    };
+    requestStub.resolves({ data: appointmentWithLocation });
 
     const { getByTestId } = renderWithStoreAndRouter(
       <EpsAppointmentDetailsPage />,
       {
-        store: createTestStore(stateWithLocation),
+        store: createTestStore(emptyAppointmentState),
         path: `/${appointmentId}`,
       },
     );
-
+    await waitFor(() => {
+      expect(getByTestId('appointment-card')).to.exist;
+    });
     expect(getByTestId('address-block')).to.exist;
     expect(getByTestId('directions-link-wrapper')).to.exist;
   });
 
-  it('should render provider phone number when available', () => {
+  it('should render provider phone number when available', async () => {
     const appointmentWithPhone = {
       ...referralAppointmentInfo,
       attributes: {
@@ -241,22 +239,17 @@ describe('EpsAppointmentDetailsPage', () => {
         },
       },
     };
-
-    const stateWithPhone = {
-      referral: {
-        ...initialState.referral,
-        referralAppointmentInfo: appointmentWithPhone,
-      },
-    };
-
+    requestStub.resolves({ data: appointmentWithPhone });
     const { getByTestId } = renderWithStoreAndRouter(
       <EpsAppointmentDetailsPage />,
       {
-        store: createTestStore(stateWithPhone),
+        store: createTestStore(emptyAppointmentState),
         path: `/${appointmentId}`,
       },
     );
-
+    await waitFor(() => {
+      expect(getByTestId('appointment-card')).to.exist;
+    });
     expect(getByTestId('provider-telephone')).to.exist;
   });
 

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -17,7 +17,7 @@ import * as flow from './flow';
 describe('VAOS Component: ReviewAndConfirm', () => {
   let requestStub;
   const slotDate = '2024-09-09T16:00:00.000Z';
-  let sandbox;
+  const sandbox = sinon.createSandbox();
   const draftAppointmentInfo = createDraftAppointmentInfo(1);
 
   draftAppointmentInfo.attributes.slots[0].start = slotDate;
@@ -54,7 +54,6 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     appointmentApi: {},
   };
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     requestStub = sandbox.stub(utils, 'apiRequestWithUrl');
   });
   afterEach(() => {

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -17,7 +17,7 @@ import * as flow from './flow';
 describe('VAOS Component: ReviewAndConfirm', () => {
   let requestStub;
   const slotDate = '2024-09-09T16:00:00.000Z';
-  const sandbox = sinon.createSandbox();
+  let sandbox;
   const draftAppointmentInfo = createDraftAppointmentInfo(1);
 
   draftAppointmentInfo.attributes.slots[0].start = slotDate;
@@ -54,6 +54,7 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     appointmentApi: {},
   };
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     requestStub = sandbox.stub(utils, 'apiRequestWithUrl');
   });
   afterEach(() => {

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -1,7 +1,5 @@
-import { formatISO, differenceInMilliseconds } from 'date-fns';
-
 import { captureError } from '../../utils/error';
-import { getProviderById, getAppointmentInfo } from '../../services/referral';
+import { getProviderById } from '../../services/referral';
 // import { filterReferrals } from '../utils/referrals';
 import { STARTED_NEW_APPOINTMENT_FLOW } from '../../redux/sitewide';
 
@@ -12,12 +10,6 @@ export const FETCH_PROVIDER_DETAILS = 'FETCH_PROVIDER_DETAILS';
 export const FETCH_PROVIDER_DETAILS_SUCCEEDED =
   'FETCH_PROVIDER_DETAILS_SUCCEEDED';
 export const FETCH_PROVIDER_DETAILS_FAILED = 'FETCH_PROVIDER_DETAILS_FAILED';
-export const FETCH_REFERRAL_APPOINTMENT_INFO =
-  'FETCH_REFERRAL_APPOINTMENT_INFO';
-export const FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED =
-  'FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED';
-export const FETCH_REFERRAL_APPOINTMENT_INFO_FAILED =
-  'FETCH_REFERRAL_APPOINTMENT_INFO_FAILED';
 export const FETCH_REFERRAL = 'FETCH_REFERRAL';
 export const SET_SELECTED_SLOT_START_TIME = 'SET_SELECTED_SLOT_START_TIME';
 export const SET_INIT_REFERRAL_FLOW = 'SET_INIT_REFERRAL_FLOW';
@@ -54,86 +46,6 @@ export function fetchProviderDetails(id) {
     } catch (error) {
       dispatch({
         type: FETCH_PROVIDER_DETAILS_FAILED,
-      });
-      return captureError(error);
-    }
-  };
-}
-
-export function pollFetchAppointmentInfo(
-  appointmentId,
-  { timeOut = 30000, retryCount = 0, retryDelay = 1000 },
-) {
-  return async (dispatch, getState) => {
-    try {
-      const { referral } = getState();
-      // Get the time the request started
-      const pollingRequestStart =
-        referral.pollingRequestStart || formatISO(new Date());
-
-      // Calculate the time the request has been running
-      const requestTime = differenceInMilliseconds(
-        new Date(),
-        new Date(pollingRequestStart),
-      );
-      // If the request has been running for more than the timeout, stop it
-      if (requestTime > timeOut) {
-        dispatch({
-          type: FETCH_REFERRAL_APPOINTMENT_INFO_FAILED,
-          payload: true,
-        });
-        return captureError(new Error('Request timed out'));
-      }
-      // Poll the api for state change
-      dispatch({
-        type: FETCH_REFERRAL_APPOINTMENT_INFO,
-        payload: {
-          pollingRequestStart,
-        },
-      });
-      const appointmentInfo = await getAppointmentInfo(appointmentId);
-      // If the appointment is still in draft state, retry the request in 1 second to avoid spamming the api with requests
-      if (appointmentInfo.attributes?.status !== 'booked') {
-        setTimeout(() => {
-          dispatch(
-            pollFetchAppointmentInfo(appointmentId, {
-              retryCount: retryCount + 1,
-            }),
-          );
-        }, retryDelay);
-
-        return null;
-      }
-      dispatch({
-        type: FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED,
-        data: appointmentInfo,
-      });
-      return appointmentInfo;
-    } catch (error) {
-      dispatch({ type: FETCH_REFERRAL_APPOINTMENT_INFO_FAILED });
-      return captureError(error);
-    }
-  };
-}
-
-export function fetchAppointmentInfo(appointmentId) {
-  return async dispatch => {
-    try {
-      dispatch({
-        type: FETCH_REFERRAL_APPOINTMENT_INFO,
-        payload: {
-          pollingRequestStart: formatISO(new Date()),
-        },
-      });
-      const appointmentInfo = await getAppointmentInfo(appointmentId);
-      dispatch({
-        type: FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED,
-        data: appointmentInfo,
-      });
-      return appointmentInfo;
-    } catch (error) {
-      dispatch({
-        type: FETCH_REFERRAL_APPOINTMENT_INFO_FAILED,
       });
       return captureError(error);
     }

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -1,9 +1,6 @@
 import {
   SET_FORM_CURRENT_PAGE,
   CACHE_DRAFT_REFERRAL_APPOINTMENT,
-  FETCH_REFERRAL_APPOINTMENT_INFO,
-  FETCH_REFERRAL_APPOINTMENT_INFO_FAILED,
-  FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED,
   SET_INIT_REFERRAL_FLOW,
   SET_SELECTED_SLOT_START_TIME,
 } from './actions';
@@ -19,12 +16,6 @@ const initialState = {
   selectedSlotStartTime: '',
   referralsFetchStatus: FETCH_STATUS.notStarted,
   referralFetchStatus: FETCH_STATUS.notStarted,
-  appointmentCreateStatus: FETCH_STATUS.notStarted,
-  pollingRequestStart: null,
-  referralAppointmentInfo: {},
-  appointmentInfoLoading: false,
-  appointmentInfoError: false,
-  appointmentInfoTimeout: false,
 };
 
 function ccAppointmentReducer(state = initialState, action) {
@@ -38,29 +29,6 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         draftAppointmentInfo: action.data,
-      };
-    case FETCH_REFERRAL_APPOINTMENT_INFO:
-      return {
-        ...state,
-        appointmentInfoError: false,
-        appointmentInfoLoading: true,
-        appointmentInfoTimeout: false,
-        pollingRequestStart: action.payload.pollingRequestStart,
-      };
-    case FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED:
-      return {
-        ...state,
-        appointmentInfoLoading: false,
-        appointmentInfoError: false,
-        appointmentInfoTimeout: false,
-        referralAppointmentInfo: action.data,
-      };
-    case FETCH_REFERRAL_APPOINTMENT_INFO_FAILED:
-      return {
-        ...state,
-        appointmentInfoLoading: false,
-        appointmentInfoError: true,
-        appointmentInfoTimeout: action.payload,
       };
     case SET_SELECTED_SLOT_START_TIME:
       return {

--- a/src/applications/vaos/referral-appointments/redux/reducers.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/redux/reducers.unit.spec.jsx
@@ -2,9 +2,6 @@ import { expect } from 'chai';
 import reducer from './reducers';
 import {
   SET_FORM_CURRENT_PAGE,
-  FETCH_REFERRAL_APPOINTMENT_INFO,
-  FETCH_REFERRAL_APPOINTMENT_INFO_FAILED,
-  FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED,
   SET_SELECTED_SLOT_START_TIME,
   SET_INIT_REFERRAL_FLOW,
 } from './actions';
@@ -16,35 +13,6 @@ describe('ccAppointmentReducer', () => {
       payload: 'review',
     });
     expect(state.currentPage).to.equal('review');
-  });
-
-  it('should handle FETCH_REFERRAL_APPOINTMENT_INFO', () => {
-    const state = reducer(undefined, {
-      type: FETCH_REFERRAL_APPOINTMENT_INFO,
-      payload: { pollingRequestStart: 'now' },
-    });
-    expect(state.appointmentInfoLoading).to.be.true;
-    expect(state.pollingRequestStart).to.equal('now');
-  });
-
-  it('should handle FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED', () => {
-    const info = { id: 'abc123' };
-    const state = reducer(undefined, {
-      type: FETCH_REFERRAL_APPOINTMENT_INFO_SUCCEEDED,
-      data: info,
-    });
-    expect(state.appointmentInfoLoading).to.be.false;
-    expect(state.referralAppointmentInfo).to.deep.equal(info);
-  });
-
-  it('should handle FETCH_REFERRAL_APPOINTMENT_INFO_FAILED', () => {
-    const state = reducer(undefined, {
-      type: FETCH_REFERRAL_APPOINTMENT_INFO_FAILED,
-      payload: true,
-    });
-    expect(state.appointmentInfoLoading).to.be.false;
-    expect(state.appointmentInfoError).to.be.true;
-    expect(state.appointmentInfoTimeout).to.be.true;
   });
 
   it('should handle SET_SELECTED_SLOT_START_TIME', () => {

--- a/src/applications/vaos/referral-appointments/redux/selectors.js
+++ b/src/applications/vaos/referral-appointments/redux/selectors.js
@@ -13,15 +13,6 @@ export function getAppointmentCreateStatus(state) {
   return state.referral.appointmentCreateStatus;
 }
 
-export function getReferralAppointmentInfo(state) {
-  return {
-    referralAppointmentInfo: state.referral.referralAppointmentInfo,
-    appointmentInfoLoading: state.referral.appointmentInfoLoading,
-    appointmentInfoError: state.referral.appointmentInfoError,
-    appointmentInfoTimeout: state.referral.appointmentInfoTimeout,
-  };
-}
-
 export function getCachedDraftAppointmentInfo(state) {
   return state.referral.draftAppointmentInfo;
 }

--- a/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/referrals-workflow/referral-api-errors.cypress.spec.js
@@ -426,6 +426,10 @@ describe('VAOS Referral API Error Handling', () => {
       // Click the continue button to finalize the appointment
       reviewAndConfirm.clickContinue();
 
+      // Reset clock, using new Date for request timeout.
+      cy.clock().then(clock => clock.restore());
+      cy.clock(new Date(), ['Date']);
+
       // Wait for submit appointment response
       cy.wait('@v2:post:submitAppointment');
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Add new RTK query for getting booked status on appointment info
- Remove old selectors, actions, and reducers for old appointment info query process
- Update tests to test lifecycle instead of redux state

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106293

## Testing done

- Updated unit tests to make sure everything is still passing and coverage is met
- Manually tested the referral test cases in the mock data to make sure results were the same

## Screenshots

N/A just logic updates.

## What areas of the site does it impact?

The Confirm and EPS Details pages in the vaos application. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A