### PR TITLE
Migrate simple-forms shared page test utils to platform

### DIFF
--- a/src/applications/simple-forms/20-10206/tests/unit/pages/address.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/address.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/citizenIdInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/citizenIdInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/disabilityExamDetails.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/disabilityExamDetails.unit.spec.jsx
@@ -6,7 +6,7 @@ import { render } from 'enzyme';
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/financialRecordDetails.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/financialRecordDetails.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/lifeInsuranceBenefitDetails.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/lifeInsuranceBenefitDetails.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/nonCitizenIdInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/nonCitizenIdInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/otherBenefitDetails.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/otherBenefitDetails.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/otherCompensationAndPensionDetails.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/otherCompensationAndPensionDetails.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/personalInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/personalInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/phoneEmail.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/phoneEmail.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/preparerType.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/preparerType.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfWebComponentFields,
   testNumberOfErrorsOnSubmitForWebComponents,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10206/tests/unit/pages/recordSelections.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/pages/recordSelections.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10207/tests/unit/pages/nonVeteranPointOfContact.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10207/tests/unit/pages/nonVeteranPointOfContact.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10207/tests/unit/pages/pointOfContact.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10207/tests/unit/pages/pointOfContact.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/20-10207/tests/unit/pages/veteranPointOfContact.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10207/tests/unit/pages/veteranPointOfContact.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/authorizerAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/authorizerAddress.unit.spec.jsx
@@ -7,7 +7,7 @@ import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../config/form';
 import authTypeNonVet from '../e2e/fixtures/data/authTypeNonVet.json';

--- a/src/applications/simple-forms/21-0845/tests/pages/authorizerContactInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/authorizerContactInfo.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/authorizerPersonalInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/authorizerPersonalInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/authorizerType.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/authorizerType.unit.spec.jsx
@@ -5,7 +5,7 @@ import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 import authTypeNonVet from '../e2e/fixtures/data/authTypeNonVet.json';
 

--- a/src/applications/simple-forms/21-0845/tests/pages/infoScope.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/infoScope.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/limitedInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/limitedInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/organizationAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/organizationAddress.unit.spec.jsx
@@ -7,7 +7,7 @@ import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 import authTypeVet from '../e2e/fixtures/data/authTypeVet.json';
 

--- a/src/applications/simple-forms/21-0845/tests/pages/organizationName.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/organizationName.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/organizationReps.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/organizationReps.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/personAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/personAddress.unit.spec.jsx
@@ -8,7 +8,7 @@ import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 import authTypeVet from '../e2e/fixtures/data/authTypeVet.json';
 

--- a/src/applications/simple-forms/21-0845/tests/pages/personName.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/personName.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/releaseDuration.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/releaseDuration.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/releaseEndDate.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/releaseEndDate.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/securityAnswer.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/securityAnswer.unit.spec.jsx
@@ -8,7 +8,7 @@ import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 import authTypeVet from '../e2e/fixtures/data/authTypeVet.json';
 import { SECURITY_QUESTIONS } from '../../definitions/constants';

