### PR TITLE
Fix(526): Resolve ESLint unsafe-to-chain-command

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -409,11 +409,13 @@ export const pageHooks = (cy, testOptions) => ({
               'textarea[id="root_view:secondaryFollowUp_causedByDisabilityDescription"]',
             )
               .should('be.visible')
-              .clear()
-              .type(
-                disability['view:secondaryFollowUp']
-                  .causedByDisabilityDescription,
-              );
+              .clear();
+            cy.get(
+              'textarea[id="root_view:secondaryFollowUp_causedByDisabilityDescription"]',
+            ).type(
+              disability['view:secondaryFollowUp']
+                .causedByDisabilityDescription,
+            );
 
             cy.findByText(/continue/i, { selector: 'button' }).click();
           } else if (disability.cause === 'WORSENED') {
@@ -425,13 +427,17 @@ export const pageHooks = (cy, testOptions) => ({
               'input[name="root_view:worsenedFollowUp_worsenedDescription"]',
             )
               .should('be.visible')
-              .clear()
-              .type(disability['view:worsenedFollowUp'].worsenedDescription);
+              .clear();
+            cy.get(
+              'input[name="root_view:worsenedFollowUp_worsenedDescription"]',
+            ).type(disability['view:worsenedFollowUp'].worsenedDescription);
 
             cy.get('textarea[id="root_view:worsenedFollowUp_worsenedEffects"]')
               .should('be.visible')
-              .clear()
-              .type(disability['view:worsenedFollowUp'].worsenedEffects);
+              .clear();
+            cy.get(
+              'textarea[id="root_view:worsenedFollowUp_worsenedEffects"]',
+            ).type(disability['view:worsenedFollowUp'].worsenedEffects);
 
             cy.findByText(/continue/i, { selector: 'button' }).click();
           } else if (disability.cause === 'VA') {
@@ -443,18 +449,24 @@ export const pageHooks = (cy, testOptions) => ({
               'textarea[id="root_view:vaFollowUp_vaMistreatmentDescription"]',
             )
               .should('be.visible')
-              .clear()
-              .type(disability['view:vaFollowUp'].vaMistreatmentDescription);
+              .clear();
+            cy.get(
+              'textarea[id="root_view:vaFollowUp_vaMistreatmentDescription"]',
+            ).type(disability['view:vaFollowUp'].vaMistreatmentDescription);
 
             cy.get('input[id="root_view:vaFollowUp_vaMistreatmentLocation"]')
               .should('be.visible')
-              .clear()
-              .type(disability['view:vaFollowUp'].vaMistreatmentLocation);
+              .clear();
+            cy.get(
+              'input[id="root_view:vaFollowUp_vaMistreatmentLocation"]',
+            ).type(disability['view:vaFollowUp'].vaMistreatmentLocation);
 
             cy.get('input[id="root_view:vaFollowUp_vaMistreatmentDate"]')
               .should('be.visible')
-              .clear()
-              .type(disability['view:vaFollowUp'].vaMistreatmentDate);
+              .clear();
+            cy.get('input[id="root_view:vaFollowUp_vaMistreatmentDate"]').type(
+              disability['view:vaFollowUp'].vaMistreatmentDate,
+            );
 
             cy.findByText(/continue/i, { selector: 'button' }).click();
           }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Changes to the way that a handful of cypress test helpers were chaining `cy.get()` which was causing the `cypress/unsafe-to-chain-command` error/flag when running `yarn eslint src/applications/disability-benefits/all-claims`
- The bug was the error cropping up due to chaining with `cy.get` that cannot reliably be used to do both `is visible` checks and getting specific object values. This bug appeared in both PR's andwhen running the above ESLint command.
- The solution was to break out the checks of specific object values from the payload to be different checks to the ones making sure something is visible. This is the correct approach as the mentioned method cannot be used reliably/safely to do multiple checks at once without using a `cy.clear();` with emphasis on the `;`
- Disability Benefits on Pathways Team

## Related issue(s)

- (https://github.com/department-of-veterans-affairs/va.gov-team/issues/117226)

## Testing done

- The old behavior was that in both PR's and in running ESLint for linting of our FE, we would get a `cypress/unsafe-to-chain-command` for `vets-website/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js`
- To verify that this is fixed, run `yarn eslint src/applications/disability-benefits/all-claims` and ensure all instances of `cypress/unsafe-to-chain-command` are no longer present inside of `all-claims`.
- After each chaining that was fixed, the cypress suite was run. When each of these passed, then I would walk through the 0781 form to ensure that all data was retained. Then, with the use of the github actions for stability 

## Screenshots

Not needed as this focuses on a test helper file and doesn't touch the frontend.

## What areas of the site does it impact?

This impacts the `cypress.helpers.js` that touches all of `all-claims` testing suite files.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
