### PR TITLE
Fixed Button Ordering on VA OCC Mobile

### DIFF
--- a/src/platform/user/authentication/config/dev.config.js
+++ b/src/platform/user/authentication/config/dev.config.js
@@ -65,8 +65,8 @@ export default {
   },
   [EXTERNAL_APPS.VA_OCC_MOBILE]: {
     allowedSignInProviders: {
-      logingov: true,
       idme: true,
+      logingov: true,
     },
     legacySignInProviders,
     isMobile: true,

--- a/src/platform/user/authentication/config/prod.config.js
+++ b/src/platform/user/authentication/config/prod.config.js
@@ -65,8 +65,8 @@ export default {
   },
   [EXTERNAL_APPS.VA_OCC_MOBILE]: {
     allowedSignInProviders: {
-      logingov: true,
       idme: true,
+      logingov: true,
     },
     legacySignInProviders,
     isMobile: true,

--- a/src/platform/user/authentication/config/staging.config.js
+++ b/src/platform/user/authentication/config/staging.config.js
@@ -65,8 +65,8 @@ export default {
   },
   [EXTERNAL_APPS.VA_OCC_MOBILE]: {
     allowedSignInProviders: {
-      logingov: true,
       idme: true,
+      logingov: true,
     },
     legacySignInProviders,
     isMobile: true,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updated the button ordering on the Unified Sign-in Page for VA OCC Mobile so that ID.me is shown before Login.gov.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/649)

## Testing done
- Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit src/platform/user/tests/authentication/components/*.unit.spec.jsx`.

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="786" height="846" alt="before" src="https://github.com/user-attachments/assets/db33f988-f29e-4674-8c0a-4ec0a2dc2a13" /> | <img width="853" height="847" alt="after" src="https://github.com/user-attachments/assets/5ea75a3f-55e0-40c2-9e13-d67e0570b133" /> |

## What areas of the site does it impact?
This only impacts the `externalApplicationsConfig` for VA OCC Mobile.

## Acceptance criteria
- [x] ID.me sign-in button is listed first followed by Login.gov on USiP for VA OCC Mobile