### PR TITLE
1010d standalone | Fix spelling of dependent

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/migrations.js
+++ b/src/applications/ivc-champva/10-10D/config/migrations.js
@@ -122,7 +122,7 @@ export const migrateCardUploadKeys = ({ formData, metadata, _formId }) => {
  *
  * Since much of the form's conditional flow depends on this property, this
  * migration just blows away the prior setting so that the user is directed to
- * choose a valid option and then correct any dependant pages down the line.
+ * choose a valid option and then correct any dependent pages down the line.
  *
  * @param {{formData: object, metadata: object, formId: string}} param0 - Object containing form data/metadata
  * @param {object} param0.formData - current formData from SIP interface

--- a/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
@@ -24,7 +24,7 @@ const IntroductionPage = props => {
       />
 
       <p>
-        If you’re the spouse, dependant, or survivor of a Veteran or service
+        If you’re the spouse, dependent, or survivor of a Veteran or service
         member who meets certain requirements, you may qualify for health
         insurance through the Civilian Health and Medical Program of the
         Department of Veterans Affairs (CHAMPVA).


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR performs a minor spelling update for the word dependent to utilize the US spelling and not the UK spelling.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118216

## Screenshots

| Before | After |
| ------ | ----- |
| | |

## Acceptance criteria

 - App contains no spelling issues

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user