### PR TITLE
Removed Aria Label From Sign In Form

### DIFF
--- a/src/platform/static-data/SubmitSignInForm.jsx
+++ b/src/platform/static-data/SubmitSignInForm.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  createHref,
-  formatAriaLabel,
-  formatPhoneNumber,
-} from './utilities/sign-in-phone-utils';
+import { createHref, formatPhoneNumber } from './utilities/sign-in-phone-utils';
 
 // NOTE: Do not convert these phone links to web components as they are
 // used in the injected header, which does not support web components
@@ -12,12 +8,7 @@ export default function SubmitSignInForm({ startSentence }) {
   const helpDeskNumber = '8662793677';
 
   const helpDeskLink = (
-    <a
-      href={createHref(helpDeskNumber)}
-      aria-label={formatAriaLabel(helpDeskNumber)}
-    >
-      {formatPhoneNumber(helpDeskNumber)}
-    </a>
+    <a href={createHref(helpDeskNumber)}>{formatPhoneNumber(helpDeskNumber)}</a>
   );
 
   return (


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed `aria-label` from the Help Desk number on `SubmitSignInForm.jsx`.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/667)

## Testing done
- Ran tests locally to ensure no breaking changes.

## What areas of the site does it impact?
This impacts any component that renders ``SubmitSignInForm.jsx` (primarily the Sign in page and Modal).

## Acceptance criteria
- [x] aria label is removed from phone number on the sign in page
- [x] aria label is removed from the sign in modal