### PR TITLE
VEBT-3139: 22-10297 - Step 2 - Training Providers Page - Business feedback implementation

### DIFF
--- a/src/applications/edu-benefits/10297/config/submit-transformer.js
+++ b/src/applications/edu-benefits/10297/config/submit-transformer.js
@@ -71,7 +71,7 @@ export function transform(formConfig, form) {
         ...parsedData,
         trainingProviders: {
           providers: [],
-          plannedStartDate: parsedData.plannedStartDate || 'XXZZ-XX-XX',
+          plannedStartDate: parsedData.plannedStartDate || 'XXXX-XX-XX',
         },
       };
     }

--- a/src/applications/edu-benefits/10297/config/submit-transformer.js
+++ b/src/applications/edu-benefits/10297/config/submit-transformer.js
@@ -63,7 +63,7 @@ export function transform(formConfig, form) {
           providers: trainingProviders.map(provider => ({
             ...provider,
           })),
-          plannedStartDate: parsedData.plannedStartDate || '2025-08-20',
+          plannedStartDate: parsedData.plannedStartDate || 'XXXX-XX-XX',
         },
       };
     } else {
@@ -71,7 +71,7 @@ export function transform(formConfig, form) {
         ...parsedData,
         trainingProviders: {
           providers: [],
-          plannedStartDate: parsedData.plannedStartDate || '2025-08-20',
+          plannedStartDate: parsedData.plannedStartDate || 'XXZZ-XX-XX',
         },
       };
     }

--- a/src/applications/edu-benefits/10297/containers/App.jsx
+++ b/src/applications/edu-benefits/10297/containers/App.jsx
@@ -15,7 +15,7 @@ export default function App({ location, children }) {
     // Insert CSS to hide 'For example: January 19 2000' hint on memorable dates
     // (can't be overridden by passing 'hint' to uiOptions):
     addStyleToShadowDomOnPages(
-      ['date-released-from-active-duty'],
+      ['date-released-from-active-duty', 'training-provider-start-date'],
       ['va-memorable-date'],
       '#dateHint {display: none}',
     );

--- a/src/applications/edu-benefits/10297/helpers.js
+++ b/src/applications/edu-benefits/10297/helpers.js
@@ -182,11 +182,9 @@ export const validateTrainingProviderStartDate = (errors, dateString) => {
   const picked = new Date(`${dateString}T00:00:00`);
   const startDate = new Date('2025-01-02T00:00:00');
 
-  if (picked < startDate)
-    errors.addError(
-      'Training must start on or after 1/2/2025 to qualify for VET TEC 2.0',
-    );
+  if (picked < startDate) errors.addError('Enter a date after 1/2/2025');
 };
+
 export const dateSigned = () => {
   const date = new Date();
   date.setDate(date.getDate() + 365);

--- a/src/applications/edu-benefits/10297/pages/trainingProviderStartDate.js
+++ b/src/applications/edu-benefits/10297/pages/trainingProviderStartDate.js
@@ -12,7 +12,6 @@ const uiSchema = {
     ...currentOrPastDateUI({
       title: `You can leave this blank if you haven't chosen a program yet.`,
       errorMessages: { pattern: 'Please enter a valid date' },
-      hint: null,
     }),
     'ui:validations': [validateTrainingProviderStartDate],
   },

--- a/src/applications/edu-benefits/10297/tests/helpers.unit.spec.jsx
+++ b/src/applications/edu-benefits/10297/tests/helpers.unit.spec.jsx
@@ -262,7 +262,7 @@ describe('10297 Helpers', () => {
       validateTrainingProviderStartDate(errors, '2025-01-01');
       expect(errors.addError.calledOnce).to.be.true;
       expect(errors.addError.firstCall.args[0]).to.match(
-        /Training must start/i,
+        /Enter a date after 1\/2\/2025/i,
       );
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Updates the error message for the `plannedStartDate` field when the user enters a date before the program start date
- The hint message is now hidden for this field
- Default `plannedStartDate` form data transformed to `XXXX-XX-XX` string to match date pattern

## Related issue(s)

- https://jira.devops.va.gov/browse/VEBT-3139

**As a...**

 VEBT Business user,

**I want…**

To implement validation changes based on business feedback for Step 3 - Training provider details page 

**So that…**

the date entered cannot be prior to the effective date of Vet Tec 2.0 program which is 1/2/25

**Acceptance Criteria**

**AC1:** Given the user is on Step 2: Page 4 of the Training provider details page, the date entered for Month, Day, Year cannot be before 1/2/2025.
**AC2:** Given the user is on Step 2: Page 4 of the Training provider details page, if the date entered for Month, Day, Year is before 1/2/2025 the following error will display: "Enter a date after 1/2/2025"
**AC3:** Given the user is on Step 2: Page 4 of the Training provider details page, the Month, Day and Year can be left blank, select Continue and the page will progress to the next successfully without error. 

## Testing done

- Manual testing done locally to verify updated error message for dates before `1/2/2025`
- Form is still able to be submitted successfully with the default empty date `XXXX-XX-XX`
- Unit test updated to match new error message

## Screenshots

**Before:**

<img width="544" height="444" alt="Default (Before)" src="https://github.com/user-attachments/assets/b4aff46f-de88-4526-9896-9024ab031247" />
<img width="553" height="496" alt="Error (Before)" src="https://github.com/user-attachments/assets/3febd9db-9008-496d-b9ca-831d64103f2f" />

**After:**

<img width="545" height="416" alt="Default (After)" src="https://github.com/user-attachments/assets/0c356501-56a2-4199-ba24-749faa7a5236" />
<img width="544" height="451" alt="Error (After)" src="https://github.com/user-attachments/assets/8c5d556d-cb0d-4e13-a894-e8ba34fc9f95" />

## What areas of the site does it impact?

- Form 22-10297 | Training provider details

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A