### PR TITLE
DV | Fix displayed dependent age

### DIFF
--- a/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformation.jsx
@@ -10,6 +10,7 @@ import { DEPENDENT_CHOICES, DEPENDENT_TITLE } from '../constants';
 import { maskID } from '../../shared/utils';
 
 import { removeEditContactInformation } from '../util/contact-info';
+import { calculateAge } from '../helpers';
 
 export const DependentsInformation = ({
   data = {},
@@ -107,14 +108,15 @@ export const DependentsInformation = ({
                       {dependent.dob}
                     </dd>
                   </div>
-                  {dependent.age && (
+                  {dependent.dob && (
                     <div className="item vads-u-display--flex vads-u-justify-content--start vads-u-margin-bottom--1">
                       <dt>Age:&nbsp;</dt>
                       <dd
                         className="dd-privacy-hidden"
                         data-dd-action-name="Dependent's age"
                       >
-                        {dependent.age} years old
+                        {calculateAge(dependent.dateOfBirth).labeledAge ||
+                          'Unable to determine'}
                       </dd>
                     </div>
                   )}

--- a/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
+++ b/src/applications/dependents/dependents-verification/components/DependentsInformationReview.jsx
@@ -1,11 +1,19 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { DEPENDENT_CHOICES } from '../constants';
 import { maskID } from '../../shared/utils';
+import { calculateAge } from '../helpers';
 
 export const DependentsInformationReview = ({ data, goToPath }) => {
-  const { dependents, hasDependentsStatusChanged = '' } = data || {};
+  const { hasDependentsStatusChanged = '' } = data || {};
+  // Using dependents from Redux state because dependents are only set in the
+  // form data on the dependents page; this change allows the mock server to
+  // jump straight to the review page and still show dependents
+  const dependents = useSelector(
+    state => state.form?.data?.dependents || state.dependents?.data || [],
+  );
 
   const onEditClick = () => {
     sessionStorage.setItem('onReviewPage', 'true');
@@ -74,7 +82,8 @@ export const DependentsInformationReview = ({ data, goToPath }) => {
                   className="dd-privacy-hidden"
                   data-dd-action-name="Dependent's age"
                 >
-                  {dep.age} years old
+                  {calculateAge(dep.dateOfBirth).labeledAge ||
+                    'Unable to determine'}
                 </dd>
               </div>
               <div className="review-row">

--- a/src/applications/dependents/dependents-verification/components/EditPhonePage.jsx
+++ b/src/applications/dependents/dependents-verification/components/EditPhonePage.jsx
@@ -59,7 +59,7 @@ const EditPhonePage = ({
   return (
     <>
       <h3 className="vads-u-margin-bottom--4">
-        {`Edit ${data['view:phoneSource']} phone number`}
+        {`Edit ${data['view:phoneSource'] || 'mobile'} phone number`}
       </h3>
       <SchemaForm
         addNameAttribute

--- a/src/applications/dependents/dependents-verification/components/ExitForm.jsx
+++ b/src/applications/dependents/dependents-verification/components/ExitForm.jsx
@@ -12,6 +12,7 @@ export const ExitForm = ({
   goBack,
   contentBeforeButtons,
   contentAfterButtons,
+  location = window.location,
 }) => {
   useEffect(() => {
     scrollAndFocus('h1.page-title');

--- a/src/applications/dependents/dependents-verification/components/ExitForm.jsx
+++ b/src/applications/dependents/dependents-verification/components/ExitForm.jsx
@@ -12,7 +12,6 @@ export const ExitForm = ({
   goBack,
   contentBeforeButtons,
   contentAfterButtons,
-  location = window.location,
 }) => {
   useEffect(() => {
     scrollAndFocus('h1.page-title');

--- a/src/applications/dependents/dependents-verification/components/ExitForm.jsx
+++ b/src/applications/dependents/dependents-verification/components/ExitForm.jsx
@@ -12,6 +12,7 @@ export const ExitForm = ({
   goBack,
   contentBeforeButtons,
   contentAfterButtons,
+  location = window.location,
 }) => {
   useEffect(() => {
     scrollAndFocus('h1.page-title');
@@ -23,7 +24,7 @@ export const ExitForm = ({
     },
     goTo686: async () => {
       await deleteInProgressForm(VA_FORM_IDS.FORM_21_0538);
-      window.location.assign(form686Url);
+      location.assign(form686Url);
     },
   };
 
@@ -77,4 +78,7 @@ ExitForm.propTypes = {
   router: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
+  location: PropTypes.shape({
+    assign: PropTypes.func,
+  }),
 };

--- a/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
@@ -66,9 +66,8 @@ const VeteranContactInformationPage = ({
   );
   const profileHomePhoneString = convertPhoneObjectToString(profileHomePhone);
   const phoneSource =
-    data['view:phoneSource'] || phone || profileMobilePhoneString
-      ? 'Mobile'
-      : 'Home';
+    data['view:phoneSource'] ||
+    (phone || profileMobilePhoneString ? 'Mobile' : 'Home');
 
   // Get international phone from mobile or home, if it's international
   let profileInternationalPhone = null;
@@ -124,7 +123,7 @@ const VeteranContactInformationPage = ({
     }
 
     updateContactInfo({
-      'view:phoneSource': data['view:phoneSource'] || phoneSource,
+      'view:phoneSource': phoneSource,
       email: email || profileEmail?.emailAddress || '',
       phone: phone || profileMobilePhoneString || profileHomePhoneString || '',
       address: newAddress,

--- a/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranContactInformationPage.jsx
@@ -356,7 +356,7 @@ const VeteranContactInformationPage = ({
 
       <va-card class="vads-u-margin-top--3" data-field="phone">
         <h4 className="vads-u-font-size--h3 vads-u-margin-top--0">
-          {`${data['view:phoneSource']} phone number`}
+          {`${phoneSource} phone number`}
         </h4>
         <div className="phone vads-u-margin-y--2">
           {phone ? (
@@ -373,7 +373,7 @@ const VeteranContactInformationPage = ({
         <EditCardLink
           value={phone}
           name="phone"
-          type={data['view:phoneSource']}
+          type={phoneSource}
           onClick={handlers.editClick}
         />
       </va-card>

--- a/src/applications/dependents/dependents-verification/components/VeteranContactInformationReviewPage.jsx
+++ b/src/applications/dependents/dependents-verification/components/VeteranContactInformationReviewPage.jsx
@@ -90,6 +90,7 @@ const VeteranContactInformationReviewPage = ({ data, goToPath }) => {
     <span className="usa-input-error-message">{message}</span>
   );
   const isUSA = address.country === 'USA';
+  const phoneSource = data['view:phoneSource'] || 'Mobile';
 
   return (
     <div className="form-review-panel-page">
@@ -206,23 +207,23 @@ const VeteranContactInformationReviewPage = ({ data, goToPath }) => {
 
       <div className="form-review-panel-page-header-row vads-u-margin-top--4">
         <h4 className="form-review-panel-page-header vads-u-font-size--h5 vads-u-margin--0">
-          {`${data['view:phoneSource']} phone number`}
+          {`${phoneSource} phone number`}
         </h4>
         <va-button
           secondary
           class="edit-page float-right"
           onClick={handlers.editPhone}
-          label={`Edit ${data['view:phoneSource']} phone number`}
+          label={`Edit ${phoneSource} phone number`}
           text="Edit"
           ref={phoneRef}
         />
       </div>
       <dl className="review">
         <div className="review-row">
-          <dt>{`${data['view:phoneSource']} phone number`}</dt>
+          <dt>{`${phoneSource} phone number`}</dt>
           <dd
             className="dd-privacy-hidden"
-            data-dd-action-name={`${data['view:phoneSource']} phone number`}
+            data-dd-action-name={`${phoneSource} phone number`}
           >
             <strong>
               {phone ? (

--- a/src/applications/dependents/dependents-verification/containers/App.jsx
+++ b/src/applications/dependents/dependents-verification/containers/App.jsx
@@ -23,9 +23,9 @@ export default function App({ location, children }) {
   const dependentsLoading = useSelector(state => {
     return state?.dependents?.loading;
   });
-  const isIntroPage = location?.pathname?.endsWith('/introduction');
-  const { pathname } = location || {};
-  const pageUrl = pathname?.slice(1);
+  const { pathname = '' } = location || {};
+  const isIntroPage = pathname.endsWith('/introduction');
+  const pageUrl = pathname.slice(1);
 
   const breadcrumbs = [
     {
@@ -49,8 +49,9 @@ export default function App({ location, children }) {
 
   useEffect(() => {
     if (!isIntroPage && dependentsLoading) {
-      window.location.replace(`${manifest.rootUrl}/introduction`);
+      location.replace(`${manifest.rootUrl}/introduction`);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   let content;

--- a/src/applications/dependents/dependents-verification/helpers.js
+++ b/src/applications/dependents/dependents-verification/helpers.js
@@ -1,7 +1,68 @@
 import React from 'react';
-import { parse, isValid, differenceInYears, format } from 'date-fns';
+import {
+  parse,
+  isValid,
+  differenceInYears,
+  differenceInMonths,
+  differenceInDays,
+  format,
+} from 'date-fns';
 
 export const hasSession = () => localStorage.getItem('hasSession') === 'true';
+
+export const calculateAge = dob => {
+  if (!dob) {
+    return {
+      age: 0,
+      dobStr: '',
+      labeledAge: '',
+    };
+  }
+
+  const dobObj = parse(dob, 'MM/dd/yyyy', new Date());
+  const dobStr = isValid(dobObj) ? format(dobObj, 'MMMM d, yyyy') : '';
+  const invalid = {
+    age: 0,
+    dobStr,
+    labeledAge: '',
+  };
+
+  if (!dobStr) {
+    return invalid;
+  }
+
+  const ageInYears = differenceInYears(new Date(), dobObj);
+  if (ageInYears > 0) {
+    return {
+      age: ageInYears,
+      dobStr,
+      labeledAge: `${ageInYears} year${ageInYears > 1 ? 's' : ''} old`,
+    };
+  }
+
+  const ageInMonths =
+    ageInYears > 0 ? 0 : differenceInMonths(new Date(), dobObj);
+  if (ageInMonths > 0) {
+    return {
+      age: 0,
+      dobStr,
+      labeledAge: `${ageInMonths} month${ageInMonths > 1 ? 's' : ''} old`,
+    };
+  }
+
+  // If less than a month old, show days
+  const ageInDays = ageInMonths > 0 ? 0 : differenceInDays(new Date(), dobObj);
+  return ageInDays >= 0
+    ? {
+        age: 0,
+        dobStr,
+        labeledAge:
+          ageInDays === 0
+            ? 'Newborn'
+            : `${ageInDays} day${ageInDays > 1 ? 's' : ''} old`,
+      }
+    : invalid;
+};
 
 /**
  * @typedef DependentsArrayFromAPI
@@ -43,19 +104,17 @@ export const processDependents = (persons = []) => {
       .filter(person => person.awardIndicator === 'Y')
       .map(person => {
         // Format the date of birth and calculate age
-        const dobObj = parse(person.dateOfBirth, 'MM/dd/yyyy', new Date());
-        const dobStr = isValid(dobObj) ? format(dobObj, 'MMMM d, yyyy') : '';
+        const { dobStr, age } = calculateAge(person.dateOfBirth);
         const removalDate = person.upcomingRemoval
           ? parse(person.upcomingRemoval, 'MM/dd/yyyy', new Date())
           : '';
-        const ageInYears = dobStr ? differenceInYears(new Date(), dobObj) : '';
 
         return {
           ...person,
           dob: dobStr || '',
           ssn: (person.ssn || '').toString().slice(-4),
           fullName: `${person.firstName || ''} ${person.lastName || ''}`.trim(),
-          age: ageInYears || '',
+          age,
           removalDate: removalDate ? format(removalDate, 'MMMM d, yyyy') : '',
         };
       });

--- a/src/applications/dependents/dependents-verification/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/dependents/dependents-verification/tests/e2e/fixtures/data/maximal-test.json
@@ -1,19 +1,20 @@
 {
-    "veteranInformation": {
-      "ssnLastFour": "5678"
-    },
-    "email": "test@test.com",
-    "phone": "8005551212",
-    "address": {
-      "street": "123 Main St",
-      "street2": "Apt 99",
-      "city": "Beverly Hills",
-      "state": "CA",
-      "postalCode": "90210",
-      "country": "USA"
-    },
-
-    "hasDependentsStatusChanged": "N",
-    "statementOfTruthSignature": "John Doe",
-    "statementOfTruthCertified": true
-  }
+  "veteranInformation": {
+    "ssnLastFour": "5678"
+  },
+  "email": "test@test.com",
+  "phone": "8005551212",
+  "view:phoneSource": "Mobile",
+  "address": {
+    "street": "123 Main St",
+    "street2": "Apt 99",
+    "city": "Beverly Hills",
+    "state": "CA",
+    "postalCode": "90210",
+    "country": "USA"
+  },
+  "internationalPhone": "63123456789",
+  "hasDependentsStatusChanged": "N",
+  "statementOfTruthSignature": "John Doe",
+  "statementOfTruthCertified": true
+}

--- a/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformation.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformation.unit.spec.jsx
@@ -42,6 +42,18 @@ function renderPage({
 }
 
 describe('DependentsInformation', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    if (sandbox) {
+      sandbox.restore();
+    }
+  });
+
   it('should render no dependents found message', () => {
     // You shouldn't be able to see this because we don't allow starting the
     // form without
@@ -77,7 +89,7 @@ describe('DependentsInformation', () => {
   });
 
   it('should set form data with radio choice', async () => {
-    const setFormDataSpy = sinon.spy();
+    const setFormDataSpy = sandbox.spy();
     const { container } = renderPage({
       data: { dependents: defaultData.dependents },
       setFormData: setFormDataSpy,
@@ -103,8 +115,8 @@ describe('DependentsInformation', () => {
   });
 
   it('navigates forward to review page when "No" is selected', async () => {
-    const goToPathSpy = sinon.spy();
-    const goForwardSpy = sinon.spy();
+    const goToPathSpy = sandbox.spy();
+    const goForwardSpy = sandbox.spy();
     const { container } = renderPage({
       data: { hasDependentsStatusChanged: 'N' },
       goToPath: goToPathSpy,
@@ -119,8 +131,8 @@ describe('DependentsInformation', () => {
   });
 
   it('navigates to exit page when "Yes" is selected', async () => {
-    const goToPathSpy = sinon.spy();
-    const goForwardSpy = sinon.spy();
+    const goToPathSpy = sandbox.spy();
+    const goForwardSpy = sandbox.spy();
     const { container } = renderPage({
       data: { hasDependentsStatusChanged: 'Y' },
       goToPath: goToPathSpy,
@@ -136,7 +148,7 @@ describe('DependentsInformation', () => {
   });
 
   it('navigates back to Veteran info page', async () => {
-    const goToPathSpy = sinon.spy();
+    const goToPathSpy = sandbox.spy();
     const { container } = renderPage({ data: {}, goToPath: goToPathSpy });
 
     await waitFor(() => {

--- a/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformation.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformation.unit.spec.jsx
@@ -8,6 +8,7 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import { DependentsInformation } from '../../../components/DependentsInformation';
 import { defaultData } from './dependent-data';
+import { calculateAge } from '../../../helpers';
 
 function renderPage({
   data = defaultData,
@@ -50,6 +51,7 @@ describe('DependentsInformation', () => {
 
   it('renders all sections with prefilled data', () => {
     const { container } = renderPage();
+    const child1 = calculateAge(defaultData.dependents[0].dateOfBirth);
 
     const cards = $$('va-card', container);
     expect(cards).to.have.lengthOf(2);
@@ -57,14 +59,14 @@ describe('DependentsInformation', () => {
     expect($('h4', cards[0]).textContent).to.include('Morty Smith');
     expect(firstList[0].textContent).to.include('Relationship:\u00a0Child');
     expect(firstList[1].textContent).to.include(
-      'Date of birth:\u00a0January 4, 2011',
+      `Date of birth:\u00a0${child1.dobStr}`,
     );
-    expect(firstList[2].textContent).to.include('Age:\u00a014 years old');
+    expect(firstList[2].textContent).to.include('Age:\u00a011 months old');
     expect(firstList[3].textContent).to.include('SSN:\u00a0●●●–●●-6791');
 
     expect($('h4', cards[1]).textContent).to.include('Summer Smith');
     expect($('.removal-date', cards[1]).textContent).to.include(
-      'Automatic removal date:\u00a0August 1, 2026',
+      `Automatic removal date:\u00a0${defaultData.dependents[1].removalDate}`,
     );
     expect($('va-alert[status="info"]', cards[1]));
 

--- a/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
@@ -26,6 +26,18 @@ function renderPage({ data = defaultData, goToPath = () => {} } = {}) {
 }
 
 describe('DependentsInformationReview', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    if (sandbox) {
+      sandbox.restore();
+    }
+  });
+
   it('renders all sections with prefilled data', () => {
     const { container } = renderPage();
 
@@ -66,7 +78,7 @@ describe('DependentsInformationReview', () => {
   });
 
   it('should redirect edit button to dependents page', async () => {
-    const goToPathSpy = sinon.spy();
+    const goToPathSpy = sandbox.spy();
     const { container } = renderPage({ data: null, goToPath: goToPathSpy });
 
     await waitFor(() => {

--- a/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/DependentsInformationReview.unit.spec.jsx
@@ -8,10 +8,13 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import { DependentsInformationReview } from '../../../components/DependentsInformationReview';
 import { defaultData } from './dependent-data';
+import { calculateAge } from '../../../helpers';
 
 function renderPage({ data = defaultData, goToPath = () => {} } = {}) {
   const mockStore = {
-    getState: () => {},
+    getState: () => ({
+      form: { data },
+    }),
     dispatch: () => {},
     subscribe: () => {},
   };
@@ -32,14 +35,17 @@ describe('DependentsInformationReview', () => {
       'Has the status of your dependents changed?',
     ]);
     const text = $$('.review-row', container).map(row => row.textContent);
+    const child1 = calculateAge(defaultData.dependents[0].dateOfBirth);
+    const child2 = calculateAge(defaultData.dependents[1].dateOfBirth);
+
     expect(text).to.deep.equal([
       'Social Security number●●●–●●-6791ending with 6 7 9 1',
-      'Date of birthJanuary 4, 2011',
-      'Age14 years old',
+      `Date of birth${child1.dobStr}`,
+      `Age${child1.labeledAge}`,
       'RelationshipChild',
       'Social Security number●●●–●●-6790ending with 6 7 9 0',
-      'Date of birthAugust 1, 2008',
-      'Age17 years old',
+      `Date of birth${child2.dobStr}`,
+      `Age${child2.labeledAge}`,
       'RelationshipChild',
       'Has the status of your dependents changed?Yes, I need to update my dependents’ information.',
     ]);

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -42,8 +42,8 @@ describe('ExitForm', () => {
       .resolves();
     const { container } = render(<ExitForm />);
     const assignSpy = sinon.spy();
-    global.window = window;
-    global.window.location = { assign: assignSpy };
+
+    window.location.assign = assignSpy;
 
     fireEvent.click($('va-button[continue]', container));
 

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -40,10 +40,8 @@ describe('ExitForm', () => {
     const deleteInProgressFormStub = sinon
       .stub(utils, 'deleteInProgressForm')
       .resolves();
-    const { container } = render(<ExitForm />);
     const assignSpy = sinon.spy();
-
-    global.window.location.assign = assignSpy;
+    const { container } = render(<ExitForm location={{ assign: assignSpy }} />);
 
     fireEvent.click($('va-button[continue]', container));
 

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -43,7 +43,7 @@ describe('ExitForm', () => {
     const { container } = render(<ExitForm />);
     const assignSpy = sinon.spy();
 
-    window.location.assign = assignSpy;
+    global.window.location.assign = assignSpy;
 
     fireEvent.click($('va-button[continue]', container));
 

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -51,10 +51,9 @@ describe('ExitForm', () => {
       .stub(utils, 'deleteInProgressForm')
       .resolves();
     const assignSpy = sinon.spy();
-    global.window.location.assign = assignSpy;
-    const { container } = render(<ExitForm />);
+    const { container } = render(<ExitForm location={{ assign: assignSpy }} />);
 
-    fireEvent.click($('va-button[continue]', container));
+    fireEvent.click($('.exit-form', container));
 
     await waitFor(() => {
       expect(deleteInProgressFormStub.calledWith(VA_FORM_IDS.FORM_21_0538)).to

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -50,8 +50,9 @@ describe('ExitForm', () => {
     const deleteInProgressFormStub = sandbox
       .stub(utils, 'deleteInProgressForm')
       .resolves();
-    const assignSpy = sandbox.spy();
-    const { container } = render(<ExitForm location={{ assign: assignSpy }} />);
+    const assignSpy = sinon.spy();
+    global.window.location.assign = assignSpy;
+    const { container } = render(<ExitForm />);
 
     fireEvent.click($('va-button[continue]', container));
 

--- a/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/ExitForm.unit.spec.jsx
@@ -9,8 +9,16 @@ import * as utils from '../../../util';
 import { form686Url, ExitForm } from '../../../components/ExitForm';
 
 describe('ExitForm', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
   afterEach(() => {
-    sinon.restore();
+    if (sandbox) {
+      sandbox.restore();
+    }
   });
 
   it('should render the exit form with correct title and subtitle', () => {
@@ -29,18 +37,20 @@ describe('ExitForm', () => {
   });
 
   it('should push url to router when back button is clicked', async () => {
-    const goBackSpy = sinon.spy();
+    const goBackSpy = sandbox.spy();
     const { container } = render(<ExitForm goBack={goBackSpy} />);
 
     fireEvent.click($('va-button[back]', container));
-    await expect(goBackSpy.called).to.be.true;
+    await waitFor(() => {
+      expect(goBackSpy.called).to.be.true;
+    });
   });
 
   it('should call redirect to 686c-674 when Go to button is clicked', async () => {
-    const deleteInProgressFormStub = sinon
+    const deleteInProgressFormStub = sandbox
       .stub(utils, 'deleteInProgressForm')
       .resolves();
-    const assignSpy = sinon.spy();
+    const assignSpy = sandbox.spy();
     const { container } = render(<ExitForm location={{ assign: assignSpy }} />);
 
     fireEvent.click($('va-button[continue]', container));

--- a/src/applications/dependents/dependents-verification/tests/unit/components/dependent-data.js
+++ b/src/applications/dependents/dependents-verification/tests/unit/components/dependent-data.js
@@ -1,19 +1,26 @@
+import { sub, format } from 'date-fns';
+
+const child1 = sub(new Date(), { months: 11 });
+const child2 = sub(new Date(), { years: 17 });
+
 export const defaultData = {
   dependents: [
     {
       fullName: 'Morty Smith',
       relationship: 'Child',
-      dob: 'January 4, 2011',
+      dob: format(child1, 'MMMM d, yyyy'),
+      dateOfBirth: format(child1, 'MM/dd/yyyy'),
       ssn: '6791',
-      age: 14,
+      age: 0,
     },
     {
       fullName: 'Summer Smith',
       relationship: 'Child',
-      dob: 'August 1, 2008',
+      dob: format(child2, 'MMMM d, yyyy'),
+      dateOfBirth: format(child2, 'MM/dd/yyyy'),
       ssn: '6790',
       age: 17,
-      removalDate: 'August 1, 2026',
+      removalDate: format(sub(new Date(), { years: -1 }), 'MMMM d, yyyy'),
     },
   ],
   hasDependentsStatusChanged: 'Y',

--- a/src/applications/dependents/dependents-verification/tests/unit/containers/App.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/containers/App.unit.spec.jsx
@@ -100,7 +100,16 @@ function renderApp({
 }
 
 describe('App container logic', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
   afterEach(() => {
+    if (sandbox) {
+      sandbox.restore();
+    }
     localStorage.removeItem('hasSession');
   });
 
@@ -143,7 +152,7 @@ describe('App container logic', () => {
   });
 
   it('should not redirect when on intro page (with session)', () => {
-    const mockReplace = sinon.stub();
+    const mockReplace = sandbox.stub();
 
     renderApp({
       pathname: '/introduction',
@@ -156,7 +165,7 @@ describe('App container logic', () => {
   });
 
   it('should not redirect when on intro page (without session)', () => {
-    const mockReplace = sinon.stub();
+    const mockReplace = sandbox.stub();
 
     renderApp({
       pathname: '/introduction',

--- a/src/applications/dependents/dependents-verification/tests/unit/containers/App.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/containers/App.unit.spec.jsx
@@ -76,12 +76,11 @@ function getDefaultState({
 
 function renderApp({
   pathname = '/introduction',
-  search = '',
-  hash = '',
   featureToggle,
   loading,
   hasSession,
   dependentsLoading,
+  replace = () => {},
 } = {}) {
   const state = getDefaultState({
     featureToggle,
@@ -91,16 +90,9 @@ function renderApp({
   });
   const store = mockStore(state);
 
-  const _location = {
-    ...window.location,
-    pathname,
-    search,
-    hash,
-  };
-
   return render(
     <Provider store={store}>
-      <App location={_location}>
+      <App location={{ pathname, replace, search: '' }}>
         <div data-testid="children-content">Child content</div>
       </App>
     </Provider>,
@@ -108,10 +100,7 @@ function renderApp({
 }
 
 describe('App container logic', () => {
-  const oldLocation = global.window.location;
-
   afterEach(() => {
-    global.window.location = oldLocation;
     localStorage.removeItem('hasSession');
   });
 
@@ -155,13 +144,12 @@ describe('App container logic', () => {
 
   it('should not redirect when on intro page (with session)', () => {
     const mockReplace = sinon.stub();
-    delete window.location;
-    window.location = { replace: mockReplace };
 
     renderApp({
       pathname: '/introduction',
       hasSession: true,
       dependentsLoading: true,
+      replace: mockReplace,
     });
 
     expect(mockReplace.called).to.be.false;
@@ -169,13 +157,12 @@ describe('App container logic', () => {
 
   it('should not redirect when on intro page (without session)', () => {
     const mockReplace = sinon.stub();
-    delete window.location;
-    window.location = { replace: mockReplace };
 
     renderApp({
       pathname: '/introduction',
       hasSession: false,
       dependentsLoading: true,
+      replace: mockReplace,
     });
 
     expect(mockReplace.called).to.be.false;

--- a/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -73,14 +73,12 @@ describe('ConfirmationPage', () => {
 
   it('should call print function when button is clicked', () => {
     const printSpy = sinon.spy();
-    const oldPrint = global.window.print;
     global.window.print = printSpy;
 
     const { container } = initConfirmationPage({});
     fireEvent.click($('va-button[text*="Print this page"]', container));
 
     expect(printSpy.calledOnce).to.be.true;
-    global.window.print = oldPrint;
   });
 
   it('should render when API fails', () => {

--- a/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { cleanup, render, fireEvent } from '@testing-library/react';
+import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
 import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/state/helpers';
 import sinon from 'sinon';
 
@@ -47,7 +47,16 @@ const initConfirmationPage = ({
 };
 
 describe('ConfirmationPage', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
   afterEach(() => {
+    if (sandbox) {
+      sandbox.restore();
+    }
     cleanup();
   });
 
@@ -71,14 +80,16 @@ describe('ConfirmationPage', () => {
     expect($$('va-link-action', container)).to.have.lengthOf(2);
   });
 
-  it('should call print function when button is clicked', () => {
-    const printSpy = sinon.spy();
+  it('should call print function when button is clicked', async () => {
+    const printSpy = sandbox.spy();
     global.window.print = printSpy;
 
     const { container } = initConfirmationPage({});
-    fireEvent.click($('va-button[text*="Print this page"]', container));
 
-    expect(printSpy.calledOnce).to.be.true;
+    await waitFor(() => {
+      fireEvent.click($('va-button[text*="Print this page"]', container));
+      expect(printSpy.calledOnce).to.be.true;
+    });
   });
 
   it('should render when API fails', () => {

--- a/src/applications/dependents/dependents-verification/tests/unit/helpers.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/helpers.unit.spec.jsx
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
+import { sub, format } from 'date-fns';
 
-import { hasSession, processDependents } from '../../helpers';
+import { hasSession, calculateAge, processDependents } from '../../helpers';
 
 describe('hasSession', () => {
   global.localStorage = localStorage;
@@ -11,6 +12,124 @@ describe('hasSession', () => {
   it('should return false if hasSession is not set in localStorage', () => {
     localStorage.removeItem('hasSession');
     expect(hasSession()).to.be.false;
+  });
+});
+
+describe('calculateAge', () => {
+  it('should return 0 age and empty strings if dob is not provided', () => {
+    const result = calculateAge();
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: '',
+      labeledAge: '',
+    });
+  });
+
+  it('should return 0 age and empty strings if dob is invalid', () => {
+    const result = calculateAge('');
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: '',
+      labeledAge: '',
+    });
+  });
+
+  it('should return 0 age and correct dobStr for future dates', () => {
+    const testDate = sub(new Date(), {
+      months: -1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '',
+    });
+  });
+
+  it('should correctly calculate age an 18 year old', () => {
+    const testDate = sub(new Date(), {
+      years: 18,
+      months: 1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 18,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '18 years old',
+    });
+  });
+
+  it('should correctly calculate age for a 1 year old', () => {
+    const testDate = sub(new Date(), {
+      years: 1,
+      days: 3,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 1,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '1 year old',
+    });
+  });
+
+  it('should correctly calculate age for a 4 month old', () => {
+    const testDate = sub(new Date(), {
+      months: 4,
+      days: 3,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '4 months old',
+    });
+  });
+
+  it('should correctly calculate age for a 1 month old', () => {
+    const testDate = sub(new Date(), {
+      months: 1,
+      days: 1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '1 month old',
+    });
+  });
+
+  it('should correctly calculate age for a 10 day old', () => {
+    const testDate = sub(new Date(), {
+      days: 10,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '10 days old',
+    });
+  });
+
+  it('should correctly calculate age for a 1 day old', () => {
+    const testDate = sub(new Date(), {
+      days: 1,
+    });
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: '1 day old',
+    });
+  });
+
+  it('should correctly calculate age for a baby born today', () => {
+    const testDate = new Date();
+    const result = calculateAge(format(testDate, 'MM/dd/yyyy'));
+    expect(result).to.deep.equal({
+      age: 0,
+      dobStr: format(testDate, 'MMMM d, yyyy'),
+      labeledAge: 'Newborn',
+    });
   });
 });
 
@@ -26,7 +145,7 @@ describe('processDependents', () => {
     expect(result[0].dob).to.equal('');
     expect(result[0].ssn).to.equal('');
     expect(result[0].fullName).to.equal('');
-    expect(result[0].age).to.equal('');
+    expect(result[0].age).to.equal(0);
     expect(result[0].removalDate).to.equal('');
   });
 

--- a/src/applications/dependents/dependents-verification/tests/unit/helpers.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/helpers.unit.spec.jsx
@@ -4,7 +4,6 @@ import { sub, format } from 'date-fns';
 import { hasSession, calculateAge, processDependents } from '../../helpers';
 
 describe('hasSession', () => {
-  global.localStorage = localStorage;
   it('should return true if hasSession is set to true in localStorage', () => {
     localStorage.setItem('hasSession', 'true');
     expect(hasSession()).to.be.true;

--- a/src/applications/dependents/dependents-verification/tests/unit/util/util.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/util/util.unit.spec.jsx
@@ -65,15 +65,18 @@ describe('dependents/686c-674 util', () => {
       .resolves({ data: { attributes: { test: 123 } } });
     stubs.push(utils.ensureValidCSRFToken, apiStub);
 
-    window.dataLayer = [];
+    global.window.dataLayer = [];
     const fakeFormConfig = { trackingPrefix: 'test' };
     const fakeForm = {};
 
     const result = await utils.submit(fakeForm, fakeFormConfig);
 
     expect(result).to.deep.equal({ test: 123 });
-    expect(window.dataLayer.some(e => e.event === 'test-submission-successful'))
-      .to.be.true;
+    expect(
+      global.window.dataLayer.some(
+        e => e.event === 'test-submission-successful',
+      ),
+    ).to.be.true;
   });
 
   it('submit - CSRF failure retries then fails', async () => {
@@ -89,7 +92,7 @@ describe('dependents/686c-674 util', () => {
       .resolves({ data: { attributes: { foo: 'bar' } } });
     stubs.push(utils.ensureValidCSRFToken, apiStub);
 
-    window.dataLayer = [];
+    global.window.dataLayer = [];
     const fakeFormConfig = { trackingPrefix: 'again' };
     const fakeForm = {};
 

--- a/src/applications/dependents/dependents-verification/tests/unit/util/util.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/util/util.unit.spec.jsx
@@ -6,22 +6,25 @@ import * as helpers from 'platform/forms-system/src/js/helpers';
 import * as utils from '../../../util/index';
 
 describe('dependents/686c-674 util', () => {
-  let stubs = [];
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
 
   afterEach(() => {
-    stubs.forEach(stub => stub.restore && stub.restore());
-    stubs = [];
-    sinon.restore && sinon.restore();
+    if (sandbox) {
+      sandbox.restore();
+    }
   });
 
   it('should call transformForSubmit and return stringified payload', () => {
     const fakeFormConfig = { foo: 'bar' };
     const fakeForm = { baz: 'qux' };
     const fakeResult = { formData: 'transformed' };
-    const transformStub = sinon
+    const transformStub = sandbox
       .stub(helpers, 'transformForSubmit')
       .returns(fakeResult);
-    stubs.push(transformStub);
 
     const result = utils.transform(fakeFormConfig, fakeForm);
 
@@ -59,11 +62,11 @@ describe('dependents/686c-674 util', () => {
   //   });
 
   it('submit - successful request', async () => {
-    sinon.stub(utils, 'ensureValidCSRFToken').resolves();
-    const apiStub = sinon
+    sandbox.stub(utils, 'ensureValidCSRFToken').resolves();
+    // eslint-disable-next-line no-unused-vars
+    const apiStub = sandbox
       .stub(apiModule, 'apiRequest')
       .resolves({ data: { attributes: { test: 123 } } });
-    stubs.push(utils.ensureValidCSRFToken, apiStub);
 
     global.window.dataLayer = [];
     const fakeFormConfig = { trackingPrefix: 'test' };
@@ -80,17 +83,16 @@ describe('dependents/686c-674 util', () => {
   });
 
   it('submit - CSRF failure retries then fails', async () => {
-    sinon.stub(utils, 'ensureValidCSRFToken').resolves();
+    sandbox.stub(utils, 'ensureValidCSRFToken').resolves();
     const fakeResponse = {
       errors: [{ status: '403', detail: 'Invalid Authenticity Token' }],
     };
-    const apiStub = sinon.stub(apiModule, 'apiRequest');
+    const apiStub = sandbox.stub(apiModule, 'apiRequest');
     apiStub
       .onFirstCall()
       .rejects(fakeResponse)
       .onSecondCall()
       .resolves({ data: { attributes: { foo: 'bar' } } });
-    stubs.push(utils.ensureValidCSRFToken, apiStub);
 
     global.window.dataLayer = [];
     const fakeFormConfig = { trackingPrefix: 'again' };
@@ -102,12 +104,12 @@ describe('dependents/686c-674 util', () => {
   });
 
   it('submit - onFailure for 429 response', async () => {
-    sinon.stub(utils, 'ensureValidCSRFToken').resolves();
+    sandbox.stub(utils, 'ensureValidCSRFToken').resolves();
 
     const fakeResp = new Response(null, { status: 429 });
     fakeResp.headers.set('x-ratelimit-reset', '123');
-    const apiStub = sinon.stub(apiModule, 'apiRequest').rejects(fakeResp);
-    stubs.push(utils.ensureValidCSRFToken, apiStub);
+    // eslint-disable-next-line no-unused-vars
+    const apiStub = sandbox.stub(apiModule, 'apiRequest').rejects(fakeResp);
 
     const fakeFormConfig = { trackingPrefix: 'rate' };
     const fakeForm = {};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > The FE displays a calculated dependent age based on their date of birth. We are currently using a fallback to an empty string when age is a falsy value, so the pages are not displaying any age. This PR updates the displayed age to show the number of months if less than 12 months, or days if less than a month old. 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119871

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         |  |
| ------- | ------ | 
| Current implementation < 1 year old | <img width="500" alt="currently displays an empty age field if the child is less than 1 year old" src="https://github.com/user-attachments/assets/82f69cd0-3001-49a9-ac16-9106df83f5a1" /> |
| Current implementation (unchanged in update) | <img width="500" alt="dependent is 17 years old" src="https://github.com/user-attachments/assets/1f6662c5-67d5-4d2f-8829-c962065abd31" /> |
| Updated < 1 year old | <img width="500" alt="dependent is 7 months old" src="https://github.com/user-attachments/assets/356f807d-4900-4889-ac32-9e5907c0c0be" /> |
| Updated < 1 month old | <img width="500" alt="Dependent is 28 days old" src="https://github.com/user-attachments/assets/f1752313-cc7a-4be2-86ac-76bfea16555f" /> |
| Updated born same day | <img width="500" alt="dependent is born on the same day, age shown as 'newborn'" src="https://github.com/user-attachments/assets/348bcc79-6c88-4d56-bfbf-0cb67de922cb" /> |
| Future date (shouldn't be possible to enter) | <img width="500" alt="future date" src="https://github.com/user-attachments/assets/4b393b02-6fda-46e7-89c0-560ceaea890f" /> |

## What areas of the site does it impact?

Dependents Verification (Form 21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
