### PR TITLE
better 403 redirects

### DIFF
--- a/src/applications/accredited-representative-portal/containers/DashboardPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/DashboardPage.jsx
@@ -39,7 +39,15 @@ const DashboardPage = props => {
   );
 };
 
-DashboardPage.loader = async () => {
+DashboardPage.loader = async ({ request }) => {
+  // If explicitly marked unauthorized in query params, skip server call
+  const { searchParams } = new URL(request.url);
+  const unauthorizedParam = (
+    searchParams.get('unauthorized') || ''
+  ).toLowerCase();
+  const isUnauthorizedQuery = ['1', 'true', 'yes'].includes(unauthorizedParam);
+  if (isUnauthorizedQuery) return { authorized: false };
+
   const res = await api.checkAuthorized();
   // Bubble up 401 to the route guard so it can redirect to sign-in
   if (res.status === 401) throw res;


### PR DESCRIPTION
our 403 handling for the dashboard was flashing the error page before showing the dashboard. This fixes that by handling the redirect if fetch throws the 403. Adding a `promise` so we avoid temporarily showing the target page.

Also making the dashboard not hit the server if we're explicitly going to unauthorized version.