### PR TITLE
Feedback Tool Vet Tec toggle to make use of ToggleSync

### DIFF
--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import merge from 'lodash/merge';
 import fullSchema from 'vets-json-schema/dist/FEEDBACK-TOOL-schema.json';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
@@ -21,7 +22,7 @@ const { get, omit, set } = dataUtils;
 import VaCheckboxGroupField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-import SchoolSelectField from '../components/SchoolSelectField.jsx';
+import SchoolSelectField from '../components/SchoolSelectField';
 
 import {
   conditionallyShowPrefillMessage,
@@ -138,12 +139,12 @@ function manualSchoolEntryIsCheckedAndIsUS(formData) {
  * The (VET TEC 2.0) program will only appear if the feature toggle is enabled.
  * @returns education benefits programs
  */
-const getPrograms = () => {
-  const showVetTecToggle = sessionStorage.getItem('showVecTecToggle');
-  if (showVetTecToggle !== 'true') {
-    delete programs.properties.vetTec;
+const updateProgramsSchema = formData => {
+  const clonedPrograms = cloneDeep(programs);
+  if (formData.giFeedbackToolVetTecEducationBenefit !== true) {
+    delete clonedPrograms.properties.vetTec;
   }
-  return programs;
+  return clonedPrograms;
 };
 
 const formConfig = {
@@ -363,6 +364,7 @@ const formConfig = {
                 'ui:validations': [validateBooleanGroup],
                 'ui:options': {
                   showFieldLabel: true,
+                  updateSchema: formData => updateProgramsSchema(formData),
                 },
                 'ui:errorMessages': {
                   atLeastOne: 'Please select at least one',
@@ -392,7 +394,7 @@ const formConfig = {
                 type: 'object',
                 required: ['programs'],
                 properties: {
-                  programs: getPrograms(),
+                  programs,
                   assistance: {
                     type: 'object',
                     properties: {

--- a/src/applications/edu-benefits/feedback-tool/containers/FeedbackToolApp.jsx
+++ b/src/applications/edu-benefits/feedback-tool/containers/FeedbackToolApp.jsx
@@ -5,15 +5,13 @@ import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 
 import formConfig from '../config/form';
-import { useSetVetTecToggle } from '../hooks/useSetVetTecToggle';
 
 export default function FeedbackToolApp({ location, children }) {
-  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
-  const showVetTecEduBenefit = useToggleValue(
-    TOGGLE_NAMES.giFeedbackToolVetTecEducationBenefit,
-  );
-
-  useSetVetTecToggle(showVetTecEduBenefit);
+  const { useFormFeatureToggleSync } = useFeatureToggle();
+  useFormFeatureToggleSync([
+    // Feature toggle name & form data key will be the same
+    'giFeedbackToolVetTecEducationBenefit',
+  ]);
 
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Refactors the `giFeedbackToolVetTecEducationBenefit` feature toggle to make use of the `useFormFeatureToggleSync` hook to update the Feedback Tool toggle synchronously

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/38215

## Testing done

- Manual testing with `http://localhost:3000/flipper` configuration to ensure `uiSchema.educationDetails` updates synchronously when feature toggle is flipped

## Screenshots

N/A

## What areas of the site does it impact?

- GI Bill School Feedback Tool - Education Benefits

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A