### PR TITLE
added sm category margin

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -920,7 +920,7 @@ const ComposeForm = props => {
           {cernerPilotSmFeatureFlag && (
             <SelectedRecipientTitle draftInProgress={draftInProgress} />
           )}
-          <div className="compose-form-div">
+          <div className="compose-form-div vads-u-margin-y--3">
             {noAssociations || allTriageGroupsBlocked ? (
               <ViewOnlyDraftSection
                 title={FormLabels.CATEGORY}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Fixed a margin issue on the error warning of the SM message Categories.

## Related issue(s)

- original ticket : https://github.com/department-of-veterans-affairs/va.gov-team/issues/116497

## Testing done

- Full E2E testing.

## Screenshots

| Before |

<img width="993" height="1082" alt="Screenshot 2025-09-03 at 1 53 16 PM" src="https://github.com/user-attachments/assets/94a88ad7-4823-41fb-acb8-526ef1aa119d" />

| After |

<img width="977" height="1115" alt="Screenshot 2025-09-03 at 1 54 49 PM" src="https://github.com/user-attachments/assets/4b191f70-0888-468e-964b-b11faa4f2af3" />

## What areas of the site does it impact?
Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
