### PR TITLE
118116 update props when using MessageActionButtons

### DIFF
--- a/src/applications/mhv-secure-messaging/components/MessageActionButtons.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageActionButtons.jsx
@@ -123,7 +123,7 @@ MessageActionButtons.propTypes = {
   messageId: PropTypes.number,
   setIsCreateNewModalVisible: PropTypes.func,
   showEditDraftButton: PropTypes.bool,
-  threadId: PropTypes.number,
+  threadId: PropTypes.number.isRequired,
 };
 
 export default MessageActionButtons;

--- a/src/applications/mhv-secure-messaging/components/MessageActionButtons.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageActionButtons.jsx
@@ -116,6 +116,7 @@ const MessageActionButtons = props => {
 };
 
 MessageActionButtons.propTypes = {
+  threadId: PropTypes.number.isRequired,
   handleEditDraftButton: PropTypes.func,
   hasMultipleDrafts: PropTypes.bool,
   hideReplyButton: PropTypes.bool,
@@ -123,7 +124,6 @@ MessageActionButtons.propTypes = {
   messageId: PropTypes.number,
   setIsCreateNewModalVisible: PropTypes.func,
   showEditDraftButton: PropTypes.bool,
-  threadId: PropTypes.number.isRequired,
 };
 
 export default MessageActionButtons;

--- a/src/applications/mhv-secure-messaging/containers/MessageReply.jsx
+++ b/src/applications/mhv-secure-messaging/containers/MessageReply.jsx
@@ -92,6 +92,7 @@ const MessageReply = () => {
         <MessageThread messageHistory={messages} />
         {customFoldersRedesignEnabled && (
           <MessageActionButtons
+            threadId={messages[0]?.threadId}
             message={messages[0]}
             cannotReply={false}
             isCreateNewModalVisible={isCreateNewModalVisible}

--- a/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
+++ b/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
@@ -156,6 +156,7 @@ const ThreadDetails = props => {
 
             {customFoldersRedesignEnabled && (
               <MessageActionButtons
+                threadId={threadId}
                 message={messages[0]}
                 cannotReply={cannotReply}
                 isCreateNewModalVisible={isCreateNewModalVisible}
@@ -195,6 +196,7 @@ const ThreadDetails = props => {
 
           {customFoldersRedesignEnabled && (
             <MessageActionButtons
+              threadId={threadId}
               message={messages[0]}
               cannotReply={cannotReply}
               isCreateNewModalVisible={isCreateNewModalVisible}

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -116,6 +116,24 @@ class PatientMessageDetailsPage {
       .click();
   };
 
+  openMoveToButtonModal = () => {
+    cy.get(Locators.BUTTONS.MOVE_BUTTON_TEXT).click();
+    cy.get(Locators.ALERTS.MOVE_MODAL, { timeout: 8000 })
+      .find('p')
+      .contains('Any replies to this message will appear in your inbox')
+      .should('be.visible');
+    cy.get(Locators.BUTTONS.DELETE_RADIOBTN).should('be.visible');
+    cy.get(Locators.BUTTONS.TEST2).should('be.visible');
+    cy.get(Locators.BUTTONS.TESTAGAIN)
+      .should('be.visible')
+      .click();
+    cy.get(Locators.BUTTONS.NEW_FOLDER_RADIOBTN).should('be.visible');
+    cy.get(Locators.ALERTS.MOVE_MODAL)
+      .find('va-button[text="Confirm"]')
+      .should('be.visible')
+      .click();
+  };
+
   loadReplyPage = mockMessageDetails => {
     cy.intercept(
       'GET',

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
@@ -3,6 +3,7 @@ import PatientInboxPage from './pages/PatientInboxPage';
 import PatientMessageDetailsPage from './pages/PatientMessageDetailsPage';
 import { AXE_CONTEXT } from './utils/constants';
 import threadResponse from './fixtures/thread-response-new-api.json';
+import GeneralFunctionsPage from './pages/GeneralFunctionsPage';
 
 describe('SM THREAD SINGLE MESSAGE DETAILED VIEW', () => {
   const date = new Date();
@@ -21,5 +22,50 @@ describe('SM THREAD SINGLE MESSAGE DETAILED VIEW', () => {
 
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
+  });
+
+  context('without Custom Folders Redesign', () => {
+    it('moves folders with ease', () => {
+      cy.intercept('**/v1/messaging/threads/7176615/move?folder_id=*', {
+        statusCode: 200,
+      }).as('mockMoveThread');
+
+      SecureMessagingSite.login();
+      PatientInboxPage.loadInboxMessages();
+      PatientMessageDetailsPage.loadSingleThread();
+
+      PatientMessageDetailsPage.openMoveToButtonModal();
+
+      cy.get('[data-testid="folder-header"]').should('be.visible');
+
+      cy.injectAxe();
+      cy.axeCheck(AXE_CONTEXT);
+    });
+  });
+
+  context('with Custom Folders Redesign', () => {
+    const updatedFeatureToggles = GeneralFunctionsPage.updateFeatureToggles([
+      {
+        name: 'mhv_secure_messaging_custom_folders_redesign',
+        value: true,
+      },
+    ]);
+
+    it('moves folders with ease', () => {
+      cy.intercept('**/v1/messaging/threads/2666253/move?folder_id=*', {
+        statusCode: 200,
+      }).as('mockMoveThread');
+
+      SecureMessagingSite.login(updatedFeatureToggles);
+      PatientInboxPage.loadInboxMessages();
+      PatientMessageDetailsPage.loadSingleThread();
+
+      PatientMessageDetailsPage.openMoveToButtonModal();
+
+      cy.get('[data-testid="folder-header"]').should('be.visible');
+
+      cy.injectAxe();
+      cy.axeCheck(AXE_CONTEXT);
+    });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-on-reply-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-on-reply-draft.cypress.spec.js
@@ -12,8 +12,14 @@ describe('SM DELETE REPLY DRAFT', () => {
   const updatedSingleThreadResponse = GeneralFunctionsPage.updatedThreadDates(
     singleThreadResponse,
   );
+  const updatedFeatureToggles = GeneralFunctionsPage.updateFeatureToggles([
+    {
+      name: 'mhv_secure_messaging_custom_folders_redesign',
+      value: false,
+    },
+  ]);
   it('verify user can delete draft on reply', () => {
-    SecureMessagingSite.login();
+    SecureMessagingSite.login(updatedFeatureToggles);
     PatientInboxPage.loadInboxMessages();
     PatientMessageDetailsPage.loadSingleThread(updatedSingleThreadResponse);
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Ensure that moving threads between folders does not fail
## Related issue(s)
[118116](https://github.com/department-of-veterans-affairs/va.gov-team/issues/118116)

## Testing done
e2e tests added

## What areas of the site does it impact?
Secure Messaging Application

## Acceptance criteria
Moving threads between folders does not fail