### PR TITLE
DV | Update confirmation page layout

### DIFF
--- a/src/applications/dependents/dependents-verification/containers/ConfirmationPage.jsx
+++ b/src/applications/dependents/dependents-verification/containers/ConfirmationPage.jsx
@@ -113,19 +113,21 @@ export const ConfirmationPage = props => {
             </h3>
             <ul className="vads-u-padding--0 remove-bullets">
               {dependents?.length > 0
-                ? dependents.map(dep => (
-                    <>
+                ? dependents.map((dep, index) => (
+                    <li key={index}>
                       <h4
                         className="dd-privacy-mask"
                         dd-action-name="dependent name"
                       >
                         {dep.fullName}
                       </h4>
-                      {showItem('Social Security number', maskID(dep.ssn))}
-                      {showItem('Date of birth', dep.dob)}
-                      {showItem('Age', `${dep.age} years old`)}
-                      {showItem('Relationship', dep.relationship)}
-                    </>
+                      <ul className="vads-u-padding--0 remove-bullets">
+                        {showItem('Social Security number', maskID(dep.ssn))}
+                        {showItem('Date of birth', dep.dob)}
+                        {showItem('Age', `${dep.age} years old`)}
+                        {showItem('Relationship', dep.relationship)}
+                      </ul>
+                    </li>
                   ))
                 : 'No dependents found.'}
             </ul>

--- a/src/applications/dependents/dependents-verification/containers/ConfirmationPage.jsx
+++ b/src/applications/dependents/dependents-verification/containers/ConfirmationPage.jsx
@@ -1,21 +1,35 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { format } from 'date-fns';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
 import { selectProfile } from 'platform/user/selectors';
 import { scrollToTop } from 'platform/utilities/scroll';
+import { formatDateParsedZoneLong } from 'platform/utilities/date/index';
 
-import { getFullName } from '../../shared/utils';
+import { maskID } from '../../shared/utils';
+import { DEPENDENT_CHOICES } from '../constants';
 
 export const ConfirmationPage = props => {
   const form = useSelector(state => state.form || {});
-  const { userFullName = {} } = useSelector(selectProfile);
+  const {
+    veteranInformation,
+    email,
+    phone,
+    address = {},
+    internationalPhone,
+    dependents,
+    hasDependentsStatusChanged,
+  } = form.data || {};
+  const { ssnLastFour } = veteranInformation || {};
+  const { dob, userFullName = {} } = useSelector(selectProfile);
   const submission = form?.submission || {};
   const submitDate = submission?.timestamp || Date.now();
   const confirmationNumber = submission?.response?.confirmationNumber || '';
+
+  const dobDate = dob ? formatDateParsedZoneLong(dob) : null;
+  const phoneSource = form.data?.['view:phoneSource'] || 'Mobile';
 
   useEffect(() => {
     scrollToTop();
@@ -39,6 +53,16 @@ export const ConfirmationPage = props => {
     </p>
   );
 
+  const showItem = (label, value) =>
+    value ? (
+      <li>
+        <div className="vads-u-color--gray">{label}</div>
+        <div className="dd-privacy-mask" dd-action-name={label}>
+          {value}
+        </div>
+      </li>
+    ) : null;
+
   return (
     <ConfirmationView
       formConfig={props.route?.formConfig}
@@ -47,34 +71,75 @@ export const ConfirmationPage = props => {
       pdfUrl={submission.response?.pdfUrl}
     >
       <ConfirmationView.SubmissionAlert content={alertContent} />
-      <va-summary-box>
-        <h3 slot="headline">Your submission information</h3>
-        <p>
-          <strong>Veteran’s name</strong>
-        </p>
-        <p className="dd-privacy-hidden" data-dd-action-name="Veteran's name">
-          {getFullName(userFullName)}
-        </p>
-        <p>
-          <strong>Date submitted</strong>
-        </p>
-        <p data-testid="dateSubmitted">{format(submitDate, 'MMMM d, yyyy')}</p>
-        {confirmationNumber && (
-          <>
-            <p>
-              <strong>Confirmation number</strong>
-            </p>
-            <p>{confirmationNumber}</p>
-          </>
-        )}
-        <va-button
-          text="Print this page for your records"
-          onClick={() => {
-            window.print();
-          }}
-        />
-      </va-summary-box>
-      <ConfirmationView.ChapterSectionCollection />
+      {submission.response?.pdfUrl && <ConfirmationView.SavePdfDownload />}
+
+      {/* <ConfirmationView.ChapterSectionCollection /> */}
+      <va-accordion bordered open-single>
+        <va-accordion-item
+          header="Information you submitted on this form"
+          bordered
+        >
+          <div>
+            <h3 className="vads-u-margin-top--0">Your personal information</h3>
+            <ul className="vads-u-padding--0 remove-bullets">
+              {showItem('First name', userFullName.first)}
+              {showItem('Middle name', userFullName.middle)}
+              {showItem('Last name', userFullName.last)}
+              {showItem('Social Security number', maskID(ssnLastFour))}
+              {showItem('Date of birth', dobDate)}
+            </ul>
+            <hr className="vads-u-border--1px vads-u-border-color--gray-light vads-u-margin-y--2" />
+            <h3 className="vads-u-margin-top--0">
+              Veteran’s contact information
+            </h3>
+            <ul className="vads-u-padding--0 remove-bullets">
+              {showItem('Country', address.country)}
+              {showItem('Street address', address.street)}
+              {showItem('Street address line 2', address.street2)}
+              {showItem('City', address.city)}
+              {showItem('State', address.state)}
+              {showItem('Postal code', address.postalCode)}
+              {showItem('Email address', email)}
+              {showItem(
+                `${phoneSource} phone number`,
+                <va-telephone contact={phone} not-clickable="true" />,
+              )}
+              {showItem('International number', internationalPhone)}
+            </ul>
+            <hr className="vads-u-border--1px vads-u-border-color--gray-light vads-u-margin-y--2" />
+
+            <h3 className="vads-u-margin-top--0">
+              Dependents on your VA benefits
+            </h3>
+            <ul className="vads-u-padding--0 remove-bullets">
+              {dependents?.length > 0
+                ? dependents.map(dep => (
+                    <>
+                      <h4
+                        className="dd-privacy-mask"
+                        dd-action-name="dependent name"
+                      >
+                        {dep.fullName}
+                      </h4>
+                      {showItem('Social Security number', maskID(dep.ssn))}
+                      {showItem('Date of birth', dep.dob)}
+                      {showItem('Age', `${dep.age} years old`)}
+                      {showItem('Relationship', dep.relationship)}
+                    </>
+                  ))
+                : 'No dependents found.'}
+            </ul>
+            <ul className="vads-u-padding--0 remove-bullets">
+              {showItem(
+                'Has the status of your dependents changed?',
+                DEPENDENT_CHOICES[hasDependentsStatusChanged],
+              )}
+            </ul>
+          </div>
+        </va-accordion-item>
+      </va-accordion>
+
+      <ConfirmationView.PrintThisPage />
       <ConfirmationView.WhatsNextProcessList item1Content={step1Content} />
       <ConfirmationView.HowToContact />
       <p>

--- a/src/applications/dependents/dependents-verification/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/dependents/dependents-verification/tests/e2e/fixtures/data/maximal-test.json
@@ -12,8 +12,8 @@
       "postalCode": "90210",
       "country": "USA"
     },
-    "internationalPhone": "63123456789",
-    "hasDependentsStatusChanged": "Y",
+
+    "hasDependentsStatusChanged": "N",
     "statementOfTruthSignature": "John Doe",
     "statementOfTruthCertified": true
   }

--- a/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/dependents/dependents-verification/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -66,9 +66,6 @@ describe('ConfirmationPage', () => {
     expect($('va-link-action', alert).getAttribute('text')).to.eq(
       'Check the status of your form on My VA',
     );
-    const summaryBox = $('va-summary-box', container);
-    expect(summaryBox).to.exist;
-    expect(summaryBox.textContent).to.include('John A. Doe, Jr.');
     expect($('va-accordion', container)).to.exist;
     expect($('va-process-list', container)).to.exist;
     expect($$('va-link-action', container)).to.have.lengthOf(2);
@@ -96,8 +93,6 @@ describe('ConfirmationPage', () => {
       'Your confirmation number is',
     );
 
-    const summaryBox = $('va-summary-box', container);
-    expect(summaryBox).to.exist;
-    expect(summaryBox.textContent).to.include('nameDate submitted');
+    expect($('va-accordion', container)).to.exist;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Default form data is displayed within an accordion on the confirmation page, but the formatted isn't what we were expecting. Switched to render custom content to match expectations. 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Lifestages / Dependents Management Team
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/117008

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| <img width="500" alt="before confirmation page showing a summary box with print page button inside" src="https://github.com/user-attachments/assets/0f127dc6-ccca-4e66-ac9a-e38ea9f23c39" /> | <img width="500" alt="after removed summary box and added print page button below form data" src="https://github.com/user-attachments/assets/d766a5d4-2a8f-4b75-8c6f-0a857e361f91" /> |

Additionally, heading levels and the addition of DataDog privacy classes were added:
<img width="500" alt="expanded form data accordion showing data dog highlights from the VA page checker browser extension" src="https://github.com/user-attachments/assets/bc4302fc-1cdb-407c-969a-544949c10e58" />

## What areas of the site does it impact?

Dependents Verification form (21-0538)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
