### PR TITLE
Show page validation errors on Cypress failure

### DIFF
--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -7,6 +7,10 @@ import disableFTUXModals from 'platform/user/tests/disableFTUXModals';
 const APP_SELECTOR = '#react-root';
 const ARRAY_ITEM_SELECTOR =
   'div[name^="topOfTable_"] ~ div.va-growable-background';
+const ERROR_SELECTORS = [
+  'fieldset [error]:not([error=""])', // For web components
+  'fieldset .usa-input-error-message', // For non-web components
+];
 const FIELD_SELECTOR = 'input, select, textarea';
 const WEB_COMPONENT_SELECTORS =
   'va-text-input, va-select, va-textarea, va-radio-option, va-checkbox, va-date, va-memorable-date, va-telephone-input, va-file-input, va-file-input-multiple';
@@ -185,6 +189,63 @@ const performPageActions = (pathname, _13647Exception = false) => {
   });
 };
 
+const captureValidationErrors = () => {
+  try {
+    const errors = [];
+    const $body = Cypress.$('body');
+
+    ERROR_SELECTORS.forEach(selector => {
+      const elements = $body.find(selector);
+      elements.each((index, element) => {
+        const $el = Cypress.$(element);
+        const tagName = element.tagName.toLowerCase();
+
+        let text = '';
+
+        if (tagName.startsWith('va-') && $el.attr('error')) {
+          text = $el.attr('error');
+        } else {
+          text = $el.text().trim();
+          text = text.replace(/^Error\s+/, '');
+        }
+
+        if (text && $el.is(':visible')) {
+          let fieldName = $el.attr('name') || $el.attr('id') || '';
+
+          // When directly selecting '.usa-input-error-message'
+          // remove the '-error-message' to refer to the actual field
+          if (fieldName.endsWith('-error-message')) {
+            fieldName = fieldName.replace('-error-message', '');
+          }
+
+          /**
+           * Examples:
+           * fieldName = "root_veteran_fullName_first"
+           * tagName = "va-text-input"
+           * text = "Please enter a first name"
+           *
+           * Example outputs web components:
+           * "  • root_veteran_fullName_first" (va-text-input): "Please enter a first name"
+           * "  • root_veteran_dateOfBirth" (va-memorable-date): "Please provide the date of birth"
+           *
+           * Example outputs non-web components:
+           * "  • root_veteranFullName_first": "Please enter a first name"
+           */
+          const fieldPrefix = fieldName ? `"${fieldName}" ` : '';
+          const tagNameSuffix = tagName.startsWith('va-') ? `(${tagName})` : '';
+          errors.push(`  • ${fieldPrefix}${tagNameSuffix}: "${text}"`);
+        }
+      });
+    });
+
+    return errors;
+  } catch (error) {
+    // If error capture fails, return empty array to avoid breaking the test
+    // The original navigation error will still be thrown
+    return [];
+  }
+};
+
 /**
  * Top level loop that invokes all of the processing for a form page and
  * asserts that it proceeds to the next page until it gets to the confirmation.
@@ -201,7 +262,16 @@ const processPage = ({ _13647Exception, stopTestAfterPath }) => {
       cy.location('pathname', NO_LOG_OPTION)
         .should(newPathname => {
           if (pathname === newPathname) {
-            throw new Error(`Expected to navigate away from ${pathname}`);
+            let errorMessage = `Expected to navigate away from ${pathname}`;
+
+            const pageErrors = captureValidationErrors();
+            if (pageErrors.length > 0) {
+              errorMessage += `\n\nPage contains validation errors:\n${pageErrors.join(
+                '\n',
+              )}\n\nThis suggests required fields may be missing or invalid.`;
+            }
+
+            throw new Error(errorMessage);
           }
         })
         .then(() => processPage({ _13647Exception, stopTestAfterPath }));


### PR DESCRIPTION
## Summary

- Show page validation errors when Cypress fails to navigate away from a page

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4741

## Testing done

- Goal: Show real CI examples - however having difficulty doing this due to hanging tests.


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
