### PR TITLE
[VA-IIR 2030] create readme

### DIFF
--- a/src/applications/vre/28-1900/README.md
+++ b/src/applications/vre/28-1900/README.md
@@ -1,0 +1,79 @@
+# VR&E 28-1900 Form App
+
+This app implements the online Application for Veteran Readiness and Employment benefits. It lives in vets-website and is built with the VA Forms Library using Web Component Fields and Patterns.
+
+## What this is
+
+A standard Forms Library application that follows the VA.gov form flow: Introduction → Form pages → Review → Submit → Confirmation. It uses the Forms Library’s web component patterns and fields, not the legacy vets-json-schema. If you are updating or extending the form, lean on web component and patterns first.
+
+## Run it locally
+
+Clone and set up the VA.gov frontend per platform docs, then install dependencies.
+Start the webpack dev server for this app using the manifest entryName. If you need login, save in progress, feature toggles, or real submission, run vets-api locally or mock endpoints.
+
+**Examples:**
+
+```bash
+# from vets-website
+
+yarn install
+
+yarn mock-api --responses src/applications/vre/28-1900/tests/fixtures/mocks/local-mock-responses.js
+
+yarn watch --env entry=28-1900-chapter-31
+
+# unit tests for this app
+
+yarn test:unit --app-folder vre/28-1900
+
+# open Cypress runner
+
+yarn cy:open
+```
+Full setup details and common commands are in the repo README and platform docs.
+
+## Architecture
+
+**Forms Library + web components**
+
+Use web component patterns when possible. Patterns package standardized schema, uiSchema, labels, and validation. Examples:
+
+- `addressSchema`
+- `addressUI`
+- `phoneSchema`
+- `phoneUI`
+
+When a pattern does not cover your need, use a web component field.
+Design and accessibility guidance for forms is in the VA Design System. Follow its patterns for steps, review, and confirmation pages.
+
+## Adding or changing fields
+
+**Prefer a pattern**: import from `web-component-patterns` and spread schema/uiSchema into your page definition.
+
+**If no pattern exists**: use a web component field from `web-component-fields` and supply validation where needed. Only write custom fields if absolutely necessary, and follow Design System guidance.
+
+## Tests
+
+**Unit tests**: found in `tests/unit` 
+
+**E2E tests**: Cypress specs found in `tests/e2e` 
+
+## Operational notes
+
+**Entry name**: build/watch by passing `entryName` from `manifest.json`
+
+**Mocking**: use local mock API for `/v0/user`, feature toggles, and submission endpoint
+
+**Design alignment**: defer to Design System patterns and Web Component documentation
+
+**Production check**: confirm public flow on staging 28-1900 page when validating releases
+
+## References
+
+- [VA Forms Library overview](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-overview) (form flow, RJSF integration)
+- [Web Component Fields and Patterns](https://depo-platform-documentation.scrollhelp.site/developer-docs/va-forms-library-web-component-fields-and-patterns) from the Forms Library
+- Design System guidance for forms and patterns
+- vets-website README and commands
+- [Staging VR&E 28-1900 application page](https://staging.va.gov/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900) on VA.gov
+
+If you need deeper platform help, use the “Get help” links in the platform docs.


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This work creates documentation for the app.

## Related issue(s)

- VA-IIR ticket # 2030.

## What areas of the site does it impact?

No other areas.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
