### PR TITLE
117488 [Medical Records] Tech Debt: Remove feature flag mhv_medical_records_display_labs_and_tests

### DIFF
--- a/src/applications/mhv-medical-records/containers/LandingPage.jsx
+++ b/src/applications/mhv-medical-records/containers/LandingPage.jsx
@@ -26,7 +26,6 @@ import {
   selectNotesFlag,
   selectVaccinesFlag,
   selectVitalsFlag,
-  selectLabsAndTestsFlag,
   selectMarch17UpdatesFlag,
 } from '../util/selectors';
 import ExternalLink from '../components/shared/ExternalLink';
@@ -53,7 +52,6 @@ const LandingPage = () => {
   const displayNotes = useSelector(selectNotesFlag);
   const displayVaccines = useSelector(selectVaccinesFlag);
   const displayVitals = useSelector(selectVitalsFlag);
-  const displayLabsAndTest = useSelector(selectLabsAndTestsFlag);
   const displayMarch17Updates = useSelector(selectMarch17UpdatesFlag);
   const killExternalLinks = useSelector(
     state => state.featureToggles.mhv_medical_records_kill_external_links,
@@ -158,28 +156,26 @@ const LandingPage = () => {
 
       {!isLoading && (
         <>
-          {displayLabsAndTest && (
-            <section>
-              <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
-                Lab and test results
-              </h2>
-              <p className="vads-u-margin-bottom--2">
-                Get results of your VA medical tests. This includes blood tests,
-                X-rays, and other imaging tests.
-              </p>
-              <Link
-                to="/labs-and-tests"
-                className="vads-c-action-link--blue"
-                data-testid="labs-and-tests-landing-page-link"
-                onClick={() => {
-                  sendAalViewList('Lab and test results');
-                  sendDataDogAction(LAB_TEST_RESULTS_LABEL);
-                }}
-              >
-                {LAB_TEST_RESULTS_LABEL}
-              </Link>
-            </section>
-          )}
+          <section>
+            <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">
+              Lab and test results
+            </h2>
+            <p className="vads-u-margin-bottom--2">
+              Get results of your VA medical tests. This includes blood tests,
+              X-rays, and other imaging tests.
+            </p>
+            <Link
+              to="/labs-and-tests"
+              className="vads-c-action-link--blue"
+              data-testid="labs-and-tests-landing-page-link"
+              onClick={() => {
+                sendAalViewList('Lab and test results');
+                sendDataDogAction(LAB_TEST_RESULTS_LABEL);
+              }}
+            >
+              {LAB_TEST_RESULTS_LABEL}
+            </Link>
+          </section>
           {displayNotes && (
             <section>
               <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1">

--- a/src/applications/mhv-medical-records/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-medical-records/mocks/api/feature-toggles/index.js
@@ -5,7 +5,6 @@ const APPLICATION_FEATURE_TOGGLES = Object.freeze({
   // medical records
   mhvMedicalRecordsAllowTxtDownloads: true,
   mhvMedicalRecordsDisplayDomains: true,
-  mhvMedicalRecordsDisplayLabsAndTests: true,
   mhvMedicalRecordsDisplayNotes: true,
   mhvMedicalRecordsDisplaySidenav: true,
   mhvMedicalRecordsDisplayVaccines: true,

--- a/src/applications/mhv-medical-records/routes.jsx
+++ b/src/applications/mhv-medical-records/routes.jsx
@@ -128,38 +128,26 @@ const routes = (
         >
           <VitalDetails />
         </FeatureFlagRoute>
-        <FeatureFlagRoute
-          exact
-          path="/labs-and-tests"
-          key="LabsAndTests"
-          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
-        >
+        <AppRoute exact path="/labs-and-tests" key="LabsAndTests">
           <LabsAndTests />
-        </FeatureFlagRoute>
-        <FeatureFlagRoute
-          exact
-          path="/labs-and-tests/:labId"
-          key="LabAndTestDetails"
-          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
-        >
+        </AppRoute>
+        <AppRoute exact path="/labs-and-tests/:labId" key="LabAndTestDetails">
           <LabAndTestDetails />
-        </FeatureFlagRoute>
-        <FeatureFlagRoute
+        </AppRoute>
+        <AppRoute
           exact
           path="/labs-and-tests/:labId/images"
           key="RadiologyImagesList"
-          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
         >
           <RadiologyImagesList />
-        </FeatureFlagRoute>
-        <FeatureFlagRoute
+        </AppRoute>
+        <AppRoute
           exact
           path="/labs-and-tests/:labId/images/:imageId"
           key="RadiologySingleImage"
-          featureFlag={FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests}
         >
           <RadiologySingleImage />
-        </FeatureFlagRoute>
+        </AppRoute>
         <FeatureFlagRoute
           exact
           path="/settings"

--- a/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LandingPage.unit.spec.jsx
@@ -101,7 +101,6 @@ describe('Landing Page', () => {
       /* eslint-disable camelcase */
       featureToggles: {
         loading: false,
-        mhv_medical_records_display_labs_and_tests: true,
         mhv_medical_records_display_notes: true,
         mhv_medical_records_display_vaccines: true,
         mhv_medical_records_display_vitals: true,

--- a/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
+++ b/src/applications/mhv-medical-records/tests/e2e/mr_site/MedicalRecordsSite.js
@@ -91,10 +91,6 @@ class MedicalRecordsSite {
             value: true,
           },
           {
-            name: 'mhv_medical_records_display_labs_and_tests',
-            value: true,
-          },
-          {
             name: 'mhv_medical_records_display_settings_page',
             value: true,
           },

--- a/src/applications/mhv-medical-records/util/selectors.js
+++ b/src/applications/mhv-medical-records/util/selectors.js
@@ -31,8 +31,6 @@ export const selectNotesFlag = state =>
   state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayNotes];
 export const selectVitalsFlag = state =>
   state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVitals];
-export const selectLabsAndTestsFlag = state =>
-  state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayLabsAndTests];
 export const selectSettingsPageFlag = state =>
   state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplaySettingsPage];
 export const selectMarch17UpdatesFlag = state =>

--- a/src/platform/mhv/api/mocks/feature-toggles/index.js
+++ b/src/platform/mhv/api/mocks/feature-toggles/index.js
@@ -16,7 +16,6 @@ const generateFeatureToggles = (toggles = {}) => {
     // medical records
     mhvMedicalRecordsAllowTxtDownloads = true,
     mhvMedicalRecordsDisplayDomains = true,
-    mhvMedicalRecordsDisplayLabsAndTests = true,
     mhvMedicalRecordsDisplayNotes = true,
     mhvMedicalRecordsDisplaySidenav = true,
     mhvMedicalRecordsDisplayVaccines = true,
@@ -123,10 +122,6 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_medical_records_display_domains',
           value: mhvMedicalRecordsDisplayDomains,
-        },
-        {
-          name: 'mhv_medical_records_display_labs_and_tests',
-          value: mhvMedicalRecordsDisplayLabsAndTests,
         },
         {
           name: 'mhv_medical_records_display_notes',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -153,7 +153,6 @@
   "mhvMedicalRecordsAllowTxtDownloads": "mhv_medical_records_allow_txt_downloads",
   "mhvMedicalRecordsCcdExtendedFileTypes": "mhv_medical_records_ccd_extended_file_types",
   "mhvMedicalRecordsDisplayDomains": "mhv_medical_records_display_domains",
-  "mhvMedicalRecordsDisplayLabsAndTests": "mhv_medical_records_display_labs_and_tests",
   "mhvMedicalRecordsDisplayNotes": "mhv_medical_records_display_notes",
   "mhvMedicalRecordsDisplaySettingsPage": "mhv_medical_records_display_settings_page",
   "mhvMedicalRecordsDisplaySidenav": "mhv_medical_records_display_sidenav",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- 117488 [Medical Records] Tech Debt: Remove feature flag mhv_medical_records_display_labs_and_tests


## Related issue(s)

- [Ticket 117488](https://github.com/department-of-veterans-affairs/va.gov-team/issues/117488)

## Testing done

- Verify Changes on local machine

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
