### PR TITLE
0969 - Move dependent description component

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -39,9 +39,6 @@ import {
   relationshipLabels,
 } from '../../../labels';
 
-const renderAdditionalInfo = props =>
-  !props.formData.unassociatedIncomes?.length && <DependentDescription />;
-
 /** @type {ArrayBuilderOptions} */
 export const options = {
   arrayPath: 'unassociatedIncomes',
@@ -495,7 +492,6 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     unassociatedIncomePagesUpdatedSummary: pageBuilder.summaryPage({
-      ContentBeforeButtons: showUpdatedContent() ? renderAdditionalInfo : null,
       title: 'Recurring income',
       path: 'recurring-income-summary-updated',
       depends: formData =>
@@ -507,7 +503,6 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     unassociatedIncomePagesUpdatedSpouseSummary: pageBuilder.summaryPage({
-      ContentBeforeButtons: showUpdatedContent() ? renderAdditionalInfo : null,
       title: 'Recurring income',
       path: 'recurring-income-summary-spouse',
       depends: formData =>
@@ -516,7 +511,6 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     unassociatedIncomePagesUpdatedChildSummary: pageBuilder.summaryPage({
-      ContentBeforeButtons: showUpdatedContent() ? renderAdditionalInfo : null,
       title: 'Recurring income',
       path: 'recurring-income-summary-child',
       depends: formData =>
@@ -525,7 +519,6 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     unassociatedIncomePagesUpdatedCustodianSummary: pageBuilder.summaryPage({
-      ContentBeforeButtons: showUpdatedContent() ? renderAdditionalInfo : null,
       title: 'Recurring income',
       path: 'recurring-income-summary-custodian',
       depends: formData =>
@@ -534,6 +527,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     unassociatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription />
+      ) : null,
       title: 'Recurring income recipient',
       path: 'recurring-income/:index/veteran-income-recipient',
       depends: formData =>
@@ -542,6 +538,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: veteranIncomeRecipientPage.schema,
     }),
     unassociatedIncomeSpouseRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription />
+      ) : null,
       title: 'Recurring income recipient',
       path: 'recurring-income/:index/spouse-income-recipient',
       depends: formData =>
@@ -550,6 +549,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: spouseIncomeRecipientPage.schema,
     }),
     unassociatedIncomeCustodianRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription />
+      ) : null,
       title: 'Recurring income recipient',
       path: 'recurring-income/:index/custodian-income-recipient',
       depends: formData =>
@@ -558,6 +560,9 @@ export const unassociatedIncomePages = arrayBuilderPages(
       schema: custodianIncomeRecipientPage.schema,
     }),
     unassociatedIncomeParentRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription />
+      ) : null,
       title: 'Recurring income recipient',
       path: 'recurring-income/:index/parent-income-recipient',
       depends: formData =>

--- a/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
@@ -121,7 +121,7 @@ const summaryPage = {
         },
       },
       {
-        title: 'Do you have more recurring income to report?',
+        title: 'Do you have more financial accounts to report?',
         labels: {
           Y: 'Yes',
           N: 'No',


### PR DESCRIPTION
## Summary
Moved the **Dependent description component** in the **Recurring income** chapter of the Income and Asset Statement form (VA Form 21P-0969) from the summary page without items to the **Relationship to Veteran** page based on design QA feedback. This improves content relevance and aligns with the expected location in the user flow.

## Issue
- Design QA adjustment to improve UX and content placement

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature flag:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Go to:  
   `http://localhost:3001/income-and-asset-statement-form-21p-0969/`

## How to verify

1. Navigate to the **Recurring income** chapter
2. Confirm that the **dependent description** content no longer appears on the summary page
3. Confirm it appears correctly on the **Relationship to Veteran** page
4. Ensure it is only shown when appropriate (based on claimantType, if applicable)

## What areas of the site does it impact?

- Income and Asset Statement Application (21P-0969)  
- Recurring income → Relationship to Veteran page

## Screenshots

| Before (Summary Page) | After (Relationship Page) |
|-----------------------|---------------------------|
| Dependent description visible | Dependent description moved and rendered on correct page |

## Quality Assurance & Testing

- [x] Moved content renders on the correct page
- [x] No longer rendered on the summary page
- [x] Existing unit tests and E2E tests are passing
- [x] No sensitive information is exposed
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

## Error Handling
- [x] N/A – static content movement only

## Authentication
- [x] Verified for authenticated and unauthenticated users (if applicable)

## Milestone
- 0969 Post-MVP
- Gated behind `income_and_assets_content_updates` feature toggle

## Requested Feedback

Please confirm that the component now renders in the correct step of the list-and-loop and that it no longer appears on the summary page.
