### PR TITLE
Update marriage history conditional logic

### DIFF
--- a/src/applications/pensions/components/MarriageCountReview.jsx
+++ b/src/applications/pensions/components/MarriageCountReview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isMarried } from '../config/chapters/04-household-information/helpers';
+import { hasMarriageHistory } from '../config/chapters/04-household-information/helpers';
 
 export const content = {
   label: 'How many times have you been married?',
@@ -11,7 +11,7 @@ export const content = {
 const MarriageCountReview = ({ data, editPage }) => {
   const { marriages = [] } = data;
 
-  return isMarried(data) ? (
+  return hasMarriageHistory(data) ? (
     <div className="form-review-panel-page vads-u-margin-bottom--7">
       <div className="form-review-panel-page-header-row">
         <h4 className="form-review-panel-page-header vads-u-font-size--h5 vads-u-margin--0">

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseFormerMarriages.jsx
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseFormerMarriages.jsx
@@ -23,7 +23,7 @@ import {
   validateAfterMarriageDates,
   validateUniqueMarriageDates,
 } from '../../../validation';
-import { currentSpouseHasFormerMarriages } from './helpers';
+import { currentSpouseHasFormerMarriages, requiresSpouseInfo } from './helpers';
 
 const { marriages } = fullSchemaPensions.definitions;
 
@@ -51,7 +51,8 @@ SpouseMarriageView.propTypes = {
 export default {
   title: 'Spouse’s former marriages',
   path: 'household/marital-status/spouse-marriages',
-  depends: currentSpouseHasFormerMarriages,
+  depends: formData =>
+    requiresSpouseInfo(formData) && currentSpouseHasFormerMarriages(formData),
   uiSchema: {
     ...titleUI(SpouseMarriageTitle),
     'view:contactWarning': {

--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseMaritalHistory.js
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseMaritalHistory.js
@@ -3,7 +3,7 @@ import {
   radioSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { isMarried } from './helpers';
+import { requiresSpouseInfo } from './helpers';
 
 const radioOptions = {
   YES: 'Yes',
@@ -15,7 +15,7 @@ const radioOptions = {
 export default {
   title: 'Current spouse marital history',
   path: 'household/marital-status/spouse-marital-history',
-  depends: isMarried,
+  depends: requiresSpouseInfo,
   uiSchema: {
     ...titleUI('Current spouse’s marital history'),
     currentSpouseMaritalHistory: radioUI({

--- a/src/applications/pensions/config/chapters/04-household-information/marriageHistory.js
+++ b/src/applications/pensions/config/chapters/04-household-information/marriageHistory.js
@@ -14,7 +14,7 @@ import {
   getMarriageTitleWithCurrent,
   MarriageTitle,
   isCurrentMarriage,
-  isMarried,
+  hasMarriageHistory,
 } from './helpers';
 
 const dateSchema = {
@@ -27,7 +27,7 @@ export default {
   title: (form, { pagePerItemIndex } = { pagePerItemIndex: 0 }) =>
     getMarriageTitleWithCurrent(form, pagePerItemIndex),
   path: 'household/marriages/:index',
-  depends: isMarried,
+  depends: hasMarriageHistory,
   showPagePerItem: true,
   arrayPath: 'marriages',
   uiSchema: {

--- a/src/applications/pensions/config/chapters/04-household-information/marriageInfo.js
+++ b/src/applications/pensions/config/chapters/04-household-information/marriageInfo.js
@@ -1,4 +1,4 @@
-import { isMarried } from './helpers';
+import { hasMarriageHistory } from './helpers';
 import { marriages } from '../../definitions';
 import MarriageCount from '../../../components/MarriageCount';
 import MarriageCountReview from '../../../components/MarriageCountReview';
@@ -6,7 +6,7 @@ import MarriageCountReview from '../../../components/MarriageCountReview';
 export default {
   title: 'Marriage history',
   path: 'household/marriage-info',
-  depends: isMarried,
+  depends: hasMarriageHistory,
   CustomPage: MarriageCount,
   CustomPageReview: MarriageCountReview,
   uiSchema: {},

--- a/src/applications/pensions/config/chapters/04-household-information/spouseInfo.js
+++ b/src/applications/pensions/config/chapters/04-household-information/spouseInfo.js
@@ -11,7 +11,7 @@ import {
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
-import { createSpouseLabelSelector, isMarried } from './helpers';
+import { createSpouseLabelSelector, requiresSpouseInfo } from './helpers';
 import createHouseholdMemberTitle from '../../../components/DisclosureTitle';
 
 const { spouseIsVeteran } = fullSchemaPensions.properties;
@@ -20,7 +20,7 @@ const { spouseIsVeteran } = fullSchemaPensions.properties;
 export default {
   title: 'Spouse information',
   path: 'household/spouse-info',
-  depends: isMarried,
+  depends: requiresSpouseInfo,
   uiSchema: {
     ...titleUI(createHouseholdMemberTitle('spouseFullName', 'information')),
     spouseDateOfBirth: merge({}, dateOfBirthUI(), {

--- a/src/applications/pensions/structure.json
+++ b/src/applications/pensions/structure.json
@@ -118,16 +118,16 @@
       {
         "title": "Marriage history",
         "path": "household/marriage-info",
-        "depends": "isMarried"
+        "depends": "hasMarriageHistory"
       },
       {
         "path": "household/marriages/:index",
-        "depends": "isMarried"
+        "depends": "hasMarriageHistory"
       },
       {
         "title": "Spouse information",
         "path": "household/spouse-info",
-        "depends": "isMarried"
+        "depends": "hasMarriageHistory"
       },
       {
         "title": "Reason for separation",
@@ -147,7 +147,7 @@
       {
         "title": "Current spouse marital history",
         "path": "household/marital-status/spouse-marital-history",
-        "depends": "isMarried"
+        "depends": "hasMarriageHistory"
       },
       {
         "title": "Spouse’s former marriages",

--- a/src/applications/pensions/tests/unit/helpers.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/helpers.unit.spec.jsx
@@ -9,7 +9,7 @@ import { formatCurrency, isHomeAcreageMoreThanTwo } from '../../helpers';
 import * as helpers from '../../helpers';
 import {
   getMarriageTitleWithCurrent,
-  isMarried,
+  hasMarriageHistory,
 } from '../../config/chapters/04-household-information/helpers';
 import { replacer, submit } from '../../config/submit';
 
@@ -138,8 +138,30 @@ describe('Pensions helpers', () => {
       };
       expect(getMarriageTitleWithCurrent(form, 1)).to.equal('Current marriage');
     });
+    it('should return current marriage title', () => {
+      const form = {
+        maritalStatus: 'SEPARATED',
+        marriages: [{}, {}],
+      };
+      expect(getMarriageTitleWithCurrent(form, 1)).to.equal('Current marriage');
+    });
+    it('should NOT return current marriage title', () => {
+      const form = {
+        maritalStatus: 'WIDOWED',
+        marriages: [{}, {}],
+      };
+      expect(getMarriageTitleWithCurrent(form, 1)).to.equal('Second marriage');
+    });
+    it('should NOT return current marriage title', () => {
+      const form = {
+        maritalStatus: 'DIVORCED',
+        marriages: [{}, {}],
+      };
+      expect(getMarriageTitleWithCurrent(form, 1)).to.equal('Second marriage');
+    });
   });
-  describe('isMarried', () => {
+
+  describe('hasMarriageHistory', () => {
     let showPdfFormAlignmentStub;
 
     beforeEach(() => {
@@ -157,22 +179,23 @@ describe('Pensions helpers', () => {
         showPdfFormAlignmentStub.returns(false);
       });
       it('should return false for no data', () => {
-        expect(isMarried()).to.be.false;
+        expect(hasMarriageHistory()).to.be.false;
       });
       it('should return true when maritalStatus is MARRIED', () => {
-        expect(isMarried({ maritalStatus: 'MARRIED' })).to.be.true;
+        expect(hasMarriageHistory({ maritalStatus: 'MARRIED' })).to.be.true;
       });
       it('should return false when maritalStatus is WIDOWED', () => {
-        expect(isMarried({ maritalStatus: 'WIDOWED' })).to.be.false;
+        expect(hasMarriageHistory({ maritalStatus: 'WIDOWED' })).to.be.false;
       });
       it('should return false when maritalStatus is DIVORCED', () => {
-        expect(isMarried({ maritalStatus: 'DIVORCED' })).to.be.false;
+        expect(hasMarriageHistory({ maritalStatus: 'DIVORCED' })).to.be.false;
       });
       it('should return true when maritalStatus is SEPARATED', () => {
-        expect(isMarried({ maritalStatus: 'SEPARATED' })).to.be.true;
+        expect(hasMarriageHistory({ maritalStatus: 'SEPARATED' })).to.be.true;
       });
       it('should return false when maritalStatus is NEVER_MARRIED', () => {
-        expect(isMarried({ maritalStatus: 'NEVER_MARRIED' })).to.be.false;
+        expect(hasMarriageHistory({ maritalStatus: 'NEVER_MARRIED' })).to.be
+          .false;
       });
     });
 
@@ -181,22 +204,23 @@ describe('Pensions helpers', () => {
         showPdfFormAlignmentStub.returns(true);
       });
       it('should return false for no data', () => {
-        expect(isMarried()).to.be.false;
+        expect(hasMarriageHistory()).to.be.false;
       });
       it('should return true when maritalStatus is MARRIED', () => {
-        expect(isMarried({ maritalStatus: 'MARRIED' })).to.be.true;
+        expect(hasMarriageHistory({ maritalStatus: 'MARRIED' })).to.be.true;
       });
       it('should return true when maritalStatus is WIDOWED', () => {
-        expect(isMarried({ maritalStatus: 'WIDOWED' })).to.be.true;
+        expect(hasMarriageHistory({ maritalStatus: 'WIDOWED' })).to.be.true;
       });
       it('should return true when maritalStatus is DIVORCED', () => {
-        expect(isMarried({ maritalStatus: 'DIVORCED' })).to.be.true;
+        expect(hasMarriageHistory({ maritalStatus: 'DIVORCED' })).to.be.true;
       });
       it('should return true when maritalStatus is SEPARATED', () => {
-        expect(isMarried({ maritalStatus: 'SEPARATED' })).to.be.true;
+        expect(hasMarriageHistory({ maritalStatus: 'SEPARATED' })).to.be.true;
       });
       it('should return false when maritalStatus is NEVER_MARRIED', () => {
-        expect(isMarried({ maritalStatus: 'NEVER_MARRIED' })).to.be.false;
+        expect(hasMarriageHistory({ maritalStatus: 'NEVER_MARRIED' })).to.be
+          .false;
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR updates the **marriage history conditional logic** in the Pension Benefits form (VA Form 21P-527EZ).  
- Replaced `isMarried` usage with the new `hasMarriageHistory` helper to determine when marriage history should be collected.  
- Added `requiresSpouseInfo` helper to centralize logic for when spouse information is required.  
- Updated `marriageTitle` logic in the helpers file to reflect the new conditions.  

These changes are gated behind the **`showPdfFormAlignment`** feature toggle to align with ongoing PDF-to-digital parity work.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118115

## Related issue(s)

- Continuation of logic cleanup around marital status and prior marriages

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/show_pdf_form_alignment`  
4. Navigate to the Pension Benefits form:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
5. Progress through the marital status section

## How to verify

1. With **`showPdfFormAlignment`** enabled:  
   - **MARRIED / SEPARATED / WIDOWED / DIVORCED** → Marriage history flow should appear (via `hasMarriageHistory`).  
   - **MARRIED / SEPARATED** → Spouse info required (via `requiresSpouseInfo`).  
   - **NEVER MARRIED** → No marriage history or spouse info required.  
   - Verify `marriageTitle` displays correct context-sensitive titles.  

2. With **`showPdfFormAlignment`** disabled:  
   - Confirm legacy behavior still applies (marriage history only for MARRIED / SEPARATED).  

3. Confirm Review & Submit includes the correct information for each path.  
4. Validate no console errors and that form submission works as expected.  

## What areas of the site does it impact?

- Pension Benefits (21P-527EZ)  
- Helpers file (marital status, spouse info, and marriage titles)  
- Marriage history and spouse information flows

## Screenshots

_N/A — logic-only update_

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) Please confirm the updated logic behind **`showPdfFormAlignment`** correctly applies to each marital status and that `hasMarriageHistory`, `requiresSpouseInfo`, and `marriageTitle` are functioning consistently across the application.