### PR TITLE
113542 - Add toggle for new My VA dashboard layout

### DIFF
--- a/src/applications/personalization/dashboard/actions/preferences.js
+++ b/src/applications/personalization/dashboard/actions/preferences.js
@@ -1,0 +1,18 @@
+// import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
+
+export const SET_MYVA_LAYOUT_PREFERENCE = 'SET_MYVA_LAYOUT_PREFERENCE';
+
+export const updateMyVaLayoutVersion = selectedVersion => {
+  // Record the event when a user changes
+  // const event = {
+  //   event: 'dashboard-myva-layout-version-changed',
+  //   'myva-layout-version': selectedVersion,
+  // };
+  // recordEvent(event);
+  return {
+    type: SET_MYVA_LAYOUT_PREFERENCE,
+    layout: {
+      version: selectedVersion,
+    },
+  };
+};

--- a/src/applications/personalization/dashboard/actions/preferences.js
+++ b/src/applications/personalization/dashboard/actions/preferences.js
@@ -3,12 +3,6 @@
 export const SET_MY_VA_LAYOUT_PREFERENCE = 'SET_MY_VA_LAYOUT_PREFERENCE';
 
 export const updateMyVaLayoutVersion = selectedVersion => {
-  // Record the event when a user changes
-  // const event = {
-  //   event: 'dashboard-myva-layout-version-changed',
-  //   'myva-layout-version': selectedVersion,
-  // };
-  // recordEvent(event);
   return {
     type: SET_MY_VA_LAYOUT_PREFERENCE,
     layout: {

--- a/src/applications/personalization/dashboard/actions/preferences.js
+++ b/src/applications/personalization/dashboard/actions/preferences.js
@@ -1,6 +1,6 @@
 // import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 
-export const SET_MYVA_LAYOUT_PREFERENCE = 'SET_MYVA_LAYOUT_PREFERENCE';
+export const SET_MY_VA_LAYOUT_PREFERENCE = 'SET_MY_VA_LAYOUT_PREFERENCE';
 
 export const updateMyVaLayoutVersion = selectedVersion => {
   // Record the event when a user changes
@@ -10,7 +10,7 @@ export const updateMyVaLayoutVersion = selectedVersion => {
   // };
   // recordEvent(event);
   return {
-    type: SET_MYVA_LAYOUT_PREFERENCE,
+    type: SET_MY_VA_LAYOUT_PREFERENCE,
     layout: {
       version: selectedVersion,
     },

--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -59,6 +59,7 @@ import EducationAndTraining from './education-and-training/EducationAndTraining'
 import { ContactInfoNeeded } from '../../profile/components/alerts/ContactInfoNeeded';
 import FormsAndApplications from './benefit-application-drafts/FormsAndApplications';
 import PaymentsAndDebts from './benefit-payments/PaymentsAndDebts';
+import NewMyVaToggle from './NewMyVaToggle';
 
 const DashboardHeader = ({ isLOA3, showNotifications, user }) => {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
@@ -374,6 +375,15 @@ const Dashboard = ({
                   user={user}
                 />
               )}
+              <Toggler
+                toggleName={
+                  Toggler.TOGGLE_NAMES.myVaAuthExpRedesignAvailableToOptIn
+                }
+              >
+                <Toggler.Enabled>
+                  <NewMyVaToggle />
+                </Toggler.Enabled>
+              </Toggler>
 
               {/* LOA3 user experience */}
               {props.showClaimsAndAppeals && (

--- a/src/applications/personalization/dashboard/components/NewMyVaToggle.jsx
+++ b/src/applications/personalization/dashboard/components/NewMyVaToggle.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { VaButtonSegmented } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import './NewMyVaToggle.scss';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { updateFeatureToggleValue } from 'platform/utilities/feature-toggles';
 import { updateMyVaLayoutVersion } from '../actions/preferences';
 
@@ -18,20 +18,31 @@ const NewMyVaToggle = () => {
   const [selected, setSelected] = useState(() => {
     return localStorage.getItem(LOCAL_STORAGE_KEY) || MY_VA_LAYOUT_VERSION_OLD;
   });
+  const storeVersion = useSelector(
+    state => state.myVaPreferences?.layout?.version,
+  );
 
   useEffect(
     () => {
-      const redesignEnabled = selected === MY_VA_LAYOUT_VERSION_NEW;
       localStorage.setItem(LOCAL_STORAGE_KEY, selected);
       dispatch(updateMyVaLayoutVersion(selected));
-      dispatch(
-        updateFeatureToggleValue({
-          // eslint-disable-next-line camelcase
-          my_va_auth_exp_redesign_enabled: redesignEnabled,
-        }),
-      );
     },
     [selected, dispatch],
+  );
+
+  useEffect(
+    () => {
+      if (storeVersion && storeVersion === selected) {
+        const redesignEnabled = storeVersion === MY_VA_LAYOUT_VERSION_NEW;
+        dispatch(
+          updateFeatureToggleValue({
+            // eslint-disable-next-line camelcase
+            my_va_auth_exp_redesign_enabled: redesignEnabled,
+          }),
+        );
+      }
+    },
+    [storeVersion, selected, dispatch],
   );
 
   const handleClick = event => {
@@ -49,6 +60,7 @@ const NewMyVaToggle = () => {
         label="Select a My VA version"
         onVaButtonClick={handleClick}
         selected={getSelectedIndex()}
+        testId="my-va-layout-toggle"
       />
     </div>
   );

--- a/src/applications/personalization/dashboard/components/NewMyVaToggle.jsx
+++ b/src/applications/personalization/dashboard/components/NewMyVaToggle.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { VaButtonSegmented } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import './NewMyVaToggle.scss';
+
+const LOCAL_STORAGE_KEY = 'myVaVersion';
+const BUTTONS = [
+  { value: 'new', label: 'New My VA' },
+  { value: 'old', label: 'Old My VA' },
+];
+
+const NewMyVaToggle = () => {
+  const [selected, setSelected] = useState(() => {
+    return localStorage.getItem(LOCAL_STORAGE_KEY) || 'old';
+  });
+
+  useEffect(
+    () => {
+      localStorage.setItem(LOCAL_STORAGE_KEY, selected);
+    },
+    [selected],
+  );
+
+  const handleClick = event => {
+    setSelected(event.detail.value);
+  };
+
+  const getSelectedIndex = () => {
+    return BUTTONS.findIndex(button => button.value === selected);
+  };
+
+  return (
+    <div className="vads-u-margin-y--4 my-va-toggle">
+      <VaButtonSegmented
+        buttons={BUTTONS}
+        label="Select a My VA version"
+        onVaButtonClick={handleClick}
+        selected={getSelectedIndex()}
+      />
+    </div>
+  );
+};
+
+export default NewMyVaToggle;

--- a/src/applications/personalization/dashboard/components/NewMyVaToggle.jsx
+++ b/src/applications/personalization/dashboard/components/NewMyVaToggle.jsx
@@ -1,23 +1,37 @@
 import React, { useEffect, useState } from 'react';
 import { VaButtonSegmented } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import './NewMyVaToggle.scss';
+import { useDispatch } from 'react-redux';
+import { updateFeatureToggleValue } from 'platform/utilities/feature-toggles';
+import { updateMyVaLayoutVersion } from '../actions/preferences';
 
-const LOCAL_STORAGE_KEY = 'myVaVersion';
+const LOCAL_STORAGE_KEY = 'myVaLayoutVersion';
+const MY_VA_LAYOUT_VERSION_OLD = 'old';
+const MY_VA_LAYOUT_VERSION_NEW = 'new';
 const BUTTONS = [
-  { value: 'new', label: 'New My VA' },
-  { value: 'old', label: 'Old My VA' },
+  { value: MY_VA_LAYOUT_VERSION_NEW, label: 'New My VA' },
+  { value: MY_VA_LAYOUT_VERSION_OLD, label: 'Old My VA' },
 ];
 
 const NewMyVaToggle = () => {
+  const dispatch = useDispatch();
   const [selected, setSelected] = useState(() => {
-    return localStorage.getItem(LOCAL_STORAGE_KEY) || 'old';
+    return localStorage.getItem(LOCAL_STORAGE_KEY) || MY_VA_LAYOUT_VERSION_OLD;
   });
 
   useEffect(
     () => {
+      const redesignEnabled = selected === MY_VA_LAYOUT_VERSION_NEW;
       localStorage.setItem(LOCAL_STORAGE_KEY, selected);
+      dispatch(updateMyVaLayoutVersion(selected));
+      dispatch(
+        updateFeatureToggleValue({
+          // eslint-disable-next-line camelcase
+          my_va_auth_exp_redesign_enabled: redesignEnabled,
+        }),
+      );
     },
-    [selected],
+    [selected, dispatch],
   );
 
   const handleClick = event => {

--- a/src/applications/personalization/dashboard/components/NewMyVaToggle.scss
+++ b/src/applications/personalization/dashboard/components/NewMyVaToggle.scss
@@ -1,0 +1,3 @@
+.my-va-toggle va-button-segmented {
+  justify-content: left!important;
+}

--- a/src/applications/personalization/dashboard/mocks/server.js
+++ b/src/applications/personalization/dashboard/mocks/server.js
@@ -46,6 +46,7 @@ const responses = {
       myVaFormPdfLink: true,
       veteranOnboardingShowWelcomeMessageToNewUsers: true,
       myVaAuthExpRedesignEnabled: false,
+      myVaAuthExpRedesignAvailableToOptIn: true,
     },
     true,
   ),

--- a/src/applications/personalization/dashboard/mocks/server.js
+++ b/src/applications/personalization/dashboard/mocks/server.js
@@ -45,7 +45,6 @@ const responses = {
       myVaFormSubmissionStatuses: true,
       myVaFormPdfLink: true,
       veteranOnboardingShowWelcomeMessageToNewUsers: true,
-      myVaAuthExpRedesignEnabled: false,
       myVaAuthExpRedesignAvailableToOptIn: true,
     },
     true,

--- a/src/applications/personalization/dashboard/reducers/index.js
+++ b/src/applications/personalization/dashboard/reducers/index.js
@@ -11,6 +11,7 @@ import debts from './debts';
 import payments from './payments';
 import forms from './form-status';
 import formPdfs from './form-pdf-urls';
+import preferences from './preferences';
 
 export default {
   ...profile,
@@ -19,6 +20,7 @@ export default {
   allPayments: payments,
   allDebts: debts,
   submittedForms: forms,
+  myVaPreferences: preferences,
   myVaFormPdfs: formPdfs,
   health: combineReducers({
     appointments,

--- a/src/applications/personalization/dashboard/reducers/preferences.js
+++ b/src/applications/personalization/dashboard/reducers/preferences.js
@@ -1,10 +1,10 @@
 import set from 'platform/utilities/data/set';
-import { SET_MYVA_LAYOUT_PREFERENCE } from '../actions/preferences';
+import { SET_MY_VA_LAYOUT_PREFERENCE } from '../actions/preferences';
 
 const initialState = {};
 
 export default function preferencesReducer(state = initialState, action) {
-  if (action.type === SET_MYVA_LAYOUT_PREFERENCE) {
+  if (action.type === SET_MY_VA_LAYOUT_PREFERENCE) {
     return set('layout.version', action.layout.version, state);
   }
 

--- a/src/applications/personalization/dashboard/reducers/preferences.js
+++ b/src/applications/personalization/dashboard/reducers/preferences.js
@@ -1,0 +1,12 @@
+import set from 'platform/utilities/data/set';
+import { SET_MYVA_LAYOUT_PREFERENCE } from '../actions/preferences';
+
+const initialState = {};
+
+export default function preferencesReducer(state = initialState, action) {
+  if (action.type === SET_MYVA_LAYOUT_PREFERENCE) {
+    return set('layout.version', action.layout.version, state);
+  }
+
+  return state;
+}

--- a/src/applications/personalization/dashboard/tests/components/NewMyVaToggle.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/NewMyVaToggle.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
@@ -24,10 +24,8 @@ describe('NewMyVaToggle', () => {
     await waitFor(() => {
       expect(container.getElementsByTagName('va-button-segmented')).to.exist;
     });
-    const segmentedButtons = container.getElementsByTagName(
-      'va-button-segmented',
-    );
-    expect(segmentedButtons[0].selected).to.equal(1);
+    const buttonSegmented = container.querySelector('va-button-segmented');
+    expect(buttonSegmented.selected).to.equal(1);
   });
 
   it('renders with selection from localStorage (old)', async () => {
@@ -40,10 +38,8 @@ describe('NewMyVaToggle', () => {
     await waitFor(() => {
       expect(container.getElementsByTagName('va-button-segmented')).to.exist;
     });
-    const segmentedButtons = container.getElementsByTagName(
-      'va-button-segmented',
-    );
-    expect(segmentedButtons[0].selected).to.equal(1);
+    const buttonSegmented = container.querySelector('va-button-segmented');
+    expect(buttonSegmented.selected).to.equal(1);
   });
 
   it('renders with selection from localStorage (new)', async () => {
@@ -56,13 +52,32 @@ describe('NewMyVaToggle', () => {
     await waitFor(() => {
       expect(container.getElementsByTagName('va-button-segmented')).to.exist;
     });
-    const segmentedButtons = container.getElementsByTagName(
-      'va-button-segmented',
-    );
-    expect(segmentedButtons[0].selected).to.equal(0);
+    const buttonSegmented = container.querySelector('va-button-segmented');
+    expect(buttonSegmented.selected).to.equal(0);
   });
 
-  it.skip('updates localStorage when New My VA is clicked', async () => {
+  it('updates localStorage when New My VA is clicked', async () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'old');
+    const { container } = render(
+      <Provider store={mockStore({})}>
+        <NewMyVaToggle />
+      </Provider>,
+    );
+    await waitFor(() => {
+      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
+    });
+    const buttonSegmented = container.querySelector('va-button-segmented');
+    fireEvent(
+      buttonSegmented,
+      new CustomEvent('vaButtonClick', {
+        bubbles: true,
+        detail: { value: 'new' },
+      }),
+    );
+    expect(localStorage.getItem(LOCAL_STORAGE_KEY)).to.equal('new');
+  });
+
+  it('updates localStorage when Old My VA is clicked', async () => {
     localStorage.setItem(LOCAL_STORAGE_KEY, 'new');
     const { container } = render(
       <Provider store={mockStore({})}>
@@ -72,21 +87,26 @@ describe('NewMyVaToggle', () => {
     await waitFor(() => {
       expect(container.getElementsByTagName('va-button-segmented')).to.exist;
     });
-    const segmentedButtons = container.getElementsByTagName(
-      'va-button-segmented',
+    const buttonSegmented = container.querySelector('va-button-segmented');
+    fireEvent(
+      buttonSegmented,
+      new CustomEvent('vaButtonClick', {
+        bubbles: true,
+        detail: { value: 'old' },
+      }),
     );
-    // eslint-disable-next-line no-console
-    console.log(segmentedButtons[0].selected);
-    expect(localStorage.getItem(LOCAL_STORAGE_KEY)).to.equal('new');
+    expect(localStorage.getItem(LOCAL_STORAGE_KEY)).to.equal('old');
   });
 
-  it.skip('updates localStorage when Old My VA is clicked', async () => {
-    localStorage.setItem(LOCAL_STORAGE_KEY, 'new');
-    render(<NewMyVaToggle />);
-  });
-
-  it.skip('has correct aria label for accessibility', () => {
-    render(<NewMyVaToggle />);
-    expect(screen.getByLabelText('Select a My VA version')).to.exist;
+  it('has correct label for accessibility', () => {
+    const { container } = render(
+      <Provider store={mockStore({})}>
+        <NewMyVaToggle />
+      </Provider>,
+    );
+    expect(container.querySelector('va-button-segmented')).to.have.attribute(
+      'label',
+      'Select a My VA version',
+    );
   });
 });

--- a/src/applications/personalization/dashboard/tests/components/NewMyVaToggle.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/NewMyVaToggle.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
@@ -21,11 +21,8 @@ describe('NewMyVaToggle', () => {
         <NewMyVaToggle />
       </Provider>,
     );
-    await waitFor(() => {
-      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
-    });
     const buttonSegmented = container.querySelector('va-button-segmented');
-    expect(buttonSegmented.selected).to.equal(1);
+    expect(buttonSegmented.selected).to.equal(1); // "old" is the second button
   });
 
   it('renders with selection from localStorage (old)', async () => {
@@ -35,11 +32,8 @@ describe('NewMyVaToggle', () => {
         <NewMyVaToggle />
       </Provider>,
     );
-    await waitFor(() => {
-      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
-    });
     const buttonSegmented = container.querySelector('va-button-segmented');
-    expect(buttonSegmented.selected).to.equal(1);
+    expect(buttonSegmented.selected).to.equal(1); // "old" is the second button
   });
 
   it('renders with selection from localStorage (new)', async () => {
@@ -49,11 +43,8 @@ describe('NewMyVaToggle', () => {
         <NewMyVaToggle />
       </Provider>,
     );
-    await waitFor(() => {
-      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
-    });
     const buttonSegmented = container.querySelector('va-button-segmented');
-    expect(buttonSegmented.selected).to.equal(0);
+    expect(buttonSegmented.selected).to.equal(0); // "new" is the first button
   });
 
   it('updates localStorage when New My VA is clicked', async () => {
@@ -63,9 +54,6 @@ describe('NewMyVaToggle', () => {
         <NewMyVaToggle />
       </Provider>,
     );
-    await waitFor(() => {
-      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
-    });
     const buttonSegmented = container.querySelector('va-button-segmented');
     fireEvent(
       buttonSegmented,
@@ -84,9 +72,6 @@ describe('NewMyVaToggle', () => {
         <NewMyVaToggle />
       </Provider>,
     );
-    await waitFor(() => {
-      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
-    });
     const buttonSegmented = container.querySelector('va-button-segmented');
     fireEvent(
       buttonSegmented,

--- a/src/applications/personalization/dashboard/tests/components/NewMyVaToggle.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/NewMyVaToggle.unit.spec.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, screen, waitFor } from '@testing-library/react';
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import NewMyVaToggle from '../../components/NewMyVaToggle';
+
+const LOCAL_STORAGE_KEY = 'myVaLayoutVersion';
+
+const mockStore = configureStore([thunk]);
+
+describe('NewMyVaToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders with default selection (old) when localStorage is empty', async () => {
+    const { container } = render(
+      <Provider store={mockStore({})}>
+        <NewMyVaToggle />
+      </Provider>,
+    );
+    await waitFor(() => {
+      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
+    });
+    const segmentedButtons = container.getElementsByTagName(
+      'va-button-segmented',
+    );
+    expect(segmentedButtons[0].selected).to.equal(1);
+  });
+
+  it('renders with selection from localStorage (old)', async () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'old');
+    const { container } = render(
+      <Provider store={mockStore({})}>
+        <NewMyVaToggle />
+      </Provider>,
+    );
+    await waitFor(() => {
+      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
+    });
+    const segmentedButtons = container.getElementsByTagName(
+      'va-button-segmented',
+    );
+    expect(segmentedButtons[0].selected).to.equal(1);
+  });
+
+  it('renders with selection from localStorage (new)', async () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'new');
+    const { container } = render(
+      <Provider store={mockStore({})}>
+        <NewMyVaToggle />
+      </Provider>,
+    );
+    await waitFor(() => {
+      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
+    });
+    const segmentedButtons = container.getElementsByTagName(
+      'va-button-segmented',
+    );
+    expect(segmentedButtons[0].selected).to.equal(0);
+  });
+
+  it.skip('updates localStorage when New My VA is clicked', async () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'new');
+    const { container } = render(
+      <Provider store={mockStore({})}>
+        <NewMyVaToggle />
+      </Provider>,
+    );
+    await waitFor(() => {
+      expect(container.getElementsByTagName('va-button-segmented')).to.exist;
+    });
+    const segmentedButtons = container.getElementsByTagName(
+      'va-button-segmented',
+    );
+    // eslint-disable-next-line no-console
+    console.log(segmentedButtons[0].selected);
+    expect(localStorage.getItem(LOCAL_STORAGE_KEY)).to.equal('new');
+  });
+
+  it.skip('updates localStorage when Old My VA is clicked', async () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'new');
+    render(<NewMyVaToggle />);
+  });
+
+  it.skip('has correct aria label for accessibility', () => {
+    render(<NewMyVaToggle />);
+    expect(screen.getByLabelText('Select a My VA version')).to.exist;
+  });
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -346,6 +346,7 @@
   "accreditedRepresentativePortalHelp": "accredited_representative_portal_help",
   "accreditedRepresentativePortalProfile": "accredited_representative_portal_profile",
   "myVaAuthExpRedesignEnabled": "my_va_auth_exp_redesign_enabled",
+  "myVaAuthExpRedesignAvailableToOptIn": "my_va_auth_exp_redesign_available_to_opt_in",
   "accreditedRepresentativePortalSelfServiceAuth": "accredited_representative_portal_self_service_auth",
   "accreditedRepresentativePortalForm": "accredited_representative_portal_form",
   "accreditedRepresentativePortalDashboardLink": "accredited_representative_portal_dashboard_link",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Provide a method for allowing users to toggle the new My VA Dashboard design on and off at will
- The goal for allowing users to manipulate the flipper setting on their local browser through the use of the [VA Segmented Button](https://design.va.gov/components/button/button-segmented) component is in an effort to allow the continued and standardized use of the `<Toggler />` component. Once we are through the "Try it out" phase of the redesign this will further allow us to more easily move everyone over to the new design by toggling off the ability to opt-in for the redesign and just setting it as enabled for everyone.
- Authenticated Experience Team AuthentiKnights
- Flipper: `my_va_auth_exp_redesign_available_to_opt_in`

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#113542

## Testing done

- Tested clicking the buttons and checking that the localStorage values were properly updated and further tested that the proper rendering takes place when all 3 scenarios (new visitor, visitor that selected old, visitor that selected new) happen.
- Use the mocked api available [here](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/personalization/dashboard) and view the My VA Dashboard page and see that toggling the options at the top change the page layout below.

## Screenshots

### See note at the bottom about the weird button layout (it is expected at the moment)

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="438" height="562" alt="image" src="https://github.com/user-attachments/assets/92a37d8e-8b98-4a87-a9d3-c533718f01a6" />| <img width="431" height="606" alt="image" src="https://github.com/user-attachments/assets/760de6ce-5a28-4b61-aa88-1ecf3efa2302" /> |
| Desktop |<img width="990" height="688" alt="image" src="https://github.com/user-attachments/assets/1e521112-0388-48c7-baf9-f77ccecc4551" />| <img width="962" height="642" alt="image" src="https://github.com/user-attachments/assets/0de69b81-ac09-4aa6-a233-825bb17486d7" /> |

## What areas of the site does it impact?

This just touched the My VA Dashboard page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

The layout of the segmented buttons is currently buggy and this is not going out to prod yet. There is an [active bug ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4777) that will need to be resolved before this can go to prod but it doesn't impact the ability to test this / shouldn't require a future code change once the bug is resolved so we should be good to merge this before that fix is in.