### PR TITLE
Hook up pensionPdfFormAlignment to net worth threshold

### DIFF
--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -16,6 +16,9 @@ export default function PensionEntry({ location, children }) {
   const pensionMultiplePageResponse = useToggleValue(
     TOGGLE_NAMES.pensionMultiplePageResponse,
   );
+  const pensionPdfFormAlignment = useToggleValue(
+    TOGGLE_NAMES.pensionPdfFormAlignment,
+  );
   const isLoadingFeatures = useSelector(
     state => state?.featureToggles?.loading,
   );
@@ -36,9 +39,13 @@ export default function PensionEntry({ location, children }) {
           'showMultiplePageResponse',
           pensionMultiplePageResponse,
         );
+        window.sessionStorage.setItem(
+          'showPdfFormAlignment',
+          pensionPdfFormAlignment,
+        );
       }
     },
-    [isLoadingFeatures, pensionMultiplePageResponse],
+    [isLoadingFeatures, pensionMultiplePageResponse, pensionPdfFormAlignment],
   );
 
   if (isLoadingFeatures !== false || redirectToHowToPage) {

--- a/src/applications/pensions/components/FormAlerts/index.jsx
+++ b/src/applications/pensions/components/FormAlerts/index.jsx
@@ -215,12 +215,12 @@ export const SpecialMonthlyPensionEvidenceAlert = () => (
   </RequestFormAlert>
 );
 
-export const TotalNetWorthOverThresholdAlert = () => (
+export const TotalNetWorthOverThresholdAlert = ({ threshold = 75000 }) => (
   <va-alert status="warning">
     <p className="vads-u-margin-y--0">
-      You answered that you have more than $75,000 in assets. You’ll need to
-      submit an Income and Asset Statement in Support of Claim for Pension or
-      Parents' Dependency and Indemnity Compensation (
+      You answered that you have more than {threshold.toLocaleString()} in
+      assets. You’ll need to submit an Income and Asset Statement in Support of
+      Claim for Pension or Parents' Dependency and Indemnity Compensation (
       <va-link
         external
         href="https://www.va.gov/find-forms/about-form-21-2680/"

--- a/src/applications/pensions/components/FormAlerts/index.jsx
+++ b/src/applications/pensions/components/FormAlerts/index.jsx
@@ -215,10 +215,10 @@ export const SpecialMonthlyPensionEvidenceAlert = () => (
   </RequestFormAlert>
 );
 
-export const TotalNetWorthOverThresholdAlert = ({ threshold = 75000 }) => (
+export const TotalNetWorthOverThresholdAlert = ({ threshold = 25000 }) => (
   <va-alert status="warning">
     <p className="vads-u-margin-y--0">
-      You answered that you have more than {threshold.toLocaleString()} in
+      You answered that you have more than ${threshold.toLocaleString()} in
       assets. You’ll need to submit an Income and Asset Statement in Support of
       Claim for Pension or Parents' Dependency and Indemnity Compensation (
       <va-link

--- a/src/applications/pensions/config/chapters/05-financial-information/netWorthEstimation.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/netWorthEstimation.js
@@ -7,13 +7,16 @@ import {
   AssetInformationAlert,
   TotalNetWorthOverThresholdAlert,
 } from '../../../components/FormAlerts';
+import { showPdfFormAlignment } from '../../../helpers';
 
-export const hideIfUnder75000 = formData => {
+const threshold = showPdfFormAlignment() ? 75000 : 25000;
+
+export const hideIfUnderThreshold = formData => {
   const value = parseInt(formData.netWorthEstimation, 10);
   return (
     formData.netWorthEstimation == null || // null or undefined
     Number.isNaN(value) ||
-    value <= 75000
+    value <= threshold
   );
 };
 
@@ -25,7 +28,7 @@ export default {
   uiSchema: {
     ...titleUI(
       'Income and assets',
-      'We need to know if you and your dependents have over $75,000 in assets.',
+      `We need to know if you and your dependents have over $${threshold.toLocaleString()} in assets.`,
     ),
     'view:warningAlert': {
       'ui:description': AssetInformationAlert,
@@ -33,9 +36,9 @@ export default {
     netWorthEstimation: currencyUI('Estimate the total value of your assets'),
 
     'view:warningAlertOnHighValue': {
-      'ui:description': TotalNetWorthOverThresholdAlert,
+      'ui:description': TotalNetWorthOverThresholdAlert(threshold),
       'ui:options': {
-        hideIf: hideIfUnder75000,
+        hideIf: hideIfUnderThreshold,
       },
     },
   },

--- a/src/applications/pensions/config/chapters/05-financial-information/totalNetWorth.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/totalNetWorth.js
@@ -4,8 +4,11 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 import { AssetsInformation } from '../../../components/FormAlerts';
+import { showPdfFormAlignment } from '../../../helpers';
 
 const { totalNetWorth } = fullSchemaPensions.properties;
+
+const threshold = showPdfFormAlignment() ? 75000 : 25000;
 
 /** @type {PageSchema} */
 export default {
@@ -14,13 +17,13 @@ export default {
   uiSchema: {
     ...titleUI(
       'Income and assets',
-      'We need to know if you and your dependents have over $75,000 in combined assets.',
+      `We need to know if you and your dependents have over $${threshold.toLocaleString()} in combined assets.`,
     ),
     'view:AssetsInformation': {
       'ui:description': AssetsInformation,
     },
     totalNetWorth: yesNoUI({
-      title: 'Do you and your dependents have over $75,000 in combined assets?',
+      title: `Do you and your dependents have over $${threshold.toLocaleString()} in combined assets?`,
     }),
   },
   schema: {

--- a/src/applications/pensions/config/chapters/06-additional-information/supportingDocuments.js
+++ b/src/applications/pensions/config/chapters/06-additional-information/supportingDocuments.js
@@ -75,7 +75,7 @@ function Documents({ formData }) {
   const hasSpecialMonthlyPension = formData.specialMonthlyPension;
   const hasSocialSecurityDisability = formData.socialSecurityDisability;
   const livesInNursingHome = formData.nursingHome;
-  const assetsOverThreshold = formData.totalNetWorth; // over $75,000 in assets
+  const assetsOverThreshold = formData.totalNetWorth;
   const homeAcreageMoreThanTwo =
     formData.homeOwnership && formData.homeAcreageMoreThanTwo;
   const hasTransferredAssets = formData.transferredAssets;

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -121,3 +121,6 @@ export const isProductionEnv = () => {
 
 export const showMultiplePageResponse = () =>
   window.sessionStorage.getItem('showMultiplePageResponse') === 'true';
+
+export const showPdfFormAlignment = () =>
+  window.sessionStorage.getItem('showPdfFormAlignment') === 'true';

--- a/src/applications/pensions/tests/e2e/pensions-net-worth-estimation.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensions-net-worth-estimation.cypress.spec.js
@@ -41,7 +41,7 @@ describe('Pensions net worth asset alert', () => {
       // check warning exists
       cy.get('va-alert[status="warning"]').should(
         'contain.text',
-        'You answered that you have more than $75,000 in assets.',
+        'You answered that you have more than $25,000 in assets.',
       );
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/pensions/tests/e2e/pensions-net-worth-estimation.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensions-net-worth-estimation.cypress.spec.js
@@ -20,12 +20,12 @@ describe('Pensions net worth asset alert', () => {
     });
   });
   context('Net worth estimation', () => {
-    it('should show an alert if assets are over 75000', () => {
+    it('should show an alert if assets are over 25000', () => {
       // start the form
       // earlier chapters have been prefilled
       cy.findByTestId('continue-your-application').click();
 
-      // select no to do you have >$75000 in assets
+      // select no to do you have >$25000 in assets
       cy.get(`va-radio-option[value="N"]`).click();
       cy.get('va-button[continue]').click();
 
@@ -36,7 +36,7 @@ describe('Pensions net worth asset alert', () => {
       cy.get('va-text-input[name="root_netWorthEstimation"]')
         .shadow()
         .find('input')
-        .type('75001');
+        .type('25001');
 
       // check warning exists
       cy.get('va-alert[status="warning"]').should(

--- a/src/applications/pensions/tests/unit/chapters/05-financial-information/netWorthEstimation.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/05-financial-information/netWorthEstimation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
 } from '../pageTests.spec';
 import formConfig from '../../../../config/form';
 import netWorthEstimation, {
-  hideIfUnder75000,
+  hideIfUnderThreshold,
 } from '../../../../config/chapters/05-financial-information/netWorthEstimation';
 
 const { schema, uiSchema } = netWorthEstimation;
@@ -43,18 +43,18 @@ describe('Financial information net worth estimation pension page', () => {
     pageTitle,
   );
 
-  describe('hideIfUnder75000', () => {
-    it('should return true if under 75000', () => {
-      expect(hideIfUnder75000({ netWorthEstimation: 74999 })).to.be.true;
+  describe('hideIfUnderThreshold', () => {
+    it('should return true if under 25000', () => {
+      expect(hideIfUnderThreshold({ netWorthEstimation: 24999 })).to.be.true;
     });
-    it('should return false if over 75000', () => {
-      expect(hideIfUnder75000({ netWorthEstimation: 76000 })).to.be.false;
+    it('should return false if over 25000', () => {
+      expect(hideIfUnderThreshold({ netWorthEstimation: 26000 })).to.be.false;
     });
     it('should return true if undefined', () => {
-      expect(hideIfUnder75000({})).to.be.true;
+      expect(hideIfUnderThreshold({})).to.be.true;
     });
     it('should return true if null', () => {
-      expect(hideIfUnder75000({ netWorthEstimation: null })).to.be.true;
+      expect(hideIfUnderThreshold({ netWorthEstimation: null })).to.be.true;
     });
   });
 });

--- a/src/applications/pensions/tests/unit/chapters/05-financial-information/totalNetWorth.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/05-financial-information/totalNetWorth.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('Financial information total net worth pension page', () => {
     schema,
     uiSchema,
     [
-      `va-radio[label="Do you and your dependents have over $75,000 in combined assets?"]`,
+      `va-radio[label="Do you and your dependents have over $25,000 in combined assets?"]`,
     ],
     pageTitle,
   );

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -218,6 +218,7 @@
   "pensionFormEnabled": "pension_form_enabled",
   "pensionIncomeAndAssetsClarification": "pension_income_and_assets_clarification",
   "pensionMultiplePageResponse": "pension_multiple_page_response",
+  "pensionPdfFormAlignment": "pension_pdf_form_alignment",
   "pensionsBrowserMonitoringEnabled": "pension_browser_monitoring_enabled",
   "preEntryCovid19Screener": "pre_entry_covid19_screener",
   "profileDoNotRequireInternationalZipCode": "profile_do_not_require_international_zip_code",


### PR DESCRIPTION
## Summary

Hooked up the `pensionPdfFormAlignment` feature toggle to control the **net worth threshold** used by the Pension Benefits form (VA Form 21P-527EZ).  
- **Toggle OFF (current PDF alignment):** threshold = **$25,000**  
- **Toggle ON (upcoming PDF alignment):** threshold = **$75,000**

This ensures the web experience matches the PDF form version we are aligned to during the transition period.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118100

## Related issue(s)

- N/A

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Navigate to the form:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
4. Toggle the feature flag here:  
   `http://localhost:3000/flipper/features/pension_pdf_form_alignment`

## How to verify

1. **With the toggle OFF:** confirm all logic that relies on the threshold uses **$25,000** (e.g., any net worth guidance, validation, or conditional content).  
2. **With the toggle ON:** confirm those same checks now use **$75,000**.  
3. Verify any conditional UI or messages tied to the threshold are consistent with the active value.  
4. Ensure no regressions in submission behavior or derived calculations.

## What areas of the site does it impact?

- Pension Benefits (21P-527EZ) — net worth threshold logic, any dependent content/validation using that value

## Screenshots

_N/A — threshold logic update_

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) Please confirm that all threshold checks correctly switch between **$25,000** and **$75,000** based on the `pensionPdfFormAlignment` flag and that there are no missed references to the threshold in validation or UI copy.