### PR TITLE
Add Datadog masking to array builder

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCancelButton.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCancelButton.jsx
@@ -136,6 +136,8 @@ const ArrayBuilderCancelButton = ({
       <VaModal
         clickToClose
         status="warning"
+        data-dd-privacy="mask"
+        data-dd-action-name="Cancel Modal"
         modalTitle={getText(
           isEdit ? 'cancelEditTitle' : 'cancelAddTitle',
           currentItem,
@@ -160,7 +162,12 @@ const ArrayBuilderCancelButton = ({
         visible={isModalVisible}
         uswds
       >
-        {getText(modalDescriptionKey, currentItem, formData, arrayIndex)}
+        <div
+          className="dd-privacy-mask"
+          data-dd-action-name="Cancel Confirmation"
+        >
+          {getText(modalDescriptionKey, currentItem, formData, arrayIndex)}
+        </div>
       </VaModal>
     </div>
   );

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
@@ -35,6 +35,8 @@ const EditLink = withRouter(({ to, srText, router }) => {
       text="Edit"
       onClick={handleRouteChange}
       data-action="edit"
+      data-dd-privacy="mask"
+      data-dd-action-name="Edit Link"
       label={srText}
     />
   );
@@ -45,6 +47,8 @@ const RemoveButton = ({ onClick, srText }) => (
     data-action="remove"
     button-type="delete"
     onClick={onClick}
+    data-dd-privacy="mask"
+    data-dd-action-name="Delete Button"
     label={srText}
   />
 );
@@ -207,7 +211,7 @@ const ArrayBuilderCards = ({
                       {isIncomplete(itemData) && <IncompleteLabel />}
                       <CardTitle
                         className={`vads-u-margin-top--0${cardHeadingStyling} dd-privacy-mask`}
-                        data-dd-action-name="Card title"
+                        data-dd-action-name="Item Name"
                       >
                         {itemName}
                       </CardTitle>
@@ -254,6 +258,8 @@ const ArrayBuilderCards = ({
       <VaModal
         clickToClose
         status="warning"
+        data-dd-privacy="mask"
+        data-dd-action-name="Delete Modal"
         modalTitle={getText('deleteTitle', currentItem, formData, currentIndex)}
         primaryButtonText={getText(
           'deleteYes',
@@ -281,14 +287,19 @@ const ArrayBuilderCards = ({
         visible={isModalVisible}
         uswds
       >
-        {required(formData) && arrayData?.length === 1
-          ? getText(
-              'deleteNeedAtLeastOneDescription',
-              currentItem,
-              formData,
-              currentIndex,
-            )
-          : getText('deleteDescription', currentItem, formData, currentIndex)}
+        <div
+          className="dd-privacy-mask"
+          data-dd-action-name="Delete Confirmation"
+        >
+          {required(formData) && arrayData?.length === 1
+            ? getText(
+                'deleteNeedAtLeastOneDescription',
+                currentItem,
+                formData,
+                currentIndex,
+              )
+            : getText('deleteDescription', currentItem, formData, currentIndex)}
+        </div>
       </VaModal>
     </div>
   );

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -36,7 +36,9 @@ const SuccessAlert = ({ nounSingular, index, onDismiss, text }) => (
       closeBtnAriaLabel="Close notification"
       uswds
     >
-      {text}
+      <div className="dd-privacy-mask" data-dd-action-name="Success Alert">
+        {text}
+      </div>
     </VaAlert>
   </div>
 );


### PR DESCRIPTION
## Summary

- Defensively add dd-masking classes to many array builder text JSX, since it contains item name.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4846

## Testing done

- No regressions on main
- TODO: Test on Datadog when available

## Screenshots

n/a until can test on datadog.

## What areas of the site does it impact?

only datadog environment
