### PR TITLE
Replace imposter component with va card

### DIFF
--- a/src/applications/appeals/onramp/components/dr-results-screens/NotGoodFitCard.jsx
+++ b/src/applications/appeals/onramp/components/dr-results-screens/NotGoodFitCard.jsx
@@ -12,12 +12,16 @@ const NotGoodFitCard = ({ card, formResponses }) => {
   const learnMoreLink = getLearnMoreLink(card);
 
   return (
-    <div className="not-good-fit-card" data-testid={`not-good-fit-${card}`}>
+    <va-card
+      background
+      class="not-good-fit-card"
+      data-testid={`not-good-fit-${card}`}
+    >
       <h3 className="vads-u-margin-top--0">{H3}</h3>
       <p>This may not be an option because:</p>
       {content}
       {learnMoreLink}
-    </div>
+    </va-card>
   );
 };
 

--- a/src/applications/appeals/onramp/sass/onramp.scss
+++ b/src/applications/appeals/onramp/sass/onramp.scss
@@ -15,7 +15,6 @@
   .not-good-fit-card {
     margin-top: 1.5em;
     padding: 1em 1em 1.5em;
-    background-color: $vads-color-base-lightest;
   }
 
   va-radio::part(form-header) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Replaced the imposter  Not a good fit card with va card component.

## Related issue(s)

[Issue ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/119859)

Nothing in the original [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/38472/files#diff-ee9db732022ab9db2b91b1d43ff13ba8d19c8ae620360bf1d0a8672cef27edc1) suggests that it was a div for a particular reason. 

## Testing done

- Tested it locally to make sure the va-card component is rendering and that the style was correct.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="391" height="846" alt="Screenshot 2025-09-18 at 12 08 30 PM" src="https://github.com/user-attachments/assets/a30d6935-1fc5-4536-bfbe-4acae5a03542" /> | <img width="391" height="846" alt="Screenshot 2025-09-18 at 12 07 04 PM" src="https://github.com/user-attachments/assets/87c51289-acf2-4be2-8b70-abb95edf728d" /> |
| Desktop |  <img width="700" height="924" alt="Screenshot 2025-09-18 at 12 10 00 PM" src="https://github.com/user-attachments/assets/d90cbdc2-25df-4f2b-8260-a028b6fd87f3" /> | <img width="712" height="929" alt="Screenshot 2025-09-18 at 11 57 24 AM" src="https://github.com/user-attachments/assets/c6d66d25-479b-4015-bc6c-9d5ebae47c04" /> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

