### PR TITLE
0969 - Add dependent description

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
@@ -16,6 +16,7 @@ import {
 } from '~/platform/forms-system/src/js/web-component-patterns';
 import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { DependentDescription } from '../../../components/DependentDescription';
 import {
   formatCurrency,
   formatPossessiveString,
@@ -336,6 +337,9 @@ export const associatedIncomePages = arrayBuilderPages(
       schema: summaryPage.schema,
     }),
     associatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription />
+      ) : null,
       title: 'Financial account recipient',
       path: 'financial-accounts/:index/veteran-income-recipient',
       depends: formData =>
@@ -344,6 +348,9 @@ export const associatedIncomePages = arrayBuilderPages(
       schema: veteranIncomeRecipientPage.schema,
     }),
     associatedIncomeSpouseRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription />
+      ) : null,
       title: 'Financial account recipient',
       path: 'financial-accounts/:index/spouse-income-recipient',
       depends: formData =>


### PR DESCRIPTION
## Summary

This PR adds the **Dependent description component** to the **Relationship to Veteran** pages within the **Financial Accounts** chapter of the **Income and Asset Statement form (VA Form 21P-0969)**. This update ensures consistent communication across the application and aligns with design expectations for Post MVP content structure.

## Issue

- Improves clarity when the applicant is not the Veteran
- Ensures dependent guidance is presented at the point of relevance

## Related issue(s)

- N/A

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content-updates`  
4. Navigate to:  
   `http://localhost:3001/income-and-asset-statement-form-21p-0969/`  
5. Proceed through the form to the **Financial Accounts** chapter with an applicable claimantType

## How to verify

1. Navigate to the **Financial Accounts → Relationship to Veteran** page
2. Confirm the **dependent description** content appears below the relationship question
3. Ensure the content is:
   - Visible only when the feature toggle is enabled
   - Accurate based on design and content requirements
4. Confirm that the dependent description is **not** shown on the summary page

## What areas of the site does it impact?

- Income and Asset Statement Application (21P-0969)  
- Financial Accounts → Relationship to Veteran list-and-loop page

## Screenshots

| Before | After |
|--------|-------|
| No description shown | Dependent description displayed under relationship radio options |

## Quality Assurance & Testing

- [x] Dependent description renders correctly on the Relationship to Veteran page
- [x] Content hidden on the summary page
- [x] Behind `income_and_assets_content_updates` feature toggle
- [ ] No console errors or warnings
- [x] All tests pass (unit + E2E)
- [x] Accessibility and screen reader compatibility confirmed

## Error Handling

- [x] N/A – static content addition
