### PR TITLE
Added Confirm Contact Email Interstitial Redirect to AuthApp

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { AUTH_ERRORS, AUTH_LEVEL } from 'platform/user/authentication/errors';
 import ContactCenterInformation from 'platform/user/authentication/components/ContactCenterInformation';
 
@@ -455,13 +454,3 @@ export default function RenderErrorContainer({
     </div>
   );
 }
-
-RenderErrorContainer.propTypes = {
-  auth: PropTypes.oneOf(Object.values(AUTH_LEVEL)),
-  code: PropTypes.oneOf(
-    Object.values(AUTH_ERRORS).map(({ errorCode }) => errorCode),
-  ),
-  openLoginModal: PropTypes.func,
-  recordEvent: PropTypes.func,
-  requestId: PropTypes.string,
-};

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -20,6 +20,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 
 import { generateReturnURL } from 'platform/user/authentication/utilities';
 import { OAUTH_EVENTS } from 'platform/utilities/oauth/constants';
+import { isBefore, parseISO } from 'date-fns';
 import RenderErrorUI from '../components/RenderErrorContainer';
 import AuthMetrics from './AuthMetrics';
 import {
@@ -175,8 +176,10 @@ export default function AuthApp({ location }) {
       userProfile.verified &&
       userAttributes.vaProfile?.vaPatient &&
       userAttributes.vaProfile?.facilities?.length > 0 &&
-      new Date(userAttributes.vet360ContactInformation?.email?.updatedAt) <
-        new Date('2025-03-01')
+      isBefore(
+        parseISO(userAttributes.vet360ContactInformation?.email?.updatedAt),
+        new Date('2025-03-01'),
+      )
     ) {
       window.location.replace('/sign-in-confirm-contact-email');
       return;

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -20,11 +20,11 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 
 import { generateReturnURL } from 'platform/user/authentication/utilities';
 import { OAUTH_EVENTS } from 'platform/utilities/oauth/constants';
-import { isBefore, parseISO } from 'date-fns';
 import RenderErrorUI from '../components/RenderErrorContainer';
 import AuthMetrics from './AuthMetrics';
 import {
   checkReturnUrl,
+  emailNeedsConfirmation,
   generateSentryAuthError,
   handleTokenRequest,
 } from '../helpers';
@@ -171,15 +171,11 @@ export default function AuthApp({ location }) {
       setupProfileSession(userProfile);
     }
     if (
-      isEmailInterstitialEnabled &&
-      [CSP_IDS.LOGIN_GOV, CSP_IDS.ID_ME].includes(loginType) &&
-      userProfile.verified &&
-      userAttributes.vaProfile?.vaPatient &&
-      userAttributes.vaProfile?.facilities?.length > 0 &&
-      isBefore(
-        parseISO(userAttributes.vet360ContactInformation?.email?.updatedAt),
-        new Date('2025-03-01'),
-      )
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled,
+        loginType,
+        userAttributes,
+      })
     ) {
       window.location.replace('/sign-in-confirm-contact-email');
       return;

--- a/src/applications/auth/containers/AuthMetrics.jsx
+++ b/src/applications/auth/containers/AuthMetrics.jsx
@@ -11,7 +11,8 @@ export default class AuthMetrics {
     this.payload = payload;
     this.requestId = requestId;
     this.errorCode = errorCode;
-    this.userProfile = get('data.attributes.profile', payload, {});
+    this.userAttributes = get('data.attributes', payload, {});
+    this.userProfile = get('profile', this.userAttributes, {});
     this.loaCurrent = get('loa.current', this.userProfile, null);
     this.serviceName = get('signIn.serviceName', this.userProfile, null);
   }

--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -3,6 +3,7 @@ import {
   EXTERNAL_APPS,
   ARP_APPS,
   EXTERNAL_REDIRECTS,
+  CSP_IDS,
 } from 'platform/user/authentication/constants';
 import {
   SENTRY_TAGS,
@@ -16,6 +17,7 @@ import {
   OAUTH_KEYS,
 } from 'platform/utilities/oauth/constants';
 import { requestToken } from 'platform/utilities/oauth/utilities';
+import { isBefore, parseISO } from 'date-fns';
 
 export const checkReturnUrl = passedUrl => {
   return (
@@ -25,6 +27,24 @@ export const checkReturnUrl = passedUrl => {
     passedUrl.includes(EXTERNAL_REDIRECTS[EXTERNAL_APPS.ARP]) ||
     passedUrl.includes(EXTERNAL_REDIRECTS[EXTERNAL_APPS.SMHD]) ||
     passedUrl.includes(EXTERNAL_REDIRECTS[ARP_APPS.FORM21A])
+  );
+};
+
+export const emailNeedsConfirmation = ({
+  isEmailInterstitialEnabled,
+  loginType,
+  userAttributes,
+}) => {
+  return (
+    isEmailInterstitialEnabled &&
+    [CSP_IDS.LOGIN_GOV, CSP_IDS.ID_ME].includes(loginType) &&
+    userAttributes.profile?.verified &&
+    userAttributes.vaProfile?.vaPatient &&
+    userAttributes.vaProfile?.facilities?.length > 0 &&
+    isBefore(
+      parseISO(userAttributes.vet360ContactInformation?.email?.updatedAt),
+      new Date('2025-03-01'),
+    )
   );
 };
 

--- a/src/applications/auth/helpers.js
+++ b/src/applications/auth/helpers.js
@@ -35,16 +35,36 @@ export const emailNeedsConfirmation = ({
   loginType,
   userAttributes,
 }) => {
+  const beforeDate = new Date('2025-03-01');
+  const {
+    profile = {},
+    vaProfile = {},
+    vet360ContactInformation,
+  } = userAttributes;
+
+  if (isEmailInterstitialEnabled === false || !profile || !vaProfile) {
+    return false;
+  }
+
+  // Confirmation Date is null
+  const hasNoConfirmationDate =
+    vet360ContactInformation?.email?.confirmationDate === null;
+
+  // Confirmation Date is before March 1, 2025
+  const confirmationDateIsBefore =
+    hasNoConfirmationDate === false
+      ? isBefore(
+          parseISO(userAttributes.vet360ContactInformation?.email?.updatedAt),
+          beforeDate,
+        )
+      : false;
+
   return (
-    isEmailInterstitialEnabled &&
     [CSP_IDS.LOGIN_GOV, CSP_IDS.ID_ME].includes(loginType) &&
-    userAttributes.profile?.verified &&
-    userAttributes.vaProfile?.vaPatient &&
-    userAttributes.vaProfile?.facilities?.length > 0 &&
-    isBefore(
-      parseISO(userAttributes.vet360ContactInformation?.email?.updatedAt),
-      new Date('2025-03-01'),
-    )
+    profile?.verified && // Verified User
+    vaProfile?.vaPatient && // VA Patient
+    vaProfile?.facilities?.length > 0 && // Assigned to a facility
+    (hasNoConfirmationDate || confirmationDateIsBefore) // Confirmation Date related
   );
 };
 

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -10,7 +10,7 @@ import {
   jsonResponse,
   setupServer,
 } from 'platform/testing/unit/msw-adapter';
-import { handleTokenRequest } from '../helpers';
+import { handleTokenRequest, emailNeedsConfirmation } from '../helpers';
 
 import AuthApp from '../containers/AuthApp';
 
@@ -517,5 +517,31 @@ describe('handleTokenRequest', () => {
       csp: 'logingov',
     });
     expect(handleTokenSpy.called).to.be.true;
+  });
+});
+
+describe('emailNeedsConfirmation', () => {
+  it('should return false when conditions are met', () => {
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: false,
+        userAttributes: {
+          profile: { verified: true },
+          vaProfile: { vaPatient: true },
+        },
+      }),
+    ).to.be.false;
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        userAttributes: { profile: {} },
+      }),
+    ).to.be.false;
+    expect(
+      emailNeedsConfirmation({
+        isEmailInterstitialEnabled: true,
+        userAttributes: { profile: {} },
+      }),
+    ).to.be.false;
   });
 });

