### PR TITLE
10-10EZ | Update return URL formatting for migrations

### DIFF
--- a/src/applications/hca/config/migrations.js
+++ b/src/applications/hca/config/migrations.js
@@ -168,11 +168,11 @@ export default [
     [
       {
         selector: 'veteranAddress.city',
-        returnUrl: 'veteran-information/veteran-address',
+        returnUrl: '/veteran-information/veteran-address',
       },
       {
         selector: 'veteranAddress.street',
-        returnUrl: 'veteran-information/veteran-address',
+        returnUrl: '/veteran-information/veteran-address',
       },
     ].forEach(({ selector, returnUrl }) => {
       if (!notBlankStringPattern.test(get(selector, newFormData))) {
@@ -201,7 +201,7 @@ export default [
           );
           newMetaData = set(
             'returnUrl',
-            'insurance-information/general',
+            '/insurance-information/general',
             newMetaData,
           );
         }
@@ -213,7 +213,7 @@ export default [
           );
           newMetaData = set(
             'returnUrl',
-            'insurance-information/general',
+            '/insurance-information/general',
             newMetaData,
           );
         }
@@ -254,7 +254,7 @@ export default [
     }
 
     // temp fix until we get insurance v2 enabled
-    (formData?.providers || []).forEach(policy => {
+    for (const policy of formData?.providers || []) {
       const isValid =
         policy.insuranceName &&
         policy.insurancePolicyHolderName &&
@@ -263,11 +263,12 @@ export default [
       if (!isValid) {
         newMetadata = set(
           'returnUrl',
-          'insurance-information/general',
+          '/insurance-information/general',
           newMetadata,
         );
+        break;
       }
-    });
+    }
 
     return { formData, metadata: newMetadata };
   },

--- a/src/applications/hca/tests/unit/config/migrations.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/config/migrations.unit.spec.jsx
@@ -285,7 +285,7 @@ describe('hca migrations', () => {
       const { formData, metadata } = migration(data);
       expect(formData.veteranAddress).to.eql({});
       expect(metadata.returnUrl).to.equal(
-        'veteran-information/veteran-address',
+        '/veteran-information/veteran-address',
       );
     });
   });
@@ -330,15 +330,15 @@ describe('hca migrations', () => {
     const migration = migrations[7];
 
     it('should update the `va-facility` return URL to remove the `-api` reference', () => {
-      const returnUrl = 'insurance-information/va-facility-api';
-      const desiredUrl = 'insurance-information/va-facility';
+      const returnUrl = '/insurance-information/va-facility-api';
+      const desiredUrl = '/insurance-information/va-facility';
       const data = { formData: {}, metadata: { returnUrl } };
       const { metadata } = migration(data);
       expect(metadata.returnUrl).to.eq(desiredUrl);
     });
 
     it('should update the return URL when invalid insurance values are present in the form data', () => {
-      const desiredUrl = 'insurance-information/general';
+      const desiredUrl = '/insurance-information/general';
       const data = {
         formData: { providers: [{ insuranceName: 'Dave Jones' }] },
         metadata: { returnUrl: '/review-and-submit' },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the formatting for `return_url` metadata in the form migrations for the Health Care Application. The correct formatting for the URL needs to _include_ a leading slash for the route, and _exclude_ a trailing slash. This ensures we send users to the correct desired route.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#44427

## Testing done

- Prior to change, URLs with the leading slash omitted (or with a trailing slash included) would be deemed invalid and the user would be sent to the first page in the form flow
- After the change, users are sent to the proper route

## Acceptance criteria

- Users are sent to the desired route on each return with valid in-progress data

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution