### PR TITLE
Update VAOS scheduling flow radio options to use custom widgets - pt 1/3

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClosestCityStatePage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClosestCityStatePage.jsx
@@ -1,9 +1,11 @@
+import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import { useHistory } from 'react-router-dom';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 import FormButtons from '../../components/FormButtons';
+import useFormState from '../../hooks/useFormState';
+import { focusFormHeader } from '../../utils/scrollAndFocus';
+import { getPageTitle } from '../newAppointmentFlow';
 import {
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
@@ -13,9 +15,7 @@ import {
   selectCommunityCareSupportedSites,
   selectPageChangeInProgress,
 } from '../redux/selectors';
-import { focusFormHeader } from '../../utils/scrollAndFocus';
-import useFormState from '../../hooks/useFormState';
-import { getPageTitle } from '../newAppointmentFlow';
+import SimpleRadioWidget from './SimpleRadioWidget';
 
 const pageKey = 'ccClosestCity';
 
@@ -25,15 +25,13 @@ export default function ClosestCityStatePage() {
   const uiSchema = {
     communityCareSystemId: {
       'ui:title': pageTitle,
-      'ui:widget': 'radio', // Required
-      'ui:webComponentField': VaRadioField,
+      'ui:widget': SimpleRadioWidget,
       'ui:errorMessages': {
         required: 'Select a city',
       },
       'ui:options': {
         classNames: 'vads-u-margin-top--neg2',
-        showFieldLabel: false,
-        labelHeaderLevel: '1',
+        hideLabelText: true,
       },
     },
   };
@@ -79,6 +77,12 @@ export default function ClosestCityStatePage() {
 
   return (
     <div>
+      <h1 className="vaos__dynamic-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {!!schema && (
         <SchemaForm
           name="Closest city and state"

--- a/src/applications/vaos/new-appointment/components/ClosestCityStatePage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ClosestCityStatePage.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 
-import { waitFor } from '@testing-library/dom';
+import { fireEvent, waitFor } from '@testing-library/dom';
 import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import ClosestCityStatePage from './ClosestCityStatePage';
 import {
@@ -29,19 +29,19 @@ describe('VAOS Page: ClosestCityStatePage', () => {
       store,
     });
 
-    // Then the primary header should have focus
-    const radioSelector = screen.container.querySelector('va-radio');
-    expect(radioSelector).to.exist;
-    expect(radioSelector).to.have.attribute(
-      'label',
-      'What’s the nearest city to you?',
-    );
+    // Should show title
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: /What’s the nearest city to you\?/,
+      }),
+    ).to.exist;
 
     // And the user should see radio buttons for each city and state
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
+    const radioOptions = screen.getAllByRole('radio');
     expect(radioOptions).to.have.lengthOf(2);
-    expect(radioOptions[0]).to.have.attribute('label', 'Bozeman, MT');
-    expect(radioOptions[1]).to.have.attribute('label', 'Belgrade, MT');
+    await screen.findByLabelText(/Bozeman, MT/i);
+    await screen.findByLabelText(/Belgrade, MT/i);
   });
 
   it('should not submit without choosing a site', async () => {
@@ -84,11 +84,7 @@ describe('VAOS Page: ClosestCityStatePage', () => {
     });
 
     // And the user selected a site
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: '983' },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/Bozeman, MT/i));
 
     // When the user continues
     userEvent.click(screen.getByText(/Continue/i));

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
@@ -443,7 +443,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
     // Belgrade is the 2nd of three options so the expectation is
     // that it should be selected when we get to the CommunityCareProviderSelectionPage.
