### PR TITLE
ArrayBuilder | Fix Yes/No value set on review page

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/chapterSelect.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/chapterSelect.js
@@ -16,7 +16,7 @@ const DeselectAll = ({ formData, setFormData }) => {
   return <va-button text="Deselect all" onClick={onClick} uswds />;
 };
 
-/** @type {PageSchema}  */
+/** @type {PageSchema} */
 export default {
   ContentBeforeButtons: DeselectAll,
   uiSchema: {

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -263,6 +263,9 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
 
     useEffect(
       () => {
+        // Ensure yes/no field is never left in a bad state:
+        // - On summary page: force false when max items reached (field hidden but still required)
+        // - On review page: force false to avoid hidden validation error
         const length = Array.isArray(arrayData) ? arrayData.length : 0;
         const reachedMax =
           Number.isFinite(maxItems) && maxItems > 0 && length >= maxItems;

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -169,13 +169,17 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
       isReviewPage && checkHasYesNoReviewError(props.reviewErrors, hasItemsKey);
 
     const setDataFromRef = data => {
-      const curr = dataRef.current || {};
-      props.setData({ ...curr, ...data });
+      const dataToSet = { ...(dataRef.current || {}), ...data };
+      dataRef.current = dataToSet;
+      props.setData(dataToSet);
     };
 
-    useEffect(() => {
-      dataRef.current = props.data;
-    });
+    useEffect(
+      () => {
+        dataRef.current = props.data;
+      },
+      [props.data],
+    );
 
     useEffect(() => {
       const cleanupEmptyItems = () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the ArrayBuilder to fix a bug on the review page. The Yes/No question value was not being set when adding a new item to the array from the review page. It also fixes a bug where when migrating from the array wizard to the ArrayBuilder, the user would not have answered the Yes/No question in the form.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#117946

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="662" height="378" alt="Screenshot 2025-08-27 at 11 20 50" src="https://github.com/user-attachments/assets/8f2fb91c-939f-4ef7-95e4-8e8d284e0470" /> | <img width="662" height="325" alt="Screenshot 2025-08-27 at 11 20 18" src="https://github.com/user-attachments/assets/7f6127d7-4532-4d0d-b957-ceb774d76e90" /> |

## Acceptance criteria

- Yes/No question value is successfully set on the review page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution