### PR TITLE
DV | Staging review fixes continued

### DIFF
--- a/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
@@ -238,9 +238,9 @@ const VeteranContactInformationPage = ({
         </va-alert>
       ) : null}
       <p>
-        If you notice any errors, correct them now.{' '}
-        <strong>Changes made here apply only to this form.</strong> If you want
-        to update your contact information in our system, go to your VA profile.
+        If you notice any errors, correct them now. Changes made here apply only
+        to this form. If you want to update your contact information in our
+        system, go to your VA profile.
       </p>
       <va-link
         text="Update your contact information in your VA profile"

--- a/src/applications/dependents/dependents-verification/containers/IntroductionPage.jsx
+++ b/src/applications/dependents/dependents-verification/containers/IntroductionPage.jsx
@@ -18,9 +18,13 @@ const ProcessList = () => {
     <va-process-list>
       <va-process-list-item header="Check your eligibility">
         <p>
-          You must have previously added dependents to your benefits in order to
-          use this form to verify your VA dependents.
+          You can only use this form if you have dependents on your VA
+          disability benefits.
         </p>
+        <va-link
+          text=" Not sure? Check your VA dependents."
+          href="/manage-dependents/"
+        />
       </va-process-list-item>
       <va-process-list-item header="Review your active dependents and your information">
         <p>Here’s what you’ll need to review:</p>

--- a/src/applications/dependents/dependents-verification/containers/IntroductionPage.jsx
+++ b/src/applications/dependents/dependents-verification/containers/IntroductionPage.jsx
@@ -18,17 +18,17 @@ const ProcessList = () => {
     <va-process-list>
       <va-process-list-item header="Check your eligibility">
         <p>
-          You must have previously added dependents to your disability benefits
-          in order to use this form to verify your VA dependents.
+          You must have previously added dependents to your benefits in order to
+          use this form to verify your VA dependents.
         </p>
       </va-process-list-item>
       <va-process-list-item header="Review your active dependents and your information">
         <p>Here’s what you’ll need to review:</p>
         <ul>
           <li>
-            Your active VA dependents currently listed under your disability
-            benefits, including any recent life events (such as recent marriage,
-            divorce, or a child reaching adulthood).
+            Your active VA dependents currently listed on your benefits,
+            including any recent life events (such as recent marriage, divorce,
+            or a child reaching adulthood).
           </li>
           <li>
             Your personal information, including your date of birth, Social
@@ -49,7 +49,7 @@ const ProcessList = () => {
       <va-process-list-item header="After you submit">
         <p>
           You don’t need to do anything else. But you’ll need to verify your
-          dependents’ information on your disability benefits each year.
+          dependents’ information on your benefits each year.
         </p>
         <p>
           Verifying your dependents each year makes sure you get your full
@@ -78,7 +78,7 @@ export const IntroductionPage = props => {
         disability benefits.
       </p>
       <h2 className="vads-u-margin-top--0">
-        Follow the steps below to get started
+        Follow these steps to get started
       </h2>
       <ProcessList />
       <Gateway route={route} />


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Addresses staging review findings

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117013
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117011
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117012
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117010

## Testing done

- Manual / Unit / E2E

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
