### PR TITLE
115707Go to My VA Health link does not open new tab

### DIFF
--- a/src/applications/mhv-secure-messaging/components/MessageList/CernerFacilityAlert.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/CernerFacilityAlert.jsx
@@ -87,11 +87,10 @@ const CernerFacilityAlert = ({ cernerFacilities }) => {
           <a
             className="vads-c-action-link--blue vads-u-margin-bottom--0p5"
             href={getCernerURL('/pages/messaging/inbox', true)}
-            target="_blank"
             rel="noopener noreferrer"
             onClick={handleUrlClick}
           >
-            Go to My VA Health (opens in new tab)
+            Go to My VA Health
           </a>
 
           <p>

--- a/src/applications/mhv-secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
@@ -108,7 +108,7 @@ describe('Cerner Facility Alert', () => {
       facilities: userProfileFacilities.filter(f => f.facilityId === '668'),
     });
     expect(screen.queryByTestId('cerner-facilities-alert')).to.exist;
-    const link = screen.getByText('Go to My VA Health (opens in new tab)');
+    const link = screen.getByText('Go to My VA Health');
     expect(link).to.exist;
     fetchStub.resetHistory();
     fireEvent.click(link);
@@ -129,7 +129,7 @@ describe('Cerner Facility Alert', () => {
       facilities: userProfileFacilities.filter(f => f.facilityId === '668'),
     });
     expect(screen.queryByTestId('cerner-facilities-alert')).to.exist;
-    const link = screen.getByText('Go to My VA Health (opens in new tab)');
+    const link = screen.getByText('Go to My VA Health');
     expect(link).to.exist;
     fetchStub.resetHistory();
     fireEvent.click(link);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-aal.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-aal.cypress.spec.js
@@ -64,6 +64,8 @@ describe('SECURE MESSAGING AAL', () => {
       }).as('submitLaunchMessagingAal');
       PatientInboxPage.loadInboxMessages();
 
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+
       cy.get(Locators.ALERTS.CERNER_ALERT)
         .find('a')
         .click();
@@ -79,8 +81,6 @@ describe('SECURE MESSAGING AAL', () => {
           },
           product: 'sm',
         });
-
-        cy.injectAxeThenAxeCheck(AXE_CONTEXT);
       });
     });
 
@@ -97,12 +97,13 @@ describe('SECURE MESSAGING AAL', () => {
       }).as('submitLaunchMessagingAal');
       PatientInboxPage.loadInboxMessages();
 
+      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
+
       cy.get(Locators.ALERTS.CERNER_ALERT)
         .find('a')
         .click();
 
       cy.get('@submitLaunchMessagingAal.all').should('have.length', 0);
-      cy.injectAxeThenAxeCheck(AXE_CONTEXT);
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Link no longer opens new tab

## Related issue(s)
[115707](https://github.com/department-of-veterans-affairs/va.gov-team/issues/115707)

## Testing done
Tests updated and passing 

## Screenshots
<img width="800" height="687" alt="Screenshot 2025-08-26 at 10 53 17 AM" src="https://github.com/user-attachments/assets/c792595d-1464-49f5-ae74-8cfdd9ebed8e" />


## What areas of the site does it impact?
Secure Messaging Application

## Acceptance criteria
The 'Go to My VA Health' link no longer opens a new tab