### PR TITLE
BMT-116273 / Change Address Validation text/label to match

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -245,7 +245,8 @@ class AddressValidationView extends React.Component {
         <va-button
           data-testid="edit-address-button"
           onClick={this.onEditClick}
-          text="Edit address"
+          label="Edit address"
+          text="Edit"
           class="vads-u-margin-top--1 vads-u-width--full mobile-lg:vads-u-width--auto"
         />
       );
@@ -421,7 +422,8 @@ class AddressValidationView extends React.Component {
                 <va-button
                   data-testid="edit-address-button"
                   onClick={this.onEditClick}
-                  text="Edit address"
+                  label="Edit address"
+                  text="Edit"
                   class="vads-u-margin-top--1 vads-u-width--full mobile-lg:vads-u-width--auto"
                   secondary
                 />

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
@@ -114,7 +114,7 @@ describe('<AddressValidationView/>', () => {
         text: 'Use address you entered',
         dataTestId: 'confirm-address-button',
       },
-      { text: 'Edit address' },
+      { text: 'Edit' },
     ]);
   });
 
@@ -184,10 +184,7 @@ describe('<AddressValidationView/>', () => {
       </Provider>,
     );
 
-    expectVaButtons(container, [
-      { text: 'Edit address' },
-      { text: 'Edit address' },
-    ]);
+    expectVaButtons(container, [{ text: 'Edit' }, { text: 'Edit' }]);
   });
 
   it('does not render Go back to edit button while pending transaction', () => {
@@ -212,7 +209,7 @@ describe('<AddressValidationView/>', () => {
       </Provider>,
     );
 
-    expectVaButtons(container, [{ text: 'Edit address' }]);
+    expectVaButtons(container, [{ text: 'Edit' }]);
   });
 
   it('renders "Use suggested address" button when a suggested address is selected', () => {
@@ -264,7 +261,7 @@ describe('<AddressValidationView/>', () => {
         text: 'Use suggested address',
         dataTestId: 'confirm-address-button',
       },
-      { text: 'Edit address' },
+      { text: 'Edit' },
     ]);
   });
 
@@ -350,7 +347,7 @@ describe('<AddressValidationView/>', () => {
           text: 'Use address you entered',
           dataTestId: 'confirm-address-button',
         },
-        { text: 'Edit address' },
+        { text: 'Edit' },
       ]);
     });
 
@@ -452,10 +449,7 @@ describe('<AddressValidationView/>', () => {
       expect(alertMessage).to.exist;
 
       // Validate correct buttons are getting displayed
-      expectVaButtons(container, [
-        { text: 'Edit address' },
-        { text: 'Edit address' },
-      ]);
+      expectVaButtons(container, [{ text: 'Edit' }, { text: 'Edit' }]);
     });
 
     it('renders the alert with the correct headline and message for NO validationKey and has suggestedAddresses', () => {
@@ -533,7 +527,7 @@ describe('<AddressValidationView/>', () => {
       // Validate correct buttons are getting displayed
       expectVaButtons(container, [
         { text: 'Use suggested address', submit: 'prevent' },
-        { text: 'Edit address' },
+        { text: 'Edit' },
       ]);
     });
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Staging review of Benefit Letters called out the Edit address buttons of the Mailing Address Component & AddressValidationView as not matching. One says "Edit" with and aria label of "Edit address" and the other says "Edit address" with no aria label.
- Changed the AddressValidationView to have text "Edit" with aria label of "Edit address" to match since this format is the default among our button components.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116273

## Testing done
- Updated component tests & ran through the component with screen reader

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="555" height="460" alt="Screenshot 2025-09-02 at 10 49 07 AM" src="https://github.com/user-attachments/assets/47823cc8-5170-4195-aa24-5f59a79eed08" />|<img width="556" height="464" alt="Screenshot 2025-09-02 at 10 48 38 AM" src="https://github.com/user-attachments/assets/2a771320-65cb-48f9-9ac3-a25ab7c0948d" />|

## What areas of the site does it impact?
- Address Validation View component

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed