### PR TITLE
DR 114839 (part 1): Adding dynamic summary screens for DR

### DIFF
--- a/src/applications/appeals/onramp/components/dr-results-screens/OutsideDROption.jsx
+++ b/src/applications/appeals/onramp/components/dr-results-screens/OutsideDROption.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const OutsideDROption = () => {
+  return (
+    <>
+      <h2 className="vads-u-margin-top--3" data-testid="outside-dr-option">
+        Options outside of decision reviews
+      </h2>
+      <p>
+        These options are outside VA’s decision review process and may be a good
+        fit in certain situations.
+      </p>
+      <va-card class="vads-u-display--block vads-u-margin-top--3">
+        <h3 className="vads-u-margin-top--0">
+          US Court of Appeals for Veterans Claims
+        </h3>
+        <p>
+          This is a legal appeal outside of the VA and may be a good fit for an
+          appeal of a Board decision.
+        </p>
+        <p>
+          <strong>Note:</strong> This option is available only if it has been
+          fewer than 120 days since your decision date.{' '}
+        </p>
+        <va-link
+          external
+          href="https://www.uscourts.cavc.gov/"
+          text="How to file an appeal on the US Court of Appeals website"
+        />
+      </va-card>
+    </>
+  );
+};
+
+export default OutsideDROption;

--- a/src/applications/appeals/onramp/components/dr-results-screens/OverviewPanel.jsx
+++ b/src/applications/appeals/onramp/components/dr-results-screens/OverviewPanel.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DISPLAY_CONDITIONS } from '../../constants/display-conditions';
+import { displayConditionsMet } from '../../utilities/display-conditions';
+import { renderSingleOrList } from '../../utilities';
+import * as c from '../../constants/results-content/dr-screens/card-content';
+
+const OverviewPanel = ({ formResponses }) => {
+  const availableOptions = c.OVERVIEW.filter(option => {
+    const displayConditionsForOption = DISPLAY_CONDITIONS?.[option] || {};
+
+    return displayConditionsMet(formResponses, displayConditionsForOption);
+  });
+
+  return (
+    <div className="onramp-options-overview vads-u-padding--3">
+      <h2 className="vads-u-margin-top--0 vads-u-font-size--h3">
+        Decision review options based on your answers
+      </h2>
+      <p>You may be eligible for these decision review options:</p>
+      {renderSingleOrList(
+        availableOptions,
+        false,
+        'vads-u-margin-bottom--0 vads-u-font-weight--bold',
+        'vads-u-font-weight--bold',
+        'overview-option',
+      )}
+    </div>
+  );
+};
+
+OverviewPanel.propTypes = {
+  formResponses: PropTypes.object.isRequired,
+};
+
+export default OverviewPanel;

--- a/src/applications/appeals/onramp/constants/results-content/common.jsx
+++ b/src/applications/appeals/onramp/constants/results-content/common.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import manifest from '../../manifest.json';
 
-const HORIZ_RULE = <hr className="vads-u-margin-y--4" />;
+export const HORIZ_RULE = <hr className="vads-u-margin-y--4" />;
 export const NON_DR_HEADING = `Your available options`;
 export const DR_HEADING = `Your decision review options`;
 
