### PR TITLE
Update VAOS scheduling flow radio options to use custom widgets - 2/3

### DIFF
--- a/src/applications/vaos/new-appointment/components/AppointmentsRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/AppointmentsRadioWidget.jsx
@@ -6,14 +6,14 @@ import PropTypes from 'prop-types';
  * code to disable certain options. This isn't currently supported by the
  * form system.
  */
-export default function SimpleRadioWidget({
+export default function AppointmentsRadioWidget({
   id,
   options,
   value,
   onChange,
   required,
 }) {
-  const { enumOptions } = options;
+  const { enumOptions, labels, descriptions } = options;
 
   return (
     <div className="vads-u-margin-top--3">
@@ -24,7 +24,6 @@ export default function SimpleRadioWidget({
 
         {enumOptions.map((option, i) => {
           const checked = option.value === value;
-          const { label } = option;
 
           return (
             <div className="form-radio-buttons" key={option.value}>
@@ -37,7 +36,14 @@ export default function SimpleRadioWidget({
                 value={value}
                 onChange={_ => onChange(option.value)}
               />
-              <label htmlFor={`${id}_${i}`}>{option.label}</label>
+              <label htmlFor={`${id}_${i}`}>
+                {labels ? labels[option.value] : option.label}
+                {descriptions && (
+                  <span className="vaos-radio__label-description">
+                    {descriptions[option.value]}
+                  </span>
+                )}
+              </label>
             </div>
           );
         })}
@@ -45,7 +51,7 @@ export default function SimpleRadioWidget({
     </div>
   );
 }
-SimpleRadioWidget.propTypes = {
+AppointmentsRadioWidget.propTypes = {
   formContext: PropTypes.object,
   id: PropTypes.string,
   options: PropTypes.object,

--- a/src/applications/vaos/new-appointment/components/ClosestCityStatePage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClosestCityStatePage.jsx
@@ -15,7 +15,7 @@ import {
   selectCommunityCareSupportedSites,
   selectPageChangeInProgress,
 } from '../redux/selectors';
-import SimpleRadioWidget from './SimpleRadioWidget';
+import AppointmentsRadioWidget from './AppointmentsRadioWidget';
 
 const pageKey = 'ccClosestCity';
 
@@ -25,7 +25,7 @@ export default function ClosestCityStatePage() {
   const uiSchema = {
     communityCareSystemId: {
       'ui:title': pageTitle,
-      'ui:widget': SimpleRadioWidget,
+      'ui:widget': AppointmentsRadioWidget,
       'ui:errorMessages': {
         required: 'Select a city',
       },

--- a/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.jsx
@@ -1,10 +1,8 @@
-import React, { useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
+import React, { useEffect } from 'react';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import FormButtons from '../../components/FormButtons';
-import { getFormPageInfo } from '../redux/selectors';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
 import {
   openFormPage,
@@ -12,6 +10,8 @@ import {
   routeToPreviousAppointmentPage,
   updateFormData,
 } from '../redux/actions';
+import { getFormPageInfo } from '../redux/selectors';
+import AppointmentsRadioWidget from './AppointmentsRadioWidget';
 
 const pageKey = 'audiologyCareType';
 const pageTitle = 'Which type of audiology care do you need?';
@@ -30,11 +30,10 @@ const initialSchema = {
 const uiSchema = {
   audiologyType: {
     'ui:title': pageTitle,
-    'ui:widget': 'radio', // Required
-    'ui:webComponentField': VaRadioField,
+    'ui:widget': AppointmentsRadioWidget,
     'ui:options': {
       classNames: 'vads-u-margin-top--neg2',
-      labelHeaderLevel: '1',
+      hideLabelText: true,
       labels: {
         CCAUDRTNE: 'Routine hearing exam',
         CCAUDHEAR: 'Hearing aid support',
@@ -78,6 +77,12 @@ export default function TypeOfAudiologyCarePage() {
 
   return (
     <div className="vaos-form__radio-field-descriptive">
+      <h1 className="vaos__dynamic-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {!!schema && (
         <SchemaForm
           name="Type of appointment"

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -23,7 +23,7 @@ import { TYPE_OF_CARE_IDS, TYPES_OF_CARE } from '../../../utils/constants';
 import useFormState from '../../../hooks/useFormState';
 import { getLongTermAppointmentHistoryV2 } from '../../../services/appointment';
 import { getPageTitle } from '../../newAppointmentFlow';
-import SimpleRadioWidget from '../SimpleRadioWidget';
+import AppointmentsRadioWidget from '../AppointmentsRadioWidget';
 
 const pageKey = 'typeOfCare';
 
@@ -95,7 +95,7 @@ export default function TypeOfCarePage() {
     uiSchema: {
       typeOfCareId: {
         'ui:title': pageTitle,
-        'ui:widget': SimpleRadioWidget,
+        'ui:widget': AppointmentsRadioWidget,
         'ui:options': {
           classNames: 'vads-u-margin-top--neg2',
           hideLabelText: true,

--- a/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
@@ -1,20 +1,19 @@
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 
 import FormButtons from '../../components/FormButtons';
-import { getFormPageInfo } from '../redux/selectors';
 import { TYPES_OF_EYE_CARE } from '../../utils/constants';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
-
 import {
   openFormPage,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
   updateFormData,
 } from '../redux/actions';
+import { getFormPageInfo } from '../redux/selectors';
+import AppointmentsRadioWidget from './AppointmentsRadioWidget';
 
 const pageKey = 'typeOfEyeCare';
 const pageTitle = 'Which type of eye care do you need?';
@@ -33,11 +32,10 @@ const initialSchema = {
 const uiSchema = {
   typeOfEyeCareId: {
     'ui:title': pageTitle,
-    'ui:widget': 'radio', // Required
-    'ui:webComponentField': VaRadioField,
+    'ui:widget': AppointmentsRadioWidget,
     'ui:options': {
       classNames: 'vads-u-margin-top--neg2',
-      labelHeaderLevel: '1',
+      hideLabelText: true,
       labels: {
         [TYPES_OF_EYE_CARE[0].id]: TYPES_OF_EYE_CARE[0].name,
         [TYPES_OF_EYE_CARE[1].id]: TYPES_OF_EYE_CARE[1].name,
@@ -79,6 +77,12 @@ export default function TypeOfEyeCarePage() {
 
   return (
     <div className="vaos-form__radio-field-descriptive">
+      <h1 className="vaos__dynamic-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {!!schema && (
         <SchemaForm
           name="Type of eye care"

--- a/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
@@ -21,7 +21,6 @@ import {
   mockSchedulingConfigurationsApi,
   mockV2CommunityCareEligibility,
 } from '../../tests/mocks/mockApis';
-import { TYPE_OF_CARE_IDS } from '../../utils/constants';
 import TypeOfEyeCarePage from './TypeOfEyeCarePage';
 
 const initialState = {
@@ -66,19 +65,19 @@ describe('VAOS Page: TypeOfEyeCarePage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    // Then the primary header should have focus
-    const radioSelector = screen.container.querySelector('va-radio');
-    expect(radioSelector).to.exist;
-    expect(radioSelector).to.have.attribute(
-      'label',
-      'Which type of eye care do you need?',
-    );
+    // Should show title
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: /Which type of eye care do you need\?/,
+      }),
+    ).to.exist;
 
-    // And the user should see radio buttons for each clinic
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
+    // And the user should see radio buttons for each type of eye care
+    const radioOptions = screen.getAllByRole('radio');
     expect(radioOptions).to.have.lengthOf(2);
-    expect(radioOptions[0]).to.have.attribute('label', 'Optometry');
-    expect(radioOptions[1]).to.have.attribute('label', 'Ophthalmology');
+    await screen.findByLabelText(/Optometry/i);
+    await screen.findByLabelText(/Ophthalmology/i);
 
     // When the user continues
     fireEvent.click(screen.getByText(/Continue/));
@@ -86,17 +85,10 @@ describe('VAOS Page: TypeOfEyeCarePage', () => {
     // The user should stay on the page
     expect(screen.history.push.called).to.be.false;
 
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: TYPE_OF_CARE_IDS.OPHTHALMOLOGY_ID },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
-    await waitFor(() => {
-      expect(radioSelector).to.have.attribute(
-        'value',
-        TYPE_OF_CARE_IDS.OPHTHALMOLOGY_ID,
-      );
-    });
+    // Then there should be a validation error
+    expect(await screen.findByText('You must provide a response')).to.exist;
 
+    fireEvent.click(screen.getByText(/Ophthalmology/));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal('location'),
@@ -111,23 +103,16 @@ describe('VAOS Page: TypeOfEyeCarePage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: TYPE_OF_CARE_IDS.OPTOMETRY_ID },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(screen.getByText(/Optometry/));
     await cleanup();
 
     screen = renderWithStoreAndRouter(<Route component={TypeOfEyeCarePage} />, {
       store,
     });
 
-    await waitFor(() => {
-      expect(radioSelector).to.have.attribute(
-        'value',
-        TYPE_OF_CARE_IDS.OPTOMETRY_ID,
-      );
-    });
+    expect(await screen.findByLabelText(/Optometry/i)).to.have.attribute(
+      'checked',
+    );
   });
 
   it('should facility type page when CC eligible and optometry is chosen', async () => {
@@ -153,11 +138,7 @@ describe('VAOS Page: TypeOfEyeCarePage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: TYPE_OF_CARE_IDS.OPTOMETRY_ID },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(screen.getByText(/Optometry/));
     fireEvent.click(screen.getByText(/Continue/));
 
     await waitFor(() =>

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
@@ -14,7 +14,7 @@ import {
   updateFormData,
 } from '../redux/actions';
 import { getFormPageInfo } from '../redux/selectors';
-import SimpleRadioWidget from './SimpleRadioWidget';
+import AppointmentsRadioWidget from './AppointmentsRadioWidget';
 
 const facilityTypesValues = Object.values(FACILITY_TYPES);
 
@@ -38,7 +38,7 @@ export default function TypeOfFacilityPage() {
   const uiSchema = {
     facilityType: {
       'ui:title': pageTitle,
-      'ui:widget': SimpleRadioWidget,
+      'ui:widget': AppointmentsRadioWidget,
       'ui:options': {
         classNames: 'vads-u-margin-top--neg2',
         hideLabelText: true,

--- a/src/applications/vaos/new-appointment/components/TypeOfMentalHealthPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfMentalHealthPage.jsx
@@ -1,12 +1,11 @@
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 import FormButtons from '../../components/FormButtons';
-import { getFormPageInfo } from '../redux/selectors';
 import { TYPES_OF_MENTAL_HEALTH } from '../../utils/constants';
 import { focusFormHeader } from '../../utils/scrollAndFocus';
+import { getFormPageInfo } from '../redux/selectors';
 
 import {
   openFormPage,
@@ -14,6 +13,7 @@ import {
   routeToPreviousAppointmentPage,
   updateFormData,
 } from '../redux/actions';
+import AppointmentsRadioWidget from './AppointmentsRadioWidget';
 
 const pageKey = 'typeOfMentalHealth';
 const pageTitle = 'Which type of mental health care do you need?';
@@ -32,11 +32,10 @@ const initialSchema = {
 const uiSchema = {
   typeOfMentalHealthId: {
     'ui:title': pageTitle,
-    'ui:widget': 'radio', // Required
-    'ui:webComponentField': VaRadioField,
+    'ui:widget': AppointmentsRadioWidget,
     'ui:options': {
       classNames: 'vads-u-margin-top--neg2',
-      labelHeaderLevel: '1',
+      hideLabelText: true,
       labels: {
         [TYPES_OF_MENTAL_HEALTH[0].id]: TYPES_OF_MENTAL_HEALTH[0].name,
         [TYPES_OF_MENTAL_HEALTH[1].id]: TYPES_OF_MENTAL_HEALTH[1].name,
@@ -76,6 +75,12 @@ export default function TypeOfMentalHealthPage() {
 
   return (
     <div className="vaos-form__radio-field-descriptive">
+      <h1 className="vaos__dynamic-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {!!schema && (
         <SchemaForm
           name="Type of mental health care"

--- a/src/applications/vaos/new-appointment/components/TypeOfMentalHealthPage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfMentalHealthPage.unit.spec.jsx
@@ -11,7 +11,6 @@ import {
   renderWithStoreAndRouter,
   setTypeOfCare,
 } from '../../tests/mocks/setup';
-import { TYPE_OF_CARE_IDS } from '../../utils/constants';
 
 import TypeOfMentalHealthPage from './TypeOfMentalHealthPage';
 
@@ -42,38 +41,26 @@ describe('VAOS Page: TypeOfMentalHealthPage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    // Then the primary header should have focus
-    const radioSelector = screen.container.querySelector('va-radio');
-    expect(radioSelector).to.exist;
-    expect(radioSelector).to.have.attribute(
-      'label',
-      'Which type of mental health care do you need?',
-    );
+    // Should show title
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: /Which type of mental health care do you need\?/,
+      }),
+    ).to.exist;
 
-    // And the user should see radio buttons for each clinic
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
+    // And the user should see radio buttons for each type of sleep care
+    const radioOptions = screen.getAllByRole('radio');
     expect(radioOptions).to.have.lengthOf(2);
-    expect(radioOptions[0]).to.have.attribute(
-      'label',
-      'Mental health services',
-    );
-    expect(radioOptions[1]).to.have.attribute(
-      'label',
-      'Substance use problem services',
-    );
+    await screen.findByLabelText(/Mental health services/i);
+    await screen.findByLabelText(/Substance use problem services/i);
 
     fireEvent.click(screen.getByText(/Continue/));
     // Then there should be a validation error
-    // Assertion currently disabled due to
-    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/82624
-    // expect(await screen.findByText('You must provide a response')).to.exist;
+    expect(await screen.findByText('You must provide a response')).to.exist;
     expect(screen.history.push.called).to.be.false;
 
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
-
+    fireEvent.click(screen.getByText(/Mental health services/));
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal('location'),
@@ -88,11 +75,7 @@ describe('VAOS Page: TypeOfMentalHealthPage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: TYPE_OF_CARE_IDS.MENTAL_HEALTH_SUBSTANCE_USE_ID },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(screen.getByText(/Mental health services/));
     await cleanup();
 
     screen = renderWithStoreAndRouter(
@@ -102,11 +85,8 @@ describe('VAOS Page: TypeOfMentalHealthPage', () => {
       },
     );
 
-    await waitFor(() => {
-      expect(radioSelector).to.have.attribute(
-        'value',
-        TYPE_OF_CARE_IDS.MENTAL_HEALTH_SUBSTANCE_USE_ID,
-      );
-    });
+    expect(
+      await screen.findByLabelText(/Mental health services/i),
+    ).to.have.attribute('checked');
   });
 });

--- a/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
@@ -33,6 +33,7 @@ const uiSchema = {
     'ui:title': pageTitle,
     'ui:widget': AppointmentsRadioWidget,
     'ui:options': {
+      classNames: 'vads-u-margin-top--neg2',
       hideLabelText: true,
       labels: {
         [TYPES_OF_SLEEP_CARE[0].id]: TYPES_OF_SLEEP_CARE[0].name,

--- a/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
@@ -1,9 +1,10 @@
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
 import FormButtons from '../../components/FormButtons';
+import { TYPES_OF_SLEEP_CARE } from '../../utils/constants';
+import { focusFormHeader } from '../../utils/scrollAndFocus';
 import {
   openFormPage,
   routeToNextAppointmentPage,
@@ -11,8 +12,7 @@ import {
   updateFormData,
 } from '../redux/actions';
 import { getFormPageInfo } from '../redux/selectors';
-import { focusFormHeader } from '../../utils/scrollAndFocus';
-import { TYPES_OF_SLEEP_CARE } from '../../utils/constants';
+import AppointmentsRadioWidget from './AppointmentsRadioWidget';
 
 const pageKey = 'typeOfSleepCare';
 const pageTitle = 'Which type of sleep care do you need?';
@@ -31,11 +31,9 @@ const initialSchema = {
 const uiSchema = {
   typeOfSleepCareId: {
     'ui:title': pageTitle,
-    'ui:widget': 'radio', // Required
-    'ui:webComponentField': VaRadioField,
+    'ui:widget': AppointmentsRadioWidget,
     'ui:options': {
-      classNames: 'vads-u-margin-top--neg2',
-      labelHeaderLevel: '1',
+      hideLabelText: true,
       labels: {
         [TYPES_OF_SLEEP_CARE[0].id]: TYPES_OF_SLEEP_CARE[0].name,
         [TYPES_OF_SLEEP_CARE[1].id]: TYPES_OF_SLEEP_CARE[1].name,
@@ -77,6 +75,12 @@ export default function TypeOfSleepCarePage() {
 
   return (
     <div className="vaos-form__radio-field-descriptive">
+      <h1 className="vaos__dynamic-font-size--h2">
+        {pageTitle}
+        <span className="schemaform-required-span vads-u-font-family--sans vads-u-font-weight--normal">
+          (*Required)
+        </span>
+      </h1>
       {!!schema && (
         <SchemaForm
           name="Type of sleep care"

--- a/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
@@ -11,7 +11,6 @@ import {
   renderWithStoreAndRouter,
   setTypeOfCare,
 } from '../../tests/mocks/setup';
-import { TYPE_OF_CARE_IDS } from '../../utils/constants';
 
 import TypeOfSleepCarePage from './TypeOfSleepCarePage';
 
@@ -41,38 +40,31 @@ describe('VAOS Page: TypeOfSleepCarePage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    // Then the primary header should have focus
-    const radioSelector = screen.container.querySelector('va-radio');
-    expect(radioSelector).to.exist;
-    expect(radioSelector).to.have.attribute(
-      'label',
-      'Which type of sleep care do you need?',
-    );
+    // Should show title
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: /Which type of sleep care do you need\?/,
+      }),
+    ).to.exist;
 
-    // And the user should see radio buttons for each clinic
-    const radioOptions = screen.container.querySelectorAll('va-radio-option');
+    // And the user should see radio buttons for each type of sleep care
+    const radioOptions = screen.getAllByRole('radio');
     expect(radioOptions).to.have.lengthOf(2);
-    expect(radioOptions[0]).to.have.attribute(
-      'label',
-      'Continuous Positive Airway Pressure (CPAP)',
+    await screen.findByLabelText(
+      /Continuous Positive Airway Pressure \(CPAP\)/i,
     );
-    expect(radioOptions[1]).to.have.attribute(
-      'label',
-      'Sleep medicine and home sleep testing',
-    );
+    await screen.findByLabelText(/Sleep medicine and home sleep testing/i);
 
     fireEvent.click(screen.getByText(/Continue/));
+
     // Then there should be a validation error
-    // Assertion currently disabled due to
-    // https://github.com/department-of-veterans-affairs/va.gov-team/issues/82624
-    // expect(await screen.findByText('You must provide a response')).to.exist;
+    expect(await screen.findByText('You must provide a response')).to.exist;
     expect(screen.history.push.called).to.be.false;
 
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: TYPE_OF_CARE_IDS.CPAP_ID },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
-
+    fireEvent.click(
+      await screen.findByLabelText(/Sleep medicine and home sleep testing/i),
+    );
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal('location'),
@@ -87,11 +79,9 @@ describe('VAOS Page: TypeOfSleepCarePage', () => {
     );
     await screen.findByText(/Continue/i);
 
-    const radioSelector = screen.container.querySelector('va-radio');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: TYPE_OF_CARE_IDS.HOME_SLEEP_TESTING_ID },
-    });
-    radioSelector.__events.vaValueChange(changeEvent);
+    fireEvent.click(
+      await screen.findByLabelText(/Sleep medicine and home sleep testing/i),
+    );
     await cleanup();
 
     screen = renderWithStoreAndRouter(
@@ -101,11 +91,8 @@ describe('VAOS Page: TypeOfSleepCarePage', () => {
       },
     );
 
-    await waitFor(() => {
-      expect(radioSelector).to.have.attribute(
-        'value',
-        TYPE_OF_CARE_IDS.HOME_SLEEP_TESTING_ID,
-      );
-    });
+    expect(
+      await screen.findByLabelText(/Sleep medicine and home sleep testing/i),
+    ).to.have.attribute('checked');
   });
 });

--- a/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
@@ -13,7 +13,7 @@ import {
   updateFormData,
 } from '../redux/actions';
 import { getFormPageInfo, getNewAppointment } from '../redux/selectors';
-import SimpleRadioWidget from './SimpleRadioWidget';
+import AppointmentsRadioWidget from './AppointmentsRadioWidget';
 
 const pageKey = 'visitType';
 
@@ -29,7 +29,7 @@ export default function TypeOfVisitPage() {
   const uiSchema = {
     visitType: {
       'ui:title': pageTitle,
-      'ui:widget': SimpleRadioWidget,
+      'ui:widget': AppointmentsRadioWidget,
       'ui:errorMessages': {
         required: 'Select an option',
       },

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.eligibility.unit.spec.jsx
@@ -21,7 +21,6 @@ import {
   setTypeOfMentalHealth,
 } from '../../../tests/mocks/setup';
 import VAFacilityPage from './VAFacilityPageV2';
-import { TYPE_OF_CARE_IDS } from '../../../utils/constants';
 
 describe('VAOS Page: VAFacilityPage eligibility check', () => {
   describe('when there is a single supported facility', () => {
@@ -190,10 +189,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
 
       const store = createTestStore(defaultState);
       await setTypeOfCare(store, /mental health/i);
-      await setTypeOfMentalHealth(
-        store,
-        TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
-      );
+      await setTypeOfMentalHealth(store, /Mental health services/);
 
       const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -1014,10 +1010,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
 
         const store = createTestStore(defaultState);
         await setTypeOfCare(store, /mental health/i);
-        await setTypeOfMentalHealth(
-          store,
-          TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
-        );
+        await setTypeOfMentalHealth(store, /Mental health services/);
 
         // Act
         const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -1082,10 +1075,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
 
         const store = createTestStore(defaultState);
         await setTypeOfCare(store, /mental health/i);
-        await setTypeOfMentalHealth(
-          store,
-          TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
-        );
+        await setTypeOfMentalHealth(store, /Mental health services/);
 
         // Act
         const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -1155,10 +1145,7 @@ describe('VAOS Page: VAFacilityPage eligibility check', () => {
           featureToggles: {},
         });
         await setTypeOfCare(store, /mental health/i);
-        await setTypeOfMentalHealth(
-          store,
-          TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
-        );
+        await setTypeOfMentalHealth(store, /Mental health services/);
 
         // Act
         const screen = renderWithStoreAndRouter(<VAFacilityPage />, {

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.unit.spec.jsx
@@ -600,7 +600,7 @@ describe.skip('VAOS Page: VAFacilityPage', () => {
       await cleanup();
 
       await setTypeOfCare(store, /eye care/i);
-      await setTypeOfEyeCare(store, TYPE_OF_CARE_IDS.OPTOMETRY_ID);
+      await setTypeOfEyeCare(store, /Optometry/);
 
       screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
@@ -1162,7 +1162,7 @@ describe.skip('VAOS Page: VAFacilityPage', () => {
 
       const store = createTestStore(initialState);
       await setTypeOfCare(store, /eye care/i);
-      await setTypeOfEyeCare(store, TYPE_OF_CARE_IDS.OPTOMETRY_ID);
+      await setTypeOfEyeCare(store, /Optometry/);
 
       // Act
       let screen = renderWithStoreAndRouter(<VAFacilityPage />, {
@@ -1173,7 +1173,7 @@ describe.skip('VAOS Page: VAFacilityPage', () => {
       await screen.findByText(/You can.t schedule an appointment online/i);
 
       await cleanup();
-      await setTypeOfEyeCare(store, TYPE_OF_CARE_IDS.OPHTHALMOLOGY_ID);
+      await setTypeOfEyeCare(store, /Ophthalmology/);
       screen = renderWithStoreAndRouter(<VAFacilityPage />, {
         store,
       });

--- a/src/applications/vaos/new-appointment/sass/styles.scss
+++ b/src/applications/vaos/new-appointment/sass/styles.scss
@@ -10,6 +10,11 @@
   margin-top: 0;
 }
 
+.vaos-radio__label-description {
+    display: block;
+    margin-top: 0.5rem
+}
+
 .vaos-form__radio-field, .vaos-form__radio-field-descriptive {
   va-radio {
     max-width: none;

--- a/src/applications/vaos/tests/e2e/page-objects/AudiologyPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/AudiologyPageObject.js
@@ -10,12 +10,12 @@ class AudiologyPageObject extends PageObject {
 
   assertAudiologyValidationErrors() {
     this.clickNextButton();
-    this.assertValidationErrorShadow('You must provide a response');
+    this.assertValidationError('You must provide a response');
     return this;
   }
 
   selectTypeOfCare(label) {
-    return super.selectRadioButtonShadow(label);
+    return super.selectRadioButton(label);
   }
 }
 

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfEyeCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfEyeCarePageObject.js
@@ -10,13 +10,13 @@ class TypeOfEyeCarePageObject extends PageObject {
 
   assertTypeOfEyeCareValidationErrors() {
     this.clickNextButton();
-    this.assertValidationErrorShadow('You must provide a response');
+    this.assertValidationError('You must provide a response');
 
     return this;
   }
 
   selectTypeOfEyeCare(label) {
-    return super.selectRadioButtonShadow(label);
+    return super.selectRadioButton(label);
   }
 }
 

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfMentalHealthPageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfMentalHealthPageObject.js
@@ -16,7 +16,7 @@ class TypeOfMentalHealthPageObject extends PageObject {
   }
 
   selectTypeOfMentalHealth(label) {
-    return super.selectRadioButtonShadow(label);
+    return super.selectRadioButton(label);
   }
 }
 

--- a/src/applications/vaos/tests/e2e/page-objects/TypeOfSleepCarePageObject.js
+++ b/src/applications/vaos/tests/e2e/page-objects/TypeOfSleepCarePageObject.js
@@ -10,13 +10,13 @@ class TypeOfSleepCarePageObject extends PageObject {
 
   assertTypeOfSleepCareValidationErrors() {
     this.clickNextButton();
-    this.assertValidationErrorShadow('You must provide a response');
+    this.assertValidationError('You must provide a response');
 
     return this;
   }
 
   selectTypeOfSleepCare(label) {
-    return super.selectRadioButtonShadow(label);
+    return super.selectRadioButton(label);
   }
 }
 

--- a/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/direct-schedule-workflow/mental-health.cypress.spec.js
@@ -150,7 +150,7 @@ describe('VAOS direct schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(typeOfCareName)
+            .selectTypeOfMentalHealth(/Mental health services/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()
@@ -234,7 +234,7 @@ describe('VAOS direct schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(typeOfCareName)
+            .selectTypeOfMentalHealth(/Mental health services/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()
@@ -325,7 +325,7 @@ describe('VAOS direct schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(typeOfCareName)
+            .selectTypeOfMentalHealth(/Substance use problem services/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()

--- a/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/request-schedule-workflow/mental-health.cypress.spec.js
@@ -39,7 +39,7 @@ const typeOfCareRegex = /Mental health/i;
 
 describe('VAOS request schedule flow - Mental health', () => {
   describe('When patient chooses mental health services', () => {
-    const { idV2: typeOfCareId, name: typeOfCareName } = getTypeOfCareById(
+    const { idV2: typeOfCareId } = getTypeOfCareById(
       TYPE_OF_CARE_IDS.MENTAL_HEALTH_SERVICES_ID,
     );
 
@@ -112,7 +112,7 @@ describe('VAOS request schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(typeOfCareName)
+            .selectTypeOfMentalHealth(/Mental health services/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()
@@ -172,7 +172,7 @@ describe('VAOS request schedule flow - Mental health', () => {
   });
 
   describe('When patient chooses substance use problem services', () => {
-    const { idV2: typeOfCareId, name: typeOfCareName } = getTypeOfCareById(
+    const { idV2: typeOfCareId } = getTypeOfCareById(
       TYPE_OF_CARE_IDS.MENTAL_HEALTH_SUBSTANCE_USE_ID,
     );
 
@@ -245,7 +245,7 @@ describe('VAOS request schedule flow - Mental health', () => {
             .clickNextButton();
 
           TypeOfMentalHealthPageObject.assertUrl()
-            .selectTypeOfMentalHealth(typeOfCareName)
+            .selectTypeOfMentalHealth(/Substance use problem services/i)
             .clickNextButton();
 
           VAFacilityPageObject.assertUrl()

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -170,11 +170,7 @@ export async function setTypeOfEyeCare(store, label) {
   const screen = renderWithStoreAndRouter(<TypeOfEyeCarePage />, { store });
   await screen.findByText(/Continue/i);
 
-  const radioSelector = screen.container.querySelector('va-radio');
-  const changeEvent = new CustomEvent('selected', {
-    detail: { value: label },
-  });
-  radioSelector.__events.vaValueChange(changeEvent);
+  fireEvent.click(await screen.findByLabelText(label));
   fireEvent.click(screen.getByText(/Continue/));
   await waitFor(() => expect(screen.history.push.called).to.be.true);
   await cleanup();

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -198,11 +198,7 @@ export async function setTypeOfMentalHealth(store, label) {
   });
   await screen.findByText(/Continue/i);
 
-  const radioSelector = screen.container.querySelector('va-radio');
-  const changeEvent = new CustomEvent('selected', {
-    detail: { value: label },
-  });
-  radioSelector.__events.vaValueChange(changeEvent);
+  fireEvent.click(await screen.findByLabelText(label));
   fireEvent.click(screen.getByText(/Continue/));
   await waitFor(() => expect(screen.history.push.called).to.be.true);
   await cleanup();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- We noticed that the "Skip to content" link wasn't always focusing on the primary heading on the scheduling pages
- This is because the header was hidden under the shadow DOM by the VaRadioField widget
- To solve this, we'll use our own heading-less custom widget (to avoid the empty *Required element) and an explicit primary heading element.
- This is part 2/3 for this issue and covers the 4 types of speciality care pages in the scheduling flow
- United Appointments Experience
- This is not behind a Flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111878

## Testing done

- Tested locally, see screenshots
- Updated unit and e2e tests

## Screenshots

|         | Skip link focus - Before | Skip link focus - After | Validation error - Before | Validation error - After |
| ------- | ------ | ----- | ------ | ----- |
| Type of Audiology  |   <img width="850" height="1292" alt="image" src="https://github.com/user-attachments/assets/53279c87-1832-459c-bd74-081b8a2bda38" />   |   <img width="848" height="1408" alt="image" src="https://github.com/user-attachments/assets/a5c5571b-b938-47d9-81a3-cfa0e70c7030" />  |   <img width="854" height="1396" alt="image" src="https://github.com/user-attachments/assets/530bc4e2-0a3d-4c5d-b640-d22f70ca3acd" />   |  <img width="852" height="1538" alt="image" src="https://github.com/user-attachments/assets/f638bc4b-f033-4aad-afe8-e5836593fc30" />   |
| Type of Eye Care  |   <img width="850" height="1236" alt="image" src="https://github.com/user-attachments/assets/a7480226-063f-4dfe-8721-3e8719bdc2a2" />   |   <img width="854" height="1362" alt="image" src="https://github.com/user-attachments/assets/86278730-d80f-4e70-a93d-89c298bfb7a5" />  |   <img width="852" height="1348" alt="image" src="https://github.com/user-attachments/assets/cb6dd421-b32c-4e0f-ab50-d7b064dc3e97" />   |  <img width="850" height="1540" alt="image" src="https://github.com/user-attachments/assets/564e52d1-a773-4975-a1ec-ded8d56b863f" />   |
| Type of Mental Health  |   <img width="850" height="1120" alt="image" src="https://github.com/user-attachments/assets/99713561-b201-45db-8177-b01918d0ac83" />   |   <img width="852" height="1210" alt="image" src="https://github.com/user-attachments/assets/054cccac-2e78-4227-97a3-fe0e7cf08550" />  |   <img width="854" height="1218" alt="image" src="https://github.com/user-attachments/assets/723b53f5-8497-4317-b626-334cb35cb8a1" />   |  <img width="850" height="1384" alt="image" src="https://github.com/user-attachments/assets/389bb9a5-32ae-4977-8fd2-7f3974c62df2" />   |
| Type of Sleep Care  |   <img width="850" height="1248" alt="image" src="https://github.com/user-attachments/assets/4ae8e17f-3385-445d-9e7c-75a74a294e00" />   |  <img width="850" height="1362" alt="image" src="https://github.com/user-attachments/assets/98608f07-52d9-4b2f-a699-d8c9f1b6dae3" />   |   <img width="850" height="1348" alt="image" src="https://github.com/user-attachments/assets/b5f00599-c58b-480a-9772-37ff6e0b9388" />   |  <img width="850" height="1540" alt="image" src="https://github.com/user-attachments/assets/9ed19ac8-0c58-40ac-ac6d-213ec97d5859" />   |

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
