### PR TITLE
Adding in a default to the formData arg for the VaCheckboxGroup

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField.jsx
@@ -8,7 +8,7 @@ import formsPatternFieldMapping from './formsPatternFieldMapping';
 
 // Combines schema, uiSchema, and formData together
 // for each checkbox for easier access
-const getCheckboxData = ({ schema, uiSchema, formData }) => {
+const getCheckboxData = ({ schema, uiSchema, formData = {} }) => {
   return Object.keys(schema.properties).map(key => ({
     key,
     schema: schema.properties[key],


### PR DESCRIPTION
We removed this [here](https://github.com/department-of-veterans-affairs/vets-website/pull/37958/commits/7ba19f7fc80eb1d0bc82a711aaf564a5be6d35d6) because it was requiring extra approvers, and we didnt know if adding it was required.

However since removing, and with further testing, we do think this is required and sensible.

We think we observed the following:

- Page loads/renders with a checkbox
- formData has not loaded yet
- This function errors trying to access an attribute of an undefined object
- Defaulting to an empty object when not provided allows it to render without error
- When the data does actually load it re-renders correctly then

