### PR TITLE
hide extra sub nav header

### DIFF
--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -109,12 +109,14 @@ const ProfileWrapper = ({
               <div className="vads-u-display--none medium-screen:vads-u-display--block vads-l-col--3 vads-u-padding-left--2">
                 <nav className="va-subnav" aria-labelledby="subnav-header">
                   <div>
-                    <h2
-                      id="subnav-header"
-                      className="vads-u-font-size--h4 vads-u-margin-top--0 vads-u-margin-bottom--0 vads-u-padding-y--2"
-                    >
-                      Profile <span className="sr-only">menu</span>
-                    </h2>
+                    {!paperlessDeliveryToggle && (
+                      <h2
+                        id="subnav-header"
+                        className="vads-u-font-size--h4 vads-u-margin-top--0 vads-u-margin-bottom--0 vads-u-padding-y--2"
+                      >
+                        Profile <span className="sr-only">menu</span>
+                      </h2>
+                    )}
                     <ProfileSubNav
                       routes={routesForNav}
                       isLOA3={isLOA3}


### PR DESCRIPTION
## Summary

- _This hides the side navigation heading when the Paperless delivery feature toggle is on_

## Related issue(s)


## Testing done

- _Describe what the old behavior was prior to the change_

## Screenshots
<img width="792" height="664" alt="Screenshot 2025-08-27 at 12 55 43" src="https://github.com/user-attachments/assets/0db51bc7-a7b4-4803-8256-2e8df8d93529" />


## What areas of the site does it impact?

Paperless Delivery in Profile

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
