### PR TITLE
Example CI failure B (includes new cypress messaging)

### DIFF
--- a/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/veteran-minimal-test.json
+++ b/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/veteran-minimal-test.json
@@ -16,7 +16,7 @@
     "street": "867 Five St",
     "city": "Threeoh",
     "state": "ON",
-    "postalCode": "A9A 9A9"
+    "postalCode": ""
   },
   "veteranPhone": "1122334455",
   "veteranEmail": "veteran@person.com"

--- a/src/applications/simple-forms/21-4142/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/simple-forms/21-4142/tests/e2e/fixtures/data/maximal-test.json
@@ -10,7 +10,7 @@
         "postalCode": "98745"
       },
       "preparerFullName": {
-        "first": "Alternate",
+        "first": "",
         "middle": "Signer",
         "last": "Name",
         "suffix": "Jr."

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -7,6 +7,10 @@ import disableFTUXModals from 'platform/user/tests/disableFTUXModals';
 const APP_SELECTOR = '#react-root';
 const ARRAY_ITEM_SELECTOR =
   'div[name^="topOfTable_"] ~ div.va-growable-background';
+const ERROR_SELECTORS = [
+  'fieldset [error]:not([error=""])', // For web components
+  'fieldset .usa-input-error-message', // For non-web components
+];
 const FIELD_SELECTOR = 'input, select, textarea';
 const WEB_COMPONENT_SELECTORS =
   'va-text-input, va-select, va-textarea, va-radio-option, va-checkbox, va-date, va-memorable-date, va-telephone-input, va-file-input, va-file-input-multiple';
@@ -185,6 +189,63 @@ const performPageActions = (pathname, _13647Exception = false) => {
   });
 };
 
+const captureValidationErrors = () => {
+  try {
+    const errors = [];
+    const $body = Cypress.$('body');
+
+    ERROR_SELECTORS.forEach(selector => {
+      const elements = $body.find(selector);
+      elements.each((index, element) => {
+        const $el = Cypress.$(element);
+        const tagName = element.tagName.toLowerCase();
+
+        let text = '';
+
+        if (tagName.startsWith('va-') && $el.attr('error')) {
+          text = $el.attr('error');
+        } else {
+          text = $el.text().trim();
+          text = text.replace(/^Error\s+/, '');
+        }
+
+        if (text && $el.is(':visible')) {
+          let fieldName = $el.attr('name') || $el.attr('id') || '';
+
+          // When directly selecting '.usa-input-error-message'
+          // remove the '-error-message' to refer to the actual field
+          if (fieldName.endsWith('-error-message')) {
+            fieldName = fieldName.replace('-error-message', '');
+          }
+
+          /**
+           * Examples:
+           * fieldName = "root_veteran_fullName_first"
+           * tagName = "va-text-input"
+           * text = "Please enter a first name"
+           *
+           * Example outputs web components:
+           * "  • root_veteran_fullName_first" (va-text-input): "Please enter a first name"
+           * "  • root_veteran_dateOfBirth" (va-memorable-date): "Please provide the date of birth"
+           *
+           * Example outputs non-web components:
+           * "  • root_veteranFullName_first": "Please enter a first name"
+           */
+          const fieldPrefix = fieldName ? `"${fieldName}" ` : '';
+          const tagNameSuffix = tagName.startsWith('va-') ? `(${tagName})` : '';
+          errors.push(`  • ${fieldPrefix}${tagNameSuffix}: "${text}"`);
+        }
+      });
+    });
+
+    return errors;
+  } catch (error) {
+    // If error capture fails, return empty array to avoid breaking the test
+    // The original navigation error will still be thrown
+    return [];
+  }
+};
+
 /**
  * Top level loop that invokes all of the processing for a form page and
  * asserts that it proceeds to the next page until it gets to the confirmation.
@@ -201,7 +262,16 @@ const processPage = ({ _13647Exception, stopTestAfterPath }) => {
       cy.location('pathname', NO_LOG_OPTION)
         .should(newPathname => {
           if (pathname === newPathname) {
-            throw new Error(`Expected to navigate away from ${pathname}`);
+            let errorMessage = `Expected to navigate away from ${pathname}`;
+
+            const pageErrors = captureValidationErrors();
+            if (pageErrors.length > 0) {
+              errorMessage += `\n\nPage contains validation errors:\n${pageErrors.join(
+                '\n',
+              )}\n\nThis suggests required fields may be missing or invalid.`;
+            }
+
+            throw new Error(errorMessage);
           }
         })
         .then(() => processPage({ _13647Exception, stopTestAfterPath }));


### PR DESCRIPTION
Example showing CI failure, including the following:
- https://github.com/department-of-veterans-affairs/vets-website/pull/38628