### PR TITLE
Add cache tags to vaosapi and update tests

### DIFF
--- a/src/applications/vaos/redux/api/vaosApi.js
+++ b/src/applications/vaos/redux/api/vaosApi.js
@@ -14,6 +14,7 @@ export const vaosApi = createApi({
   // Cache is normally 60 seconds by default, but it causes each test
   // to take an additional 60 seconds to run, so we set it to 0.
   keepUnusedDataFor: environment.isUnitTest() ? 0 : 60,
+  tagTypes: ['Referral'],
   endpoints: builder => ({
     getReferralById: builder.query({
       async queryFn(referralId) {
@@ -26,6 +27,7 @@ export const vaosApi = createApi({
           };
         }
       },
+      providesTags: ['Referral'],
     }),
     getPatientReferrals: builder.query({
       async queryFn() {
@@ -38,6 +40,7 @@ export const vaosApi = createApi({
           };
         }
       },
+      providesTags: ['Referral'],
       // Needs an argumant to be passed in to trigger the query.
       async onQueryStarted(id, { dispatch }) {
         dispatch(fetchPendingAppointments());
@@ -111,6 +114,7 @@ export const vaosApi = createApi({
           };
         }
       },
+      invalidatesTags: ['Referral'],
     }),
   }),
 });

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -36,40 +36,6 @@ describe('VAOS Component: ReviewAndConfirm', () => {
       appointmentInfoLoading: false,
       referralAppointmentInfo: {},
     },
-    appointmentApi: {
-      queries: {
-        // 'getPatientReferrals(undefined)': {
-        //   status: 'fulfilled',
-        //   endpointName: 'getPatientReferrals',
-        //   requestId: 'UiGaEjXQrhh6VUwbuctyx',
-        //   startedTimeStamp: 1757089760670,
-        //   data: [
-        //     {
-        //       id: '6cg8T26YivnL68JzeTaV0w==00',
-        //       type: 'referrals',
-        //       attributes: {
-        //         expirationDate: '2026-03-05',
-        //         uuid: '6cg8T26YivnL68JzeTaV0w==00',
-        //         categoryOfCare: 'OPTOMETRY',
-        //         referralNumber: 'VA0000007241',
-        //         referralConsultId: '984_646907',
-        //         stationId: '659',
-        //       },
-        //     },
-        //   ],
-        //   fulfilledTimeStamp: 1757089760799,
-        // },
-      },
-      prodvided: {
-        // Referral: {
-        //   // eslint-disable-next-line camelcase
-        //   __internal_without_id: ['getPatientReferrals(undefined)'],
-        // },
-      },
-      subscriptions: {
-        // 'getPatientReferrals(undefined)': {},
-      },
-    },
   };
   const initialEmptyState = {
     featureToggles: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds RTK cache tags to getReferral queries and invalidates after submitting a referral appointment.
- This should help reduce stale data on the referral list page. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118780

## Testing done

- When completing a referral appointment and clicking back to appointments followed by clicking the see referrals link, there wasn't a network request to get new data so a completed referral could show.
- The redux store now has all getReferral requests cleared after submitting the appointment. 

## Screenshots
N/A

## What areas of the site does it impact?

The referral list page at `/my-health/appointments/referrals-requests`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A