### PR TITLE
DV | Add form data to confirmation page

### DIFF
--- a/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
@@ -6,7 +6,7 @@ import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { scrollToFirstError } from 'platform/utilities/ui';
 
-import { DEPENDENT_CHOICES } from '../constants';
+import { DEPENDENT_CHOICES, DEPENDENT_TITLE } from '../constants';
 import { maskID } from '../../shared/utils';
 
 import { removeEditContactInformation } from '../util/contact-info';
@@ -184,7 +184,7 @@ export const DependentsInformation = ({
       </ul>
 
       <VaRadio
-        label="Has the status of your dependents changed?"
+        label={DEPENDENT_TITLE}
         required
         onVaValueChange={handlers.onValueChange}
         label-header-level="3"

--- a/src/applications/dependents/dependents-verification/config/chapters/dependents/dependents.js
+++ b/src/applications/dependents/dependents-verification/config/chapters/dependents/dependents.js
@@ -1,5 +1,7 @@
 import { radioSchema } from 'platform/forms-system/src/js/web-component-patterns';
 
+import { DEPENDENT_TITLE, DEPENDENT_CHOICES } from '../../../constants';
+
 export const dependents = {
   schema: {
     type: 'object',
@@ -8,14 +10,33 @@ export const dependents = {
         type: 'array',
         items: {
           type: 'object',
-          properties: {},
+          properties: {
+            fullName: { type: 'string' },
+            ssn: { type: 'string' },
+            dob: { type: 'string' },
+            age: { type: 'number' },
+            relationship: { type: 'string' },
+          },
         },
       },
       hasDependentsStatusChanged: radioSchema(['Y', 'N']),
     },
   },
   uiSchema: {
-    dependents: {},
-    hasDependentsStatusChanged: {},
+    dependents: {
+      items: {
+        fullName: { 'ui:title': 'First name' },
+        ssn: { 'ui:title': 'Social Security number' },
+        dob: { 'ui:title': 'Date of birth' },
+        age: { 'ui:title': 'Age' },
+        relationship: { 'ui:title': 'Relationship' },
+      },
+    },
+    hasDependentsStatusChanged: {
+      'ui:title': DEPENDENT_TITLE,
+      'ui:options': {
+        labels: DEPENDENT_CHOICES,
+      },
+    },
   },
 };

--- a/src/applications/dependents/dependents-verification/constants.js
+++ b/src/applications/dependents/dependents-verification/constants.js
@@ -1,6 +1,7 @@
 export const TITLE = 'Verify your dependents for disability benefits';
 export const SUBTITLE = 'VA Form 21-0538';
 
+export const DEPENDENT_TITLE = 'Has the status of your dependents changed?';
 export const DEPENDENT_CHOICES = {
   Y: 'Yes, I need to update my dependents’ information.',
   N: 'No, my dependents’ information is up to date.',

--- a/src/applications/dependents/dependents-verification/containers/ConfirmationPage.jsx
+++ b/src/applications/dependents/dependents-verification/containers/ConfirmationPage.jsx
@@ -74,6 +74,7 @@ export const ConfirmationPage = props => {
           }}
         />
       </va-summary-box>
+      <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.WhatsNextProcessList item1Content={step1Content} />
       <ConfirmationView.HowToContact />
       <p>

--- a/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -11,11 +11,12 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 import ConfirmationPage from '../../../containers/ConfirmationPage';
 
 import formConfig from '../../../config/form';
+import maxData from '../../e2e/fixtures/data/maximal-test.json';
 
 const mockStore = state => createStore(() => state);
 
 const initConfirmationPage = ({
-  formData,
+  formData = maxData,
   confirmationNumber,
   timestamp,
   userFullName,
@@ -52,7 +53,6 @@ describe('ConfirmationPage', () => {
 
   it('should show success alert, h2, and confirmation number if present', () => {
     const { container } = initConfirmationPage({
-      formData: {},
       confirmationNumber: '1234567890',
       timestamp: Date.now(),
       userFullName: { first: 'John', middle: 'A.', last: 'Doe', suffix: 'Jr.' },
@@ -69,6 +69,7 @@ describe('ConfirmationPage', () => {
     const summaryBox = $('va-summary-box', container);
     expect(summaryBox).to.exist;
     expect(summaryBox.textContent).to.include('John A. Doe, Jr.');
+    expect($('va-accordion', container)).to.exist;
     expect($('va-process-list', container)).to.exist;
     expect($$('va-link-action', container)).to.have.lengthOf(2);
   });
@@ -87,7 +88,7 @@ describe('ConfirmationPage', () => {
 
   it('should render when API fails', () => {
     const { container } = render(
-      <Provider store={mockStore({ form: {} })}>
+      <Provider store={mockStore({ form: { data: {} } })}>
         <ConfirmationPage route={{ formConfig }} />
       </Provider>,
     );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Adding form data to Dependents Verification (VA form 21-0538) to match content recommendations for the confirmation page.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > [Recommendation per confirmation page template](https://design.va.gov/templates/forms/confirmation#production-example)
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/117008

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
|  ------ | ----- |
| <img width="500" alt="before confirmation page not showing form data accordion" src="https://github.com/user-attachments/assets/1c8ac1b4-d667-4b3d-a0b8-8abdc6493474" /> | <img width="500" alt="after form data accordion on confirmation page" src="https://github.com/user-attachments/assets/77230659-f9b3-4337-8918-ecead0253432" /> |

## What areas of the site does it impact?

Dependents Verification (VA form 21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
