### PR TITLE
Change pension question content for 686c6745

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/veteran-information/check-veteran-pension.js
+++ b/src/applications/dependents/686c-674/config/chapters/veteran-information/check-veteran-pension.js
@@ -5,7 +5,7 @@ import {
 
 export const uiSchema = {
   'view:checkVeteranPension': yesNoUI({
-    title: 'Do you receive Veteran Pension or Survivors benefits?',
+    title: 'Do you receive Veteran Pension benefits?',
     hint:
       "If yes, we'll ask you questions about your dependents' income. If no, we'll skip questions about your dependents' income.",
     hideOnReview: true,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  - Simple change to remove `Survivor's` within the claiming pensions question due to the fact that claiming/receiving are 2 different things 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Lifestage Benefits - Dependents Management
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119185

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
  - Run app locally and verify that part of the content is not there (will need to have feature flag `va_dependents_net_worth_and_pension` turned on) in step 1 of 686c
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="1094" height="994" alt="Screenshot 2025-09-12 at 11 42 09 AM" src="https://github.com/user-attachments/assets/22e62bb4-8578-4418-b5a3-fde89042b570" /> | <img width="1098" height="993" alt="Screenshot 2025-09-12 at 11 41 50 AM" src="https://github.com/user-attachments/assets/cacc1c0c-f157-4a94-923b-97e22245c9c1" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

## Steps to Verify

### With feature flag off
1. Make sure `va_dependents_net_worth_and_pension` feature flipper is turned on
2. 1. Login to myva.gov with `vets.gov.user+0@gmail.com`
3. Click 'Add or remove a dependent' at bottom of page
4. Verify that claiming pensions question no longer has `Survivor's` in the text

