### PR TITLE
Update net worth estimation alert text

### DIFF
--- a/src/applications/pensions/config/chapters/05-financial-information/netWorthEstimation.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/netWorthEstimation.js
@@ -37,16 +37,10 @@ export default {
       'ui:description': (
         <va-alert status="warning">
           <p className="vads-u-margin-y--0">
-            You answered that you have more than ${threshold.toLocaleString()}{' '}
-            in assets. You’ll need to submit an Income and Asset Statement in
-            Support of Claim for Pension or Parents' Dependency and Indemnity
-            Compensation (
-            <va-link
-              external
-              href="https://www.va.gov/find-forms/about-form-21-2680/"
-              text="VA Form 21P-0969"
-            />
-            ).
+            Because you have more than ${threshold.toLocaleString()} in assets,
+            you’ll need to submit an Income and Asset Statement in Support of
+            Claim for Pension or Parents' Dependency and Indemnity Compensation
+            (VA Form 21P-0969).
           </p>
           <p>
             We’ll ask you to upload this form at the end of this application. Or

--- a/src/applications/pensions/tests/e2e/pensions-net-worth-estimation.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensions-net-worth-estimation.cypress.spec.js
@@ -41,7 +41,7 @@ describe('Pensions net worth asset alert', () => {
       // check warning exists
       cy.get('va-alert[status="warning"]').should(
         'contain.text',
-        'You answered that you have more than $25,000 in assets.',
+        'Because you have more than $25,000 in assets',
       );
       cy.injectAxe();
       cy.axeCheck();


### PR DESCRIPTION
## Summary

This PR updates the **Net worth estimation alert text** in the **Pension Benefits form (VA Form 21P-527EZ)** based on Design QA feedback. The text has been refined for clarity, consistency, and alignment with VA plain language standards.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118100

## Related issue(s)

- Follows prior work on threshold alignment for net worth alert logic

## Related comment(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118100#issuecomment-3312642686

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Navigate to the Pension Benefits form:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
4. Go to the **Income and assets** section to view the updated net worth estimation alert

## How to verify

1. Confirm the **Net worth estimation alert** displays updated content per Design QA feedback  
2. Ensure the threshold value logic (25,000 vs 75,000) continues to respect the `pensionPdfFormAlignment` toggle  
3. Validate that the alert renders consistently across desktop and mobile  
4. Verify no console errors or accessibility regressions (screen reader, focus order, heading hierarchy)  

## What areas of the site does it impact?

- Pension Benefits (21P-527EZ)  
- Income and assets → Net worth estimation alert

## Screenshots
| Previous alert text | Updated alert text per Design QA |
|--------|-------|
|<img width="568" height="620" alt="Screenshot 2025-09-23 at 2 17 19 PM" src="https://github.com/user-attachments/assets/c18046ca-2954-4033-bcc9-19d8beaa3ead" />|<img width="578" height="591" alt="Screenshot 2025-09-23 at 2 18 18 PM" src="https://github.com/user-attachments/assets/059cb459-aa29-4b2e-8674-d5eede133233" />



### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) Please confirm the updated alert text aligns with Design QA expectations and that threshold logic continues to display correctly when the `pensionPdfFormAlignment` toggle is enabled/disabled.