### PR TITLE
DMT | Add duplicate spouse modal

### DIFF
--- a/src/applications/dependents/686c-674/components/CurrentSpouse.jsx
+++ b/src/applications/dependents/686c-674/components/CurrentSpouse.jsx
@@ -1,0 +1,132 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { SchemaForm } from 'platform/forms-system/exportsFile';
+import { scrollToTop } from 'platform/utilities/scroll';
+import { focusElement } from 'platform/utilities/ui';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+
+import { modalContent } from '../config/chapters/report-add-a-spouse/spouse-information/spouseInformation';
+
+const CurrentSpouseInformation = ({
+  name,
+  title,
+  data = {},
+  goBack,
+  goForward,
+  goToPath,
+  setFormData,
+  contentBeforeButtons,
+  contentAfterButtons,
+  schema,
+  uiSchema,
+  updatePage,
+  onReviewPage,
+}) => {
+  const [showSpouseModal, setShowSpouseModal] = useState(false);
+
+  useEffect(() => {
+    scrollToTop();
+  }, []);
+
+  // Get current spouse from dependents list from API (added via prefill)
+  const dependents =
+    (data?.dependents?.hasDependents && data.dependents?.awarded) || [];
+  const currentSpouse =
+    dependents.find(
+      dependent => dependent.relationshipToVeteran === 'Spouse',
+    ) || {};
+
+  const handlers = {
+    onModalClose: () => {
+      setShowSpouseModal(false);
+      setTimeout(() => {
+        focusElement('.usa-button-primary');
+      }, 100);
+    },
+    onModalCancel: () => {
+      setShowSpouseModal(false);
+      // Canceling redirects back to the add dependents options page
+      goToPath('/options-selection/add-dependents');
+    },
+    onModalAdd: () => {
+      setShowSpouseModal(false);
+      goForward(data);
+    },
+
+    onChange: newData => {
+      setFormData(newData);
+    },
+    onSubmit: () => {
+      if (currentSpouse.dateOfBirth === data.spouseInformation.birthDate) {
+        setShowSpouseModal(true);
+      } else {
+        goForward(data);
+      }
+    },
+  };
+
+  return (
+    <>
+      {showSpouseModal && (
+        <VaModal
+          status="warning"
+          modalTitle={modalContent.title}
+          primaryButtonText={modalContent.primaryButtonText}
+          secondaryButtonText={modalContent.secondaryButtonText}
+          onCloseEvent={handlers.onModalClose}
+          onPrimaryButtonClick={handlers.onModalCancel}
+          onSecondaryButtonClick={handlers.onModalAdd}
+          visible={showSpouseModal}
+        >
+          {modalContent.content(currentSpouse)}
+        </VaModal>
+      )}
+      <SchemaForm
+        name={name}
+        title={title}
+        data={data}
+        appStateData={data}
+        schema={schema}
+        uiSchema={uiSchema}
+        pagePerItemIndex={0}
+        onChange={handlers.onChange}
+        onSubmit={handlers.onSubmit}
+      >
+        {onReviewPage ? (
+          <va-button
+            onClick={updatePage}
+            text="Update page"
+            label="Update your spouse's personal information"
+            full-width="true"
+          />
+        ) : (
+          <>
+            {contentBeforeButtons}
+            <FormNavButtons goBack={goBack} submitToContinue />
+            {contentAfterButtons}
+          </>
+        )}
+      </SchemaForm>
+    </>
+  );
+};
+
+CurrentSpouseInformation.propTypes = {
+  data: PropTypes.object.isRequired,
+  goBack: PropTypes.func.isRequired,
+  goForward: PropTypes.func.isRequired,
+  goToPath: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+  schema: PropTypes.object.isRequired,
+  setFormData: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  uiSchema: PropTypes.object.isRequired,
+  contentAfterButtons: PropTypes.node,
+  contentBeforeButtons: PropTypes.node,
+  updatePage: PropTypes.func,
+  onReviewPage: PropTypes.bool,
+};
+
+export default CurrentSpouseInformation;

--- a/src/applications/dependents/686c-674/components/CurrentSpouse.jsx
+++ b/src/applications/dependents/686c-674/components/CurrentSpouse.jsx
@@ -8,6 +8,7 @@ import { focusElement } from 'platform/utilities/ui';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 
 import { modalContent } from '../config/chapters/report-add-a-spouse/spouse-information/spouseInformation';
