### PR TITLE
Fixed vitals date in Blue Button TXT download

### DIFF
--- a/src/applications/mhv-medical-records/tests/util/txtHelpers/vitals.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/txtHelpers/vitals.unit.spec.jsx
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { parseVitals } from '../../../util/txtHelpers/vitals';
+
+describe('parseVitals', () => {
+  it('should correctly pull the date from the date field in vitals records', () => {
+    const vitalsRecords = [
+      {
+        type: 'PULSE',
+        date: '2025-08-25',
+        measurement: '72 bpm',
+        location: 'Clinic A',
+        notes: 'Normal',
+      },
+      {
+        type: 'RESPIRATION',
+        date: '2025-08-24',
+        measurement: '16 breaths/min',
+        location: 'Clinic B',
+        notes: 'Normal',
+      },
+    ];
+    const result = parseVitals(vitalsRecords);
+    expect(result).to.contain('2025-08-25');
+    expect(result).to.contain('2025-08-24');
+    expect(result).to.contain('72 bpm');
+    expect(result).to.contain('16 breaths/min');
+  });
+});

--- a/src/applications/mhv-medical-records/util/txtHelpers/vitals.js
+++ b/src/applications/mhv-medical-records/util/txtHelpers/vitals.js
@@ -37,7 +37,7 @@ ${txtLineDotted}
     .filter(record => record.type === vitalType)
     .map(
       record => `
-${record.dateTime}
+${record.date}
 Result: ${record.measurement}
 Location: ${record.location}
 Provider Notes: ${record.notes}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Blue Button Vitals was pulling a non-existent field for "date". It is now corrected.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117684

## Testing done

- Unit test added to make sure date is correctly pulled from the "date" field.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="300" height="306" alt="image" src="https://github.com/user-attachments/assets/565c234e-2bfb-4420-ba80-94efe91e0cbd" /> | <img width="300" height="306" alt="image" src="https://github.com/user-attachments/assets/7c5a19ec-b4f0-42ad-b81d-c6d9e1e03418" /> |

## What areas of the site does it impact?

MHV Medical Recods

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
