### PR TITLE
Added Confirm Contact Email Interstitial Feature Flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -53,6 +53,7 @@
   "coeAccess": "coe_access",
   "combinedDebtPortalAccess": "combined_debt_portal_access",
   "confirmationPageNew": "confirmation_page_new",
+  "confirmContactEmailInterstitialEnabled": "confirm_contact_email_interstitial_enabled",
   "cstClaimPhases": "cst_claim_phases",
   "cstIncludeDdl5103Letters": "cst_include_ddl_5103_letters",
   "cstIncludeDdlBoaLetters": "cst_include_ddl_boa_letters",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Added the `confirm_contact_email_interstitial_enabled` feature flag.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/681)

## Testing done
- Ran tests locally to ensure no breaking changes.

## What areas of the site does it impact?
This only impacts `featureFlagNames.json`.

## Acceptance criteria
- [x] Create a feature flag in vets-website `featureFlagNames.json` which maps the following feature flag to camelcase: `confirm_contact_email_interstitial_enabled`.