### PR TITLE
115450 Implement revised content for CHAMPVA beneficiaries and others who use Meds by Mail

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedsByMailContent.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedsByMailContent.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+const MedsByMailContent = () => (
+  <>
+    <h2
+      className="vads-u-margin-top--3 medium-screen:vads-u-font-size--h3"
+      data-testid="meds-by-mail-header"
+    >
+      If you use Meds by Mail
+    </h2>
+    <p data-testid="meds-by-mail-top-level-text">
+      We may not have your allergy records in our My HealtheVet tools. But the
+      Meds by Mail servicing center keeps a record of your allergies and
+      reactions to medications.
+    </p>
+    <div className="vads-u-margin-bottom--4">
+      <va-additional-info
+        data-testId="meds-by-mail-additional-info"
+        trigger="How to update your allergies and reactions if you use Meds by Mail"
+      >
+        <p>
+          If you have a new allergy or reaction, tell your provider. Or you can
+          call us at{' '}
+          <va-telephone
+            className="help-phone-number-link"
+            contact="8662297389"
+          />{' '}
+          or{' '}
+          <va-telephone
+            className="help-phone-number-link"
+            contact="8883850235"
+          />{' '}
+          (<va-telephone contact={CONTACTS[711]} tty />) and ask us to update
+          your records. We’re here Monday through Friday, 8:00 a.m. to 7:30 p.m.
+          ET.
+        </p>
+      </va-additional-info>
+    </div>
+  </>
+);
+
+export default MedsByMailContent;

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -61,7 +61,11 @@ import {
   setFilterOption,
   setPageNumber,
 } from '../redux/preferencesSlice';
