### PR TITLE
117532 - profile - update direct deposit errors & alerts

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/alerts/UpdateErrorAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/UpdateErrorAlert.jsx
@@ -45,12 +45,9 @@ function InvalidRoutingNumber() {
   return (
     <>
       <p
-        className="vads-u-margin-top--0"
+        className="vads-u-margin-y--0"
         data-testid="invalid-routing-number-error"
       >
-        We can’t find a bank linked to the routing number you entered.
-      </p>
-      <p className="vads-u-margin-bottom--0">
         Review your routing number and make sure it’s correct.
       </p>
     </>
@@ -160,7 +157,7 @@ export const UpdateErrorAlert = ({ className, saveError }) => {
   }
 
   let content = <GenericError />;
-  let title = 'We couldn’t update your bank information';
+  let title = '';
 
   if (Array.isArray(saveError) && saveError?.length > 0) {
     if (
@@ -170,9 +167,10 @@ export const UpdateErrorAlert = ({ className, saveError }) => {
       title = "We couldn't update your direct deposit information";
       content = <PaymentRestrictionError />;
     } else if (hasRoutingNumberFlaggedError(saveError)) {
+      title = "We couldn't update your direct deposit information";
       content = <FlaggedRoutingNumber />;
     } else if (hasInvalidRoutingNumberError(saveError)) {
-      title = '';
+      title = 'We can’t find a bank linked to the routing number you entered.';
       content = <InvalidRoutingNumber />;
     } else if (hasInvalidAddressError(saveError)) {
       content = <UpdateAddressError />;

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/UpdateErrorAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/UpdateErrorAlert.jsx
@@ -29,13 +29,14 @@ function FlaggedRoutingNumber() {
         (<va-telephone contact={CONTACTS['711']} tty />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
-      <p className="vads-u-margin-bottom--0">
+      <p>
         You can also update this information by mail or in person at a VA
-        regional office.{' '}
+        regional office.
+      </p>
+      <p className="vads-u-margin-bottom--0">
         <a href="/change-direct-deposit">
-          Learn how to update your direct deposit bank information
+          Learn how to update your direct deposit bank information.
         </a>
-        .
       </p>
     </>
   );
@@ -45,9 +46,12 @@ function InvalidRoutingNumber() {
   return (
     <>
       <p
-        className="vads-u-margin-y--0"
+        className="vads-u-margin-top--0"
         data-testid="invalid-routing-number-error"
       >
+        We can’t find a bank linked to the routing number you entered.
+      </p>
+      <p className="vads-u-margin-bottom--0">
         Review your routing number and make sure it’s correct.
       </p>
     </>
@@ -119,10 +123,11 @@ function PaymentRestrictionError() {
         details and fix the problem. We’re here Monday through Friday, 8:00 a.m.
         to 9:00 p.m. ET.
       </p>
-      <p className="vads-u-margin-bottom--0">
+      <p>
         Or you can contact a regional office near you to come in for help in
         person.
-        <br />
+      </p>
+      <p className="vads-u-margin-bottom--0">
         <a
           href="/find-locations/?page=&facilityType=benefits&serviceType"
           target="_blank"
@@ -157,43 +162,35 @@ export const UpdateErrorAlert = ({ className, saveError }) => {
   }
 
   let content = <GenericError />;
-  let title = 'We couldn’t update your bank information';
 
   if (Array.isArray(saveError) && saveError?.length > 0) {
     if (
       hasAccountFlaggedError(saveError) ||
       hasPaymentRestrictionIndicatorsError(saveError)
     ) {
-      title = 'We couldn’t update your direct deposit information';
       content = <PaymentRestrictionError />;
     } else if (hasRoutingNumberFlaggedError(saveError)) {
-      title = 'We couldn’t update your direct deposit information';
       content = <FlaggedRoutingNumber />;
     } else if (hasInvalidRoutingNumberError(saveError)) {
-      title = 'We can’t find a bank linked to the routing number you entered';
       content = <InvalidRoutingNumber />;
     } else if (hasInvalidAddressError(saveError)) {
-      title = '';
       content = <UpdateAddressError />;
     } else if (hasInvalidHomePhoneNumberError(saveError)) {
-      title = '';
       content = <UpdatePhoneNumberError phoneNumberType="home" />;
     } else if (hasInvalidWorkPhoneNumberError(saveError)) {
-      title = '';
       content = <UpdatePhoneNumberError phoneNumberType="work" />;
     }
   }
 
   return (
     <va-alert
-      slim={!title}
+      slim
       status="error"
       visible="true"
       class={className}
       ref={alertRef}
       uswds
     >
-      {title && <h2 slot="headline">{title}</h2>}
       {content}
     </va-alert>
   );

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/UpdateErrorAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/UpdateErrorAlert.jsx
@@ -157,26 +157,29 @@ export const UpdateErrorAlert = ({ className, saveError }) => {
   }
 
   let content = <GenericError />;
-  let title = '';
+  let title = 'We couldn’t update your bank information';
 
   if (Array.isArray(saveError) && saveError?.length > 0) {
     if (
       hasAccountFlaggedError(saveError) ||
       hasPaymentRestrictionIndicatorsError(saveError)
     ) {
-      title = "We couldn't update your direct deposit information";
+      title = 'We couldn’t update your direct deposit information';
       content = <PaymentRestrictionError />;
     } else if (hasRoutingNumberFlaggedError(saveError)) {
-      title = "We couldn't update your direct deposit information";
+      title = 'We couldn’t update your direct deposit information';
       content = <FlaggedRoutingNumber />;
     } else if (hasInvalidRoutingNumberError(saveError)) {
-      title = 'We can’t find a bank linked to the routing number you entered.';
+      title = 'We can’t find a bank linked to the routing number you entered';
       content = <InvalidRoutingNumber />;
     } else if (hasInvalidAddressError(saveError)) {
+      title = '';
       content = <UpdateAddressError />;
     } else if (hasInvalidHomePhoneNumberError(saveError)) {
+      title = '';
       content = <UpdatePhoneNumberError phoneNumberType="home" />;
     } else if (hasInvalidWorkPhoneNumberError(saveError)) {
+      title = '';
       content = <UpdatePhoneNumberError phoneNumberType="work" />;
     }
   }

--- a/src/applications/personalization/profile/mocks/endpoints/direct-deposits/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/direct-deposits/index.js
@@ -83,14 +83,19 @@ const unspecifiedError = {
     {
       title: 'Bad Request',
       detail: 'Unspecified Error Detail',
-      code: 'cnp.payment.unspecified.error',
+      code: 'direct.deposit.unspecified.error',
       status: 400,
       source: 'Lighthouse Direct Deposit',
     },
   ],
 };
 
-const createError = ({ code = '', detail = '' } = {}) => {
+const createError = ({
+  code = '',
+  detail = '',
+  title = '',
+  status = '',
+} = {}) => {
   const errorBase = _.cloneDeep(unspecifiedError);
   if (code) {
     _.set(errorBase, 'errors[0].code', code);
@@ -98,49 +103,61 @@ const createError = ({ code = '', detail = '' } = {}) => {
   if (detail) {
     _.set(errorBase, 'errors[0].detail', detail);
   }
+  if (title) {
+    _.set(errorBase, 'errors[0].title', title);
+  }
+  if (status) {
+    _.set(errorBase, 'errors[0].status', status);
+  }
   return errorBase;
 };
 
 const errors = {
   unspecified: unspecifiedError,
   generic: createError({
-    code: 'cnp.payment.generic.error',
+    code: 'direct.deposit.generic.error',
   }),
   accountNumberFlagged: createError({
-    code: 'cnp.payment.account.number.fraud',
+    code: 'direct.deposit.account.number.fraud',
   }),
   routingNumberFlagged: createError({
-    code: 'cnp.payment.routing.number.fraud',
+    code: 'direct.deposit.routing.number.fraud',
   }),
   invalidRoutingNumber: createError({
-    code: 'cnp.payment.routing.number.invalid',
+    code: 'direct.deposit.routing.number.invalid',
   }),
   invalidChecksumRoutingNumber: createError({
-    code: 'cnp.payment.routing.number.invalid.checksum',
+    code: 'direct.deposit.routing.number.invalid.checksum',
   }),
   invalidRoutingNumberUnspecified: createError({
     detail: 'No changes were made: Invalid Routing Number',
   }),
   invalidAccountNumber: createError({
-    code: 'cnp.payment.account.number.invalid',
+    code: 'direct.deposit.account.number.invalid',
   }),
   paymentRestrictionsPresent: createError({
-    code: 'cnp.payment.restriction.indicators.present',
+    code: 'direct.deposit.restriction.indicators.present',
   }),
   invalidDayPhone: createError({
-    code: 'cnp.payment.day.phone.number.invalid',
+    code: 'direct.deposit.day.phone.number.invalid',
   }),
   invalidDayPhoneArea: createError({
-    code: 'cnp.payment.day.area.number.invalid',
+    code: 'direct.deposit.day.area.number.invalid',
   }),
   invalidNightPhone: createError({
-    code: 'cnp.payment.night.phone.number.invalid',
+    code: 'direct.deposit.night.phone.number.invalid',
   }),
   invalidNightPhoneArea: createError({
-    code: 'cnp.payment.night.area.number.invalid',
+    code: 'direct.deposit.night.area.number.invalid',
   }),
   invalidMailingAddress: createError({
-    code: 'cnp.payment.mailing.address.invalid',
+    code: 'direct.deposit.mailing.address.invalid',
+  }),
+  missingPaymentAddress: createError({
+    title: 'Missing Required Data',
+    detail: 'Payment Address Data Not Found',
+    code: 'direct.deposit.payment.address.missing',
+    status: 422,
   }),
 };
 

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -216,12 +216,9 @@ const responses = {
     const secondsOfDelay = 1;
     delaySingleResponse(
       // () => res.status(500).json(error500),
-      // () => res.status(200).json(mockDisabilityCompensations.updates.success),
-      () => res.status(400).json(directDeposits.updates.errors.invalidDayPhone),
-      // () =>
-      //   res
-      //     .status(422)
-      //     .json(directDeposits.updates.errors.paymentRestrictionsPresent),
+      () => res.status(200).json(directDeposits.updates.success),
+      // () => res.status(400).json(directDeposits.updates.errors.invalidDayPhone),
+      // () => res.status(422).json(directDeposits.updates.errors.missingPaymentAddress),
       secondsOfDelay,
     );
   },

--- a/src/applications/personalization/profile/tests/components/direct-deposit/AccountUpdateView.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/AccountUpdateView.unit.spec.jsx
@@ -112,7 +112,6 @@ describe('<AccountUpdateView />', () => {
   });
 
   it('renders the UpdateErrorAlert when saveError is provided', () => {
-    const errorHeadline = 'We couldn’t update your bank information';
     const errorMessage =
       'We’re sorry. We couldn’t update your payment information. Please try again later.';
     props.saveError = 'Internal Server Error';
@@ -124,7 +123,6 @@ describe('<AccountUpdateView />', () => {
       },
     );
 
-    expect(getByText(errorHeadline)).to.exist;
     expect(getByText(errorMessage)).to.exist;
   });
 

--- a/src/applications/personalization/profile/tests/components/direct-deposit/UpdateErrorAlert.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/UpdateErrorAlert.unit.spec.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
-import mockDisabilityCompensations from '@@profile/mocks/endpoints/disability-compensations';
+import directDeposits from '@@profile/mocks/endpoints/direct-deposits';
 
-const { errors } = mockDisabilityCompensations.updates;
+const { errors } = directDeposits.updates;
 
 import { UpdateErrorAlert } from '../../../components/direct-deposit/alerts/UpdateErrorAlert';
 
@@ -35,7 +35,7 @@ describe('<UpdateErrorAlert />', () => {
     );
     expect(
       await findByText(
-        'We can’t find a bank linked to the routing number you entered.',
+        'We can’t find a bank linked to the routing number you entered',
       ),
     ).to.exist;
   });
@@ -46,7 +46,7 @@ describe('<UpdateErrorAlert />', () => {
     );
     expect(
       await findByText2(
-        'We can’t find a bank linked to the routing number you entered.',
+        'We can’t find a bank linked to the routing number you entered',
       ),
     ).to.exist;
   });
@@ -82,6 +82,17 @@ describe('<UpdateErrorAlert />', () => {
   it('renders the mailing address error', async () => {
     const { findByText } = render(
       <UpdateErrorAlert saveError={errors.invalidMailingAddress.errors} />,
+    );
+    expect(
+      await findByText(
+        /We’re sorry. We couldn’t update your direct deposit bank information because your mailing address is missing or invalid./i,
+      ),
+    ).to.exist;
+  });
+
+  it('renders the mailing address error for missing payment address', async () => {
+    const { findByText } = render(
+      <UpdateErrorAlert saveError={errors.missingPaymentAddress.errors} />,
     );
     expect(
       await findByText(

--- a/src/applications/personalization/profile/tests/components/direct-deposit/UpdateErrorAlert.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/UpdateErrorAlert.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('<UpdateErrorAlert />', () => {
     );
     expect(
       await findByText(
-        'We can’t find a bank linked to the routing number you entered',
+        'We can’t find a bank linked to the routing number you entered.',
       ),
     ).to.exist;
   });
@@ -46,7 +46,7 @@ describe('<UpdateErrorAlert />', () => {
     );
     expect(
       await findByText2(
-        'We can’t find a bank linked to the routing number you entered',
+        'We can’t find a bank linked to the routing number you entered.',
       ),
     ).to.exist;
   });

--- a/src/applications/personalization/profile/tests/e2e/contact-information/edit-phone-number.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/edit-phone-number.cypress.spec.js
@@ -195,7 +195,7 @@ describe('Profile - Contact Information - editing phone numbers', () => {
     cy.get('va-telephone-input').should(
       'have.attr',
       'error',
-      'Enter a United States of America phone number in a valid format, for example, (xxx) xxx-xxxx',
+      'Enter a valid United States of America phone number. Use 10 digits.',
     );
 
     cy.contains('Update saved.').should('not.exist');

--- a/src/applications/personalization/profile/tests/util/index.hasErrorCombos.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/index.hasErrorCombos.unit.spec.jsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import directDeposits from '@@profile/mocks/endpoints/direct-deposits';
+import mockDirectDeposits from '@@profile/mocks/endpoints/direct-deposits';
 import { DIRECT_DEPOSIT_ERROR_KEYS, hasErrorCombos } from '../../util';
 
 describe('hasErrorCombos', () => {
@@ -8,7 +8,7 @@ describe('hasErrorCombos', () => {
     it('return true for routing number error', () => {
       expect(
         hasErrorCombos({
-          errors: directDeposits.updates.errors.invalidRoutingNumber.errors,
+          errors: mockDirectDeposits.updates.errors.invalidRoutingNumber.errors,
           errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.ROUTING_NUMBER_INVALID],
         }),
       ).to.be.true;
@@ -19,7 +19,7 @@ describe('hasErrorCombos', () => {
     it('return true for Lighthouse day phone error', () => {
       expect(
         hasErrorCombos({
-          errors: directDeposits.updates.errors.invalidDayPhone.errors,
+          errors: mockDirectDeposits.updates.errors.invalidDayPhone.errors,
           errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.DAY_PHONE_NUMBER_INVALID],
         }),
       ).to.be.true;
@@ -28,7 +28,7 @@ describe('hasErrorCombos', () => {
     it('return true for Lighthouse day phone area error', () => {
       expect(
         hasErrorCombos({
-          errors: directDeposits.updates.errors.invalidDayPhoneArea.errors,
+          errors: mockDirectDeposits.updates.errors.invalidDayPhoneArea.errors,
           errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.DAY_PHONE_AREA_INVALID],
         }),
       ).to.be.true;

--- a/src/applications/personalization/profile/tests/util/index.hasErrorCombos.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/index.hasErrorCombos.unit.spec.jsx
@@ -1,17 +1,15 @@
 import { expect } from 'chai';
 
-import mockDisabilityCompensations from '@@profile/mocks/endpoints/disability-compensations';
-import { LIGHTHOUSE_ERROR_KEYS, hasErrorCombos } from '../../util';
+import directDeposits from '@@profile/mocks/endpoints/direct-deposits';
+import { DIRECT_DEPOSIT_ERROR_KEYS, hasErrorCombos } from '../../util';
 
 describe('hasErrorCombos', () => {
   context('cases for invalid routing number', () => {
     it('return true for routing number error', () => {
       expect(
         hasErrorCombos({
-          errors:
-            mockDisabilityCompensations.updates.errors.invalidRoutingNumber
-              .errors,
-          errorKeys: [LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_INVALID],
+          errors: directDeposits.updates.errors.invalidRoutingNumber.errors,
+          errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.ROUTING_NUMBER_INVALID],
         }),
       ).to.be.true;
     });
@@ -21,20 +19,17 @@ describe('hasErrorCombos', () => {
     it('return true for Lighthouse day phone error', () => {
       expect(
         hasErrorCombos({
-          errors:
-            mockDisabilityCompensations.updates.errors.invalidDayPhone.errors,
-          errorKeys: [LIGHTHOUSE_ERROR_KEYS.DAY_PHONE_NUMBER_INVALID],
+          errors: directDeposits.updates.errors.invalidDayPhone.errors,
+          errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.DAY_PHONE_NUMBER_INVALID],
         }),
       ).to.be.true;
     });
 
-    it('return true for Lighthouse day area error', () => {
+    it('return true for Lighthouse day phone area error', () => {
       expect(
         hasErrorCombos({
-          errors:
-            mockDisabilityCompensations.updates.errors.invalidDayPhoneArea
-              .errors,
-          errorKeys: [LIGHTHOUSE_ERROR_KEYS.DAY_PHONE_AREA_INVALID],
+          errors: directDeposits.updates.errors.invalidDayPhoneArea.errors,
+          errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.DAY_PHONE_AREA_INVALID],
         }),
       ).to.be.true;
     });

--- a/src/applications/personalization/profile/tests/util/index.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/index.unit.spec.jsx
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import directDeposits from '@@profile/mocks/endpoints/direct-deposits';
+import mockDirectDeposits from '@@profile/mocks/endpoints/direct-deposits';
 
 import {
   createDirectDepositAnalyticsDataObject,
@@ -63,43 +63,43 @@ describe('profile utils', () => {
     });
     it('returns the correct data when a bad address error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject({
-        errors: directDeposits.updates.errors.invalidMailingAddress.errors,
+        errors: mockDirectDeposits.updates.errors.invalidMailingAddress.errors,
       });
       expect(eventDataObject).to.deep.equal(badAddressDataObject);
     });
     it('returns the correct data when a work phone number error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject(
-        directDeposits.updates.errors.invalidDayPhone,
+        mockDirectDeposits.updates.errors.invalidDayPhone,
       );
       expect(eventDataObject).to.deep.equal(badWorkPhoneDataObject);
     });
     it('returns the correct data when a day phone number error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject(
-        directDeposits.updates.errors.invalidNightPhone,
+        mockDirectDeposits.updates.errors.invalidNightPhone,
       );
       expect(eventDataObject).to.deep.equal(badHomePhoneDataObject);
     });
     it('returns the correct data when an account flagged for fraud error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject(
-        directDeposits.updates.errors.accountNumberFlagged,
+        mockDirectDeposits.updates.errors.accountNumberFlagged,
       );
       expect(eventDataObject).to.deep.equal(accountFlaggedForFraudDataObject);
     });
     it('returns the correct data when an invalid routing number error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject(
-        directDeposits.updates.errors.invalidRoutingNumber,
+        mockDirectDeposits.updates.errors.invalidRoutingNumber,
       );
       expect(eventDataObject).to.deep.equal(invalidRoutingNumberDataObject);
     });
     it('returns the correct data when an invalid routing number error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject(
-        directDeposits.updates.errors.invalidRoutingNumber,
+        mockDirectDeposits.updates.errors.invalidRoutingNumber,
       );
       expect(eventDataObject).to.deep.equal(invalidRoutingNumberDataObject);
     });
     it('returns the correct data when a payment restriction indicators error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject(
-        directDeposits.updates.errors.paymentRestrictionsPresent,
+        mockDirectDeposits.updates.errors.paymentRestrictionsPresent,
       );
       expect(eventDataObject).to.deep.equal(
         paymentRestrictionIndicatorsDataObject,
@@ -111,7 +111,7 @@ describe('profile utils', () => {
     it('hasRoutingNumberFlaggedError returns true on error', () => {
       expect(
         hasRoutingNumberFlaggedError(
-          directDeposits.updates.errors.routingNumberFlagged.errors,
+          mockDirectDeposits.updates.errors.routingNumberFlagged.errors,
         ),
       ).to.equal(true);
     });
@@ -119,23 +119,23 @@ describe('profile utils', () => {
     it('hasAccountFlaggedError returns true on error', () => {
       expect(
         hasAccountFlaggedError(
-          directDeposits.updates.errors.accountNumberFlagged.errors,
+          mockDirectDeposits.updates.errors.accountNumberFlagged.errors,
         ),
       ).to.equal(true);
     });
 
     it('hasInvalidHomePhoneNumberError returns false if text does not contain night phone', () => {
-      const { errors } = directDeposits.updates.errors.generic;
+      const { errors } = mockDirectDeposits.updates.errors.generic;
       expect(hasInvalidHomePhoneNumberError(errors)).to.not.be.ok;
     });
 
     it('should return false with multiple errors with text not matching desired error conditions', () => {
-      const { errors } = directDeposits.updates.errors.generic;
+      const { errors } = mockDirectDeposits.updates.errors.generic;
 
       expect(
         !!hasInvalidHomePhoneNumberError([
           ...errors,
-          ...directDeposits.updates.errors.invalidAccountNumber.errors,
+          ...mockDirectDeposits.updates.errors.invalidAccountNumber.errors,
         ]),
       ).to.be.not.ok;
     });

--- a/src/applications/personalization/profile/tests/util/index.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/util/index.unit.spec.jsx
@@ -1,50 +1,50 @@
 import { expect } from 'chai';
 
-import mockDisabilityCompensations from '@@profile/mocks/endpoints/disability-compensations';
+import directDeposits from '@@profile/mocks/endpoints/direct-deposits';
 
 import {
-  createCNPDirectDepositAnalyticsDataObject,
+  createDirectDepositAnalyticsDataObject,
   hasAccountFlaggedError,
   hasRoutingNumberFlaggedError,
   hasInvalidHomePhoneNumberError,
 } from '../../util';
 
 describe('profile utils', () => {
-  describe('createCNPDirectDepositAnalyticsDataObject', () => {
+  describe('createDirectDepositAnalyticsDataObject', () => {
     const createEventDataObjectWithError = (
       errorKey,
       errorKeyDetail = 'Unspecified Error Detail',
     ) => ({
       event: 'profile-edit-failure',
       'profile-action': 'save-failure',
-      'profile-section': 'cnp-direct-deposit-information',
+      'profile-section': 'direct-deposit-information',
       'error-key': `${errorKey} | ${errorKeyDetail || ''}-update`,
     });
     const defaultDataObject = createEventDataObjectWithError('other-error', '');
     const badAddressDataObject = createEventDataObjectWithError(
-      'cnp.payment.mailing.address.invalid',
+      'direct.deposit.mailing.address.invalid',
     );
     const badHomePhoneDataObject = createEventDataObjectWithError(
-      'cnp.payment.night.phone.number.invalid',
+      'direct.deposit.night.phone.number.invalid',
     );
     const badWorkPhoneDataObject = createEventDataObjectWithError(
-      'cnp.payment.day.phone.number.invalid',
+      'direct.deposit.day.phone.number.invalid',
     );
     const accountFlaggedForFraudDataObject = createEventDataObjectWithError(
-      'cnp.payment.account.number.fraud',
+      'direct.deposit.account.number.fraud',
     );
     const invalidRoutingNumberDataObject = createEventDataObjectWithError(
-      'cnp.payment.routing.number.invalid',
+      'direct.deposit.routing.number.invalid',
     );
     const paymentRestrictionIndicatorsDataObject = createEventDataObjectWithError(
-      'cnp.payment.restriction.indicators.present',
+      'direct.deposit.restriction.indicators.present',
     );
     it('returns the correct data when passed nothing', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject();
+      const eventDataObject = createDirectDepositAnalyticsDataObject();
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
     it('returns the correct data when passed an empty array', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject([]);
+      const eventDataObject = createDirectDepositAnalyticsDataObject([]);
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
     // Wednesday, April 22, 2020 We saw errors in Sentry due to unsafe prop
@@ -52,9 +52,9 @@ describe('profile utils', () => {
     // the error.
     // http://sentry.vfs.va.gov/vets-gov/website-production/issues/115880/
     it('returns the default error  event object when nothing is passed', () => {
-      let eventDataObject = createCNPDirectDepositAnalyticsDataObject([{}]);
+      let eventDataObject = createDirectDepositAnalyticsDataObject([{}]);
       expect(eventDataObject).to.deep.equal(defaultDataObject);
-      eventDataObject = createCNPDirectDepositAnalyticsDataObject([
+      eventDataObject = createDirectDepositAnalyticsDataObject([
         {
           meta: {},
         },
@@ -62,46 +62,44 @@ describe('profile utils', () => {
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
     it('returns the correct data when a bad address error is passed', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject({
-        errors:
-          mockDisabilityCompensations.updates.errors.invalidMailingAddress
-            .errors,
+      const eventDataObject = createDirectDepositAnalyticsDataObject({
+        errors: directDeposits.updates.errors.invalidMailingAddress.errors,
       });
       expect(eventDataObject).to.deep.equal(badAddressDataObject);
     });
     it('returns the correct data when a work phone number error is passed', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject(
-        mockDisabilityCompensations.updates.errors.invalidDayPhone,
+      const eventDataObject = createDirectDepositAnalyticsDataObject(
+        directDeposits.updates.errors.invalidDayPhone,
       );
       expect(eventDataObject).to.deep.equal(badWorkPhoneDataObject);
     });
     it('returns the correct data when a day phone number error is passed', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject(
-        mockDisabilityCompensations.updates.errors.invalidNightPhone,
+      const eventDataObject = createDirectDepositAnalyticsDataObject(
+        directDeposits.updates.errors.invalidNightPhone,
       );
       expect(eventDataObject).to.deep.equal(badHomePhoneDataObject);
     });
     it('returns the correct data when an account flagged for fraud error is passed', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject(
-        mockDisabilityCompensations.updates.errors.accountNumberFlagged,
+      const eventDataObject = createDirectDepositAnalyticsDataObject(
+        directDeposits.updates.errors.accountNumberFlagged,
       );
       expect(eventDataObject).to.deep.equal(accountFlaggedForFraudDataObject);
     });
     it('returns the correct data when an invalid routing number error is passed', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject(
-        mockDisabilityCompensations.updates.errors.invalidRoutingNumber,
+      const eventDataObject = createDirectDepositAnalyticsDataObject(
+        directDeposits.updates.errors.invalidRoutingNumber,
       );
       expect(eventDataObject).to.deep.equal(invalidRoutingNumberDataObject);
     });
     it('returns the correct data when an invalid routing number error is passed', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject(
-        mockDisabilityCompensations.updates.errors.invalidRoutingNumber,
+      const eventDataObject = createDirectDepositAnalyticsDataObject(
+        directDeposits.updates.errors.invalidRoutingNumber,
       );
       expect(eventDataObject).to.deep.equal(invalidRoutingNumberDataObject);
     });
     it('returns the correct data when a payment restriction indicators error is passed', () => {
-      const eventDataObject = createCNPDirectDepositAnalyticsDataObject(
-        mockDisabilityCompensations.updates.errors.paymentRestrictionsPresent,
+      const eventDataObject = createDirectDepositAnalyticsDataObject(
+        directDeposits.updates.errors.paymentRestrictionsPresent,
       );
       expect(eventDataObject).to.deep.equal(
         paymentRestrictionIndicatorsDataObject,
@@ -113,8 +111,7 @@ describe('profile utils', () => {
     it('hasRoutingNumberFlaggedError returns true on error', () => {
       expect(
         hasRoutingNumberFlaggedError(
-          mockDisabilityCompensations.updates.errors.routingNumberFlagged
-            .errors,
+          directDeposits.updates.errors.routingNumberFlagged.errors,
         ),
       ).to.equal(true);
     });
@@ -122,25 +119,23 @@ describe('profile utils', () => {
     it('hasAccountFlaggedError returns true on error', () => {
       expect(
         hasAccountFlaggedError(
-          mockDisabilityCompensations.updates.errors.accountNumberFlagged
-            .errors,
+          directDeposits.updates.errors.accountNumberFlagged.errors,
         ),
       ).to.equal(true);
     });
 
     it('hasInvalidHomePhoneNumberError returns false if text does not contain night phone', () => {
-      const { errors } = mockDisabilityCompensations.updates.errors.generic;
+      const { errors } = directDeposits.updates.errors.generic;
       expect(hasInvalidHomePhoneNumberError(errors)).to.not.be.ok;
     });
 
     it('should return false with multiple errors with text not matching desired error conditions', () => {
-      const { errors } = mockDisabilityCompensations.updates.errors.generic;
+      const { errors } = directDeposits.updates.errors.generic;
 
       expect(
         !!hasInvalidHomePhoneNumberError([
           ...errors,
-          ...mockDisabilityCompensations.updates.errors.invalidAccountNumber
-            .errors,
+          ...directDeposits.updates.errors.invalidAccountNumber.errors,
         ]),
       ).to.be.not.ok;
     });

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -13,6 +13,7 @@ export const BASE_DIRECT_DEPOSIT_ERROR_KEYS = {
   NIGHT_PHONE_NUMBER_INVALID: '.night.phone.number.invalid',
   NIGHT_PHONE_AREA_INVALID: '.night.area.number.invalid',
   MAILING_ADDRESS_INVALID: '.mailing.address.invalid',
+  PAYMENT_ADDRESS_MISSING: '.payment.address.missing',
   UNSPECIFIED_ERROR: '.unspecified.error',
   GENERIC_ERROR: '.generic.error',
 };
@@ -122,9 +123,10 @@ export const hasInvalidRoutingNumberError = errors =>
   });
 
 // the cases for invalid address include:
-// - unspecified error code with error text 'address update' in the error detail
-// - generic error code with error text 'address update' in the error detail
+// - unspecified error code with error text 'address update' or 'Payment Address Data Not Found' in the error detail
+// - generic error code with error text 'address update' or 'Payment Address Data Not Found' in the error detail
 // - mailing address invalid error code
+// - payment address missing error code
 export const hasInvalidAddressError = errors =>
   hasErrorCombos({
     errors,
@@ -134,13 +136,14 @@ export const hasInvalidAddressError = errors =>
       DIRECT_DEPOSIT_ERROR_KEYS.UNSPECIFIED_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.GENERIC_ERROR,
     ],
-    errorTexts: ['address update'],
+    errorTexts: ['address update', 'Payment Address Data Not Found'],
   }) ||
   hasErrorCombos({
     errors,
     errorKeys: [
       LIGHTHOUSE_ERROR_KEYS.MAILING_ADDRESS_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.MAILING_ADDRESS_INVALID,
+      DIRECT_DEPOSIT_ERROR_KEYS.PAYMENT_ADDRESS_MISSING,
     ],
   });
 

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -18,16 +18,6 @@ export const BASE_DIRECT_DEPOSIT_ERROR_KEYS = {
   GENERIC_ERROR: '.generic.error',
 };
 
-// error keys for profile/direct_deposits/disability_compensations endpoint
-// easier to export and use than importing one by one constants
-// add cnp to the front of each base error key
-export const LIGHTHOUSE_ERROR_KEYS = Object.keys(
-  BASE_DIRECT_DEPOSIT_ERROR_KEYS,
-).reduce((acc, key) => {
-  acc[key] = `cnp.payment${BASE_DIRECT_DEPOSIT_ERROR_KEYS[key]}`;
-  return acc;
-}, {});
-
 export const DIRECT_DEPOSIT_ERROR_KEYS = Object.keys(
   BASE_DIRECT_DEPOSIT_ERROR_KEYS,
 ).reduce((acc, key) => {
@@ -83,17 +73,14 @@ export const hasErrorCombos = ({
 export const hasAccountFlaggedError = errors => {
   return hasErrorCombos({
     errors,
-    errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.ACCOUNT_FLAGGED_FOR_FRAUD,
-      DIRECT_DEPOSIT_ERROR_KEYS.ACCOUNT_FLAGGED_FOR_FRAUD,
-    ],
+    errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.ACCOUNT_FLAGGED_FOR_FRAUD],
   });
 };
 
 export const hasRoutingNumberFlaggedError = errors =>
   hasErrorCombos({
     errors,
-    errorKeys: [LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_FLAGGED_FOR_FRAUD],
+    errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.ROUTING_NUMBER_FLAGGED_FOR_FRAUD],
   });
 
 // the cases for invalid routing number include:
@@ -105,8 +92,6 @@ export const hasInvalidRoutingNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_INVALID_CHECKSUM,
-      LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.ROUTING_NUMBER_INVALID_CHECKSUM,
       DIRECT_DEPOSIT_ERROR_KEYS.ROUTING_NUMBER_INVALID,
     ],
@@ -114,8 +99,6 @@ export const hasInvalidRoutingNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
-      LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.UNSPECIFIED_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -131,8 +114,6 @@ export const hasInvalidAddressError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
-      LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.UNSPECIFIED_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -141,7 +122,6 @@ export const hasInvalidAddressError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.MAILING_ADDRESS_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.MAILING_ADDRESS_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.PAYMENT_ADDRESS_MISSING,
     ],
@@ -156,8 +136,6 @@ export const hasInvalidHomePhoneNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
-      LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.UNSPECIFIED_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -166,8 +144,6 @@ export const hasInvalidHomePhoneNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.NIGHT_PHONE_NUMBER_INVALID,
-      LIGHTHOUSE_ERROR_KEYS.NIGHT_PHONE_AREA_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.NIGHT_PHONE_NUMBER_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.NIGHT_PHONE_AREA_INVALID,
     ],
@@ -182,8 +158,6 @@ export const hasInvalidWorkPhoneNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
-      LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.UNSPECIFIED_ERROR,
       DIRECT_DEPOSIT_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -192,8 +166,6 @@ export const hasInvalidWorkPhoneNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.DAY_PHONE_NUMBER_INVALID,
-      LIGHTHOUSE_ERROR_KEYS.DAY_PHONE_AREA_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.DAY_PHONE_NUMBER_INVALID,
       DIRECT_DEPOSIT_ERROR_KEYS.DAY_PHONE_AREA_INVALID,
     ],
@@ -204,10 +176,7 @@ export const hasInvalidWorkPhoneNumberError = errors =>
 export const hasPaymentRestrictionIndicatorsError = errors =>
   hasErrorCombos({
     errors,
-    errorKeys: [
-      LIGHTHOUSE_ERROR_KEYS.PAYMENT_RESTRICTIONS_PRESENT,
-      DIRECT_DEPOSIT_ERROR_KEYS.PAYMENT_RESTRICTIONS_PRESENT,
-    ],
+    errorKeys: [DIRECT_DEPOSIT_ERROR_KEYS.PAYMENT_RESTRICTIONS_PRESENT],
   });
 
 // BEGIN TODO: remove this once the direct deposit form is updated to use single form

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -208,9 +208,9 @@ const getLighthouseErrorCode = (errors = []) => {
 
 // Helper that creates and returns an object to pass to the recordEvent()
 // function when an error occurs while trying to save/update a user's direct
-// deposit for compensation and pension payment information. The value of the
-// `error-key` prop will change depending on the content of the `errors` array.
-export const createCNPDirectDepositAnalyticsDataObject = ({
+// deposit information. The value of the `error-key` prop will change depending
+// on the content of the `errors` array.
+export const createDirectDepositAnalyticsDataObject = ({
   errors = [],
   isEnrolling = false,
 } = {}) => {
@@ -219,7 +219,7 @@ export const createCNPDirectDepositAnalyticsDataObject = ({
   return cloneDeep({
     event: 'profile-edit-failure',
     'profile-action': 'save-failure',
-    'profile-section': `cnp-direct-deposit-information`,
+    'profile-section': `direct-deposit-information`,
     'error-key': `${errorCode}${isEnrolling ? '-enroll' : '-update'}`,
   });
 };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Direct deposit errors for “Payment Address Data Not Found” surfaced a non-actionable generic error to users. This PR maps this error response to our existing `UpdateAddressError` alert:
- Adds the `direct.deposit.payment.address.missing` error code under the `hasInvalidAddress` function in our utils file
- Modifies `UpdateErrorAlert` to use slim alerts based on design feedback
- Replaces deprecated references to `cnp.payment` with `direct.deposit` in our utils file and local mocks for the `direct-deposits` endpoint
- Removes/updates other CNP & disability compensations references throughout updated files

Team: Authenticated Experience

This [vets-api PR](https://github.com/department-of-veterans-affairs/vets-api/pull/24087) will add the `direct.deposit.payment.address.missing` error code to the BE

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/117532

## Testing done

- Manually tested with local mocks & updated/added unit and e2e tests
- To test locally:
  - Follow [these instructions](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/personalization/profile#step-4-start-mock-api) to run the mock api
  - Start the local server with `yarn watch --env entry=profile`
  - Comment out [this line](https://github.com/department-of-veterans-affairs/vets-website/blob/b63dc122b77615085ae1ad113dd691ae07e0142c/src/applications/personalization/profile/mocks/server.js#L219) and uncomment [this line](https://github.com/department-of-veterans-affairs/vets-website/blob/b63dc122b77615085ae1ad113dd691ae07e0142c/src/applications/personalization/profile/mocks/server.js#L221) to mock the missing payment address response
  - Navigate to `127.0.0.1:3001/profile/direct-deposit` and edit the bank account info
  - You should see the `UpdateAddressError` alert

Since this change depends on LH error responses, we can only do local testing at this time. Our team will monitor Datadog to confirm this change works as expected.

## Screenshots

The main change is to use the UpdateAddressError instead of the generic error for the "Payment Address Data Not Found" response:

| Before | After |
| ------ | ----- |
| GenericError <img width="638" height="372" alt="image" src="https://github.com/user-attachments/assets/41c0bb85-8e0f-4389-9851-2e799c5b76d1" /> | UpdateAddressError <img width="646" height="342" alt="image" src="https://github.com/user-attachments/assets/e41b0560-3d52-4f83-bd2e-0390b24faab3" /> |

The secondary change is to use slim alerts without a headline ([designs will be updated here](https://www.figma.com/design/CUR39JNnF2CS8SidGiWmYG/Profile---Direct-Deposit?node-id=0-1&p=f&t=tNL7fjxhiyNh48VX-0)):

| Alert name | UI |
| ---- | ---- |
| GenericError | <img width="320" alt="genericError" src="https://github.com/user-attachments/assets/0a6744af-3ae6-4f5a-8fdc-3f0b1d9248f1" /> |
| PaymentRestrictionError | <img width="320" alt="paymentRestrictionError" src="https://github.com/user-attachments/assets/8ba22aad-e8ae-4565-8421-f90aa6948eb9" /> |
| FlaggedRoutingNumber | <img width="320" alt="flaggedRoutingNumberError" src="https://github.com/user-attachments/assets/adf472f2-a9d5-4791-bcd4-6b64b13719e8" /> |
| InvalidRoutingNumber | <img width="320" alt="invalidRoutingNumberError" src="https://github.com/user-attachments/assets/5260b285-664e-44cf-9d6d-3194dda5516d" /> |
| UpdatePhoneNumberError | <img width="320" alt="updatePhoneNumberError_night" src="https://github.com/user-attachments/assets/d0bf1de6-b932-4a39-a117-bd3e08fa80d9" /> |
| UpdateAddressError | shown above |


## What areas of the site does it impact?

Profile > Direct Deposit

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
