### PR TITLE
Update instantiation

### DIFF
--- a/src/applications/pensions/components/FormAlerts/index.jsx
+++ b/src/applications/pensions/components/FormAlerts/index.jsx
@@ -215,33 +215,6 @@ export const SpecialMonthlyPensionEvidenceAlert = () => (
   </RequestFormAlert>
 );
 
-export const TotalNetWorthOverThresholdAlert = ({ threshold = 25000 }) => (
-  <va-alert status="warning">
-    <p className="vads-u-margin-y--0">
-      You answered that you have more than ${threshold.toLocaleString()} in
-      assets. You’ll need to submit an Income and Asset Statement in Support of
-      Claim for Pension or Parents' Dependency and Indemnity Compensation (
-      <va-link
-        external
-        href="https://www.va.gov/find-forms/about-form-21-2680/"
-        text="VA Form 21P-0969"
-      />
-      ).
-    </p>
-    <p>
-      We’ll ask you to upload this form at the end of this application. Or you
-      can send it to us by mail.
-    </p>
-    <p>
-      <va-link
-        href="https://www.va.gov/find-forms/about-form-21p-0969/"
-        external
-        text="Get VA Form 21P-0969 to download"
-      />
-    </p>
-  </va-alert>
-);
-
 export const WartimeWarningAlert = () => (
   <va-alert status="warning">
     <p className="vads-u-margin-y--0">

--- a/src/applications/pensions/config/chapters/05-financial-information/netWorthEstimation.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/netWorthEstimation.js
@@ -1,12 +1,10 @@
+import React from 'react';
 import {
   currencyUI,
   currencySchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import {
-  AssetInformationAlert,
-  TotalNetWorthOverThresholdAlert,
-} from '../../../components/FormAlerts';
+import { AssetInformationAlert } from '../../../components/FormAlerts';
 import { showPdfFormAlignment } from '../../../helpers';
 
 const threshold = showPdfFormAlignment() ? 75000 : 25000;
@@ -36,7 +34,33 @@ export default {
     netWorthEstimation: currencyUI('Estimate the total value of your assets'),
 
     'view:warningAlertOnHighValue': {
-      'ui:description': TotalNetWorthOverThresholdAlert(threshold),
+      'ui:description': (
+        <va-alert status="warning">
+          <p className="vads-u-margin-y--0">
+            You answered that you have more than ${threshold.toLocaleString()}{' '}
+            in assets. You’ll need to submit an Income and Asset Statement in
+            Support of Claim for Pension or Parents' Dependency and Indemnity
+            Compensation (
+            <va-link
+              external
+              href="https://www.va.gov/find-forms/about-form-21-2680/"
+              text="VA Form 21P-0969"
+            />
+            ).
+          </p>
+          <p>
+            We’ll ask you to upload this form at the end of this application. Or
+            you can send it to us by mail.
+          </p>
+          <p>
+            <va-link
+              href="https://www.va.gov/find-forms/about-form-21p-0969/"
+              external
+              text="Get VA Form 21P-0969 to download"
+            />
+          </p>
+        </va-alert>
+      ),
       'ui:options': {
         hideIf: hideIfUnderThreshold,
       },


### PR DESCRIPTION
## Summary

This PR fixes the **net worth alert text** on the Pension Benefits form (VA Form 21P-527EZ) so that the correct threshold value is displayed when the `pensionPdfFormAlignment` feature toggle is enabled.  

Previously, the alert text was not reflecting the updated threshold of **$75,000** when the flipper was on, and continued to display **$25,000**. This update ensures the alert text is properly synced with the threshold logic introduced in the last PR.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118100

## Related issue(s)

- Follow-up to the PR that hooked the threshold logic to the `pensionPdfFormAlignment` toggle

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable/disable the feature toggle here:  
   `http://localhost:3000/flipper/features/pension_pdf_form_alignment`  
4. Navigate to the form:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
5. Go to the **Income and assets** section and review the conditional net worth alert on the `/financial/net-worth-estimation` page

## How to verify

1. **With the toggle OFF:** confirm the alert text displays **$25,000** as the threshold  
2. **With the toggle ON:** confirm the alert text displays **$75,000** as the threshold  
3. Confirm formatting (currency, commas) is correct and matches VA.gov standards  
4. Verify no console errors or regressions

## What areas of the site does it impact?

- Pension Benefits (21P-527EZ)  
- Income and assets → Net worth alert text

## Screenshots

| Toggle OFF | Toggle ON |
|------------|-----------|
| $25,000 displayed in alert | $75,000 displayed in alert |
|<img width="608" height="543" alt="Screenshot 2025-09-19 at 7 48 02 AM" src="https://github.com/user-attachments/assets/fbb13015-c253-4948-9fed-ad27de940e10" />|<img width="601" height="533" alt="Screenshot 2025-09-19 at 7 47 43 AM" src="https://github.com/user-attachments/assets/26eb6707-08d8-469c-806e-e642e2560889" />




### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) Please confirm the alert text now dynamically reflects the correct threshold value for both toggle states and no stale references to the old text remain.