### PR TITLE
Removes call to usePrescriptionData in <RxBreadcrumbs />

### DIFF
--- a/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
+++ b/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
@@ -6,7 +6,6 @@ import { createBreadcrumbs } from '../util/helpers';
 import { medicationsUrls } from '../util/constants';
 import { selectPageNumber } from '../selectors/selectPreferences';
 import { selectIsDisplayingDocumentation } from '../util/selectors';
-import { usePrescriptionData } from '../hooks/usePrescriptionData';
 
 const RxBreadcrumbs = () => {
   const location = useLocation();
@@ -15,7 +14,6 @@ const RxBreadcrumbs = () => {
   const isDisplayingDocumentation = useSelector(
     selectIsDisplayingDocumentation,
   );
-  const { prescriptionApiError } = usePrescriptionData(prescriptionId);
 
   const [breadcrumbs, setBreadcrumbs] = useState([]);
 
@@ -32,10 +30,6 @@ const RxBreadcrumbs = () => {
     !isDisplayingDocumentation &&
     location.pathname.includes(medicationsUrls.subdirectories.DOCUMENTATION)
   ) {
-    return null;
-  }
-
-  if (prescriptionApiError && prescriptionApiError.status === '404') {
     return null;
   }
 

--- a/src/applications/mhv-medications/tests/containers/RxBreadcrumbs.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/containers/RxBreadcrumbs.unit.spec.jsx
@@ -1,16 +1,10 @@
 import { expect } from 'chai';
 import React from 'react';
-import { waitFor } from '@testing-library/dom';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { renderWithStoreAndRouterV6 } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
-import sinon from 'sinon';
-import { cleanup } from '@testing-library/react';
 import reducers from '../../reducers';
 import RxBreadcrumbs from '../../containers/RxBreadcrumbs';
 import { medicationsUrls } from '../../util/constants';
-import { stubPrescriptionIdApi } from '../testing-utils';
-
-let sandbox;
 
 describe('Medications Breadcrumbs', () => {
   const setup = (state = {}) => {
@@ -41,16 +35,6 @@ describe('Medications Breadcrumbs', () => {
     });
   };
 
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    stubPrescriptionIdApi({ sandbox });
-  });
-
-  afterEach(async () => {
-    cleanup();
-    await sandbox.restore();
-  });
-
   it('renders without errors', () => {
     const screen = setup();
     expect(screen);
@@ -63,9 +47,6 @@ describe('Medications Breadcrumbs', () => {
   });
 
   it('Correct link is shown on documentation page', () => {
-    sandbox.restore();
-    stubPrescriptionIdApi({ sandbox });
-
     const screen = renderWithStoreAndRouterV6(
       <Routes>
         <Route
@@ -101,19 +82,5 @@ describe('Medications Breadcrumbs', () => {
     });
     const breadcrumbs = screen.getByTestId('rx-breadcrumb-link');
     expect(breadcrumbs).to.exist;
-  });
-
-  it('Does not render breadcrumbs if Rx details call returns 404', async () => {
-    sandbox.restore();
-    stubPrescriptionIdApi({
-      sandbox,
-      error: { status: '404' },
-    });
-
-    const screen = setup();
-    await waitFor(() => {
-      const breadcrumbs = screen.queryByTestId('rx-breadcrumb-link');
-      expect(breadcrumbs).to.not.exist;
-    });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario


## Summary

- Removes the call to `usePrescriptionData` in `<RxBreadcrumbs />` causing 600k 404 requests per week when requesting `/my_health/v1/prescriptions/undefined`
- Reverts the changes to `<RxBreadcrumbs />` in this [merge commit](https://github.com/department-of-veterans-affairs/vets-website/commit/effc58cf9988c7ca424c5e156cdd29e7443c7bc5#diff-c4e63d6dbe252f6f73477ae8490e45c94379d4a9850d8f7574dfe4b49581d16fR18)

## Related issue(s)

- [Slack thread](https://dsva.slack.com/archives/C057H6U7R6D/p1757108059127889)
- [Merge commit](https://github.com/department-of-veterans-affairs/vets-website/commit/effc58cf9988c7ca424c5e156cdd29e7443c7bc5#diff-c4e63d6dbe252f6f73477ae8490e45c94379d4a9850d8f7574dfe4b49581d16fR18) that adds call to `usePrescriptionData`


## Testing done

- localhost, CI

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| `/my-health/medications`        |     <img width="320" height="680" alt="rx-before" src="https://github.com/user-attachments/assets/f03f1212-1e9b-41af-b0e4-21b40b9259ba" />  |  <img width="320" height="680" alt="rx-after" src="https://github.com/user-attachments/assets/c9694700-156c-44d6-8950-77c39813d0ec" />     |
| `/my-health/medications/refill` |   <img width="320" height="680" alt="refill-before" src="https://github.com/user-attachments/assets/67b91d33-213b-410f-b5de-e0032b007fa1" />    |    <img width="320" height="680" alt="refill-after" src="https://github.com/user-attachments/assets/f8df66a8-ef82-4221-ac31-92d9e65c8513" />   |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_


