### PR TITLE
Update link text to My VA Health portal in current OH/Cerner routing alerts

### DIFF
--- a/src/applications/vaos/components/CernerAlert.jsx
+++ b/src/applications/vaos/components/CernerAlert.jsx
@@ -50,15 +50,12 @@ export default function CernerAlert({ className, pageTitle, level = 2 }) {
                 </ul>
               </>
             )}
-            <a
-              className="vads-c-action-link--blue vads-u-margin-bottom--1"
-              onClick={handleClick}
+            <va-link-action
+              text="Go to My VA Health"
+              type="secondary"
               href={getCernerURL('/pages/scheduling/upcoming', true)}
-              rel="noreferrer noopener"
-              target="_blank"
-            >
-              Go to My VA Health (opens in new tab)
-            </a>
+              onClick={handleClick}
+            />
             <p>
               <strong>Note:</strong> Having trouble opening My VA Health? Try
               disabling your browser’s pop-up blocker or signing in to My VA


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We are updating the "Go to my VA Health" link text and link behavior in the OH/Cerner alerts
  - The link should open in the current tab
  - The link text should remove the "(opens in new tab)" part
  - The link should use `va-link-action` component
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115711

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="391" height="526" alt="image" src="https://github.com/user-attachments/assets/51240c3b-f542-4560-8c0e-e56ceb928bfa" />    |    <img width="391" height="497" alt="image" src="https://github.com/user-attachments/assets/654881e2-5d36-4cd3-88dd-4bac45c8ec1b" />  |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
