### PR TITLE
[#118640] Travel Pay, Claim details currency formatting

### DIFF
--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -6,7 +6,7 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles/useFeatureT
 import useSetPageTitle from '../hooks/useSetPageTitle';
 import { formatDateTime } from '../util/dates';
 import { STATUSES, FORM_100998_LINK } from '../constants';
-import { toPascalCase } from '../util/string-helpers';
+import { toPascalCase, currency } from '../util/string-helpers';
 import DocumentDownload from './DocumentDownload';
 import DecisionReason from './DecisionReason';
 
@@ -133,11 +133,11 @@ export default function ClaimDetailsContent({
                 Amount
               </p>
               <p className="vads-u-margin--0">
-                Submitted amount of ${totalCostRequested}
+                Submitted amount of {currency(totalCostRequested)}
               </p>
               {reimbursementAmount > 0 && (
                 <p className="vads-u-margin--0">
-                  Reimbursement amount of ${reimbursementAmount}
+                  Reimbursement amount of {currency(reimbursementAmount)}
                 </p>
               )}
             </div>

--- a/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
@@ -253,7 +253,7 @@ describe('ClaimDetailsContent', () => {
         },
       );
       expect(screen.getByText('Amount')).to.exist;
-      expect(screen.getByText('Submitted amount of $120.5')).to.exist;
+      expect(screen.getByText('Submitted amount of $120.50')).to.exist;
       expect(screen.getByText('Reimbursement amount of $100.25')).to.exist;
     });
 
@@ -269,7 +269,7 @@ describe('ClaimDetailsContent', () => {
         },
       );
       expect(screen.getByText('Amount')).to.exist;
-      expect(screen.getByText('Submitted amount of $75')).to.exist;
+      expect(screen.getByText('Submitted amount of $75.00')).to.exist;
       expect(screen.queryByText(/Reimbursement amount of/)).to.not.exist;
     });
 

--- a/src/applications/travel-pay/tests/util/string-helpers.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/util/string-helpers.unit.spec.jsx
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 
-import { toPascalCase, toSentenceCase } from '../../util/string-helpers';
+import {
+  toPascalCase,
+  toSentenceCase,
+  currency,
+} from '../../util/string-helpers';
 
 describe('toPascalCase', () => {
   it('Generates PascalCase from a string', () => {
@@ -23,5 +27,15 @@ describe('toSentenceCase', () => {
     expect(toSentenceCase(string)).to.eq('In manual review');
     expect(toSentenceCase(camelString)).to.eq('In manual review');
     expect(toSentenceCase(lowString)).to.eq('In manual review');
+  });
+});
+
+describe('currency', () => {
+  it('Formats numbers as US currency', () => {
+    expect(currency(123.45)).to.eq('$123.45');
+    expect(currency('123.45')).to.eq('$123.45');
+    expect(currency(123)).to.eq('$123.00');
+    expect(currency(0)).to.eq('$0.00');
+    expect(currency('1234.567')).to.eq('$1,234.57');
   });
 });

--- a/src/applications/travel-pay/tests/util/string-helpers.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/util/string-helpers.unit.spec.jsx
@@ -33,6 +33,7 @@ describe('toSentenceCase', () => {
 describe('currency', () => {
   it('Formats numbers as US currency', () => {
     expect(currency(123.45)).to.eq('$123.45');
+    expect(currency(123.4)).to.eq('$123.40');
     expect(currency('123.45')).to.eq('$123.45');
     expect(currency(123)).to.eq('$123.00');
     expect(currency(0)).to.eq('$0.00');

--- a/src/applications/travel-pay/util/string-helpers.js
+++ b/src/applications/travel-pay/util/string-helpers.js
@@ -7,3 +7,12 @@ export const toPascalCase = str => {
 export const toSentenceCase = str => {
   return upperFirst(lowerCase(str));
 };
+
+export const currency = amount => {
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+  });
+  return formatter.format(parseFloat(amount));
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adding a helper to ensure currency values are formatted correctly on the Claim Details page

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/118640

## Testing done

Tested the changes with a number of different number formatting to ensure each scenario resolved to the correct currency value.

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="400" height="195" alt="Screenshot 2025-09-04 at 12 17 18 PM" src="https://github.com/user-attachments/assets/7d8f410b-3ff5-4328-ad06-0757a741da91" /> | <img width="374" height="193" alt="Screenshot 2025-09-04 at 12 16 22 PM" src="https://github.com/user-attachments/assets/317f9659-e2c7-4ebe-9c79-e4f3878655ed" /> |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user