### PR TITLE
Added dynamic content for financial accounts pages

### DIFF
--- a/src/applications/income-and-asset-statement/components/AssociatedIncomeSummaryDescription.jsx
+++ b/src/applications/income-and-asset-statement/components/AssociatedIncomeSummaryDescription.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export const SummaryDescription = () => {
+  return (
+    <>
+      <p>Here are some examples of income from financial accounts:</p>
+      <ul>
+        <li>Savings bonds</li>
+        <li>Stocks and dividends</li>
+        <li>Interest-earning accounts, like checkings and savings</li>
+        <li>
+          Distributions from Individual Retirement Accounts (IRAs), including
+          required minimum distributions (RMDs)
+        </li>
+        <li>Pension plans with cash value</li>
+      </ul>
+    </>
+  );
+};

--- a/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
@@ -16,6 +16,7 @@ import {
 } from '~/platform/forms-system/src/js/web-component-patterns';
 import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { SummaryDescription } from '../../../components/AssociatedIncomeSummaryDescription';
 import { DependentDescription } from '../../../components/DependentDescription';
 import {
   formatCurrency,
@@ -33,9 +34,14 @@ import {
   showUpdatedContent,
 } from '../../../helpers';
 import {
+  custodianRelationshipLabels,
+  parentRelationshipLabels,
+  parentRelationshipLabelDescriptions,
   relationshipLabels,
   relationshipLabelDescriptions,
   incomeTypeEarnedLabels,
+  yesNoLabelsIncome,
+  yesNoLabels,
 } from '../../../labels';
 
 /** @type {ArrayBuilderOptions} */
@@ -51,6 +57,12 @@ export const options = {
     !isDefined(item.accountValue) ||
     !isDefined(item.payer), // include all required fields here
   text: {
+    summaryTitleWithoutItems: showUpdatedContent()
+      ? 'Income from financial accounts'
+      : null,
+    summaryDescriptionWithoutItems: showUpdatedContent()
+      ? SummaryDescription
+      : null,
     getItemName: (item, index, formData) => {
       if (!isDefined(item?.recipientRelationship) || !isDefined(item?.payer)) {
         return undefined;
@@ -102,6 +114,17 @@ export const options = {
       generateDeleteDescription(props, options.text.getItemName),
   },
 };
+const updatedTitleNoItems =
+  'Are you or your dependents receiving or expecting to receive any income in the next 12 months from financial accounts?';
+const updatedTitleWithItems = 'Do you have more financial accounts to report?';
+const summaryTitle = 'Income and net worth associated with financial accounts';
+const schema = {
+  type: 'object',
+  properties: {
+    'view:isAddingAssociatedIncomes': arrayBuilderYesNoSchema,
+  },
+  required: ['view:isAddingAssociatedIncomes'],
+};
 
 /**
  * Cards are populated on this page above the uiSchema if items are present
@@ -116,27 +139,109 @@ const summaryPage = {
         title:
           'Are you or your dependents receiving or expecting to receive any income in the next 12 months that is related to financial accounts?',
         hint: 'If yes, you’ll need to report at least one income',
-        labels: {
-          Y: 'Yes',
-          N: 'No',
-        },
+        labels: yesNoLabels,
       },
       {
-        title: 'Do you have more financial accounts to report?',
-        labels: {
-          Y: 'Yes',
-          N: 'No',
-        },
+        title: 'Do you have more recurring income to report?',
+        labels: yesNoLabels,
       },
     ),
   },
-  schema: {
-    type: 'object',
-    properties: {
-      'view:isAddingAssociatedIncomes': arrayBuilderYesNoSchema,
-    },
-    required: ['view:isAddingAssociatedIncomes'],
+  schema,
+};
+
+const updatedSummaryPage = {
+  uiSchema: {
+    'view:isAddingAssociatedIncomes': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint:
+          'Your dependents include your spouse, including a same-sex and common-law partner and children who you financially support.',
+        labels: yesNoLabelsIncome,
+      },
+      {
+        title: updatedTitleWithItems,
+        labels: yesNoLabels,
+      },
+    ),
   },
+  schema,
+};
+
+const spouseSummaryPage = {
+  uiSchema: {
+    'view:isAddingAssociatedIncomes': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint: 'Your dependents include children who you financially support.',
+        labels: yesNoLabelsIncome,
+      },
+      {
+        title: updatedTitleWithItems,
+        labels: yesNoLabels,
+      },
+    ),
+  },
+  schema,
+};
+
+const childSummaryPage = {
+  uiSchema: {
+    'view:isAddingAssociatedIncomes': arrayBuilderYesNoUI(
+      options,
+      {
+        title:
+          'Are you receiving or expecting to receive any income in the next 12 months from financial accounts?',
+        hint: null,
+        labels: yesNoLabelsIncome,
+      },
+      {
+        title: updatedTitleWithItems,
+        labels: yesNoLabels,
+      },
+    ),
+  },
+  schema,
+};
+
+const parentSummaryPage = {
+  uiSchema: {
+    'view:isAddingAssociatedIncomes': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint:
+          'Your dependents include your spouse, including a same-sex and common-law partner and children who you financially support.',
+        labels: yesNoLabelsIncome,
+      },
+      {
+        title: updatedTitleWithItems,
+        labels: yesNoLabels,
+      },
+    ),
+  },
+  schema,
+};
+
+const custodianSummaryPage = {
+  uiSchema: {
+    'view:isAddingAssociatedIncomes': arrayBuilderYesNoUI(
+      options,
+      {
+        title: updatedTitleNoItems,
+        hint:
+          'Your dependents include your spouse, including a same-sex and common-law partner and the Veteran’s children who you financially support.',
+        labels: yesNoLabelsIncome,
+      },
+      {
+        title: updatedTitleWithItems,
+        labels: yesNoLabels,
+      },
+    ),
+  },
+  schema,
 };
 
 /** @returns {PageSchema} */
@@ -177,7 +282,7 @@ const veteranIncomeRecipientPage = {
 const spouseIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Recurring income relationship',
+      title: 'Financial account relationship',
       nounSingular: options.nounSingular,
     }),
     recipientRelationship: radioUI({
@@ -217,8 +322,68 @@ const spouseIncomeRecipientPage = {
   },
 };
 
+const custodianIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Financial account relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: Object.fromEntries(Object.entries(custodianRelationshipLabels)),
+      descriptions: Object.keys(relationshipLabelDescriptions).filter(
+        key => key !== 'CHILD',
+      ),
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'associatedIncomes',
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(relationshipLabels).filter(
+          key => key !== 'VETERAN' && key !== 'PARENT',
+        ),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+const parentIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Financial account relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: Object.fromEntries(Object.entries(parentRelationshipLabels)),
+      descriptions: parentRelationshipLabelDescriptions,
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'associatedIncomes',
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(relationshipLabels).filter(
+          key => key !== 'VETERAN' && key !== 'CUSTODIAN' && key !== 'CHILD',
+        ),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
 /** @returns {PageSchema} */
-const nonVeteranIncomeRecipientPage = {
+const incomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Financial account relationship',
@@ -331,10 +496,51 @@ export const associatedIncomePages = arrayBuilderPages(
   options,
   pageBuilder => ({
     associatedIncomePagesSummary: pageBuilder.summaryPage({
-      title: 'Income and net worth associated with financial accounts',
+      title: summaryTitle,
       path: 'financial-accounts-summary',
+      depends: () => !showUpdatedContent(),
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
+    }),
+    associatedIncomePagesUpdatedSummary: pageBuilder.summaryPage({
+      title: summaryTitle,
+      path: 'financial-accounts-summary-updated',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'VETERAN',
+      uiSchema: updatedSummaryPage.uiSchema,
+      schema: updatedSummaryPage.schema,
+    }),
+    associatedIncomePagesSpouseSummary: pageBuilder.summaryPage({
+      title: summaryTitle,
+      path: 'financial-accounts-summary-spouse',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'SPOUSE',
+      uiSchema: spouseSummaryPage.uiSchema,
+      schema: spouseSummaryPage.schema,
+    }),
+    associatedIncomePagesChildSummary: pageBuilder.summaryPage({
+      title: summaryTitle,
+      path: 'financial-accounts-summary-child',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CHILD',
+      uiSchema: childSummaryPage.uiSchema,
+      schema: childSummaryPage.schema,
+    }),
+    associatedIncomePagesCustodianSummary: pageBuilder.summaryPage({
+      title: summaryTitle,
+      path: 'financial-accounts-summary-custodian',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
+      uiSchema: parentSummaryPage.uiSchema,
+      schema: parentSummaryPage.schema,
+    }),
+    associatedIncomePagesParentSummary: pageBuilder.summaryPage({
+      title: summaryTitle,
+      path: 'financial-accounts-summary-parent',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'PARENT',
+      uiSchema: custodianSummaryPage.uiSchema,
+      schema: custodianSummaryPage.schema,
     }),
     associatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (
@@ -358,16 +564,29 @@ export const associatedIncomePages = arrayBuilderPages(
       uiSchema: spouseIncomeRecipientPage.uiSchema,
       schema: spouseIncomeRecipientPage.schema,
     }),
+    associatedIncomeCustodianRecipientPage: pageBuilder.itemPage({
+      title: 'Financial account recipient',
+      path: 'financial-accounts/:index/custodian-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
+      uiSchema: custodianIncomeRecipientPage.uiSchema,
+      schema: custodianIncomeRecipientPage.schema,
+    }),
+    associatedIncomeParentRecipientPage: pageBuilder.itemPage({
+      title: 'Financial account recipient',
+      path: 'financial-accounts/:index/parent-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'PARENT',
+      uiSchema: parentIncomeRecipientPage.uiSchema,
+      schema: parentIncomeRecipientPage.schema,
+    }),
     associatedIncomeRecipientPage: pageBuilder.itemPage({
       title: 'Financial account recipient',
       path: 'financial-accounts/:index/income-recipient',
       depends: formData =>
-        !showUpdatedContent() ||
-        (showUpdatedContent() &&
-          formData.claimantType !== 'VETERAN' &&
-          formData.claimantType !== 'SPOUSE'),
-      uiSchema: nonVeteranIncomeRecipientPage.uiSchema,
-      schema: nonVeteranIncomeRecipientPage.schema,
+        !showUpdatedContent() || formData.claimantType === 'CHILD',
+      uiSchema: incomeRecipientPage.uiSchema,
+      schema: incomeRecipientPage.schema,
     }),
     associatedIncomeRecipientNamePage: pageBuilder.itemPage({
       title: 'Financial account recipient name',

--- a/src/applications/income-and-asset-statement/labels.jsx
+++ b/src/applications/income-and-asset-statement/labels.jsx
@@ -26,6 +26,23 @@ export const transferMethodLabels = {
   OTHER: 'Other',
 };
 
+export const custodianRelationshipLabels = {
+  CUSTODIAN: 'Child’s custodian',
+  SPOUSE: 'Custodian’s spouse',
+  CHILD: 'Veteran’s surviving child',
+  OTHER: 'Another dependent not listed here',
+};
+
+export const parentRelationshipLabels = {
+  PARENT: 'Me',
+  SPOUSE: 'My spouse',
+  OTHER: 'Another dependent not listed here',
+};
+
+export const parentRelationshipLabelDescriptions = {
+  SPOUSE: 'The Veteran’s other parent should file a separate claim',
+};
+
 export const claimantTypeLabels = {
   VETERAN: "I'm a Veteran submitting this form to support my own claim",
   SPOUSE: "I'm the Veteran's surviving spouse",
@@ -72,4 +89,13 @@ export const trustTypeLabels = {
   REVOCABLE: 'Revocable',
   IRREVOCABLE: 'Irrevocable',
   BURIAL: 'Burial trust',
+};
+
+export const yesNoLabelsIncome = {
+  Y: 'Yes, I have income to report',
+  N: 'No, I don’t have any income to report',
+};
+export const yesNoLabels = {
+  Y: 'Yes',
+  N: 'No',
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added dynamic content updates based on claimant role for financial accounts (with no items).
- Pension and Burial Benefits to own this change.
- Using `incomeAndAssetsContentUpdates` end date pending. Need to wait for after 0969 is fully launched. Canary launch is scheduled for today, 08/26.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#111546

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
