### PR TITLE
[art/116754] - dashboard unauth qa feedback

### DIFF
--- a/src/applications/accredited-representative-portal/components/Dashboard/Unauthorized.jsx
+++ b/src/applications/accredited-representative-portal/components/Dashboard/Unauthorized.jsx
@@ -1,40 +1,44 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Unauthorized = () => {
   return (
     <>
       <h1 className="dashboard__header">Dashboard</h1>
-      <div className="dashboard__banner">
-        <va-banner
-          data-label="dashboard banner"
-          headline="We can’t verify that you’re a VA accredited representative "
-          type="warning"
-          visible
-        >
-          <p>
-            To unlock full access, you need to be a VA accredited Veterans
-            Service Organization (VSO) representative, attorney, or claims
-            agent.{' '}
-          </p>
-          <p>
-            If you have current accreditation with the VA, check out our help
-            resources to troubleshoot access issues. Get help with access issues
-          </p>
-          <a href="/representative/get-help#creating-your-account">
-            Get help with access issues
-          </a>
-        </va-banner>
+      <div className="dashboard__content">
+        <div className="dashboard__banner">
+          <va-banner
+            data-label="dashboard banner"
+            headline="We can’t verify that you’re a VA accredited representative "
+            type="warning"
+            visible
+          >
+            <p>
+              To unlock full access, you need to be a VA accredited Veterans
+              Service Organization (VSO) representative, attorney, or claims
+              agent.{' '}
+            </p>
+            <p>
+              If you have current accreditation with the VA, check out our help
+              resources to troubleshoot access issues. Get help with access
+              issues
+            </p>
+            <Link to="/get-help#creating-your-account">
+              Get help with access issues
+            </Link>
+          </va-banner>
+        </div>
+        <h2 className="dashboard__header">Would you like to get accredited?</h2>
+        <p>
+          To apply for accreditation as a VSO representative, claims agent, or
+          attorney, you need to submit an application to the Office of General
+          Counsel.
+        </p>
+        <va-link
+          href="https://www.va.gov/ogc/accreditation.asp"
+          text="Learn about applying for accreditation"
+        />
       </div>
-      <h2 className="dashboard__header">Would you like to get accredited?</h2>
-      <p>
-        To apply for accreditation as a VSO representative, claims agent, or
-        attorney, you need to submit an application to the Office of General
-        Counsel.
-      </p>
-      <va-link
-        href="https://www.va.gov/ogc/accreditation.asp"
-        text="Learn about applying for accreditation"
-      />
     </>
   );
 };

--- a/src/applications/accredited-representative-portal/containers/GetHelpPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/GetHelpPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from 'platform/utilities/ui';
 import { HELP_BC_LABEL, HelpBC } from '../utilities/poaRequests';
@@ -29,12 +29,23 @@ const RepresentationLink = () => (
 );
 
 const GetHelpPage = title => {
+  const { hash } = useLocation();
+
   useEffect(
     () => {
-      focusElement('h1');
       document.title = title.title;
+      if (hash) {
+        const id = hash.replace('#', '');
+        const el = document.getElementById(id);
+        if (el) {
+          el.scrollIntoView({ behavior: 'smooth' });
+          focusElement('h2');
+        }
+      } else {
+        focusElement('h1');
+      }
     },
-    [title],
+    [title, hash],
   );
 
   /* eslint-disable no-irregular-whitespace */

--- a/src/applications/accredited-representative-portal/sass/Dashboard.scss
+++ b/src/applications/accredited-representative-portal/sass/Dashboard.scss
@@ -1,6 +1,7 @@
 @import "~@department-of-veterans-affairs/css-library/dist/tokens/scss/variables";
 
 .dashboard {
+  &__content,
   &__banner {
     max-width: 627px;
   }


### PR DESCRIPTION
- fix width [around content](https://github.com/department-of-veterans-affairs/va.gov-team/issues/116754)
- scroll to section on help page. set focus on section header if there is a hash in the url, if not the focus will remain on the page header/h1.

<img width="1044" height="862" alt="Screenshot 2025-09-04 at 2 52 56 PM" src="https://github.com/user-attachments/assets/8a53493b-4568-4708-9716-f3df7973742f" />
<img width="855" height="588" alt="Screenshot 2025-09-04 at 2 52 43 PM" src="https://github.com/user-attachments/assets/14733379-6fcf-4bb2-90a0-235207171f3b" />
<img width="1040" height="585" alt="Screenshot 2025-09-04 at 2 52 33 PM" src="https://github.com/user-attachments/assets/bf0ab2da-05f6-4f3a-8efd-81c9ce9acd20" />

