### PR TITLE
DR 118521 Add focus management for headers in Onramp tool

### DIFF
--- a/src/applications/appeals/onramp/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/onramp/containers/IntroductionPage.jsx
@@ -4,11 +4,16 @@ import PropTypes from 'prop-types';
 import { updateIntroPageViewed } from '../actions';
 import { QUESTION_CONTENT } from '../constants/question-data-map';
 import { ROUTES } from '../constants';
+import { pageSetup } from '../utilities';
 
 const IntroductionPage = ({ router, setIntroPageViewed }) => {
   useEffect(() => {
     setIntroPageViewed(true);
   });
+
+  useEffect(() => {
+    pageSetup();
+  }, []);
 
   const startTool = event => {
     event.preventDefault();

--- a/src/applications/appeals/onramp/containers/QuestionTemplate.jsx
+++ b/src/applications/appeals/onramp/containers/QuestionTemplate.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import RadioQuestion from '../components/RadioQuestion';
 import { ROUTES } from '../constants';
+import { pageSetup } from '../utilities';
 
 const QuestionTemplate = ({ location, router, viewedIntroPage }) => {
   const route = location?.pathname.replace('/', '');
@@ -16,6 +17,13 @@ const QuestionTemplate = ({ location, router, viewedIntroPage }) => {
       }
     },
     [router, viewedIntroPage],
+  );
+
+  useEffect(
+    () => {
+      if (document) pageSetup();
+    },
+    [route],
   );
 
   return <RadioQuestion router={router} shortName={shortName} />;

--- a/src/applications/appeals/onramp/containers/ResultsTemplate.jsx
+++ b/src/applications/appeals/onramp/containers/ResultsTemplate.jsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { scrollToTop } from 'platform/utilities/scroll';
 import { ROUTES } from '../constants';
 import {
   DR_RESULTS_CONTENT,
   isNonDR,
   NON_DR_RESULTS_CONTENT,
 } from '../constants/results-data-map';
+import { pageSetup } from '../utilities';
 
 const ResultsTemplate = ({
   formResponses,
@@ -15,13 +15,6 @@ const ResultsTemplate = ({
   router,
   viewedIntroPage,
 }) => {
-  const hasScrolled = useRef(false);
-
-  if (!hasScrolled.current) {
-    scrollToTop();
-    hasScrolled.current = true;
-  }
-
   useEffect(
     () => {
       if (!viewedIntroPage) {
@@ -30,6 +23,10 @@ const ResultsTemplate = ({
     },
     [router, viewedIntroPage],
   );
+
+  useEffect(() => {
+    pageSetup();
+  }, []);
 
   const isNonDrResultPage = isNonDR.includes(resultPage);
   let resultsPageContent;

--- a/src/applications/appeals/onramp/tests/cypress/form-validation.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/form-validation.cypress.spec.js
@@ -24,7 +24,7 @@ describe('Decision Reviews Onramp', () => {
       h.clickContinue();
       h.checkFormAlertText(
         Q_1_1_CLAIM_DECISION,
-        'Error Placeholder error message',
+        'ErrorPlaceholder error message',
       );
 
       h.selectRadio(Q_1_1_CLAIM_DECISION, 0);

--- a/src/applications/appeals/onramp/tests/cypress/helpers.js
+++ b/src/applications/appeals/onramp/tests/cypress/helpers.js
@@ -51,16 +51,10 @@ export const clickContinue = () =>
     .should('be.visible')
     .click();
 
-export const verifyFormErrorNotShown = selector =>
-  cy
-    .findByTestId(selector)
-    .get('span[role="alert"]')
-    .should('have.text', '');
-
 export const verifyFormErrorDoesNotExist = selector =>
   cy
     .findByTestId(selector)
-    .get('span[role="alert"]')
+    .get('[error="ErrorPlaceholder error message"]')
     .should('not.exist');
 
 export const checkFormAlertText = (selector, expectedValue) =>

--- a/src/applications/appeals/onramp/utilities/index.jsx
+++ b/src/applications/appeals/onramp/utilities/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 export const printErrorMessage = message =>
   // eslint-disable-next-line no-console
@@ -50,4 +51,22 @@ export const renderSingleOrList = (
       ))}
     </ul>
   );
+};
+
+/**
+ * When page first loads, scroll to the top and focus on the h1
+ * We have two different types of question setups, so the header must be targeted accordingly
+ * 1. Plain header: no descriptionText (refer to question-data-map). Plain <h1>
+ * 2. Shadow header: descriptionText present. <h1> ends up in the shadow DOM of the va-radio
+ */
+export const pageSetup = () => {
+  window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  const plainHeader = document?.querySelector('h1');
+  const radio = document?.getElementById('onramp-radio');
+
+  focusElement('h1');
+
+  if (!plainHeader) {
+    focusElement('h1', {}, radio);
+  }
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

We have an a11y issue regarding header focus to address. From ticket:

> Focus needs to be managed when the page changes. After pressing the Continue button & the new screen loads focus should move to the H1 of each new page. Otherwise AT users won’t know that the screen changed (see Loom). It benefits keyboard navigation users as well. Currently they have to navigate backwards from the Continue button to fill out the new page’s radio button questions. Tabbing forwards is the expected interaction.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/118521

## Testing done & screen recording

Tested locally with VoiceOver running. Yellow focus outline on the header (when the page first loads and nothing else has been interacted with) should be visible whether AT is being used or not.

https://github.com/user-attachments/assets/d7dc7ced-d315-47d6-bc24-519a9998ef85