### PR TITLE
Add additional null state log metadata

### DIFF
--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -102,6 +102,11 @@ export function captureMissingModalityLogs(appointment) {
         'metadata',
         JSON.stringify({
           // Raw API fields
+          created: appointment.vaos.apiData.created,
+          status: appointment.vaos.apiData.status,
+          past: appointment.vaos.apiData.past,
+          pending: appointment.vaos.apiData.pending,
+          future: appointment.vaos.apiData.future,
           serviceType: appointment.vaos.apiData.serviceType,
           serviceCategory: appointment.vaos.apiData.serviceCategory,
           kind: appointment.vaos.apiData.kind,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adding some additional metadata to diagnose missing modality for CC appointments in our logs.
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/115714

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

