### PR TITLE
EZR: Update dependent edu expenses field to use new currencyUI pattern

### DIFF
--- a/src/applications/ezr/config/chapters/householdInformation/dependentEducationExpenses.js
+++ b/src/applications/ezr/config/chapters/householdInformation/dependentEducationExpenses.js
@@ -1,11 +1,10 @@
 import ezrSchema from 'vets-json-schema/dist/10-10EZR-schema.json';
-import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 import {
+  currencyUI,
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { replaceStrValues } from '../../../utils/helpers/general';
-import { validateCurrency } from '../../../utils/validation';
 import { LAST_YEAR } from '../../../utils/constants';
 import content from '../../../locales/en/content.json';
 import DependentExpensesDescription from '../../../components/FormDescriptions/DependentExpensesDescription';
@@ -23,11 +22,10 @@ export default {
         LAST_YEAR,
       ),
     ),
-    dependentEducationExpenses: {
-      ...currencyUI(content['household-dependent-education-expenses-label']),
-      'ui:validations': [validateCurrency],
-      'ui:description': DependentExpensesDescription,
-    },
+    dependentEducationExpenses: currencyUI({
+      title: content['household-dependent-education-expenses-label'],
+      description: DependentExpensesDescription,
+    }),
   },
   schema: {
     type: 'object',

--- a/src/applications/ezr/tests/e2e/helpers/dependents.js
+++ b/src/applications/ezr/tests/e2e/helpers/dependents.js
@@ -138,7 +138,7 @@ export const fillDependentInformation = (dependent, showIncomePages) => {
     // fill educational expenses
     selectYesNoWebComponent('attendedSchoolLastYear', attendedSchoolLastYear);
     fillTextWebComponent(
-      'view:dependentEducationExpenses_dependentEducationExpenses',
+      'dependentEducationExpenses',
       dependentEducationExpenses,
     );
     cy.injectAxeThenAxeCheck();

--- a/src/applications/ezr/tests/e2e/helpers/dependents.js
+++ b/src/applications/ezr/tests/e2e/helpers/dependents.js
@@ -137,7 +137,8 @@ export const fillDependentInformation = (dependent, showIncomePages) => {
     goToNextPage();
     // fill educational expenses
     selectYesNoWebComponent('attendedSchoolLastYear', attendedSchoolLastYear);
-    cy.get('[name="root_dependentEducationExpenses"]').type(
+    fillTextWebComponent(
+      'view:dependentEducationExpenses_dependentEducationExpenses',
       dependentEducationExpenses,
     );
     cy.injectAxeThenAxeCheck();

--- a/src/applications/ezr/tests/unit/config/householdInformation/dependentEducationExpenses.unit.spec.jsx
+++ b/src/applications/ezr/tests/unit/config/householdInformation/dependentEducationExpenses.unit.spec.jsx
@@ -1,6 +1,5 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfWebComponentFields,
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
 } from '../helpers.spec';
@@ -10,18 +9,8 @@ import dependentEducationExpenses from '../../../../config/chapters/householdInf
 const { schema, uiSchema } = dependentEducationExpenses;
 const pageTitle = 'Dependent education expenses';
 
-// run test for correct number of web component fields on the page
-const expectedNumberOfWebComponentFields = 1;
-testNumberOfWebComponentFields(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfWebComponentFields,
-  pageTitle,
-);
-
 // run test for correct number of web component error messages on submit
-const expectedNumberOfWebComponentErrors = 0;
+const expectedNumberOfWebComponentErrors = 1;
 testNumberOfErrorsOnSubmitForWebComponents(
   formConfig,
   schema,
@@ -41,7 +30,7 @@ testNumberOfFields(
 );
 
 // run test for correct number of standard error messages on submit
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 0;
 testNumberOfErrorsOnSubmit(
   formConfig,
   schema,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Updates the 10-10 EZR form to use the `currencyPattern` for the `currencyUI` widget. This resolves a validation error message

- Missed the dependents education expenses [in the last PR](https://github.com/department-of-veterans-affairs/vets-website/pull/38235) for this issue

## Related issue(s)

[department-of-veterans-affairs/va.gov-team#93836](https://github.com/department-of-veterans-affairs/va.gov-team/issues/93836)

## Testing done

- Manual testing by using the application
- Specs are passing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="569" height="281" alt="image" src="https://github.com/user-attachments/assets/6fe2aad5-a34b-48d5-9353-d3669524ff8d" /> | <img width="563" height="264" alt="image" src="https://github.com/user-attachments/assets/c13aba1c-b196-4778-beac-a7e239c2fce8" /> |

## What areas of the site does it impact?

Form 10-10 EZR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
