### PR TITLE
Pensions | Update net worth accordions

### DIFF
--- a/src/applications/pensions/components/FormAlerts/index.jsx
+++ b/src/applications/pensions/components/FormAlerts/index.jsx
@@ -25,7 +25,9 @@ export const AssetsInformation = () => (
         <li>Antique furniture</li>
         <li>Boats</li>
       </ul>
-      <h4>We don’t include items like these in your assets:</h4>
+      <p>
+        <strong>We don’t include items like these in your assets:</strong>
+      </p>
       <ul>
         <li>
           Your primary residence (the home where you live most or all of your
@@ -39,7 +41,9 @@ export const AssetsInformation = () => (
       </ul>
     </va-accordion-item>
     <va-accordion-item header="Who we consider a dependent">
-      <h5>A dependent is:</h5>
+      <p>
+        <strong>A dependent is:</strong>
+      </p>
       <ul>
         <li>
           A spouse (<strong>Note:</strong> We recognize same-sex and common-law
@@ -54,10 +58,12 @@ export const AssetsInformation = () => (
           one of the eligibility requirements listed here
         </li>
       </ul>
-      <h5>
-        To be considered a dependent, one of these must be true of an unmarried
-        child:
-      </h5>
+      <p>
+        <strong>
+          To be considered a dependent, one of these must be true of an
+          unmarried child:
+        </strong>
+      </p>
       <ul>
         <li>
           They’re under 18 years old, <strong>or</strong>


### PR DESCRIPTION
## Summary

This PR updates the accordion content on the **Income and assets** page of the **Pension Benefits form (21P-527EZ)** to improve semantic structure. Specifically, heading tags within `<va-accordion>` items are replaced with paragraph tags to follow best practices for accessible markup. This update is behind the `pension_income_and_assets_clarification` feature toggle.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117236

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/pension_income_and_assets_clarification`  
4. Navigate to the form at:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
5. Proceed to the **Income and assets** page (`/financial/income-and-assets`)

## How to verify

1. Navigate to the **Income and assets** page
2. Expand the accordion items and inspect the DOM
3. Confirm content now uses `<p>` tags instead of heading tags (e.g., `<h4>`)
4. Validate accessibility behavior remains consistent

## What areas of the site does it impact?
- Pension Benefits form  
- Income and assets page (accordion content only)

## Screenshots
| Accordion | Accordion |
|--------|--------|
|<img width="533" height="504" alt="Screenshot 2025-09-03 at 1 57 01 PM" src="https://github.com/user-attachments/assets/be0c3880-5ebf-417a-9157-f3ef56a30695" />|<img width="539" height="506" alt="Screenshot 2025-09-03 at 1 56 54 PM" src="https://github.com/user-attachments/assets/2e5c64ea-7af9-462d-a42c-e3a20e72bf3e" />|


### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Please confirm the updated markup improves semantic structure and meets expectations for accessibility within collapsible content.