### PR TITLE
Add safety checks to ChapterSectionCollection

### DIFF
--- a/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
+++ b/src/platform/forms-system/src/js/components/ConfirmationView/ChapterSectionCollection.jsx
@@ -114,7 +114,7 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState, index) => {
   } = uiSchema;
 
   const label =
-    uiSchema['ui:title'] ||
+    uiSchema?.['ui:title'] ||
     schemaFromState?.properties?.[key]?.title ||
     schema?.properties?.[key]?.title;
 
@@ -267,7 +267,7 @@ export const buildFields = (
 
     const fields = Object.entries(page.uiSchema).flatMap(
       ([uiSchemaKey, uiSchemaValue]) => {
-        const data = formData[uiSchemaKey];
+        const data = formData?.[uiSchemaKey];
         return fieldEntries(
           uiSchemaKey,
           uiSchemaValue,


### PR DESCRIPTION
Found an edge case where the confirmation view can throw an error if this check is not included.