### PR TITLE
wrap va-link in p tag

### DIFF
--- a/src/applications/simple-forms/shared/components/GetFormHelp.jsx
+++ b/src/applications/simple-forms/shared/components/GetFormHelp.jsx
@@ -15,10 +15,12 @@ export default function() {
         </strong>{' '}
         you can appoint a VA accredited representative.
       </p>
-      <va-link
-        href="https://www.va.gov/get-help-from-accredited-representative/"
-        text="Get help filling out a form"
-      />
+      <p>
+        <va-link
+          href="https://www.va.gov/get-help-from-accredited-representative/"
+          text="Get help filling out a form"
+        />
+      </p>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Components not wrapped in semantic html are not resizing when using native browser font resizing settings.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4752
- 
## Testing done

- locally, enabled font resizing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Get help text |   <img width="450" height="572" alt="image" src="https://github.com/user-attachments/assets/024e6bfe-60f3-4a8c-acf7-0b093e6cb9ae" />  |  <img width="450" height="630" alt="image" src="https://github.com/user-attachments/assets/e6aae7eb-a015-4c62-8574-757f23c9c01d" />  |

## What areas of the site does it impact?

Forms that use `/src/applications/simple-forms/shared/components/GetFormHelp.jsx`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
