### PR TITLE
10-7959f-2 | Require Social Security number

### DIFF
--- a/src/applications/ivc-champva/10-7959f-2/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-2/config/form.js
@@ -1,16 +1,14 @@
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import { cloneDeep } from 'lodash';
-import merge from 'lodash/merge';
-import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import React from 'react';
+import { cloneDeep, merge } from 'lodash';
+import environment from 'platform/utilities/environment';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 
 import {
-  ssnOrVaFileNumberNoHintSchema,
-  ssnOrVaFileNumberNoHintUI,
+  ssnUI,
+  ssnSchema,
   fullNameUI,
   fullNameSchema,
   titleUI,
-  titleSchema,
   dateOfBirthUI,
   dateOfBirthSchema,
   addressUI,
@@ -127,7 +125,6 @@ const formConfig = {
             type: 'object',
             required: ['veteranFullName', 'veteranDateOfBirth'],
             properties: {
-              titleSchema,
               veteranFullName: fullNameSchema,
               veteranDateOfBirth: dateOfBirthSchema,
             },
@@ -139,23 +136,17 @@ const formConfig = {
       title: 'Identification information',
       pages: {
         page2: {
-          path: 'identification-information ',
-          title: 'Identification information ',
+          path: 'identification-information',
+          title: 'Identification information',
           uiSchema: {
-            ...titleUI(
-              'Identification information ',
-              'You must enter either a Social Security Number or a VA file number.',
-            ),
-            messageAriaDescribedby:
-              'You must enter either a Social Security number or VA file number.',
-            veteranSocialSecurityNumber: ssnOrVaFileNumberNoHintUI(),
+            ...titleUI('Identification information'),
+            veteranSocialSecurityNumber: ssnUI(),
           },
           schema: {
             type: 'object',
             required: ['veteranSocialSecurityNumber'],
             properties: {
-              titleSchema,
-              veteranSocialSecurityNumber: ssnOrVaFileNumberNoHintSchema,
+              veteranSocialSecurityNumber: ssnSchema,
             },
           },
         },
@@ -190,7 +181,6 @@ const formConfig = {
             type: 'object',
             required: ['veteranAddress'],
             properties: {
-              titleSchema,
               veteranAddress: addressSchema(),
             },
           },
@@ -217,7 +207,6 @@ const formConfig = {
             type: 'object',
             required: ['sameMailingAddress'],
             properties: {
-              titleSchema,
               sameMailingAddress: yesNoSchema,
             },
           },
@@ -249,7 +238,6 @@ const formConfig = {
             type: 'object',
             required: ['physicalAddress'],
             properties: {
-              titleSchema,
               physicalAddress: addressSchema(),
             },
           },
@@ -280,7 +268,6 @@ const formConfig = {
             type: 'object',
             required: ['veteranPhoneNumber', 'veteranEmailAddress'],
             properties: {
-              titleSchema,
               veteranPhoneNumber: phoneSchema,
               veteranEmailAddress: emailSchema,
             },
@@ -315,7 +302,6 @@ const formConfig = {
             type: 'object',
             required: ['sendPayment'],
             properties: {
-              titleSchema,
               sendPayment: radioSchema(['Veteran', 'Provider']),
             },
           },
@@ -351,7 +337,6 @@ const formConfig = {
             type: 'object',
             required: ['uploadSectionVeteran'],
             properties: {
-              titleSchema,
               'view:UploadDocuments': {
                 type: 'object',
                 properties: {},
@@ -385,7 +370,6 @@ const formConfig = {
             type: 'object',
             required: ['uploadSectionProvider'],
             properties: {
-              titleSchema,
               'view:UploadDocuments': {
                 type: 'object',
                 properties: {},

--- a/src/applications/ivc-champva/10-7959f-2/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959f-2/tests/e2e/fixtures/data/test-data.json
@@ -6,10 +6,7 @@
       "last": "last"
     },
     "veteranDateOfBirth": "2000-01-01",
-    "veteranSocialSecurityNumber": {
-      "ssn": "123123123",
-      "vaFileNumber": "123123123"
-    },
+    "veteranSocialSecurityNumber": "123123123",
     "veteranAddress": {
       "country": "USA",
       "street": "123 Street Lane",

--- a/src/applications/ivc-champva/10-7959f-2/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/tests/unit/config/form.unit.spec.jsx
@@ -17,7 +17,7 @@ testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.veteranIdentificationChapter.pages.page2.schema,
   formConfig.chapters.veteranIdentificationChapter.pages.page2.uiSchema,
-  2,
+  1,
   'Applicant identification',
   { ...mockdata.data },
 );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

In an effort to cut down on processing issues, this PR replaces the option to input either a Social Security or VA file number with the option for Social Security number only.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#114057

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="537" height="475" alt="Screenshot 2025-09-03 at 13 11 55" src="https://github.com/user-attachments/assets/0c42e70f-5144-45b0-a2f6-f6e90555196a" /> | <img width="537" height="353" alt="Screenshot 2025-09-03 at 13 10 59" src="https://github.com/user-attachments/assets/58186418-419f-445e-bcff-75d4b7b6ea4e" /> |

## Acceptance criteria

- Social Security number is the only option for applicant identification

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
