### PR TITLE
#114082: Update DLC phone number

### DIFF
--- a/src/applications/health-care-supply-reordering/components/Accessories.jsx
+++ b/src/applications/health-care-supply-reordering/components/Accessories.jsx
@@ -165,7 +165,7 @@ class Accessories extends Component {
               placed an order for resupply items within the last 2 years. If you
               need an accessory that hasn’t been ordered within the last 2
               years, call the DLC Customer Service Section at{' '}
-              <DlcTelephoneLink /> or email
+              <DlcTelephoneLink /> or email{' '}
               <a
                 href="mailto:dalc.css@va.gov"
                 className="vads-u-margin-left--0p5"

--- a/src/applications/health-care-supply-reordering/components/Accessories.jsx
+++ b/src/applications/health-care-supply-reordering/components/Accessories.jsx
@@ -12,7 +12,8 @@ import { setData } from '@department-of-veterans-affairs/platform-forms-system/a
 // FIXME: figure out why cypress doesn't like this import.
 import recordEvent from 'platform/monitoring/record-event';
 
-import { ACCESSORY, DLC_PHONE } from '../constants';
+import { ACCESSORY } from '../constants';
+import DlcTelephoneLink from './DlcTelephoneLink';
 
 class Accessories extends Component {
   componentDidMount() {
@@ -91,7 +92,7 @@ class Accessories extends Component {
                 <p>
                   If you need accessories like domes, wax guards, cleaning
                   supplies, or dessicant, call the DLC Customer Service Section
-                  at <va-telephone contact={DLC_PHONE} /> or email{' '}
+                  at <DlcTelephoneLink /> or email{' '}
                   <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
                 </p>
               </div>
@@ -164,11 +165,7 @@ class Accessories extends Component {
               placed an order for resupply items within the last 2 years. If you
               need an accessory that hasn’t been ordered within the last 2
               years, call the DLC Customer Service Section at{' '}
-              <va-telephone
-                contact={DLC_PHONE}
-                className="vads-u-margin--0p5"
-              />
-              or email
+              <DlcTelephoneLink /> or email
               <a
                 href="mailto:dalc.css@va.gov"
                 className="vads-u-margin-left--0p5"

--- a/src/applications/health-care-supply-reordering/components/ApneaSupplies.jsx
+++ b/src/applications/health-care-supply-reordering/components/ApneaSupplies.jsx
@@ -179,7 +179,7 @@ class ApneaSupplies extends Component {
               placed an order for resupply items within the last 2 years. If you
               need a CPAP supply that hasn’t been ordered within the last 2
               years, call the DLC Customer Service Section at{' '}
-              <DlcTelephoneLink /> or email
+              <DlcTelephoneLink /> or email{' '}
               <a
                 href="mailto:dalc.css@va.gov"
                 className="vads-u-margin-left--0p5"

--- a/src/applications/health-care-supply-reordering/components/ApneaSupplies.jsx
+++ b/src/applications/health-care-supply-reordering/components/ApneaSupplies.jsx
@@ -12,7 +12,8 @@ import { setData } from '@department-of-veterans-affairs/platform-forms-system/a
 // FIXME: figure out why cypress doesn't like this import.
 import recordEvent from 'platform/monitoring/record-event';
 
-import { APNEA, DLC_PHONE } from '../constants';
+import { APNEA } from '../constants';
+import DlcTelephoneLink from './DlcTelephoneLink';
 
 class ApneaSupplies extends Component {
   componentDidMount() {
@@ -90,8 +91,7 @@ class ApneaSupplies extends Component {
                 </p>
                 <p>
                   If you need a CPAP supply that is not listed here, call the
-                  DLC Customer Service Section at{' '}
-                  <va-telephone contact={DLC_PHONE} /> or email{' '}
+                  DLC Customer Service Section at <DlcTelephoneLink /> or email{' '}
                   <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
                 </p>
               </div>
@@ -179,11 +179,7 @@ class ApneaSupplies extends Component {
               placed an order for resupply items within the last 2 years. If you
               need a CPAP supply that hasn’t been ordered within the last 2
               years, call the DLC Customer Service Section at{' '}
-              <va-telephone
-                contact={DLC_PHONE}
-                className="vads-u-margin--0p5"
-              />
-              or email
+              <DlcTelephoneLink /> or email
               <a
                 href="mailto:dalc.css@va.gov"
                 className="vads-u-margin-left--0p5"

--- a/src/applications/health-care-supply-reordering/components/Batteries.jsx
+++ b/src/applications/health-care-supply-reordering/components/Batteries.jsx
@@ -12,7 +12,8 @@ import { setData } from '@department-of-veterans-affairs/platform-forms-system/a
 // FIXME: figure out why cypress doesn't like this import.
 import recordEvent from 'platform/monitoring/record-event';
 
-import { BATTERY, DLC_PHONE } from '../constants';
+import { BATTERY } from '../constants';
+import DlcTelephoneLink from './DlcTelephoneLink';
 
 class Batteries extends Component {
   componentDidMount() {
@@ -98,8 +99,7 @@ class Batteries extends Component {
                 </ul>
                 <p>
                   If you need unavailable batteries sooner, call the DLC
-                  Customer Service Section at{' '}
-                  <va-telephone contact={DLC_PHONE} /> or email{' '}
+                  Customer Service Section at <DlcTelephoneLink /> or email{' '}
                   <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
                 </p>
               </div>
@@ -178,11 +178,7 @@ class Batteries extends Component {
               Your hearing aid device may not be listed here if you haven’t
               placed an order for resupply items within the last 2 years. If you
               need to order batteries, call the DLC Customer Service Section at
-              <va-telephone
-                contact={DLC_PHONE}
-                className="vads-u-margin--0p5"
-              />
-              or email
+              <DlcTelephoneLink /> or email
               <a
                 href="mailto:dalc.css@va.gov"
                 className="vads-u-margin-left--0p5"

--- a/src/applications/health-care-supply-reordering/components/Batteries.jsx
+++ b/src/applications/health-care-supply-reordering/components/Batteries.jsx
@@ -178,7 +178,7 @@ class Batteries extends Component {
               Your hearing aid device may not be listed here if you haven’t
               placed an order for resupply items within the last 2 years. If you
               need to order batteries, call the DLC Customer Service Section at
-              <DlcTelephoneLink /> or email
+              <DlcTelephoneLink /> or email{' '}
               <a
                 href="mailto:dalc.css@va.gov"
                 className="vads-u-margin-left--0p5"

--- a/src/applications/health-care-supply-reordering/components/BatteriesAndAccessories.jsx
+++ b/src/applications/health-care-supply-reordering/components/BatteriesAndAccessories.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 
-import { DLC_PHONE } from '../constants';
-
 import Accessories from './Accessories';
 import ApneaSupplies from './ApneaSupplies';
 import Batteries from './Batteries';
+import DlcTelephoneLink from './DlcTelephoneLink';
 
 const BatteriesAndAccessories = () => (
   <>
@@ -15,7 +14,7 @@ const BatteriesAndAccessories = () => (
     </p>
     <p>
       If you need unavailable items sooner, please call the DLC Customer Service
-      Section at <va-telephone contact={DLC_PHONE} /> or email{' '}
+      Section at <DlcTelephoneLink /> or email{' '}
       <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
     </p>
     <Batteries />

--- a/src/applications/health-care-supply-reordering/components/DlcTelephoneLink.jsx
+++ b/src/applications/health-care-supply-reordering/components/DlcTelephoneLink.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { DLC_PHONE } from '../constants';
+
+const DlcTelephoneLink = () => (
+  <>
+    <va-telephone contact={DLC_PHONE} /> (
+    <va-telephone contact={CONTACTS['711']} tty />)
+  </>
+);
+
+export default DlcTelephoneLink;

--- a/src/applications/health-care-supply-reordering/components/ErrorMessage.jsx
+++ b/src/applications/health-care-supply-reordering/components/ErrorMessage.jsx
@@ -104,7 +104,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
             </p>
             <p className="vads-u-margin-top--0">
               For help ordering {supplyDescription}, please call the DLC
-              Customer Service Section at <DlcTelephoneLink /> or email
+              Customer Service Section at <DlcTelephoneLink /> or email{' '}
               <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
             </p>
           </div>

--- a/src/applications/health-care-supply-reordering/components/ErrorMessage.jsx
+++ b/src/applications/health-care-supply-reordering/components/ErrorMessage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
+import DlcTelephoneLink from './DlcTelephoneLink';
 
 const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
   const supplyDescription = 'hearing aid or CPAP supplies';
@@ -19,7 +20,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
             </span>
             <span className="vads-u-margin-top--1">
               If you need an item sooner, call the DLC Customer Service Section
-              at <va-telephone contact="3032736200" /> or email{' '}
+              at <DlcTelephoneLink /> or email{' '}
               <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
             </span>
           </div>
@@ -64,7 +65,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
 
             <span className="vads-u-margin-top--1">
               If you need to place an order, call the DLC Customer Service
-              Section at <va-telephone contact="3032736200" /> or email{' '}
+              Section at <DlcTelephoneLink /> or email{' '}
               <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
             </span>
           </div>
@@ -95,16 +96,16 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
           <h3 slot="headline">We’re sorry. Something went wrong on our end.</h3>
           <div className="mdot-server-error-alert">
             <p>
-              You can’t place an order for {supplyDescription}
-              because something went wrong on our end.
+              You can’t place an order for {supplyDescription} because something
+              went wrong on our end.
             </p>
             <p className="vads-u-font-weight--bold vads-u-margin-y--1 vads-u-font-family--serif">
               What you can do
             </p>
             <p className="vads-u-margin-top--0">
               For help ordering {supplyDescription}, please call the DLC
-              Customer Service Section at <va-telephone contact="3032736200" />{' '}
-              or email <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+              Customer Service Section at <DlcTelephoneLink />{' '}
+              <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
             </p>
           </div>
         </va-alert>

--- a/src/applications/health-care-supply-reordering/components/ErrorMessage.jsx
+++ b/src/applications/health-care-supply-reordering/components/ErrorMessage.jsx
@@ -104,7 +104,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
             </p>
             <p className="vads-u-margin-top--0">
               For help ordering {supplyDescription}, please call the DLC
-              Customer Service Section at <DlcTelephoneLink />{' '}
+              Customer Service Section at <DlcTelephoneLink /> or email
               <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
             </p>
           </div>

--- a/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
+++ b/src/applications/health-care-supply-reordering/components/FooterInfo.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import DlcTelephoneLink from './DlcTelephoneLink';
 
 const FooterInfo = () => (
   <section className="need-help-footer row vads-u-padding-x--1p5">
@@ -13,9 +14,7 @@ const FooterInfo = () => (
     </p>
     <p>
       <strong>For help ordering hearing aid or CPAP supplies,</strong> please
-      call the DLC Customer Service Section at{' '}
-      <va-telephone contact="8776778710" /> (
-      <va-telephone contact={CONTACTS['711']} tty />) or email{' '}
+      call the DLC Customer Service Section at <DlcTelephoneLink /> or email{' '}
       <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
     </p>
   </section>

--- a/src/applications/health-care-supply-reordering/components/IntroductionPage.jsx
+++ b/src/applications/health-care-supply-reordering/components/IntroductionPage.jsx
@@ -6,6 +6,7 @@ import DowntimeNotification, {
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import UnverifiedPrefillAlert from './UnverifiedPrefillAlert';
+import DlcTelephoneLink from './DlcTelephoneLink';
 
 const IntroductionPage = ({ route }) => {
   const supplyDescription = 'hearing aid or CPAP supplies';
@@ -26,8 +27,7 @@ const IntroductionPage = ({ route }) => {
           Right now, only hearing aid and CPAP supplies are available to reorder
           online. If you’d like to order other medical supplies available
           through VA, contact the VA Denver Logistics Center (DLC) at{' '}
-          <va-telephone contact="8776778710" /> (
-          <va-telephone contact="711" tty="true" />) or email{' '}
+          <DlcTelephoneLink /> or email{' '}
           <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>. We’re available
           Monday through Friday, 8:15 a.m. to 5:00 p.m. ET.
         </p>
@@ -127,8 +127,7 @@ const IntroductionPage = ({ route }) => {
               </h3>
               <p>
                 If you need help or have questions about your order, contact the
-                DLC at <va-telephone contact="8776778710" /> (
-                <va-telephone contact="711" tty="true" />) or email{' '}
+                DLC at <DlcTelephoneLink /> or email{' '}
                 <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>. We’re
                 available Monday through Friday, 8:15 a.m. to 5:00 p.m. ET.
               </p>
@@ -163,10 +162,8 @@ const IntroductionPage = ({ route }) => {
               <p>
                 We’ll send you a 6-month supply of each item you add to your
                 order. You can only reorder each item once every 5 months. If
-                you need an item sooner, call the DLC at{' '}
-                <va-telephone contact="8776778710" /> (
-                <va-telephone contact="711" tty="true" />
-                ), Monday through Friday, 8:15 a.m. to 5:00 p.m. ET.
+                you need an item sooner, call the DLC at <DlcTelephoneLink />,
+                Monday through Friday, 8:15 a.m. to 5:00 p.m. ET.
               </p>
             </va-accordion-item>
             <va-accordion-item>

--- a/src/applications/health-care-supply-reordering/config/form.js
+++ b/src/applications/health-care-supply-reordering/config/form.js
@@ -153,7 +153,7 @@ const formConfig = {
   subTitle: '',
   savedFormMessages: {
     notFound:
-      'You can’t reorder your items at this time because your items aren’t available for reorder or we can’t find your records in our system. For help, please call the Denver Logistics Center (DLC) at 303-273-6200 or email us at dalc.css@va.gov.',
+      'You can’t reorder your items at this time because your items aren’t available for reorder or we can’t find your records in our system. For help, please call the Denver Logistics Center (DLC) at 877-677-8710 (TTY: 711) or email us at dalc.css@va.gov.',
     noAuth: 'Please sign in again to continue your application for benefits.',
     forbidden:
       'We can’t fulfill an order for this Veteran because they are deceased in our records. If this information is incorrect, please call Veterans Benefits Assistance at 800-827-1000, Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',

--- a/src/applications/health-care-supply-reordering/constants/index.js
+++ b/src/applications/health-care-supply-reordering/constants/index.js
@@ -16,4 +16,4 @@ export const ACCESSORY = 'Accessory';
 export const BATTERY = 'Battery';
 export const APNEA = 'Apnea';
 
-export const DLC_PHONE = '3032736200';
+export const DLC_PHONE = '8776778710';

--- a/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
+++ b/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
@@ -189,7 +189,7 @@ const ConfirmationPage = ({
                 </a>
                 , please select at least one item before submitting your order.
                 For help ordering {supplyDescription}, please call the DLC
-                Customer Service Section at <DlcTelephoneLink /> or email
+                Customer Service Section at <DlcTelephoneLink /> or email{' '}
                 <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
               </p>
             </div>
@@ -224,7 +224,7 @@ const ConfirmationPage = ({
               </p>
               <p className="vads-u-margin-top--0">
                 For help ordering {supplyDescription}, please call the DLC
-                Customer Service Section at <DlcTelephoneLink /> or email
+                Customer Service Section at <DlcTelephoneLink /> or email{' '}
                 <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
               </p>
             </div>

--- a/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
+++ b/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import environment from 'platform/utilities/environment';
 import { BATTERY } from '../constants';
+import DlcTelephoneLink from '../components/DlcTelephoneLink';
 
 const ConfirmationPage = ({
   vetEmail,
@@ -67,7 +68,7 @@ const ConfirmationPage = ({
         </h4>
         <p>
           If you have any questions about your order please call the Denver
-          Logistics Center at <va-telephone contact="3032736200" /> .
+          Logistics Center at <DlcTelephoneLink />.
         </p>
       </section>
     </div>
@@ -140,12 +141,11 @@ const ConfirmationPage = ({
                   <strong>Confirmation number</strong>
                 </p>
                 <p className="vads-u-margin-y--0">{orderId}</p>
-                <button
-                  className="usa-button button"
+                <va-button
+                  className="button"
+                  text="Print this page"
                   onClick={() => window.print()}
-                >
-                  Print this page
-                </button>
+                />
               </section>
             </va-alert>
             <section className="order-timeframe-section">
@@ -160,8 +160,7 @@ const ConfirmationPage = ({
               <h4>What if I have questions about my order?</h4>
               <p>
                 If you have any questions about your order, please call the DLC
-                Customer Service Section at{' '}
-                <va-telephone contact="3032736200" /> or email{' '}
+                Customer Service Section at <DlcTelephoneLink /> or email{' '}
                 <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
               </p>
             </section>
@@ -191,8 +190,7 @@ const ConfirmationPage = ({
                 </a>
                 , please select at least one item before submitting your order.
                 For help ordering {supplyDescription}, please call the DLC
-                Customer Service Section at{' '}
-                <va-telephone contact="3032736200" /> or email{' '}
+                Customer Service Section at <DlcTelephoneLink /> or email
                 <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
               </p>
             </div>
@@ -227,8 +225,7 @@ const ConfirmationPage = ({
               </p>
               <p className="vads-u-margin-top--0">
                 For help ordering {supplyDescription}, please call the DLC
-                Customer Service Section at{' '}
-                <va-telephone contact="3032736200" /> or email{' '}
+                Customer Service Section at <DlcTelephoneLink /> or email
                 <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
               </p>
             </div>
@@ -249,8 +246,7 @@ const ConfirmationPage = ({
                 </p>
                 <p className="vads-u-margin-top--0">
                   For help ordering {supplyDescription}, please call the DLC
-                  Customer Service Section at{' '}
-                  <va-telephone contact="3032736200" /> or email{' '}
+                  Customer Service Section at <DlcTelephoneLink /> or email{' '}
                   <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
                 </p>
               </>

--- a/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
+++ b/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
@@ -142,6 +142,7 @@ const ConfirmationPage = ({
                 </p>
                 <p className="vads-u-margin-y--0">{orderId}</p>
                 <va-button
+                  className="button"
                   text="Print this page"
                   onClick={() => window.print()}
                 />

--- a/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
+++ b/src/applications/health-care-supply-reordering/containers/ConfirmationPage.jsx
@@ -142,7 +142,6 @@ const ConfirmationPage = ({
                 </p>
                 <p className="vads-u-margin-y--0">{orderId}</p>
                 <va-button
-                  className="button"
                   text="Print this page"
                   onClick={() => window.print()}
                 />

--- a/src/applications/health-care-supply-reordering/tests/DlcTelephoneLink.unit.spec.jsx
+++ b/src/applications/health-care-supply-reordering/tests/DlcTelephoneLink.unit.spec.jsx
@@ -5,8 +5,8 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 import DlcTelephoneLink from '../components/DlcTelephoneLink';
 import { DLC_PHONE } from '../constants';
 
-describe('ErrorMessage', () => {
-  it('should render va-alert', () => {
+describe('DlcTelephoneLink', () => {
+  it('should render the component correctly', () => {
     const telephoneLink = mount(<DlcTelephoneLink />);
     const telephoneElements = telephoneLink.find('va-telephone');
 

--- a/src/applications/health-care-supply-reordering/tests/DlcTelephoneLink.unit.spec.jsx
+++ b/src/applications/health-care-supply-reordering/tests/DlcTelephoneLink.unit.spec.jsx
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import DlcTelephoneLink from '../components/DlcTelephoneLink';
+import { DLC_PHONE } from '../constants';
+
+describe('ErrorMessage', () => {
+  it('should render va-alert', () => {
+    const telephoneLink = mount(<DlcTelephoneLink />);
+    const telephoneElements = telephoneLink.find('va-telephone');
+
+    const telephoneAttributes = telephoneElements.map(node => {
+      const props = node.props();
+      return [props.contact, props.tty];
+    });
+
+    expect(telephoneAttributes).to.deep.equal([
+      [DLC_PHONE, undefined],
+      [CONTACTS[711], true],
+    ]);
+
+    telephoneLink.unmount();
+  });
+});

--- a/src/applications/mhv-supply-reordering/constants.js
+++ b/src/applications/mhv-supply-reordering/constants.js
@@ -6,7 +6,7 @@ export const INTRO_SUBTITLE =
   'Use this form to order hearing aid batteries and accessories and CPAP supplies';
 
 export const DLC_EMAIL = 'dalc.css@va.gov';
-export const DLC_TELEPHONE = '3032736200';
+export const DLC_TELEPHONE = '8776778710';
 
 export const HEALTH_FACILITIES_URL = '/find-locations/?facilityType=health';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_

This updates the DLC phone number in the medical supplies reordering applications from `303-273-6200` to `877-677-8710` and appends the `TTY: 711` phone number.

- _(Which team do you work for, does your team own the maintenance of this component?)_

Medications / Medical supply reordering. Yes.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/114082)
- _Link to epic if not included in ticket_
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/117223)

## Testing done

- _Describe what the old behavior was prior to the change_

Old `303` phone number was being shown, but should be updated to the new `877` phone number.

- _Describe the steps required to verify your changes are working as expected_

View the pages where the old `303` phone number was being shown and make sure it's updated to the correct phone number.

- _Describe the tests completed and the results_

The phone number was replaced in all cases I found in both medical supply reordering applications.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="417" height="702" alt="Screenshot 2025-09-11 at 11 09 16 AM" src="https://github.com/user-attachments/assets/2d014f4b-7dd8-49cb-9998-4a3e8c7430b9" /><img width="435" height="703" alt="Screenshot 2025-09-11 at 11 10 10 AM" src="https://github.com/user-attachments/assets/9adfce05-7f73-4545-8dcd-1a7181ab7d6e" /> <img width="415" height="608" alt="Screenshot 2025-09-11 at 11 15 56 AM" src="https://github.com/user-attachments/assets/bf4383a1-0eab-447e-8291-1500372a3fe2" /><img width="412" height="605" alt="Screenshot 2025-09-11 at 11 16 41 AM" src="https://github.com/user-attachments/assets/9d697b4d-8316-4030-acce-27459c2255af" /> <img width="415" height="581" alt="Screenshot 2025-09-11 at 11 19 49 AM" src="https://github.com/user-attachments/assets/c65e5ac7-c314-419d-8453-13f7d41bc954" /> <img width="418" height="580" alt="Screenshot 2025-09-11 at 11 20 02 AM" src="https://github.com/user-attachments/assets/f29599fa-49a5-43c7-b813-cdb4fb3aaf82" /> <img width="412" height="581" alt="Screenshot 2025-09-11 at 11 20 40 AM" src="https://github.com/user-attachments/assets/67f0749a-a36b-4c55-b44f-6cee1f59b507" /> <img width="415" height="582" alt="Screenshot 2025-09-11 at 11 25 37 AM" src="https://github.com/user-attachments/assets/21621458-7c59-4fd5-9974-6cfda5fb6591" /> | <img width="397" height="568" alt="banner-five-month-limit" src="https://github.com/user-attachments/assets/82316eba-bb97-4cce-84fd-defe45e05f23" /> <img width="402" height="561" alt="banner-general" src="https://github.com/user-attachments/assets/834975f4-3d52-44a9-afa7-b6bbae01db61" /> <img width="398" height="576" alt="banner-two-year-limit" src="https://github.com/user-attachments/assets/1df32e55-dd64-430a-8f3a-58ffe10e975e" /> <img width="395" height="562" alt="error-couldnt-be-ordered" src="https://github.com/user-attachments/assets/d58dfde7-38f5-4be3-9ca8-a0620fdcc18e" /> <img width="400" height="566" alt="error-general" src="https://github.com/user-attachments/assets/e94009d2-c5d5-497d-8f6b-e1d219a08ca4" /> <img width="389" height="562" alt="error-no-selection" src="https://github.com/user-attachments/assets/35ec8e2a-3e7d-4df5-8b27-47e9bd693639" /> <img width="396" height="561" alt="footer" src="https://github.com/user-attachments/assets/ce0aabe7-9d2a-49bb-b8c9-eaa122e6b374" /> <img width="397" height="561" alt="form-confirmations" src="https://github.com/user-attachments/assets/649b791d-a5c2-43e2-ba87-6d35bef80621" /> |
| Desktop | <img width="1303" height="728" alt="banner-five-month-limit" src="https://github.com/user-attachments/assets/6c35262f-860a-4848-a130-4977168d870d" /><img width="1300" height="730" alt="banner-two-year-limit" src="https://github.com/user-attachments/assets/79cf3ae0-574d-4464-a198-65f99d92d01b" /> <img width="1304" height="845" alt="confirmation" src="https://github.com/user-attachments/assets/3c18be35-83f7-4c86-afe1-9c3749afb15a" /> <img width="1300" height="729" alt="error-couldnt-be-ordered" src="https://github.com/user-attachments/assets/71f64944-0afe-4803-90bf-55ab30eba34b" /> <img width="1300" height="848" alt="error-general" src="https://github.com/user-attachments/assets/3c041c65-48df-454d-981f-7a3d9b65aca7" /> <img width="1302" height="758" alt="error-no-selection" src="https://github.com/user-attachments/assets/32432259-b433-4894-8d76-bee4f8b4a15b" /> <img width="1300" height="730" alt="form-descriptions" src="https://github.com/user-attachments/assets/3d90bc39-8fba-4720-ab56-38aeef4bdad4" />  | <img width="1302" height="732" alt="banner-five-month-limit" src="https://github.com/user-attachments/assets/2d6134fc-0d29-42c1-8863-c3e41aae15e4" /><img width="1303" height="731" alt="banner-two-year-limit" src="https://github.com/user-attachments/assets/0767fa8e-3c30-4876-9565-d6de62ca3fbd" /><img width="817" height="729" alt="confirmation" src="https://github.com/user-attachments/assets/22be71a5-d9f7-498a-9de3-e29a679bff28" /> <img width="1061" height="733" alt="error-couldnt-be-ordered" src="https://github.com/user-attachments/assets/d1bcf100-f58b-4431-8d40-98af7098ae7e" /><img width="1062" height="731" alt="error-general" src="https://github.com/user-attachments/assets/d0a8b756-bb75-4e12-84fe-12988c2d9d4e" /> <img width="1059" height="732" alt="error-no-selection" src="https://github.com/user-attachments/assets/8040236a-1347-4b8a-8eb1-88e6774aae38" /><img width="837" height="442" alt="footer" src="https://github.com/user-attachments/assets/7d2c2584-51b4-4695-be7b-a19245b9b363" /> <img width="749" height="731" alt="form-descriptions" src="https://github.com/user-attachments/assets/144fd624-3276-40d6-8ff0-1c8166857dc5" /> <img width="857" height="733" alt="intro-page" src="https://github.com/user-attachments/assets/ae50cf06-96cb-47ca-944d-025ee0d464a3" /> |

## What areas of the site does it impact?

This only impacts the medical supply reordering pages.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