-export const PRINT_OR_RESTART = (
+export const PRINT_RESULTS = (
   <>
-    <h2 className="vads-u-margin-bottom--3">Print your results</h2>
+    <h2 className="vads-u-margin-y--3">Print your results</h2>
     <p>
       You can print this page to keep a summary of your answers and the options
       that may apply to you.
@@ -17,14 +17,26 @@ export const PRINT_OR_RESTART = (
       onClick={window.print}
       text="Print this page"
     />
-    {HORIZ_RULE}
-    <h2 className="vads-u-margin-bottom--3">Want to explore other pathways?</h2>
+  </>
+);
+
+export const RESTART_GUIDE = (
+  <>
+    <h2 className="vads-u-margin-y--0">Want to explore other pathways?</h2>
     <p className="vads-u-margin-bottom--3">
       We showed decision review options based on your responses. If your
       situation changes—or you want to see other options for a different
       reason—you can restart the guide.
     </p>
     <va-link-action href={manifest.rootUrl} text="Restart the guide" />
+  </>
+);
+
+export const PRINT_OR_RESTART = (
+  <>
+    {PRINT_RESULTS}
+    {HORIZ_RULE}
+    {RESTART_GUIDE}
   </>
 );
 

--- a/src/applications/appeals/onramp/constants/results-content/dr-screens/card-content.js
+++ b/src/applications/appeals/onramp/constants/results-content/dr-screens/card-content.js
@@ -1,0 +1,177 @@
+/** OPTION CARD TITLES / OVERVIEW PANEL LIST ============================================================ */
+export const TITLE_SC = 'Supplemental Claim';
+export const TITLE_HLR = 'Higher-Level Review';
+export const TITLE_BOARD_DIRECT = 'Board Appeal: Direct Review';
+export const TITLE_BOARD_EVIDENCE = 'Board Appeal: Evidence Submission';
+export const TITLE_BOARD_HEARING = 'Board Appeal: Hearing';
+export const TITLE_BOARD = 'Board Appeal';
+
+export const OVERVIEW = Object.freeze([
+  TITLE_SC,
+  TITLE_HLR,
+  TITLE_BOARD_DIRECT,
+  TITLE_BOARD_EVIDENCE,
+  TITLE_BOARD_HEARING,
+]);
+
+/** OPTION CARD "Good Fit" (white cards) CONTENT ========================================================== */
+export const CARD_REVIEW_HLR = `You’re requesting a review of a Higher-Level Review decision, so your next options are a Board Appeal or a Supplemental Claim`;
+export const CARD_REVIEW_SC = `You’re requesting a review of a Supplemental Claim, so your next step could be another Supplemental Claim, a Higher-Level Review, or a Board Appeal`;
+export const CARD_REVIEW_BOARD = `You’re requesting a review of a Board decision, so your next options are a Higher-Level Review or a Supplemental Claim`;
+export const CARD_REVIEW_INIT = `You’re requesting a review of an initial claim, so your next step could be a Supplemental Claim or a Board Appeal`;
+export const CARD_NEW_EVIDENCE = `You have new or relevant evidence`;
+export const CARD_NO_NEW_EVIDENCE = `You don’t have new or relevant evidence`;
+export const CARD_LAW_POLICY_CHANGE = `You’re requesting a review based on a change in law or policy`;
+export const CARD_NOT_LAW_POLICY_CHANGE = `You’re not requesting a review based on a change in law or policy`;
+export const CARD_NOT_CONTESTED = `Your claim is not contested`;
+export const CARD_SUBMITTED_BOARD_APPEAL = `You’ve already submitted a Board Appeal on a Higher-Level Review, so Supplemental Claim is the only available option`;
+export const CARD_BOARD_ONLY_OPTION = `Board Appeal is the only available review option for contested claims`;
+export const CARD_HEARING = `You want a hearing with a Veterans Law Judge`;
+export const CARD_NO_HEARING = `You don’t want a hearing with a Veterans Law Judge`;
+
+export const CARD_CONTENT_GF_SC = Object.freeze([
+  CARD_REVIEW_HLR,
+  CARD_REVIEW_SC,
+  CARD_REVIEW_BOARD,
+  CARD_REVIEW_INIT,
+  CARD_NEW_EVIDENCE,
+  CARD_LAW_POLICY_CHANGE,
+  CARD_NOT_CONTESTED,
+  CARD_SUBMITTED_BOARD_APPEAL,
+]);
+
+export const CARD_CONTENT_GF_HLR = Object.freeze([
+  CARD_REVIEW_BOARD,
+  CARD_REVIEW_SC,
+  CARD_REVIEW_INIT,
+  CARD_NO_NEW_EVIDENCE,
+  CARD_NOT_CONTESTED,
+  CARD_NOT_LAW_POLICY_CHANGE,
+]);
+
+export const CARD_CONTENT_GF_BOARD_DIRECT = Object.freeze([
+  CARD_REVIEW_HLR,
+  CARD_REVIEW_SC,
+  CARD_REVIEW_BOARD,
+  CARD_REVIEW_INIT,
+  CARD_NO_NEW_EVIDENCE,
+  CARD_BOARD_ONLY_OPTION,
+  CARD_NO_HEARING,
+]);
+
+export const CARD_CONTENT_GF_BOARD_EVIDENCE = Object.freeze([
+  CARD_REVIEW_HLR,
+  CARD_REVIEW_SC,
+  CARD_REVIEW_BOARD,
+  CARD_REVIEW_INIT,
+  CARD_NEW_EVIDENCE,
+  CARD_BOARD_ONLY_OPTION,
+  CARD_NO_HEARING,
+]);
+
+export const CARD_CONTENT_GF_BOARD_HEARING = Object.freeze([
+  CARD_REVIEW_HLR,
+  CARD_REVIEW_SC,
+  CARD_REVIEW_BOARD,
+  CARD_REVIEW_INIT,
+  CARD_NEW_EVIDENCE,
+  CARD_NO_NEW_EVIDENCE,
+  CARD_BOARD_ONLY_OPTION,
+  CARD_HEARING,
+]);
+
+export const LEARN_MORE_SC = {
+  text: 'Learn more about Supplemental Claims',
+  url: '/decision-reviews/supplemental-claim/',
+};
+
+export const LEARN_MORE_HLR = {
+  text: 'Learn more about Higher-Level Reviews',
+  url: '/decision-reviews/higher-level-review/',
+};
+
+export const LEARN_MORE_BOARD = {
+  text: 'Learn more about Board Appeals',
+  url: '/decision-reviews/board-appeal/',
+};
+
+export const START_SC = {
+  text: 'Start Supplemental Claim',
+  url:
+    '/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start',
+};
+
+export const START_HLR = {
+  text: 'Start Higher-Level Review Request',
+  url:
+    '/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/start',
+};
+
+export const START_BOARD = {
+  text: 'Start Board Appeal Request',
+  url: '/decision-reviews/board-appeal/request-board-appeal-form-10182/start',
+};
+
+export const DECISION_TIMELINES = {
+  SC: '86.4 days',
+  HLR: '125 days (4 to 5 months)',
+  BOARD_DIRECT: '365 days (1 year)',
+  BOARD_EVIDENCE: '550 days (1.5 years)',
+  BOARD_HEARING: '730 days (2 years)',
+};
+
+/** OPTION CARD "Not Good Fit" (gray cards) CONTENT ====================================================== */
+export const CARD_NEED_EVIDENCE = `You need to submit new and relevant evidence to request this type of review`;
+export const CARD_CLAIM_CONTESTED = `Your claim is contested, and this option isn’t available for contested claims`;
+export const CARD_HEARING_NOT_INCLUDED = `You said you want a hearing with a Veterans Law Judge, but this type of review doesn’t include one`;
+export const CARD_HEARING_NOT_DESIRED = `You said you don’t want a hearing with a Veterans Law Judge, but this type of review requires one`;
+export const CARD_HLR_NOT_AVAILABLE = `You're requesting a review of a Higher-Level Review decision, but this option isn't available for that type of review`;
+export const CARD_CANNOT_SUBMIT_EVIDENCE = `You can’t submit new and relevant evidence for this type of review`;
+export const CARD_RECEIVED_BOARD_DECISION = `You’ve already received a Board decision for this issue, and you can’t request another for the same claim`;
+
+export const CARD_CONTENT_NGF_SC = Object.freeze([
+  CARD_NEED_EVIDENCE,
+  CARD_CLAIM_CONTESTED,
+  CARD_HEARING_NOT_INCLUDED,
+]);
+
+export const CARD_CONTENT_NGF_HLR = Object.freeze([
+  CARD_HLR_NOT_AVAILABLE,
+  CARD_CANNOT_SUBMIT_EVIDENCE,
+  CARD_CLAIM_CONTESTED,
+  CARD_HEARING_NOT_INCLUDED,
+]);
+
+export const CARD_CONTENT_NGF_BOARD_DIRECT = Object.freeze([
+  CARD_RECEIVED_BOARD_DECISION,
+  CARD_CANNOT_SUBMIT_EVIDENCE,
+  CARD_HEARING_NOT_INCLUDED,
+]);
+
+export const CARD_CONTENT_NGF_BOARD_EVIDENCE = Object.freeze([
+  CARD_RECEIVED_BOARD_DECISION,
+  CARD_NEED_EVIDENCE,
+  CARD_HEARING_NOT_INCLUDED,
+]);
+
+export const CARD_CONTENT_NGF_BOARD_HEARING = Object.freeze([
+  CARD_RECEIVED_BOARD_DECISION,
+  CARD_HEARING_NOT_DESIRED,
+]);
+
+/** OPTION CARD OVERALL (FOR DISPLAY CONDITIONS) ========================================================= */
+// For display conditions
+export const CARD_SC = 'CARD_SC';
+export const CARD_HLR = 'CARD_HLR';
+export const CARD_BOARD_DIRECT = 'CARD_BOARD_DIRECT';
+export const CARD_BOARD_EVIDENCE = 'CARD_BOARD_EVIDENCE';
+export const CARD_BOARD_HEARING = 'CARD_BOARD_HEARING';
+export const CARD_COURT_OF_APPEALS = 'CARD_COURT_OF_APPEALS';
+
+export const CARDS = Object.freeze([
+  CARD_SC,
+  CARD_HLR,
+  CARD_BOARD_DIRECT,
+  CARD_BOARD_EVIDENCE,
+  CARD_BOARD_HEARING,
+]);

--- a/src/applications/appeals/onramp/tests/components/dr-results-screens/OverviewPanel.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/components/dr-results-screens/OverviewPanel.unit.spec.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import OverviewPanel from '../../../components/dr-results-screens/OverviewPanel';
+import { RESPONSES } from '../../../constants/question-data-map';
+
+const { YES, NO } = RESPONSES;
+
+describe('OverviewPanel', () => {
+  it('renders all available options as list items', () => {
+    const formResponses = {
+      Q_1_1_CLAIM_DECISION: YES,
+      Q_1_2_CLAIM_DECISION: YES,
+      Q_1_3_CLAIM_CONTESTED: YES,
+      Q_1_3A_FEWER_60_DAYS: YES,
+      Q_2_H_2_NEW_EVIDENCE: NO,
+      Q_2_H_2B_JUDGE_HEARING: YES,
+    };
+
+    const expectedOptions = [
+      'Board Appeal: Direct Review',
+      'Board Appeal: Evidence Submission',
+      'Board Appeal: Hearing',
+    ];
+
+    const screen = render(<OverviewPanel formResponses={formResponses} />);
+
+    expectedOptions.forEach(option => {
+      expect(screen.getByText(option)).to.exist;
+    });
+  });
+});

--- a/src/applications/appeals/onramp/tests/utilities/index.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/utilities/index.unit.spec.jsx
@@ -29,7 +29,7 @@ describe('utilities', () => {
     });
 
     describe('single item', () => {
-      it('should render in a <p> without a period if includeAnds is false', () => {
+      it('should render in a <p> without a period if useSentenceFormat is false', () => {
         const cardContent = ['You have new or relevant evidence'];
         const screen = render(
           renderSingleOrList(cardContent, false, 'test-class', null, 'testid'),
@@ -40,7 +40,7 @@ describe('utilities', () => {
         expect(p).to.have.text(cardContent[0]);
       });
 
-      it('should render in a <p> with a period if includeAnds is true', () => {
+      it('should render in a <p> with a period if useSentenceFormat is true', () => {
         const cardContent = ['You have new or relevant evidence'];
         const screen = render(
           renderSingleOrList(cardContent, true, null, null, 'testid'),
@@ -53,7 +53,7 @@ describe('utilities', () => {
     });
 
     describe('multiple items', () => {
-      it('should render a list of items correctly if includeAnds is false', () => {
+      it('should render a list of items correctly if useSentenceFormat is false', () => {
         const cardContent = ['Supplemental Claims', 'Higher-Level Reviews'];
         const screen = render(
           renderSingleOrList(cardContent, false, null, 'test-class', 'testid'),
@@ -67,7 +67,7 @@ describe('utilities', () => {
         expect(items[1]).to.have.text(cardContent[1]);
       });
 
-      it('should include comma and "and" for all but last item if includeAnds is true', () => {
+      it('should include comma and "and" for all but last item if useSentenceFormat is true', () => {
         const cardContent = [
           'You have new or relevant evidence',
           'Your claim is not contested',

--- a/src/applications/appeals/onramp/tests/utilities/index.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/utilities/index.unit.spec.jsx
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import sinon from 'sinon';
+import { printErrorMessage, renderSingleOrList } from '../../utilities';
+
+describe('utilities', () => {
+  describe('printErrorMessage', () => {
+    const sandbox = sinon.createSandbox();
+    let errorStub;
+
+    beforeEach(() => {
+      errorStub = sandbox.stub(console, 'error');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should call console.error with the given message', () => {
+      printErrorMessage('Test error');
+      expect(errorStub.calledWith('Test error')).to.be.true;
+    });
+  });
+
+  describe('renderSingleOrList', () => {
+    it('should return null for empty or undefined items', () => {
+      expect(renderSingleOrList()).to.be.null;
+      expect(renderSingleOrList([])).to.be.null;
+    });
+
+    describe('single item', () => {
+      it('should render in a <p> without a period if includeAnds is false', () => {
+        const cardContent = ['You have new or relevant evidence'];
+        const screen = render(
+          renderSingleOrList(cardContent, false, 'test-class', null, 'testid'),
+        );
+
+        const p = screen.getByTestId('testid-0');
+        expect(p).to.have.class('test-class');
+        expect(p).to.have.text(cardContent[0]);
+      });
+
+      it('should render in a <p> with a period if includeAnds is true', () => {
+        const cardContent = ['You have new or relevant evidence'];
+        const screen = render(
+          renderSingleOrList(cardContent, true, null, null, 'testid'),
+        );
+
+        const p = screen.getByTestId('testid-0');
+        expect(p).not.to.have.class();
+        expect(p).to.have.text(`${cardContent[0]}.`);
+      });
+    });
+
+    describe('multiple items', () => {
+      it('should render a list of items correctly if includeAnds is false', () => {
+        const cardContent = ['Supplemental Claims', 'Higher-Level Reviews'];
+        const screen = render(
+          renderSingleOrList(cardContent, false, null, 'test-class', 'testid'),
+        );
+
+        const items = screen.getAllByRole('listitem');
+
+        expect(items).to.have.lengthOf(2);
+        expect(items[0]).to.have.class('test-class');
+        expect(items[0]).to.have.text(cardContent[0]);
+        expect(items[1]).to.have.text(cardContent[1]);
+      });
+
+      it('should include comma and "and" for all but last item if includeAnds is true', () => {
+        const cardContent = [
+          'You have new or relevant evidence',
+          'Your claim is not contested',
+        ];
+
+        const screen = render(
+          renderSingleOrList(cardContent, true, null, null, 'testid'),
+        );
+
+        const items = screen.getAllByRole('listitem');
+
+        expect(items[0].innerHTML).to.eq(
+          `${cardContent[0]}, <strong>and</strong>`,
+        );
+
+        expect(items[1].innerHTML).to.eq(cardContent[1]);
+      });
+    });
+  });
+});

--- a/src/applications/appeals/onramp/utilities/index.js
+++ b/src/applications/appeals/onramp/utilities/index.js
@@ -1,3 +1,0 @@
-export const printErrorMessage = message =>
-  // eslint-disable-next-line no-console
-  console.error(message);

--- a/src/applications/appeals/onramp/utilities/index.jsx
+++ b/src/applications/appeals/onramp/utilities/index.jsx
@@ -9,14 +9,14 @@ export const printErrorMessage = message =>
  * Takes a list of 0 or more items and returns the proper markup
  *
  * @param {*} items List of 0 or more items to render
- * @param {*} includeAnds Flag indicating whether to include ', and'
+ * @param {*} useSentenceFormat Flag indicating whether to include ', and'
  * after each list item except the last one
  * @param {*} paragraphClass Optional param for class name(s) for the single item
  * @param {*} listItemClasses Optional param for class name(s) for each list item
  */
 export const renderSingleOrList = (
   items,
-  includeAnds,
+  useSentenceFormat,
   paragraphClass = null,
   listItemClasses = null,
   testId = null,
@@ -27,7 +27,7 @@ export const renderSingleOrList = (
     return (
       <p className={paragraphClass || ''} data-testid={`${testId}-0`}>
         {items[0]}
-        {includeAnds && '.'}
+        {useSentenceFormat && '.'}
       </p>
     );
   }
@@ -41,7 +41,7 @@ export const renderSingleOrList = (
           key={index}
         >
           {item}
-          {includeAnds && index <= items.length - 2 ? (
+          {useSentenceFormat && index <= items.length - 2 ? (
             <>
               , <strong>and</strong>
             </>

--- a/src/applications/appeals/onramp/utilities/index.jsx
+++ b/src/applications/appeals/onramp/utilities/index.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export const printErrorMessage = message =>
+  // eslint-disable-next-line no-console
+  console.error(message);
+
+/**
+ * Used for summary screens
+ * Takes a list of 0 or more items and returns the proper markup
+ *
+ * @param {*} items List of 0 or more items to render
+ * @param {*} includeAnds Flag indicating whether to include ', and'
+ * after each list item except the last one
+ * @param {*} paragraphClass Optional param for class name(s) for the single item
+ * @param {*} listItemClasses Optional param for class name(s) for each list item
+ */
+export const renderSingleOrList = (
+  items,
+  includeAnds,
+  paragraphClass = null,
+  listItemClasses = null,
+  testId = null,
+) => {
+  if (!items?.length) return null;
+
+  if (items.length === 1) {
+    return (
+      <p className={paragraphClass || ''} data-testid={`${testId}-0`}>
+        {items[0]}
+        {includeAnds && '.'}
+      </p>
+    );
+  }
+
+  return (
+    <ul>
+      {items.map((item, index) => (
+        <li
+          className={listItemClasses}
+          data-testid={`${testId}-${index}`}
+          key={index}
+        >
+          {item}
+          {includeAnds && index <= items.length - 2 ? (
+            <>
+              , <strong>and</strong>
+            </>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

### PART ONE

The work for dynamic summary screens is nearly finished, and it's time to start breaking off chunks to merge in.

Specific comments/context are in the diffs.

- Version of the decision tree that I used for this work: [here](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=148-12838&t=XpjRGlzfRItPrB7V-0)
- Dynamic summary screen Figma [here](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=976-39721&t=SaaQTuEJBmgZr9sR-0)

Note that we have requirements for unit test coverage as part of Staging Review (I think), so lots of effort was made to cover the code as best (and as meaningfully) as possible. But we do still have limitations where we cannot access the shadow DOM (inside web components) and that will be covered in the Cypress tests instead.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/114839

## Testing done & screenshots

Regression check for the non-DR summary screens is below. I made a couple of design/spacing tweaks to make the shared components suitable for DR summary screens as well.

<details><summary>Results 1.3.B</summary>
<img width="240" alt="results-1-3-b-A" src="https://github.com/user-attachments/assets/8717d313-ed8e-4997-871d-f276db41fb56" /><br />
<img width="240" alt="results-1-2-b-B" src="https://github.com/user-attachments/assets/c334b122-d141-40dc-8b35-71d88517dde8" />
</details>

<details><summary>Results 1.2.C.1</summary>
<img width="244" height="957" alt="results-1-2-c-1" src="https://github.com/user-attachments/assets/d0eae991-245a-43af-ad4b-88f34b318c63" />
</details>

<details><summary>Results 2.IS.3</summary>
<img width="244" height="846" alt="results-2-is-3" src="https://github.com/user-attachments/assets/a4da283b-c2a1-4e09-a50d-1528a35c6059" />
</details>

<details><summary>Results 1.1.B</summary>
<img width="244" height="875" alt="results-1-1-b" src="https://github.com/user-attachments/assets/417bea1c-1335-4042-9fcf-357054ef5941" />
</details>

<details><summary>Results 1.1.C</summary>
<img width="243" height="1007" alt="results-1-1-c" src="https://github.com/user-attachments/assets/4b26576e-aae1-4aa3-b667-614026955654" />
</details>