### PR TITLE
Income and Asset Statement Staged Entry Widget - Add to static page entries

### DIFF
--- a/src/applications/static-pages/income-and-asset/components/App/index.js
+++ b/src/applications/static-pages/income-and-asset/components/App/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useFeatureToggle } from 'platform/utilities/feature-toggles/useFeatureToggle';
+import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 
 const START_URL =
   'supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969';

--- a/src/applications/static-pages/income-and-asset/index.js
+++ b/src/applications/static-pages/income-and-asset/index.js
@@ -1,16 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 
-export default (store, widgetType) => {
+export default async (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(/* webpackChunkName: "income-and-asset-statement-form-21p-0969" */
+    import(/* webpackChunkName: "income-and-asset-statement-staged-entry" */
     './components/App').then(module => {
       const App = module.default;
-      connectFeatureToggle(store.dispatch);
-
       ReactDOM.render(
         <Provider store={store}>
           <App />

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -96,6 +96,7 @@ import create400247Access from './simple-forms/40-0247/entry';
 import createFormUploadAccess from './simple-forms/form-upload/entry';
 import createBurialHowDoIApplyWidget from './burial-how-do-i-apply-widget';
 import createPensionApp from './pension-how-do-i-apply-widget';
+import create21P0969Access from './income-and-asset';
 import createVYEEnrollmentWidget from './vye-enrollment-login-widget/createVYEEnrollmentWidget';
 
 import create1010DExtendedAccess from './ivc-champva/10-10d-extended/entry';
@@ -137,6 +138,7 @@ connectFeatureToggle(store.dispatch);
 
 // Create widgets.
 createPensionApp(store, widgetTypes.PENSION_APP_STATUS);
+create21P0969Access(store, widgetTypes.INCOME_AND_ASSET_STATEMENT_STAGED_ENTRY);
 
 createApplicationStatus(store, {
   formId: VA_FORM_IDS.FORM_10_10EZ,

--- a/src/platform/site-wide/widgetTypes.js
+++ b/src/platform/site-wide/widgetTypes.js
@@ -58,6 +58,8 @@ export default {
   HOMEPAGE_HERO_RANDOMIZER: 'homepage-hero-randomizer',
   HOMEPAGE_SEARCH: 'homepage-search',
   I_18_SELECT: 'i18-select',
+  INCOME_AND_ASSET_STATEMENT_STAGED_ENTRY:
+    'income-and-asset-statement-staged-entry',
   MAINTENANCE_BANNER: 'maintenance-banner',
   MANAGE_VA_DEBT_CTA: 'manage-va-debt-cta',
   MEDICAL_COPAYS_CTA: 'medical-copays-cta',


### PR DESCRIPTION
## Summary

This PR adds the **Staged Entry Widget** to the static page entries for the **Income and Asset Statement form (VA Form 21P-0969)**. The widget is now integrated into the form’s static page setup to support staged rollout and feature toggling of the online application.

## What areas of the site does it impact?
[- Static content page: `/supporting-forms-for-claims/income-and-asset-statement-form-21p-0969/`](https://www.va.gov/supporting-forms-for-claims/)

## Issue
- [https://github.com/department-of-veterans-affairs/va.gov-team/issues/116616](https://github.com/department-of-veterans-affairs/va.gov-team/issues/116616)

## Related issue(s)


## How to run in local environment
> This widget is rendered on a static content page, not within the form flow.

1. Run `vets-website` locally  
2. Navigate to:  
   `http://localhost:3001/supporting-forms-for-claims/`  
3. In a separate tab, enable the `income_and_assets_form_enabled` toggle at:  
   `http://localhost:3000/flipper/features/income_and_assets_form_enabled`

## How to verify
1. With the toggle **enabled**, confirm that the call-to-action link is visible:
   > “Submit a Pension or DIC income and asset statement”
2. With the toggle **disabled**, confirm that no link or widget content is displayed
3. Verify that there are no layout regressions or visible artifacts when the widget is hidden

## Screenshots
| Form disabled | Form enabled |
|------------|-----------|
|<img width="1301" height="497" alt="0969-Staged-Entry-Widget-DISABLED" src="https://github.com/user-attachments/assets/a7133791-0e1a-4616-a321-a836a10741a2" />|<img width="1246" height="550" alt="0969-Staged-Entry-Widget-ENABLED" src="https://github.com/user-attachments/assets/d4d33be6-6a83-4248-b73c-7977c57cf59f" />|

## Quality Assurance & Testing

- [ ] Widget renders as expected on the static page
- [x] No console errors or warnings
- [x] Static content updates do not affect other forms
- [ ] Feature toggle `income_and_assets_form_enabled` is respected

## Error Handling

- [x] Fallback content displays correctly when the form is disabled via feature flag

## Authentication

- [x] Not applicable (static page behavior)

## Milestone

- 0969 MVP Launch  
- Widget integration for staggered release

## Requested Feedback

Please verify that the widget loads correctly on the static page and toggles based on the current flipper state.
