### PR TITLE
display loading only when network call has been initiated

### DIFF
--- a/src/applications/personalization/profile/components/paperless-delivery/PaperlessDelivery.jsx
+++ b/src/applications/personalization/profile/components/paperless-delivery/PaperlessDelivery.jsx
@@ -34,9 +34,7 @@ export const PaperlessDelivery = () => {
   const hasVAPServiceError = useSelector(hasVAPServiceConnectionError);
   const { loadingStatus } = communicationPreferencesState;
   const hasLoadingError = loadingStatus === LOADING_STATES.error;
-  const isLoading =
-    loadingStatus === LOADING_STATES.idle ||
-    loadingStatus === LOADING_STATES.pending;
+  const isLoading = loadingStatus === LOADING_STATES.pending;
   const hasAPIError = hasVAPServiceError || hasLoadingError;
   const showContent = !hasAPIError && !isLoading;
 


### PR DESCRIPTION
## Summary

- _This is a bug fix to correctly display the loading indicator only when a network call is initiated_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_

## Testing done

- _Unit tests exist_

## Screenshots


## What areas of the site does it impact?
Paperless Delivery page in Profile

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
