### PR TITLE
Log Defined Oracle Health site Unique User Metrics

### DIFF
--- a/src/platform/mhv/unique_user_metrics/eventRegistry.js
+++ b/src/platform/mhv/unique_user_metrics/eventRegistry.js
@@ -45,3 +45,31 @@ export const EVENT_REGISTRY = Object.freeze({
   // Appointments Events
   APPOINTMENTS_ACCESSED: 'mhv_appointments_accessed',
 });
+
+/**
+ * Site IDs that should have Oracle Health-specific event logging.
+ * Only facilities listed here will trigger additional site-specific events.
+ */
+export const ORACLE_HEALTH_TRACKED_SITES = Object.freeze({
+  // Site IDs that should trigger Oracle Health specific logging
+  COLUMBUS_OH: '757',
+  // Add more sites here as needed
+  // EXAMPLE_SITE: '123',
+});
+
+/**
+ * Events that should have Oracle Health site-specific logging.
+ * When any of these events are logged, if the user is registered at an Oracle Health site,
+ * we'll also log a site-specific version of the event.
+ */
+export const ORACLE_HEALTH_TRACKED_EVENTS = Object.freeze([
+  EVENT_REGISTRY.SECURE_MESSAGING_MESSAGE_SENT,
+  EVENT_REGISTRY.PRESCRIPTIONS_REFILL_REQUESTED,
+  EVENT_REGISTRY.APPOINTMENTS_ACCESSED,
+  EVENT_REGISTRY.MEDICAL_RECORDS_ALLERGIES_ACCESSED,
+  EVENT_REGISTRY.MEDICAL_RECORDS_VACCINES_ACCESSED,
+  EVENT_REGISTRY.MEDICAL_RECORDS_LABS_ACCESSED,
+  EVENT_REGISTRY.MEDICAL_RECORDS_NOTES_ACCESSED,
+  EVENT_REGISTRY.MEDICAL_RECORDS_VITALS_ACCESSED,
+  EVENT_REGISTRY.MEDICAL_RECORDS_CONDITIONS_ACCESSED,
+]);

--- a/src/platform/mhv/unique_user_metrics/index.js
+++ b/src/platform/mhv/unique_user_metrics/index.js
@@ -1,6 +1,31 @@
 import * as Sentry from '@sentry/browser';
-import { EVENT_REGISTRY } from './eventRegistry';
+import {
+  EVENT_REGISTRY,
+  ORACLE_HEALTH_TRACKED_SITES,
+  ORACLE_HEALTH_TRACKED_EVENTS,
+} from './eventRegistry';
 import { logUniqueUserMetrics } from './apiClient';
+
+/**
+ * Get the user's tracked Oracle Health facility IDs from the Redux store.
+ * This function safely accesses the user's profile facilities and filters
+ * to only those facilities that we're tracking events for.
+ *
+ * @returns {string[]} Array of facility IDs that are tracked Oracle Health sites
+ */
+const getUserTrackedOracleHealthFacilities = () => {
+  // Access the Redux store - this is available globally in the VA.gov app
+  const state = window.store?.getState?.();
+  const facilities = state?.user?.profile?.facilities || [];
+
+  // Get all Oracle Health tracked site IDs
+  const oracleHealthSiteIds = Object.values(ORACLE_HEALTH_TRACKED_SITES);
+
+  // Filter user's facilities to only Oracle Health sites
+  return facilities
+    .map(facility => facility.facilityId)
+    .filter(facilityId => oracleHealthSiteIds.includes(facilityId));
+};
 
 /**
  * Log unique user metrics events using event values from the registry.
@@ -48,9 +73,32 @@ export const logUniqueUserMetricsEvents = (...eventValues) => {
     return;
   }
 
-  // Make the fire-and-forget API call with the event names
-  logUniqueUserMetrics(eventValues);
+  // Get user's tracked Oracle Health facilities
+  const userOracleHealthFacilities = getUserTrackedOracleHealthFacilities();
+
+  // Create array to hold all events to log (original + site-specific)
+  const allEventsToLog = [...eventValues];
+
+  // If user has Oracle Health facilities, add site-specific events
+  if (userOracleHealthFacilities.length > 0) {
+    eventValues.forEach(eventValue => {
+      // Check if this event should have Oracle Health site-specific logging
+      if (ORACLE_HEALTH_TRACKED_EVENTS.includes(eventValue)) {
+        // Add site-specific events for each of the user's Oracle Health facilities
+        userOracleHealthFacilities.forEach(facilityId => {
+          allEventsToLog.push(`${eventValue}_oh_site_${facilityId}`);
+        });
+      }
+    });
+  }
+
+  // Make the fire-and-forget API call with all events (original + site-specific)
+  logUniqueUserMetrics(allEventsToLog);
 };
 
-// Re-export the EVENT_REGISTRY for convenience
-export { EVENT_REGISTRY } from './eventRegistry';
+// Re-export constants for convenience
+export {
+  EVENT_REGISTRY,
+  ORACLE_HEALTH_TRACKED_SITES,
+  ORACLE_HEALTH_TRACKED_EVENTS,
+} from './eventRegistry';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- It is important to note that we are logging events for users that are associated with the defined OH sites regardless if they are performing the operation on the specific site.
- Log defined Oracle Health site Unique User Metrics.
- Team: MHV Horizon

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/119996

## Testing done
- Added unit tests

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria
Log Defined Oracle Health site Unique User Metrics

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