--- a/src/applications/simple-forms/21-0845/tests/pages/securityQuestion.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/securityQuestion.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/thirdPartyType.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/thirdPartyType.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/veteranContactInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/veteranContactInfo.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/veteranIdInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/veteranIdInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0845/tests/pages/veteranPersonalInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0845/tests/pages/veteranPersonalInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/confirmVeteranPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/confirmVeteranPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/preparerIdentificationInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/preparerIdentificationInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/reviewVeteranEmailAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/reviewVeteranEmailAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/survivingDependentBenefitSelection.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/survivingDependentBenefitSelection.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/survivingDependentIdentification.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/survivingDependentIdentification.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/survivingDependentMailingAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/survivingDependentMailingAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/survivingDependentPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/survivingDependentPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/survivingDependentPhoneAndEmailAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/survivingDependentPhoneAndEmailAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/survivingDependentRelationshipToVeteran.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/survivingDependentRelationshipToVeteran.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/survivingDependentVeteranPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/survivingDependentVeteranPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/thirdPartyPreparerName.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/thirdPartyPreparerName.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/thirdPartyPreparerRole.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/thirdPartyPreparerRole.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/thirdPartySurvivingDependentBenefitSelection.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/thirdPartySurvivingDependentBenefitSelection.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/thirdPartySurvivingDependentRelationshipToVeteran.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/thirdPartySurvivingDependentRelationshipToVeteran.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/thirdPartySurvivingDependentVeteranPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/thirdPartySurvivingDependentVeteranPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/thirdPartyVeteranBenefitSelection.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/thirdPartyVeteranBenefitSelection.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/veteranBenefitSelection.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/veteranBenefitSelection.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/veteranBenefitSelectionCompensation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/veteranBenefitSelectionCompensation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/veteranBenefitSelectionPension.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/veteranBenefitSelectionPension.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/veteranIdentificationInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/veteranIdentificationInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/veteranMailingAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/veteranMailingAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/veteranPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/veteranPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0966/tests/pages/veteranPhoneAndEmailAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/veteranPhoneAndEmailAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/additionalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/additionalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/claimantAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/claimantAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/claimantContactInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/claimantContactInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/claimantIdentification.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/claimantIdentification.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/claimantPersonalnformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/claimantPersonalnformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/claimantSsn.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/claimantSsn.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/preparerAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/preparerAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/preparerContactInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/preparerContactInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/preparerPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/preparerPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/preparerQualifications1.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/preparerQualifications1.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 [

--- a/src/applications/simple-forms/21-0972/tests/pages/preparerQualifications2.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/preparerQualifications2.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/veteranIdentificationInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/veteranIdentificationInformation1.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/veteranIdentificationInformation2.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/veteranIdentificationInformation2.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-0972/tests/pages/veteranPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/veteranPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-10210/tests/pages/claimOwnership.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/claimOwnership.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/claimantAddrInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/claimantAddrInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/claimantContInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/claimantContInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/claimantIdInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/claimantIdInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/claimantPersInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/claimantPersInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/claimantType.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/claimantType.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/statementA.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/statementA.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/statementB.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/statementB.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/statementC.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/statementC.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/vetAddrInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/vetAddrInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/vetContInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/vetContInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/vetIdInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/vetIdInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/vetPersInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/vetPersInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/witnessContInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/witnessContInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { CLAIM_OWNERSHIPS, CLAIMANT_TYPES } from '../../definitions/constants';
 import formConfig from '../../config/form';
 

--- a/src/applications/simple-forms/21-10210/tests/pages/witnessOtherRelationship.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/witnessOtherRelationship.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-10210/tests/pages/witnessPersInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/21-10210/tests/pages/witnessPersInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import {
   CLAIM_OWNERSHIPS,
   CLAIMANT_TYPES,

--- a/src/applications/simple-forms/21-4138/tests/unit/pages/pageTests.spec.jsx
+++ b/src/applications/simple-forms/21-4138/tests/unit/pages/pageTests.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 export const testPage = ({

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/authorization.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/authorization.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/contactInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/contactInformation1.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/contactInformation2.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/contactInformation2.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/limitations.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/limitations.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.limitations.pages.limitations;

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/patientIdentification1.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/patientIdentification1.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/patientIdentification2.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/patientIdentification2.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/personalInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/personalInformation1.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/personalInformation2.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/personalInformation2.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/preparerAddress1.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/preparerAddress1.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import {
   preparerIdentificationFields,
   veteranFields,

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/preparerAddress2.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/preparerAddress2.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import {
   preparerIdentificationFields,
   veteranIsSelfText,

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/preparerIdentification.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/preparerIdentification.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/preparerPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/preparerPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import {
   preparerIdentificationFields,
   veteranDirectRelative,

--- a/src/applications/simple-forms/21-4142/tests/unit/pages/recordsRequested.unit.spec.jsx
+++ b/src/applications/simple-forms/21-4142/tests/unit/pages/recordsRequested.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import { patientIdentificationFields } from '../../../definitions/constants';
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/21P-0847/tests/pages/additionalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/additionalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21P-0847/tests/pages/deceasedClaimantPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/deceasedClaimantPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21P-0847/tests/pages/preparerAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/preparerAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21P-0847/tests/pages/preparerContactInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/preparerContactInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21P-0847/tests/pages/preparerIdentificationInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/preparerIdentificationInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21P-0847/tests/pages/preparerPersonalInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/preparerPersonalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21P-0847/tests/pages/relationshipToDeceasedClaimant.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/relationshipToDeceasedClaimant.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/21P-0847/tests/pages/veteranIdentificationInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21P-0847/tests/pages/veteranIdentificationInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/contactInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/contactInformation1.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/contactInformation2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/contactInformation2.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/livingSituation1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/livingSituation1.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/livingSituation2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/livingSituation2.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/personalInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/personalInformation1.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/personalInformation2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/personalInformation2.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication1.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousHiApplication2.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication1.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication1.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication2.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/previousSahApplication2.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/26-4555/tests/pages/remarks.unit.spec.jsx
+++ b/src/applications/simple-forms/26-4555/tests/pages/remarks.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/additionalCertificatesRequest.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/additionalCertificatesRequest.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/additionalCertificatesYesNo.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/additionalCertificatesYesNo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/applicantAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/applicantAddress.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/applicantContactInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/applicantContactInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/applicantPersonalInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/applicantPersonalInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/certificates.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/certificates.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/requestType.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/requestType.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/veteranIdInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/veteranIdInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/veteranPersonalInfo.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/veteranPersonalInfo.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/40-0247/tests/unit/pages/veteranSupportDocs.unit.spec.jsx
+++ b/src/applications/simple-forms/40-0247/tests/unit/pages/veteranSupportDocs.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmit,
   testNumberOfFields,
-} from '../../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockArrayMultiPageAggregateStart.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockArrayMultiPageAggregateStart.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockArrayMultiPageBuilderSummary.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockArrayMultiPageBuilderSummary.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockArraySinglePage.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockArraySinglePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockCheckbox.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockCheckbox.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.checkbox.pages.checkbox;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockCheckboxGroup.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockCheckboxGroup.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.checkbox.pages.checkboxGroup;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockDate.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockDate.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.date.pages.date;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFileInput.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFileInput.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.fileInput.pages.fileInput;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFileInputMultiple.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFileInputMultiple.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternMultiple.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternMultiple.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleCheckboxGroup.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleCheckboxGroup.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleRadio.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleRadio.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockInternationalPhone.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockInternationalPhone.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockNumberInput.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockNumberInput.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.numberInput.pages.numberInput;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockRadio.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockRadio.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.radio.pages.radio;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockRadioRelationshipToVeteran.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockRadioRelationshipToVeteran.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockSelect.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockSelect.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.select.pages.select;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInput.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInput.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.textInput.pages.textInput;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputAddress.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputAddress.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.textInput.pages.address;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputFullName.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputFullName.unit.spec.jsx
@@ -3,7 +3,7 @@ import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFields,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.textInput.pages.fullName;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputSsn.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputSsn.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.textInput.pages.ssn;

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputWidgets1.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputWidgets1.unit.spec.jsx
@@ -1,7 +1,7 @@
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
-} from '../../../shared/tests/pages/pageTests.spec';
+} from 'platform/forms-system/test/pageTestHelpers.spec';
 import formConfig from '../../config/form';
 
 const { schema, uiSchema } = formConfig.chapters.textInput.pages.textEmailPhone;

--- a/src/platform/forms-system/test/pageTestHelpers.spec.jsx
+++ b/src/platform/forms-system/test/pageTestHelpers.spec.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
-import navigationState from 'platform/forms-system/src/js/utilities/navigation/navigationState.js';
+import navigationState from 'platform/forms-system/src/js/utilities/navigation/navigationState';
 
 const expectedFieldTypes = 'input, select, textarea';
 


### PR DESCRIPTION
## Summary

- Migrate simple-forms page test utilities to platform, so other forms can use it, and reduce duplication of code.
```
import { ... } from 'platform/forms-system/test/pageTestHelpers.spec';

testNumberOfFields
testNumberOfErrorsOnSubmit
testNumberOfWebComponentFields
testNumberOfErrorsOnSubmitForWebComponents
```

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4772

## Testing done

All tests still pass the same as before.

## What areas of the site does it impact?

- allows other forms besides simple-forms to use the test utilities

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed