### PR TITLE
ArrayBuilder | Allow maxItems prop to be number or function

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockAddress.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockAddress.js
@@ -4,7 +4,7 @@ import {
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
-/** @type {PageSchema}  */
+/** @type {PageSchema} */
 export default {
   uiSchema: {
     ...titleUI('Web component v3 address'),

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -19,6 +19,7 @@ import {
   createArrayBuilderItemAddPath,
   getUpdatedItemFromPath,
   isDeepEmpty,
+  maxItemsFn,
   slugifyText,
   useHeadingLevels,
   validateIncompleteItems,
@@ -82,7 +83,7 @@ function getYesNoReviewErrorMessage(reviewErrors, hasItemsKey) {
  *   introPath: string,
  *   isItemIncomplete: function,
  *   isReviewPage: boolean,
- *   maxItems: number,
+ *   maxItems: number | ((formData: object) => number),
  *   missingInformationKey: string,
  *   nounPlural: string,
  *   nounSingular: string,
@@ -103,7 +104,6 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
     introPath,
     isItemIncomplete,
     isReviewPage,
-    maxItems,
     missingInformationKey,
     nounPlural,
     nounSingular,
@@ -146,6 +146,7 @@ export default function ArrayBuilderSummaryPage(arrayBuilderOptions) {
       isReviewPage,
     );
     const Heading = `h${headingLevel}`;
+    const maxItems = maxItemsFn(arrayBuilderOptions.maxItems, props.data);
     const isMaxItemsReached = arrayData?.length >= maxItems;
     const hasReviewError =
       isReviewPage && checkHasYesNoReviewError(props.reviewErrors, hasItemsKey);

--- a/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
@@ -484,15 +484,26 @@ export const useHeadingLevels = (userHeaderLevel, isReviewPage) => {
 /**
  * Resolves `maxItems` to a numeric value.
  *
- * If `maxItems` is a function, it is called with `formData` and the returned
- * number is used. If it is a number, that value is returned as-is.
+ * - If `maxItems` is a function, it is called with `formData` and the returned
+ *   value is validated as a number.
+ * - If `maxItems` is a number, it is validated as finite and returned.
+ * - If `maxItems` is a string, it is trimmed, parsed into a number, and validated.
  *
- * @param {number | ((formData: object) => number)} maxItems
- *   A static limit or a resolver that derives the limit from `formData`.
+ * @param {number | string | ((formData: object) => number | string)} maxItems
+ *   A static limit, string value, or resolver function.
  * @param {object} formData
  *   Data passed to the resolver when `maxItems` is a function.
- * @returns {number}
- *   The resolved maximum item count.
+ * @returns {number | undefined}
+ *   The resolved maximum item count, or `undefined` if invalid or an error occurs.
  */
-export const maxItemsFn = (maxItems, formData = {}) =>
-  typeof maxItems === 'function' ? maxItems(formData) : maxItems;
+export const maxItemsFn = (maxItems, formData = {}) => {
+  try {
+    const raw = typeof maxItems === 'function' ? maxItems(formData) : maxItems;
+    const value = typeof raw === 'string' ? Number(raw.trim()) : raw;
+    return typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
@@ -480,3 +480,19 @@ export const useHeadingLevels = (userHeaderLevel, isReviewPage) => {
 
   return { headingLevel, headingStyle };
 };
+
+/**
+ * Resolves `maxItems` to a numeric value.
+ *
+ * If `maxItems` is a function, it is called with `formData` and the returned
+ * number is used. If it is a number, that value is returned as-is.
+ *
+ * @param {number | ((formData: object) => number)} maxItems
+ *   A static limit or a resolver that derives the limit from `formData`.
+ * @param {object} formData
+ *   Data passed to the resolver when `maxItems` is a function.
+ * @returns {number}
+ *   The resolved maximum item count.
+ */
+export const maxItemsFn = (maxItems, formData = {}) =>
+  typeof maxItems === 'function' ? maxItems(formData) : maxItems;

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.jsx
@@ -144,6 +144,7 @@ describe('ArrayBuilderSummaryPage', () => {
     stubUrlParams(urlParams);
     const data = {
       employers: arrayData,
+      applicants: [{}, {}],
     };
     if (radioData) {
       // Added separately so the removed item tests doesn't need to include
@@ -296,7 +297,7 @@ describe('ArrayBuilderSummaryPage', () => {
     expect(container.querySelector('va-card')).to.exist;
   });
 
-  it('should display appropriately with max items', () => {
+  it('should display appropriately when max items value is a number', () => {
     const { getText, container, getByText } = setupArrayBuilderSummaryPage({
       arrayData: [
         { name: 'Test' },
@@ -311,6 +312,20 @@ describe('ArrayBuilderSummaryPage', () => {
 
     expect(container.querySelector('va-radio')).to.not.exist;
     expect(container.querySelectorAll('va-card')).to.have.lengthOf(5);
+    expect(container.querySelector('va-alert')).to.include.text(
+      'You have added the maximum number',
+    );
+  });
+
+  it('should display appropriately when max items value is a function', () => {
+    const { getText, container, getByText } = setupArrayBuilderSummaryPage({
+      arrayData: [{ name: 'Test' }, { name: 'Test 2' }],
+      urlParams: '',
+      maxItems: formData => formData?.applicants.length,
+    });
+
+    expect(container.querySelector('va-radio')).to.not.exist;
+    expect(container.querySelectorAll('va-card')).to.have.lengthOf(2);
     expect(container.querySelector('va-alert')).to.include.text(
       'You have added the maximum number',
     );
@@ -331,7 +346,7 @@ describe('ArrayBuilderSummaryPage', () => {
     expect($modal.getAttribute('visible')).to.eq('true');
     $modal.__events.primaryButtonClick();
     sinon.assert.calledOnce(onChange);
-    sinon.assert.calledWithExactly(onChange, { employers: [] });
+    sinon.assert.calledWithMatch(onChange, { employers: [] });
     expect(goToPath.args[0][0]).to.eql(
       '/first-item/0?add=true&removedAllWarn=true',
     );
@@ -533,7 +548,7 @@ describe('ArrayBuilderSummaryPage', () => {
     modal.__events.primaryButtonClick();
     await waitFor(() => {
       sinon.assert.calledOnce(onChange);
-      sinon.assert.calledWithExactly(onChange, {});
+      sinon.assert.calledWithMatch(onChange, {});
       const alert = container.querySelector('va-alert');
       expect(alert).to.include.text('has been deleted');
     });
@@ -555,7 +570,7 @@ describe('ArrayBuilderSummaryPage', () => {
     modal.__events.primaryButtonClick();
     await waitFor(() => {
       sinon.assert.calledOnce(onChange);
-      sinon.assert.calledWithExactly(onChange, {
+      sinon.assert.calledWithMatch(onChange, {
         employers: [{ name: 'Test 2' }],
       });
       const alert = container.querySelector('va-alert');

--- a/src/platform/forms-system/src/js/web-component-patterns/arrayBuilderPatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/arrayBuilderPatterns.jsx
@@ -3,6 +3,7 @@ import { titleUI } from './titlePattern';
 import { yesNoSchema, yesNoUI } from './yesNoPattern';
 import {
   getArrayUrlSearchParams,
+  maxItemsFn,
   maxItemsHint,
 } from '../patterns/array-builder/helpers';
 
@@ -151,7 +152,7 @@ export const arrayBuilderItemSubsequentPageTitleUI = (
  *   arrayPath: string,
  *   nounSingular: string,
  *   required: boolean | (formData) => boolean,
- *   maxItems?: number,
+ *   maxItems?: number | (formData) => number,
  * }} arrayBuilderOptions partial of same options you pass into `arrayBuilderPages`
  * @param {ArrayBuilderYesNoUIOptions} yesNoOptions yesNoUI options for 0 items
  * @param {ArrayBuilderYesNoUIOptions} yesNoOptionsMore yesNoUI options for more than 0 items
@@ -194,13 +195,7 @@ export const arrayBuilderYesNoUI = (
   yesNoOptions,
   yesNoOptionsMore,
 ) => {
-  const {
-    arrayPath,
-    nounSingular,
-    nounPlural,
-    maxItems,
-    required,
-  } = arrayBuilderOptions;
+  const { arrayPath, nounSingular, nounPlural, required } = arrayBuilderOptions;
   const defaultTitle =
     yesNoOptions?.title || `Do you have a ${nounSingular} to add?`;
 
@@ -224,6 +219,7 @@ export const arrayBuilderYesNoUI = (
       classNames: 'wc-pattern-array-builder-yes-no',
       updateUiSchema: formData => {
         const arrayData = formData?.[arrayPath];
+        const maxItems = maxItemsFn(arrayBuilderOptions.maxItems, formData);
         return arrayData?.length
           ? {
               'ui:title':


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the `maxItems` prop from the `arrayBuiderOptions` to allow a function that contains the form data object. This update allows for one array length to be contingent upon another array length or another static number in the form data.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118002

## Testing done

- [x] Added unit tests to cover the new behavior

## Acceptance criteria

- `maxItems` value can be form data dependent

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user