### PR TITLE
0969 | Update dependent description component

### DIFF
--- a/src/applications/income-and-asset-statement/components/DependentDescription.jsx
+++ b/src/applications/income-and-asset-statement/components/DependentDescription.jsx
@@ -1,45 +1,108 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export const DependentDescription = () => {
-  const LAST_YEAR = new Date().getFullYear() - 1;
+const SpouseDependentListItem = () => (
+  <li>
+    A spouse, unless you live apart, are estranged, and don’t help pay for their
+    support. We recognize same-sex and common-law marriages
+  </li>
+);
+
+const ChildCriteriaList = () => (
+  <ul>
+    <li>
+      They’re under 18 years old, <strong>or</strong>
+    </li>
+    <li>
+      They’re between the ages of 18 and 23 years old and were enrolled in
+      school full time, <strong>or</strong>
+    </li>
+    <li>
+      They’re living with a permanent disability that happened before they
+      turned 18 years old
+    </li>
+  </ul>
+);
+
+export const DependentDescription = ({ claimantType }) => {
+  let content = null;
+
+  switch (claimantType) {
+    case 'VETERAN':
+      content = (
+        <div>
+          <ul className="vads-u-margin-top--0">
+            <SpouseDependentListItem />
+            <li>
+              An unmarried child (including adopted children or stepchildren)
+            </li>
+            <li>
+              If your dependent is an unmarried child, one of these must also be
+              true:
+              <ChildCriteriaList />
+            </li>
+          </ul>
+          <p>
+            <strong>Note:</strong> A natural or adoptive parent has custody of a
+            child unless custody is legally removed. For pension purposes, a
+            child who has attained age 18 remains in the custody of the person
+            who had custody before the child turned 18 unless custody is legally
+            removed.
+          </p>
+        </div>
+      );
+      break;
+    case 'SPOUSE':
+      content = (
+        <div>
+          <p className="vads-u-margin-top--0">
+            An unmarried child (including an adopted child or stepchild) who you
+            support and who meets one of the requirements listed below:
+          </p>
+          <ChildCriteriaList />
+        </div>
+      );
+      break;
+    case 'CUSTODIAN':
+      content = (
+        <div>
+          <ul className="vads-u-margin-top--0">
+            <SpouseDependentListItem />
+            <li>
+              The Veteran’s surviving unmarried child/children who you support
+              and who meets one of the requirements listed below:
+              <ChildCriteriaList />
+            </li>
+          </ul>
+          <p className="vads-u-margin-bottom--0">
+            <strong>Note:</strong> If the child’s custodian is an institution,
+            income and assets do not need to be reported.
+          </p>
+        </div>
+      );
+      break;
+    case 'PARENT':
+      content = (
+        <p className="vads-u-margin-top--0">
+          A spouse, unless you live apart, are estranged, and don’t help pay for
+          their support. We recognize same-sex and common-law marriages
+        </p>
+      );
+      break;
+    default:
+      content = null;
+  }
+
+  if (!content) return null;
 
   return (
-    <va-additional-info
-      trigger="Who we consider a dependent"
-      class="hydrated"
-      uswds
-    >
-      <div>
-        <p className="vads-u-margin-top--0">
-          <strong>Here’s who we consider to be a dependent:</strong>
-        </p>
-        <ul>
-          <li>A spouse (we recognize same-sex and common-law marriages)</li>
-          <li>
-            An unmarried child (including adopted children or stepchildren)
-          </li>
-        </ul>
-        <p>
-          <strong>
-            If your dependent is an unmarried child, one of these descriptions
-            must be true:
-          </strong>
-        </p>
-        <ul className="vads-u-margin-bottom--0">
-          <li>
-            They’re under 18 years old, <strong>or</strong>
-          </li>
-          <li>
-            They’re between the ages of 18 and 23 years old and were enrolled as
-            a full-time or part-time student in high school, college, or
-            vocational school in {LAST_YEAR}, <strong>or</strong>
-          </li>
-          <li>
-            They’re living with a permanent disability that happened before they
-            turned 18 years old
-          </li>
-        </ul>
-      </div>
+    <va-additional-info trigger="Who we consider a dependent">
+      {content}
     </va-additional-info>
   );
+};
+
+DependentDescription.propTypes = {
+  claimantType: PropTypes.oneOf(['VETERAN', 'SPOUSE', 'CUSTODIAN', 'PARENT'])
+    .isRequired,
 };

--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -535,7 +535,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
     }),
     unassociatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (
-        <DependentDescription />
+        <DependentDescription claimantType="VETERAN" />
       ) : null,
       title: incomeRecipientPageTitle,
       path: 'recurring-income/:index/veteran-income-recipient',
@@ -546,7 +546,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
     }),
     unassociatedIncomeSpouseRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (
-        <DependentDescription />
+        <DependentDescription claimantType="SPOUSE" />
       ) : null,
       title: incomeRecipientPageTitle,
       path: 'recurring-income/:index/spouse-income-recipient',
@@ -557,7 +557,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
     }),
     unassociatedIncomeCustodianRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (
-        <DependentDescription />
+        <DependentDescription claimantType="CUSTODIAN" />
       ) : null,
       title: incomeRecipientPageTitle,
       path: 'recurring-income/:index/custodian-income-recipient',
@@ -568,7 +568,7 @@ export const unassociatedIncomePages = arrayBuilderPages(
     }),
     unassociatedIncomeParentRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (
-        <DependentDescription />
+        <DependentDescription claimantType="PARENT" />
       ) : null,
       title: incomeRecipientPageTitle,
       path: 'recurring-income/:index/parent-income-recipient',