--- a/src/applications/auth/tests/AuthApp.unit.spec.jsx
+++ b/src/applications/auth/tests/AuthApp.unit.spec.jsx
@@ -375,8 +375,71 @@ describe('AuthApp', () => {
     );
 
     await waitFor(() => expect(window.location.replace.calledOnce).to.be.true);
-    expect(window.location.replace.calledWith('/sign-in-changes-reminder'));
+    expect(window.location.replace.calledWith('/sign-in-changes-reminder')).to
+      .be.true;
 
+    window.location = originalLocation;
+    sessionStorage.clear();
+  });
+
+  it('should redirect to /sign-in-confirm-contact-email interstitial page', async () => {
+    const originalLocation = window.location;
+    if (!Location.prototype.replace) {
+      window.location = { replace: sinon.spy() };
+    } else {
+      window.location.replace = sinon.spy();
+    }
+
+    const store = {
+      dispatch: sinon.spy(),
+      subscribe: sinon.spy(),
+      getState: () => ({
+        featureToggles: {
+          confirmContactEmailInterstitialEnabled: true,
+        },
+      }),
+    };
+    sessionStorage.setItem('authReturnUrl', 'https://dev.va.gov/my-va');
+    server.use(
+      createGetHandler('https://dev-api.va.gov/v0/user', () => {
+        return jsonResponse(
+          {
+            data: {
+              attributes: {
+                profile: {
+                  signIn: { serviceName: 'idme', ssoe: true },
+                  verified: true,
+                },
+                vaProfile: {
+                  vaPatient: true,
+                  facilities: [
+                    {
+                      facilityId: 'facility',
+                      isCerner: true,
+                    },
+                  ],
+                },
+                vet360ContactInformation: {
+                  email: {
+                    updatedAt: '2018-04-21T20:09:50Z',
+                  },
+                },
+              },
+            },
+          },
+          { status: 200 },
+        );
+      }),
+    );
+
+    render(
+      <Provider store={store}>
+        <AuthApp location={{ query: { auth: 'success', type: 'idme' } }} />
+      </Provider>,
+    );
+    await waitFor(() => expect(window.location.replace.calledOnce).to.be.true);
+    expect(window.location.replace.calledWith('/sign-in-confirm-contact-email'))
+      .to.be.true;
     window.location = originalLocation;
     sessionStorage.clear();
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Added a redirect to the Confirm Contact Email Interstitial (`/sign-in-confirm-contact-email`) provided the following are true:
- Must be verified
- Must sign in with either ID.me or Login.gov credentials
- Must be a VA Patient
- Must have at least 1 facility assigned to them
- Must have either of the following be true:
   - The email confirmation date for their contact email is null OR
   - The email confirmation date was updated before March 1, 2025

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/687)

## Testing done
- Updated and added a test to `AuthApp.unit.spec.jsx`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit --app-folder auth`.

## What areas of the site does it impact?
This only impacts `AuthApp.jsx`, `AuthMetrics.jsx`, and their related tests.

## Acceptance criteria
- [x] Update `AuthApp.jsx` to point to the new confirm-contact-email interstitial. 