### PR TITLE
[#118712] Travel Pay, Partial payment letter matching on claim details

### DIFF
--- a/src/applications/travel-pay/components/ClaimDetailsContent.jsx
+++ b/src/applications/travel-pay/components/ClaimDetailsContent.jsx
@@ -62,11 +62,12 @@ export default function ClaimDetailsContent({
 
   const documentCategories = (documents ?? []).reduce(
     (acc, doc) => {
-      // Do not show clerk note attachments
+      // Do not show clerk note attachments, which should be missing the mimetype
       if (!doc.mimetype) return acc;
-      // TODO: Solidify on pattern match criteria for decision letter, other statically named docs
+
       if (
         doc.filename.includes('Rejection Letter') ||
+        doc.filename.includes('Partial Payment Letter') ||
         doc.filename.includes('Decision Letter')
       )
         acc.clerk.push({ ...doc, text: 'Download your decision letter' });

--- a/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
@@ -185,28 +185,6 @@ describe('ClaimDetailsContent', () => {
       expect($('va-link[text="screenshot.png"]')).to.exist;
     });
 
-    it('renders download links for partial payment letter as decision letter', () => {
-      renderWithStoreAndRouter(
-        <ClaimDetailsContent
-          {...claimDetailsProps}
-          documents={[
-            {
-              filename: 'Partial Payment Letter.docx',
-              mimetype:
-                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            },
-            { filename: 'screenshot.png', mimetype: 'image/png' },
-          ]}
-        />,
-        {
-          initialState: getState(),
-        },
-      );
-
-      expect($('va-link[text="Download your decision letter"]')).to.exist;
-      expect($('va-link[text="screenshot.png"]')).to.exist;
-    });
-
     it('renders only user document links', () => {
       renderWithStoreAndRouter(
         <ClaimDetailsContent

--- a/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/components/ClaimDetailsContent.unit.spec.jsx
@@ -163,6 +163,50 @@ describe('ClaimDetailsContent', () => {
       expect($('va-link[text="note-1.txt"]')).to.not.exist;
     });
 
+    it('renders download links for partial payment letter as decision letter', () => {
+      renderWithStoreAndRouter(
+        <ClaimDetailsContent
+          {...claimDetailsProps}
+          documents={[
+            {
+              filename: 'Partial Payment Letter.docx',
+              mimetype:
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            },
+            { filename: 'screenshot.png', mimetype: 'image/png' },
+          ]}
+        />,
+        {
+          initialState: getState(),
+        },
+      );
+
+      expect($('va-link[text="Download your decision letter"]')).to.exist;
+      expect($('va-link[text="screenshot.png"]')).to.exist;
+    });
+
+    it('renders download links for partial payment letter as decision letter', () => {
+      renderWithStoreAndRouter(
+        <ClaimDetailsContent
+          {...claimDetailsProps}
+          documents={[
+            {
+              filename: 'Partial Payment Letter.docx',
+              mimetype:
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            },
+            { filename: 'screenshot.png', mimetype: 'image/png' },
+          ]}
+        />,
+        {
+          initialState: getState(),
+        },
+      );
+
+      expect($('va-link[text="Download your decision letter"]')).to.exist;
+      expect($('va-link[text="screenshot.png"]')).to.exist;
+    });
+
     it('renders only user document links', () => {
       renderWithStoreAndRouter(
         <ClaimDetailsContent

--- a/src/applications/travel-pay/tests/e2e/claim-details-content.cypress.spec.js
+++ b/src/applications/travel-pay/tests/e2e/claim-details-content.cypress.spec.js
@@ -217,8 +217,9 @@ describe(`${appName} -- Claim Details Content`, () => {
         documents: [
           {
             documentId: 'decision123',
-            filename: 'Decision Letter - Claim TC123.pdf',
-            mimetype: 'application/pdf',
+            filename: 'Decision Letter.docx',
+            mimetype:
+              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
           },
         ],
       });
@@ -227,6 +228,64 @@ describe(`${appName} -- Claim Details Content`, () => {
       cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
 
       // Decision letter should be displayed above claim information
+      cy.get('va-link').should('have.length.at.least', 1);
+    });
+
+    it('displays partial payment letter as decision letter', () => {
+      ApiInitializer.initializeFeatureToggle.withAllFeatures(); // Ensure feature toggles are enabled
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Partial payment',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 20.0,
+        reimbursementAmount: 14.52,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [
+          {
+            documentId: 'partial123',
+            filename: 'Partial Payment Letter.docx',
+            mimetype:
+              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          },
+        ],
+      });
+
+      cy.login(user);
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Partial payment letter should be displayed as decision letter
+      cy.get('va-link').should('have.length.at.least', 1);
+    });
+
+    it('displays rejection letter as decision letter', () => {
+      ApiInitializer.initializeFeatureToggle.withAllFeatures(); // Ensure feature toggles are enabled
+      cy.intercept('GET', '/travel_pay/v0/claims/*', {
+        claimId: '73611905-71bf-46ed-b1ec-e790593b8565',
+        claimNumber: 'TC0000000000001',
+        claimStatus: 'Denied',
+        appointmentDate: '2024-01-01T16:45:34.465Z',
+        facilityName: 'Cheyenne VA Medical Center',
+        totalCostRequested: 20.0,
+        reimbursementAmount: 0,
+        createdOn: '2025-03-12T20:27:14.088Z',
+        modifiedOn: '2025-03-12T20:27:14.088Z',
+        documents: [
+          {
+            documentId: 'rejection123',
+            filename: 'Rejection Letter.docx',
+            mimetype:
+              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          },
+        ],
+      });
+
+      cy.login(user);
+      cy.visit(`${rootUrl}/claims/73611905-71bf-46ed-b1ec-e790593b8565`);
+
+      // Rejection letter should be displayed as decision letter
       cy.get('va-link').should('have.length.at.least', 1);
     });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

On the claim details page, the front end uses simple filename pattern matching on claim documents to determine which documents are user uploaded and which is a decision letter. Currently, it's looking for filenames "Decision Letter" and "Rejection Letter". However, when a claim is partially paid, that letter is called "Partial Payment Letter". Because this filename isn't included in the pattern match condition, it is shown on the screen as a "user uploaded document" -- which it is not.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/118712

## Testing done

Tested the scenario described above with mock data to ensure the correct rendering.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="750" height="2885" alt="before_mobile" src="https://github.com/user-attachments/assets/42de44b0-c564-4ff7-9814-43caa37f5381" /> | <img width="750" height="2909" alt="after_mobile" src="https://github.com/user-attachments/assets/a43b2f10-7aa3-468c-9546-62adca363d8c" /> |
| Desktop | <img width="2414" height="2121" alt="before_desktop" src="https://github.com/user-attachments/assets/c16faf56-ad77-4fb5-a7ce-cd5a6d109b61" /> | <img width="2414" height="2134" alt="after_desktop" src="https://github.com/user-attachments/assets/cfff4868-12f7-40db-9755-42a195bc373e" /> |

## What areas of the site does it impact?

Travel Pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user