### PR TITLE
File input / Multiple file input patterns: show upload progress when skipUpload true

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFileInput.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFileInput.js
@@ -4,7 +4,6 @@ import {
   fileInputUI,
   fileInputSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 /** @type {PageSchema} */
 export default {
@@ -12,14 +11,11 @@ export default {
     wcv3FileInput: fileInputUI({
       title: 'Web component v3 file input',
       required: true,
-      fileUploadUrl: `${
-        environment.API_URL
-      }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
       accept: '.png,.pdf,.txt',
       hint: 'Upload a file that is less than 5MB',
       headerSize: '3',
       formNumber: '31-4159',
-      // skipUpload: true, // mock-forms does not have a backend for upload
+      skipUpload: true, // mock-forms does not have a backend for upload
       maxFileSize: 1024 * 1024 * 5,
       minFileSize: 1,
       errorMessages: {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFileInputMultiple.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFileInputMultiple.js
@@ -4,7 +4,6 @@ import {
   fileInputMultipleUI,
   fileInputMultipleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 /** @type {PageSchema} */
 export default {
@@ -12,15 +11,11 @@ export default {
     wcv3FileInputMultiple: fileInputMultipleUI({
       title: 'Web component v3 file input',
       required: true,
-      fileUploadUrl: `${
-        environment.API_URL
-      }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
-      accept: '.png,.pdf,.txt',
       hint: 'Upload a file that is between 1KB and 5MB',
       headerSize: '3',
       formNumber: '31-4159',
       // disallowEncryptedPdfs: true,
-      // skipUpload: true, // mock-forms does not have a backend for upload
+      skipUpload: true, // mock-forms does not have a backend for upload
       maxFileSize: 1024 * 1024 * 5,
       minFileSize: 1,
       errorMessages: {

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputMultipleField.jsx
@@ -14,6 +14,7 @@ import {
   useFileUpload,
   DEBOUNCE_WAIT,
   getFileError,
+  simulateUploadMultiple,
 } from './vaFileInputFieldHelpers';
 import vaFileInputFieldMapping from './vaFileInputFieldMapping';
 
@@ -186,10 +187,7 @@ const VaFileInputMultipleField = props => {
     if (!uploadedFile || !uploadedFile.file) return;
 
     const _errors = [...errors];
-    // if there is no back-end (e.g. mock-forms) don't set network errors that would prevent navigation
-    const _error = uiOptions.skipUpload
-      ? null
-      : uploadedFile.errorMessage || null;
+    const _error = uploadedFile.errorMessage || null;
     _errors[index] = _error;
     setErrors(_errors);
     assignFileUploadToStore(uploadedFile, index);
@@ -215,14 +213,26 @@ const VaFileInputMultipleField = props => {
     _encrypted[index] = encryptedCheck;
     setEncrypted(_encrypted);
 
+    // keep track of potential missisng password errors
+    errorManager.addPasswordInstance(index, encryptedCheck);
+
     // cypress test / skip the network call and its callbacks
     if (environment.isTest() && !environment.isUnitTest()) {
       childrenProps.onChange([mockFormData]);
       return;
     }
 
-    // keep track of potential missisng password errors
-    errorManager.addPasswordInstance(index, encryptedCheck);
+    // mock form has no back-end but we want to add files and simulate progress of upload
+    if (uiOptions.skipUpload && !encryptedCheck) {
+      simulateUploadMultiple(
+        setPercentsUploaded,
+        percentsUploaded,
+        index,
+        childrenProps,
+        file,
+      );
+      return;
+    }
 
     // this file not encrypted - upload right now
     if (!encryptedCheck) {
@@ -255,11 +265,19 @@ const VaFileInputMultipleField = props => {
       debounce(DEBOUNCE_WAIT, ({ file, password }, index) => {
         if (password && password.length > 0) {
           errorManager.resetInstance(index);
-          handleUpload(file, handleFileProcessing, password, index);
           const _encrypted = [...encrypted];
           _encrypted[index] = null;
-          // don't show password input after password entered
           setEncrypted(_encrypted);
+          // eslint-disable-next-line no-unused-expressions
+          uiOptions.skipUpload
+            ? simulateUploadMultiple(
+                setPercentsUploaded,
+                percentsUploaded,
+                index,
+                childrenProps,
+                file,
+              )
+            : handleUpload(file, handleFileProcessing, password, index);
         }
       }),
     [handleUpload],

--- a/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldHelpers.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaFileInputFieldHelpers.jsx
@@ -127,3 +127,68 @@ export async function getFileError(file, uiOptions) {
 }
 
 export const DEBOUNCE_WAIT = 500;
+
+// generate file data when no backend
+function getMockFileData(file) {
+  return {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+    confirmationCode: `mock-upload-${Date.now()}`,
+  };
+}
+
+const START_PERCENT = 10;
+const PERCENT_MAX_STEP = 20;
+const INTERVAL = 50;
+
+/**
+ * This function invoked for mock form on staging which lacks a back-end but where we would like to show the progress of uploads.
+ * @param {Function} setPercent - function to set percent uploaded value
+ * @param {Function} update - function that updates the form state
+ * @param {File} file - the file to be uploaded
+ */
+export function simulateUploadSingle(setPercent, update, file) {
+  let per = START_PERCENT;
+  const id = setInterval(() => {
+    setPercent(per);
+    if (per >= 100) {
+      update(getMockFileData(file));
+      setPercent(null);
+      clearInterval(id);
+    }
+    per += Math.random() * PERCENT_MAX_STEP;
+  }, INTERVAL);
+}
+
+/**
+ * This function invoked skipUpload is true. Simulates progress of upload.
+ * @param {Function} setPercentsUploaded - function to set array of percent uploaded value
+ * @param {Array<string>} percentsUploaded - array of percent uploaded values
+ * @param {number} index - index of the file
+ * @param {Object} childrenProps - props passed to field, including data and onchange function
+ * @param {File} file - the file to be uploaded
+ */
+export function simulateUploadMultiple(
+  setPercentsUploaded,
+  percentsUploaded,
+  index,
+  childrenProps,
+  file,
+) {
+  let per = START_PERCENT;
+  const id = setInterval(() => {
+    const _percents = [...percentsUploaded];
+    _percents[index] = per;
+    setPercentsUploaded(_percents);
+    if (per >= 100) {
+      const files = [...childrenProps.formData];
+      files[index] = getMockFileData(file);
+      childrenProps.onChange(files);
+      _percents[index] = null;
+      setPercentsUploaded(_percents);
+      clearInterval(id);
+    }
+    per += Math.random() * PERCENT_MAX_STEP;
+  }, INTERVAL);
+}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the fields behind single and multiple file input patterns so that when `skipUpload` is true a user can add a file or files and still see a progress upload indicator and have the file add to the form data.
Also updates the mock-form to use `skipUpload` so that no backend is needed to use the patterns.

## Related issue(s)

## Testing done

local testing

## Screenshots
Add a file when `skipUpload` is true in ui params:

https://github.com/user-attachments/assets/d56ea04e-88fe-48f2-bbdf-b5d7fe40aaff


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
