### PR TITLE
fix: Remove Line Breaks in Mental Health Support Alert

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781.jsx
@@ -204,7 +204,6 @@ export const mentalHealthSupportAlert = () => {
         even if you don’t file a claim for disability compensation or you aren’t
         eligible for compensation.
       </p>
-      <br />
       <p>
         <va-link
           external
@@ -212,7 +211,6 @@ export const mentalHealthSupportAlert = () => {
           text="Learn how to get support for mental health care"
         />
       </p>
-      <br />
       <p>
         <va-link
           external


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed break line in the Mental Health Support Alert between links and description.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/119178

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/119178

## Testing done

Ran tests associated to expanding the Mental Support Alert.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mental Health Alert Modal |<img width="610" height="498" alt="Screenshot 2025-09-10 at 2 05 59 PM" src="https://github.com/user-attachments/assets/e8799491-4399-43aa-980d-fa5b1c5dcbcf" />|<img width="514" height="338" alt="Screenshot 2025-09-10 at 1 50 08 PM" src="https://github.com/user-attachments/assets/0b3a266c-b6e8-482d-a54d-5147269b5fc3" />|


## What areas of the site does it impact?
The `mstAlert` affects these additional pages: 
- Traumatic Events Types Page
- Traumatic Events Summary Page
- Behavior Changes List Page
- Supporting Evidence Page
- Treatment Received Page
- Consent Page
- Additional Information Page
- 0781 Review Page


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
