### PR TITLE
arp/landing_page_photo_to_colomn

### DIFF
--- a/src/applications/accredited-representative-portal/sass/accredited-representative-portal.scss
+++ b/src/applications/accredited-representative-portal/sass/accredited-representative-portal.scss
@@ -107,7 +107,7 @@
     .home__full-width--portal & {
       display: flex;
       align-items: center;
-      flex-direction: column-reverse;
+      flex-direction: column;
 
       @media (min-width: $small-desktop-screen) {
         padding: 0;
@@ -385,6 +385,9 @@
       @media (min-width: $medium-screen) {
         padding: 0;
         margin-left: 24px;
+      }
+      @media (max-width: $small-desktop-screen) {
+        order: -1;
       }
     }
     .is--redesign & {


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No


## Summary

- Fixed the location of the Help Improve Tools photo on the landing page in mobile view. It needs to be above the title

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117093


## Screenshots
<img width="570" height="656" alt="Screenshot 2025-08-29 at 9 57 55 AM" src="https://github.com/user-attachments/assets/80e26483-084f-4d09-bd7b-ad74aecd7168" />

## What areas of the site does it impact?

arp representative landing page

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user