### PR TITLE
Update MHV Appointments to log unique user events

### DIFF
--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.jsx
@@ -6,6 +6,10 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useHistory, useLocation } from 'react-router-dom';
+import {
+  logUniqueUserMetricsEvents,
+  EVENT_REGISTRY,
+} from '@department-of-veterans-affairs/mhv/exports';
 import CernerAlert from '../../../components/CernerAlert';
 import WarningNotification from '../../../components/WarningNotification';
 import { selectPendingAppointments } from '../../../redux/selectors';
@@ -58,6 +62,7 @@ export default function AppointmentsPage() {
   useEffect(
     () => {
       dispatch(setFormCurrentPage('appointments'));
+      logUniqueUserMetricsEvents(EVENT_REGISTRY.APPOINTMENTS_ACCESSED);
     },
     [location, dispatch],
   );

--- a/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/appointment-list/pages/AppointmentsPage/index.unit.spec.jsx
@@ -9,6 +9,8 @@ import { expect } from 'chai';
 import { addDays, format, subDays, subMonths } from 'date-fns';
 import MockDate from 'mockdate';
 import React from 'react';
+import sinon from 'sinon';
+import * as uniqueUserMetrics from '~/platform/mhv/unique_user_metrics';
 import AppointmentsPage from '.';
 import { createReferralById } from '../../../referral-appointments/utils/referrals';
 import MockAppointmentResponse from '../../../tests/fixtures/MockAppointmentResponse';
@@ -30,9 +32,17 @@ const initialState = {
 };
 
 describe('VAOS Page: AppointmentsPage', () => {
+  let logUniqueUserMetricsEventsStub;
+  let sandbox;
+
   beforeEach(() => {
     mockFetch();
     MockDate.set(getTestDate());
+    sandbox = sinon.createSandbox();
+    logUniqueUserMetricsEventsStub = sandbox.stub(
+      uniqueUserMetrics,
+      'logUniqueUserMetricsEvents',
+    );
 
     mockAppointmentsApi({
       start: subDays(new Date(), 30),
@@ -76,6 +86,7 @@ describe('VAOS Page: AppointmentsPage', () => {
   });
   afterEach(() => {
     MockDate.reset();
+    sandbox.restore();
   });
 
   const userState = {
@@ -83,6 +94,21 @@ describe('VAOS Page: AppointmentsPage', () => {
       facilities: [{ facilityId: '983', isCerner: false }],
     },
   };
+
+  it('should log appointments accessed event when component mounts', async () => {
+    const store = createTestStore(initialState);
+    renderWithStoreAndRouter(<AppointmentsPage />, {
+      store,
+    });
+
+    await waitFor(() => {
+      expect(
+        logUniqueUserMetricsEventsStub.calledWith(
+          uniqueUserMetrics.EVENT_REGISTRY.APPOINTMENTS_ACCESSED,
+        ),
+      ).to.be.true;
+    });
+  });
 
   it('should render warning message', async () => {
     setFetchJSONResponse(

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -4,6 +4,7 @@
 
 import schedulingConfigurations from '../../services/mocks/v2/scheduling_configurations.json';
 import featureFlags from '../../services/mocks/featureFlags';
+import mockUumResponse from '../fixtures/unique-user-metrics-response.json';
 
 /**
  * Function to mock feature toggle endpoint.
@@ -211,6 +212,9 @@ export function mockAppointmentsGetApi({ response: data, responseCode = 200 }) {
       }
     },
   ).as('v2:get:appointments');
+  cy.intercept('POST', '/my_health/v1/unique_user_metrics', mockUumResponse).as(
+    'uum',
+  );
 }
 
 /**

--- a/src/applications/vaos/tests/fixtures/unique-user-metrics-response.json
+++ b/src/applications/vaos/tests/fixtures/unique-user-metrics-response.json
@@ -1,0 +1,9 @@
+{
+  "results": [
+      {
+          "event_name": "mhv_appointments_accessed",
+          "status": "exists",
+          "new_event": false
+      }
+  ]
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update MHV Appointments to log unique user events. Note the logging can be turned off at the backend with the `unique_user_metrics_logging` feature flag.
- Logging is done when viewing appointments.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/117473

## Testing done
- Updated unit tests

## Screenshots
N/A

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

