### PR TITLE
0969 | Staged Entry Widget - Update start path

### DIFF
--- a/src/applications/static-pages/income-and-asset/components/App/index.js
+++ b/src/applications/static-pages/income-and-asset/components/App/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 
-const START_URL =
-  'supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969';
+const START_PATH = 'submit-income-and-asset-statement-form-21p-0969';
 const DOWNLOAD_URL = 'https://www.va.gov/find-forms/about-form-21p-0969/';
 
 export const App = () => {
@@ -22,7 +21,7 @@ export const App = () => {
       <p>You can submit this form online or by mail.</p>
       <div className="vads-u-margin-y--2">
         <va-link-action
-          href={START_URL}
+          href={START_PATH}
           text="Submit a Pension or DIC income and asset statement"
           type="secondary"
         />


### PR DESCRIPTION
## Summary

This PR updates the **start path** used by the **Staged Entry Widget** on the static page for the **Income and Asset Statement form (VA Form 21P-0969)**. The change ensures that users are routed to the correct form entry URL when the widget is active and the feature toggle is enabled.

## Issue

- Widget start path was outdated or incorrect
- Needed to align with final production routing for 0969

## Related issue(s)

- N/A

## Associated Pull Request(s)

- N/A

## How to run in local environment

> This change affects the static page entry and requires validation outside of the form flow.

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_form_enabled`  
4. Visit the form introduction page:  
   `http://localhost:3001/income-and-asset-statement-form-21p-0969-introduction/`

## How to verify

1. Ensure the **Staged Entry Widget** appears when the toggle is enabled
2. Click the **Start** button and confirm it routes to the correct form URL:
