### PR TITLE
Null state diagnostic updates

### DIFF
--- a/src/applications/vaos/components/layouts/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layouts/InPersonLayout.jsx
@@ -25,6 +25,7 @@ import NewTabAnchor from '../NewTabAnchor';
 import {
   NULL_STATE_FIELD,
   recordAppointmentDetailsNullStates,
+  captureMissingModalityLogs,
 } from '../../utils/events';
 
 export default function InPersonLayout({ data: appointment }) {
@@ -57,6 +58,9 @@ export default function InPersonLayout({ data: appointment }) {
     heading = 'Canceled in-person appointment';
   else if (isPastAppointment) heading = 'Past in-person appointment';
 
+  if (!appointment.modality) {
+    captureMissingModalityLogs(appointment);
+  }
   recordAppointmentDetailsNullStates(
     {
       type: appointment.type,

--- a/src/applications/vaos/components/layouts/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layouts/PhoneLayout.jsx
@@ -23,6 +23,7 @@ import NewTabAnchor from '../NewTabAnchor';
 import {
   NULL_STATE_FIELD,
   recordAppointmentDetailsNullStates,
+  captureMissingModalityLogs,
 } from '../../utils/events';
 
 export default function PhoneLayout({ data: appointment }) {
@@ -49,6 +50,9 @@ export default function PhoneLayout({ data: appointment }) {
     heading = 'Canceled phone appointment';
   else if (isPastAppointment) heading = 'Past phone appointment';
 
+  if (!appointment.modality) {
+    captureMissingModalityLogs(appointment);
+  }
   recordAppointmentDetailsNullStates(
     {
       type: appointment.type,

--- a/src/applications/vaos/components/layouts/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layouts/VARequestLayout.jsx
@@ -18,6 +18,7 @@ import NewTabAnchor from '../NewTabAnchor';
 import {
   NULL_STATE_FIELD,
   recordAppointmentDetailsNullStates,
+  captureMissingModalityLogs,
 } from '../../utils/events';
 
 export default function VARequestLayout({ data: appointment }) {
@@ -47,6 +48,9 @@ export default function VARequestLayout({ data: appointment }) {
   else if (APPOINTMENT_STATUS.cancelled === status)
     heading = 'Canceled request for appointment';
 
+  if (!appointment.modality) {
+    captureMissingModalityLogs(appointment);
+  }
   recordAppointmentDetailsNullStates(
     {
       type: appointment.type,

--- a/src/applications/vaos/components/layouts/VideoLayout.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayout.jsx
@@ -28,6 +28,7 @@ import State from '../State';
 import {
   NULL_STATE_FIELD,
   recordAppointmentDetailsNullStates,
+  captureMissingModalityLogs,
 } from '../../utils/events';
 
 export default function VideoLayout({ data: appointment }) {
@@ -61,6 +62,9 @@ export default function VideoLayout({ data: appointment }) {
     heading = 'Canceled video appointment';
   else if (isPastAppointment) heading = 'Past video appointment';
 
+  if (!appointment.modality) {
+    captureMissingModalityLogs(appointment);
+  }
   recordAppointmentDetailsNullStates(
     {
       type: appointment.type,

--- a/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutAtlas.jsx
@@ -25,6 +25,7 @@ import State from '../State';
 import {
   NULL_STATE_FIELD,
   recordAppointmentDetailsNullStates,
+  captureMissingModalityLogs,
 } from '../../utils/events';
 
 export default function VideoLayoutAtlas({ data: appointment }) {
@@ -53,6 +54,9 @@ export default function VideoLayoutAtlas({ data: appointment }) {
   else if (isPastAppointment)
     heading = 'Past video appointment at an ATLAS location';
 
+  if (!appointment.modality) {
+    captureMissingModalityLogs(appointment);
+  }
   recordAppointmentDetailsNullStates(
     {
       type: appointment.type,

--- a/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layouts/VideoLayoutVA.jsx
@@ -24,6 +24,7 @@ import FacilityDirectionsLink from '../FacilityDirectionsLink';
 import {
   NULL_STATE_FIELD,
   recordAppointmentDetailsNullStates,
+  captureMissingModalityLogs,
 } from '../../utils/events';
 
 export default function VideoLayoutVA({ data: appointment }) {
@@ -51,6 +52,9 @@ export default function VideoLayoutVA({ data: appointment }) {
     heading = 'Canceled video appointment at VA location';
   else if (isPastAppointment) heading = 'Past video appointment at VA location';
 
+  if (!appointment.modality) {
+    captureMissingModalityLogs(appointment);
+  }
   recordAppointmentDetailsNullStates(
     {
       type: appointment.type,

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -59,7 +59,6 @@ function getAtlasLocation(appt) {
 
 export function transformVAOSAppointment(appt) {
   const appointmentType = getAppointmentType(appt);
-  const isCerner = appt?.id?.startsWith('CERN');
   const isCC = appt.kind === 'cc';
   const isPast = appt.past;
   const isRequest = appt.pending;
@@ -236,7 +235,7 @@ export function transformVAOSAppointment(appt) {
       isInPersonVisit,
       isVideoAtHome,
       isVideoAtVA,
-      isCerner,
+      isCerner: appt.isCerner || false,
       apiData: appt,
       timeZone: appointmentTZ,
       facilityData,

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -106,7 +106,7 @@ export function captureMissingModalityLogs(appointment) {
           serviceCategory: appointment.vaos.apiData.serviceCategory,
           kind: appointment.vaos.apiData.kind,
           vvsKind: appointment.vaos.apiData.telehealth?.vvsKind,
-          atlas: appointment.vaos.apiData.telehealth?.atlas,
+          hasAtlas: !!appointment.vaos.apiData.telehealth?.atlas,
           vvsVideoAppt: appointment.vaos.apiData.extension?.vvsVistaVideoAppt,
           apiModality: appointment.vaos.apiData.modality,
           // Derived fields

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -1,4 +1,5 @@
 import recordEvent from 'platform/monitoring/record-event';
+import * as Sentry from '@sentry/browser';
 import { GA_PREFIX } from './constants';
 
 export function recordVaosError(errorKey) {
@@ -91,5 +92,35 @@ export function recordAppointmentDetailsNullStates(attributes, nullStates) {
     ...attributes,
     'fields-load-success': presentFields.join(','),
     'fields-load-fail': missingFields.join(','),
+  });
+}
+
+export function captureMissingModalityLogs(appointment) {
+  Sentry.withScope(scope => {
+    try {
+      scope.setExtra(
+        'metadata',
+        JSON.stringify({
+          // Raw API fields
+          serviceType: appointment.vaos.apiData.serviceType,
+          serviceCategory: appointment.vaos.apiData.serviceCategory,
+          kind: appointment.vaos.apiData.kind,
+          vvsKind: appointment.vaos.apiData.telehealth?.vvsKind,
+          atlas: appointment.vaos.apiData.telehealth?.atlas,
+          vvsVideoAppt: appointment.vaos.apiData.extension?.vvsVistaVideoAppt,
+          apiModality: appointment.vaos.apiData.modality,
+          // Derived fields
+          type: appointment.type,
+          modality: appointment.modality,
+          isCerner: appointment.vaos.isCerner,
+        }),
+      );
+    } catch (error) {
+      scope.setExtra('metadataError', error);
+    }
+
+    Sentry.captureMessage(
+      `VAOS appointment with missing modality: ${appointment.modality}.`,
+    );
   });
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We are trying to address the two issues identified in the null state reports
  - We will rely on the API to indicate whether an appointment is a Cerner appointment. This should be updated to the correct behavior in Prod after https://github.com/department-of-veterans-affairs/vets-api/pull/23809 is deployed.
  - We're adding some Sentry diagnostics to try to identify the cause of appointments missing modalities.
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115714

## Testing done

- Tested locally

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
