### PR TITLE
e2e test selection logic alongside triggering typo change to arrayBui…

### DIFF
--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -59,16 +59,15 @@ function selectTests(pathsOfChangedFiles) {
       // Custom logic needed to ensure that changes to the array builder inside the
       // platform directory trigger the e2e specs that live in the simple forms app
       
-      const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
-      
-      if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
-        const neededSimpleFormsPattern = path.join(
-          __dirname,
-          '../..',
-          'src/applications/simple-forms/mock-simple-forms-patterns',
-          '**/tests/**/*.cypress.spec.js?(x)',
-        );
-        tests.push(...glob.sync(neededSimpleFormsPattern));
+        const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
+        if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
+          const neededSimpleFormsPattern = path.join(
+            __dirname,
+            '../..',
+            'src/applications/simple-forms/mock-simple-forms-patterns',
+            '**/tests/**/*.cypress.spec.js?(x)',
+          );
+          tests.push(...glob.sync(neededSimpleFormsPattern));
       }
 
       if (IS_CHANGED_APPS_BUILD) {

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -59,15 +59,15 @@ function selectTests(pathsOfChangedFiles) {
       // Custom logic needed to ensure that changes to the array builder inside the
       // platform directory trigger the e2e specs that live in the simple forms app
       
-        const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
-        if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
-          const neededSimpleFormsPattern = path.join(
-            __dirname,
-            '../..',
-            'src/applications/simple-forms/mock-simple-forms-patterns',
-            '**/tests/**/*.cypress.spec.js?(x)',
-          );
-          tests.push(...glob.sync(neededSimpleFormsPattern));
+      const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
+      if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
+        const neededSimpleFormsPattern = path.join(
+          __dirname,
+          '../..',
+          'src/applications/simple-forms/mock-simple-forms-patterns',
+          '**/tests/**/*.cypress.spec.js?(x)',
+        );
+        tests.push(...glob.sync(neededSimpleFormsPattern));
       }
 
       if (IS_CHANGED_APPS_BUILD) {

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -59,7 +59,8 @@ function selectTests(pathsOfChangedFiles) {
       // Custom logic needed to ensure that changes to the array builder inside the
       // platform directory trigger the e2e specs that live in the simple forms app
       
-      const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
+      const ARRAY_BUILDER = 
+        'src/platform/forms-system/src/js/patterns/array-builder';
       if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
         const neededSimpleFormsPattern = path.join(
           __dirname,

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -26,6 +26,10 @@ const ALLOW_LIST =
       )
     : [];
 
+// Custom logic needed to ensure that changes to the array builder inside the
+// platform directory trigger the e2e specs that live in the simple forms app
+const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
+
 function allTests() {
   const pattern = path.join(__dirname, '../..', specPattern);
   return glob.sync(pattern);
@@ -55,6 +59,19 @@ function selectTests(pathsOfChangedFiles) {
 
         tests.push(...glob.sync(selectedTestsPattern));
       });
+
+      // Custom logic needed to ensure that changes to the array builder inside the
+      // platform directory trigger the e2e specs that live in the simple forms app
+      const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
+      if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
+        const neededSimpleFormsPattern = path.join(
+          __dirname,
+          '../..',
+          'src/applications/simple-forms/mock-simple-forms-patterns',
+          '**/tests/**/*.cypress.spec.js?(x)',
+        );
+        tests.push(...glob.sync(neededSimpleFormsPattern));
+      }
 
       if (IS_CHANGED_APPS_BUILD) {
         const megaMenuTestPath = path.join(

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -58,6 +58,7 @@ function selectTests(pathsOfChangedFiles) {
 
       // Custom logic needed to ensure that changes to the array builder inside the
       // platform directory trigger the e2e specs that live in the simple forms app
+      
       const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
       if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
         const neededSimpleFormsPattern = path.join(

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -56,10 +56,11 @@ function selectTests(pathsOfChangedFiles) {
         tests.push(...glob.sync(selectedTestsPattern));
       });
 
-    // Custom logic needed to ensure that changes to the array builder inside the
-    // platform directory trigger the e2e specs that live in the simple forms app
-
+      // Custom logic needed to ensure that changes to the array builder inside the
+      // platform directory trigger the e2e specs that live in the simple forms app
+      
       const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
+      
       if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
         const neededSimpleFormsPattern = path.join(
           __dirname,

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -58,8 +58,7 @@ function selectTests(pathsOfChangedFiles) {
 
       // Custom logic needed to ensure that changes to the array builder inside the
       // platform directory trigger the e2e specs that live in the simple forms app
-      
-      const ARRAY_BUILDER = 
+      const ARRAY_BUILDER =
         'src/platform/forms-system/src/js/patterns/array-builder';
       if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
         const neededSimpleFormsPattern = path.join(

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -56,9 +56,9 @@ function selectTests(pathsOfChangedFiles) {
         tests.push(...glob.sync(selectedTestsPattern));
       });
 
-      // Custom logic needed to ensure that changes to the array builder inside the
-      // platform directory trigger the e2e specs that live in the simple forms app
-      
+    // Custom logic needed to ensure that changes to the array builder inside the
+    // platform directory trigger the e2e specs that live in the simple forms app
+
       const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
       if (filteredChangedFiles.some(p => p.includes(ARRAY_BUILDER))) {
         const neededSimpleFormsPattern = path.join(

--- a/script/github-actions/select-e2e-tests.js
+++ b/script/github-actions/select-e2e-tests.js
@@ -26,10 +26,6 @@ const ALLOW_LIST =
       )
     : [];
 
-// Custom logic needed to ensure that changes to the array builder inside the
-// platform directory trigger the e2e specs that live in the simple forms app
-const ARRAY_BUILDER = 'src/platform/forms-system/src/js/patterns/array-builder';
-
 function allTests() {
   const pattern = path.join(__dirname, '../..', specPattern);
   return glob.sync(pattern);

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -37,7 +37,7 @@ import { DEFAULT_ARRAY_BUILDER_TEXT } from './arrayBuilderText';
 
 function throwErrorPage(pageType, option) {
   throw new Error(
-    `arrayBuilderPages \`pageBuilder.${pageType}()\` must include \`${option}\` property like this: ` +
+    `arrayBuilderPagess \`pageBuilder.${pageType}()\` must include \`${option}\` property like this: ` +
       `\`...arrayBuilderPages(options, pageBuilder => ({ examplePage: pageBuilder.${pageType}({ ${option}: ... }) }))\``,
   );
 }

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -37,7 +37,7 @@ import { DEFAULT_ARRAY_BUILDER_TEXT } from './arrayBuilderText';
 
 function throwErrorPage(pageType, option) {
   throw new Error(
-    `arrayBuilderPagess \`pageBuilder.${pageType}()\` must include \`${option}\` property like this: ` +
+    `arrayBuilderPages \`pageBuilder.${pageType}()\` must include \`${option}\` property like this: ` +
       `\`...arrayBuilderPages(options, pageBuilder => ({ examplePage: pageBuilder.${pageType}({ ${option}: ... }) }))\``,
   );
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _As a platform engineer, I want to ensure that all required Cypress test specs are being run when changes are made to apps, even if the required specs do not live in the same directory as the app code.  It had been reported to the front-end Community of Practice (CoP) that there is a gap in e2e test selection. Changes made to the forms library's array build needs to trigger the e2e specs stored in applications/simple-forms/mock-simple-forms-patterns to ensure the coding quality of any such changes._

## Related issue(s)

- [Platform SRE Team ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/118787)

## Testing done

- _The test selection changes were triggered successfully with a dummy change to the arrayBuilder.jsx file itself.  The results can be found in the Run Cypress Tests step of this [CI job](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/17957213186/job/51072707020)._

