### PR TITLE
[Disability Benefits] rel: vets-json-schema latest version (25.2.4) bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c78f4d3f0aa9eea7b7bb1ebe390286e28d293392",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#40306e3de819eb3edb9b49aff8d0f6deeada94e2",
     "web-vitals": "^4.2.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22654,9 +22654,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#c78f4d3f0aa9eea7b7bb1ebe390286e28d293392":
-  version "25.2.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c78f4d3f0aa9eea7b7bb1ebe390286e28d293392"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#40306e3de819eb3edb9b49aff8d0f6deeada94e2":
+  version "25.2.4"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#40306e3de819eb3edb9b49aff8d0f6deeada94e2"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Bumps `vets-json-schema` dependency to latest version (25.2.4)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119382
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1054
- https://github.com/department-of-veterans-affairs/vets-api/pull/24171