+import { showDupeModalIfEnabled } from '../config/utilities';
 
 const CurrentSpouseInformation = ({
   name,
@@ -59,7 +60,10 @@ const CurrentSpouseInformation = ({
       setFormData(newData);
     },
     onSubmit: () => {
-      if (currentSpouse.dateOfBirth === data.spouseInformation.birthDate) {
+      if (
+        showDupeModalIfEnabled(data) &&
+        currentSpouse.dateOfBirth === data.spouseInformation.birthDate
+      ) {
         setShowSpouseModal(true);
       } else {
         goForward(data);

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
@@ -3,8 +3,12 @@ import {
   fullNameNoSuffixSchema,
   fullNameNoSuffixUI,
   titleUI,
+  dateOfBirthUI,
+  dateOfBirthSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+
 import { CancelButton, certificateNotice } from '../../../helpers';
+import { getFullName, getFormatedDate } from '../../../../../shared/utils';
 
 export const schema = {
   type: 'object',
@@ -13,6 +17,7 @@ export const schema = {
       type: 'object',
       properties: {
         fullName: fullNameNoSuffixSchema,
+        birthDate: dateOfBirthSchema,
       },
     },
     'view:certificateNotice': {
@@ -28,8 +33,13 @@ export const schema = {
 
 export const uiSchema = {
   spouseInformation: {
-    ...titleUI('Spouse’s current legal name'),
+    ...titleUI('Spouse’s current legal name and date of birth'),
     fullName: fullNameNoSuffixUI(title => `Spouse’s ${title}`),
+    birthDate: dateOfBirthUI({
+      title: 'Spouse’s date of birth',
+      dataDogHidden: true,
+      required: () => true,
+    }),
   },
   'view:certificateNotice': {
     'ui:description': certificateNotice,
@@ -41,4 +51,23 @@ export const uiSchema = {
   'view:cancelAddSpouse': {
     'ui:description': <CancelButton dependentType="spouse" isAddChapter />,
   },
+};
+
+export const modalContent = {
+  title: 'Potential duplicate',
+  primaryButtonText: 'Don’t add, it’s a duplicate',
+  secondaryButtonText: 'Add, it’s a different person',
+  content: currentSpouse => (
+    <>
+      We checked your VA records and found another dependent already listed on
+      your benefits with the birth date of{' '}
+      <strong>{getFormatedDate(currentSpouse.dateOfBirth)}</strong>:{' '}
+      <strong>{getFullName(currentSpouse.fullName)}</strong>.
+      <p>Are you adding a different person, or is this a duplicate?</p>
+      <p>
+        <strong>Note</strong>: If you don’t add this dependent, we’ll take you
+        back to Step 1 to update your selection.
+      </p>
+    </>
+  ),
 };

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
@@ -5,6 +5,8 @@ import {
   titleUI,
   dateOfBirthUI,
   dateOfBirthSchema,
+  ssnUI,
+  ssnSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import { CancelButton, certificateNotice } from '../../../helpers';
@@ -18,6 +20,7 @@ export const schema = {
       properties: {
         fullName: fullNameNoSuffixSchema,
         birthDate: dateOfBirthSchema,
+        ssn: ssnSchema,
       },
     },
     'view:certificateNotice': {
@@ -33,13 +36,17 @@ export const schema = {
 
 export const uiSchema = {
   spouseInformation: {
-    ...titleUI('Spouse’s current legal name and date of birth'),
+    ...titleUI('Your spouse’s personal information'),
     fullName: fullNameNoSuffixUI(title => `Spouse’s ${title}`),
     birthDate: dateOfBirthUI({
       title: 'Spouse’s date of birth',
       dataDogHidden: true,
       required: () => true,
     }),
+    ssn: {
+      ...ssnUI('Spouse’s Social Security number'),
+      'ui:required': () => true,
+    },
   },
   'view:certificateNotice': {
     'ui:description': certificateNotice,

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
@@ -61,19 +61,22 @@ export const uiSchema = {
 };
 
 export const modalContent = {
-  title: 'Potential duplicate',
-  primaryButtonText: 'Don’t add, it’s a duplicate',
-  secondaryButtonText: 'Add, it’s a different person',
+  title: 'You already have a dependent with this date of birth',
+  primaryButtonText: 'Don’t add this dependent',
+  secondaryButtonText: 'Add this dependent',
   content: currentSpouse => (
     <>
-      We checked your VA records and found another dependent already listed on
-      your benefits with the birth date of{' '}
-      <strong>{getFormatedDate(currentSpouse.dateOfBirth)}</strong>:{' '}
-      <strong>{getFullName(currentSpouse.fullName)}</strong>.
-      <p>Are you adding a different person, or is this a duplicate?</p>
+      Our records show <strong>{getFullName(currentSpouse.fullName)}</strong> is
+      already listed on your benefits with{' '}
+      <strong>{getFormatedDate(currentSpouse.dateOfBirth)}</strong> as a date of
+      birth.
       <p>
-        <strong>Note</strong>: If you don’t add this dependent, we’ll take you
-        back to Step 1 to update your selection.
+        If you don’t have another dependent with the same date of birth, we’ll
+        take you back to Step 1 to update your selection.
+      </p>
+      <p>
+        If you need to add another dependent with the same date of birth, you
+        can continue adding this dependent.
       </p>
     </>
   ),

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformationPartTwo.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformationPartTwo.js
@@ -1,8 +1,6 @@
 import {
   ssnUI,
   ssnSchema,
-  dateOfBirthUI,
-  dateOfBirthSchema,
   yesNoUI,
   yesNoSchema,
   titleUI,
@@ -15,7 +13,6 @@ export const schema = {
       type: 'object',
       properties: {
         ssn: ssnSchema,
-        birthDate: dateOfBirthSchema,
         isVeteran: yesNoSchema,
       },
     },
@@ -29,11 +26,6 @@ export const uiSchema = {
       ...ssnUI('Spouse’s Social Security number'),
       'ui:required': () => true,
     },
-    birthDate: dateOfBirthUI({
-      title: 'Spouse’s date of birth',
-      dataDogHidden: true,
-      required: () => true,
-    }),
 
     isVeteran: {
       ...yesNoUI('Is your spouse a Veteran?'),

--- a/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformationPartTwo.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformationPartTwo.js
@@ -1,9 +1,6 @@
 import {
-  ssnUI,
-  ssnSchema,
   yesNoUI,
   yesNoSchema,
-  titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 export const schema = {
@@ -12,7 +9,6 @@ export const schema = {
     spouseInformation: {
       type: 'object',
       properties: {
-        ssn: ssnSchema,
         isVeteran: yesNoSchema,
       },
     },
@@ -21,15 +17,12 @@ export const schema = {
 
 export const uiSchema = {
   spouseInformation: {
-    ...titleUI('Spouse’s identification information'),
-    ssn: {
-      ...ssnUI('Spouse’s Social Security number'),
-      'ui:required': () => true,
-    },
-
     isVeteran: {
-      ...yesNoUI('Is your spouse a Veteran?'),
-      'ui:required': () => true,
+      ...yesNoUI({
+        title: 'Is your spouse a Veteran?',
+        labelHeaderLevel: '3',
+        required: () => true,
+      }),
     },
   },
 };

--- a/src/applications/dependents/686c-674/config/form.js
+++ b/src/applications/dependents/686c-674/config/form.js
@@ -130,15 +130,14 @@ import prefillTransformer from './prefill-transformer';
 import { chapter as addChild } from './chapters/report-add-child';
 import { spouseAdditionalEvidence } from './chapters/additional-information/spouseAdditionalEvidence';
 import { childAdditionalEvidence as finalChildAdditionalEvidence } from './chapters/additional-information/childAdditionalEvidence';
+
 import {
   spouseEvidence,
   childEvidence,
   showPensionRelatedQuestions,
   showPensionBackupPath,
 } from './utilities';
-
-const emptyMigration = savedData => savedData;
-const migrations = [emptyMigration];
+import migrations from './migrations';
 
 export const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -266,7 +265,7 @@ export const formConfig = {
           depends: formData =>
             isChapterFieldRequired(formData, TASK_KEYS.addSpouse) &&
             formData?.['view:addOrRemoveDependents']?.add,
-          title: 'Spouse’s current legal name',
+          title: 'Your spouse’s personal information',
           path: 'add-spouse/current-legal-name',
           CustomPage: CurrentSpouse,
           CustomPageReview: null,

--- a/src/applications/dependents/686c-674/config/form.js
+++ b/src/applications/dependents/686c-674/config/form.js
@@ -10,6 +10,7 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../components/GetFormHelp';
 import { customSubmit686 } from '../analytics/helpers';
+import CurrentSpouse from '../components/CurrentSpouse';
 
 // Chapter imports
 import {
@@ -267,6 +268,8 @@ export const formConfig = {
             formData?.['view:addOrRemoveDependents']?.add,
           title: 'Spouse’s current legal name',
           path: 'add-spouse/current-legal-name',
+          CustomPage: CurrentSpouse,
+          CustomPageReview: null,
           uiSchema: spouseInformation.uiSchema,
           schema: spouseInformation.schema,
         },

--- a/src/applications/dependents/686c-674/config/helpers.js
+++ b/src/applications/dependents/686c-674/config/helpers.js
@@ -65,7 +65,7 @@ export const ServerErrorAlert = (
 );
 
 export const certificateNotice = () => (
-  <p className="vads-u-font-size--base vads-u-margin-top--neg3">
+  <p className="vads-u-font-size--base">
     You’ll need to submit a copy of your marriage certificate or a church record
     of your marriage. We’ll ask you to submit this document at the end of the
     form

--- a/src/applications/dependents/686c-674/config/migrations.js
+++ b/src/applications/dependents/686c-674/config/migrations.js
@@ -1,0 +1,17 @@
+const emptyMigration = savedData => savedData;
+
+const movedSpouseDob = savedData => {
+  const { formData, metadata } = savedData;
+  // Spouse date of birth was moved from /personal-information to the page
+  // before /current-legal-name, so if the returnUrl indicates that the in
+  // progress is on that page. We can't assume that the birth date is valid
+  // so that's why we're including this redirect
+  if (metadata.returnUrl?.includes('add-spouse/personal-information')) {
+    metadata.returnUrl = '/add-spouse/current-legal-name';
+  }
+  return { formData, metadata };
+};
+
+const migrations = [emptyMigration, movedSpouseDob];
+
+export default migrations;

--- a/src/applications/dependents/686c-674/config/utilities.js
+++ b/src/applications/dependents/686c-674/config/utilities.js
@@ -328,3 +328,6 @@ export const showPensionRelatedQuestions = (formData = {}) => {
   // keep current behavior if feature flag is off
   return true;
 };
+
+export const showDupeModalIfEnabled = (formData = {}) =>
+  !!formData.vaDependentsDuplicateModals;

--- a/src/applications/dependents/686c-674/containers/App.jsx
+++ b/src/applications/dependents/686c-674/containers/App.jsx
@@ -48,7 +48,10 @@ function App({
     useToggleValue,
     TOGGLE_NAMES,
   } = useFeatureToggle();
-  useFormFeatureToggleSync(['vaDependentsNetWorthAndPension']);
+  useFormFeatureToggleSync([
+    'vaDependentsNetWorthAndPension',
+    'vaDependentsDuplicateModals',
+  ]);
   const dependentsModuleEnabled = useToggleValue(
     TOGGLE_NAMES.dependentsModuleEnabled,
   );

--- a/src/applications/dependents/686c-674/tests/components/CurrentSpouse.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/components/CurrentSpouse.unit.spec.jsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+
+import CurrentSpouse from '../../components/CurrentSpouse';
+import {
+  uiSchema,
+  schema,
+} from '../../config/chapters/report-add-a-spouse/spouse-information/spouseInformation';
+
+describe('CurrentSpouse', () => {
+  const defaultData = {
+    vaDependentsDuplicateModals: true,
+    spouseInformation: {
+      fullName: {
+        first: 'Sue',
+        last: 'Foster',
+      },
+      birthDate: '1970-07-07',
+      ssn: '333445555',
+    },
+  };
+  const duplicateData = {
+    ...defaultData,
+    spouseInformation: defaultData.spouseInformation,
+    dependents: {
+      hasDependents: true,
+      awarded: [
+        {
+          relationshipToVeteran: 'Spouse',
+          dateOfBirth: '1970-07-07',
+          fullName: {
+            first: 'Mary',
+            last: 'Foster',
+          },
+        },
+      ],
+    },
+  };
+
+  const renderComponent = ({
+    data = defaultData,
+    goBack = () => {},
+    goForward = () => {},
+    goToPath = () => {},
+    setFormData = () => {},
+    updatePage = () => {},
+    onReviewPage = false,
+    contentBeforeButtons = <div id="before">before</div>,
+    contentAfterButtons = <div id="after">after</div>,
+  } = {}) =>
+    render(
+      <>
+        <div name="topScrollElement" />
+        <CurrentSpouse
+          name="currentSpouse"
+          title="Spouse info"
+          data={data}
+          goBack={goBack}
+          goForward={goForward}
+          goToPath={goToPath}
+          setFormData={setFormData}
+          updatePage={updatePage}
+          schema={schema}
+          uiSchema={uiSchema}
+          onReviewPage={onReviewPage}
+          contentBeforeButtons={contentBeforeButtons}
+          contentAfterButtons={contentAfterButtons}
+        />
+      </>,
+    );
+
+  it('should render the full name, date of birth fields text & navigation', () => {
+    const { container } = renderComponent();
+
+    expect($$('va-text-input', container).length).to.equal(4);
+    expect($$('va-memorable-date', container).length).to.equal(1);
+    expect($('.form-progress-buttons', container)).to.exist;
+    expect($('#before', container)).to.exist;
+    expect($('#after', container)).to.exist;
+  });
+
+  it('should render update page button on review page', async () => {
+    const updatePage = sinon.spy();
+    const { container } = renderComponent({ updatePage, onReviewPage: true });
+
+    await fireEvent.click($('va-button[text="Update page"]', container));
+
+    await waitFor(() => {
+      expect(updatePage.called).to.be.true;
+    });
+  });
+
+  it('should navigate to previous page', async () => {
+    const goBack = sinon.spy();
+    const { container } = renderComponent({ goBack });
+
+    await fireEvent.click($('.usa-button-secondary', container));
+
+    await waitFor(() => {
+      expect(goBack.called).to.be.true;
+    });
+  });
+
+  it('should not show duplicate modal if feature toggle is disabled', async () => {
+    const goForward = sinon.spy();
+    const goToPath = sinon.spy();
+
+    const { container } = renderComponent({
+      data: { ...duplicateData, vaDependentsDuplicateModals: false },
+      goForward,
+      goToPath,
+    });
+
+    await fireEvent.submit($('form', container));
+
+    await waitFor(() => {
+      expect($('va-modal[visible="true"]', container)).to.not.exist;
+    });
+  });
+
+  it('should show a duplicate modal if the dob matches a current spouse on navigating forward', async () => {
+    const goForward = sinon.spy();
+    const goToPath = sinon.spy();
+
+    const { container } = renderComponent({
+      data: duplicateData,
+      goForward,
+      goToPath,
+    });
+
+    await fireEvent.submit($('form', container));
+
+    await waitFor(() => {
+      const modal = $('va-modal[visible="true"]', container);
+      expect(modal).to.exist;
+      expect(modal.getAttribute('modal-title')).to.eq('Potential duplicate');
+      expect(modal.textContent).to.contain(
+        'We checked your VA records and found another dependent already listed',
+      );
+    });
+  });
+
+  it('should return to current page if modal is closed', async () => {
+    const goForward = sinon.spy();
+    const goToPath = sinon.spy();
+
+    const { container } = renderComponent({
+      data: duplicateData,
+      goForward,
+      goToPath,
+    });
+
+    await fireEvent.submit($('form', container));
+
+    await waitFor(() => {
+      const modal = $('va-modal[visible="true"]', container);
+      expect(modal).to.exist;
+      modal.__events.closeEvent();
+    }).then(() => {
+      expect(goToPath.called).to.be.false;
+      expect(goForward.called).to.be.false;
+      expect($('va-modal[visible="true"]', container)).to.not.exist;
+    });
+  });
+
+  it('should navigate to near beginning of form if modal primary button (cancel add) is used', async () => {
+    const goForward = sinon.spy();
+    const goToPath = sinon.spy();
+
+    const { container } = renderComponent({
+      data: duplicateData,
+      goForward,
+      goToPath,
+    });
+
+    await fireEvent.submit($('form', container));
+
+    await waitFor(() => {
+      const modal = $('va-modal[visible="true"]', container);
+      expect(modal).to.exist;
+      modal.__events.primaryButtonClick();
+    }).then(() => {
+      expect($('va-modal[visible="true"]', container)).to.not.exist;
+      expect(goToPath.calledWith('/options-selection/add-dependents')).to.be
+        .true;
+      expect(goForward.called).to.be.false;
+    });
+  });
+
+  it('should navigate to forward if modal secondary button (accept add) is used', async () => {
+    const goForward = sinon.spy();
+    const goToPath = sinon.spy();
+
+    const { container } = renderComponent({
+      data: duplicateData,
+      goForward,
+      goToPath,
+    });
+
+    await fireEvent.submit($('form', container));
+
+    await waitFor(() => {
+      const modal = $('va-modal[visible="true"]', container);
+      expect(modal).to.exist;
+      modal.__events.secondaryButtonClick();
+    }).then(() => {
+      expect($('va-modal[visible="true"]', container)).to.not.exist;
+      expect(goToPath.called).to.be.false;
+      expect(goForward.called).to.be.true;
+    });
+  });
+});

--- a/src/applications/dependents/686c-674/tests/components/CurrentSpouse.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/components/CurrentSpouse.unit.spec.jsx
@@ -9,6 +9,7 @@ import CurrentSpouse from '../../components/CurrentSpouse';
 import {
   uiSchema,
   schema,
+  modalContent,
 } from '../../config/chapters/report-add-a-spouse/spouse-information/spouseInformation';
 
 describe('CurrentSpouse', () => {
@@ -137,10 +138,8 @@ describe('CurrentSpouse', () => {
     await waitFor(() => {
       const modal = $('va-modal[visible="true"]', container);
       expect(modal).to.exist;
-      expect(modal.getAttribute('modal-title')).to.eq('Potential duplicate');
-      expect(modal.textContent).to.contain(
-        'We checked your VA records and found another dependent already listed',
-      );
+      expect(modal.getAttribute('modal-title')).to.eq(modalContent.title);
+      expect(modal.textContent).to.contain('already listed on your benefits');
     });
   });
 

--- a/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/spouseNameInformation.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/chapters/report-add-a-spouse/spouseNameInformation.unit.spec.jsx
@@ -16,7 +16,7 @@ const formData = {
   },
 };
 
-describe('686 current marriage information: Spouse legal name', () => {
+describe('686 current marriage information: Spouse personal information', () => {
   const {
     schema,
     uiSchema,
@@ -33,11 +33,12 @@ describe('686 current marriage information: Spouse legal name', () => {
         />
       </Provider>,
     );
-    expect($$('va-text-input', container).length).to.equal(3);
+    expect($$('va-text-input', container).length).to.equal(4);
+    expect($$('va-memorable-date', container).length).to.equal(1);
   });
 });
 
-describe('686 current marriage information: Spouse identification information', () => {
+describe('686 current marriage information: Spouse is a Veteran', () => {
   const {
     schema,
     uiSchema,
@@ -55,8 +56,6 @@ describe('686 current marriage information: Spouse identification information', 
       </Provider>,
     );
 
-    expect($$('va-text-input', container).length).to.equal(1);
-    expect($$('va-memorable-date', container).length).to.equal(1);
     expect($$('va-radio', container).length).to.equal(1);
     expect($$('va-radio-option', container).length).to.equal(2);
   });

--- a/src/applications/dependents/686c-674/tests/config/migrations.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/migrations.unit.spec.jsx
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+import migrations from '../../config/migrations';
+
+describe('Migrations', () => {
+  const runMigrations = savedData =>
+    migrations.reduce((data, migration) => migration(data), savedData);
+
+  it('should run all migrations', () => {
+    const savedData = {
+      formData: { test: true },
+      metadata: {
+        returnUrl: '/veteran-information',
+      },
+    };
+
+    const migratedData = runMigrations(savedData);
+
+    expect(migratedData).to.deep.equal(savedData);
+  });
+
+  it('should run all migrations', () => {
+    const savedData = {
+      formData: { test: true },
+      metadata: {
+        returnUrl: '/add-spouse/personal-information',
+      },
+    };
+
+    const migratedData = runMigrations(savedData);
+
+    expect(migratedData).to.deep.equal({
+      formData: { test: true },
+      metadata: {
+        returnUrl: '/add-spouse/current-legal-name',
+      },
+    });
+  });
+});

--- a/src/applications/dependents/686c-674/tests/config/utilities.unit.spec.jsx
+++ b/src/applications/dependents/686c-674/tests/config/utilities.unit.spec.jsx
@@ -16,6 +16,7 @@ import {
   showPensionBackupPath,
   showPensionRelatedQuestions,
   buildSubmissionData,
+  showDupeModalIfEnabled,
 } from '../../config/utilities';
 
 describe('Utilities', () => {
@@ -603,5 +604,18 @@ describe('buildSubmissionData', () => {
     expect(result.data['view:removeDependentOptions']).to.deep.equal({
       reportDivorce: true,
     });
+  });
+});
+
+describe('showDupeModalIfEnabled', () => {
+  it('should return false if feature flag is off', () => {
+    expect(showDupeModalIfEnabled({})).to.be.false;
+    expect(showDupeModalIfEnabled({ vaDependentsDuplicateModals: false })).to.be
+      .false;
+  });
+
+  it('should return true if feature flag is on', () => {
+    expect(showDupeModalIfEnabled({ vaDependentsDuplicateModals: true })).to.be
+      .true;
   });
 });

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/maximal.json
@@ -89,14 +89,51 @@
       "ssn": "333445555",
       "vaFileNumber": "987654321",
       "serviceNumber": "W123456",
-      "birthDate": "1991-02-19",
+      "birthDate": "1970-07-07",
       "isVeteran": true,
       "fullName": {
-        "first": "Two-Names",
-        "last": "Doe"
+        "first": "Mary",
+        "last": "Foster"
       }
     },
     "view:cancelAddSpouse": {},
+    "dependents": {
+      "hasDependents": true,
+      "awarded": [
+        {
+          "fullName": {
+            "first": "SPOUSY",
+            "last": "FOSTER"
+          },
+          "dateOfBirth": "1970-07-07",
+          "ssn": "702023332",
+          "relationshipToVeteran": "Spouse",
+          "awardIndicator": "Y"
+        },
+        {
+          "fullName": {
+            "first": "PENNY",
+            "last": "FOSTER"
+          },
+          "dateOfBirth": "2014-08-08",
+          "ssn": "793473479",
+          "relationshipToVeteran": "Child",
+          "awardIndicator": "Y"
+        }
+      ],
+      "notAwarded": [
+        {
+          "fullName": {
+            "first": "NOMY",
+            "last": "FOSTER"
+          },
+          "dateOfBirth": "2000-09-09",
+          "ssn": "793473470",
+          "relationshipToVeteran": "Child",
+          "awardIndicator": "N"
+        }
+      ]
+    },
     "veteranContactInformation": {
       "veteranAddress": {
         "isMilitary": false,

--- a/src/applications/dependents/686c-674/tests/mock-api-full-data.js
+++ b/src/applications/dependents/686c-674/tests/mock-api-full-data.js
@@ -93,7 +93,15 @@ const responses = {
   'GET /v0/user': userData(),
   'GET /v0/feature_toggles': {
     data: {
-      features: [{ name: 'vaDependentsV2', value: true }],
+      type: 'feature_toggles',
+      features: [
+        { name: 'vaDependentsV2', value: true },
+        { name: 'va_dependents_v2', value: true },
+        { name: 'vaDependentsNetWorthAndPension', value: true },
+        { name: 'va_dependents_net_worth_and_pension', value: true },
+        { name: 'vaDependentsDuplicateModals', value: true },
+        { name: 'va_dependents_duplicate_modals', value: true },
+      ],
     },
   },
   'OPTIONS /v0/maintenance_windows': 'OK',

--- a/src/applications/dependents/shared/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/dependents/shared/tests/utils/utils.unit.spec.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 
 import {
   getFullName,
+  getFormatedDate,
   maskID,
   isEmptyObject,
   getRootParentUrl,
@@ -106,5 +107,26 @@ describe('getRootParentUrl', () => {
     expect(
       getRootParentUrl('/manage-dependents/add-remove-form-21-686c-674/'),
     ).to.equal('/manage-dependents');
+  });
+});
+
+describe('getFormatedDate', () => {
+  it('should return empty string for undefined date', () => {
+    const formattedDate = getFormatedDate();
+    expect(formattedDate).to.equal('Unknown date');
+  });
+
+  it('should return empty string for invalid date', () => {
+    const formattedDate = getFormatedDate('Summer 2000');
+    expect(formattedDate).to.equal('Summer 2000');
+  });
+
+  it('should return formatted date for valid date', () => {
+    const formattedDate = getFormatedDate('2020-01-01');
+    expect(formattedDate).to.equal('January 1, 2020');
+  });
+  it('should return formatted date for valid Date object', () => {
+    const formattedDate = getFormatedDate('12/05/2022', 'MM/dd/yyyy', 'PPPP');
+    expect(formattedDate).to.equal('Monday, December 5th, 2022');
   });
 });

--- a/src/applications/dependents/shared/utils/index.js
+++ b/src/applications/dependents/shared/utils/index.js
@@ -1,3 +1,5 @@
+import { parse, isValid, format } from 'date-fns';
+
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
 /**
@@ -12,6 +14,22 @@ import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-str
 export const getFullName = ({ first, middle, last, suffix } = {}) =>
   [first || '', middle || '', last || ''].filter(Boolean).join(' ') +
   (suffix ? `, ${suffix}` : '');
+
+/**
+ *
+ * @param {String} date - date string that matches the `startFormat`
+ * @param {String} startFormat - input date string format using Date-fn patterns
+ * @param {String} endFormat - output date string format using Date-fn patterns
+ * @returns {String} - formatted date string, or 'Unknown date' if invalid
+ */
+export const getFormatedDate = (
+  date,
+  startFormat = 'yyyy-MM-dd',
+  endFormat = 'MMMM d, yyyy',
+) => {
+  const dobObj = parse(date, startFormat, new Date());
+  return isValid(dobObj) ? format(dobObj, endFormat) : date || 'Unknown date';
+};
 
 /**
  * Separate each number so the screen reader reads "number ending with 1 2 3 4"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > When a dependent spouse is added, we now check the date of birth against the current spouse listed in the Veteran's dependents. If the birthdays match, we show a modal indicating that it may be a duplicate.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Testing locally

- Pull down this branch
- Open `src/applications/dependents/686c-674/tests/mock-api-full-data.js` in your editor
- Change return url to point to `const returnUrl = '/add-spouse/personal-information';`
- Run mock server using `yarn mock-api --responses ./src/applications/dependents/686c-674/tests/mock-api-full-data.js`
- Open a browser window at http://localhost:3001/manage-dependents/add-remove-form-21-686c-674/
- Open the dev tools & go to the console
- Enter `localStorage.setItem('hasSession', true)`
- Reload the page
- You can now click on "Continue your application" button
- On the spouse page, use the "Continue" button to see the modal

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/116962

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated & added unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Spouse name  |  <img width="500" alt="before: asking for spouse's full name" src="https://github.com/user-attachments/assets/ec21783a-3833-4e82-9edf-20ca2bcc0334" /> |  <img width="500" alt="After: spouse information asking for full name, date of birth, and SSN" src="https://github.com/user-attachments/assets/2aafc68d-50ff-4be6-9c89-326766ac4308" /> |
| Duplicate modal | N/A | <img width="500" alt="Modal between spouse information and is spouse a veteran pages. The modal shows the matching date of birth and dependent name on file that matches the date of birth with extra content asking if they can cancel adding, or continue" src="https://github.com/user-attachments/assets/fef313e8-6c00-4772-8687-b99597de9512" /> |
| Spouse info page 2 | <img width="500" alt="spouse info page asking for SSN, date of birth and if spouse is a veteran" src="https://github.com/user-attachments/assets/4fddab0c-e20e-42d8-9636-3bb4c40dc9b7" /> | <img width="500" alt="is spouse a veteran question only" src="https://github.com/user-attachments/assets/8ed8e85b-cefe-4791-8126-75f479f5afb2" /> |

## What areas of the site does it impact?

Dependents Management form (686c-674)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
