### PR TITLE
fixed flaky test with cy.wait

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -47,11 +47,15 @@ class PatientMessageDetailsPage {
   };
 
   expandAllThreadMessages = () => {
-    cy.findByTestId(Locators.ALERTS.THREAD_EXPAND).should('be.visible');
     cy.findByTestId(Locators.ALERTS.THREAD_EXPAND)
+      .should('be.visible')
       .shadow()
       .find('button')
       .click({ force: true });
+
+    // Wait for accordion state to stabilize after button click - fix flakiness
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500);
   };
 
   verifyMessageDetails = messageDetails => {
@@ -244,18 +248,16 @@ class PatientMessageDetailsPage {
   };
 
   verifyExpandedThreadBody = (messageThread, messageIndex = 0) => {
-    cy.get(
-      `[data-testid="expand-message-button-${
-        messageThread.data[messageIndex].id
-      }"]`,
-    )
-      .find(
-        `[data-testid="message-body-${messageThread.data[messageIndex].id}"]`,
-      )
-      .should(
+    cy.findByTestId(
+      `expand-message-button-${messageThread.data[messageIndex].id}`,
+    ).within(() => {
+      cy.findByTestId(
+        `message-body-${messageThread.data[messageIndex].id}`,
+      ).should(
         'have.text',
         `${messageThread.data[messageIndex].attributes.body}`,
       );
+    });
   };
 
   replyToMessageTo = (messageDetails, messageIndex = 0) => {
@@ -389,6 +391,7 @@ class PatientMessageDetailsPage {
   verifyAccordionStatus = value => {
     cy.findByTestId(Locators.BUTTONS.THREAD_EXPAND)
       .find(`va-accordion-item`)
+      .should('have.length.greaterThan', 0)
       .each(el => {
         cy.wrap(el)
           .invoke(`prop`, 'open')

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
@@ -4,8 +4,7 @@ import threadResponse from './fixtures/thread-response-new-api.json';
 import PatientMessageDetailsPage from './pages/PatientMessageDetailsPage';
 import { AXE_CONTEXT } from './utils/constants';
 
-// Skipping until flaky test fixed
-describe.skip('SM EXPAND ALL ACCORDIONS', () => {
+describe('SM EXPAND ALL ACCORDIONS', () => {
   const date = new Date();
   threadResponse.data[0].attributes.sentDate = date.toISOString();
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
@@ -26,7 +26,6 @@ describe('SM EXPAND ALL ACCORDIONS', () => {
 
     PatientMessageDetailsPage.verifyAccordionStatus(true);
 
-    cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT);
+    cy.injectAxeThenAxeCheck(AXE_CONTEXT);
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

The test at src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js is flaky. This means that it fails in an unpredictable way, sometimes passing sometimes failing.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[](https://github.com/department-of-veterans-affairs/va.gov-team/issues/117471)

## Testing done

- _Describe what the old behavior was prior to the change_
  - Prior to the change, the test would fail unpredictably at least 1/10 times.
  
- _Describe the steps required to verify your changes are working as expected_
  - I looped the test to run 20+ times, enabling me to identify exactly when and how the test was failing consistently. This ultimately revealed a timing issue /race condition in which `expandAllThreadMessages` was not finishing before `verifyAccordionStatus` ran for the first time. 
  - Test now passes consistently on loop. 


## What areas of the site does it impact?
This impacted the Secure Messaging Team

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

