### PR TITLE
MHV SM Add feature flags for curated list flow and recent recipients

### DIFF
--- a/src/applications/mhv-secure-messaging/hooks/useFeatureToggles.js
+++ b/src/applications/mhv-secure-messaging/hooks/useFeatureToggles.js
@@ -11,6 +11,8 @@ const useFeatureToggles = () => {
     largeAttachmentsEnabled,
     isDowntimeBypassEnabled,
     cernerPilotSmFeatureFlag,
+    mhvSecureMessagingCuratedListFlow,
+    mhvSecureMessagingRecentRecipients,
     mhvMockSessionFlag,
   } = useSelector(
     state => {
@@ -44,6 +46,14 @@ const useFeatureToggles = () => {
           state.featureToggles[
             FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilot
           ],
+        mhvSecureMessagingCuratedListFlow:
+          state.featureToggles[
+            FEATURE_FLAG_NAMES.mhvSecureMessagingCuratedListFlow
+          ],
+        mhvSecureMessagingRecentRecipients:
+          state.featureToggles[
+            FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients
+          ],
         mhvMockSessionFlag: state.featureToggles['mhv-mock-session'],
       };
     },
@@ -62,6 +72,8 @@ const useFeatureToggles = () => {
     largeAttachmentsEnabled,
     isDowntimeBypassEnabled,
     cernerPilotSmFeatureFlag,
+    mhvSecureMessagingCuratedListFlow,
+    mhvSecureMessagingRecentRecipients,
     mhvMockSessionFlag,
   };
 };

--- a/src/applications/mhv-secure-messaging/tests/hooks/useFeatureToggles.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/hooks/useFeatureToggles.unit.spec.jsx
@@ -20,6 +20,8 @@ describe('useFeatureToggles', () => {
         [FEATURE_FLAG_NAMES.mhvSecureMessagingLargeAttachments]: false,
         [FEATURE_FLAG_NAMES.mhvBypassDowntimeNotification]: false,
         [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilot]: false,
+        [FEATURE_FLAG_NAMES.mhvSecureMessagingCuratedListFlow]: false,
+        [FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients]: false,
         'mhv-mock-session': false,
       },
     };
@@ -41,6 +43,8 @@ describe('useFeatureToggles', () => {
         [FEATURE_FLAG_NAMES.mhvSecureMessagingLargeAttachments]: true,
         [FEATURE_FLAG_NAMES.mhvBypassDowntimeNotification]: true,
         [FEATURE_FLAG_NAMES.mhvSecureMessagingCernerPilot]: true,
+        [FEATURE_FLAG_NAMES.mhvSecureMessagingCuratedListFlow]: true,
+        [FEATURE_FLAG_NAMES.mhvSecureMessagingRecentRecipients]: true,
         'mhv-mock-session': true,
       },
     };
@@ -57,6 +61,8 @@ describe('useFeatureToggles', () => {
       largeAttachmentsEnabled: true,
       isDowntimeBypassEnabled: true,
       cernerPilotSmFeatureFlag: true,
+      mhvSecureMessagingCuratedListFlow: true,
+      mhvSecureMessagingRecentRecipients: true,
       mhvMockSessionFlag: true,
     });
   });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -191,6 +191,8 @@
   "mhvSecureMessagingMilestone2AAL": "mhv_secure_messaging_milestone_2_aal",
   "mhvSecureMessagingCustomFoldersRedesign": "mhv_secure_messaging_custom_folders_redesign",
   "mhvSecureMessagingLargeAttachments": "mhv_secure_messaging_large_attachments",
+  "mhvSecureMessagingCuratedListFlow": "mhv_secure_messaging_curated_list_flow",
+  "mhvSecureMessagingRecentRecipients": "mhv_secure_messaging_recent_recipients",
   "mhvSupplyReorderingEnabled": "mhv_supply_reordering_enabled",
   "mhvVaHealthChatEnabled": "mhv_va_health_chat_enabled",
   "mhvHeaderLinks": "mhv_header_links",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request adds support for two new feature flags to the secure messaging application, allowing the app to toggle functionality related to curated list flows and recent recipients. The changes update both the feature flag names and the custom hook that provides feature flag values to the app.

New feature flag support:

* Added `mhvSecureMessagingCuratedListFlow` and `mhvSecureMessagingRecentRecipients` to the feature flag names in `featureFlagNames.json`, making them available for use throughout the application.
* Updated the `useFeatureToggles` hook in `useFeatureToggles.js` to retrieve the values of the new feature flags from the Redux store and expose them to components. [[1]](diffhunk://#diff-33c82f540bb69ed5e4177619e78711d32cb0754749cf75a6321f31dce40f8924R14-R15) [[2]](diffhunk://#diff-33c82f540bb69ed5e4177619e78711d32cb0754749cf75a6321f31dce40f8924R49-R56) [[3]](diffhunk://#diff-33c82f540bb69ed5e4177619e78711d32cb0754749cf75a6321f31dce40f8924R75-R76)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116047
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118609
- https://github.com/department-of-veterans-affairs/vets-api/pull/23924

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
