### PR TITLE
Display receivable ID instead of file number for education debts

### DIFF
--- a/src/applications/combined-debt-portal/combined/utils/mocks/mockDebts.json
+++ b/src/applications/combined-debt-portal/combined/utils/mocks/mockDebts.json
@@ -13,6 +13,7 @@
       "amountWithheld": 0,
       "originalAr": 166.67,
       "currentAr": 120.4,
+      "rcvblId": "278376456",
       "debtHistory": [
         {
           "date": "09/18/2012",
@@ -34,6 +35,7 @@
       "amountWithheld": 321.76,
       "originalAr": 321.76,
       "currentAr": 50,
+      "rcvblId": "389457829103",
       "compositeDebtId": "72321"
     },
     {
@@ -48,6 +50,7 @@
       "amountWithheld": 0,
       "originalAr": 100,
       "currentAr": 110,
+      "rcvblId": "456789012345",
       "debtHistory": [
         {
           "date": "12/19/2014",
@@ -84,6 +87,7 @@
       "amountWithheld": 0,
       "originalAr": 101,
       "currentAr": 1800,
+      "rcvblId": "567890123456",
       "debtHistory": [
         {
           "date": "12/19/2018",
@@ -110,6 +114,7 @@
       "amountWithheld": 475,
       "originalAr": 2210.9,
       "currentAr": 1000,
+      "rcvblId": "678901234567",
       "debtHistory": [
         {
           "date": "04/01/2017",
@@ -146,6 +151,7 @@
       "amountWithheld": 322.76,
       "originalAr": 322.76,
       "currentAr": 200,
+      "rcvblId": "789012345678",
       "debtHistory": [
         {
           "date": "08/08/2018",

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtSummaryCard.jsx
@@ -10,20 +10,6 @@ import { setActiveDebt } from '../../combined/actions/debts';
 import { currency } from '../utils/page';
 import { debtSummaryText } from '../const/diary-codes/debtSummaryCardContent';
 
-// Define the Post-9/11 GI Bill housing debt codes
-const HOUSING_DEBT_CODES = [
-  '16',
-  '17',
-  '18',
-  '19',
-  '20',
-  '48',
-  '49',
-  '50',
-  '51',
-  '72',
-];
-
 const DebtSummaryCard = ({ debt }) => {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const showResolveLinks = useToggleValue(TOGGLE_NAMES.showCDPOneThingPerPage);
@@ -37,9 +23,6 @@ const DebtSummaryCard = ({ debt }) => {
     mostRecentHistory?.date,
     debtCardTotal,
   );
-
-  // Check if the debt is a Post-9/11 GI Bill housing debt
-  const isHousingDebt = HOUSING_DEBT_CODES.includes(debt.deductionCode);
 
   return (
     <va-card
@@ -55,18 +38,6 @@ const DebtSummaryCard = ({ debt }) => {
         <strong>{debtCardTotal} </strong>
       </p>
       {debtCardSubHeading}
-
-      {/* Housing debt specific note */}
-      {isHousingDebt && (
-        <p className="vads-u-margin-top--2 vads-u-margin-bottom--2">
-          <strong>Note:</strong> As of August 5, 2025, we now add an ID number
-          (called a "receivable ID") to each VA education debt letter. You’ll
-          need this number instead of your VA file number or Social Security
-          number to process a payment. Questions? Call us at{' '}
-          <va-telephone contact="8008270648" />. We’re here Monday through
-          Friday, 7:30 a.m. to 7:00 p.m. ET.
-        </p>
-      )}
 
       {showResolveLinks ? (
         <>

--- a/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
@@ -43,8 +43,10 @@ const HowDoIPay = ({ userData }) => {
       {userData ? (
         <ul>
           <li>
-            <strong>File Number: </strong>
-            {userData.fileNumber}
+            <strong>
+              {userData.receivableId ? 'Receivable ID' : 'File Number'}:{' '}
+            </strong>
+            {userData.receivableId || userData.fileNumber}
           </li>
           <li>
             <strong>Payee Number: </strong>

--- a/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
@@ -113,10 +113,13 @@ const HowDoIPay = ({ userData }) => {
 
       <h3>Pay by mail</h3>
       <p>
-        Send a separate check or money order for each debt, payable to “U.S.
-        Department of Veterans Affairs.” On each, print your full name, VA file
-        number or Social Security number, and deduction code. Include your
-        payment stubs or a note with the amount you’re paying on each debt.
+        Send a separate check or money order for each debt, payable to "U.S.
+        Department of Veterans Affairs." On each, print your full name,{' '}
+        {userData?.receivableId
+          ? 'receivable ID'
+          : 'VA file number or Social Security number'}
+        , and deduction code. Include your payment stubs or a note with the
+        amount you’re paying on each debt.
       </p>
       <p>Mail to this address:</p>
       <p className="va-address-block">

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
@@ -46,6 +46,7 @@ const DebtDetails = () => {
     payeeNumber: currentDebt.payeeNumber,
     personEntitled: currentDebt.personEntitled,
     deductionCode: currentDebt.deductionCode,
+    receivableId: currentDebt.rcvblId,
   };
 
   const title = `Your ${deductionCodes[currentDebt.deductionCode]}`;

--- a/src/applications/combined-debt-portal/debt-letters/containers/ResolveDebtPage.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/ResolveDebtPage.jsx
@@ -29,6 +29,7 @@ const ResolveDebtPage = ({ match }) => {
     payeeNumber: currentDebt.payeeNumber,
     personEntitled: currentDebt.personEntitled,
     deductionCode: currentDebt.deductionCode,
+    receivableId: currentDebt.rcvblId,
   };
 
   const title = `Resolve your ${deductionCodes[currentDebt.deductionCode]}`;

--- a/src/applications/combined-debt-portal/debt-letters/tests/DebtSummaryCard.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/tests/DebtSummaryCard.unit.spec.jsx
@@ -102,62 +102,6 @@ describe('DebtSummaryCard', () => {
     expect(wrapper.find('h2').text()).to.include('Chapter 35');
   });
 
-  it('should display housing debt note for housing debt codes', () => {
-    const debt = {
-      compositeDebtId: '441300',
-      currentAr: 10000,
-      deductionCode: '16', // Housing debt code
-      benefitType: 'Post-9/11 GI Bill',
-      diaryCode: '680',
-      debtHistory: [
-        {
-          date: '09/18/2012',
-          letterCode: '100',
-        },
-      ],
-    };
-    const fakeStore = createFakeStore();
-
-    const wrapper = render(
-      <Provider store={fakeStore}>
-        <BrowserRouter>
-          <DebtSummaryCard debt={debt} />
-        </BrowserRouter>
-      </Provider>,
-    );
-
-    expect(wrapper.text()).to.include('Note:');
-    expect(wrapper.text()).to.include('receivable ID');
-    expect(wrapper.find('va-telephone')).to.have.lengthOf(1);
-  });
-
-  it('should not display housing debt note for non-housing debt codes', () => {
-    const debt = {
-      compositeDebtId: '441300',
-      currentAr: 10000,
-      deductionCode: '44', // Non-housing debt code
-      benefitType: 'CH35 EDU',
-      diaryCode: '680',
-      debtHistory: [
-        {
-          date: '09/18/2012',
-          letterCode: '100',
-        },
-      ],
-    };
-    const fakeStore = createFakeStore();
-
-    const wrapper = render(
-      <Provider store={fakeStore}>
-        <BrowserRouter>
-          <DebtSummaryCard debt={debt} />
-        </BrowserRouter>
-      </Provider>,
-    );
-
-    expect(wrapper.text()).to.not.include('receivable ID');
-  });
-
   it('should handle debt with no debtHistory', () => {
     const debt = {
       compositeDebtId: '441300',
@@ -228,43 +172,6 @@ describe('DebtSummaryCard', () => {
     );
 
     expect(wrapper.find('h2').text()).to.include('Custom Benefit Type');
-  });
-
-  it('should test all housing debt codes', () => {
-    const housingCodes = [
-      '16',
-      '17',
-      '18',
-      '19',
-      '20',
-      '48',
-      '49',
-      '50',
-      '51',
-      '72',
-    ];
-
-    housingCodes.forEach(code => {
-      const debt = {
-        compositeDebtId: '441300',
-        currentAr: 10000,
-        deductionCode: code,
-        benefitType: 'Post-9/11 GI Bill',
-        diaryCode: '680',
-        debtHistory: [],
-      };
-      const fakeStore = createFakeStore();
-
-      const wrapper = render(
-        <Provider store={fakeStore}>
-          <BrowserRouter>
-            <DebtSummaryCard debt={debt} />
-          </BrowserRouter>
-        </Provider>,
-      );
-
-      expect(wrapper.text()).to.include('receivable ID');
-    });
   });
 
   it('should test different debt amounts', () => {

--- a/src/applications/combined-debt-portal/debt-letters/tests/HowDoIPay.unit.spec.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/tests/HowDoIPay.unit.spec.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import HowDoIPay from '../components/HowDoIPay';
+
+describe('HowDoIPay', () => {
+  describe('receivableId display logic', () => {
+    it('should display Receivable ID when receivableId is present', () => {
+      const userData = {
+        fileNumber: '123456789',
+        receivableId: '987654321012',
+        payeeNumber: '00',
+        personEntitled: 'JDOE',
+        deductionCode: '71',
+      };
+
+      const { container } = render(<HowDoIPay userData={userData} />);
+      const content = container.textContent;
+
+      expect(content).to.include('Receivable ID:');
+      expect(content).to.include('987654321012');
+      expect(content).to.not.include('File Number:');
+    });
+
+    it('should display File Number when receivableId is not present', () => {
+      const userData = {
+        fileNumber: '123456789',
+        payeeNumber: '00',
+        personEntitled: 'JDOE',
+        deductionCode: '30',
+      };
+
+      const { container } = render(<HowDoIPay userData={userData} />);
+      const content = container.textContent;
+
+      expect(content).to.include('File Number:');
+      expect(content).to.include('123456789');
+      expect(content).to.not.include('Receivable ID:');
+    });
+
+    it('should display File Number when both are present but receivableId is null', () => {
+      const userData = {
+        fileNumber: '123456789',
+        receivableId: null,
+        payeeNumber: '00',
+        personEntitled: 'JDOE',
+        deductionCode: '30',
+      };
+
+      const { container } = render(<HowDoIPay userData={userData} />);
+      const content = container.textContent;
+
+      expect(content).to.include('File Number:');
+      expect(content).to.include('123456789');
+      expect(content).to.not.include('Receivable ID:');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Show receivable ID when available, otherwise show file number
- Remove temporary note about receivable ID from DebtSummaryCard
- Add unit tests for receivable ID display logic
- Update mock data with rcvblId field for education debts

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#115670

## Testing done

- Prior to the change file number was displayed for all debt types
- Select an education related debt code and click resolve from the debt summary card
- Unit tests


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
|--------|-------|
| <img width="793" height="865" alt="Before" src="https://github.com/user-attachments/assets/6a1d03be-4ef1-42a2-8908-41220adabffc" /> | <img width="991" height="857" alt="After" src="https://github.com/user-attachments/assets/f2b83f91-a6e9-4229-a696-3201e5349e9e" /> |

## What areas of the site does it impact?

Combined debt portal resolve debts / how do I pay

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

