### PR TITLE
Forms-system: validation not triggering with web components in array builder

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderItemPage.jsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
-import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import navigationState from 'platform/forms-system/src/js/utilities/navigation/navigationState';
 import { useEditOrAddForm } from './useEditOrAddForm';
@@ -110,13 +109,13 @@ export default function ArrayBuilderItemPage({
               {/* save-in-progress link, etc */}
               {props.pageContentBeforeButtons}
               {props.contentBeforeButtons}
+              {/** don't use webcomponents here until we resolve https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4716
+               * using web components the click handlers on underlying va-buttons don't run
+               */}
               <NavButtons
                 goBack={props.goBack}
                 goForward={props.onContinue}
                 submitToContinue
-                useWebComponents={
-                  props.formOptions?.useWebComponentForNavigation
-                }
               />
             </>
           )}
@@ -135,14 +134,20 @@ export default function ArrayBuilderItemPage({
                 />
               </div>
               <div>
-                <VaButton
-                  continue
+                {/** use button until we resolve https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4716
+                 * until then clicking on the va-button the onClick handler does not run
+                 */}
+                <button
+                  className="usa-button-primary vads-u-margin-top--0"
                   submit="prevent"
+                  onClick={() => navigationState.setNavigationEvent()}
                   // "Continue" will display instead of `text`
                   // prop until this is fixed:
                   // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2733
-                  text={getText('editSaveButtonText')}
-                />
+                  // text={getText('editSaveButtonText')}
+                >
+                  {getText('editSaveButtonText')}
+                </button>
               </div>
             </div>
           )}

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderFirstItemPage.unit.spec.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderFirstItemPage.unit.spec.jsx
@@ -172,7 +172,8 @@ describe('ArrayBuilderFirstItemPage', () => {
     ).to.exist;
   });
 
-  it('should display web component FormNav buttons', () => {
+  // unskip when we resolve https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4716
+  it.skip('should display web component FormNav buttons', () => {
     const { container, queryByText } = setupArrayBuilderItemPage({
       title: 'Single page employer',
       index: 0,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR addresses a [bug reported](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4837#top) in this ticket. The problem is that the click handlers that are part of the validation process were not being triggered because they were attached to web-components. This is related to an [existing bug](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4716). The temporary solution in this PR is not to use web components for the navigation buttons. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4837#top

## Testing done

local testing

## Screenshots


https://github.com/user-attachments/assets/c49b1b6c-a863-46db-83f2-2f3c31062aab



## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
