### PR TITLE
Platform | Fix review page accordion state

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -14,6 +14,7 @@ export const SET_SUBMISSION = 'SET_SUBMISSION';
 export const SET_SUBMITTED = 'SET_SUBMITTED';
 export const OPEN_REVIEW_CHAPTER = 'OPEN_REVIEW_CHAPTER';
 export const CLOSE_REVIEW_CHAPTER = 'CLOSE_REVIEW_CHAPTER';
+export const TOGGLE_ALL_REVIEW_CHAPTERS = 'TOGGLE_ALL_REVIEW_CHAPTERS';
 export const SET_FORM_ERRORS = 'SET_FORM_ERRORS';
 export const SET_ITF = 'SET_ITF';
 
@@ -29,6 +30,13 @@ export function openReviewChapter(openedChapter) {
   return {
     type: OPEN_REVIEW_CHAPTER,
     openedChapter,
+  };
+}
+
+export function toggleAllReviewChapters(chapters) {
+  return {
+    type: TOGGLE_ALL_REVIEW_CHAPTERS,
+    chapters,
   };
 }
 

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -16,6 +16,7 @@ import { getReviewPageOpenChapters, getViewedPages } from '../state/selectors';
 import {
   closeReviewChapter,
   openReviewChapter,
+  toggleAllReviewChapters,
   setData,
   setEditMode,
   setViewedPages,
@@ -35,7 +36,7 @@ class ReviewChapters extends React.Component {
     if (target) {
       const name = target.dataset?.chapter;
       const isOpen = target.getAttribute('open');
-      if (isOpen) {
+      if (isOpen === 'true') {
         this.props.openReviewChapter(name);
         scrollTo(`chapter${name}ScrollElement`);
       } else {
@@ -43,6 +44,16 @@ class ReviewChapters extends React.Component {
         this.props.closeReviewChapter(name, chapter?.pageKeys);
       }
     }
+  };
+
+  handleToggleAllChapters = ({ detail }) => {
+    const { status } = detail;
+    const allOpen = status === 'allOpen';
+    const chapterNames = this.props.chapters.reduce((acc, chapter) => {
+      acc[chapter.name] = allOpen;
+      return acc;
+    }, {});
+    this.props.toggleAllReviewChapters(chapterNames);
   };
 
   handleEdit = (pageKey, editing, index = null) => {
@@ -73,6 +84,7 @@ class ReviewChapters extends React.Component {
     return (
       <VaAccordion
         bordered
+        onAccordionExpandCollapseAll={this.handleToggleAllChapters}
         onAccordionItemToggled={this.handleToggleChapter}
         uswds
       >
@@ -157,6 +169,7 @@ export function mapStateToProps(state, ownProps) {
 const mapDispatchToProps = {
   closeReviewChapter,
   openReviewChapter,
+  toggleAllReviewChapters,
   setData,
   setEditMode,
   setViewedPages,
@@ -174,6 +187,7 @@ ReviewChapters.propTypes = {
   setData: PropTypes.func.isRequired,
   setEditMode: PropTypes.func.isRequired,
   setViewedPages: PropTypes.func.isRequired,
+  toggleAllReviewChapters: PropTypes.func.isRequired,
   uploadFile: PropTypes.func.isRequired,
   viewedPages: PropTypes.object.isRequired,
   formContext: PropTypes.object,

--- a/src/platform/forms-system/src/js/state/reducers.js
+++ b/src/platform/forms-system/src/js/state/reducers.js
@@ -3,6 +3,7 @@ import set from '../../../../utilities/data/set';
 import {
   CLOSE_REVIEW_CHAPTER,
   OPEN_REVIEW_CHAPTER,
+  TOGGLE_ALL_REVIEW_CHAPTERS,
   SET_DATA,
   SET_EDIT_MODE,
   SET_PRE_SUBMIT,
@@ -37,6 +38,9 @@ export default {
     action.pageKeys.forEach(pageKey => viewedPages.add(pageKey));
 
     return set('reviewPageView.viewedPages', viewedPages, newState);
+  },
+  [TOGGLE_ALL_REVIEW_CHAPTERS]: (state, action) => {
+    return set('reviewPageView.openChapters', action.chapters, state);
   },
   [SET_DATA]: (state, action) => {
     const newState = set('data', action.data, state);

--- a/src/platform/forms-system/test/js/actions.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/actions.unit.spec.jsx
@@ -19,6 +19,12 @@ import {
   SET_FORM_ERRORS,
   setItf,
   SET_ITF,
+  closeReviewChapter,
+  CLOSE_REVIEW_CHAPTER,
+  openReviewChapter,
+  OPEN_REVIEW_CHAPTER,
+  toggleAllReviewChapters,
+  TOGGLE_ALL_REVIEW_CHAPTERS,
 } from '../../src/js/actions';
 
 describe('Schemaform actions:', () => {
@@ -986,6 +992,40 @@ describe('Schemaform actions:', () => {
       const action = setItf(data);
       expect(action.data).to.equal(data);
       expect(action.type).to.equal(SET_ITF);
+    });
+  });
+
+  describe('closeReviewChapter', () => {
+    it('should return action', () => {
+      const data = { name: 'foo' };
+      const action = closeReviewChapter(data);
+      expect(action).to.deep.equal({
+        type: CLOSE_REVIEW_CHAPTER,
+        closedChapter: data,
+        pageKeys: [],
+      });
+    });
+  });
+
+  describe('openReviewChapter', () => {
+    it('should return action', () => {
+      const data = { name: 'foo' };
+      const action = openReviewChapter(data);
+      expect(action).to.deep.equal({
+        type: OPEN_REVIEW_CHAPTER,
+        openedChapter: data,
+      });
+    });
+  });
+
+  describe('toggleAllReviewChapters', () => {
+    it('should return action', () => {
+      const data = { foo: true, bar: true };
+      const action = toggleAllReviewChapters(data);
+      expect(action).to.deep.equal({
+        type: TOGGLE_ALL_REVIEW_CHAPTERS,
+        chapters: data,
+      });
     });
   });
 });

--- a/src/platform/forms-system/test/js/reducers.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/reducers.unit.spec.jsx
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+
+import reducers from '../../src/js/state/reducers';
+import {
+  CLOSE_REVIEW_CHAPTER,
+  OPEN_REVIEW_CHAPTER,
+  TOGGLE_ALL_REVIEW_CHAPTERS,
+} from '../../src/js/actions';
+
+describe('reducers', () => {
+  context('CLOSE_REVIEW_CHAPTER', () => {
+    it('should close named chapter', () => {
+      const state = {
+        reviewPageView: {
+          openChapters: { test1: true, test2: false, test3: true },
+          viewedPages: new Set(),
+        },
+      };
+      const action = {
+        type: CLOSE_REVIEW_CHAPTER,
+        closedChapter: 'test1',
+        pageKeys: [],
+      };
+      expect(reducers[CLOSE_REVIEW_CHAPTER](state, action)).to.deep.equal({
+        reviewPageView: {
+          openChapters: { test1: false, test2: false, test3: true },
+          viewedPages: state.reviewPageView.viewedPages,
+        },
+      });
+    });
+    it('should close named chapter', () => {
+      const state = {
+        reviewPageView: {
+          openChapters: { test1: true, test2: false, test3: true },
+          viewedPages: new Set(),
+        },
+      };
+      const action = {
+        type: CLOSE_REVIEW_CHAPTER,
+        closedChapter: 'test3',
+        pageKeys: ['page1', 'page2'],
+      };
+      expect(reducers[CLOSE_REVIEW_CHAPTER](state, action)).to.deep.equal({
+        reviewPageView: {
+          openChapters: { test1: true, test2: false, test3: false },
+          viewedPages: state.reviewPageView.viewedPages
+            .add('page1')
+            .add('page2'),
+        },
+      });
+    });
+  });
+
+  context('OPEN_REVIEW_CHAPTER', () => {
+    it('should open named chapter', () => {
+      const state = {
+        reviewPageView: {
+          openChapters: { test1: true, test2: false, test3: true },
+        },
+      };
+      const action = {
+        type: OPEN_REVIEW_CHAPTER,
+        openedChapter: 'test2',
+      };
+      expect(reducers[OPEN_REVIEW_CHAPTER](state, action)).to.deep.equal({
+        reviewPageView: {
+          openChapters: { test1: true, test2: true, test3: true },
+        },
+      });
+    });
+  });
+
+  context('TOGGLE_ALL_REVIEW_CHAPTERS', () => {
+    it('should set all chapters as open', () => {
+      const state = {
+        reviewPageView: {
+          openChapters: { test1: true, test2: false, test3: true },
+        },
+      };
+      const action = {
+        type: TOGGLE_ALL_REVIEW_CHAPTERS,
+        chapters: { test1: true, test2: true, test3: true },
+      };
+      expect(reducers[TOGGLE_ALL_REVIEW_CHAPTERS](state, action)).to.deep.equal(
+        {
+          reviewPageView: {
+            openChapters: { test1: true, test2: true, test3: true },
+          },
+        },
+      );
+    });
+  });
+  it('should set all chapters to closed', () => {
+    const state = {
+      reviewPageView: {
+        openChapters: { test1: false, test2: true, test3: true },
+      },
+    };
+    const action = {
+      type: TOGGLE_ALL_REVIEW_CHAPTERS,
+      chapters: { test1: false, test2: false, test3: false },
+    };
+    expect(reducers[TOGGLE_ALL_REVIEW_CHAPTERS](state, action)).to.deep.equal({
+      reviewPageView: {
+        openChapters: { test1: false, test2: false, test3: false },
+      },
+    });
+  });
+});

--- a/src/platform/forms-system/test/js/review/ReviewChapters.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewChapters.unit.spec.jsx
@@ -116,14 +116,14 @@ describe('Schemaform review: ReviewChapters', () => {
     instance.handleToggleChapter({
       target: {
         dataset: { chapter: 'chapter1' },
-        getAttribute: () => true,
+        getAttribute: () => 'true',
       },
     });
     expect(openReviewChapter.args[0][0]).to.eq('chapter1');
     instance.handleToggleChapter({
       target: {
         dataset: { chapter: 'chapter2' },
-        getAttribute: () => false,
+        getAttribute: () => 'false',
       },
     });
     expect(closeReviewChapter.args[0][0]).to.eq('chapter2');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > After toggling any accordions on the review & submit page, the state of the accordion in redux state indicates that it is open. So navigating away and back to the review & submit page will open all accordions that were previously toggled. Additionally, the state of the accordions when expand/collapse all is used isn't saved into the redux state.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > - Fix bug in toggle single chapter callback function
  > - Add new toggle all action & reducer functions
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages 
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119593

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

| Before | After |
|  ------ | ----- |
| ![accordion-state](https://github.com/user-attachments/assets/c95ee912-37a7-403a-a3dd-7c7f925facb4) | ![after-accordion-state](https://github.com/user-attachments/assets/27f934ec-69ab-4d40-bc84-de8821bde0d7) |

## What areas of the site does it impact?

All forms that use the form system

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
