### PR TITLE
10-10d extended | Map sponsor email in submit transformer

### DIFF
--- a/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/submitTransformer.js
@@ -253,6 +253,7 @@ export default function transformForSubmit(formConfig, form) {
     ssnOrTin: withConcatAddresses.sponsorSsn || '',
     dateOfBirth: formatDate(withConcatAddresses.sponsorDob) || '',
     phoneNumber: withConcatAddresses.sponsorPhone || '',
+    email: withConcatAddresses.sponsorEmail || '',
     address: withConcatAddresses.sponsorAddress || {},
     sponsorIsDeceased: withConcatAddresses.sponsorIsDeceased,
     dateOfDeath: formatDate(withConcatAddresses.sponsorDOD) || '',

--- a/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/tests/unit/config/submitTransformer.unit.spec.jsx
@@ -333,6 +333,18 @@ describe('10-10d-extended transform for submit', () => {
     expect(transformed.certifierRole).to.equal('other');
   });
 
+  it('should map `sponsorEmail` into veteran data', () => {
+    const testData = { data: { sponsorEmail: 'veteran@example.com' } };
+    const { veteran } = JSON.parse(transformForSubmit(formConfig, testData));
+    expect(veteran.email).to.equal('veteran@example.com');
+  });
+
+  it('should default veteran email to empty string when `sponsorEmail` is omitted', () => {
+    const testData = { data: {} };
+    const { veteran } = JSON.parse(transformForSubmit(formConfig, testData));
+    expect(veteran.email).to.equal('');
+  });
+
   describe('address formatting', () => {
     it('should properly format sponsor address fields', () => {
       const testData = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR maps the added sponsor email field to the Veteran data in the submit transformer.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#116866

## Acceptance criteria

- Sponsor email is appropriately mapped to the Veteran data

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user