### PR TITLE
DR 118527: Various accessibility fixes for Onramp

### DIFF
--- a/src/applications/appeals/onramp/components/dr-results-screens/OutsideDROption.jsx
+++ b/src/applications/appeals/onramp/components/dr-results-screens/OutsideDROption.jsx
@@ -10,7 +10,10 @@ const OutsideDROption = () => {
         These options are outside VA’s decision review process and may be a good
         fit in certain situations.
       </p>
-      <ul className="card-container">
+      {/* Adding a `role="list"` to `ul` with `list-style: none` to work around
+          a problem with Safari not treating the `ul` as a list. */}
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+      <ul className="onramp-list-none" role="list">
         <li>
           <va-card class="vads-u-display--block vads-u-margin-top--3">
             <h3 className="vads-u-margin-top--0">

--- a/src/applications/appeals/onramp/components/dr-results-screens/OutsideDROption.jsx
+++ b/src/applications/appeals/onramp/components/dr-results-screens/OutsideDROption.jsx
@@ -10,24 +10,28 @@ const OutsideDROption = () => {
         These options are outside VA’s decision review process and may be a good
         fit in certain situations.
       </p>
-      <va-card class="vads-u-display--block vads-u-margin-top--3">
-        <h3 className="vads-u-margin-top--0">
-          US Court of Appeals for Veterans Claims
-        </h3>
-        <p>
-          This is a legal appeal outside of the VA and may be a good fit for an
-          appeal of a Board decision.
-        </p>
-        <p>
-          <strong>Note:</strong> This option is available only if it has been
-          fewer than 120 days since your decision date.{' '}
-        </p>
-        <va-link
-          external
-          href="https://www.uscourts.cavc.gov/"
-          text="How to file an appeal on the US Court of Appeals website"
-        />
-      </va-card>
+      <ul className="card-container">
+        <li>
+          <va-card class="vads-u-display--block vads-u-margin-top--3">
+            <h3 className="vads-u-margin-top--0">
+              US Court of Appeals for Veterans Claims
+            </h3>
+            <p>
+              This is a legal appeal outside of the VA and may be a good fit for
+              an appeal of a Board decision.
+            </p>
+            <p>
+              <strong>Note:</strong> This option is available only if it has
+              been fewer than 120 days since your decision date.{' '}
+            </p>
+            <va-link
+              external
+              href="https://www.uscourts.cavc.gov/"
+              text="How to file an appeal on the US Court of Appeals website"
+            />
+          </va-card>
+        </li>
+      </ul>
     </>
   );
 };

--- a/src/applications/appeals/onramp/constants/results-content/common.jsx
+++ b/src/applications/appeals/onramp/constants/results-content/common.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import manifest from '../../manifest.json';
 
-export const HORIZ_RULE = <hr className="vads-u-margin-y--4" />;
+export const HORIZ_RULE = (
+  <hr className="vads-u-margin-y--4" aria-hidden="true" />
+);
 export const NON_DR_HEADING = `Your available options`;
 export const DR_HEADING = `Your decision review options`;
 

--- a/src/applications/appeals/onramp/constants/results-content/non-dr-screens/cards.jsx
+++ b/src/applications/appeals/onramp/constants/results-content/non-dr-screens/cards.jsx
@@ -1,41 +1,49 @@
 import React from 'react';
 
 export const DISABILITY_COMP_CARD = explanation => (
-  <va-card>
-    <h2 className="vads-u-margin-top--0">Disability Compensation Claim</h2>
-    <p>{explanation}</p>
-    <va-link
-      external
-      class="vads-u-display--block vads-u-margin-bottom--2"
-      href="/disability/how-to-file-claim"
-      text="Learn more about Disability Benefits"
-    />
-    <va-link-action
-      href="/disability/file-disability-claim-form-21-526ez/introduction"
-      text="Start disability compensation application"
-    />
-  </va-card>
+  <ul className="card-container">
+    <li>
+      <va-card>
+        <h2 className="vads-u-margin-top--0">Disability Compensation Claim</h2>
+        <p>{explanation}</p>
+        <va-link
+          external
+          class="vads-u-display--block vads-u-margin-bottom--2"
+          href="/disability/how-to-file-claim"
+          text="Learn more about Disability Benefits"
+        />
+        <va-link-action
+          href="/disability/file-disability-claim-form-21-526ez/introduction"
+          text="Start disability compensation application"
+        />
+      </va-card>
+    </li>
+  </ul>
 );
 
 export const CLAIM_FOR_INCREASE_CARD = (
-  <va-card>
-    <h2 className="vads-u-margin-top--0">Claim for increase</h2>
-    <p>
-      This may be a good fit because your condition has worsened since the
-      decision on your initial claim.
-    </p>
-    <p>
-      <strong>Note:</strong> You’ll need to submit evidence with your claim.
-    </p>
-    <va-link
-      external
-      class="vads-u-display--block vads-u-margin-bottom--2"
-      href="/disability/how-to-file-claim/evidence-needed/#what-should-the-evidence-show-"
-      text="Learn more about evidence for a claim for increase"
-    />
-    <va-link-action
-      href="/disability/file-disability-claim-form-21-526ez/introduction"
-      text="Start disability compensation application"
-    />
-  </va-card>
+  <ul className="card-container">
+    <li>
+      <va-card>
+        <h2 className="vads-u-margin-top--0">Claim for increase</h2>
+        <p>
+          This may be a good fit because your condition has worsened since the
+          decision on your initial claim.
+        </p>
+        <p>
+          <strong>Note:</strong> You’ll need to submit evidence with your claim.
+        </p>
+        <va-link
+          external
+          class="vads-u-display--block vads-u-margin-bottom--2"
+          href="/disability/how-to-file-claim/evidence-needed/#what-should-the-evidence-show-"
+          text="Learn more about evidence for a claim for increase"
+        />
+        <va-link-action
+          href="/disability/file-disability-claim-form-21-526ez/introduction"
+          text="Start disability compensation application"
+        />
+      </va-card>
+    </li>
+  </ul>
 );

