### PR TITLE
Adding extra check to only show when the user is still uploading private medical records

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/onFormLoaded.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/onFormLoaded.unit.spec.jsx
@@ -25,6 +25,9 @@ describe('onFormLoaded', () => {
     it('should return true when all conditions met', () => {
       const formData = {
         disability526Enable2024Form4142: true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         'view:patientAcknowledgement': { 'view:acknowledgement': true },
       };
       expect(baseDoNew4142Logic(formData)).to.be.true;
@@ -33,6 +36,9 @@ describe('onFormLoaded', () => {
     it('should return false when upload qualifier indicates upload path', () => {
       const formData = {
         disability526Enable2024Form4142: true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         'view:patientAcknowledgement': { 'view:acknowledgement': true },
         'view:uploadPrivateRecordsQualifier': {
           'view:hasPrivateRecordsToUpload': true,
@@ -44,6 +50,9 @@ describe('onFormLoaded', () => {
     it('should return false when patient4142Acknowledgement already true', () => {
       const formData = {
         disability526Enable2024Form4142: true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         'view:patientAcknowledgement': { 'view:acknowledgement': true },
         patient4142Acknowledgement: true,
       };
@@ -56,6 +65,9 @@ describe('onFormLoaded', () => {
       mockProps.formData = {
         disability526Enable2024Form4142: true,
         'view:patientAcknowledgement': { 'view:acknowledgement': true },
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
       };
 
       onFormLoaded(mockProps);
@@ -75,6 +87,9 @@ describe('onFormLoaded', () => {
       mockProps.formData = {
         disability526Enable2024Form4142: false,
         'view:patientAcknowledgement': { 'view:acknowledgement': true },
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
       };
 
       onFormLoaded(mockProps);
@@ -147,6 +162,9 @@ describe('onFormLoaded', () => {
         '/supporting-evidence/private-medical-records-authorize-release';
       mockProps.formData = {
         disability526Enable2024Form4142: true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         'view:patientAcknowledgement': { 'view:acknowledgement': true },
       };
       onFormLoaded(mockProps);

--- a/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
@@ -52,6 +52,9 @@ describe('utils', () => {
         'view:uploadPrivateRecordsQualifier': {
           'view:hasPrivateRecordsToUpload': false,
         },
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         patient4142Acknowledgement: false,
       };
       onFormLoaded({ formData, router });

--- a/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/index.unit.spec.jsx
@@ -23,6 +23,9 @@ describe('utils', () => {
     it('should return true if all conditions are met', () => {
       const formData = {
         disability526Enable2024Form4142: true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         'view:patientAcknowledgement': { 'view:acknowledgement': true },
         'view:uploadPrivateRecordsQualifier': {
           'view:hasPrivateRecordsToUpload': false,

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -1799,7 +1799,9 @@ describe('baseDoNew4142Logic', () => {
     it('should return true when user is still choosing to upload private medical records', () => {
       const formData = {
         ...baseFormData,
-        'view:hasPrivateMedicalRecords': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
       };
       expect(baseDoNew4142Logic(formData)).to.be.true;
     });
@@ -1809,7 +1811,17 @@ describe('baseDoNew4142Logic', () => {
     it('should return false when user is not choosing to upload private medical records', () => {
       const formData = {
         ...baseFormData,
-        'view:hasPrivateMedicalRecords': false,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': false,
+        },
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+
+    it('should return false when view:selectableEvidenceTypes is undefined', () => {
+      const formData = {
+        ...baseFormData,
+        // 'view:selectableEvidenceTypes' is not set
       };
       expect(baseDoNew4142Logic(formData)).to.be.false;
     });
@@ -1817,7 +1829,9 @@ describe('baseDoNew4142Logic', () => {
     it('should return false when view:hasPrivateMedicalRecords is undefined', () => {
       const formData = {
         ...baseFormData,
-        // 'view:hasPrivateMedicalRecords' is not set
+        'view:selectableEvidenceTypes': {
+          // 'view:hasPrivateMedicalRecords' is not set
+        },
       };
       expect(baseDoNew4142Logic(formData)).to.be.false;
     });
@@ -1825,7 +1839,9 @@ describe('baseDoNew4142Logic', () => {
     it('should return false when view:hasPrivateMedicalRecords is null', () => {
       const formData = {
         ...baseFormData,
-        'view:hasPrivateMedicalRecords': null,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': null,
+        },
       };
       expect(baseDoNew4142Logic(formData)).to.be.false;
     });
@@ -1836,7 +1852,9 @@ describe('baseDoNew4142Logic', () => {
       const formData = {
         ...baseFormData,
         disability526Enable2024Form4142: false,
-        'view:hasPrivateMedicalRecords': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
       };
       expect(baseDoNew4142Logic(formData)).to.be.false;
     });
@@ -1846,7 +1864,9 @@ describe('baseDoNew4142Logic', () => {
     it('should return false even if user wants to upload private medical records', () => {
       const formData = {
         ...baseFormData,
-        'view:hasPrivateMedicalRecords': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         'view:patientAcknowledgement': {
           'view:acknowledgement': false,
         },
@@ -1859,7 +1879,9 @@ describe('baseDoNew4142Logic', () => {
     it('should return false even if user wants to upload private medical records', () => {
       const formData = {
         ...baseFormData,
-        'view:hasPrivateMedicalRecords': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         'view:uploadPrivateRecordsQualifier': {
           'view:hasPrivateRecordsToUpload': true,
         },
@@ -1872,7 +1894,9 @@ describe('baseDoNew4142Logic', () => {
     it('should return false even if user wants to upload private medical records', () => {
       const formData = {
         ...baseFormData,
-        'view:hasPrivateMedicalRecords': true,
+        'view:selectableEvidenceTypes': {
+          'view:hasPrivateMedicalRecords': true,
+        },
         patient4142Acknowledgement: true,
       };
       expect(baseDoNew4142Logic(formData)).to.be.false;

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -51,6 +51,7 @@ import {
   makeConditionsSchema,
   validateConditions,
   formatFullName,
+  baseDoNew4142Logic,
 } from '../../utils';
 import { testBranches } from '../../utils/serviceBranches';
 
@@ -1779,5 +1780,108 @@ describe('formatFullName', () => {
         suffix: '',
       }),
     ).to.equal('');
+  });
+});
+
+describe('baseDoNew4142Logic', () => {
+  const baseFormData = {
+    disability526Enable2024Form4142: true,
+    'view:patientAcknowledgement': {
+      'view:acknowledgement': true,
+    },
+    'view:uploadPrivateRecordsQualifier': {
+      'view:hasPrivateRecordsToUpload': false,
+    },
+    patient4142Acknowledgement: false,
+  };
+
+  describe('when all conditions are met', () => {
+    it('should return true when user is still choosing to upload private medical records', () => {
+      const formData = {
+        ...baseFormData,
+        'view:hasPrivateMedicalRecords': true,
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.true;
+    });
+  });
+
+  describe('when private medical records condition is not met', () => {
+    it('should return false when user is not choosing to upload private medical records', () => {
+      const formData = {
+        ...baseFormData,
+        'view:hasPrivateMedicalRecords': false,
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+
+    it('should return false when view:hasPrivateMedicalRecords is undefined', () => {
+      const formData = {
+        ...baseFormData,
+        // 'view:hasPrivateMedicalRecords' is not set
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+
+    it('should return false when view:hasPrivateMedicalRecords is null', () => {
+      const formData = {
+        ...baseFormData,
+        'view:hasPrivateMedicalRecords': null,
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+  });
+
+  describe('when feature flag is disabled', () => {
+    it('should return false even if user wants to upload private medical records', () => {
+      const formData = {
+        ...baseFormData,
+        disability526Enable2024Form4142: false,
+        'view:hasPrivateMedicalRecords': true,
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+  });
+
+  describe('when user has not acknowledged 4142 authorization', () => {
+    it('should return false even if user wants to upload private medical records', () => {
+      const formData = {
+        ...baseFormData,
+        'view:hasPrivateMedicalRecords': true,
+        'view:patientAcknowledgement': {
+          'view:acknowledgement': false,
+        },
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+  });
+
+  describe('when user has switched to upload option', () => {
+    it('should return false even if user wants to upload private medical records', () => {
+      const formData = {
+        ...baseFormData,
+        'view:hasPrivateMedicalRecords': true,
+        'view:uploadPrivateRecordsQualifier': {
+          'view:hasPrivateRecordsToUpload': true,
+        },
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+  });
+
+  describe('when user has already acknowledged the new 4142', () => {
+    it('should return false even if user wants to upload private medical records', () => {
+      const formData = {
+        ...baseFormData,
+        'view:hasPrivateMedicalRecords': true,
+        patient4142Acknowledgement: true,
+      };
+      expect(baseDoNew4142Logic(formData)).to.be.false;
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty formData gracefully', () => {
+      expect(baseDoNew4142Logic({})).to.be.false;
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -33,7 +33,7 @@ import {
   CHAR_LIMITS,
 } from '../constants';
 import { getBranches } from './serviceBranches';
-import { getSharedVariable, setSharedVariable } from './sharedState';
+import { setSharedVariable } from './sharedState';
 
 /**
  * Returns an object where all the fields are prefixed with `view:` if they aren't already
@@ -873,7 +873,9 @@ export const baseDoNew4142Logic = formData => {
     // If flipper is enabled
     formData.disability526Enable2024Form4142 === true &&
     // And the user is still choosing to upload private records
-    formData?.['view:hasPrivateMedicalRecords'] === true &&
+    formData?.['view:selectableEvidenceTypes']?.[
+      'view:hasPrivateMedicalRecords'
+    ] === true &&
     // And the user has previously acknowledged the 4142 authorization
     formData['view:patientAcknowledgement']?.['view:acknowledgement'] ===
       true &&
@@ -886,13 +888,6 @@ export const baseDoNew4142Logic = formData => {
     // then we must redirect them and show the alert
   );
 };
-
-export function needs4142AlertShown(formData) {
-  return (
-    baseDoNew4142Logic(formData) &&
-    getSharedVariable('alertNeedsShown4142') === true
-  );
-}
 
 export const onFormLoaded = props => {
   const { returnUrl, formData, router } = props;

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -872,6 +872,8 @@ export const baseDoNew4142Logic = formData => {
   return (
     // If flipper is enabled
     formData.disability526Enable2024Form4142 === true &&
+    // And the user is still choosing to upload private records
+    formData?.['view:hasPrivateMedicalRecords'] === true &&
     // And the user has previously acknowledged the 4142 authorization
     formData['view:patientAcknowledgement']?.['view:acknowledgement'] ===
       true &&


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_

This change adds an additional check to make sure the "Private medical Records" checkbox is checked when deciding on if it should redirect a user to the new 4142 stuff. This covers an edge case where a user can get caught in a redirect loop.

- _(If bug, how to reproduce)_

  - Start 526
  - Make sure the flipper is off (`disability_526_form4142_use_2024_version`)
  - Go to evidence types choice page
  - Check private medical records
  - authorize on the next page
  - navigate back, uncheck the private medical records checkbox
  - turn the flipper on
  - refresh
  - without this additional logic you would get a dangling rendered page, causing you to be trapped at that page in the form (nav buttons wont know how to go forwards or back, and refresh will always redirect back to the same place)


- _(What is the solution, why is this the solution)_

This adds a check to ensure that no pages are rendered when they shouldnt be

- _(Which team do you work for, does your team own the maintenance of this component?)_

Benefits and Claims Core Team, we own it

- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

closes department-of-veterans-affairs/va.gov-team#118339

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

No changes to frontend appearance, logical/flow change


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
