### PR TITLE
protect pagination from empty data

### DIFF
--- a/src/applications/accredited-representative-portal/components/Pagination.jsx
+++ b/src/applications/accredited-representative-portal/components/Pagination.jsx
@@ -28,11 +28,14 @@ const Pagination = ({ meta, defaults }) => {
     }
   };
 
+  const page = meta.page.number;
+  const pages = meta.page.totalPages;
+
   return (
     <>
       <VaPagination
-        page={meta.page.number}
-        pages={meta.page.totalPages}
+        page={page}
+        pages={pages}
         maxPageListLength={pageSize}
         showLastPage
         onPageSelect={e => pageSelect(e.detail.page)}

--- a/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
+++ b/src/applications/accredited-representative-portal/containers/POARequestSearchPage.jsx
@@ -74,8 +74,13 @@ const POARequestSearchPage = title => {
     },
     [title],
   );
-  const loaderData = useLoaderData();
-  const { data: poaRequests, meta, showPOA403Alert } = loaderData;
+  const loaderData = useLoaderData() || {};
+  const poaRequests = loaderData.data || [];
+  const meta =
+    loaderData.meta && loaderData.meta.page
+      ? loaderData.meta
+      : { page: { total: 0, number: 1, totalPages: 1 } };
+  const { showPOA403Alert } = loaderData;
   const searchStatus = searchParams.get('status');
   const selectedIndividual = searchParams.get('as_selected_individual');
   const navigation = useNavigation();
@@ -237,8 +242,12 @@ const POARequestSearchPage = title => {
               }
             })()}
 
-            <POARequestSearchPageResults poaRequests={poaRequests} />
-            <Pagination meta={meta} defaults={PENDING_SORT_DEFAULTS} />
+            {meta.page.total > 0 && (
+              <>
+                <POARequestSearchPageResults poaRequests={poaRequests} />
+                <Pagination meta={meta} defaults={PENDING_SORT_DEFAULTS} />
+              </>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
We were getting an error when paging data was empty on poa requests page like it is for reps who don't have digital POA access.