### PR TITLE
initial setup pass for enzyme annotations

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -112,8 +112,8 @@ jobs:
           check_title: 'App Isolation Annotations'
           input_json: './isolation-annotations.json'
       
-  annotate-e2e-tests:
-    name: Annotate e2e Tests
+  annotate-files:
+    name: Platform-elected file notations
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -176,6 +176,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           check_title: 'Flaky e2e Annotations'
           input_json: './flaky-dates-times-annotations.json'
+
+      - name: Annotate files that use Enzyme instead of RTL
+        run: node script/github-actions/annotate-enzyme.js
+        env:
+          CHANGED_FILES: ${{ steps.get-changed-apps.outputs.changed_files }}
 
       - name: Create e2e annotations file  
         if: ${{ env.ENZYME_ANNOTATIONS_JSON != '[]' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -177,6 +177,20 @@ jobs:
           check_title: 'Flaky e2e Annotations'
           input_json: './flaky-dates-times-annotations.json'
 
+      - name: Create e2e annotations file  
+        if: ${{ env.ENZYME_ANNOTATIONS_JSON != '[]' }}
+        run: |
+          echo "$ENZYME_ANNOTATIONS_JSON" > enzyme-annotations.json
+          cat enzyme-annotations.json
+        
+      - name: Annotate files that use Enzyme instead of RTL
+        if: ${{ env.ENZYME_ANNOTATIONS_JSON != '[]' }}
+        uses: ./.github/workflows/annotations
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check_title: 'Enzyme Annotations'
+          input_json: './enzyme-annotations.json'
+
   eslint-disable-check:
     name: ESLint Disable Check
     runs-on: ubuntu-latest

--- a/script/github-actions/annotate-enzyme.js
+++ b/script/github-actions/annotate-enzyme.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/* eslint-disable camelcase */
+
+const core = require('@actions/core');
+const fs = require('fs');
+const path = require('path');
+
+const files = process.argv[2] || 'src';
+
+const CHANGED_SET = new Set(
+  (process.env.CHANGED_FILES || '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(p => path.normalize(p)),
+);
+
+const enzymeUsage = [
+  'from "enzyme"',
+  "from 'enzyme'",
+  'require("enzyme")',
+  "require('enzyme')",
+  'enzyme-adapter-react',
+  '@wojtekmaj/enzyme-adapter',
+  'enzyme-to-json',
+];
+
+function getEnzymeFiles(dir) {
+  let results = [];
+  const list = fs.readdirSync(dir);
+
+  list.forEach(file => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat && stat.isDirectory()) {
+      if (file === 'node_modules' || file === '.git') return;
+      results = results.concat(getEnzymeFiles(filePath));
+    } else {
+      results.push(filePath);
+    }
+  });
+
+  return results;
+}
+
+function checkSpecsForEnzyme(file) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  const enzymeAnnotations = [];
+  lines.forEach((line, index) => {
+    if (enzymeUsage.some(usage => line.includes(usage))) {
+      enzymeAnnotations.push({
+        path: file,
+        start_line: index + 1,
+        end_line: index + 1,
+        annotation_level: 'warning',
+        message:
+          'Use of Enzyme found. Enzyme is no longer maintained. React Testing Library is supported by the Platform and compatible with the latest versions of React.',
+      });
+    }
+  });
+  return enzymeAnnotations;
+}
+
+console.log(
+  `Checking for tests using Enzyme, which is no longer maintained...`,
+);
+
+const enzymeFound = getEnzymeFiles(files);
+let collectedAnnotations = [];
+
+if (enzymeFound.length > 0) {
+  enzymeFound.forEach(file => {
+    const rel = path.normalize(file);
+    if (CHANGED_SET.has(rel)) {
+      const annotations = checkSpecsForEnzyme(file);
+      collectedAnnotations = collectedAnnotations.concat(annotations);
+    }
+  });
+}
+
+if (collectedAnnotations.length === 0) {
+  console.log('No Enzyme usage found in changed apps.');
+}
+
+core.exportVariable(
+  'ENZYME_ANNOTATIONS_JSON',
+  JSON.stringify(collectedAnnotations),
+);

--- a/src/applications/vaos/components/enzyme-canary.jsx
+++ b/src/applications/vaos/components/enzyme-canary.jsx
@@ -1,0 +1,4 @@
+// ci-canary: trigger Enzyme annotation
+// import { shallow } from 'enzyme'
+// const Enzyme = require('enzyme')
+export const noop = () => {};

--- a/src/applications/vaos/components/enzyme-canary.jsx
+++ b/src/applications/vaos/components/enzyme-canary.jsx
@@ -1,2 +1,0 @@
-// const Enzyme = require('enzyme')
-export const noop = () => {};

--- a/src/applications/vaos/components/enzyme-canary.jsx
+++ b/src/applications/vaos/components/enzyme-canary.jsx
@@ -1,4 +1,2 @@
-// ci-canary: trigger Enzyme annotation
-// import { shallow } from 'enzyme'
 // const Enzyme = require('enzyme')
 export const noop = () => {};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- As a member of the Platform SRE Team, I want to encourage the voluntary deprecation of Enzyme in VFS Team apps, so that testing quality can be improved in our test suites.
- The Enzyme tool is used to "shallow render" or "mount" a component and then manipulate it, but it is no longer maintained and doesn't fully support newer versions of React. The React Testing Library (RTL) performs the same functions as Enzyme but is preferred by Platform, is actively maintained, and fully supports the latest versions of React.
- VFS Teams should be using RTL to ensure a higher quality in their React apps.

## Related issue(s)

- _[Platform SRE Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/106850)_

## Testing done

- _Triggered annotations with dummy canary file in VAOS app._
<img width="1339" height="658" alt="image" src="https://github.com/user-attachments/assets/c4b3d81d-02af-41a8-8492-3a1d5f898ad8" />


## What areas of the site does it impact?

*This only affects CI annotations on the list of a PR's changed files*
