### PR TITLE
10-10d | Validate applicant relationship to Veteran

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -291,7 +291,6 @@ const applicantRelationshipPage = {
         type: 'object',
         properties: {
           relationshipToVeteran: { type: 'string' },
-          otherRelationshipToVeteran: { type: 'string' },
         },
       },
     },
@@ -308,7 +307,6 @@ const applicantRelationshipOriginPage = {
         type: 'object',
         properties: {
           relationshipToVeteran: radioSchema(['blood', 'adoption', 'step']),
-          otherRelationshipToVeteran: { type: 'string' },
         },
       },
     },

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
@@ -220,27 +220,49 @@ export default function ApplicantRelationshipPage(props) {
   const handlers = {
     validate() {
       let isValid = true;
+
+      // clear any existing errors
+      setCheckError(null);
+      setInputError(null);
+
+      // primary field validation
       if (!checkValue[primary]) {
         setCheckError('This field is required');
         isValid = false;
-      } else {
-        setCheckError(null); // Clear any existing err msg
       }
-      if (checkValue[primary] === 'other' && !checkValue[secondary]) {
-        setInputError('This field is required');
-        isValid = false;
-      } else if (checkValue[primary] === 'other' && checkValue[secondary]) {
-        const errMsg = validateText(checkValue[secondary]);
-        if (errMsg) {
-          setInputError(errMsg);
+
+      // secondary field validation (for "other" option)
+      if (checkValue[primary] === 'other') {
+        if (!checkValue[secondary]) {
+          setInputError('This field is required');
           isValid = false;
         } else {
-          setInputError(null);
+          const errMsg = validateText(checkValue[secondary]);
+          if (errMsg) {
+            setInputError(errMsg);
+            isValid = false;
+          }
         }
-      } else {
-        setInputError(null);
       }
-      if (!isValid) setFocusOnRadio(); // we have an error, set focus on the input
+
+      // spouse validation - only one spouse allowed
+      if (checkValue[primary] === 'spouse') {
+        const hasExistingSpouse = fullData.applicants.some(
+          (item, idx) =>
+            item?.applicantRelationshipToSponsor?.relationshipToVeteran ===
+              'spouse' && idx !== pagePerItemIndex,
+        );
+        if (hasExistingSpouse) {
+          setCheckError(
+            'Only one applicant can have a spousal relationship to the Veteran',
+          );
+          isValid = false;
+        }
+      }
+
+      // we have an error, set focus on the input
+      if (!isValid) setFocusOnRadio();
+
       return isValid;
     },
     radioUpdate: ({ detail }) => {

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
@@ -247,10 +247,10 @@ export default function ApplicantRelationshipPage(props) {
 
       // spouse validation - only one spouse allowed
       if (checkValue[primary] === 'spouse') {
-        const hasExistingSpouse = fullData.applicants.some(
+        const hasExistingSpouse = fullOrItemData.applicants?.some(
           (item, idx) =>
             item?.applicantRelationshipToSponsor?.relationshipToVeteran ===
-              'spouse' && idx !== pagePerItemIndex,
+              'spouse' && idx !== parseInt(pagePerItemIndex, 10),
         );
         if (hasExistingSpouse) {
           setCheckError(

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
@@ -254,7 +254,7 @@ export default function ApplicantRelationshipPage(props) {
         );
         if (hasExistingSpouse) {
           setCheckError(
-            'Only one applicant can have a spousal relationship to the Veteran',
+            'Only one applicant can have a spousal or partner relationship to the Veteran',
           );
           isValid = false;
         }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the Applicant Relationship to the Veteran answer to validate that only one spousal relationship can be indicated.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#115110
- department-of-veterans-affairs/va.gov-team#117217

## Testing done

- Start form and indicate you are the Veteran applying for benefits for a spouse, child, etc
- Fill out all details until you get to the Applicants summary
- Add the first applicant--indicating the relationship to the Veteran is a spouse
- Attempt to add a second applicant--indicating the relationship to the Veteran is a spouse

## Screenshots

<img width="537" height="350" alt="Screenshot 2025-08-21 at 15 02 32" src="https://github.com/user-attachments/assets/fd9a291e-44b0-4656-ad08-5ab2f119e4fa" />

## Acceptance criteria

 - Only one spousal relationship may be indicated for applicants of the 10-10d

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution