### PR TITLE
Reorder array builder summary pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -481,13 +481,6 @@ const incomeTypePage = {
 export const unassociatedIncomePages = arrayBuilderPages(
   options,
   pageBuilder => ({
-    unassociatedIncomePagesSummary: pageBuilder.summaryPage({
-      title: 'Recurring income',
-      path: 'recurring-income-summary',
-      depends: () => !showUpdatedContent(),
-      uiSchema: summaryPage.uiSchema,
-      schema: summaryPage.schema,
-    }),
     unassociatedIncomePagesUpdatedSummary: pageBuilder.summaryPage({
       title: 'Recurring income',
       path: 'recurring-income-summary-updated',
@@ -521,6 +514,14 @@ export const unassociatedIncomePages = arrayBuilderPages(
       depends: formData =>
         showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
       uiSchema: updatedCustodianSummaryPage.uiSchema,
+      schema: summaryPage.schema,
+    }),
+    // Ensure MVP summary page is listed last so it’s not accidentally overridden by claimantType-specific summary pages
+    unassociatedIncomePagesSummary: pageBuilder.summaryPage({
+      title: 'Recurring income',
+      path: 'recurring-income-summary',
+      depends: () => !showUpdatedContent(),
+      uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
     unassociatedIncomeVeteranRecipientPage: pageBuilder.itemPage({

--- a/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
@@ -504,13 +504,6 @@ const incomeTypePage = {
 export const associatedIncomePages = arrayBuilderPages(
   options,
   pageBuilder => ({
-    associatedIncomePagesSummary: pageBuilder.summaryPage({
-      title: summaryTitle,
-      path: 'financial-accounts-summary',
-      depends: () => !showUpdatedContent(),
-      uiSchema: summaryPage.uiSchema,
-      schema: summaryPage.schema,
-    }),
     associatedIncomePagesUpdatedSummary: pageBuilder.summaryPage({
       title: summaryTitle,
       path: 'financial-accounts-summary-updated',
@@ -550,6 +543,14 @@ export const associatedIncomePages = arrayBuilderPages(
         showUpdatedContent() && formData.claimantType === 'PARENT',
       uiSchema: custodianSummaryPage.uiSchema,
       schema: custodianSummaryPage.schema,
+    }),
+    // Ensure MVP summary page is listed last so it’s not accidentally overridden by claimantType-specific summary pages
+    associatedIncomePagesSummary: pageBuilder.summaryPage({
+      title: summaryTitle,
+      path: 'financial-accounts-summary',
+      depends: () => !showUpdatedContent(),
+      uiSchema: summaryPage.uiSchema,
+      schema: summaryPage.schema,
     }),
     associatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (


### PR DESCRIPTION
## Summary

This PR resolves a logic issue with the **Array Builder summary page** in the **Income and Asset Statement form (VA Form 21P-0969)**. In the current MVP experience, the incorrect summary page may display after adding an item to a list-and-loop chapter due to evaluation order. This update ensures that the correct summary page is displayed by reordering the summary pages in the declaration array.

## Issue

MVP summary page was being overridden by the claimant-type summary page due to declaration order

## Related issue(s)

- N/A

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Disable the feature toggle to run the app in MVP:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the form at:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  

## How to verify

1. Proceed to the 'Recurring income' list-and-loop chapter and add an item
2. Ensure that the correct summary page content is displayed after an item is added

## What areas of the site does it impact?

- Income and Asset Statement (21P-0969)  
- Summary page rendering within arrayBuilder chapters

## Screenshots

| Before | After |
|--------|-------|
| Incorrect summary page question text shown | Correct summary page question text shown |
|<img width="597" height="547" alt="Screenshot 2025-09-03 at 8 56 20 AM" src="https://github.com/user-attachments/assets/4701274c-f76f-48ba-a599-ecbb92054bac" />|<img width="607" height="584" alt="Screenshot 2025-09-03 at 8 56 10 AM" src="https://github.com/user-attachments/assets/77478d86-e936-4aab-b173-daab0809d98c" />|

## Quality Assurance & Testing

- [x] E2E test passing
- [x] Unit tests passing
- [x] No sensitive data exposed
- [x] Linting clean


## Authentication

- [x] Tested with both authenticated and unauthenticated users


## Requested Feedback

Please confirm the page order now reliably resolves to the correct summary page, and that fallback logic works only when applicable.