### PR TITLE
UAE appts/115808 exact route matching past

### DIFF
--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -46,7 +46,6 @@ function AppointmentListSection() {
           path="/past/:id"
           component={UpcomingAppointmentsDetailsPage}
         />
-        <Route exact path="/past" component={AppointmentsPage} />
         <Route exact path="/:id" component={UpcomingAppointmentsDetailsPage} />
         <Route
           exact

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -41,8 +41,12 @@ function AppointmentListSection() {
         {isInPilotUserStations && (
           <Route path="/referrals-requests" component={ReferralsAndRequests} />
         )}
-        <Route path="/past/:id" component={UpcomingAppointmentsDetailsPage} />
-        <Route path="/past" component={AppointmentsPage} />
+        <Route
+          exact
+          path="/past/:id"
+          component={UpcomingAppointmentsDetailsPage}
+        />
+        <Route exact path="/past" component={AppointmentsPage} />
         <Route exact path="/:id" component={UpcomingAppointmentsDetailsPage} />
         <Route
           exact

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -22,36 +22,40 @@ function AppointmentListSection() {
   return (
     <>
       <Switch>
-        <Route
-          path="/pending/:id"
-          component={RequestedAppointmentDetailsPage}
-        />
-
+        {/* These are now exact so that you can still access the <whichever_route>/:id under each of them when linked */}
         {isInPilotUserStations && (
-          <Redirect from="/pending" to="/referrals-requests" />
+          <Redirect exact from="/pending" to="/referrals-requests" />
         )}
         {!isInPilotUserStations && (
-          <Redirect from="/referrals-requests" to="/pending" />
+          <Redirect exact from="/referrals-requests" to="/pending" />
         )}
-
-        <Route path="/pending" component={AppointmentsPage} />
-        {isInPilotUserStations &&
-          eps && <Route path="/:id" component={EpsAppointmentDetailsPage} />}
 
         {isInPilotUserStations && (
-          <Route path="/referrals-requests" component={ReferralsAndRequests} />
+          <Route
+            exact
+            path="/referrals-requests"
+            component={ReferralsAndRequests}
+          />
         )}
-        <Route
-          exact
-          path="/past/:id"
-          component={UpcomingAppointmentsDetailsPage}
-        />
-        <Route exact path="/:id" component={UpcomingAppointmentsDetailsPage} />
         <Route
           exact
           path={['/', '/pending', '/past']}
           component={AppointmentsPage}
         />
+        <Route
+          exact
+          path="/pending/:id"
+          component={RequestedAppointmentDetailsPage}
+        />
+        <Route
+          exact
+          path="/past/:id"
+          component={UpcomingAppointmentsDetailsPage}
+        />
+        {/* NOTE: eps should probably also be exact */}
+        {isInPilotUserStations &&
+          eps && <Route path="/:id" component={EpsAppointmentDetailsPage} />}
+        <Route exact path="/:id" component={UpcomingAppointmentsDetailsPage} />
         <Route component={PageNotFound} />
       </Switch>
     </>

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -22,20 +22,20 @@ function AppointmentListSection() {
   return (
     <>
       <Switch>
-        {/* These are now exact so that you can still access the <whichever_route>/:id under each of them when linked */}
+        <Route
+          path="/pending/:id"
+          component={RequestedAppointmentDetailsPage}
+        />
+
         {isInPilotUserStations && (
-          <Redirect exact from="/pending" to="/referrals-requests" />
+          <Redirect from="/pending" to="/referrals-requests" />
         )}
         {!isInPilotUserStations && (
-          <Redirect exact from="/referrals-requests" to="/pending" />
+          <Redirect from="/referrals-requests" to="/pending" />
         )}
 
         {isInPilotUserStations && (
-          <Route
-            exact
-            path="/referrals-requests"
-            component={ReferralsAndRequests}
-          />
+          <Route path="/referrals-requests" component={ReferralsAndRequests} />
         )}
         <Route
           exact
@@ -44,15 +44,9 @@ function AppointmentListSection() {
         />
         <Route
           exact
-          path="/pending/:id"
-          component={RequestedAppointmentDetailsPage}
-        />
-        <Route
-          exact
           path="/past/:id"
           component={UpcomingAppointmentsDetailsPage}
         />
-        {/* NOTE: eps should probably also be exact */}
         {isInPilotUserStations &&
           eps && <Route path="/:id" component={EpsAppointmentDetailsPage} />}
         <Route exact path="/:id" component={UpcomingAppointmentsDetailsPage} />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- 
This pull request reorganizes the routing logic in the `AppointmentListSection` component to improve route matching and ensure the correct components are rendered for appointment details and pilot user stations. The main changes involve reordering the `Route` definitions and adjusting their placement for more predictable behavior.

Routing logic improvements:

* Moved the `/past/:id` route to appear before the generic `/:id` route, ensuring that appointment detail pages for past appointments are matched correctly.
* Placed the pilot user station-specific route (`/:id` for `EpsAppointmentDetailsPage`) after the `/past/:id` route and before the generic `/:id` route, to avoid route conflicts and ensure the correct component is rendered for pilot users.
* Changed the route definitions so that the generic `/:id` route for `UpcomingAppointmentsDetailsPage` is now listed after the more specific routes, improving route specificity and preventing unintended matches.

- Simplified some duplicate route matching and organized a bit. Now `my-health/appointments/past/x/y` will fail to the fallback Not Found 404 page.
- UAE - Appointments team (Orion)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115808

## Testing done

- Tested routes on /appointments/id, /appointments/pending/id, /appointments/past/id, /appointments/referrals-requests -> selected pending/request still points to pending/id as in staging, checked with or without toggles (and tested toggle changes on staging)


## Screenshots

All paths relative to `/my-health/appointments`

<details><summary>no change: / </summary>
<img src="https://github.com/user-attachments/assets/7cd6fe12-47a2-4114-aaad-b06d4c98de85" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/5ca3ecff-d80e-4cdf-8db2-8317c99371ab" width="48%" alt="after">
</details>

<details><summary>no change: /:id </summary>
<img src="https://github.com/user-attachments/assets/a26d4b9c-460b-4cf2-99e4-31b4be30566a" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/1201127b-b73b-4378-b6d0-be9e575cf02a" width="48%" alt="after">
</details>

<details><summary>no change: /:id?eps=true and feature on </summary>
<img src="https://github.com/user-attachments/assets/98c1ebca-1b3f-453f-8024-12b87ec37667" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/9bde0952-8f90-4a88-b98d-6e743da22336" width="48%" alt="after">
</details>

<details><summary>no change: /past </summary>
<img src="https://github.com/user-attachments/assets/688ea6fd-0b42-497f-a89b-1218408a86c8" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/338f89ab-2e3a-40d9-88e3-d11aa985e5cc" width="48%" alt="after">
</details>

<details><summary>no change: /past/:id </summary>
<img src="https://github.com/user-attachments/assets/b9f7e111-bc7e-46cb-86b6-3671b1a97681" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/ad37269a-d6fa-49d7-b45f-b37f2b5e32e4" width="48%" alt="after">
</details>

<details><summary>no change: /past/banana (bad id)</summary>
<img src="https://github.com/user-attachments/assets/53615a41-e5b5-47da-b025-6aa095b371cc" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/c2e4eb51-17c9-4f9c-af43-a886c0ad31a8" width="48%" alt="after">
</details>

<details><summary>no change: /referrals-requests|/pending </summary>
<img src="https://github.com/user-attachments/assets/d8e70506-2249-472b-86f4-87a7c5cd89bd" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/6690ad60-9bd9-43fa-ab72-38ad79ee382a" width="48%" alt="after">
</details>


<details><summary>no change: /referrals-requests|/pending (With flipper off)</summary>
<img src="https://github.com/user-attachments/assets/82f568b8-69b6-40a7-b191-8be93619c696" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/b9eb715a-9d06-4d3e-b316-6fd47bae0768" width="48%" alt="after">
</details>


<details><summary>no change: /pending/:id</summary>
<img src="https://github.com/user-attachments/assets/b388a67f-c08f-4daf-8814-f479505f5aa9" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/1350b786-4bd8-4ad5-bede-c891f1e9ba76" width="48%" alt="after">
</details>

<details><summary>CHANGE: /past/banana/apple </summary>
<img src="https://github.com/user-attachments/assets/6bcdb604-1943-495e-831d-3eeade8b270a" width="48%" alt="before" />&nbsp;<img src="https://github.com/user-attachments/assets/78ad6cea-af7c-4a76-bd96-acd625c5b0be" width="48%" alt="after">
</details>


## What areas of the site does it impact?

Just affects the `my-health/appointments/past/<somepath>/<somepath>/` route in the switch so that it goes to the Not Found page since that pattern doesn't exist

## Acceptance criteria

- `my-health/appointments/past/<somepath>/<somepath>/` pattern goes to the Not Found Page route instead of the past appointment route with a missing appointment (i.e. bad id)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed (no a11y change)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

Check that all routes are the same as in staging except `my-health/appointments/past/somepath/somepath`