### PR TITLE
[CST] Adjust loading container heights after component library migration

### DIFF
--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -13,6 +13,10 @@
 
 .breadcrumbs-loading-container {
   min-height: 82px;
+
+  @media (min-width: $medium-screen) {
+    min-height: 100px;
+  }
 }
 
 .on-this-page-loading-container {

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -12,15 +12,15 @@
 }
 
 .breadcrumbs-loading-container {
-  min-height: 4rem;
+  min-height: 82px;
 }
 
 .on-this-page-loading-container {
-  min-height: 350px;
+  min-height: 310px;
 }
 
 .additional-info-loading-container {
-  min-height: 1.625rem;
+  min-height: 26.5px;
   margin: 1rem 0;
 }
 


### PR DESCRIPTION
## Summary

- Adjusted min-height values for loading containers in the Claims Status Tool to match updated web component dimensions after the component library migration
- These changes maintain the smooth loading experience established in the loading UX epic by preventing layout shifts during component initialization
- Using exact pixel values for precision rather than rem units
- Implemented responsive design for breadcrumbs while keeping on-this-page at fixed height to prevent excess space issues

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#107801 (Smooth loading experience epic)
- department-of-veterans-affairs/va.gov-team#111841 (Component library migration epic)

## Testing done

- Old behavior: Loading containers had mismatched heights causing either excess whitespace or potential layout shifts
- Verification steps:
  1. Navigate to /my-va/track-claims 
  2. Observe loading states for breadcrumbs, on-this-page, and additional-info components
  3. Verify no layout shift occurs when components finish loading
  4. Test responsive behavior on mobile and desktop viewports
- Test results: 
  - Breadcrumbs: Responsive (82px mobile, 100px desktop)
  - On-this-page: Fixed 310px (prevents excess space after loading)
  - Additional-info: Fixed 26.5px
  - No layout shifts observed during component initialization

## Screenshots

## What areas of the site does it impact?

Claims Status Tool loading states only - specifically the loading containers for breadcrumbs, on-this-page navigation, and additional-info components

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated
- [ ] Screenshot of the developed feature is added
- [x] Accessibility testing has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (not applicable for CSS changes)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

This PR adjusts loading container heights following the component library migration. The breadcrumbs container is responsive (82px mobile, 100px desktop), while on-this-page remains fixed at 310px to prevent holding excess space after the component loads. The values were determined by measuring the actual rendered heights of the web components.