-    await setClosestCity(store, '983');
+    await setClosestCity(store, 'City 983, WY');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
       {
@@ -517,7 +517,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
     // Belgrade is the 2nd of three options so the expectation is
     // that it should be selected when we get to the CommunityCareProviderSelectionPage.
-    await setClosestCity(store, '983');
+    await setClosestCity(store, 'City 983, WY');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
@@ -94,7 +94,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     // Given the CC iteration flag is on
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
       {
@@ -139,7 +139,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -200,7 +200,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -264,7 +264,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -361,7 +361,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -439,7 +439,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     // Belgrade is the 2nd of three options so the expectation is
     // that it should be selected when we get to the CommunityCareProviderSelectionPage.
@@ -513,7 +513,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     // Belgrade is the 2nd of three options so the expectation is
     // that it should be selected when we get to the CommunityCareProviderSelectionPage.
@@ -546,7 +546,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     // Given the CC iteration flag is on
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
       {

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -99,7 +99,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   it('should display closest city question when user has multiple supported sites', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
       {
@@ -169,7 +169,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   it('should display list of providers when choose a provider clicked', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
       {
@@ -271,7 +271,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   it('should display Select provider when remove provider clicked', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
       {
@@ -350,7 +350,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     // Facility 983 is the 2nd of three options so the expectation is
     // that it should be selected when we get to the CommunityCareProviderSelectionPage.
@@ -405,7 +405,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   it('should display an error when choose a provider clicked and provider fetch error', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
     mockCCProviderApi({
       address: initialState.user.profile.vapContactInfo.residentialAddress,
       specialties: ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
@@ -448,7 +448,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
   it('should display an alert when no providers are available', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
     mockCCProviderApi({
       address: initialState.user.profile.vapContactInfo.residentialAddress,
       specialties: ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
@@ -507,7 +507,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -562,7 +562,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -617,7 +617,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -682,7 +682,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     let screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
@@ -760,7 +760,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     });
 
     await setTypeOfCare(store, /primary care/i);
-    await setTypeOfFacility(store, 'communityCare');
+    await setTypeOfFacility(store, 'Community care facility');
 
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -354,7 +354,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
     // Facility 983 is the 2nd of three options so the expectation is
     // that it should be selected when we get to the CommunityCareProviderSelectionPage.
-    await setClosestCity(store, '983');
+    await setClosestCity(store, 'City 983, WY');
     const screen = renderWithStoreAndRouter(
       <CommunityCareProviderSelectionPage />,
       {
@@ -841,7 +841,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
 
     // Facility 984 is the 2nd of three options so the expectation is
     // that it should be selected when we get to the CommunityCareProviderSelectionPage.
-    await setClosestCity(store, '984');
+    await setClosestCity(store, 'Belgrade, MT');
 
     // When the page is displayed
     const screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -142,7 +142,7 @@ export default function ContactInfoPage() {
       'ui:title': 'What are the best times for us to call you?',
       'ui:validations':
         flowType === FLOW_TYPES.REQUEST &&
-        userData.facilityType === FACILITY_TYPES.COMMUNITY_CARE
+        userData.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id
           ? [validateBooleanGroup]
           : [],
       'ui:options': {
@@ -152,7 +152,7 @@ export default function ContactInfoPage() {
           return (
             flowType === FLOW_TYPES.DIRECT ||
             (flowType === FLOW_TYPES.REQUEST &&
-              userData.facilityType === FACILITY_TYPES.VAMC)
+              userData.facilityType === FACILITY_TYPES.VAMC.id)
           );
         },
       },
@@ -180,7 +180,7 @@ export default function ContactInfoPage() {
         classNames: classNames({
           'schemaform-first-field':
             flowType === FLOW_TYPES.REQUEST &&
-            userData.facilityType === FACILITY_TYPES.COMMUNITY_CARE,
+            userData.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id,
         }),
       },
     },

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('VAOS Page: ContactInfoPage', () => {
       },
       newAppointment: {
         data: {
-          facilityType: FACILITY_TYPES.VAMC,
+          facilityType: FACILITY_TYPES.VAMC.id,
         },
         flowType: FLOW_TYPES.DIRECT,
         previousPages: {},

--- a/src/applications/vaos/new-appointment/components/FormLayout.jsx
+++ b/src/applications/vaos/new-appointment/components/FormLayout.jsx
@@ -21,7 +21,7 @@ function Title() {
   const formData = useSelector(getFormData);
 
   if (FLOW_TYPES.REQUEST === flowType) {
-    if (FACILITY_TYPES.COMMUNITY_CARE === formData.facilityType) {
+    if (FACILITY_TYPES.COMMUNITY_CARE.id === formData.facilityType) {
       return 'Request community care';
     }
 

--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -75,7 +75,8 @@ export default function ReasonForAppointmentPage() {
     shallowEqual,
   );
   const history = useHistory();
-  const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
+  const isCommunityCare =
+    data.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id;
   const pageInitialSchema = isCommunityCare
     ? initialSchema.cc
     : initialSchema.default;

--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -200,7 +200,7 @@ describe('VAOS Page: ReasonForAppointmentPage', () => {
   describe('Community care requests', () => {
     it('should show page for Community Care medical request', async () => {
       const store = createTestStore(initialState);
-      await setTypeOfFacility(store, 'communityCare');
+      await setTypeOfFacility(store, 'Community care facility');
 
       const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
         store,
@@ -228,7 +228,7 @@ describe('VAOS Page: ReasonForAppointmentPage', () => {
 
     it.skip('should show error msg when enter all spaces for Community Care medical request', async () => {
       const store = createTestStore(initialState);
-      await setTypeOfFacility(store, 'communityCare');
+      await setTypeOfFacility(store, 'Community care facility');
 
       const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
         store,
@@ -256,7 +256,7 @@ describe('VAOS Page: ReasonForAppointmentPage', () => {
 
     it('should continue to the correct page for Community Care medical request', async () => {
       const store = createTestStore(initialState);
-      await setTypeOfFacility(store, 'communityCare');
+      await setTypeOfFacility(store, 'Community care facility');
       const screen = renderWithStoreAndRouter(
         <Route component={ReasonForAppointmentPage} />,
         {

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ContactDetailSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ContactDetailSection.jsx
@@ -75,7 +75,7 @@ export default function ContactDetailSection({ data }) {
                 contact={data.phoneNumber}
                 data-testid="patient-telephone"
               />
-              {formData.facilityType === FACILITY_TYPES.COMMUNITY_CARE && (
+              {formData.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id && (
                 <>
                   <br />
                   <strong>Best time to call: </strong>

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDatesSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/PreferredDatesSection.jsx
@@ -30,7 +30,7 @@ export default function PreferredDatesSection(props) {
   const flowType = useSelector(getFlowType);
 
   const isCommunityCare =
-    props.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
+    props.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id;
   const url = isCommunityCare ? ccRequestDateTime.url : requestDateTime.url;
 
   return (

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/index.jsx
@@ -11,8 +11,9 @@ export default function ReviewRequestInfo({
   vaCityState,
   pageTitle,
 }) {
-  const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
-  const isVAAppointment = data.facilityType === FACILITY_TYPES.VAMC;
+  const isCommunityCare =
+    data.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id;
+  const isVAAppointment = data.facilityType === FACILITY_TYPES.VAMC.id;
 
   return (
     <div>

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -53,7 +53,7 @@ describe('VAOS Page: ReviewPage CC request with VAOS service', () => {
     newAppointment: {
       pages: {},
       data: {
-        facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+        facilityType: FACILITY_TYPES.COMMUNITY_CARE.id,
         typeOfCareId: TYPE_OF_CARE_IDS.PRIMARY_CARE,
         phoneNumber: '1234567890',
         email: 'joeblow@gmail.com',

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -38,7 +38,7 @@ describe('VAOS Page: ReviewPage VA request with VAOS service', () => {
     newAppointment: {
       pages: {},
       data: {
-        facilityType: FACILITY_TYPES.VAMC,
+        facilityType: FACILITY_TYPES.VAMC.id,
         typeOfCareId: TYPE_OF_CARE_IDS.PRIMARY_CARE,
         phoneNumber: '1234567890',
         email: 'joeblow@gmail.com',

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -164,7 +164,8 @@ describe('VAOS Page: ReviewPage VA request with VAOS service', () => {
     });
   });
 
-  it('should record GA tracking event', async () => {
+  // Skipped test: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119526
+  it.skip('should record GA tracking event', async () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     store = createTestStore({

--- a/src/applications/vaos/new-appointment/components/SimpleRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/SimpleRadioWidget.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
  * code to disable certain options. This isn't currently supported by the
  * form system.
  */
-export default function TypeOfCareRadioWidget({
+export default function SimpleRadioWidget({
   id,
   options,
   value,
@@ -45,7 +45,7 @@ export default function TypeOfCareRadioWidget({
     </div>
   );
 }
-TypeOfCareRadioWidget.propTypes = {
+SimpleRadioWidget.propTypes = {
   formContext: PropTypes.object,
   id: PropTypes.string,
   options: PropTypes.object,

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -23,7 +23,7 @@ import { TYPE_OF_CARE_IDS, TYPES_OF_CARE } from '../../../utils/constants';
 import useFormState from '../../../hooks/useFormState';
 import { getLongTermAppointmentHistoryV2 } from '../../../services/appointment';
 import { getPageTitle } from '../../newAppointmentFlow';
-import TypeOfCareRadioWidget from '../VAFacilityPage/TypeOfCareRadioWidget';
+import SimpleRadioWidget from '../SimpleRadioWidget';
 
 const pageKey = 'typeOfCare';
 
@@ -95,7 +95,7 @@ export default function TypeOfCarePage() {
     uiSchema: {
       typeOfCareId: {
         'ui:title': pageTitle,
-        'ui:widget': TypeOfCareRadioWidget,
+        'ui:widget': SimpleRadioWidget,
         'ui:options': {
           classNames: 'vads-u-margin-top--neg2',
           hideLabelText: true,

--- a/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
@@ -3,6 +3,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
+
 import FormButtons from '../../components/FormButtons';
 import { getFormPageInfo } from '../redux/selectors';
 import { TYPES_OF_EYE_CARE } from '../../utils/constants';

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
+// import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 import FormButtons from '../../components/FormButtons';
 import { FACILITY_TYPES } from '../../utils/constants';
 import { getFormPageInfo } from '../redux/selectors';
@@ -15,6 +15,7 @@ import {
   updateFormData,
 } from '../redux/actions';
 import { getPageTitle } from '../newAppointmentFlow';
+import SimpleRadioWidget from './SimpleRadioWidget';
 
 const initialSchema = {
   type: 'object',
@@ -22,7 +23,8 @@ const initialSchema = {
   properties: {
     facilityType: {
       type: 'string',
-      enum: Object.keys(FACILITY_TYPES).map(key => FACILITY_TYPES[key]),
+      enum: Object.values(FACILITY_TYPES).map(type => type.id),
+      enumNames: Object.values(FACILITY_TYPES).map(type => type.name),
     },
   },
 };
@@ -35,16 +37,10 @@ export default function TypeOfFacilityPage() {
   const uiSchema = {
     facilityType: {
       'ui:title': pageTitle,
-      'ui:widget': 'radio', // Required
-      'ui:webComponentField': VaRadioField,
+      'ui:widget': SimpleRadioWidget,
       'ui:options': {
         classNames: 'vads-u-margin-top--neg2',
-        showFieldLabel: false,
-        labelHeaderLevel: '1',
-        labels: {
-          [FACILITY_TYPES.VAMC]: 'VA medical center or clinic',
-          [FACILITY_TYPES.COMMUNITY_CARE]: 'Community care facility',
-        },
+        hideLabelText: true,
       },
     },
   };
@@ -72,6 +68,12 @@ export default function TypeOfFacilityPage() {
 
   return (
     <div className="vaos-form__facility-type">
+      <h1 className="vaos__dynamic-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {!!schema && (
         <SchemaForm
           name="Type of appointment"

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
@@ -1,11 +1,11 @@
+import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import FormButtons from '../../components/FormButtons';
 import { FACILITY_TYPES } from '../../utils/constants';
-import { getFormPageInfo } from '../redux/selectors';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
+import { getPageTitle } from '../newAppointmentFlow';
 import {
   openFormPage,
   routeToNextAppointmentPage,
@@ -13,7 +13,7 @@ import {
   startDirectScheduleFlow,
   updateFormData,
 } from '../redux/actions';
-import { getPageTitle } from '../newAppointmentFlow';
+import { getFormPageInfo } from '../redux/selectors';
 import SimpleRadioWidget from './SimpleRadioWidget';
 
 const facilityTypesValues = Object.values(FACILITY_TYPES);

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
-// import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 import FormButtons from '../../components/FormButtons';
 import { FACILITY_TYPES } from '../../utils/constants';
 import { getFormPageInfo } from '../redux/selectors';
@@ -17,14 +16,16 @@ import {
 import { getPageTitle } from '../newAppointmentFlow';
 import SimpleRadioWidget from './SimpleRadioWidget';
 
+const facilityTypesValues = Object.values(FACILITY_TYPES);
+
 const initialSchema = {
   type: 'object',
   required: ['facilityType'],
   properties: {
     facilityType: {
       type: 'string',
-      enum: Object.values(FACILITY_TYPES).map(type => type.id),
-      enumNames: Object.values(FACILITY_TYPES).map(type => type.name),
+      enum: facilityTypesValues.map(type => type.id),
+      enumNames: facilityTypesValues.map(type => type.name),
     },
   },
 };

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -35,25 +35,19 @@ describe('VAOS Page: TypeOfFacilityPage', () => {
     });
     await screen.findByText(/Continue/i);
 
-    // Then the primary header should have focus
-    const radioSelector = screen.container.querySelector('va-radio');
-    expect(radioSelector).to.exist;
-    expect(radioSelector).to.have.attribute(
-      'label',
-      'Where do you prefer to receive care?',
-    );
+    // Should show title
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: /Where do you prefer to receive care/,
+      }),
+    ).to.exist;
 
     // And the user should see radio buttons for each clinic
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
+    const radioOptions = screen.getAllByRole('radio');
     expect(radioOptions).to.have.lengthOf(2);
-    expect(radioOptions[0]).to.have.attribute(
-      'label',
-      'VA medical center or clinic',
-    );
-    expect(radioOptions[1]).to.have.attribute(
-      'label',
-      'Community care facility',
-    );
+    await screen.findByLabelText(/VA medical center or clinic/i);
+    await screen.findByLabelText(/Community care facility/i);
   });
 
   it('should show validation', async () => {
@@ -82,23 +76,17 @@ describe('VAOS Page: TypeOfFacilityPage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    let changeEvent = new CustomEvent('selected', {
-      detail: { value: 'communityCare' },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/Community care facility/i));
     fireEvent.click(screen.getByText(/Continue/));
-
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
         'community-request/',
       ),
     );
 
-    changeEvent = new CustomEvent('selected', {
-      detail: { value: 'vamc' },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(
+      await screen.findByLabelText(/VA medical center or clinic/i),
+    );
     fireEvent.click(screen.getByText(/Continue/));
 
     await waitFor(() =>
@@ -116,11 +104,13 @@ describe('VAOS Page: TypeOfFacilityPage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'communityCare' },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(
+      await screen.findByLabelText(/VA medical center or clinic/i),
+    );
+    fireEvent.click(screen.getByText(/Continue/));
+    await waitFor(() =>
+      expect(screen.history.push.lastCall.args[0]).to.equal('location'),
+    );
     await cleanup();
 
     screen = renderWithStoreAndRouter(
@@ -130,8 +120,8 @@ describe('VAOS Page: TypeOfFacilityPage', () => {
       },
     );
 
-    await waitFor(() => {
-      expect(radioSelector).to.have.attribute('value', 'communityCare');
-    });
+    expect(
+      await screen.findByLabelText(/VA medical center or clinic/i),
+    ).to.have.attribute('checked');
   });
 });

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -39,7 +39,7 @@ describe('VAOS Page: TypeOfFacilityPage', () => {
     expect(
       await screen.findByRole('heading', {
         level: 1,
-        name: /Where do you prefer to receive care/,
+        name: /Where do you prefer to receive care\?/,
       }),
     ).to.exist;
 

--- a/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
@@ -1,18 +1,18 @@
+import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import FormButtons from '../../components/FormButtons';
-import { getFormPageInfo, getNewAppointment } from '../redux/selectors';
 import { FLOW_TYPES, TYPE_OF_VISIT } from '../../utils/constants';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
+import { getPageTitle } from '../newAppointmentFlow';
 import {
   openFormPage,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
   updateFormData,
 } from '../redux/actions';
-import { getPageTitle } from '../newAppointmentFlow';
+import { getFormPageInfo, getNewAppointment } from '../redux/selectors';
 import SimpleRadioWidget from './SimpleRadioWidget';
 
 const pageKey = 'visitType';

--- a/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 import FormButtons from '../../components/FormButtons';
 import { getFormPageInfo, getNewAppointment } from '../redux/selectors';
 import { FLOW_TYPES, TYPE_OF_VISIT } from '../../utils/constants';
@@ -14,6 +13,7 @@ import {
   updateFormData,
 } from '../redux/actions';
 import { getPageTitle } from '../newAppointmentFlow';
+import SimpleRadioWidget from './SimpleRadioWidget';
 
 const pageKey = 'visitType';
 
@@ -28,14 +28,14 @@ export default function TypeOfVisitPage() {
 
   const uiSchema = {
     visitType: {
-      'ui:widget': 'radio', // Required
-      'ui:webComponentField': VaRadioField,
       'ui:title': pageTitle,
+      'ui:widget': SimpleRadioWidget,
       'ui:errorMessages': {
         required: 'Select an option',
       },
       'ui:options': {
-        labelHeaderLevel: '1',
+        classNames: 'vads-u-margin-top--neg2',
+        hideLabelText: true,
       },
     },
   };
@@ -73,7 +73,13 @@ export default function TypeOfVisitPage() {
   );
 
   return (
-    <div className="vads-u-margin-top--neg3">
+    <div>
+      <h1 className="vaos__dynamic-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {!!schema && (
         <SchemaForm
           name="Type of visit"

--- a/src/applications/vaos/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
@@ -34,21 +34,20 @@ describe('VAOS Page: TypeOfVisitPage ', () => {
 
     expect(await screen.findByText(/Continue/i)).to.exist;
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    expect(radioSelector).to.exist;
-    expect(radioSelector).to.have.attribute(
-      'label',
-      'How do you want to attend this appointment?',
-    );
+    // Should show title
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: /How do you want to attend this appointment\?/,
+      }),
+    ).to.exist;
 
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
+    // And the user should see radio buttons for each clinic
+    const radioOptions = screen.getAllByRole('radio');
     expect(radioOptions).to.have.lengthOf(3);
-    expect(radioOptions[0]).to.have.attribute('label', 'In person');
-    expect(radioOptions[1]).to.have.attribute('label', 'By phone');
-    expect(radioOptions[2]).to.have.attribute(
-      'label',
-      'Through VA Video Connect (telehealth)',
-    );
+    await screen.findByLabelText(/In person/i);
+    await screen.findByLabelText(/By phone/i);
+    await screen.findByLabelText(/Through VA Video Connect \(telehealth\)/i);
   });
 
   it('should not submit empty form', async () => {
@@ -77,23 +76,17 @@ describe('VAOS Page: TypeOfVisitPage ', () => {
     // Wait for page to render completely
     expect(await screen.findByText(/Continue/i)).to.exist;
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'clinic' },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
-    let [firstRadioOption] = screen.container.querySelectorAll(
-      'va-radio-option',
-    );
-    expect(firstRadioOption).to.have.attribute('checked', 'true');
+    fireEvent.click(await screen.findByLabelText(/In person/i));
+    fireEvent.click(screen.getByText(/Continue/));
     await cleanup();
 
     screen = renderWithStoreAndRouter(<Route component={TypeOfVisitPage} />, {
       store,
     });
 
-    [firstRadioOption] = screen.container.querySelectorAll('va-radio-option');
-    expect(firstRadioOption).to.have.attribute('checked', 'true');
+    expect(await screen.findByLabelText(/In person/i)).to.have.attribute(
+      'checked',
+    );
   });
 
   it('should continue to the correct page once type is selected', async () => {
@@ -108,11 +101,7 @@ describe('VAOS Page: TypeOfVisitPage ', () => {
     // Wait for page to render completely
     expect(await screen.findByText(/Continue/i)).to.exist;
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'clinic' },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(await screen.findByLabelText(/In person/i));
     fireEvent.click(screen.getByText(/Continue/));
 
     await waitFor(() =>

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -43,7 +43,7 @@ const VA_FACILITY_V2_KEY = 'vaFacilityV2';
 
 function isCCAudiology(state) {
   return (
-    getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE &&
+    getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE.id &&
     getFormData(state).typeOfCareId === TYPE_OF_CARE_IDS.AUDIOLOGY_ID
   );
 }
@@ -56,7 +56,7 @@ function isCommunityCare(state) {
 }
 
 function isCCFacility(state) {
-  return getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE;
+  return getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE.id;
 }
 
 function isSleepCare(state) {
@@ -284,7 +284,7 @@ export default function getNewAppointmentFlow(state) {
           return 'vaccineFlow';
         }
         if (isSleepCare(state)) {
-          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+          dispatch(updateFacilityType(FACILITY_TYPES.VAMC.id));
           return 'typeOfSleepCare';
         }
         if (isEyeCare(state)) {
@@ -302,7 +302,7 @@ export default function getNewAppointmentFlow(state) {
 
           if (isEligible && isPodiatry(state)) {
             // If CC enabled systems and toc is podiatry, skip typeOfFacility
-            dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
+            dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE.id));
             dispatch(startRequestAppointmentFlow(true));
             return 'ccRequestDateTime';
           }
@@ -316,7 +316,7 @@ export default function getNewAppointmentFlow(state) {
           }
         }
 
-        dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+        dispatch(updateFacilityType(FACILITY_TYPES.VAMC.id));
         return VA_FACILITY_V2_KEY;
       },
     },
@@ -335,7 +335,7 @@ export default function getNewAppointmentFlow(state) {
           }
         }
 
-        dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+        dispatch(updateFacilityType(FACILITY_TYPES.VAMC.id));
         return VA_FACILITY_V2_KEY;
       },
     },

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.unit.spec.jsx
@@ -354,7 +354,7 @@ describe('VAOS newAppointmentFlow', () => {
         const state = {
           newAppointment: {
             data: {
-              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE.id,
               typeOfCareId: TYPE_OF_CARE_IDS.AUDIOLOGY_ID,
             },
           },
@@ -370,7 +370,7 @@ describe('VAOS newAppointmentFlow', () => {
         const state = {
           newAppointment: {
             data: {
-              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE.id,
               typeOfCareId: '320',
             },
           },
@@ -584,7 +584,7 @@ describe('VAOS newAppointmentFlow', () => {
         const state = {
           newAppointment: {
             data: {
-              facilityType: FACILITY_TYPES.VAMC,
+              facilityType: FACILITY_TYPES.VAMC.id,
             },
           },
         };
@@ -682,7 +682,7 @@ describe('VAOS newAppointmentFlow', () => {
         const state = {
           newAppointment: {
             data: {
-              facilityType: FACILITY_TYPES.VAMC,
+              facilityType: FACILITY_TYPES.VAMC.id,
             },
           },
         };
@@ -697,7 +697,7 @@ describe('VAOS newAppointmentFlow', () => {
         const state = {
           newAppointment: {
             data: {
-              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE.id,
             },
           },
         };

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -860,7 +860,7 @@ export function submitAppointmentOrRequest(history) {
       }
     } else {
       const isCommunityCare =
-        newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
+        newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id;
       const eventType = isCommunityCare ? 'community-care' : 'request';
       const flow = isCommunityCare ? GA_FLOWS.CC_REQUEST : GA_FLOWS.VA_REQUEST;
       const today = new Date();

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -720,7 +720,7 @@ export default function formReducer(state = initialState, action) {
       const formData = state.data;
       let additionalInfoTitle = REASON_ADDITIONAL_INFO_TITLES.ccRequest;
 
-      if (formData.facilityType !== FACILITY_TYPES.COMMUNITY_CARE) {
+      if (formData.facilityType !== FACILITY_TYPES.COMMUNITY_CARE.id) {
         additionalInfoTitle = REASON_ADDITIONAL_INFO_TITLES.va;
       } else {
         delete formData.reasonForAppointment;

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -78,7 +78,7 @@ export function getTypeOfCare(data) {
 
   if (
     data.typeOfCareId === TYPE_OF_CARE_IDS.AUDIOLOGY_ID &&
-    data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
+    data.facilityType === FACILITY_TYPES.COMMUNITY_CARE.id
   ) {
     return AUDIOLOGY_TYPES_OF_CARE.find(
       care => care.ccId === data.audiologyType,

--- a/src/applications/vaos/tests/e2e/page-objects/AudiologyPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/AudiologyPageObject.js
@@ -10,7 +10,7 @@ class AudiologyPageObject extends PageObject {
 
   assertAudiologyValidationErrors() {
     this.clickNextButton();
-    this.assertValidationError('You must provide a response');
+    this.assertValidationErrorShadow('You must provide a response');
     return this;
   }
 

--- a/src/applications/vaos/tests/e2e/page-objects/ClinicChoicePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ClinicChoicePageObject.js
@@ -15,7 +15,7 @@ class ClinicChoicePageObject extends PageObject {
 
   assertClinicChoiceValidationErrors() {
     this.clickNextButton();
-    this.assertValidationError('You must provide a response');
+    this.assertValidationErrorShadow('You must provide a response');
     return this;
   }
 

--- a/src/applications/vaos/tests/e2e/page-objects/ClosestCityStatePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ClosestCityStatePageObject.js
@@ -1,13 +1,6 @@
 import PageObject from './PageObject';
 
 class ClosestCityStatePageObject extends PageObject {
-  assertHeading({ name }) {
-    return this.assertShadow({
-      element: 'va-radio',
-      text: name,
-    });
-  }
-
   assertUrl() {
     cy.url().should('include', 'closest-city');
     cy.axeCheckBestPractice();
@@ -17,13 +10,13 @@ class ClosestCityStatePageObject extends PageObject {
 
   assertClosestCityStateValidationErrors() {
     this.clickNextButton();
-    this.assertValidationErrorShadow('Select a city');
+    this.assertValidationError('Select a city');
 
     return this;
   }
 
   selectFacility({ label }) {
-    return super.selectRadioButtonShadow(label);
+    return super.selectRadioButton(label);
   }
 }
 

--- a/src/applications/vaos/tests/e2e/page-objects/ClosestCityStatePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/ClosestCityStatePageObject.js
@@ -17,7 +17,7 @@ class ClosestCityStatePageObject extends PageObject {
 
   assertClosestCityStateValidationErrors() {
     this.clickNextButton();
-    this.assertValidationError('Select a city');
+    this.assertValidationErrorShadow('Select a city');
 
     return this;
   }

--- a/src/applications/vaos/tests/e2e/page-objects/PageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PageObject.js
@@ -48,6 +48,14 @@ export default class PageObject {
   }
 
   assertValidationError(error) {
+    cy.get(`span[role="alert"]`).as('alert');
+    cy.get('@alert')
+      .contains(error)
+      .should('exist');
+    return this;
+  }
+
+  assertValidationErrorShadow(error) {
     cy.get(`[error="${error}"]`).should('exist');
     return this;
   }

--- a/src/applications/vaos/tests/e2e/page-objects/PreferredDatePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/PreferredDatePageObject.js
@@ -68,10 +68,10 @@ class PreferredDatePageObject extends PageObject {
 
     this.typeDate({ date: pastDate });
     this.clickNextButton();
-    this.assertValidationError('Please enter a future date');
+    this.assertValidationErrorShadow('Please enter a future date');
     this.typeDate({ date: farFutureDate });
     this.clickNextButton();
-    this.assertValidationError(
+    this.assertValidationErrorShadow(
       'Please enter a date less than 395 days in the future',
     );
 

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfEyeCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfEyeCarePageObject.js
@@ -10,7 +10,7 @@ class TypeOfEyeCarePageObject extends PageObject {
 
   assertTypeOfEyeCareValidationErrors() {
     this.clickNextButton();
-    this.assertValidationError('You must provide a response');
+    this.assertValidationErrorShadow('You must provide a response');
 
     return this;
   }

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfFacilityPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfFacilityPageObject.js
@@ -17,7 +17,7 @@ class TypeOfFacilityPageObject extends PageObject {
   }
 
   selectTypeOfFacility(label) {
-    return super.selectRadioButtonShadow(label);
+    return super.selectRadioButton(label);
   }
 }
 

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfSleepCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfSleepCarePageObject.js
@@ -10,7 +10,7 @@ class TypeOfSleepCarePageObject extends PageObject {
 
   assertTypeOfSleepCareValidationErrors() {
     this.clickNextButton();
-    this.assertValidationError('You must provide a response');
+    this.assertValidationErrorShadow('You must provide a response');
 
     return this;
   }

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfVisitPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfVisitPageObject.js
@@ -1,13 +1,6 @@
 import PageObject from './PageObject';
 
 class TypeOfVisitPageObject extends PageObject {
-  assertHeading({ name }) {
-    return this.assertShadow({
-      element: 'va-radio',
-      text: name,
-    });
-  }
-
   assertUrl() {
     cy.url().should('include', '/preferred-method');
     cy.axeCheckBestPractice();
@@ -17,13 +10,13 @@ class TypeOfVisitPageObject extends PageObject {
 
   assertTypeOfVisitValidationErrors() {
     this.clickNextButton();
-    this.assertValidationErrorShadow('Select an option');
+    this.assertValidationError('Select an option');
 
     return this;
   }
 
   selectVisitType(label) {
-    return super.selectRadioButtonShadow(label);
+    return super.selectRadioButton(label);
   }
 }
 

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfVisitPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfVisitPageObject.js
@@ -17,7 +17,7 @@ class TypeOfVisitPageObject extends PageObject {
 
   assertTypeOfVisitValidationErrors() {
     this.clickNextButton();
-    this.assertValidationError('Select an option');
+    this.assertValidationErrorShadow('Select an option');
 
     return this;
   }

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -114,18 +114,16 @@ export function getTestDate() {
  * @export
  * @async
  * @param {ReduxStore} store The Redux store to use to render the page
- * @param {string} value The string value of the radio button to click on
+ * @param {string|RegExp} label The string or regex to pass to *ByText query to get
+ *   a radio button to click on
  * @returns {Promise string} The url path that was routed to after clicking Continue
  */
-export async function setTypeOfFacility(store, value) {
+export async function setTypeOfFacility(store, label) {
   const screen = renderWithStoreAndRouter(<TypeOfFacilityPage />, { store });
   await screen.findByText(/Continue/i);
 
-  const radioSelector = screen.container.querySelector('va-radio');
-  const changeEvent = new CustomEvent('selected', {
-    detail: { value },
-  });
-  radioSelector.__events.vaValueChange(changeEvent);
+  const radioButton = await screen.findByLabelText(label);
+  fireEvent.click(radioButton);
   fireEvent.click(screen.getByText(/Continue/));
   await waitFor(() => expect(screen.history.push.called).to.be.true);
   await cleanup();
@@ -453,7 +451,7 @@ export async function setCommunityCareFlow({
   });
 
   await setTypeOfCare(store, new RegExp(typeOfCare.name));
-  await setTypeOfFacility(store, 'communityCare');
+  await setTypeOfFacility(store, 'Community care facility');
 
   return store;
 }

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -468,12 +468,7 @@ export async function setCommunityCareFlow({
 export async function setClosestCity(store, cityValue) {
   const screen = renderWithStoreAndRouter(<ClosestCityStatePage />, { store });
 
-  const radioSelector = screen.container.querySelector('va-radio');
-  const changeEvent = new CustomEvent('selected', {
-    detail: { value: cityValue },
-  });
-  radioSelector.__events.vaValueChange(changeEvent);
-
+  fireEvent.click(await screen.findByLabelText(cityValue));
   fireEvent.click(screen.getByText(/Continue/));
   await waitFor(() => expect(screen.history.push.called).to.be.true);
   await cleanup();

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -250,8 +250,14 @@ export const AUDIOLOGY_TYPES_OF_CARE = [
 ];
 
 export const FACILITY_TYPES = {
-  VAMC: 'vamc',
-  COMMUNITY_CARE: 'communityCare',
+  VAMC: {
+    id: 'vamc',
+    name: 'VA medical center or clinic',
+  },
+  COMMUNITY_CARE: {
+    id: 'communityCare',
+    name: 'Community care facility',
+  },
 };
 
 export const FACILITY_SORT_METHODS = {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We noticed that the "Skip to content" link wasn't always focusing on the primary heading on the scheduling pages
- This is because the header was hidden under the shadow DOM by the VaRadioField widget
- To solve this, we'll use our own heading-less custom widget (to avoid the empty *Required element) and an explicit primary heading element.
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111878

## Testing done

- Tested locally, see screenshots
- Updated unit and e2e tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Skip link focus - Before | Skip link focus - After | Validation error - Before | Validation error - After |
| ------- | ------ | ----- | ------ | ----- |
| Type of Facility  |   <img width="846" height="964" alt="image" src="https://github.com/user-attachments/assets/97f3e79f-292e-4b95-97fb-2ad67ced6037" />    |  <img width="832" height="776" alt="image" src="https://github.com/user-attachments/assets/0f6e2b65-5d06-4e28-bdeb-5b2632f7b610" />    |    <img width="850" height="822" alt="image" src="https://github.com/user-attachments/assets/9e154def-fdcd-4fe2-8808-f45f1cba3e67" />   |   <img width="848" height="900" alt="image" src="https://github.com/user-attachments/assets/066bccf7-4cd6-47bb-8245-46633ebef031" />   |
| Type of Visit |    <img width="840" height="870" alt="image" src="https://github.com/user-attachments/assets/74c6dab0-2c30-4dc3-8949-43932187bc47" />   |   <img width="846" height="682" alt="image" src="https://github.com/user-attachments/assets/ae9aedd9-7cfe-4bea-9b45-c48b8084031f" />   |         <img width="842" height="722" alt="image" src="https://github.com/user-attachments/assets/a94a4d2f-6d75-4259-9863-ca039ef61e2c" />|   <img width="856" height="810" alt="image" src="https://github.com/user-attachments/assets/43107ac5-9f76-496a-b1bd-360bb8b88fd8" />   |
| Closest City/State |   <img width="852" height="916" alt="image" src="https://github.com/user-attachments/assets/b07bde1c-b670-412b-b456-e4edf109f043" />    |   <img width="846" height="708" alt="image" src="https://github.com/user-attachments/assets/8c582629-cec4-48a5-817b-dc4aa8cb370b" />   |    <img width="850" height="766" alt="image" src="https://github.com/user-attachments/assets/f07d6ec4-fd85-42c8-99ee-58b8346bd423" />   |   <img width="858" height="832" alt="image" src="https://github.com/user-attachments/assets/66b9bb94-9eac-48a6-b64d-827955396032" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