--- a/src/applications/appeals/onramp/constants/results-content/non-dr-screens/cards.jsx
+++ b/src/applications/appeals/onramp/constants/results-content/non-dr-screens/cards.jsx
@@ -1,49 +1,62 @@
 import React from 'react';
 
 export const DISABILITY_COMP_CARD = explanation => (
-  <ul className="card-container">
-    <li>
-      <va-card>
-        <h2 className="vads-u-margin-top--0">Disability Compensation Claim</h2>
-        <p>{explanation}</p>
-        <va-link
-          external
-          class="vads-u-display--block vads-u-margin-bottom--2"
-          href="/disability/how-to-file-claim"
-          text="Learn more about Disability Benefits"
-        />
-        <va-link-action
-          href="/disability/file-disability-claim-form-21-526ez/introduction"
-          text="Start disability compensation application"
-        />
-      </va-card>
-    </li>
-  </ul>
+  <>
+    {/* Adding a `role="list"` to `ul` with `list-style: none` to work around
+      a problem with Safari not treating the `ul` as a list. */}
+    {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+    <ul className="onramp-list-none" role="list">
+      <li>
+        <va-card>
+          <h2 className="vads-u-margin-top--0">
+            Disability Compensation Claim
+          </h2>
+          <p>{explanation}</p>
+          <va-link
+            external
+            class="vads-u-display--block vads-u-margin-bottom--2"
+            href="/disability/how-to-file-claim"
+            text="Learn more about Disability Benefits"
+          />
+          <va-link-action
+            href="/disability/file-disability-claim-form-21-526ez/introduction"
+            text="Start disability compensation application"
+          />
+        </va-card>
+      </li>
+    </ul>
+  </>
 );
 
 export const CLAIM_FOR_INCREASE_CARD = (
-  <ul className="card-container">
-    <li>
-      <va-card>
-        <h2 className="vads-u-margin-top--0">Claim for increase</h2>
-        <p>
-          This may be a good fit because your condition has worsened since the
-          decision on your initial claim.
-        </p>
-        <p>
-          <strong>Note:</strong> You’ll need to submit evidence with your claim.
-        </p>
-        <va-link
-          external
-          class="vads-u-display--block vads-u-margin-bottom--2"
-          href="/disability/how-to-file-claim/evidence-needed/#what-should-the-evidence-show-"
-          text="Learn more about evidence for a claim for increase"
-        />
-        <va-link-action
-          href="/disability/file-disability-claim-form-21-526ez/introduction"
-          text="Start disability compensation application"
-        />
-      </va-card>
-    </li>
-  </ul>
+  <>
+    {/* Adding a `role="list"` to `ul` with `list-style: none` to work around
+      a problem with Safari not treating the `ul` as a list. */}
+    {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+    <ul className="onramp-list-none" role="list">
+      <li>
+        <va-card>
+          <h2 className="vads-u-margin-top--0">Claim for increase</h2>
+          <p>
+            This may be a good fit because your condition has worsened since the
+            decision on your initial claim.
+          </p>
+          <p>
+            <strong>Note:</strong> You’ll need to submit evidence with your
+            claim.
+          </p>
+          <va-link
+            external
+            class="vads-u-display--block vads-u-margin-bottom--2"
+            href="/disability/how-to-file-claim/evidence-needed/#what-should-the-evidence-show-"
+            text="Learn more about evidence for a claim for increase"
+          />
+          <va-link-action
+            href="/disability/file-disability-claim-form-21-526ez/introduction"
+            text="Start disability compensation application"
+          />
+        </va-card>
+      </li>
+    </ul>
+  </>
 );

--- a/src/applications/appeals/onramp/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/onramp/containers/IntroductionPage.jsx
@@ -48,7 +48,7 @@ const IntroductionPage = ({ router, setIntroPageViewed }) => {
         onClick={startTool}
         text="Start the tool"
       />
-      <hr className="vads-u-margin-y--4" />
+      <hr className="vads-u-margin-y--4" aria-hidden="true" />
       <h3 className="vads-u-margin-top--3">Haven’t received a decision yet?</h3>
       <p>
         This tool is for reviewing VA decisions that have already been made. If

--- a/src/applications/appeals/onramp/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/onramp/containers/IntroductionPage.jsx
@@ -104,7 +104,10 @@ const IntroductionPage = ({ router, setIntroPageViewed }) => {
         If you need to request a decision review for a different VA benefit, you
         can find information about your options here:
       </p>
-      <ul className="onramp-list-none">
+      {/* Adding a `role="list"` to `ul` with `list-style: none` to work around
+        a problem with Safari not treating the `ul` as a list. */}
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+      <ul className="onramp-list-none" role="list">
         <li className="vads-u-margin-bottom--2">
           <va-link
             href="/family-and-caregiver-benefits/survivor-compensation/survivors-pension"

--- a/src/applications/appeals/onramp/sass/onramp.scss
+++ b/src/applications/appeals/onramp/sass/onramp.scss
@@ -12,12 +12,6 @@
     border: 1px solid $vads-color-primary-alt-light;
   }
 
-  .card-container {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
   .not-good-fit-card {
     margin-top: 1.5em;
     padding: 1em 1em 1.5em;

--- a/src/applications/appeals/onramp/sass/onramp.scss
+++ b/src/applications/appeals/onramp/sass/onramp.scss
@@ -12,6 +12,12 @@
     border: 1px solid $vads-color-primary-alt-light;
   }
 
+  .card-container {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
   .not-good-fit-card {
     margin-top: 1.5em;
     padding: 1em 1em 1.5em;

--- a/src/applications/appeals/onramp/utilities/dr-results-card-display-utils.jsx
+++ b/src/applications/appeals/onramp/utilities/dr-results-card-display-utils.jsx
@@ -63,7 +63,12 @@ export const displayNotGoodFitCards = formResponses => {
           Based on your answers, these choices may not fit your situation. You
           are always free to submit any claim you choose.
         </p>
-        <ul className="card-container">{cardsToDisplay}</ul>
+        {/* Adding a `role="list"` to `ul` with `list-style: none` to work around
+          a problem with Safari not treating the `ul` as a list. */}
+        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+        <ul className="onramp-list-none" role="list">
+          {cardsToDisplay}
+        </ul>
       </>
     );
   }
@@ -88,7 +93,16 @@ export const getCardProps = formResponses => {
         {INTRO}
         <OverviewPanel formResponses={formResponses} />
         {PRINT_RESULTS}
-        {gfCards?.length && <ul className="card-container">{gfCards}</ul>}
+        {gfCards?.length && (
+          <>
+            {/* Adding a `role="list"` to `ul` with `list-style: none` to work around
+            a problem with Safari not treating the `ul` as a list. */}
+            {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+            <ul className="onramp-list-none" role="list">
+              {gfCards}
+            </ul>
+          </>
+        )}
         {showOutsideDROption(formResponses)}
         {displayNotGoodFitCards(formResponses)}
         {HORIZ_RULE}

--- a/src/applications/appeals/onramp/utilities/dr-results-card-display-utils.jsx
+++ b/src/applications/appeals/onramp/utilities/dr-results-card-display-utils.jsx
@@ -32,15 +32,15 @@ export const displayCards = (formResponses, goodFit) => {
     if (displayConditionsMet(formResponses, displayConditionsForCard)) {
       if (goodFit) {
         cardsToDisplay.push(
-          <GoodFitCard key={card} card={card} formResponses={formResponses} />,
+          <li key={card}>
+            <GoodFitCard card={card} formResponses={formResponses} />
+          </li>,
         );
       } else {
         cardsToDisplay.push(
-          <NotGoodFitCard
-            key={card}
-            card={card}
-            formResponses={formResponses}
-          />,
+          <li key={card}>
+            <NotGoodFitCard card={card} formResponses={formResponses} />
+          </li>,
         );
       }
     }
@@ -63,7 +63,7 @@ export const displayNotGoodFitCards = formResponses => {
           Based on your answers, these choices may not fit your situation. You
           are always free to submit any claim you choose.
         </p>
-        {cardsToDisplay}
+        <ul className="card-container">{cardsToDisplay}</ul>
       </>
     );
   }
@@ -79,6 +79,8 @@ const INTRO = (
 );
 
 export const getCardProps = formResponses => {
+  const gfCards = displayCards(formResponses, true);
+
   return {
     h1: DR_HEADING,
     bodyContent: (
@@ -86,7 +88,7 @@ export const getCardProps = formResponses => {
         {INTRO}
         <OverviewPanel formResponses={formResponses} />
         {PRINT_RESULTS}
-        {displayCards(formResponses, true)}
+        {gfCards?.length && <ul className="card-container">{gfCards}</ul>}
         {showOutsideDROption(formResponses)}
         {displayNotGoodFitCards(formResponses)}
         {HORIZ_RULE}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add unordered list wrappers for all sections including `<va-card>`s, including places where only one `<va-card>` is present. This helps folks using AT understand the shape of the content for these sections and is in line with the [accessibility guidance](https://design.va.gov/components/card#accessibility-considerations) for `<va-card>`.

Note that the "Not Good Fit" cards (gray cards) on the dynamic summary screen do not use `<va-card>` as they are not a stylistic match for the `<va-card>`, but they were modified so they will be read out similarly to `<va-card>`.

Also includes a change to hide the `<hr>` (horizontal rule) elements from the AT as well so they are not read out.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118527
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118525

## Testing done & screenshots

Ran through screen reader flows to ensure horizontal rules were ignored and the cards were read out properly. Some screenshot examples below.

### Video capture of going through a dynamic summary page with good and not good fit cards
https://github.com/user-attachments/assets/fed67a68-1549-4490-90c6-ee99a75586a5

| Results screen | Markup |
| --- | --- |
| <img width="716" height="887" alt="Screenshot 2025-09-04 at 2 22 01 PM" src="https://github.com/user-attachments/assets/b292584b-d555-40d7-903c-fdb34b8f6069" /> | <img width="401" height="358" alt="Screenshot 2025-09-04 at 2 22 08 PM" src="https://github.com/user-attachments/assets/8e8c9b5e-9c0c-46eb-a742-699a48229fc6" /> |
| <img width="733" height="859" alt="Screenshot 2025-09-04 at 2 24 15 PM" src="https://github.com/user-attachments/assets/2dcf73f9-35ab-4433-92e2-13b82755a162" /> | <img width="401" height="380" alt="Screenshot 2025-09-04 at 2 24 27 PM" src="https://github.com/user-attachments/assets/7fbdf7c7-9010-498e-afec-17b60c6e15c7" /> |
| <img width="715" height="938" alt="Screenshot 2025-09-04 at 2 25 03 PM" src="https://github.com/user-attachments/assets/ca3f7a90-4b58-4244-89ec-e48f15a31124" /> | <img width="404" height="346" alt="Screenshot 2025-09-04 at 2 25 11 PM" src="https://github.com/user-attachments/assets/0a9983f2-0dd0-4dc8-ad7a-a5efb0a12cdd" /> |
| <img width="376" height="934" alt="Screenshot 2025-09-04 at 2 26 07 PM" src="https://github.com/user-attachments/assets/a7351abd-54de-4580-82e1-534cc0d19a7c" /><br/><img width="374" height="493" alt="Screenshot 2025-09-04 at 2 26 13 PM" src="https://github.com/user-attachments/assets/d8f4d170-2147-4d01-8100-262a129c9022" /> | Good Fit Cards<img width="401" height="294" alt="Screenshot 2025-09-04 at 2 26 45 PM" src="https://github.com/user-attachments/assets/718f39a8-3060-4302-8194-965e73f3e180" /><br/>Not Good Fit Cards<img width="402" height="178" alt="Screenshot 2025-09-04 at 2 26 54 PM" src="https://github.com/user-attachments/assets/4a212ee7-05c0-4094-ab97-9d887ae730fa" /><br/>Horizontal Rule<img width="398" height="36" alt="Screenshot 2025-09-04 at 2 27 02 PM" src="https://github.com/user-attachments/assets/b21ff6d6-73ac-4f39-b11c-7759473aaf30" /> |