### PR TITLE
Update label for edit scheduling facility section

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/SchedulingFacilitySection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/SchedulingFacilitySection.jsx
@@ -53,7 +53,7 @@ export default function SchedulingFacilitySection({ facility }) {
           <va-link
             href={ccClosestCity.url}
             onClick={handleClick(history, home, ccClosestCity)}
-            label="Edit facility preference"
+            label="Edit scheduling facility"
             text="Edit"
             data-testid="edit-new-appointment"
           />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updating the label for the edit scheduling facility link based on Accessibility feedback.
- UAE Orion
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111662#issuecomment-3200945778

## Testing done

- Tested locally using Voice Over

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
