### PR TITLE
0969 - Add staged entry widget for static pages

### DIFF
--- a/src/applications/registry.scaffold.json
+++ b/src/applications/registry.scaffold.json
@@ -146,5 +146,10 @@
     "appName": "Order Medical Supplies",
     "entryName": "mhv-supply-reordering",
     "rootUrl": "/my-health/order-medical-supplies"
+  },
+  {
+    "appName": "Income & Asset Staged Entry Widget",
+    "widgetType": "income-and-asset-statement-staged-entry",
+    "rootUrl": "/income-and-asset-statement-form-21p-0969"
   }
 ]

--- a/src/applications/static-pages/income-and-asset/components/App/index.js
+++ b/src/applications/static-pages/income-and-asset/components/App/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles/useFeatureToggle';
 
 const START_URL =
-  'supporting-forms-for-claims/income-and-asset-statement-form-21p-0969';
+  'supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969';
 const DOWNLOAD_URL = 'https://www.va.gov/find-forms/about-form-21p-0969/';
 
 export const App = () => {

--- a/src/applications/static-pages/income-and-asset/components/App/index.js
+++ b/src/applications/static-pages/income-and-asset/components/App/index.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles/useFeatureToggle';
+
+const START_URL =
+  'supporting-forms-for-claims/income-and-asset-statement-form-21p-0969';
+const DOWNLOAD_URL = 'https://www.va.gov/find-forms/about-form-21p-0969/';
+
+export const App = () => {
+  const {
+    useToggleValue,
+    useToggleLoadingValue,
+    TOGGLE_NAMES,
+  } = useFeatureToggle();
+  const isLoadingFeatures = useToggleLoadingValue();
+  const formEnabled = useToggleValue(TOGGLE_NAMES.incomeAndAssetFormEnabled);
+
+  if (isLoadingFeatures) {
+    return <va-loading-indicator label="Loading" message="Loading..." />;
+  }
+  return formEnabled ? (
+    <>
+      <p>You can submit this form online or by mail.</p>
+      <div className="vads-u-margin-y--2">
+        <va-link-action
+          href={START_URL}
+          text="Submit a Pension or DIC income and asset statement"
+          type="secondary"
+        />
+      </div>
+      <div className="vads-u-margin-y--2">
+        <va-link href={DOWNLOAD_URL} text="Get VA Form 21P-0969 to download" />
+      </div>
+    </>
+  ) : (
+    <>
+      <p>You can submit this form by mail.</p>
+      <div className="vads-u-margin-y--2">
+        <va-link href={DOWNLOAD_URL} text="Get VA Form 21P-0969 to download" />
+      </div>
+    </>
+  );
+};
+
+export default App;

--- a/src/applications/static-pages/income-and-asset/components/App/index.js
+++ b/src/applications/static-pages/income-and-asset/components/App/index.js
@@ -12,7 +12,7 @@ export const App = () => {
     TOGGLE_NAMES,
   } = useFeatureToggle();
   const isLoadingFeatures = useToggleLoadingValue();
-  const formEnabled = useToggleValue(TOGGLE_NAMES.incomeAndAssetFormEnabled);
+  const formEnabled = useToggleValue(TOGGLE_NAMES.incomeAndAssetsFormEnabled);
 
   if (isLoadingFeatures) {
     return <va-loading-indicator label="Loading" message="Loading..." />;

--- a/src/applications/static-pages/income-and-asset/components/App/index.unit.spec.jsx
+++ b/src/applications/static-pages/income-and-asset/components/App/index.unit.spec.jsx
@@ -1,4 +1,3 @@
-// /static-pages/income-and-asset/components/App/index.unit.spec.jsx
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';

--- a/src/applications/static-pages/income-and-asset/components/App/index.unit.spec.jsx
+++ b/src/applications/static-pages/income-and-asset/components/App/index.unit.spec.jsx
@@ -1,0 +1,73 @@
+// /static-pages/income-and-asset/components/App/index.unit.spec.jsx
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import { App } from '.';
+
+const mockStore = configureStore([]);
+
+function makeStore({ loading, enabled }) {
+  return mockStore({
+    featureToggles: {
+      loading,
+      // eslint-disable-next-line camelcase
+      income_and_assets_form_enabled: enabled,
+    },
+  });
+}
+
+describe('0969 Staged Entry <App>', () => {
+  it('shows loading indicator while feature toggles are loading', () => {
+    const store = makeStore({ loading: true, enabled: false });
+    const wrapper = mount(
+      <Provider store={store}>
+        <App />
+      </Provider>,
+    );
+
+    expect(wrapper.find('va-loading-indicator')).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  describe('when the form is enabled', () => {
+    it('renders the online form link and the download link', () => {
+      const store = makeStore({ loading: false, enabled: true });
+      const wrapper = mount(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(
+        wrapper.contains(<p>You can submit this form online or by mail.</p>),
+      ).to.equal(true);
+
+      expect(wrapper.find('va-link-action')).to.have.lengthOf(1);
+      expect(wrapper.find('va-link')).to.have.lengthOf(1);
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('when the form is disabled', () => {
+    it('renders only the download link (no online form link)', () => {
+      const store = makeStore({ loading: false, enabled: false });
+      const wrapper = mount(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+      );
+
+      expect(
+        wrapper.contains(<p>You can submit this form by mail.</p>),
+      ).to.equal(true);
+
+      expect(wrapper.find('va-link-action')).to.have.lengthOf(0);
+      expect(wrapper.find('va-link')).to.have.lengthOf(1);
+
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/applications/static-pages/income-and-asset/index.js
+++ b/src/applications/static-pages/income-and-asset/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "income-and-asset-statement-form-21p-0969" */
+    './components/App').then(module => {
+      const App = module.default;
+      connectFeatureToggle(store.dispatch);
+
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};


### PR DESCRIPTION
## Summary
Added a **staged entry widget** to the VA Form 21P-0969 (Income and Asset Statement) to support a progressive, percentage-based rollout of the online form. The widget determines whether users see the link to start the online form based on the `income_and_asset_form_enabled` feature toggle status.

This improves the content experience by ensuring that Veterans are only shown the link when they are eligible to begin the digital version of the form.

## What areas of the site does it impact?
[- Static content page: `/supporting-forms-for-claims/income-and-asset-statement-form-21p-0969/`](https://www.va.gov/supporting-forms-for-claims/)

## Issue
- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/116616](https://github.com/department-of-veterans-affairs/va.gov-team/issues/116616)

## Related issue(s)


## How to run in local environment
> This widget is rendered on a static content page, not within the form flow.

1. Run `vets-website` locally  
2. Navigate to:  
   `http://localhost:3001/supporting-forms-for-claims/`  
3. In a separate tab, enable the `income_and_assets_form_enabled` toggle at:  
   `http://localhost:3000/flipper/features/income_and_assets_form_enabled`

## How to verify
1. With the toggle **enabled**, confirm that the call-to-action link is visible:
   > “Submit a Pension or DIC income and asset statement”
2. With the toggle **disabled**, confirm that no link or widget content is displayed
3. Verify that there are no layout regressions or visible artifacts when the widget is hidden

## Screenshots
| Form disabled | Form enabled |
|------------|-----------|
|<img width="1301" height="497" alt="0969-Staged-Entry-Widget-DISABLED" src="https://github.com/user-attachments/assets/a7133791-0e1a-4616-a321-a836a10741a2" />|<img width="1246" height="550" alt="0969-Staged-Entry-Widget-ENABLED" src="https://github.com/user-attachments/assets/d4d33be6-6a83-4248-b73c-7977c57cf59f" />|



### Quality Assurance & Testing
- [x] New unit tests (if applicable)
- [ ] New E2E tests added (if applicable)
- [x] Existing unit tests and integration tests are passing
- [x] Existing E2E tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot style, layout and content matches the design references
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] No console warnings or errors
- [x] Toggle properly controls widget visibility
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Not applicable — no authentication required for this public page

## Milestone
- 0969 MVP rollout strategy

## Requested Feedback
Please confirm this widget behaves as expected under toggled rollout and renders only when enabled. Let me know if additional visibility logic or tracking is required.
