### PR TITLE
fix: remove extra ampersand from feature toggles URL

### DIFF
--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -3,7 +3,7 @@
 import { getFlipperId } from './helpers';
 
 const FLIPPER_ID = getFlipperId();
-const TOGGLE_VALUES_PATH = `/v0/feature_toggles?&cookie_id=${FLIPPER_ID}`;
+const TOGGLE_VALUES_PATH = `/v0/feature_toggles?cookie_id=${FLIPPER_ID}`;
 const TOGGLE_POLLING_INTERVAL = 5000;
 
 let flipperClientInstance;


### PR DESCRIPTION
The flipper client was generating malformed URLs like: /v0/feature_toggles?&cookie_id=123

This creates an empty first parameter that causes crashes in the backend WAF when processing the request. Fixed to generate proper URLs: /v0/feature_toggles?cookie_id=123

Fixes the 500 errors on feature toggles endpoint in staging. See https://github.com/department-of-veterans-affairs/vets-api/pull/24018.

Bug report to DD: https://github.com/DataDog/libddwaf-rb/issues/94
