### PR TITLE
Update preferred dates and times to use full weekdays

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentDateTime.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentDateTime.jsx
@@ -2,11 +2,12 @@ import { formatInTimeZone } from 'date-fns-tz';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { getAppointmentTimezone } from '../../services/appointment';
+import { DATE_FORMATS } from '../../utils/constants';
 
 export function AppointmentDate({
   date,
   timezone,
-  format = 'EEEE, MMMM d, yyyy',
+  format = DATE_FORMATS.friendlyWeekdayDate,
 }) {
   return (
     <span data-dd-privacy="mask">

--- a/src/applications/vaos/appointment-list/pages/CancelAppointmentPage/CancelPageLayoutRequest.jsx
+++ b/src/applications/vaos/appointment-list/pages/CancelAppointmentPage/CancelPageLayoutRequest.jsx
@@ -1,5 +1,6 @@
 import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import React from 'react';
+import classNames from 'classnames';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom/cjs/react-router-dom.min';
 import { shallowEqual } from 'recompose';
@@ -48,7 +49,11 @@ export default function CancelPageLayoutRequest() {
         {`Request for ${isCC ? 'community care appointment' : 'appointment'}`}
       </h2>
       <Section heading="Preferred date and time" level={3}>
-        <ul className="usa-unstyled-list">
+        <ul
+          className={classNames({
+            'usa-unstyled-list': preferredDates.length === 1,
+          })}
+        >
           {preferredDates.map((date, index) => (
             <li key={`${id}-option-${index}`}>{date}</li>
           ))}

--- a/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/UpcomingAppointmentsDetailsPage/index.jsx
@@ -12,7 +12,7 @@ import {
   isInPersonVisit,
   isVAPhoneAppointment,
 } from '../../../services/appointment';
-import { FETCH_STATUS } from '../../../utils/constants';
+import { FETCH_STATUS, DATE_FORMATS } from '../../../utils/constants';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import AppointmentDetailsErrorMessage from '../../components/AppointmentDetailsErrorMessage';
 import PageLayout from '../../components/PageLayout';
@@ -90,7 +90,7 @@ export default function UpcomingAppointmentsDetailsPage() {
         document.title = `${pageTitle} ${formatInTimeZone(
           appointment.start,
           appointment.timezone,
-          'EEEE, MMMM d, yyyy',
+          DATE_FORMATS.friendlyWeekdayDate,
         )} | Veterans Affairs`;
         scrollAndFocus();
       }

--- a/src/applications/vaos/components/layouts/CCRequestLayout.jsx
+++ b/src/applications/vaos/components/layouts/CCRequestLayout.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { shallowEqual } from 'recompose';
 import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
@@ -66,7 +67,11 @@ export default function CCRequestLayout({ data: appointment }) {
         facility={facility}
       >
         <Section heading="Preferred date and time">
-          <ul className="usa-unstyled-list">
+          <ul
+            className={classNames({
+              'usa-unstyled-list': preferredDates.length === 1,
+            })}
+          >
             {preferredDates.map((date, index) => (
               <li key={`${appointment.id}-option-${index}`}>
                 <span data-dd-privacy="mask">{date}</span>

--- a/src/applications/vaos/components/layouts/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { shallowEqual } from 'recompose';
 import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
@@ -68,7 +69,11 @@ export default function VARequestLayout({ data: appointment }) {
         facility={facility}
       >
         <Section heading="Preferred date and time">
-          <ul className="usa-unstyled-list">
+          <ul
+            className={classNames({
+              'usa-unstyled-list': preferredDates.length === 1,
+            })}
+          >
             {preferredDates.map((date, index) => (
               <li key={`${appointment.id}-option-${index}`}>
                 <span data-dd-privacy="mask">{date}</span>

--- a/src/applications/vaos/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -158,7 +158,7 @@ describe('VAOS vaccine flow: ReviewPage', () => {
       formatInTimeZone(
         start,
         'America/Denver',
-        "EEEE, MMMM d, yyyy 'at' h:mm aaaa",
+        `${DATE_FORMATS.friendlyWeekdayDate} 'at' h:mm aaaa`,
       ),
     );
     expect(dateHeading).to.have.tagName('h3');

--- a/src/applications/vaos/new-appointment/components/ReviewPage/AppointmentDate.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/AppointmentDate.jsx
@@ -1,6 +1,7 @@
 import { formatInTimeZone } from 'date-fns-tz';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { DATE_FORMATS } from '../../../utils/constants';
 import {
   getTimezoneAbbrByFacilityId,
   getTimezoneByFacilityId,
@@ -29,7 +30,11 @@ export default function AppointmentDate({
           return (
             <React.Fragment key={index}>
               <span>
-                {formatInTimeZone(date, timezone, 'EEEE, MMMM d, yyyy')}
+                {formatInTimeZone(
+                  date,
+                  timezone,
+                  DATE_FORMATS.friendlyWeekdayDate,
+                )}
               </span>
               <br />
               <span>
@@ -44,8 +49,12 @@ export default function AppointmentDate({
 
   return dates?.map((date, i) => (
     <h3 key={i} className="vaos-appts__block-label">
-      {formatInTimeZone(date, timezone, "EEEE, MMMM d, yyyy 'at' h:mm aaaa ") +
-        getTimezoneAbbrByFacilityId(facilityId)}
+      {formatInTimeZone(
+        date,
+        timezone,
+        `${DATE_FORMATS.friendlyWeekdayDate} 'at' h:mm aaaa `,
+        getTimezoneAbbrByFacilityId(facilityId),
+      )}
     </h3>
   ));
 }

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDates.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDates.jsx
@@ -1,15 +1,17 @@
-import { formatDateLong } from 'platform/utilities/date';
 import React from 'react';
+import { format } from 'date-fns';
+import { DATE_FORMATS } from '../../../../utils/constants';
 
 function PreferredDates(props) {
-  return props.dates?.map((selected, i) => (
-    <li key={i}>
-      {formatDateLong(selected)}
-      {new Date(selected).getHours() < 12
-        ? ' in the morning'
-        : ' in the afternoon'}
-    </li>
-  ));
+  return props.dates?.map((selected, i) => {
+    const dateObj = new Date(selected);
+    return (
+      <li key={i}>
+        {format(dateObj, DATE_FORMATS.friendlyWeekdayDate)}
+        {dateObj.getHours() < 12 ? ' in the morning' : ' in the afternoon'}
+      </li>
+    );
+  });
 }
 
 export default PreferredDates;

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDatesSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDatesSection.jsx
@@ -48,7 +48,12 @@ export default function PreferredDatesSection(props) {
               Preferred date and timeframe
             </h2>
             {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-            <ul className="usa-unstyled-list" role="list">
+            <ul
+              className={classNames({
+                'usa-unstyled-list': props.data.selectedDates.length === 1,
+              })}
+              role="list"
+            >
               <PreferredDates dates={props.data.selectedDates} />
             </ul>
           </div>

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -2109,7 +2109,7 @@
         "station": null,
         "ien": null,
         "avsPath": null,
-        "preferredDates": ["Wed, August 21, 2024 in the afternoon"],
+        "preferredDates": ["Wednesday, August 21, 2024 in the afternoon"],
         "location": {
           "id": "668",
           "type": "appointments",

--- a/src/applications/vaos/services/mocks/v2/requests.json
+++ b/src/applications/vaos/services/mocks/v2/requests.json
@@ -87,8 +87,8 @@
         "patientComments": "Test",
         "reasonForAppointment": "Routine/Follow-up",
         "preferredDates": [
-          "Wed, March 26, 2025 in the morning",
-          "Wed, March 12, 2025 in the morning"
+          "Wednesday, March 26, 2025 in the morning",
+          "Wednesday, March 12, 2025 in the morning"
         ],
         "preferredModality": "Video",
         "location": {
@@ -212,7 +212,7 @@
         },
         "station": null,
         "ien": null,
-        "preferredDates": ["Tue, January 28, 2025 in the morning"],
+        "preferredDates": ["Tuesday, January 28, 2025 in the morning"],
         "preferredProviderName": null,
         "location": {
           "id": "984",
@@ -354,7 +354,7 @@
         },
         "patientComments": "testing",
         "reasonForAppointment": "Routine/Follow-up",
-        "preferredDates": ["Tue, November 12, 2024 in the morning"],
+        "preferredDates": ["Tuesday, November 12, 2024 in the morning"],
         "preferredModality": "In person",
         "location": {
           "id": "983",
@@ -498,7 +498,7 @@
         },
         "patientComments": "routine",
         "reasonForAppointment": "Routine/Follow-up",
-        "preferredDates": ["Mon, December 9, 2026 in the morning"],
+        "preferredDates": ["Monday, December 9, 2026 in the morning"],
         "preferredModality": "In person",
         "location": {
           "id": "983",
@@ -635,7 +635,7 @@
         },
         "patientComments": "testing",
         "reasonForAppointment": "Medication concern",
-        "preferredDates": ["Thu, March 27, 2025 in the morning"],
+        "preferredDates": ["Thursday, March 27, 2025 in the morning"],
         "preferredModality": "Phone",
         "location": {
           "id": "983GC",

--- a/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
+++ b/src/applications/vaos/tests/fixtures/MockAppointmentResponse.js
@@ -77,7 +77,7 @@ export default class MockAppointmentResponse {
       preferredDates: [
         format(
           startOfDay(new Date(), 'day'),
-          "eeee, MMMM d, yyyy 'in the morning'",
+          `${DATE_FORMATS.friendlyWeekdayDate} 'in the morning'`,
         ),
       ],
       requestedPeriods:


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- From Accessibility feedback, we've decided to use the full weekday instead of abbreviations
- I've also taken the chance to remove some magic strings and use the format defined in the constants file
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111877

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After - Single | After - Multiple |
| ------- | ------ | ----- | ----- |
| Cancel page  |    <img width="850" height="5252" alt="image" src="https://github.com/user-attachments/assets/44601cfb-f211-4210-9383-4bd9546526e6" />   |   <img width="850" height="5398" alt="image" src="https://github.com/user-attachments/assets/241a646e-e488-4345-beb4-62337489ba50" />   |   <img width="850" height="5286" alt="image" src="https://github.com/user-attachments/assets/a0d137f6-12f9-43d6-84ab-d943514078eb" />   |
| CC VA Request details  |   <img width="850" height="5490" alt="image" src="https://github.com/user-attachments/assets/2276b652-a169-438c-b867-fc0b3431ab30" />    |   <img width="850" height="5630" alt="image" src="https://github.com/user-attachments/assets/4021539b-ad76-48c7-9ba6-6f1b336c300a" />   |    <img width="850" height="5524" alt="image" src="https://github.com/user-attachments/assets/8e6db1a8-a098-45b4-9b8c-034e9ad55ff6" />  |
| Review page  |    <img width="850" height="5154" alt="image" src="https://github.com/user-attachments/assets/7cd4aed0-2c8d-482b-a51e-f1afb30e9d09" />   |   <img width="850" height="5052" alt="image" src="https://github.com/user-attachments/assets/1e4ed10c-54ce-4c29-b6a0-5c6c7b5a7b9b" />   |   <img width="850" height="5186" alt="image" src="https://github.com/user-attachments/assets/94882f39-b91c-4d7c-99c6-547bef1fa8b3" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
