### PR TITLE
10-10d Extended | Activate Cypress test suite

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/10-10d-extended.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/10-10d-extended.cypress.spec.js
@@ -57,9 +57,25 @@ const testConfig = createTestConfig(
           });
         });
       },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            cy.get('va-statement-of-truth')
+              .shadow()
+              .within(() => {
+                cy.get('va-text-input').then($el =>
+                  cy.fillVaTextInput($el, data.statementOfTruthSignature),
+                );
+                cy.get('va-checkbox').then($el =>
+                  cy.selectVaCheckbox($el, true),
+                );
+              });
+            cy.findByText(/submit/i, { selector: 'button' }).click();
+          });
+        });
+      },
     },
     setupPerTest: () => setupBasicTest(),
-    skip: Cypress.env('CI'),
   },
   manifest,
   formConfig,

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/utils/helpers.js
@@ -11,7 +11,10 @@ export const startAsGuestUser = () => {
   cy.get('.schemaform-start-button')
     .first()
     .click();
-  cy.location('pathname').should('include', '/signer-type');
+  cy.location('pathname').should(
+    'include',
+    '/your-information/who-is-applying',
+  );
 };
 
 // helpers for creating state machines to handle ArrayBuilder actions


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR activates the Cypress test suite for the 10-10d/OHI merged form. The test suite was being skipped due to failing Axe checks around heading levels. With those issues fixed, the suite could be completed and activated for CI.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#115055

## Acceptance criteria

 - Test suite is active in CI

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution