### PR TITLE
Merge Form Launch blockers/Intro page 

### DIFF
--- a/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
@@ -11,7 +11,7 @@ const PROPERTY_NAMES = {
 
 function generateOptions({ data, pagePerItemIndex }) {
   const bp = appRelBoilerplate({ data, pagePerItemIndex });
-  const customTitle = `${bp.applicant}’s status`;
+  const customTitle = `${bp.applicant}’s dependent status`;
   const relativeBeingVerb = `${bp.relative} ${bp.beingVerbPresent}`;
   const options = [
     {

--- a/src/applications/ivc-champva/10-10d-extended/chapters/ApplicantRelOriginPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/ApplicantRelOriginPage.jsx
@@ -6,7 +6,7 @@ const KEYNAME = 'applicantRelationshipOrigin';
 
 function generateOptions({ data, pagePerItemIndex }) {
   const bp = appRelBoilerplate({ data, pagePerItemIndex });
-  const customTitle = `${bp.applicant}’s relationship to the Veteran`;
+  const customTitle = `${bp.applicant}’s dependent status`;
   const relativeBeingVerb = `${bp.relative} ${bp.beingVerbPresent}`;
   const surv = data.sponsorIsDeceased ? 'surviving' : '';
 

--- a/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-10d-extended/chapters/applicantInformation.js
@@ -332,9 +332,9 @@ const applicantBirthCertUploadPage = {
           certifierRole: index === 0 ? formData?.['view:certifierRole'] : '',
         };
         const posessiveName = (
-          <p className="dd-privacy-hidden">
+          <span className="dd-privacy-hidden">
             {nameWording(tmpFormData, true, false)}
-          </p>
+          </span>
         );
 
         return (

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -21,7 +21,7 @@ import {
   certifierRelationshipSchema,
 } from '../chapters/signerInformation';
 
-import mockData from '../tests/e2e/fixtures/data/maximal-test.json';
+// import mockData from '../tests/e2e/fixtures/data/maximal-test.json';
 import transformForSubmit from './submitTransformer';
 
 import {
@@ -118,7 +118,7 @@ const formConfig = {
       title: 'Your information',
       pages: {
         page1: {
-          initialData: mockData.data,
+          // initialData: mockData.data,
           path: 'your-information/who-is-applying',
           title: 'Which of these best describes you?',
           ...certifierRoleSchema,

--- a/src/applications/ivc-champva/10-10d-extended/config/form.js
+++ b/src/applications/ivc-champva/10-10d-extended/config/form.js
@@ -21,7 +21,7 @@ import {
   certifierRelationshipSchema,
 } from '../chapters/signerInformation';
 
-// import mockData from '../tests/e2e/fixtures/data/maximal-test.json';
+import mockData from '../tests/e2e/fixtures/data/maximal-test.json';
 import transformForSubmit from './submitTransformer';
 
 import {
@@ -118,7 +118,7 @@ const formConfig = {
       title: 'Your information',
       pages: {
         page1: {
-          // initialData: mockData.data,
+          initialData: mockData.data,
           path: 'your-information/who-is-applying',
           title: 'Which of these best describes you?',
           ...certifierRoleSchema,

--- a/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/IntroductionPage.jsx
@@ -9,9 +9,15 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { TITLE, SUBTITLE } from '../constants';
 
-const OMB_RES_BURDEN = 24;
-const OMB_NUMBER = '2900-0219';
-const OMB_EXP_DATE = '12/31/2027';
+const OMB_RES_BURDEN_CHAMPVA = 15;
+const OMB_NUMBER_CHAMPVA = '2900-0219';
+const OMB_EXP_DATE_CHAMPVA = '12/31/2027';
+
+const OMB_RES_BURDEN_OHI = 10;
+const OMB_NUMBER_OHI = '2900-0219';
+const OMB_EXP_DATE_OHI = '12/31/2027';
+
+const TOTAL_RES_BURDEN = OMB_RES_BURDEN_CHAMPVA + OMB_RES_BURDEN_OHI;
 
 const ProcessList = () => {
   return (
@@ -49,10 +55,6 @@ const ProcessList = () => {
           <li>Proof of adoption</li>
           <li>Birth certificate of dependent(s)</li>
         </ul>
-        <p>
-          You may also need to submit supporting documents, like copies of your
-          health insurance cards or proof of school enrollment.
-        </p>
         <va-link
           text="Find out which documents you’ll need to apply for CHAMPVA"
           href="https://www.va.gov/family-and-caregiver-benefits/health-and-disability/champva/#supporting-documents-for-your-"
@@ -61,7 +63,7 @@ const ProcessList = () => {
       <va-process-list-item header="Start your application">
         <p>
           We’ll take you through each step of the process. It should take about{' '}
-          {OMB_RES_BURDEN} minutes.
+          {TOTAL_RES_BURDEN} minutes.
         </p>
       </va-process-list-item>
       <va-process-list-item header="After you apply">
@@ -112,13 +114,18 @@ export const IntroductionPage = props => {
         </span>
       </va-alert-sign-in>
       <p />
+      <va-omb-info
+        res-burden={OMB_RES_BURDEN_CHAMPVA}
+        omb-number={OMB_NUMBER_CHAMPVA}
+        exp-date={OMB_EXP_DATE_CHAMPVA}
+      />
       <h3>Additional form you may need to complete</h3>
       <h3>CHAMPVA other health insurance (OHI) certification</h3>
       <p>VA form 10-7959c</p>
       <va-omb-info
-        res-burden={OMB_RES_BURDEN}
-        omb-number={OMB_NUMBER}
-        exp-date={OMB_EXP_DATE}
+        res-burden={OMB_RES_BURDEN_OHI}
+        omb-number={OMB_NUMBER_OHI}
+        exp-date={OMB_EXP_DATE_OHI}
       />
     </article>
   );


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR addresses the content updates to the intro page (time form will take, OMB info for CHAMPVA, remove text from step 2, respondent burden on OHI) and 2 other issues that are launch-blocking (dependent status page title, weird birth certificate spacing). 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/117906

## Testing done
e2e
unit

## Screenshots
<img width="672" height="519" alt="Screenshot 2025-09-08 at 11 00 39 AM" src="https://github.com/user-attachments/assets/f4b36e4b-e23e-44fb-946c-1a9be2934c6d" />
<img width="711" height="72" alt="Screenshot 2025-09-08 at 11 00 29 AM" src="https://github.com/user-attachments/assets/9353a81e-7d10-4197-8385-588c5271c92c" />
<img width="818" height="507" alt="Screenshot 2025-09-08 at 11 00 16 AM" src="https://github.com/user-attachments/assets/6686cf7c-b16b-4cdd-9ff3-9b1cdb95a1bd" />
<img width="600" height="249" alt="Screenshot 2025-09-08 at 10 58 33 AM" src="https://github.com/user-attachments/assets/3758d213-12b2-436b-828a-b5083e804bb8" />
<img width="555" height="184" alt="Screenshot 2025-09-08 at 10 55 27 AM" src="https://github.com/user-attachments/assets/5b0a2a58-a848-4d31-b828-381763b54c28" />

## What areas of the site does it impact?
this form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
