### PR TITLE
Add extra error check in CompleteReferral useEffect

### DIFF
--- a/src/applications/vaos/referral-appointments/CompleteReferral.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.jsx
@@ -77,7 +77,7 @@ export const CompleteReferral = props => {
       } else if (requestTime > timeOut && !booked) {
         // Stop polling if not booked after timeout.
         setAppointmentInfoTimeout(true);
-      } else {
+      } else if (!booked && !appointmentInfoError) {
         // Refetch data after polling interval and increment request time.
         requestInterval = setInterval(() => {
           referralAppointmentRefetch();
@@ -91,7 +91,13 @@ export const CompleteReferral = props => {
       }
       return () => clearInterval(requestInterval);
     },
-    [booked, referralAppointmentInfo, referralAppointmentRefetch, requestTime],
+    [
+      appointmentInfoError,
+      booked,
+      referralAppointmentInfo,
+      referralAppointmentRefetch,
+      requestTime,
+    ],
   );
 
   if (appointmentInfoError || appointmentInfoTimeout) {

--- a/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
@@ -91,9 +91,6 @@ describe('CompleteReferral', () => {
       },
     );
     await sandbox.clock.tick(35000);
-    // await waitFor(() => {
-    //   expect(getByTestId('error-alert')).to.exist;
-    // });
     await waitFor(
       () => {
         expect(getByTestId('error-alert')).to.exist;

--- a/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/CompleteReferral.unit.spec.jsx
@@ -90,9 +90,17 @@ describe('CompleteReferral', () => {
         store: createTestStore(errorState),
       },
     );
-    await waitFor(() => {
-      expect(getByTestId('error-alert')).to.exist;
-    });
+    await sandbox.clock.tick(35000);
+    // await waitFor(() => {
+    //   expect(getByTestId('error-alert')).to.exist;
+    // });
+    await waitFor(
+      () => {
+        expect(getByTestId('error-alert')).to.exist;
+      },
+      { timeout: 3000, interval: 1000 },
+    );
+    expect(requestStub.calledOnce).to.be.true;
     expect(getByTestId('error-alert')).to.exist;
   });
 

--- a/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/tests/utils/referrals.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('VAOS referral generator', () => {
     });
     it('Creates referrals with extra error referrals when specified', () => {
       const referrals = referralUtil.createReferrals(2, null, null, true);
-      expect(referrals.length).to.equal(7);
+      expect(referrals.length).to.equal(8);
     });
     it('Creates each referral on day later', () => {
       const referrals = referralUtil.createReferrals(2, '2025-10-11');

--- a/src/applications/vaos/referral-appointments/utils/provider.js
+++ b/src/applications/vaos/referral-appointments/utils/provider.js
@@ -91,6 +91,9 @@ const createDraftAppointmentInfo = (
   if (referralNumber === 'details-retry-error') {
     draftApppointmentInfo.id = 'details-retry-error';
   }
+  if (referralNumber === 'eps-error-appointment-id') {
+    draftApppointmentInfo.id = 'eps-error-appointment-id';
+  }
 
   let hourFromNow = 12;
   for (let i = 0; i < numberOfSlots; i++) {

--- a/src/applications/vaos/referral-appointments/utils/referrals.js
+++ b/src/applications/vaos/referral-appointments/utils/referrals.js
@@ -10,6 +10,7 @@ const errorUUIDs = [
   'details-error',
   'draft-no-slots-error',
   'referral-without-provider-error',
+  'eps-error-appointment-id',
 ];
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added additional not error check for CompleteReferral polling to stop the timeout count when the server returns an error.
- I added a new mock referral item, the last one on the referral list, that throws an error to test that it works. If you remove the new conditional check and use it it should keep polling for 30 seconds even though an error is returned.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117984

## Testing done

- Added new mock data item to manually test.
- Updated unit tests.

## Screenshots

N/A

## What areas of the site does it impact?

The polling only happens on the CompleteReferral component at the end of the referral path. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A