### PR TITLE
Fix Skipped getLongTermAppointmentHistoryV2 unit test

### DIFF
--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -1,5 +1,8 @@
 /* eslint-disable @department-of-veterans-affairs/axe-check-required */
-import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
+import {
+  mockFetch,
+  resetFetch,
+} from '@department-of-veterans-affairs/platform-testing/helpers';
 import { expect } from 'chai';
 
 import { addDays, format, subDays } from 'date-fns';
@@ -19,8 +22,27 @@ import {
 import { APPOINTMENT_TYPES, VIDEO_TYPES } from '../../utils/constants';
 
 describe('VAOS Services: Appointment ', () => {
+  // Global cleanup to ensure clean state for all tests
+  beforeEach(() => {
+    // Reset any global fetch state that might be lingering
+    if (global.fetch && global.fetch.isSinonProxy) {
+      global.fetch.resetHistory();
+    }
+  });
+
+  afterEach(() => {
+    // Ensure complete cleanup after each test
+    if (global.fetch && global.fetch.isSinonProxy) {
+      global.fetch.resetHistory();
+    }
+  });
+
   describe('fetchBookedAppointment by id', () => {
     beforeEach(() => mockFetch());
+
+    afterEach(() => {
+      resetFetch();
+    });
 
     it('should return data for an in person VA appointment', async () => {
       mockAppointmentApi({
@@ -185,6 +207,10 @@ describe('VAOS Services: Appointment ', () => {
   describe('getAppointmentRequests', () => {
     beforeEach(() => mockFetch());
 
+    afterEach(() => {
+      resetFetch();
+    });
+
     it('should return data for a VA appointment request', async () => {
       // Given VA appointment request
       const start = subDays(new Date(), 30);
@@ -284,11 +310,41 @@ describe('VAOS Services: Appointment ', () => {
   });
 
   describe('getLongTermAppointmentHistoryV2', () => {
+    let originalUserAgent;
+
     beforeEach(() => {
+      // Complete reset to ensure clean state
+      resetFetch();
       mockFetch();
+
+      // Force navigator.userAgent to node.js to ensure fresh function calls
+      originalUserAgent = navigator.userAgent;
+      Object.defineProperty(navigator, 'userAgent', {
+        value: 'node.js',
+        writable: true,
+      });
+
+      // Verify the mock is properly set up
+      if (!global.fetch || !global.fetch.isSinonProxy) {
+        throw new Error('Mock fetch was not properly set up');
+      }
     });
 
-    it.skip('should fetch 3 years of appointment history', async () => {
+    afterEach(() => {
+      // Restore navigator.userAgent
+      if (originalUserAgent) {
+        Object.defineProperty(navigator, 'userAgent', {
+          value: originalUserAgent,
+          writable: true,
+        });
+      }
+      resetFetch();
+    });
+
+    it('should fetch 3 years of appointment history', async () => {
+      // Verify clean starting state
+      expect(global.fetch.callCount).to.equal(0);
+
       const dateRanges = getDateRanges(3);
       dateRanges.forEach(range => {
         mockAppointmentsApi({
@@ -300,8 +356,11 @@ describe('VAOS Services: Appointment ', () => {
         });
       });
 
+      const initialCallCount = global.fetch.callCount;
       await getLongTermAppointmentHistoryV2();
-      expect(global.fetch.callCount).to.equal(3);
+
+      // Verify exactly 3 new calls were made
+      expect(global.fetch.callCount - initialCallCount).to.equal(3);
       expect(global.fetch.firstCall.args[0]).to.contain(
         `${format(dateRanges[0].start, 'yyyy-MM-dd')}`,
       );
@@ -326,6 +385,14 @@ describe('VAOS Services: Appointment ', () => {
   //--------
 
   describe('getVAAppointmentLocationId', () => {
+    beforeEach(() => {
+      // Setup before each test
+    });
+
+    afterEach(() => {
+      // Cleanup after each test
+    });
+
     it('should return null for undefined appointment', () => {
       expect(getVAAppointmentLocationId(undefined)).to.be.null;
     });

--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -382,17 +382,7 @@ describe('VAOS Services: Appointment ', () => {
     });
   });
 
-  //--------
-
   describe('getVAAppointmentLocationId', () => {
-    beforeEach(() => {
-      // Setup before each test
-    });
-
-    afterEach(() => {
-      // Cleanup after each test
-    });
-
     it('should return null for undefined appointment', () => {
       expect(getVAAppointmentLocationId(undefined)).to.be.null;
     });


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder



### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary


The test for getLongTermAppointmentHistoryV2 passed when run individually but failed as part of the full test suite. This was due to state leaking from other tests, which affected the fetch call count.

To resolve this, I implemented a cleanup strategy:

Added beforeEach and afterEach hooks: These hooks now call resetFetch() and mockFetch() to ensure the mock environment is completely reset before and after each test run.

Isolated the test: This guarantees that the fetch call history is clean and the test can accurately count its own calls.

Updated assertions: I changed the call count assertion from an absolute (equal(3)) to a relative assertion (callCount - initialCallCount), ensuring we only count the calls made by the function under test.

These changes prevent test interference and make the test suite more reliable. The getLongTermAppointmentHistoryV2 test now passes consistently with yarn test:unit:summary --apps=vaos --legacy.

## Related issue(s)

- https://github.com/issues/assigned?issue=department-of-veterans-affairs%7Cva.gov-team%7C115891


## Testing done

- Testing locally individually and in a test suite by running yarn test:unit:summary --apps=vaos --legacy no screenshots as this is a unit test

## What areas of the site does it impact?

Appointments

## Quality Assurance & Testing

- [x]  I fixed|updated|added unit tests and integration tests for each feature 
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x]  Linting warnings have been addressed




