### PR TITLE
117686 add route guard to Care-Team-Help page

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/CareTeamHelp.jsx
+++ b/src/applications/mhv-secure-messaging/containers/CareTeamHelp.jsx
@@ -8,11 +8,21 @@ import {
 import { VaTelephone } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { Paths, PageTitles } from '../util/constants';
+import { populatedDraft } from '../selectors';
 
 const CareTeamHelp = () => {
   const isCerner = useSelector(selectIsCernerPatient);
   const isCernerOnly = useSelector(selectIsCernerOnlyPatient);
   const history = useHistory();
+  const { acceptInterstitial } = useSelector(state => state.sm.threadDetails);
+  const validDraft = useSelector(populatedDraft);
+
+  useEffect(
+    () => {
+      if (!acceptInterstitial && !validDraft) history.push(Paths.COMPOSE);
+    },
+    [acceptInterstitial, validDraft, history],
+  );
 
   // Set page title
   useEffect(() => {

--- a/src/applications/mhv-secure-messaging/tests/containers/CareTeamHelp.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/CareTeamHelp.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import reducer from '../../reducers';
 import { Paths } from '../../util/constants';
@@ -227,5 +227,57 @@ describe('CareTeamHelp', () => {
     // Should have at least one "Update your contact list" link
     const updateLinks = screen.getAllByText(/Update your contact list/);
     expect(updateLinks.length).to.be.greaterThan(0);
+  });
+
+  it('redirects users to interstitial page if interstitial not accepted', async () => {
+    const oldLocation = global.window.location;
+    global.window.location = {
+      replace: sinon.spy(),
+    };
+
+    const customState = {
+      ...baseState,
+      sm: {
+        ...baseState.sm,
+        threadDetails: {
+          acceptInterstitial: false,
+          draftInProgress: {},
+        },
+      },
+    };
+
+    const { history } = setup(customState);
+
+    await waitFor(() => {
+      expect(history.location.pathname).to.equal('/new-message/');
+    });
+
+    global.window.location = oldLocation;
+  });
+
+  it('does not redirect users to interstitial page if interstitial not accepted', async () => {
+    const oldLocation = global.window.location;
+    global.window.location = {
+      replace: sinon.spy(),
+    };
+
+    const customState = {
+      ...baseState,
+      sm: {
+        ...baseState.sm,
+        threadDetails: {
+          acceptInterstitial: true,
+          draftInProgress: {},
+        },
+      },
+    };
+
+    setup(customState);
+
+    await waitFor(() => {
+      expect(window.location.replace.called).to.be.false;
+    });
+
+    global.window.location = oldLocation;
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/CareTeamHelp.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/CareTeamHelp.unit.spec.jsx
@@ -256,11 +256,6 @@ describe('CareTeamHelp', () => {
   });
 
   it('does not redirect users to interstitial page if interstitial not accepted', async () => {
-    const oldLocation = global.window.location;
-    global.window.location = {
-      replace: sinon.spy(),
-    };
-
     const customState = {
       ...baseState,
       sm: {
@@ -272,12 +267,10 @@ describe('CareTeamHelp', () => {
       },
     };
 
-    setup(customState);
+    const { history } = setup(customState);
 
     await waitFor(() => {
-      expect(window.location.replace.called).to.be.false;
+      expect(history.location.pathname).to.equal('/new-message/care-team-help');
     });
-
-    global.window.location = oldLocation;
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
@@ -514,11 +514,6 @@ describe('SelectCareTeam', () => {
   });
 
   it('wont redirect users if interstitial accepted', async () => {
-    const oldLocation = global.window.location;
-    global.window.location = {
-      replace: sinon.spy(),
-    };
-
     const customState = {
       ...initialState,
       sm: {
@@ -530,16 +525,14 @@ describe('SelectCareTeam', () => {
       },
     };
 
-    renderWithStoreAndRouter(<SelectCareTeam />, {
+    const { history } = renderWithStoreAndRouter(<SelectCareTeam />, {
       initialState: customState,
       reducers: reducer,
       path: Paths.SELECT_CARE_TEAM,
     });
 
     await waitFor(() => {
-      expect(window.location.replace.called).to.be.false;
+      expect(history.location.pathname).to.equal('select-care-team');
     });
-
-    global.window.location = oldLocation;
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
@@ -488,7 +488,6 @@ describe('SelectCareTeam', () => {
     global.window.location = {
       replace: sinon.spy(),
     };
-    window.location.replace = sinon.spy();
 
     const customState = {
       ...initialState,
@@ -519,7 +518,6 @@ describe('SelectCareTeam', () => {
     global.window.location = {
       replace: sinon.spy(),
     };
-    window.location.replace = sinon.spy();
 
     const customState = {
       ...initialState,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Gate access to message routes until after they've seen the interstitial page

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#116274
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#117686

## Testing done
Specs added

## What areas of the site does it impact?
Secure Messaging application

## Acceptance criteria
`/new-message/select-care-team` redirects to `/new-message` if the user has not accepted the interstitial page and lacks an in-progress draft message
