### PR TITLE
removes deprecated csps from mocked auth

### DIFF
--- a/src/applications/login/components/MockAuthButton.jsx
+++ b/src/applications/login/components/MockAuthButton.jsx
@@ -22,16 +22,21 @@ export default function MockAuthButton() {
         value={authType}
         onVaSelect={({ detail: { value } }) => setAuthType(value)}
       >
-        {Object.values(SERVICE_PROVIDERS).map(provider => (
-          <option key={provider.policy} value={provider.policy}>
-            {provider.label}
-          </option>
-        ))}
+        {Object.values(SERVICE_PROVIDERS)
+          .filter(
+            provider =>
+              provider.policy === 'idme' || provider.policy === 'logingov',
+          )
+          .map(provider => (
+            <option key={provider.policy} value={provider.policy}>
+              {provider.label}
+            </option>
+          ))}
       </VaSelect>
-      <button
-        type="button"
+      <va-button
         aria-label="Mock Authentication"
-        className="usa-button mauth-button vads-u-margin-y--1p5 vads-u-padding-y--2"
+        className="mauth-button vads-u-margin-y--1p5 vads-u-padding-y--2"
+        text="Sign in with mocked authentication"
         onClick={async () => {
           try {
             await mockLogin({ type: authType });
@@ -39,9 +44,7 @@ export default function MockAuthButton() {
             setMockLoginError(error.toString());
           }
         }}
-      >
-        Sign in with mocked authentication
-      </button>
+      />
     </>
   ) : null;
 }

--- a/src/applications/login/tests/containers/MockAuth.unit.spec.jsx
+++ b/src/applications/login/tests/containers/MockAuth.unit.spec.jsx
@@ -112,7 +112,7 @@ describe('MockAuthButton', () => {
   it('should be rendered on the mocked auth page', () => {
     __BUILDTYPE__ = environments.LOCALHOST;
     const { container } = render(<MockAuth />);
-    expect(container.querySelector('.mauth-button', container)).to.exist;
+    expect(container.querySelector('va-button')).to.exist;
   });
 
   it('does not, cannot show up on staging or production stacks', () => {
@@ -139,7 +139,7 @@ describe('MockAuthButton', () => {
         detail: { value: null },
       }),
     );
-    const button = container.querySelector('button');
+    const button = container.querySelector('va-button');
     fireEvent.click(button);
     await waitFor(() => {
       expect(select.getAttribute('error')).to.not.equal('');

--- a/src/applications/login/tests/containers/MockAuth.unit.spec.jsx
+++ b/src/applications/login/tests/containers/MockAuth.unit.spec.jsx
@@ -22,7 +22,9 @@ const mockGADefaultArgs = {
   throwGAError: false,
 };
 
-const csps = Object.values(SERVICE_PROVIDERS);
+const csps = Object.values(SERVICE_PROVIDERS).filter(
+  provider => provider.policy === 'idme' || provider.policy === 'logingov',
+);
 
 const setup = ({ path, mockGA = mockGADefaultArgs }) => {
   const startingLocation = path ? new URL(`${base}${path}`) : originalLocation;


### PR DESCRIPTION
## Are you removing, renaming or moving 
a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
<img width="1080" height="676" alt="Screenshot 2025-08-19 at 2 14 32 PM" src="https://github.com/user-attachments/assets/357d3b22-d9b1-45a7-8dfb-fdaea5e92a55" />

## What areas of the site does it impact?

- /sign-in/mock-auth (dev & prod)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
