### PR TITLE
#107658: OH - update request appointment link to start appointment request flow #107658

### DIFF
--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.jsx
@@ -15,10 +15,13 @@ export default function ScheduleWithDifferentProvider({
   const dispatch = useDispatch();
   const pageKey = 'selectProvider';
   const facilityPhone = getFacilityPhone(selectedFacility);
+  const isEligibleForRequest = eligibility?.request;
   const overRequestLimit =
     eligibility.requestReasons[0] === ELIGIBILITY_REASONS.overRequestLimit;
 
-  if (overRequestLimit) {
+  // currently using both facility configurations and eligibility endpoints as source of truth for request eligibility
+  // TODO: once we switch to using only eligibility endpoint, we can remove this test
+  if (overRequestLimit || !isEligibleForRequest) {
     return (
       <>
         <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0 vads-u-margin-top--2">
@@ -46,7 +49,6 @@ export default function ScheduleWithDifferentProvider({
         Call and ask to schedule with that provider:{' '}
         <FacilityPhone contact={facilityPhone} icon={false} />
       </p>
-
       <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-margin-top--1">
         Option 2: Request your preferred date and time online
       </h3>

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
@@ -46,7 +46,6 @@ describe('ScheduleWithDifferentProvider', () => {
   it('should only display Call and ask to schedule with provider option when over request limit', () => {
     const store = createTestStore(defaultState);
     const eligibility = {
-      request: false,
       requestReasons: ['overRequestLimit'],
     };
     const selectedFacility = {

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
@@ -105,7 +105,7 @@ describe('ScheduleWithDifferentProvider', () => {
 
   it('should render correct facility phone number', () => {
     const store = createTestStore(defaultState);
-    const eligibility = { request: true, requestReasons: [] };
+    const eligibility = { requestReasons: [] };
     const selectedFacility = {
       id: '692',
       name: 'White City VA Medical Center',

--- a/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ProviderSelectPage/ScheduleWithDifferentProvider.unit.spec.jsx
@@ -18,7 +18,7 @@ const defaultState = {
 describe('ScheduleWithDifferentProvider', () => {
   it('should display both options when user is eligible', () => {
     const store = createTestStore(defaultState);
-    const eligibility = { requestReasons: [] };
+    const eligibility = { request: true, requestReasons: [] };
     const selectedFacility = {
       id: '692',
       name: 'White City VA Medical Center',
@@ -45,7 +45,41 @@ describe('ScheduleWithDifferentProvider', () => {
 
   it('should only display Call and ask to schedule with provider option when over request limit', () => {
     const store = createTestStore(defaultState);
-    const eligibility = { requestReasons: ['overRequestLimit'] };
+    const eligibility = {
+      request: false,
+      requestReasons: ['overRequestLimit'],
+    };
+    const selectedFacility = {
+      id: '692',
+      name: 'White City VA Medical Center',
+    };
+
+    const screen = renderWithStoreAndRouter(
+      <ScheduleWithDifferentProvider
+        eligibility={eligibility}
+        selectedFacility={selectedFacility}
+      />,
+      { store },
+    );
+
+    expect(screen.getByText(/Call and ask to schedule with that provider/i)).to
+      .exist;
+    expect(screen.queryByText(/Option 1: Call the facility/i)).to.not.exist;
+    expect(
+      screen.queryByText(
+        /Option 2: Request your preferred date and time online/i,
+      ),
+    ).to.not.exist;
+    expect(screen.queryByText(/Request an appointment/i)).to.not.exist;
+  });
+  // currently using both facility configurations and eligibility endpoints as source of truth for request eligibility
+  // TODO: once we switch to using only eligibility endpoint, we can remove this test
+  it('should only display Call and ask to schedule with provider option when patient is not eligible for requests', () => {
+    const store = createTestStore(defaultState);
+    const eligibility = {
+      request: false,
+      requestReasons: ['overRequestLimit'],
+    };
     const selectedFacility = {
       id: '692',
       name: 'White City VA Medical Center',
@@ -72,7 +106,7 @@ describe('ScheduleWithDifferentProvider', () => {
 
   it('should render correct facility phone number', () => {
     const store = createTestStore(defaultState);
-    const eligibility = { requestReasons: [] };
+    const eligibility = { request: true, requestReasons: [] };
     const selectedFacility = {
       id: '692',
       name: 'White City VA Medical Center',
@@ -101,7 +135,7 @@ describe('ScheduleWithDifferentProvider', () => {
   });
   it('should route to request appointment URL when link clicked', async () => {
     const store = createTestStore(defaultState);
-    const eligibility = { requestReasons: [] };
+    const eligibility = { request: true, requestReasons: [] };
     const selectedFacility = {
       id: '692',
       name: 'White City VA Medical Center',


### PR DESCRIPTION
On the Oracle Health provider selection screen, users are presented with a choice of providers. When a user is unable to self schedule with a given provider, a user should be able to submit an appointment request. 


## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)
https://github.com/orgs/department-of-veterans-affairs/projects/1554/views/6?pane=issue&itemId=106637414&issue=department-of-veterans-affairs%7Cva.gov-team%7C107658