--- a/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
@@ -559,7 +559,7 @@ export const associatedIncomePages = arrayBuilderPages(
     }),
     associatedIncomeVeteranRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (
-        <DependentDescription />
+        <DependentDescription claimantType="VETERAN" />
       ) : null,
       title: incomeRecipientPageTitle,
       path: 'financial-accounts/:index/veteran-income-recipient',
@@ -570,7 +570,7 @@ export const associatedIncomePages = arrayBuilderPages(
     }),
     associatedIncomeSpouseRecipientPage: pageBuilder.itemPage({
       ContentBeforeButtons: showUpdatedContent() ? (
-        <DependentDescription />
+        <DependentDescription claimantType="SPOUSE" />
       ) : null,
       title: incomeRecipientPageTitle,
       path: 'financial-accounts/:index/spouse-income-recipient',

--- a/src/applications/income-and-asset-statement/tests/unit/components/DependentDescription.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/components/DependentDescription.unit.spec.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import { DependentDescription } from '../../../components/DependentDescription';
+
+describe('pension <DependentDescription>', () => {
+  it('should render Veteran content', () => {
+    const { container } = render(
+      <DependentDescription claimantType="VETERAN" />,
+    );
+    const selector = container.querySelector('va-additional-info');
+    expect(selector).to.exist;
+    expect(container.textContent).to.include(
+      'A spouse, unless you live apart, are estranged, and don’t help pay',
+    );
+    expect(container.textContent).to.include(
+      'An unmarried child (including adopted children or stepchildren)',
+    );
+    expect(container.textContent).to.include(
+      'If your dependent is an unmarried child',
+    );
+    expect(container.textContent).to.include(
+      'A natural or adoptive parent has custody of a child',
+    );
+  });
+
+  it('should render Spouse content', () => {
+    const { container } = render(
+      <DependentDescription claimantType="SPOUSE" />,
+    );
+    const selector = container.querySelector('va-additional-info');
+    expect(selector).to.exist;
+    expect(container.textContent).to.include(
+      'An unmarried child (including an adopted child or stepchild) who you support',
+    );
+    expect(container.textContent).to.include('They’re under 18 years old');
+    expect(container.textContent).to.include(
+      'They’re between the ages of 18 and 23 years old',
+    );
+    expect(container.textContent).to.include(
+      'They’re living with a permanent disability',
+    );
+  });
+
+  it('should render Custodian content', () => {
+    const { container } = render(
+      <DependentDescription claimantType="CUSTODIAN" />,
+    );
+    const selector = container.querySelector('va-additional-info');
+    expect(selector).to.exist;
+    expect(container.textContent).to.include(
+      'A spouse, unless you live apart, are estranged, and don’t help pay',
+    );
+    expect(container.textContent).to.include(
+      'The Veteran’s surviving unmarried child/children who you support',
+    );
+    expect(container.textContent).to.include(
+      'If the child’s custodian is an institution',
+    );
+  });
+
+  it('should render Parent content', () => {
+    const { container } = render(
+      <DependentDescription claimantType="PARENT" />,
+    );
+    const selector = container.querySelector('va-additional-info');
+    expect(selector).to.exist;
+    expect(container.textContent).to.include(
+      'A spouse, unless you live apart, are estranged, and don’t help pay',
+    );
+  });
+
+  it('should render empty when claimantType is missing', () => {
+    const { container } = render(<DependentDescription />);
+    const selector = container.querySelector('va-additional-info');
+    expect(selector).not.to.exist;
+  });
+});


### PR DESCRIPTION
## Summary

This PR updates the **DependentDescription** component used in the **Income and Asset Statement form (VA Form 21P-0969)** to accept a `claimantType` prop. The component now dynamically displays content based on the provided `claimantType` value, ensuring the messaging is tailored correctly for Veterans, Spouses, Parents, and Custodians.

This improves maintainability by consolidating conditional logic into the component itself, rather than duplicating it across multiple pages.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117592

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the form at:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`

## How to verify
1. Navigate to pages where the **DependentDescription** component is rendered (e.g., Relationship to Veteran pages)  
2. Confirm that:  
   - The component displays different text based on the `claimantType` prop  
   - Each claimant type renders the correct explanatory content (Veteran, Spouse, Parent, Custodian)  
   - Content matches design and content expectations  
3. Validate that no content displays incorrectly when no `claimantType` is passed  
4. Confirm accessibility audit passes when additional information component is expanded

## What areas of the site does it impact?
- Income and Asset Statement (VA Form 21P-0969)  
- 'Recurring income' and 'Financial accounts' chapters in Post MVP rendering the **DependentDescription** component, particularly Relationship to Veteran pages

## Screenshots
| Veteran | Spouse  |
|---------------|--------|
|<img width="589" height="1051" alt="Screenshot 2025-09-08 at 3 22 44 PM" src="https://github.com/user-attachments/assets/2ca858c4-85b5-4271-8642-a330b72d5541" />|<img width="559" height="775" alt="Screenshot 2025-09-08 at 3 09 52 PM" src="https://github.com/user-attachments/assets/7b40ddfd-9cec-4b1b-8b6e-223afde349d6" />|

| Custodian | Parent  |
|---------------|--------|
|<img width="575" height="1001" alt="Screenshot 2025-09-08 at 3 13 56 PM" src="https://github.com/user-attachments/assets/ec56e2ab-4826-49e0-953a-cf98d9dd20d3" />|<img width="565" height="626" alt="Screenshot 2025-09-08 at 3 13 18 PM" src="https://github.com/user-attachments/assets/d8808b99-3d75-4cd1-8e84-2cb4d89c6534" />|


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone

- Post-MVP improvements for 0969  
- Behind `income_and_assets_content_updates` feature toggle

## Requested Feedback

Please confirm that the `claimantType`-based rendering logic covers all expected scenarios and that the component is correctly used in list-and-loop pages where dependent guidance is needed.