### PR TITLE
Merged Form Content Updates

### DIFF
--- a/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
@@ -15,9 +15,8 @@ function generateOptions({ data, pagePerItemIndex }) {
   const relativeBeingVerb = `${bp.relative} ${bp.beingVerbPresent}`;
   const options = [
     {
-      label: `${relativeBeingVerb} between the ages of 18 and 23 years old and ${
-        bp.beingVerbPresent
-      } enrolled as a student in a high school, college, or vocational school`,
+      label: `${relativeBeingVerb} between the ages of 18 and 23 years old and will be
+       enrolled as a student in a high school, college, or vocational school`,
       value: 'enrolled',
     },
     {

--- a/src/applications/ivc-champva/10-10d-extended/chapters/SelectHealthcareParticipantsPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/SelectHealthcareParticipantsPage.jsx
@@ -64,7 +64,7 @@ function dynamicSchema(data, item) {
       ),
       healthcareParticipants: checkboxGroupUI({
         title,
-        hint: 'Check all that apply',
+        hint: 'Select all that apply',
         required: () => true,
         labels,
       }),

--- a/src/applications/ivc-champva/10-10d-extended/chapters/SelectMedicareParticipantsPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/SelectMedicareParticipantsPage.jsx
@@ -71,7 +71,7 @@ export const selectMedicareParticipantPage = {
       ...radioUI({
         title: 'Which applicant would you like to add Medicare insurance for?',
         hint:
-          'If you have more applicants with Medicare plans you can add them later in this form.',
+          'If you have more applicants with Medicare plans, you can add them later in this form.',
         required: () => true,
         labels: {
           na: 'NA',

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -105,7 +105,7 @@ export const applicantOptions = {
     cardDescription: item => (
       <ul className="no-bullets">
         <li>
-          <b>Date of Birth:</b>{' '}
+          <b>Date of birth:</b>{' '}
           {item?.applicantDob ? fmtDate(item?.applicantDob) : ''}
         </li>
         <li>
@@ -212,7 +212,7 @@ const applicantMailingAddressPage = {
     applicantAddress: addressUI({
       labels: {
         militaryCheckbox:
-          'Address is on a United States military base outside the country.',
+          'Address is on a military base outside the United States.',
       },
     }),
   },
@@ -231,12 +231,12 @@ const applicantContactInfoPage = {
       ({ formData }) =>
         editTitleWrapper(`${applicantWording(formData)} contact information`),
       ({ formData, formContext }) => {
-        const txt = `We will use this information to contact ${applicantWording(
+        const txt = `We’ll use this information to contact ${applicantWording(
           formData,
           false,
           false,
           true,
-        )} if we have more questions`;
+        )} if we have any questions about this application.`;
         // Prefill message conditionally displays based on `certifierRole`
         return formContext.pagePerItemIndex === '0' ? (
           <>
@@ -334,9 +334,9 @@ const applicantBirthCertUploadPage = {
           certifierRole: index === 0 ? formData?.['view:certifierRole'] : '',
         };
         const posessiveName = (
-          <b className="dd-privacy-hidden">
+          <p className="dd-privacy-hidden">
             {nameWording(tmpFormData, true, false)}
-          </b>
+          </p>
         );
 
         return (
@@ -348,7 +348,7 @@ const applicantBirthCertUploadPage = {
     ),
     ...fileUploadBlurbCustom(),
     applicantBirthCertOrSocialSecCard: fileUploadUI({
-      label: 'Upload a copy of birth certificate',
+      label: 'Upload copy of birth certificate',
     }),
   },
   schema: {
@@ -497,24 +497,23 @@ const applicantSchoolCertUploadPage = {
             <p>
               <b>If {nameBeingVerb} already enrolled in school</b>
             </p>
-            <p>You’ll need to submit a letter on the school’s letterhead.</p>
             <p>
-              Ask the school to write us a letter on school letterhead that
-              includes all of these pieces of information:
+              Ask the school to write us a letter on their letterhead that
+              includes this information:
             </p>
             <ul>
-              <li>{posessiveName} first and last name</li>
+              <li>{posessiveName} first and last name, and</li>
               <li>
-                The last 4 digits of {posessiveName} Social Security number
+                Last 4 digits of {posessiveName} Social Security number, and
               </li>
               <li>
-                The start and end dates for each semester or enrollment term
+                Start and end dates for each semester or enrollment term, and
               </li>
-              <li>Enrollment status (full-time or part-time)</li>
-              <li>Expected graduation date</li>
+              <li>Enrollment status (full-time or part-time), and</li>
+              <li>Expected graduation date, and</li>
               <li>
-                Signature and title of a school official (like a director or
-                principal)
+                Signature and title of a school official, such as director or
+                principal
               </li>
             </ul>
             <p>

--- a/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/healthInsuranceInformation.js
@@ -46,9 +46,9 @@ const INSURANCE_TYPE_LABELS = {
   ppo: 'Preferred Provider Organization (PPO) program',
   medicaid: 'Medicaid or a State Assistance program',
   rxDiscount: 'Prescription Discount program',
+  medigap: 'Medigap policy',
   other:
     'Other (specialty, limited coverage, or exclusively CHAMPVA supplemental) insurance',
-  medigap: 'Medigap program',
 };
 
 export function generateParticipantNames(item) {
@@ -75,14 +75,14 @@ const yesNoOptions = {
   labelHeaderLevel: '2',
   labelHeaderLevelStyle: '5',
   hint:
-    'If any applicants have other health insurance, it is required to report it to process your application for CHAMPVA benefits.',
+    'If so, you must report this information for us to process your application for CHAMPVA benefits.',
 };
 const yesNoOptionsMore = {
   title: 'Do you have any other health insurance to report?',
   labelHeaderLevel: '2',
   labelHeaderLevelStyle: '5',
   hint:
-    'If any applicants have other health insurance, it is required to report it to process your application for CHAMPVA benefits.',
+    'If so, you must report this information for us to process your application for CHAMPVA benefits.',
 };
 export const healthInsuranceOptions = {
   arrayPath: 'healthInsurance',
@@ -123,10 +123,14 @@ const healthInsuranceIntroPage = {
     insuranceType: {
       ...radioUI({
         labels: INSURANCE_TYPE_LABELS,
-        title:
-          'Select the type of insurance plan or program the applicant(s) are enrolled in',
-        hint:
-          'You may find this information on the front of the health insurance card.',
+        title: `Which type of insurance plan or program are the applicant(s) enrolled in?`,
+        hint: 'This information is on the front of the health insurance card.',
+        description: (
+          <p>
+            <b> Note:</b> You can add more insurance plans later in the
+            application.
+          </p>
+        ),
         required: () => true,
       }),
     },
@@ -169,7 +173,7 @@ const medigapInformation = {
     ...arrayBuilderItemSubsequentPageTitleUI('Medigap information'),
     medigapPlan: {
       ...radioUI({
-        title: 'Which type of Medigap plan are the applicant(s) enrolled in?',
+        title: 'Select the Medigap policy the applicants are enrolled in',
         required: () => true,
         labels: MEDIGAP,
       }),
@@ -190,8 +194,7 @@ const providerInformation = {
     provider: textUI('Name of insurance provider'),
     effectiveDate: currentOrPastDateUI({
       title: 'Insurance start date',
-      hint:
-        'You may find the start date on the declarations page of your insurance policy.',
+      hint: 'This information is on the insurance policy declarations pages.',
     }),
     expirationDate: currentOrPastDateUI({
       title: 'Insurance termination date',
@@ -239,7 +242,8 @@ const additionalComments = {
         `${formData?.provider} health insurance additional comments`,
     ),
     additionalComments: textareaUI({
-      title: 'Any additional comments about the applicant(s) health insurance?',
+      title:
+        'Do you have any additional comments about the applicant(s) health insurance?',
       charcount: true,
     }),
     'ui:validations': [
@@ -264,6 +268,7 @@ const healthInsuranceCardUploadPage = {
     ...fileUploadBlurb,
     insuranceCardFront: fileUploadUI({
       label: 'Upload front of the health insurance card',
+      'ui:hint': 'Upload front and back as separate files.',
     }),
     insuranceCardBack: fileUploadUI({
       label: 'Upload back of the health insurance card',

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -49,18 +49,18 @@ const toHashMemoized = memoize(str => toHash(str));
  * Options for the yes/no text on summary page:
  */
 const yesNoOptions = {
-  title: 'Do you have any Medicare to report for one or more applicants?',
+  title: 'Do any applicants have medicare plans?',
   labelHeaderLevel: '2',
   labelHeaderLevelStyle: '5',
   hint:
-    'If any applicants have Medicare, it is required to report it to process your application for CHAMPVA benefits.',
+    'If so, you must report this information for us to process your application for CHAMPVA benefits.',
 };
 const yesNoOptionsMore = {
-  title: 'Do you have any other applicants with Medicare to report?',
+  title: 'Do you have any other applicants with Medicare plans to report?',
   labelHeaderLevel: '2',
   labelHeaderLevelStyle: '5',
   hint:
-    'If any applicants have Medicare, it is required to report it to process your application for CHAMPVA benefits.',
+    'If so, you must report this information for us to process your application for CHAMPVA benefits.',
 };
 
 // Get the name of the applicant selected on the Medicare participant page
@@ -71,7 +71,7 @@ export function generateParticipantName(item) {
       app => item?.medicareParticipant === toHashMemoized(app.applicantSSN),
     );
     const name = applicantWording(match, false, false, false);
-    return name.length > 0 ? name : 'applicant';
+    return name.length > 0 ? name`${"'s"}` : 'applicant';
   }
   return 'No participant';
 }
@@ -129,11 +129,12 @@ const medicarePlanOver65 = {
           'Which of the following Medicare plans does this beneficiary have?',
         required: () => true,
         labels: {
-          ab: 'Original Medicare Parts A and B (hospital and medical coverage)',
+          ab:
+            'Original Medicare Parts A and B (Hospital and Medical Insurance)',
           c:
-            'Medicare Part C Advantage Plan (this option includes being previously enrolled in Part A and B )',
-          a: 'Medicare Part A only (hospital coverage)',
-          b: 'Medicare Part B only (medical coverage)',
+            'Update to Medicare Part C, also known as Medicare Advantage (includes previous enrollment in Part A and B )',
+          a: 'Medicare Part A only (Hospital Insurance)',
+          b: 'Medicare Part B only (Medical Insurance)',
         },
       }),
     },
@@ -186,11 +187,12 @@ const medicarePartAPartBEffectiveDatesPage = partC => {
     uiProperties['view:partCExplanation'] = {
       'ui:description': (
         <va-additional-info
-          trigger="If I have a Part C plan why do you need Part A and B information?"
+          trigger="
+          Why do we need Parts A and B information if you have a Part C plan?"
           class="vads-u-margin-bottom--4"
         >
           <p className="vads-u-margin-y--0">
-            We need to confirm the dates you first became eligible for Part A
+            We need to confirm the dates you first became eligible for Parts A
             and B.
           </p>
         </va-additional-info>
@@ -205,10 +207,16 @@ const medicarePartAPartBEffectiveDatesPage = partC => {
         ({ formData }) =>
           `${generateParticipantName(formData)} Medicare effective dates`,
       ),
+      medicarePartAEffectiveDate: currentOrPastDateUI({
+        title: 'Effective date',
+        hint:
+          'This will be on the front of the Medicare card near "Coverage starts".',
+        required: () => true,
+      }),
       'view:partATitle': {
         'ui:description': <h3>Medicare Part A</h3>,
       },
-      medicarePartAEffectiveDate: currentOrPastDateUI({
+      medicarePartBEffectiveDate: currentOrPastDateUI({
         title: 'Effective date',
         hint:
           'You may find your effective date on the front of your Medicare card near "Coverage starts" or "Effective date."',
@@ -217,12 +225,6 @@ const medicarePartAPartBEffectiveDatesPage = partC => {
       'view:partBTitle': {
         'ui:description': <h3>Medicare Part B</h3>,
       },
-      medicarePartBEffectiveDate: currentOrPastDateUI({
-        title: 'Effective date',
-        hint:
-          'You may find your effective date on the front of your Medicare card near "Coverage starts" or "Effective date."',
-        required: () => true,
-      }),
       ...uiProperties,
     },
     schema: {
@@ -246,13 +248,15 @@ const medicarePartAPartBDescription = (
       You’ll need to submit a copy of your Original Medicare Health Card,
       sometimes referred to as the "red, white, and blue" Medicare card.
     </p>
-    <p>This card shows:</p>
+    <p>
+      <b>Your card should include this information:</b>
+    </p>
     <ul>
       <li>
-        You have Medicare Part A (listed as HOSPITAL), <strong>and</strong>
+        Medicare Part A (listed as HOSPITAL), <strong>and</strong>
       </li>
       <li>
-        You have Medicare Part B (listed as MEDICAL), <strong>and</strong>
+        Medicare Part B (listed as MEDICAL), <strong>and</strong>
       </li>
       <li>The date your coverage begins</li>
     </ul>
@@ -274,15 +278,15 @@ const {
   backAltText:
     'Back of a red, white, and blue Medicare card. Includes card usage instructions and the Medicare phone number and website.',
   cardTitle: 'Sample of Original Medicare card',
-  frontLabel: 'Upload front of original Medicare card',
-  backLabel: 'Upload back of original Medicare card',
+  frontLabel: 'Upload front of Original Medicare card',
+  backLabel: 'Upload back of Original Medicare card',
 });
 
 // Define the Medicare A/B card upload page using the generic schema
 const medicareABCardUploadPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
-      'Upload Medicare card for hospital and medical coverage',
+      'Upload Medicare card for Hospital and Medical insurance',
     ),
     ...medicareCardUiSchema,
   },
@@ -317,10 +321,18 @@ const medicarePartAEffectiveDatePage = {
 const medicarePartADescription = (
   <div>
     <p>
-      You’ll need to submit a copy of your Original Medicare Health Part A Card,
-      sometimes referred to as the "red, white, and blue" Medicare card.
+      You’ll need to submit a copy of your Original Medicare Health Part A card,
+      sometimes called the "red, white, and blue" Medicare card.
     </p>
-    {fileUploadBlurb['view:fileUploadBlurb']['ui:description']}
+    <p>
+      <b>Your card should include this information</b>
+    </p>
+    <ul>
+      <li>
+        Medicare Part A (listed as HOSPITAL), <strong>and</strong>
+      </li>
+      <li>The date your coverage begins</li>
+    </ul>
   </div>
 );
 
@@ -330,7 +342,6 @@ const {
   schema: medicarePartACardSchema,
 } = createCardUploadSchema({
   customDescription: medicarePartADescription,
-  showFilesBlurb: false,
   frontProperty: 'medicarePartAFrontCard',
   backProperty: 'medicarePartABackCard',
   frontImageSrc: '/img/ivc-champva/part_a_card_front_high_res.png',
@@ -361,10 +372,13 @@ const medicarePartBEffectiveDatePage = {
       ({ formData }) =>
         `${generateParticipantName(formData)} Medicare Part B effective date`,
     ),
+    'view:partBTitle': {
+      'ui:description': <h3>Medicare Part B</h3>,
+    },
     medicarePartBEffectiveDate: currentOrPastDateUI({
-      title: 'Medicare Part B effective date',
+      title: 'Effective date',
       hint:
-        'You may find your effective date on the front of your Medicare card near "Coverage starts" or "Effective date."',
+        'This will be on the front of your Medicare card near "Coverage starts."',
       required: () => true,
     }),
   },
@@ -373,6 +387,7 @@ const medicarePartBEffectiveDatePage = {
     required: ['medicarePartBEffectiveDate'],
     properties: {
       medicarePartBEffectiveDate: currentOrPastDateSchema,
+      'view:partBTitle': blankSchema,
     },
   },
 };
@@ -394,7 +409,6 @@ const {
   schema: medicarePartBCardSchema,
 } = createCardUploadSchema({
   customDescription: medicarePartBDescription,
-  showFilesBlurb: false,
   frontProperty: 'medicarePartBFrontCard',
   backProperty: 'medicarePartBBackCard',
   frontImageSrc: '/img/ivc-champva/part_b_card_front_high_res.png',
@@ -458,12 +472,12 @@ const medicarePartADenialProofUploadPage = {
       ({ formData }) => {
         return (
           <>
-            {generateParticipantName(formData)} is 65 years or older and you
-            selected that they do not have Medicare Part A.
+            {generateParticipantName(formData)} is 65 years old. And you
+            selected that they don’t have Medicare Part A.
             <br />
             <br />
             You’ll need to submit a copy of a letter from the Social Security
-            Administration that confirms that they don’t qualify for Medicare
+            Administration. This confirms that they don’t qualify for Medicare
             benefits under anyone’s Social Security number.
           </>
         );
@@ -506,12 +520,12 @@ const medicarePartCCarrierEffectiveDatePage = {
     ),
     medicarePartCCarrier: textUI({
       title: 'Name of insurance carrier',
-      hint: 'Your insurance carrier is your insurance company.',
+      hint: 'This is the name of your insurance company.',
     }),
     medicarePartCEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part C effective date',
       hint:
-        'You may find your effective date on the front of your Medicare card near "Coverage starts" or "Effective date."',
+        'This information is on the front of your Medicare card near "Effective date." or "Issue date. If it’s not there, it may be on your plan’s online portal or enrollment documents.',
       required: () => true,
     }),
   },
@@ -535,9 +549,8 @@ const medicarePartCPharmacyBenefitsPage = {
     hasPharmacyBenefits: {
       ...yesNoUI({
         title:
-          'Does this Medicare Part C (Advantage Plan) provide pharmacy benefits?',
-        hint:
-          'This information can be found on your Medicare Part C (Advantage Plan) card.',
+          'Does your Medicare Part C (Advantage Plan) provide pharmacy benefits?',
+        hint: 'This information is on the front of the card.',
         required: () => true,
       }),
     },
@@ -633,9 +646,12 @@ const medicarePartDCarrierEffectiveDatePage = {
     ),
     medicarePartDEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part D effective date',
-      hint:
-        'You may find your effective date on the front of your Medicare card near "Coverage starts" or "Effective date."',
+      hint: 'This information is at the top of your card.',
       required: () => true,
+    }),
+    medicarePartDTerminationDate: currentOrPastDateUI({
+      title: 'Medicare Part D termination date',
+      hint: 'Only enter this date if your plan is inactive',
     }),
   },
   schema: {
@@ -643,6 +659,7 @@ const medicarePartDCarrierEffectiveDatePage = {
     required: ['medicarePartDEffectiveDate'],
     properties: {
       medicarePartDEffectiveDate: currentOrPastDateSchema,
+      medicarePartDTerminationDate: currentOrPastDateSchema,
     },
   },
 };
@@ -652,14 +669,14 @@ const medicarePartDCardUploadPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       'Upload Medicare Part D card',
-      'You’ll need to submit a copy of the front and back of your Medicare Part D prescription drug coverage card.',
+      'You’ll need to submit a copy of the front and back of your Medicare Part D card.',
     ),
     ...fileUploadBlurb,
     medicarePartDFrontCard: fileUploadUI({
-      label: 'Upload front of Part D Medicare card',
+      label: 'Upload front of Medicare Part D card',
     }),
     medicarePartDBackCard: fileUploadUI({
-      label: 'Upload back of Part D Medicare card',
+      label: 'Upload back of Medicare Part D card',
     }),
   },
   schema: {

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -71,7 +71,7 @@ export function generateParticipantName(item) {
       app => item?.medicareParticipant === toHashMemoized(app.applicantSSN),
     );
     const name = applicantWording(match, false, false, false);
-    return name.length > 0 ? `${name}${"'s"}` : 'applicant';
+    return name.length > 0 ? `${name}${'’s'}` : 'applicant';
   }
   return 'No participant';
 }

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -71,7 +71,7 @@ export function generateParticipantName(item) {
       app => item?.medicareParticipant === toHashMemoized(app.applicantSSN),
     );
     const name = applicantWording(match, false, false, false);
-    return name.length > 0 ? name`${"'s"}` : 'applicant';
+    return name.length > 0 ? `${name}${"'s"}` : 'applicant';
   }
   return 'No participant';
 }

--- a/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/medicareInformation.js
@@ -71,7 +71,7 @@ export function generateParticipantName(item) {
       app => item?.medicareParticipant === toHashMemoized(app.applicantSSN),
     );
     const name = applicantWording(match, false, false, false);
-    return name.length > 0 ? `${name}${'’s'}` : 'applicant';
+    return name.length > 0 ? `${name}` : 'applicant';
   }
   return 'No participant';
 }

--- a/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/signerInformation.js
@@ -94,9 +94,14 @@ export const certifierAddressSchema = {
   uiSchema: {
     ...titleUI(
       'Your mailing address',
-      'We’ll send any important information about this application to your address',
+      'We’ll send any important information about this application to your address.',
     ),
-    certifierAddress: addressUI(),
+    certifierAddress: addressUI({
+      labels: {
+        militaryCheckbox:
+          'Address is on military base outside of the United States.',
+      },
+    }),
     // TODO: get these validations back in place
     /*
     'ui:validations': [
@@ -246,7 +251,7 @@ export const certifierRelationshipSchema = {
       relationshipToVeteran: checkboxGroupUI({
         title: 'Which of these best describes you?',
         hint:
-          'If you’re applying on behalf of multiple applicants, you can select all applicable options',
+          'If you’re applying for multiple applicants, select all that apply.',
         required: () => true,
         labels: {
           spouse: 'I’m an applicant’s spouse',

--- a/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
@@ -9,7 +9,7 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { TITLE, SUBTITLE } from '../constants';
 
-const OMB_RES_BURDEN = 10;
+const OMB_RES_BURDEN = 24;
 const OMB_NUMBER = '2900-0219';
 const OMB_EXP_DATE = '12/31/2027';
 
@@ -25,22 +25,30 @@ const ProcessList = () => {
       </va-process-list-item>
       <va-process-list-item header="Gather your information">
         <p>
-          <b>Here’s what you need to apply:</b>
+          <b>You’ll need to provide personal information for these people:</b>
         </p>
         <ul>
+          <li>Yourself, and</li>
+          <li>Anyone you’re applying for, and</li>
           <li>
-            <b>Personal information about you</b> and anyone else you’re
-            applying for
-          </li>
-          <li>
-            <b>Personal information about your sponsor</b> (the Veteran or
-            service member you’re connected to)
+            Your sponsor (the Veteran or service member you’re connected to)
           </li>
         </ul>
         <p>
-          This includes dates of birth, Social Security numbers, and contact
-          information.
+          Personal information may include dates of birth, Social Security
+          numbers, and contact information.
         </p>
+        <p>
+          You’ll also need to submit these supporting documents if appropriate:
+        </p>
+        <ul>
+          <li>Health insurance cards</li>
+          <li>Medicare cards</li>
+          <li>Proof of school enrollment</li>
+          <li>Proof of marriage or legal union</li>
+          <li>Proof of adoption</li>
+          <li>Birth certificate of dependent(s)</li>
+        </ul>
         <p>
           You may also need to submit supporting documents, like copies of your
           health insurance cards or proof of school enrollment.
@@ -74,8 +82,14 @@ export const IntroductionPage = props => {
   return (
     <article className="schemaform-intro">
       <FormTitle title={TITLE} subTitle={SUBTITLE} />
+      <p>
+        If you’re the spouse, dependant, or survivor of a Veteran or service
+        member who meets certain requirements, you may qualify for health
+        insurance through the Civilian Health and Medical Program of the
+        Department of Veterans Affairs (CHAMPVA).
+      </p>
       <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-        Follow the steps to apply for CHAMPVA benefits
+        Follow these steps to get started
       </h2>
       <ProcessList />
       <va-alert-sign-in variant="signInOptionalNoPrefill" visible>
@@ -98,6 +112,9 @@ export const IntroductionPage = props => {
         </span>
       </va-alert-sign-in>
       <p />
+      <h3>Additional form you may need to complete</h3>
+      <h3>CHAMPVA other health insurance (OHI) certification</h3>
+      <p>VA form 10-7959c</p>
       <va-omb-info
         res-burden={OMB_RES_BURDEN}
         omb-number={OMB_NUMBER}

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
@@ -266,11 +266,11 @@ describe('generateParticipantName', () => {
         'view:applicantObjects': [
           {
             applicantSSN: '123123123',
-            applicantName: { first: 'App1', last: 'Jones’s' },
+            applicantName: { first: 'App1', last: 'Jones' },
           },
           {
             applicantSSN: '234234234',
-            applicantName: { first: 'App2', last: 'Jones’s' },
+            applicantName: { first: 'App2', last: 'Jones' },
           },
         ],
       }),

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/chapters/applicantInformation.unit.spec.jsx
@@ -266,11 +266,11 @@ describe('generateParticipantName', () => {
         'view:applicantObjects': [
           {
             applicantSSN: '123123123',
-            applicantName: { first: 'App1', last: 'Jones' },
+            applicantName: { first: 'App1', last: 'Jones’s' },
           },
           {
             applicantSSN: '234234234',
-            applicantName: { first: 'App2', last: 'Jones' },
+            applicantName: { first: 'App2', last: 'Jones’s' },
           },
         ],
       }),

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
@@ -191,13 +191,12 @@ export function ApplicantAddressCopyPage(props) {
   );
 
   // We use this a few times, so compute now.
-  const curAppFullName = fullName(currentApp.applicantName);
   const selectWording =
     customSelectText ??
     `${
       pagePerItemIndex === 0 && data.certifierRole === 'applicant'
         ? 'Do you'
-        : `Does ${curAppFullName}`
+        : `Does the applicant`
     } have the same mailing address as another person listed in this application?`;
 
   return (

--- a/src/applications/ivc-champva/shared/components/fileUploads/attachments.js
+++ b/src/applications/ivc-champva/shared/components/fileUploads/attachments.js
@@ -43,7 +43,9 @@ export const fileUploadBlurbCustom = (items, afterContent) => {
             key="upload-instructions-container"
             className="vads-u-margin-bottom--4"
           >
-            <b key="upload-instructions-heading">How to upload files:</b>
+            <b key="upload-instructions-heading">
+              What to know about uploading files
+            </b>
             <ul key="upload-instructions-list">
               <li key="upload-file-types">
                 Use a .{fileTypes.slice(0, -1).join(', .')}, or .

--- a/src/applications/ivc-champva/shared/components/fileUploads/genericCardUpload.js
+++ b/src/applications/ivc-champva/shared/components/fileUploads/genericCardUpload.js
@@ -105,7 +105,7 @@ export const createCardUploadSchema = ({
           {frontLabel}
           <br key="front-upload-br" />
           <span key="front-upload-hint" className="usa-hint">
-            Upload front and back as separate files
+            Upload front and back as separate files.
           </span>
         </div>
       ),
@@ -120,7 +120,7 @@ export const createCardUploadSchema = ({
           {backLabel}
           <br key="back-upload-br" />
           <span key="back-upload-hint" className="usa-hint">
-            Upload front and back as separate files
+            Upload front and back as separate files.
           </span>
         </div>
       ),

--- a/src/applications/ivc-champva/shared/constants.js
+++ b/src/applications/ivc-champva/shared/constants.js
@@ -24,8 +24,7 @@ export const ConfirmationPagePropTypes = {
 };
 
 export const ADDITIONAL_FILES_HINT =
-  'Depending on your response, you may need to submit additional documents with this application.';
-
+  'Depending on your response, you may need to submit additional documents.';
 const addressFormat = markup => (
   <>
     <address className="va-address-block">{markup}</address>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR updates a lot of content

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/116803

## Testing done
unit
e2e

## Screenshots
<img width="722" height="365" alt="Screenshot 2025-08-25 at 8 18 02 AM" src="https://github.com/user-attachments/assets/bab34107-150e-4bdc-9133-f7c467d12438" />
<img width="486" height="255" alt="Screenshot 2025-08-25 at 8 14 59 AM" src="https://github.com/user-attachments/assets/52c86987-ca9c-4b69-8d9e-d3af663102ed" />
<img width="565" height="642" alt="Screenshot 2025-08-25 at 8 14 22 AM" src="https://github.com/user-attachments/assets/d6066618-7a98-4115-9171-3d28521032e2" />
<img width="572" height="488" alt="Screenshot 2025-08-25 at 8 14 06 AM" src="https://github.com/user-attachments/assets/51985669-59c4-4190-b7a7-e95023d676c2" />
<img width="492" height="721" alt="Screenshot 2025-08-25 at 8 13 35 AM" src="https://github.com/user-attachments/assets/84fa3404-2ada-4a64-bd0f-70e762e4b029" />
<img width="531" height="352" alt="Screenshot 2025-08-25 at 8 13 25 AM" src="https://github.com/user-attachments/assets/166018e8-2b5f-4ec7-83a1-209e707d653a" />
<img width="581" height="387" alt="Screenshot 2025-08-25 at 8 13 18 AM" src="https://github.com/user-attachments/assets/8eb06c31-aa41-4df3-90c5-3ee282434b50" />
<img width="535" height="772" alt="Screenshot 2025-08-25 at 8 13 05 AM" src="https://github.com/user-attachments/assets/efbe5368-be1d-4f52-bd63-722e0835b8c0" />
<img width="524" height="147" alt="Screenshot 2025-08-25 at 8 12 55 AM" src="https://github.com/user-attachments/assets/1f7ae808-5588-431c-8aa4-8096f2dfe721" />
<img width="501" height="401" alt="Screenshot 2025-08-25 at 8 12 46 AM" src="https://github.com/user-attachments/assets/d3d2d49e-cefb-427a-bc84-55414195249d" />
<img width="524" height="337" alt="Screenshot 2025-08-25 at 8 12 32 AM" src="https://github.com/user-attachments/assets/79efc498-53a0-424f-b2c6-c4624808c520" />
<img width="539" height="106" alt="Screenshot 2025-08-25 at 8 12 23 AM" src="https://github.com/user-attachments/assets/0c8b38d4-a672-4fda-82b2-4f776ec101bc" />
<img width="525" height="162" alt="Screenshot 2025-08-25 at 8 12 15 AM" src="https://github.com/user-attachments/assets/551984e1-5e13-4a7c-9e79-cc4eec1df56e" />
<img width="516" height="134" alt="Screenshot 2025-08-25 at 8 11 57 AM" src="https://github.com/user-attachments/assets/8ffc4e8f-c998-4a0e-8190-7fe27b1fd644" />
<img width="596" height="413" alt="Screenshot 2025-08-25 at 8 11 22 AM" src="https://github.com/user-attachments/assets/b6807a25-1237-4415-a25c-27969d6b132a" />
<img width="535" height="248" alt="Screenshot 2025-08-25 at 8 11 14 AM" src="https://github.com/user-attachments/assets/23f52d0a-fc7e-4cd9-b306-2043849f0d1f" />
<img width="466" height="91" alt="Screenshot 2025-08-25 at 8 10 53 AM" src="https://github.com/user-attachments/assets/41f0b12b-fe08-4029-9237-d8d6fc0bb4d8" />
<img width="523" height="172" alt="Screenshot 2025-08-25 at 8 10 36 AM" src="https://github.com/user-attachments/assets/ccf90583-e22a-43e2-add6-0e515467025a" />
<img width="543" height="208" alt="Screenshot 2025-08-25 at 8 10 28 AM" src="https://github.com/user-attachments/assets/b51f83ec-9c58-4f3a-bd5b-e5a756a9253e" />
<img width="563" height="151" alt="Screenshot 2025-08-25 at 8 10 05 AM" src="https://github.com/user-attachments/assets/95e98914-5243-49c2-9bdc-7a05ef56b1cd" />
<img width="616" height="219" alt="Screenshot 2025-08-25 at 8 09 46 AM" src="https://github.com/user-attachments/assets/c633eba0-5563-4bd0-b5b1-794ded307627" />
<img width="588" height="329" alt="Screenshot 2025-08-25 at 8 09 31 AM" src="https://github.com/user-attachments/assets/9befb33a-5040-4bca-a218-6b18f2902241" />
<img width="719" height="862" alt="Screenshot 2025-08-25 at 8 09 16 AM" src="https://github.com/user-attachments/assets/196bdf6c-f44e-4d04-a4e0-6160a26878c0" />

## What areas of the site does it impact?
this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