-import { selectUserDob, selectUserFullName } from '../selectors/selectUser';
+import {
+  selectUserDob,
+  selectUserFullName,
+  selectHasMedsByMailFacility,
+} from '../selectors/selectUser';
 import { selectPrescriptionId } from '../selectors/selectPrescription';
 import {
   selectSortOption,
@@ -78,6 +82,7 @@ const Prescriptions = () => {
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const userName = useSelector(selectUserFullName);
   const dob = useSelector(selectUserDob);
+  const hasMedsByMailFacility = useSelector(selectHasMedsByMailFacility);
 
   // Get sort/filter selections from store.
   const selectedSortOption = useSelector(selectSortOption);
@@ -671,32 +676,80 @@ const Prescriptions = () => {
     );
   };
 
-  const renderHeader = () => (
-    <>
-      <h1 data-testid="list-page-title" className="vads-u-margin-bottom--2">
-        Medications
-      </h1>
-      <p
-        className="vads-u-margin-top--0 vads-u-margin-bottom--4"
-        data-testid="Title-Notes"
-      >
-        <>
-          Bring your medications list to each appointment. And tell your
-          provider about any new allergies or reactions. If you use Meds by
-          Mail, you can also call your servicing center and ask them to update
-          your records.
-        </>
-      </p>
-      <a
-        href="/my-health/medical-records/allergies"
-        rel="noreferrer"
-        className="vads-u-display--block vads-u-margin-bottom--3"
-        data-testid="allergies-link"
-      >
-        Go to your allergies and reactions
-      </a>
-    </>
-  );
+  const renderMedsByMailContent = () => {
+    if (!hasMedsByMailFacility) {
+      return null;
+    }
+
+    return (
+      <>
+        <h2 className="vads-u-margin-top--3 medium-screen:vads-u-font-size--h3">
+          If you use Meds by Mail
+        </h2>
+        <p>
+          We may not have your allergy records in our My HealtheVet tools. But
+          the Meds by Mail servicing center keeps a record of your allergies and
+          reactions to medications.
+        </p>
+        <div className="vads-u-margin-bottom--4">
+          <va-additional-info
+            data-testId="meds-by-mail-additional-info"
+            trigger="How to update your allergies and reactions if you use Meds by Mail"
+          >
+            <p>
+              If you have a new allergy or reaction, tell your provider. Or you
+              can call us at{' '}
+              <va-telephone
+                className="help-phone-number-link"
+                contact="8662297389"
+              />{' '}
+              or{' '}
+              <va-telephone
+                className="help-phone-number-link"
+                contact="8883850235"
+              />{' '}
+              (<va-telephone contact={CONTACTS[711]} tty />) and ask us to
+              update your records. We’re here Monday through Friday, 8:00 a.m.
+              to 7:30 p.m. ET.
+            </p>
+          </va-additional-info>
+        </div>
+      </>
+    );
+  };
+
+  const renderHeader = () => {
+    let titleNotesMessage =
+      'Bring your medications list to each appointment. And tell your provider about any new allergies or reactions.';
+
+    if (!hasMedsByMailFacility) {
+      titleNotesMessage +=
+        ' If you use Meds by Mail, you can also call your servicing center and ask them to update your records.';
+    }
+
+    return (
+      <>
+        <h1 data-testid="list-page-title" className="vads-u-margin-bottom--2">
+          Medications
+        </h1>
+        <p
+          className="vads-u-margin-top--0 vads-u-margin-bottom--4"
+          data-testid="Title-Notes"
+        >
+          {titleNotesMessage}
+          <a
+            href="/my-health/medical-records/allergies"
+            rel="noreferrer"
+            className="vads-u-display--block vads-u-margin-bottom--3"
+            data-testid="allergies-link"
+          >
+            Go to your allergies and reactions
+          </a>
+          {renderMedsByMailContent()}
+        </p>
+      </>
+    );
+  };
 
   const renderMedicationsContent = () => {
     // No medications exist

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -686,7 +686,7 @@ const Prescriptions = () => {
         ' If you use Meds by Mail, you can also call your servicing center and ask them to update your records.';
     }
 
-    const titleNotesBottomMarginNumber = hasMedsByMailFacility ? 3 : 4;
+    const titleNotesBottomMarginUnit = hasMedsByMailFacility ? 3 : 4;
 
     return (
       <>
@@ -694,7 +694,7 @@ const Prescriptions = () => {
           Medications
         </h1>
         <p
-          className={`vads-u-margin-top--0 vads-u-margin-bottom--${titleNotesBottomMarginNumber}`}
+          className={`vads-u-margin-top--0 vads-u-margin-bottom--${titleNotesBottomMarginUnit}`}
           data-testid="Title-Notes"
         >
           {titleNotesMessage}

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -686,13 +686,15 @@ const Prescriptions = () => {
         ' If you use Meds by Mail, you can also call your servicing center and ask them to update your records.';
     }
 
+    const titleNotesBottomMarginNumber = hasMedsByMailFacility ? 3 : 4;
+
     return (
       <>
         <h1 data-testid="list-page-title" className="vads-u-margin-bottom--2">
           Medications
         </h1>
         <p
-          className="vads-u-margin-top--0 vads-u-margin-bottom--4"
+          className={`vads-u-margin-top--0 vads-u-margin-bottom--${titleNotesBottomMarginNumber}`}
           data-testid="Title-Notes"
         >
           {titleNotesMessage}

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -698,16 +698,15 @@ const Prescriptions = () => {
           data-testid="Title-Notes"
         >
           {titleNotesMessage}
-          <a
-            href="/my-health/medical-records/allergies"
-            rel="noreferrer"
-            className="vads-u-display--block vads-u-margin-bottom--3"
-            data-testid="allergies-link"
-          >
-            Go to your allergies and reactions
-          </a>
-          {renderMedsByMailContent()}
         </p>
+        <a
+          href="/my-health/medical-records/allergies"
+          rel="noreferrer"
+          className="vads-u-display--block vads-u-margin-bottom--3"
+          data-testid="allergies-link"
+        >
+          Go to your allergies and reactions
+        </a>
         {hasMedsByMailFacility && <MedsByMailContent />}
       </>
     );

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -19,6 +19,7 @@ import {
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import MedicationsList from '../components/MedicationsList/MedicationsList';
 import MedicationsListSort from '../components/MedicationsList/MedicationsListSort';
+import MedsByMailContent from '../components/MedicationsList/MedsByMailContent';
 import {
   dateFormat,
   generateTextFile,
@@ -676,48 +677,6 @@ const Prescriptions = () => {
     );
   };
 
-  const renderMedsByMailContent = () => {
-    if (!hasMedsByMailFacility) {
-      return null;
-    }
-
-    return (
-      <>
-        <h2 className="vads-u-margin-top--3 medium-screen:vads-u-font-size--h3">
-          If you use Meds by Mail
-        </h2>
-        <p>
-          We may not have your allergy records in our My HealtheVet tools. But
-          the Meds by Mail servicing center keeps a record of your allergies and
-          reactions to medications.
-        </p>
-        <div className="vads-u-margin-bottom--4">
-          <va-additional-info
-            data-testId="meds-by-mail-additional-info"
-            trigger="How to update your allergies and reactions if you use Meds by Mail"
-          >
-            <p>
-              If you have a new allergy or reaction, tell your provider. Or you
-              can call us at{' '}
-              <va-telephone
-                className="help-phone-number-link"
-                contact="8662297389"
-              />{' '}
-              or{' '}
-              <va-telephone
-                className="help-phone-number-link"
-                contact="8883850235"
-              />{' '}
-              (<va-telephone contact={CONTACTS[711]} tty />) and ask us to
-              update your records. We’re here Monday through Friday, 8:00 a.m.
-              to 7:30 p.m. ET.
-            </p>
-          </va-additional-info>
-        </div>
-      </>
-    );
-  };
-
   const renderHeader = () => {
     let titleNotesMessage =
       'Bring your medications list to each appointment. And tell your provider about any new allergies or reactions.';
@@ -747,7 +706,7 @@ const Prescriptions = () => {
           </a>
           {renderMedsByMailContent()}
         </p>
-        {renderMedsByMailContent()}
+        {hasMedsByMailFacility && <MedsByMailContent />}
       </>
     );
   };

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -747,6 +747,7 @@ const Prescriptions = () => {
           </a>
           {renderMedsByMailContent()}
         </p>
+        {renderMedsByMailContent()}
       </>
     );
   };

--- a/src/applications/mhv-medications/mocks/api/user/index.js
+++ b/src/applications/mhv-medications/mocks/api/user/index.js
@@ -59,10 +59,6 @@ const defaultUser = {
             facility_id: '984',
             is_cerner: false,
           },
-          {
-            facility_id: '741MM',
-            is_cerner: false,
-          },
         ],
         va_patient: true,
         mhv_account_state: 'OK',

--- a/src/applications/mhv-medications/mocks/api/user/index.js
+++ b/src/applications/mhv-medications/mocks/api/user/index.js
@@ -59,6 +59,10 @@ const defaultUser = {
             facility_id: '984',
             is_cerner: false,
           },
+          {
+            facility_id: '741MM',
+            is_cerner: false,
+          },
         ],
         va_patient: true,
         mhv_account_state: 'OK',

--- a/src/applications/mhv-medications/selectors/selectUser.js
+++ b/src/applications/mhv-medications/selectors/selectUser.js
@@ -1,3 +1,10 @@
+import { MEDS_BY_MAIL_FACILITY_ID } from '../util/constants';
+
 export const selectUserDob = state => state.user.profile.dob;
 export const selectUserFullName = state => state.user.profile.userFullName;
 export const selectUserFacility = state => state?.user?.profile?.facilities;
+
+export const selectHasMedsByMailFacility = state =>
+  state?.user?.profile?.facilities?.some(
+    ({ facilityId }) => facilityId === MEDS_BY_MAIL_FACILITY_ID,
+  ) ?? false;

--- a/src/applications/mhv-medications/tests/components/MedicationsList/MedsByMailContent.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/MedicationsList/MedsByMailContent.unit.spec.jsx
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import reducer from '../../../reducers';
+import MedsByMailContent from '../../../components/MedicationsList/MedsByMailContent';
+
+describe('MedsByMailContent component', () => {
+  const setup = () => {
+    return renderWithStoreAndRouterV6(<MedsByMailContent />, {
+      reducers: reducer,
+    });
+  };
+
+  it('renders correct content', () => {
+    const screen = setup();
+
+    expect(
+      screen.getByText('If you use Meds by Mail', {
+        selector: 'h2',
+        exact: true,
+      }),
+    ).to.exist;
+
+    expect(
+      screen.queryByText(
+        'We may not have your allergy records in our My HealtheVet tools. But the Meds by Mail servicing center keeps a record of your allergies and reactions to medications.',
+        {
+          selector: 'p',
+          exact: true,
+        },
+      ),
+    ).to.exist;
+
+    const additionalContentExpandedBlock = screen.queryByText(
+      /If you have a new allergy or reaction, tell your provider\. Or you can call us at/,
+      {
+        selector: 'p',
+      },
+    );
+
+    expect(additionalContentExpandedBlock).to.exist;
+
+    expect(
+      screen.queryByText(
+        /and ask us to update your records. We’re here Monday through Friday, 8:00 a\.m\. to 7:30 p\.m\. ET./,
+        {
+          selector: 'p',
+        },
+      ),
+    ).to.exist;
+
+    const telephoneElements = Array.from(
+      additionalContentExpandedBlock.querySelectorAll('va-telephone'),
+    );
+
+    const telephoneAttributes = telephoneElements.map(node => [
+      node.getAttribute('contact'),
+      node.getAttribute('tty'),
+    ]);
+
+    expect(telephoneAttributes).to.deep.equal([
+      ['8662297389', null],
+      ['8883850235', null],
+      [CONTACTS[711], 'true'],
+    ]);
+  });
+});

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -218,19 +218,6 @@ describe('Medications Prescriptions container', () => {
     expect(screen.getByText('Go to your allergies and reactions')).to.exist;
   });
 
-  it('displays "If you print or download this list, we\'ll include a list of your allergies." if mhv_medications_display_allergies feature flag is set to false', async () => {
-    const screen = setup({
-      ...initialState,
-      featureToggles: {
-        // eslint-disable-next-line camelcase
-        mhv_medications_display_allergies: false,
-      },
-    });
-    expect(await screen.getByTestId('Title-Notes').textContent).to.match(
-      /If you print or download this list, we’ll include a list of your allergies./,
-    );
-  });
-
   it('displays filter accordion', async () => {
     const screen = setup();
     expect(await screen.getByTestId('filter-accordion')).to.exist;

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import * as uniqueUserMetrics from '~/platform/mhv/unique_user_metrics';
@@ -10,6 +11,7 @@ import * as prescriptionsApiModule from '../../api/prescriptionsApi';
 import { stubAllergiesApi, stubPrescriptionsListApi } from '../testing-utils';
 import Prescriptions from '../../containers/Prescriptions';
 import emptyPrescriptionsList from '../e2e/fixtures/empty-prescriptions-list.json';
+import { MEDS_BY_MAIL_FACILITY_ID } from '../../util/constants';
 
 let sandbox;
 let logUniqueUserMetricsEventsStub;
@@ -217,8 +219,106 @@ describe('Medications Prescriptions container', () => {
     expect(screen.getByText('Go to your allergies and reactions')).to.exist;
   });
 
+  it('displays "If you print or download this list, we\'ll include a list of your allergies." if mhv_medications_display_allergies feature flag is set to false', async () => {
+    const screen = setup({
+      ...initialState,
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        mhv_medications_display_allergies: false,
+      },
+    });
+    expect(await screen.getByTestId('Title-Notes').textContent).to.match(
+      /If you print or download this list, we’ll include a list of your allergies./,
+    );
+  });
+
   it('displays filter accordion', async () => {
     const screen = setup();
     expect(await screen.getByTestId('filter-accordion')).to.exist;
+  });
+
+  const validateMedsByMailContent = (screen, isMedsByMailUser) => {
+    const medsByMailTitleNotesMessage = screen.queryByText(
+      /If you use Meds by Mail, you can also call your servicing center and ask them to update your records\./,
+      {
+        selector: 'p',
+      },
+    );
+
+    const medsByMailHeader = screen.queryByText('If you use Meds by Mail', {
+      selector: 'h2',
+      exact: true,
+    });
+
+    const additionalContentText = screen.queryByText(
+      'We may not have your allergy records in our My HealtheVet tools. But the Meds by Mail servicing center keeps a record of your allergies and reactions to medications.',
+      {
+        selector: 'p',
+        exact: true,
+      },
+    );
+
+    const additionalContentExpandedBlock1 = screen.queryByText(
+      /If you have a new allergy or reaction, tell your provider\. Or you can call us at/,
+      {
+        selector: 'p',
+      },
+    );
+
+    const additionalContentExpandedBlock2 = screen.queryByText(
+      /and ask us to update your records. We’re here Monday through Friday, 8:00 a\.m\. to 7:30 p\.m\. ET./,
+      {
+        selector: 'p',
+      },
+    );
+
+    if (isMedsByMailUser) {
+      expect(medsByMailTitleNotesMessage).not.to.exist;
+      expect(medsByMailHeader).to.exist;
+      expect(additionalContentText).to.exist;
+      expect(additionalContentExpandedBlock1).to.exist;
+      expect(additionalContentExpandedBlock2).to.exist;
+
+      const telephoneElements = Array.from(
+        additionalContentExpandedBlock1.querySelectorAll('va-telephone'),
+      );
+
+      const telephoneAttributes = telephoneElements.map(node => [
+        node.getAttribute('contact'),
+        node.getAttribute('tty'),
+      ]);
+
+      expect(telephoneAttributes).to.deep.equal([
+        ['8662297389', null],
+        ['8883850235', null],
+        [CONTACTS[711], 'true'],
+      ]);
+    } else {
+      expect(medsByMailTitleNotesMessage).to.exist;
+      expect(medsByMailHeader).not.to.exist;
+      expect(additionalContentText).not.to.exist;
+      expect(additionalContentExpandedBlock1).not.to.exist;
+      expect(additionalContentExpandedBlock2).not.to.exist;
+    }
+  };
+
+  it('displays Meds by Mail content for Meds by Mail users', async () => {
+    const screen = setup({
+      ...initialState,
+      user: {
+        profile: {
+          userFullName: { first: 'test', last: 'last', suffix: 'jr' },
+          dob: '2000-01-01',
+          facilities: [{ facilityId: MEDS_BY_MAIL_FACILITY_ID }],
+        },
+      },
+    });
+
+    validateMedsByMailContent(screen, true);
+  });
+
+  it('does not display Meds by Mail content for non-Meds by Mail users', async () => {
+    const screen = setup();
+    validateMedsByMailContent(screen, false);
   });
 });

--- a/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/Prescriptions.unit.spec.jsx
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import React from 'react';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import * as uniqueUserMetrics from '~/platform/mhv/unique_user_metrics';
@@ -237,71 +236,6 @@ describe('Medications Prescriptions container', () => {
     expect(await screen.getByTestId('filter-accordion')).to.exist;
   });
 
-  const validateMedsByMailContent = (screen, isMedsByMailUser) => {
-    const medsByMailTitleNotesMessage = screen.queryByText(
-      /If you use Meds by Mail, you can also call your servicing center and ask them to update your records\./,
-      {
-        selector: 'p',
-      },
-    );
-
-    const medsByMailHeader = screen.queryByText('If you use Meds by Mail', {
-      selector: 'h2',
-      exact: true,
-    });
-
-    const additionalContentText = screen.queryByText(
-      'We may not have your allergy records in our My HealtheVet tools. But the Meds by Mail servicing center keeps a record of your allergies and reactions to medications.',
-      {
-        selector: 'p',
-        exact: true,
-      },
-    );
-
-    const additionalContentExpandedBlock1 = screen.queryByText(
-      /If you have a new allergy or reaction, tell your provider\. Or you can call us at/,
-      {
-        selector: 'p',
-      },
-    );
-
-    const additionalContentExpandedBlock2 = screen.queryByText(
-      /and ask us to update your records. We’re here Monday through Friday, 8:00 a\.m\. to 7:30 p\.m\. ET./,
-      {
-        selector: 'p',
-      },
-    );
-
-    if (isMedsByMailUser) {
-      expect(medsByMailTitleNotesMessage).not.to.exist;
-      expect(medsByMailHeader).to.exist;
-      expect(additionalContentText).to.exist;
-      expect(additionalContentExpandedBlock1).to.exist;
-      expect(additionalContentExpandedBlock2).to.exist;
-
-      const telephoneElements = Array.from(
-        additionalContentExpandedBlock1.querySelectorAll('va-telephone'),
-      );
-
-      const telephoneAttributes = telephoneElements.map(node => [
-        node.getAttribute('contact'),
-        node.getAttribute('tty'),
-      ]);
-
-      expect(telephoneAttributes).to.deep.equal([
-        ['8662297389', null],
-        ['8883850235', null],
-        [CONTACTS[711], 'true'],
-      ]);
-    } else {
-      expect(medsByMailTitleNotesMessage).to.exist;
-      expect(medsByMailHeader).not.to.exist;
-      expect(additionalContentText).not.to.exist;
-      expect(additionalContentExpandedBlock1).not.to.exist;
-      expect(additionalContentExpandedBlock2).not.to.exist;
-    }
-  };
-
   it('displays Meds by Mail content for Meds by Mail users', async () => {
     const screen = setup({
       ...initialState,
@@ -314,11 +248,34 @@ describe('Medications Prescriptions container', () => {
       },
     });
 
-    validateMedsByMailContent(screen, true);
+    expect(
+      screen.queryByText(
+        /If you use Meds by Mail, you can also call your servicing center and ask them to update your records\./,
+        {
+          selector: 'p',
+        },
+      ),
+    ).not.to.exist;
+
+    expect(screen.getByTestId('meds-by-mail-header')).to.exist;
+    expect(screen.getByTestId('meds-by-mail-top-level-text')).to.exist;
+    expect(screen.getByTestId('meds-by-mail-additional-info')).to.exist;
   });
 
   it('does not display Meds by Mail content for non-Meds by Mail users', async () => {
     const screen = setup();
-    validateMedsByMailContent(screen, false);
+
+    expect(
+      screen.getByText(
+        /If you use Meds by Mail, you can also call your servicing center and ask them to update your records\./,
+        {
+          selector: 'p',
+        },
+      ),
+    ).to.exist;
+
+    expect(screen.queryByTestId('meds-by-mail-header')).not.to.exist;
+    expect(screen.queryByTestId('meds-by-mail-top-level-text')).not.to.exist;
+    expect(screen.queryByTestId('meds-by-mail-additional-info')).not.to.exist;
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/fixtures/user-meds-by-mail.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/user-meds-by-mail.json
@@ -1,0 +1,144 @@
+{
+    "data": {
+        "id": "",
+        "type": "users_scaffolds",
+        "attributes": {
+            "services": [
+                "facilities",
+                "hca",
+                "edu-benefits",
+                "form-save-in-progress",
+                "form-prefill",
+                "rx",
+                "messaging",
+                "health-records",
+                "add-person",
+                "user-profile",
+                "appeals-status",
+                "identity-proofed",
+                "vet360"
+            ],
+            "account": {
+                "accountUuid": "5180b4d9-4dbb-49fc-b5aa-86802f6b7044"
+            },
+            "profile": {
+                "email": "test@test123.com",
+                "firstName": "Safari",
+                "middleName": null,
+                "lastName": "Mhvtp",
+                "birthDate": "2002-04-26",
+                "gender": "M",
+                "zip": null,
+                "lastSignedIn": "2023-06-22T19:16:07.273Z",
+                "loa": {
+                    "current": 3,
+                    "highest": 3
+                },
+                "multifactor": true,
+                "verified": true,
+                "signIn": {
+                    "serviceName": "mhv",
+                    "authBroker": "sis",
+                    "clientId": "vaweb"
+                },
+                "authnContext": "myhealthevet_loa3",
+                "claims": {
+                    "appeals": true,
+                    "ch33BankAccounts": false,
+                    "coe": true,
+                    "communicationPreferences": true,
+                    "connectedApps": true,
+                    "medicalCopays": true,
+                    "militaryHistory": true,
+                    "paymentHistory": false,
+                    "personalInformation": true,
+                    "ratingInfo": false
+                }
+            },
+            "vaProfile": {
+                "status": "OK",
+                "birthDate": "20020426",
+                "familyName": "Mhvtp",
+                "gender": "M",
+                "givenNames": [
+                    "Safari"
+                ],
+                "isCernerPatient": false,
+                "facilities": [
+                    {
+                        "facilityId": "979",
+                        "isCerner": false
+                    },
+                    {
+                        "facilityId": "741MM",
+                        "isCerner": false
+                    }
+                ],
+                "vaPatient": true,
+                "mhvAccountState": "MULTIPLE"
+            },
+            "veteranStatus": null,
+            "inProgressForms": [],
+            "prefillsAvailable": [
+                "21-686C",
+                "40-10007",
+                "0873",
+                "22-1990",
+                "22-1990N",
+                "22-1990E",
+                "22-1990EMEB",
+                "22-1995",
+                "22-5490",
+                "22-5490E",
+                "22-5495",
+                "22-0993",
+                "22-0994",
+                "FEEDBACK-TOOL",
+                "22-10203",
+                "22-1990S",
+                "22-1990EZ",
+                "21-526EZ",
+                "1010ez",
+                "21P-530",
+                "21P-527EZ",
+                "686C-674",
+                "20-0995",
+                "20-0996",
+                "10182",
+                "MDOT",
+                "5655",
+                "28-8832",
+                "28-1900",
+                "26-1880",
+                "26-4555"
+            ],
+            "vet360ContactInformation": {
+                "email": null,
+                "residentialAddress": null,
+                "mailingAddress": null,
+                "mobilePhone": null,
+                "homePhone": null,
+                "workPhone": null,
+                "temporaryPhone": null,
+                "faxNumber": null,
+                "textPermission": null
+            },
+            "session": {
+                "authBroker": "sis",
+                "ssoe": false,
+                "transactionid": null
+            }
+        }
+    },
+    "meta": {
+        "errors": [
+            {
+                "externalService": "VAProfile",
+                "startTime": "2023-06-22T19:17:15Z",
+                "endTime": null,
+                "description": "Mock Error Description for Testing",
+                "status": 404
+            }
+        ]
+    }
+}

--- a/src/applications/mhv-medications/tests/e2e/med_site/MedicationsSite.js
+++ b/src/applications/mhv-medications/tests/e2e/med_site/MedicationsSite.js
@@ -10,7 +10,7 @@ import { medicationsUrls } from '../../../util/constants';
 import listOfprescriptions from '../fixtures/listOfPrescriptions.json';
 
 class MedicationsSite {
-  login = (isMedicationsUser = true) => {
+  login = (isMedicationsUser = true, user = mockUser) => {
     this.mockFeatureToggles();
     this.mockVamcEhr();
 
@@ -26,7 +26,7 @@ class MedicationsSite {
       // src/platform/testing/e2e/cypress/support/commands/login.js handles the next two lines
       // window.localStorage.setItem('isLoggedIn', true);
       // cy.intercept('GET', '/v0/user', mockUser).as('mockUser');
-      cy.login(mockUser);
+      cy.login(user);
     } else {
       // cy.login();
       window.localStorage.setItem('isLoggedIn', false);

--- a/src/applications/mhv-medications/tests/e2e/medications-list-page-meds-by-mail-content.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-list-page-meds-by-mail-content.cypress.spec.js
@@ -1,0 +1,69 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import rxList from './fixtures/listOfPrescriptions.json';
+import mockUserMedsByMail from './fixtures/user-meds-by-mail.json';
+import MedicationsListPage from './pages/MedicationsListPage';
+
+describe('Medications List Page Meds by Mail content', () => {
+  const titleNotesMessageChunk1 =
+    'Bring your medications list to each appointment. And tell your provider about any new allergies or reactions.';
+  const titleNotesMessageChunk2 =
+    ' If you use Meds by Mail, you can also call your servicing center and ask them to update your records.';
+
+  it('shows correct content for non-Meds by Mail users', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    site.login();
+    listPage.visitMedicationsListPageURL(rxList);
+    cy.contains(titleNotesMessageChunk1 + titleNotesMessageChunk2);
+    cy.get('[data-testid="meds-by-mail-additional-info"]').should('not.exist');
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+
+  it('shows correct content for Meds by Mail users', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    site.login(true, mockUserMedsByMail);
+    listPage.visitMedicationsListPageURL(rxList);
+    cy.contains(titleNotesMessageChunk1);
+    cy.contains(
+      'span',
+      'How to update your allergies and reactions if you use Meds by Mail',
+    ).click();
+
+    cy.contains(
+      'p',
+      'We may not have your allergy records in our My HealtheVet tools. But the Meds by Mail servicing center keeps a record of your allergies and reactions to medications.',
+    );
+
+    cy.contains(
+      'p',
+      'If you have a new allergy or reaction, tell your provider. Or you can call us at',
+    );
+
+    const expectedPhoneNumbers = [
+      { text: '866-229-7389', href: 'tel:+18662297389' },
+      { text: '888-385-0235', href: 'tel:+18883850235' },
+      { text: 'TTY: 711', href: 'tel:711', tty: true },
+    ];
+
+    expectedPhoneNumbers.forEach((phoneNumber, index) => {
+      cy.get('[data-testid="meds-by-mail-additional-info"]').within(() => {
+        cy.get('va-telephone')
+          .eq(index)
+          .shadow()
+          .find('a')
+          .should('contain.text', phoneNumber.text)
+          .and('have.attr', 'href', phoneNumber.href);
+      });
+    });
+
+    cy.contains(
+      'p',
+      'and ask us to update your records. We’re here Monday through Friday, 8:00 a.m. to 7:30 p.m. ET.',
+    );
+
+    cy.injectAxe();
+    cy.axeCheck('main');
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-list-page-meds-by-mail-content.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-list-page-meds-by-mail-content.cypress.spec.js
@@ -4,17 +4,13 @@ import mockUserMedsByMail from './fixtures/user-meds-by-mail.json';
 import MedicationsListPage from './pages/MedicationsListPage';
 
 describe('Medications List Page Meds by Mail content', () => {
-  const titleNotesMessageChunk1 =
-    'Bring your medications list to each appointment. And tell your provider about any new allergies or reactions.';
-  const titleNotesMessageChunk2 =
-    ' If you use Meds by Mail, you can also call your servicing center and ask them to update your records.';
-
   it('shows correct content for non-Meds by Mail users', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
     site.login();
     listPage.visitMedicationsListPageURL(rxList);
-    cy.contains(titleNotesMessageChunk1 + titleNotesMessageChunk2);
+    cy.get('[data-testid="meds-by-mail-header"]').should('not.exist');
+    cy.get('[data-testid="meds-by-mail-top-level-text"]').should('not.exist');
     cy.get('[data-testid="meds-by-mail-additional-info"]').should('not.exist');
     cy.injectAxe();
     cy.axeCheck('main');
@@ -25,44 +21,9 @@ describe('Medications List Page Meds by Mail content', () => {
     const listPage = new MedicationsListPage();
     site.login(true, mockUserMedsByMail);
     listPage.visitMedicationsListPageURL(rxList);
-    cy.contains(titleNotesMessageChunk1);
-    cy.contains(
-      'span',
-      'How to update your allergies and reactions if you use Meds by Mail',
-    ).click();
-
-    cy.contains(
-      'p',
-      'We may not have your allergy records in our My HealtheVet tools. But the Meds by Mail servicing center keeps a record of your allergies and reactions to medications.',
-    );
-
-    cy.contains(
-      'p',
-      'If you have a new allergy or reaction, tell your provider. Or you can call us at',
-    );
-
-    const expectedPhoneNumbers = [
-      { text: '866-229-7389', href: 'tel:+18662297389' },
-      { text: '888-385-0235', href: 'tel:+18883850235' },
-      { text: 'TTY: 711', href: 'tel:711', tty: true },
-    ];
-
-    expectedPhoneNumbers.forEach((phoneNumber, index) => {
-      cy.get('[data-testid="meds-by-mail-additional-info"]').within(() => {
-        cy.get('va-telephone')
-          .eq(index)
-          .shadow()
-          .find('a')
-          .should('contain.text', phoneNumber.text)
-          .and('have.attr', 'href', phoneNumber.href);
-      });
-    });
-
-    cy.contains(
-      'p',
-      'and ask us to update your records. We’re here Monday through Friday, 8:00 a.m. to 7:30 p.m. ET.',
-    );
-
+    cy.get('[data-testid="meds-by-mail-header"]').should('exist');
+    cy.get('[data-testid="meds-by-mail-top-level-text"]').should('exist');
+    cy.get('[data-testid="meds-by-mail-additional-info"]').should('exist');
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv-medications/tests/selectors/selectUser.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/selectors/selectUser.unit.spec.jsx
@@ -3,7 +3,9 @@ import {
   selectUserDob,
   selectUserFullName,
   selectUserFacility,
+  selectHasMedsByMailFacility,
 } from '../../selectors/selectUser';
+import { MEDS_BY_MAIL_FACILITY_ID } from '../../util/constants';
 
 describe('mhv-medications selectors: selectUser', () => {
   const mockState = {
@@ -39,7 +41,7 @@ describe('mhv-medications selectors: selectUser', () => {
 
   describe('selectUserFacility', () => {
     it('should select user facility', () => {
-      const facilities = [{ id: '123', name: 'Test VA Facility' }];
+      const facilities = [{ facilityId: '123', name: 'Test VA Facility' }];
       const state = {
         user: {
           profile: {
@@ -63,6 +65,54 @@ describe('mhv-medications selectors: selectUser', () => {
     it('should return undefined if facilities is missing', () => {
       const state = { user: { profile: {} } };
       expect(selectUserFacility(state)).to.be.undefined;
+    });
+  });
+
+  describe('selectHasMedsByMailFacility', () => {
+    it('should return true if the meds by mail facility ID is present', () => {
+      const facilities = [
+        { facilityId: MEDS_BY_MAIL_FACILITY_ID, name: 'Meds by Mail Facility' },
+      ];
+      const state = {
+        user: {
+          profile: {
+            facilities,
+          },
+        },
+      };
+      expect(selectHasMedsByMailFacility(state)).to.be.true;
+    });
+
+    it('should return false if the meds by mail facility ID is not present', () => {
+      const facilities = [{ facilityId: '123', name: 'Test VA Facility' }];
+      const state = {
+        user: {
+          profile: {
+            facilities,
+          },
+        },
+      };
+      expect(selectHasMedsByMailFacility(state)).to.be.false;
+    });
+
+    it('should return false if user is missing', () => {
+      const state = {};
+      expect(selectHasMedsByMailFacility(state)).to.be.false;
+    });
+
+    it('should return false if profile is missing', () => {
+      const state = { user: {} };
+      expect(selectHasMedsByMailFacility(state)).to.be.false;
+    });
+
+    it('should return false if facilities is missing', () => {
+      const state = { user: { profile: {} } };
+      expect(selectHasMedsByMailFacility(state)).to.be.false;
+    });
+
+    it('should return false if facilities is empty', () => {
+      const state = { user: { profile: { facilities: [] } } };
+      expect(selectHasMedsByMailFacility(state)).to.be.false;
     });
   });
 });

--- a/src/applications/mhv-medications/util/constants.js
+++ b/src/applications/mhv-medications/util/constants.js
@@ -275,3 +275,5 @@ export const tooltipHintContent = {
 };
 
 export const recordNotFoundMessage = 'Record not found';
+
+export const MEDS_BY_MAIL_FACILITY_ID = '741MM';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR adds conditionally rendered content for Meds by Mail users (identified by having the facility `741MM` in their profile) as described in https://github.com/department-of-veterans-affairs/va.gov-team/issues/115450.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/115450

## Testing done

Previously there was a sentence "If you use Meds by Mail, you can also call your servicing center and ask them to update your records." included in the text at the top of the page. When the user has `741MM` in their user profile facilities (they are a Meds by Mail user) this sentence is removed and the new content is rendered. For other users there are no changes.

**Testing steps:**

1. Regression test with test user that does **NOT** have the Meds by Mail facility `741MM` in their profile. Verify no changes from `main` prior to changes.

2. Test with a test user that **DOES** have the Meds by Mail facility in their profile. Verify content is rendered according to designs.

See videos below (Firefox large screen, Chrome mobile)

https://github.com/user-attachments/assets/716a9394-8a32-44b0-89f7-0abda45d3442

https://github.com/user-attachments/assets/543c2621-9736-45b2-ada3-53480872e071

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="410" height="729" alt="Screenshot 2025-09-05 at 5 01 12 PM" src="https://github.com/user-attachments/assets/165e8332-6998-407a-a604-0ed099eb0144" />   |   <img width="419" height="878" alt="Screenshot 2025-09-05 at 5 01 34 PM" src="https://github.com/user-attachments/assets/12dff158-7b8d-47c1-bb2c-d7838f59d607" />    |
| Desktop |   <img width="896" height="690" alt="Screenshot 2025-09-05 at 5 11 47 PM" src="https://github.com/user-attachments/assets/38d179f4-1dc5-4c98-9572-e1761fbc5e5c" />  |    <img width="887" height="919" alt="Screenshot 2025-09-05 at 5 01 45 PM" src="https://github.com/user-attachments/assets/10b0791f-ccf4-4474-9776-f8391f5201b5" />   |

## What areas of the site does it impact?

This only impacts the Medications landing page.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Quality Engineer Review

- [ ] Verify content for non-Meds by Mail users (no 741MM facilityId in profile) remains unchanged
- [ ] Verify content for Meds by Mail users (includes 741MM facilityId in profile) matches designs referenced in [#115450](https://github.com/department-of-veterans-affairs/va.gov-team/issues/115450)
  - [ ] Meds by Mail sentence in top paragraph is removed
  - [ ] Text content matches designs
  - [ ] Phone numbers are correct