### PR TITLE
Refactor draftReferralAppointment from RTK mutation to query

### DIFF
--- a/src/applications/vaos/redux/api/vaosApi.js
+++ b/src/applications/vaos/redux/api/vaosApi.js
@@ -3,7 +3,6 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 import { apiRequestWithUrl } from 'applications/vaos/services/utils';
 import { captureError } from '../../utils/error';
 import { fetchPendingAppointments } from '../actions';
-import { cacheDraftReferralAppointment } from '../../referral-appointments/redux/actions';
 
 export const vaosApi = createApi({
   reducerPath: 'appointmentApi',
@@ -44,8 +43,6 @@ export const vaosApi = createApi({
       // Needs an argumant to be passed in to trigger the query.
       async onQueryStarted(id, { dispatch }) {
         dispatch(fetchPendingAppointments());
-        // Reset draft referral appointment cache when fetching new referrals.
-        dispatch(cacheDraftReferralAppointment({}));
       },
     }),
     getAppointmentInfo: builder.query({
@@ -62,7 +59,7 @@ export const vaosApi = createApi({
         }
       },
     }),
-    postDraftReferralAppointment: builder.mutation({
+    getDraftDraftReferralAppointment: builder.query({
       async queryFn({ referralNumber, referralConsultId }) {
         try {
           return await apiRequestWithUrl(`/vaos/v2/appointments/draft`, {
@@ -84,6 +81,7 @@ export const vaosApi = createApi({
           };
         }
       },
+      providesTags: ['Referral'],
     }),
     postReferralAppointment: builder.mutation({
       async queryFn({
@@ -123,6 +121,6 @@ export const {
   useGetReferralByIdQuery,
   useGetPatientReferralsQuery,
   useGetAppointmentInfoQuery,
-  usePostDraftReferralAppointmentMutation,
   usePostReferralAppointmentMutation,
+  useGetDraftDraftReferralAppointmentQuery,
 } = vaosApi;

--- a/src/applications/vaos/redux/api/vaosApi.js
+++ b/src/applications/vaos/redux/api/vaosApi.js
@@ -59,7 +59,7 @@ export const vaosApi = createApi({
         }
       },
     }),
-    getDraftDraftReferralAppointment: builder.query({
+    getDraftReferralAppointment: builder.query({
       async queryFn({ referralNumber, referralConsultId }) {
         try {
           return await apiRequestWithUrl(`/vaos/v2/appointments/draft`, {
@@ -122,5 +122,5 @@ export const {
   useGetPatientReferralsQuery,
   useGetAppointmentInfoQuery,
   usePostReferralAppointmentMutation,
-  useGetDraftDraftReferralAppointmentQuery,
+  useGetDraftReferralAppointmentQuery,
 } = vaosApi;

--- a/src/applications/vaos/referral-appointments/ChooseDateAndTime.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseDateAndTime.jsx
@@ -5,14 +5,10 @@ import { useLocation } from 'react-router-dom';
 import ReferralLayout from './components/ReferralLayout';
 // eslint-disable-next-line import/no-restricted-paths
 import { getUpcomingAppointmentListInfo } from '../appointment-list/redux/selectors';
-import {
-  setFormCurrentPage,
-  cacheDraftReferralAppointment,
-} from './redux/actions';
-import { getCachedDraftAppointmentInfo } from './redux/selectors';
+import { setFormCurrentPage } from './redux/actions';
 // eslint-disable-next-line import/no-restricted-paths
 import { fetchFutureAppointments } from '../appointment-list/redux/actions';
-import { usePostDraftReferralAppointmentMutation } from '../redux/api/vaosApi';
+import { useGetDraftDraftReferralAppointmentQuery } from '../redux/api/vaosApi';
 import { FETCH_STATUS } from '../utils/constants';
 import DateAndTimeContent from './components/DateAndTimeContent';
 
@@ -20,20 +16,17 @@ export const ChooseDateAndTime = props => {
   const { attributes: currentReferral } = props.currentReferral;
   const dispatch = useDispatch();
   const location = useLocation();
+  const {
+    data: draftAppointmentInfo,
+    isLoading: isDraftLoading,
+    isError: isDraftError,
+    isSuccess: isDraftSuccess,
+    isUninitialized: isDraftUninitialized,
+  } = useGetDraftDraftReferralAppointmentQuery({
+    referralNumber: currentReferral.referralNumber,
+    referralConsultId: currentReferral.referralConsultId,
+  });
 
-  const [
-    postDraftReferralAppointment,
-    {
-      data: draftAppointmentData,
-      isError: isDraftError,
-      isLoading: isDraftLoading,
-      isUninitialized: isDraftUninitialized,
-      isSuccess: isDraftSuccess,
-    },
-  ] = usePostDraftReferralAppointmentMutation();
-  const draftAppointmentInfo = useSelector(state =>
-    getCachedDraftAppointmentInfo(state),
-  );
   const { futureStatus, appointmentsByMonth } = useSelector(
     state => getUpcomingAppointmentListInfo(state),
     shallowEqual,
@@ -53,17 +46,9 @@ export const ChooseDateAndTime = props => {
         isDraftUninitialized ||
         futureStatus === FETCH_STATUS.notStarted
       ) {
-        if (isDraftUninitialized) {
-          postDraftReferralAppointment({
-            referralNumber: currentReferral.referralNumber,
-            referralConsultId: currentReferral.referralConsultId,
-          });
-        }
         if (futureStatus === FETCH_STATUS.notStarted) {
           dispatch(fetchFutureAppointments({ includeRequests: false }));
         }
-      } else if (isDraftSuccess) {
-        dispatch(cacheDraftReferralAppointment(draftAppointmentData));
       } else if (isDraftError || futureStatus === FETCH_STATUS.failed) {
         setLoading(false);
         setFailed(true);
@@ -72,13 +57,11 @@ export const ChooseDateAndTime = props => {
     [
       currentReferral,
       dispatch,
-      draftAppointmentData,
       draftAppointmentInfo,
       futureStatus,
       isDraftError,
       isDraftSuccess,
       isDraftUninitialized,
-      postDraftReferralAppointment,
     ],
   );
   useEffect(

--- a/src/applications/vaos/referral-appointments/ChooseDateAndTime.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseDateAndTime.jsx
@@ -8,7 +8,7 @@ import { getUpcomingAppointmentListInfo } from '../appointment-list/redux/select
 import { setFormCurrentPage } from './redux/actions';
 // eslint-disable-next-line import/no-restricted-paths
 import { fetchFutureAppointments } from '../appointment-list/redux/actions';
-import { useGetDraftDraftReferralAppointmentQuery } from '../redux/api/vaosApi';
+import { useGetDraftReferralAppointmentQuery } from '../redux/api/vaosApi';
 import { FETCH_STATUS } from '../utils/constants';
 import DateAndTimeContent from './components/DateAndTimeContent';
 
@@ -22,7 +22,7 @@ export const ChooseDateAndTime = props => {
     isError: isDraftError,
     isSuccess: isDraftSuccess,
     isUninitialized: isDraftUninitialized,
-  } = useGetDraftDraftReferralAppointmentQuery({
+  } = useGetDraftReferralAppointmentQuery({
     referralNumber: currentReferral.referralNumber,
     referralConsultId: currentReferral.referralConsultId,
   });

--- a/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.jsx
@@ -102,6 +102,21 @@ describe('VAOS ChooseDateAndTime component', () => {
       confirmed,
       confirmedStatus: FETCH_STATUS.succeeded,
     },
+    appointmentApi: {
+      queries: {
+        'getDraftDraftReferralAppointment({"referralConsultId":"984_646907","referralNumber":"VA0000007241"})': {
+          status: 'fulfilled',
+          data: createDraftAppointmentInfo(1),
+          startedTimeStamp: 1758046349181,
+          fulfilledTimeStamp: 1758046349182,
+        },
+      },
+      subscriptions: {
+        'getDraftDraftReferralAppointment({"referralConsultId":"984_646907","referralNumber":"VA0000007241"})': {
+          abc: {},
+        },
+      },
+    },
   };
   const initialEmptyState = {
     featureToggles: {
@@ -147,6 +162,7 @@ describe('VAOS ChooseDateAndTime component', () => {
     sandbox.restore();
   });
   it('should fetch provider or appointments from store if it exists and not call API', async () => {
+    const store = createTestStore(initialFullState);
     sandbox
       .stub(utils, 'apiRequestWithUrl')
       .resolves({ data: createDraftAppointmentInfo() });
@@ -155,7 +171,7 @@ describe('VAOS ChooseDateAndTime component', () => {
         currentReferral={createReferralById('2024-09-09', 'UUID')}
       />,
       {
-        store: createTestStore(initialFullState),
+        store,
       },
     );
     sandbox.assert.notCalled(utils.apiRequestWithUrl);
@@ -194,7 +210,9 @@ describe('VAOS ChooseDateAndTime component', () => {
     sandbox.assert.calledOnce(fetchAppointmentsModule.fetchAppointments);
   });
   it('should show error if any fetch fails', async () => {
-    sandbox.stub(utils, 'apiRequestWithUrl').throws();
+    sandbox.stub(utils, 'apiRequestWithUrl').throws({
+      error: { status: 500, message: 'Failed to create appointment' },
+    });
     const screen = renderWithStoreAndRouter(
       <ChooseDateAndTime
         currentReferral={createReferralById('2024-09-09', 'UUID')}
@@ -203,7 +221,7 @@ describe('VAOS ChooseDateAndTime component', () => {
         store: createTestStore(failedState),
       },
     );
-    waitFor(() => {
+    await waitFor(() => {
       expect(screen.getByTestId('error')).to.exist;
     });
   });

--- a/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseDateAndTime.unit.spec.jsx
@@ -104,16 +104,18 @@ describe('VAOS ChooseDateAndTime component', () => {
     },
     appointmentApi: {
       queries: {
-        'getDraftDraftReferralAppointment({"referralConsultId":"984_646907","referralNumber":"VA0000007241"})': {
+        'getDraftReferralAppointment({"referralConsultId":"984_646907","referralNumber":"VA0000007241"})': {
           status: 'fulfilled',
           data: createDraftAppointmentInfo(1),
+          endpoint: 'getDraftReferralAppointment',
+          requestId: 'abc',
           startedTimeStamp: 1758046349181,
           fulfilledTimeStamp: 1758046349182,
         },
       },
       subscriptions: {
-        'getDraftDraftReferralAppointment({"referralConsultId":"984_646907","referralNumber":"VA0000007241"})': {
-          abc: {},
+        'getDraftReferralAppointment({"referralConsultId":"984_646907","referralNumber":"VA0000007241"})': {
+          abc: { pollingInterval: 0 },
         },
       },
     },

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
@@ -6,15 +6,10 @@ import { useSelector, useDispatch } from 'react-redux';
 import {
   getAppointmentCreateStatus,
   getSelectedSlotStartTime,
-  getCachedDraftAppointmentInfo,
 } from './redux/selectors';
+import { setFormCurrentPage, setSelectedSlotStartTime } from './redux/actions';
 import {
-  setFormCurrentPage,
-  setSelectedSlotStartTime,
-  cacheDraftReferralAppointment,
-} from './redux/actions';
-import {
-  usePostDraftReferralAppointmentMutation,
+  useGetDraftDraftReferralAppointmentQuery,
   usePostReferralAppointmentMutation,
 } from '../redux/api/vaosApi';
 
@@ -35,20 +30,30 @@ const ReviewAndConfirm = props => {
   const { attributes: currentReferral } = props.currentReferral;
   const dispatch = useDispatch();
   const history = useHistory();
-  const draftAppointmentInfo = useSelector(state =>
-    getCachedDraftAppointmentInfo(state),
-  );
+  // const draftAppointmentInfo = useSelector(state =>
+  //   getCachedDraftAppointmentInfo(state),
+  // );
   const selectedSlot = useSelector(state => getSelectedSlotStartTime(state));
-  const [
-    postDraftReferralAppointment,
-    {
-      data: draftAppointmentData,
-      isError: isDraftError,
-      isLoading: isDraftLoading,
-      isUninitialized: isDraftUninitialized,
-      isSuccess: isDraftSuccess,
-    },
-  ] = usePostDraftReferralAppointmentMutation();
+  const {
+    data: draftAppointmentInfo,
+    isLoading: isDraftLoading,
+    isError: isDraftError,
+    isSuccess: isDraftSuccess,
+    isUninitialized: isDraftUninitialized,
+  } = useGetDraftDraftReferralAppointmentQuery({
+    referralNumber: currentReferral.referralNumber,
+    referralConsultId: currentReferral.referralConsultId,
+  });
+  // const [
+  //   postDraftReferralAppointment,
+  //   {
+  //     data: draftAppointmentData,
+  //     isError: isDraftError,
+  //     isLoading: isDraftLoading,
+  //     isUninitialized: isDraftUninitialized,
+  //     isSuccess: isDraftSuccess,
+  //   },
+  // ] = usePostDraftReferralAppointmentMutation();
 
   const appointmentCreateStatus = useSelector(getAppointmentCreateStatus);
   const [loading, setLoading] = useState(true);
@@ -90,13 +95,6 @@ const ReviewAndConfirm = props => {
     () => {
       if (draftAppointmentInfo?.attributes && !isDraftLoading) {
         setLoading(false);
-      } else if (isDraftUninitialized) {
-        postDraftReferralAppointment({
-          referralNumber: currentReferral.referralNumber,
-          referralConsultId: currentReferral.referralConsultId,
-        });
-      } else if (isDraftSuccess) {
-        dispatch(cacheDraftReferralAppointment(draftAppointmentData));
       } else if (isDraftError) {
         setFailed(true);
         setLoading(false);
@@ -109,8 +107,6 @@ const ReviewAndConfirm = props => {
       isDraftError,
       isDraftSuccess,
       isDraftUninitialized,
-      postDraftReferralAppointment,
-      draftAppointmentData,
       isDraftLoading,
       currentReferral.referralConsultId,
     ],
@@ -176,7 +172,7 @@ const ReviewAndConfirm = props => {
       isAppointmentError,
       appointmentCreateStatus,
       appointmentInfo?.id,
-      draftAppointmentInfo.id,
+      draftAppointmentInfo?.id,
       currentReferral.uuid,
       isDraftSuccess,
       history,

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.jsx
@@ -9,7 +9,7 @@ import {
 } from './redux/selectors';
 import { setFormCurrentPage, setSelectedSlotStartTime } from './redux/actions';
 import {
-  useGetDraftDraftReferralAppointmentQuery,
+  useGetDraftReferralAppointmentQuery,
   usePostReferralAppointmentMutation,
 } from '../redux/api/vaosApi';
 
@@ -47,7 +47,7 @@ const ReviewAndConfirm = props => {
     isError: isDraftError,
     isSuccess: isDraftSuccess,
     isUninitialized: isDraftUninitialized,
-  } = useGetDraftDraftReferralAppointmentQuery(
+  } = useGetDraftReferralAppointmentQuery(
     {
       referralNumber: currentReferral.referralNumber,
       referralConsultId: currentReferral.referralConsultId,

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -13,7 +13,6 @@ import { createReferralById, getReferralSlotKey } from './utils/referrals';
 import { FETCH_STATUS } from '../utils/constants';
 import { createDraftAppointmentInfo } from './utils/provider';
 import * as flow from './flow';
-import { vaosApi } from '../redux/api/vaosApi';
 import {
   generateSlotsForDay,
   transformSlotsForCommunityCare,
@@ -179,16 +178,12 @@ describe('VAOS Component: ReviewAndConfirm', () => {
         store,
       },
     );
-    // Manually dispatch the referral list and referral by id calls to have them in state.
-    store.dispatch(
-      vaosApi.util.upsertQueryData('getReferralById', 'UUID', { data: {} }),
-    );
 
     await screen.findByTestId('continue-button');
     expect(screen.getByTestId('continue-button')).to.exist;
     expect(
       Object.keys(store.getState().appointmentApi.queries).length,
-    ).to.equal(2);
+    ).to.equal(1);
     await userEvent.click(screen.getByTestId('continue-button'));
     await waitFor(() => {
       const mutation = Object.keys(

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -170,9 +170,10 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     store.dispatch(vaosApi.util.upsertQueryData('getReferralById', 'UUID', {}));
     expect(
       Object.keys(store.getState().appointmentApi.queries).length,
-    ).to.equal(2);
-    await screen.findByTestId('continue-button');
-    expect(screen.getByTestId('continue-button')).to.exist;
+    ).to.equal(3);
+    await waitFor(() => {
+      expect(screen.getByTestId('continue-button')).to.exist;
+    });
     await userEvent.click(screen.getByTestId('continue-button'));
     await waitFor(() => {
       const mutation = Object.keys(

--- a/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/ReviewAndConfirm.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { waitFor } from '@testing-library/dom';
+import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import * as utils from 'applications/vaos/services/utils';
 import ReviewAndConfirm from './ReviewAndConfirm';
@@ -75,7 +75,9 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     sessionStorage.clear();
   });
   it('should get selected slot from session storage if not in redux', async () => {
-    requestStub.resolves(draftAppointmentInfo);
+    requestStub
+      .withArgs('/vaos/v2/appointments/draft')
+      .resolves({ data: draftAppointmentInfo });
     const selectedSlotKey = getReferralSlotKey('UUID');
 
     sessionStorage.setItem(
@@ -112,6 +114,9 @@ describe('VAOS Component: ReviewAndConfirm', () => {
   it('should route to scheduleReferral if no slot selected', async () => {
     const selectedSlotKey = getReferralSlotKey('UUID');
     sessionStorage.removeItem(selectedSlotKey);
+    requestStub
+      .withArgs('/vaos/v2/appointments/draft')
+      .resolves({ data: draftAppointmentInfo });
     const noSelectState = {
       ...initialFullState,
       ...{
@@ -135,7 +140,12 @@ describe('VAOS Component: ReviewAndConfirm', () => {
   it('should call create appointment post when "continue" is pressed', async () => {
     const store = createTestStore(initialFullState);
     // Stub the appointment creation function
-    requestStub.resolves({ data: { appointmentId: draftAppointmentInfo?.id } });
+    requestStub
+      .withArgs('/vaos/v2/appointments/draft')
+      .resolves({ data: draftAppointmentInfo });
+    requestStub
+      .withArgs('/vaos/v2/appointments/submit')
+      .resolves({ data: { appointmentId: draftAppointmentInfo?.id } });
 
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
@@ -149,12 +159,18 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     waitFor(() => {
       userEvent.click(screen.queryByTestId('continue-button'));
     });
-    sandbox.assert.calledOnce(requestStub);
+    sandbox.assert.calledOnce(
+      requestStub.withArgs('/vaos/v2/appointments/draft'),
+    );
+    sandbox.assert.calledOnce(
+      requestStub.withArgs('/vaos/v2/appointments/submit'),
+    );
   });
   it('should call "routeToNextReferralPage" when appointment creation is successful', async () => {
-    const store = createTestStore(initialFullState);
+    const store = createTestStore(initialEmptyState);
     sandbox.spy(flow, 'routeToNextReferralPage');
-    requestStub.resolves({ data: { appointmentId: draftAppointmentInfo.id } });
+    requestStub.resolves({ data: draftAppointmentInfo });
+
     const screen = renderWithStoreAndRouter(
       <ReviewAndConfirm
         currentReferral={createReferralById('2024-09-09', 'UUID')}
@@ -165,15 +181,14 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     );
     // Manually dispatch the referral list and referral by id calls to have them in state.
     store.dispatch(
-      vaosApi.util.upsertQueryData('getReferralById', undefined, {}),
+      vaosApi.util.upsertQueryData('getReferralById', 'UUID', { data: {} }),
     );
-    store.dispatch(vaosApi.util.upsertQueryData('getReferralById', 'UUID', {}));
+
+    await screen.findByTestId('continue-button');
+    expect(screen.getByTestId('continue-button')).to.exist;
     expect(
       Object.keys(store.getState().appointmentApi.queries).length,
-    ).to.equal(3);
-    await waitFor(() => {
-      expect(screen.getByTestId('continue-button')).to.exist;
-    });
+    ).to.equal(2);
     await userEvent.click(screen.getByTestId('continue-button'));
     await waitFor(() => {
       const mutation = Object.keys(
@@ -183,6 +198,9 @@ describe('VAOS Component: ReviewAndConfirm', () => {
         store.getState().appointmentApi.mutations[mutation].status,
       ).to.equal('fulfilled');
     });
+    expect(
+      Object.keys(store.getState().appointmentApi.queries).length,
+    ).to.equal(0);
     await waitFor(() => {
       expect(
         screen.history.push.calledWith(
@@ -195,14 +213,14 @@ describe('VAOS Component: ReviewAndConfirm', () => {
         '/schedule-referral/complete/EEKoGzEf?id=UUID',
       ),
     ).to.be.true;
-    sandbox.assert.calledOnce(requestStub);
-    expect(
-      Object.keys(store.getState().appointmentApi.queries).length,
-    ).to.equal(0);
+    sandbox.assert.calledWith(requestStub, '/vaos/v2/appointments/submit');
   });
   it('should display an error message when appointment creation fails', async () => {
     // Stub only for that specific call
-    requestStub.throws({
+    requestStub
+      .withArgs('/vaos/v2/appointments/draft')
+      .resolves({ data: draftAppointmentInfo });
+    requestStub.withArgs('/vaos/v2/appointments/submit').throws({
       error: { status: 500, message: 'Failed to create appointment' },
     });
     const screen = renderWithStoreAndRouter(
@@ -222,7 +240,12 @@ describe('VAOS Component: ReviewAndConfirm', () => {
     expect(screen.getByTestId('create-error-alert')).to.contain.text(
       'We couldn’t schedule this appointment',
     );
-    sandbox.assert.calledOnce(requestStub);
+    sandbox.assert.calledOnce(
+      requestStub.withArgs('/vaos/v2/appointments/draft'),
+    );
+    sandbox.assert.calledOnce(
+      requestStub.withArgs('/vaos/v2/appointments/submit'),
+    );
   });
   it('should fetch draft appointment info on mount if not in store', async () => {
     const store = createTestStore(initialEmptyState);
@@ -247,7 +270,8 @@ describe('VAOS Component: ReviewAndConfirm', () => {
       },
       method: 'POST',
     });
-    expect(store.getState().referral.draftAppointmentInfo).to.deep.equal(
+    const query = Object.keys(store.getState().appointmentApi.queries)[0];
+    expect(store.getState().appointmentApi.queries[query].data).to.deep.equal(
       draftAppointmentInfo,
     );
   });
@@ -265,7 +289,12 @@ describe('VAOS Component: ReviewAndConfirm', () => {
         store,
       },
     );
-    await screen.findByTestId('error');
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('loading-container'),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('error')).to.exist;
+    });
     expect(screen.getByTestId('error')).to.contain.text(
       'Something went wrong on our end. Please try again later.',
     );

--- a/src/applications/vaos/referral-appointments/redux/actions.js
+++ b/src/applications/vaos/referral-appointments/redux/actions.js
@@ -4,8 +4,6 @@ import { getProviderById } from '../../services/referral';
 import { STARTED_NEW_APPOINTMENT_FLOW } from '../../redux/sitewide';
 
 export const SET_FORM_CURRENT_PAGE = 'SET_FORM_CURRENT_PAGE';
-export const CACHE_DRAFT_REFERRAL_APPOINTMENT =
-  'CACHE_DRAFT_REFERRAL_APPOINTMENT';
 export const FETCH_PROVIDER_DETAILS = 'FETCH_PROVIDER_DETAILS';
 export const FETCH_PROVIDER_DETAILS_SUCCEEDED =
   'FETCH_PROVIDER_DETAILS_SUCCEEDED';
@@ -18,15 +16,6 @@ export function setFormCurrentPage(currentPage) {
   return {
     type: SET_FORM_CURRENT_PAGE,
     payload: currentPage,
-  };
-}
-
-export function cacheDraftReferralAppointment(data) {
-  return async dispatch => {
-    dispatch({
-      type: CACHE_DRAFT_REFERRAL_APPOINTMENT,
-      data,
-    });
   };
 }
 

--- a/src/applications/vaos/referral-appointments/redux/reducers.js
+++ b/src/applications/vaos/referral-appointments/redux/reducers.js
@@ -1,6 +1,5 @@
 import {
   SET_FORM_CURRENT_PAGE,
-  CACHE_DRAFT_REFERRAL_APPOINTMENT,
   SET_INIT_REFERRAL_FLOW,
   SET_SELECTED_SLOT_START_TIME,
 } from './actions';
@@ -10,7 +9,6 @@ const initialState = {
   facility: null,
   sortProviderBy: '',
   currentPage: null,
-  draftAppointmentInfo: {},
   referrals: [],
   referralDetails: [],
   selectedSlotStartTime: '',
@@ -24,11 +22,6 @@ function ccAppointmentReducer(state = initialState, action) {
       return {
         ...state,
         currentPage: action.payload,
-      };
-    case CACHE_DRAFT_REFERRAL_APPOINTMENT:
-      return {
-        ...state,
-        draftAppointmentInfo: action.data,
       };
     case SET_SELECTED_SLOT_START_TIME:
       return {

--- a/src/applications/vaos/referral-appointments/redux/selectors.js
+++ b/src/applications/vaos/referral-appointments/redux/selectors.js
@@ -13,10 +13,6 @@ export function getAppointmentCreateStatus(state) {
   return state.referral.appointmentCreateStatus;
 }
 
-export function getCachedDraftAppointmentInfo(state) {
-  return state.referral.draftAppointmentInfo;
-}
-
 export function getReferrals(state) {
   return {
     referrals: state.referral.referrals,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Remove custom cacheDraftReferral action to use RTK query with a POST request in it instead of a mutation.
- This should make it work the same as other cached data in the referral app. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119549

## Testing done

- Updated unit tests to work with the new process. 
- Manually tested the paths via mocks.

## Screenshots
N/A

## What areas of the site does it impact?

The pick a slot and review pages of the referral app.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

N/A
