### PR TITLE
Fix authorization alert link for 4142

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/AuthorizationAlert.jsx
+++ b/src/applications/disability-benefits/all-claims/components/AuthorizationAlert.jsx
@@ -11,27 +11,24 @@ const AuthorizationAlert = ({ hasError, onAnchorClick }) => (
       Authorize your providers to release your records or upload them yourself
     </h3>
     <p className="vads-u-margin-bottom--0">
-      If you want us to request your non-VA medical records from your provider,
-      you must authorize the release by checking the box labeled "I acknowledge
-      and authorize this release of information."
+      You must give us permission to get your non-VA treatment records.
     </p>
     <va-link
-      class="vads-u-display--block vads-u-margin-top--2"
+      class="vads-u-display--block"
       href="#privacy-agreement"
       onClick={onAnchorClick}
       id="checkbox-anchor"
       text="Check the box to authorize"
     />
     <p className="vads-u-margin-bottom--0">
-      <strong>Or</strong>, go back a page and select ‘No’ where we ask if you
-      want us to get your non-VA medical records. You’ll be able to upload
-      non-VA records later in the form or by mail.
+      <strong>Or</strong>, you can change to provide your non-VA treatment
+      records by uploading them.
     </p>
     <BasicLink
       data-testid="goBack"
-      className="vads-u-display--block vads-u-margin-top--2"
+      className="vads-u-display--block"
       path={`/${EVIDENCE_PRIVATE_MEDICAL_RECORDS}`}
-      text="Go back to select ‘No’"
+      text="Change how to provide your non-VA treatment records"
     />
   </va-alert>
 );

--- a/src/applications/disability-benefits/all-claims/components/AuthorizationAlert.jsx
+++ b/src/applications/disability-benefits/all-claims/components/AuthorizationAlert.jsx
@@ -28,6 +28,7 @@ const AuthorizationAlert = ({ hasError, onAnchorClick }) => (
       non-VA records later in the form or by mail.
     </p>
     <BasicLink
+      data-testid="goBack"
       className="vads-u-display--block vads-u-margin-top--2"
       path={`/${EVIDENCE_PRIVATE_MEDICAL_RECORDS}`}
       text="Go back to select ‘No’"

--- a/src/applications/disability-benefits/all-claims/components/AuthorizationAlert.jsx
+++ b/src/applications/disability-benefits/all-claims/components/AuthorizationAlert.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import BasicLink from './BasicLink';
 
-export const EVIDENCE_PRIVATE_REQUEST =
-  'supporting-evidence/request-private-medical-records';
+export const EVIDENCE_PRIVATE_MEDICAL_RECORDS =
+  'supporting-evidence/private-medical-records';
 
 const AuthorizationAlert = ({ hasError, onAnchorClick }) => (
   <va-alert status="error" visible={hasError} role="alert">
@@ -29,7 +29,7 @@ const AuthorizationAlert = ({ hasError, onAnchorClick }) => (
     </p>
     <BasicLink
       className="vads-u-display--block vads-u-margin-top--2"
-      path={`/${EVIDENCE_PRIVATE_REQUEST}`}
+      path={`/${EVIDENCE_PRIVATE_MEDICAL_RECORDS}`}
       text="Go back to select ‘No’"
     />
   </va-alert>

--- a/src/applications/disability-benefits/all-claims/tests/components/AuthorizationAlert.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/AuthorizationAlert.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import { BrowserRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import AuthorizationAlert, {
   EVIDENCE_PRIVATE_MEDICAL_RECORDS,
 } from '../../components/AuthorizationAlert';
@@ -120,3 +121,10 @@ describe('AuthorizationAlert Component', () => {
     });
   });
 });
+
+MockBasicLink.propTypes = {
+  className: PropTypes.string,
+  path: PropTypes.string,
+  text: PropTypes.string,
+  onClick: PropTypes.func,
+};

--- a/src/applications/disability-benefits/all-claims/tests/components/AuthorizationAlert.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/AuthorizationAlert.unit.spec.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { expect } from 'chai';
+import { BrowserRouter } from 'react-router-dom';
+import AuthorizationAlert, {
+  EVIDENCE_PRIVATE_MEDICAL_RECORDS,
+} from '../../components/AuthorizationAlert';
+
+const MockBasicLink = ({ path, text, className, onClick, ...props }) => (
+  <a
+    href={path}
+    className={className}
+    onClick={e => {
+      e.preventDefault();
+      if (onClick) {
+        onClick(e);
+      }
+      // Simulate navigation by setting window.location
+      Object.defineProperty(window, 'location', {
+        value: { pathname: path },
+        writable: true,
+      });
+    }}
+    data-testid="basic-link"
+    {...props}
+  >
+    {text}
+  </a>
+);
+
+const createMockFunction = () => {
+  const calls = [];
+  const mockFn = (...args) => {
+    calls.push(args);
+    return mockFn;
+  };
+  mockFn.calls = calls;
+  mockFn.mockClear = () => {
+    calls.length = 0;
+  };
+  return mockFn;
+};
+
+describe('AuthorizationAlert Component', () => {
+  let mockOnAnchorClick;
+
+  const defaultProps = {
+    hasError: true,
+    onAnchorClick: null,
+  };
+
+  beforeEach(() => {
+    mockOnAnchorClick = createMockFunction();
+    defaultProps.onAnchorClick = mockOnAnchorClick;
+
+    require('../../components/BasicLink').default = MockBasicLink;
+
+    // Reset window.location
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/' },
+      writable: true,
+    });
+  });
+
+  const setup = (
+    props = {
+      hasError: true,
+      onAnchorClick: null,
+    },
+  ) => {
+    return render(
+      <BrowserRouter>
+        <AuthorizationAlert {...props} />
+      </BrowserRouter>,
+    );
+  };
+
+  describe('BasicLink Navigation', () => {
+    it('should render BasicLink with correct path and text', () => {
+      const screen = setup({
+        hasError: true,
+        onAnchorClick: null,
+      });
+
+      const basicLink = screen.getByTestId('goBack');
+
+      expect(basicLink).to.exist;
+      expect(basicLink).to.have.attribute(
+        'href',
+        `/${EVIDENCE_PRIVATE_MEDICAL_RECORDS}`,
+      );
+    });
+
+    describe('Component Integration', () => {
+      it('should render alert with error state and interactive BasicLink', () => {
+        const screen = setup({
+          hasError: true,
+          onAnchorClick: null,
+        });
+
+        expect(screen.getByRole('alert')).to.exist;
+
+        const basicLink = screen.getByTestId('goBack');
+        expect(basicLink).to.exist;
+
+        fireEvent.click(basicLink);
+        expect(window.location.pathname).to.equal(
+          `/${EVIDENCE_PRIVATE_MEDICAL_RECORDS}`,
+        );
+      });
+
+      it('should have visible set to false when BasicLink hasError is false', () => {
+        const screen = setup({
+          hasError: false,
+          onAnchorClick: null,
+        });
+
+        expect(screen.getByRole('alert')).to.attribute('visible', 'false');
+      });
+    });
+  });
+});


### PR DESCRIPTION
closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/117346
## Summary
using flipper `disability_526_form4142_use_2024_version` and navigating to 4142 page => "go back" link in Authorization Alert navigates to the wrong page. 


## Testing done

Unit test added

## Screenshots

Included text change for authorization alert
<img width="608" height="363" alt="Screenshot 2025-08-22 at 9 48 09 AM" src="https://github.com/user-attachments/assets/6c751c5a-57c2-4bb5-9358-ea942e0411d4" />

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
