### PR TITLE
10-10EZ | Update submit transformer for v2 insurance

### DIFF
--- a/src/applications/hca/config/submit-transformer.js
+++ b/src/applications/hca/config/submit-transformer.js
@@ -79,6 +79,16 @@ export const submitTransformer = (
     dataToMap = set('dependents', [], dataToMap);
   }
 
+  // map insurance policies
+  if (form.data['view:isInsuranceV2Enabled']) {
+    const { providers } = dataToMap;
+    dataToMap = set(
+      'isCoveredByHealthInsurance',
+      !!providers?.length,
+      dataToMap,
+    );
+  }
+
   let gaClientId;
   if (!disableAnalytics) {
     // add logging to track user volume of forms submitted with specific questions answered
@@ -103,7 +113,7 @@ export const submitTransformer = (
   }
 
   // stringify form data for submission
-  // NOTE: we don’t to remove dependents in the normal empty value clean up
+  // NOTE: we don’t want to remove dependents in the normal empty value clean-up
   try {
     const replacer = (key, value) => {
       if (key === 'dependents') return value;

--- a/src/applications/hca/tests/unit/config/submit-transformer.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/config/submit-transformer.unit.spec.jsx
@@ -112,6 +112,60 @@ describe('hca `submitTransformer` utility', () => {
     expect(Object.keys(dependents[0])).to.have.lengthOf(13);
   });
 
+  it('should set `isCoveredByHealthInsurance` to `true` when insurance v2 is enabled and providers exist', () => {
+    const testData = {
+      ...maxTestData,
+      isCoveredByHealthInsurance: undefined,
+      'view:isInsuranceV2Enabled': true,
+    };
+    const form = getForm({ formData: testData });
+    const transformedData = submitTransformer(formConfig, form);
+    const { form: formData } = JSON.parse(transformedData);
+    const { isCoveredByHealthInsurance } = JSON.parse(formData);
+    expect(isCoveredByHealthInsurance).to.equal(true);
+  });
+
+  it('should set `isCoveredByHealthInsurance` to `false` when insurance v2 is enabled and providers are empty/missing', () => {
+    // Case 1: explicitly empty array
+    const withEmptyProviders = {
+      ...minTestData,
+      isCoveredByHealthInsurance: undefined,
+      'view:isInsuranceV2Enabled': true,
+    };
+    const form1 = getForm({ formData: withEmptyProviders });
+    const transformed1 = submitTransformer(formConfig, form1);
+    const { form: formData1 } = JSON.parse(transformed1);
+    const parsed1 = JSON.parse(formData1);
+    expect(parsed1.isCoveredByHealthInsurance).to.equal(false);
+
+    // Case 2: providers omitted entirely (defaults to [])
+    const withoutProviders = {
+      ...minTestData,
+      providers: undefined,
+      isCoveredByHealthInsurance: undefined,
+      'view:isInsuranceV2Enabled': true,
+    };
+    const form2 = getForm({ formData: withoutProviders });
+    const transformed2 = submitTransformer(formConfig, form2);
+    const { form: formData2 } = JSON.parse(transformed2);
+    const parsed2 = JSON.parse(formData2);
+    expect(parsed2.isCoveredByHealthInsurance).to.equal(false);
+  });
+
+  it('should not set `isCoveredByHealthInsurance` when insurance v2 is disabled', () => {
+    const testData = {
+      ...maxTestData,
+      'view:isInsuranceV2Enabled': false,
+    };
+    const form = getForm({ formData: testData });
+    const transformedData = submitTransformer(formConfig, form);
+    const { form: formData } = JSON.parse(transformedData);
+    const { isCoveredByHealthInsurance } = JSON.parse(formData);
+    expect(isCoveredByHealthInsurance).to.equal(
+      testData.isCoveredByHealthInsurance,
+    );
+  });
+
   it('should default dependent income/expense values to `0` when omitted', () => {
     const testDependent = omit(maxTestData.dependents[0], [
       'view:grossIncome',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the submit transformer for the Health Care Application to properly fill a data value related to insurance policy declaration. The data update sets the value based on the `providers` array length and is targeted at the v2 update that migrates the insurance section to the ArrayBuilder form pattern.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#91361

## Acceptance criteria

- Data value is correctly-populated when v2 is active

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user