### PR TITLE
DR 119989: Onramp fix: add horizontal rule lines

### DIFF
--- a/src/applications/appeals/onramp/constants/results-content/non-dr-screens/index.js
+++ b/src/applications/appeals/onramp/constants/results-content/non-dr-screens/index.js
@@ -77,6 +77,7 @@ export const NON_DR_RESULTS_CONTENT = formResponses =>
           {DISABILITY_COMP_CARD(
             `This may be a good fit because you haven’t filed a claim yet.`,
           )}
+          {HORIZ_RULE}
           {PRINT_OR_RESTART}
         </>
       ),
@@ -104,6 +105,7 @@ export const NON_DR_RESULTS_CONTENT = formResponses =>
             text="Check status in Claim Status Tool"
           />
           {DIVIDED_BENES}
+          {HORIZ_RULE}
           {PRINT_OR_RESTART}
         </>
       ),
@@ -139,6 +141,7 @@ export const NON_DR_RESULTS_CONTENT = formResponses =>
             href="/family-and-caregiver-benefits/survivor-compensation/dependency-indemnity-compensation"
             text="Learn how to apply for survivor and dependent compensation"
           />
+          {HORIZ_RULE}
           {PRINT_OR_RESTART}
         </>
       ),
@@ -165,6 +168,7 @@ export const NON_DR_RESULTS_CONTENT = formResponses =>
             disability compensation.
           </p>
           {CLAIM_FOR_INCREASE_CARD()}
+          {HORIZ_RULE}
           {PRINT_OR_RESTART}
         </>
       ),

--- a/src/applications/appeals/onramp/utilities/dr-results-card-display-utils.jsx
+++ b/src/applications/appeals/onramp/utilities/dr-results-card-display-utils.jsx
@@ -90,6 +90,7 @@ export const getCardProps = formResponses => {
       <>
         {INTRO}
         <OverviewPanel formResponses={formResponses} />
+        {HORIZ_RULE}
         {PRINT_RESULTS}
         {isCFI && (
           <>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add horizontal rule lines where they were missing: above the "Print your results" section on many results screens.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119989

## Testing done & screenshots

Verified that all "print" sections had the horizontal rule above them. All DR summary screens were affected, but they share the same code so I'll show one example here:

### 2.S.1A ([master DR summary screen](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=976-39721&t=FpFZGLryRQByoqaX-0))

<img width="280" alt="2_S_1_A" src="https://github.com/user-attachments/assets/c8eb4cad-c10e-45ea-a358-dee94c570b33" />

Fixes for non-DR screens are below!

### 2.IS.3 ([Figma](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=345-16555&t=FpFZGLryRQByoqaX-0))

| Dev build | Figma |
| --- | --- |
| <img width="280" alt="2_IS_3" src="https://github.com/user-attachments/assets/cf0b2ea8-cd50-4c05-8bdf-e64f7a3c8eb7" /> | <img width="280" alt="Screenshot 2025-09-24 at 12 04 54 PM" src="https://github.com/user-attachments/assets/69812d63-a4bc-4483-8876-03a3f18b1441" /> |

### 1.3B ([Figma](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=319-15166&t=FpFZGLryRQByoqaX-0))

| Dev build | Figma |
| --- | --- |
| <img width="280" alt="1_3B" src="https://github.com/user-attachments/assets/7685af66-8200-443a-9520-17469a2fca1b" /> | <img width="280" alt="Screenshot 2025-09-24 at 12 06 52 PM" src="https://github.com/user-attachments/assets/918920ad-98d3-4f45-a4c4-ac411ef98d28" /> |

### 1.1B ([Figma](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=370-14346&t=FpFZGLryRQByoqaX-0))

| Dev build | Figma |
| --- | --- |
| <img width="280" alt="1_1B" src="https://github.com/user-attachments/assets/0005d40f-a9b7-4e17-b580-cf1b6c716a49" /> | <img width="280" alt="Screenshot 2025-09-24 at 12 07 41 PM" src="https://github.com/user-attachments/assets/9afecb82-f41a-4a10-8a29-c4c7a8dbce03" /> |

### 1.1.C ([Figma](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=319-15394&t=FpFZGLryRQByoqaX-0))

| Dev build | Figma |
| --- | --- |
| <img width="280" alt="1_1C" src="https://github.com/user-attachments/assets/a99be2f8-3d5a-4db9-adcf-219e23e85f85" /> | <img width="280" alt="Screenshot 2025-09-24 at 12 08 36 PM" src="https://github.com/user-attachments/assets/418d367d-f564-4057-984e-fc6e1f093292" /> |