### PR TITLE
Add routes for results page

### DIFF
--- a/src/applications/appeals/onramp/components/Breadcrumbs.jsx
+++ b/src/applications/appeals/onramp/components/Breadcrumbs.jsx
@@ -28,14 +28,21 @@ export const defaultBreadcrumbs = [
 export const makeBreadcrumbs = (h1ForRoute, resultPage, route) => {
   const breadcrumbs = [...defaultBreadcrumbs];
 
-  if (route !== ROUTES.INTRODUCTION && route !== ROUTES.RESULTS && h1ForRoute) {
+  if (
+    route !== ROUTES.INTRODUCTION &&
+    ![ROUTES.RESULTS_NON_DR, ROUTES.RESULTS_DR].includes(route) &&
+    h1ForRoute
+  ) {
     breadcrumbs.push({
       href: '#',
       label: h1ForRoute,
     });
   }
 
-  if (route === ROUTES.RESULTS && resultPage) {
+  if (
+    [ROUTES.RESULTS_NON_DR, ROUTES.RESULTS_DR].includes(route) &&
+    resultPage
+  ) {
     const isNonDrResults = isNonDR.includes(resultPage);
 
     breadcrumbs.push({

--- a/src/applications/appeals/onramp/components/Breadcrumbs.jsx
+++ b/src/applications/appeals/onramp/components/Breadcrumbs.jsx
@@ -27,10 +27,11 @@ export const defaultBreadcrumbs = [
 
 export const makeBreadcrumbs = (h1ForRoute, resultPage, route) => {
   const breadcrumbs = [...defaultBreadcrumbs];
+  const resultsRoutes = [ROUTES.RESULTS_NON_DR, ROUTES.RESULTS_DR];
 
   if (
     route !== ROUTES.INTRODUCTION &&
-    ![ROUTES.RESULTS_NON_DR, ROUTES.RESULTS_DR].includes(route) &&
+    !resultsRoutes.includes(route) &&
     h1ForRoute
   ) {
     breadcrumbs.push({
@@ -39,10 +40,7 @@ export const makeBreadcrumbs = (h1ForRoute, resultPage, route) => {
     });
   }
 
-  if (
-    [ROUTES.RESULTS_NON_DR, ROUTES.RESULTS_DR].includes(route) &&
-    resultPage
-  ) {
+  if (resultsRoutes.includes(route) && resultPage) {
     const isNonDrResults = isNonDR.includes(resultPage);
 
     breadcrumbs.push({

--- a/src/applications/appeals/onramp/constants/index.js
+++ b/src/applications/appeals/onramp/constants/index.js
@@ -1,5 +1,6 @@
 import { QUESTION_CONTENT, SHORT_NAME_MAP as S } from './question-data-map';
 import { RESULTS_NAME_MAP } from './results-data-map';
+import { NON_DR_HEADING, DR_HEADING } from './results-content/common';
 
 /**
  * We want the URL for each question to match the H1
@@ -10,49 +11,99 @@ import { RESULTS_NAME_MAP } from './results-data-map';
  * the index to differentiate the URLs to avoid routing collision
  * @returns a lowercased hyphen-separated version of the h1 with an index if isDuplicateQuestion
  */
-export const getRouteName = (shortName, index) => {
-  const questionH1 = QUESTION_CONTENT?.[shortName]?.h1;
+export const convertH1ToRoute = h1Text => {
+  if (!h1Text) return '';
 
-  if (!questionH1) {
-    return '';
-  }
-
-  const baseUrl = questionH1
+  return h1Text
     .toLowerCase()
     .replace(/[^a-zA-Z -]/g, '')
     .replace(/ /g, '-');
+};
+
+/**
+ * Generate route name for questions based on H1 content
+ * @param {string} shortName - question SHORT_NAME (e.g. Q_1_1_CLAIM_DECISION)
+ * @param {string|number} index - for questions that are mapped to multiple SHORT_NAMEs
+ * @returns {string} - URL-friendly route name with index if provided
+ */
+export const getQuestionRouteName = (shortName, index) => {
+  const questionH1 = QUESTION_CONTENT?.[shortName]?.h1;
+  const baseUrl = convertH1ToRoute(questionH1);
 
   if (!index) return baseUrl;
-
   return `${baseUrl}-${index}`;
+};
+
+/**
+ * Generate route name for results pages based on result type
+ * @param {string} resultType - 'NON_DR' or 'DR'
+ * @returns {string} - URL-friendly route name
+ */
+export const getResultsRouteName = resultType => {
+  if (resultType === 'NON_DR') {
+    return convertH1ToRoute(NON_DR_HEADING);
+  }
+
+  if (resultType === 'DR') {
+    return convertH1ToRoute(DR_HEADING);
+  }
+
+  return '';
 };
 
 // Except for INTRODUCTION and results pages, left side must match
 // short name codes in constants/question-data-map
 export const ROUTES = Object.freeze({
-  INTRODUCTION: 'introduction',
-  Q_1_1_CLAIM_DECISION: getRouteName(S.Q_1_1_CLAIM_DECISION),
-  Q_1_1A_SUBMITTED_526: getRouteName(S.Q_1_1A_SUBMITTED_526),
-  Q_1_2_CLAIM_DECISION: getRouteName(S.Q_1_2_CLAIM_DECISION),
-  Q_1_2A_1_SERVICE_CONNECTED: getRouteName(S.Q_1_2A_1_SERVICE_CONNECTED, 'a'),
-  Q_1_2A_CONDITION_WORSENED: getRouteName(S.Q_1_2A_CONDITION_WORSENED, 'a'),
-  Q_1_2A_2_DISAGREE_DECISION: getRouteName(S.Q_1_2A_2_DISAGREE_DECISION, 'a'),
-  Q_1_2B_LAW_POLICY_CHANGE: getRouteName(S.Q_1_2B_LAW_POLICY_CHANGE, 'a'),
-  Q_1_2C_NEW_EVIDENCE: getRouteName(S.Q_1_2C_NEW_EVIDENCE, 'a'),
-  Q_1_3_CLAIM_CONTESTED: getRouteName(S.Q_1_3_CLAIM_CONTESTED),
-  Q_1_3A_FEWER_60_DAYS: getRouteName(S.Q_1_3A_FEWER_60_DAYS),
-  Q_2_IS_1_SERVICE_CONNECTED: getRouteName(S.Q_2_IS_1_SERVICE_CONNECTED, 'b'),
-  Q_2_IS_2_CONDITION_WORSENED: getRouteName(S.Q_2_IS_2_CONDITION_WORSENED, 'b'),
-  Q_2_IS_4_DISAGREE_DECISION: getRouteName(S.Q_2_IS_4_DISAGREE_DECISION, 'b'),
-  Q_2_0_CLAIM_TYPE: getRouteName(S.Q_2_0_CLAIM_TYPE),
-  Q_2_IS_1A_LAW_POLICY_CHANGE: getRouteName(S.Q_2_IS_1A_LAW_POLICY_CHANGE, 'b'),
-  Q_2_IS_1B_NEW_EVIDENCE: getRouteName(S.Q_2_IS_1B_NEW_EVIDENCE, 'b'),
-  Q_2_S_1_NEW_EVIDENCE: getRouteName(S.Q_2_S_1_NEW_EVIDENCE, 'c'),
-  Q_2_S_2_WITHIN_120_DAYS: getRouteName(S.Q_2_S_2_WITHIN_120_DAYS),
-  Q_2_H_2_NEW_EVIDENCE: getRouteName(S.Q_2_H_2_NEW_EVIDENCE, 'd'),
-  Q_2_H_2A_JUDGE_HEARING: getRouteName(S.Q_2_H_2A_JUDGE_HEARING, 'a'),
-  Q_2_H_2B_JUDGE_HEARING: getRouteName(S.Q_2_H_2B_JUDGE_HEARING, 'b'),
-  RESULTS: 'results',
+  INTRODUCTION: ' ',
+  Q_1_1_CLAIM_DECISION: getQuestionRouteName(S.Q_1_1_CLAIM_DECISION),
+  Q_1_1A_SUBMITTED_526: getQuestionRouteName(S.Q_1_1A_SUBMITTED_526),
+  Q_1_2_CLAIM_DECISION: getQuestionRouteName(S.Q_1_2_CLAIM_DECISION),
+  Q_1_2A_1_SERVICE_CONNECTED: getQuestionRouteName(
+    S.Q_1_2A_1_SERVICE_CONNECTED,
+    'a',
+  ),
+  Q_1_2A_CONDITION_WORSENED: getQuestionRouteName(
+    S.Q_1_2A_CONDITION_WORSENED,
+    'a',
+  ),
+  Q_1_2A_2_DISAGREE_DECISION: getQuestionRouteName(
+    S.Q_1_2A_2_DISAGREE_DECISION,
+    'a',
+  ),
+  Q_1_2B_LAW_POLICY_CHANGE: getQuestionRouteName(
+    S.Q_1_2B_LAW_POLICY_CHANGE,
+    'a',
+  ),
+  Q_1_2C_NEW_EVIDENCE: getQuestionRouteName(S.Q_1_2C_NEW_EVIDENCE, 'a'),
+  Q_1_3_CLAIM_CONTESTED: getQuestionRouteName(S.Q_1_3_CLAIM_CONTESTED),
+  Q_1_3A_FEWER_60_DAYS: getQuestionRouteName(S.Q_1_3A_FEWER_60_DAYS),
+  Q_2_IS_1_SERVICE_CONNECTED: getQuestionRouteName(
+    S.Q_2_IS_1_SERVICE_CONNECTED,
+    'b',
+  ),
+  Q_2_IS_2_CONDITION_WORSENED: getQuestionRouteName(
+    S.Q_2_IS_2_CONDITION_WORSENED,
+    'b',
+  ),
+  Q_2_IS_4_DISAGREE_DECISION: getQuestionRouteName(
+    S.Q_2_IS_4_DISAGREE_DECISION,
+    'b',
+  ),
+  Q_2_0_CLAIM_TYPE: getQuestionRouteName(S.Q_2_0_CLAIM_TYPE),
+  Q_2_IS_1A_LAW_POLICY_CHANGE: getQuestionRouteName(
+    S.Q_2_IS_1A_LAW_POLICY_CHANGE,
+    'b',
+  ),
+  Q_2_IS_1B_NEW_EVIDENCE: getQuestionRouteName(S.Q_2_IS_1B_NEW_EVIDENCE, 'b'),
+  Q_2_S_1_NEW_EVIDENCE: getQuestionRouteName(S.Q_2_S_1_NEW_EVIDENCE, 'c'),
+  Q_2_S_2_WITHIN_120_DAYS: getQuestionRouteName(S.Q_2_S_2_WITHIN_120_DAYS),
+  Q_2_H_2_NEW_EVIDENCE: getQuestionRouteName(S.Q_2_H_2_NEW_EVIDENCE, 'd'),
+  Q_2_H_2A_JUDGE_HEARING: getQuestionRouteName(S.Q_2_H_2A_JUDGE_HEARING, 'a'),
+  Q_2_H_2B_JUDGE_HEARING: getQuestionRouteName(S.Q_2_H_2B_JUDGE_HEARING, 'b'),
+
+  // Use dedicated function for results routes for better readability
+  RESULTS_NON_DR: getResultsRouteName('NON_DR'),
+  RESULTS_DR: getResultsRouteName('DR'),
 });
 
 export const ALL_QUESTIONS = Object.freeze(Object.values(S));

--- a/src/applications/appeals/onramp/constants/index.js
+++ b/src/applications/appeals/onramp/constants/index.js
@@ -100,8 +100,6 @@ export const ROUTES = Object.freeze({
   Q_2_H_2_NEW_EVIDENCE: getQuestionRouteName(S.Q_2_H_2_NEW_EVIDENCE, 'd'),
   Q_2_H_2A_JUDGE_HEARING: getQuestionRouteName(S.Q_2_H_2A_JUDGE_HEARING, 'a'),
   Q_2_H_2B_JUDGE_HEARING: getQuestionRouteName(S.Q_2_H_2B_JUDGE_HEARING, 'b'),
-
-  // Use dedicated function for results routes for better readability
   RESULTS_NON_DR: getResultsRouteName('NON_DR'),
   RESULTS_DR: getResultsRouteName('DR'),
 });

--- a/src/applications/appeals/onramp/routes.jsx
+++ b/src/applications/appeals/onramp/routes.jsx
@@ -34,7 +34,8 @@ const routes = {
     { path: ROUTES.Q_2_H_2_NEW_EVIDENCE, component: QuestionTemplate },
     { path: ROUTES.Q_2_H_2A_JUDGE_HEARING, component: QuestionTemplate },
     { path: ROUTES.Q_2_H_2B_JUDGE_HEARING, component: QuestionTemplate },
-    { path: ROUTES.RESULTS, component: ResultsTemplate },
+    { path: ROUTES.RESULTS_NON_DR, component: ResultsTemplate },
+    { path: ROUTES.RESULTS_DR, component: ResultsTemplate },
   ],
 };
 

--- a/src/applications/appeals/onramp/tests/components/Breadcrumbs.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/components/Breadcrumbs.unit.spec.jsx
@@ -7,12 +7,13 @@ import {
   DR_HEADING,
   NON_DR_HEADING,
 } from '../../constants/results-content/common';
+import { ROUTES } from '../../constants';
 
 describe('makeBreadcrumbs', () => {
   describe('introduction page', () => {
     it('should return the three basic breadcrumbs', () => {
       expect(
-        makeBreadcrumbs('Introduction', null, 'introduction'),
+        makeBreadcrumbs('Introduction', null, ROUTES.INTRODUCTION),
       ).to.deep.equal([...defaultBreadcrumbs]);
     });
   });
@@ -33,7 +34,9 @@ describe('makeBreadcrumbs', () => {
 
   describe('DR results page', () => {
     it('should return the three basic breadcrumbs plus a trailing breadcrumb for DR results pages', () => {
-      expect(makeBreadcrumbs('', 'RESULTS_2_3_S', 'results')).to.deep.equal([
+      expect(
+        makeBreadcrumbs('', 'RESULTS_2_3_S', ROUTES.RESULTS_DR),
+      ).to.deep.equal([
         ...defaultBreadcrumbs,
         { href: '#', label: DR_HEADING },
       ]);
@@ -42,7 +45,9 @@ describe('makeBreadcrumbs', () => {
 
   describe('Non-DR results page', () => {
     it('should return the three basic breadcrumbs plus a trailing breadcrumb for non-DR results pages', () => {
-      expect(makeBreadcrumbs('', 'RESULTS_1_1B', 'results')).to.deep.equal([
+      expect(
+        makeBreadcrumbs('', 'RESULTS_1_1B', ROUTES.RESULTS_NON_DR),
+      ).to.deep.equal([
         ...defaultBreadcrumbs,
         { href: '#', label: NON_DR_HEADING },
       ]);

--- a/src/applications/appeals/onramp/tests/components/Breadcrumbs.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/components/Breadcrumbs.unit.spec.jsx
@@ -11,9 +11,15 @@ import { ROUTES } from '../../constants';
 
 describe('makeBreadcrumbs', () => {
   describe('introduction page', () => {
-    it('should return the three basic breadcrumbs', () => {
+    it('should return only the three basic breadcrumbs for introduction page', () => {
+      expect(makeBreadcrumbs('', null, ROUTES.INTRODUCTION)).to.deep.equal([
+        ...defaultBreadcrumbs,
+      ]);
+    });
+
+    it('should return only basic breadcrumbs even when H1 is provided for introduction', () => {
       expect(
-        makeBreadcrumbs('Introduction', null, ROUTES.INTRODUCTION),
+        makeBreadcrumbs('Some H1 Text', null, ROUTES.INTRODUCTION),
       ).to.deep.equal([...defaultBreadcrumbs]);
     });
   });

--- a/src/applications/appeals/onramp/tests/constants/index.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/constants/index.unit.spec.jsx
@@ -1,20 +1,38 @@
 import { expect } from 'chai';
-import { getRouteName } from '../../constants';
+import { getQuestionRouteName, getResultsRouteName } from '../../constants';
 
 describe('constants utilities', () => {
-  describe('getRouteName: ', () => {
+  describe('getQuestionRouteName: ', () => {
     it('should properly format a route with only a short name', () => {
-      expect(getRouteName('Q_1_1_CLAIM_DECISION')).to.equal('decision-status');
+      expect(getQuestionRouteName('Q_1_1_CLAIM_DECISION')).to.equal(
+        'decision-status',
+      );
     });
 
     it('should properly format a route with a short name and an index', () => {
-      expect(getRouteName('Q_1_1_CLAIM_DECISION', 'a')).to.equal(
+      expect(getQuestionRouteName('Q_1_1_CLAIM_DECISION', 'a')).to.equal(
         'decision-status-a',
       );
     });
 
     it('should return an empty string when it cannot find the H1', () => {
-      expect(getRouteName('SOME_QUESTION')).to.equal('');
+      expect(getQuestionRouteName('SOME_QUESTION')).to.equal('');
+    });
+  });
+
+  describe('getResultsRouteName: ', () => {
+    it('should return converted route for NON_DR result type', () => {
+      const result = getResultsRouteName('NON_DR');
+
+      expect(result).to.not.equal('');
+      expect(result).to.equal('your-available-options');
+    });
+
+    it('should return converted route for DR result type', () => {
+      const result = getResultsRouteName('DR');
+
+      expect(result).to.not.equal('');
+      expect(result).to.equal('your-decision-review-options');
     });
   });
 });

--- a/src/applications/appeals/onramp/tests/constants/index.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/constants/index.unit.spec.jsx
@@ -22,17 +22,13 @@ describe('constants utilities', () => {
 
   describe('getResultsRouteName: ', () => {
     it('should return converted route for NON_DR result type', () => {
-      const result = getResultsRouteName('NON_DR');
-
-      expect(result).to.not.equal('');
-      expect(result).to.equal('your-available-options');
+      expect(getResultsRouteName('NON_DR')).to.equal('your-available-options');
     });
 
     it('should return converted route for DR result type', () => {
-      const result = getResultsRouteName('DR');
-
-      expect(result).to.not.equal('');
-      expect(result).to.equal('your-decision-review-options');
+      expect(getResultsRouteName('DR')).to.equal(
+        'your-decision-review-options',
+      );
     });
   });
 });

--- a/src/applications/appeals/onramp/tests/cypress/deep-linking.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/deep-linking.cypress.spec.js
@@ -14,7 +14,7 @@ describe('Decision Reviews Onramp', () => {
     });
 
     it('redirects to introduction when the results page is loaded without the right criteria', () => {
-      cy.visit(`${h.ROOT}/${ROUTES.RESULTS}`);
+      cy.visit(`${h.ROOT}/${ROUTES.RESULTS_DR}`);
 
       h.verifyUrl(ROUTES.INTRODUCTION);
 

--- a/src/applications/appeals/onramp/tests/cypress/helpers.js
+++ b/src/applications/appeals/onramp/tests/cypress/helpers.js
@@ -14,7 +14,16 @@ export const clickStart = () =>
     .should('be.visible')
     .click();
 
-export const verifyUrl = link => cy.url().should('contain', `${ROOT}/${link}`);
+export const verifyUrl = link => {
+  if (link === ' ') {
+    // For introduction with space, just verify we're at the root path
+    // The space doesn't actually appear in the URL for the root route
+    cy.url().should('contain', `${ROOT}/`);
+  } else {
+    // Handle normal routes
+    cy.url().should('contain', `${ROOT}/${link}`);
+  }
+};
 
 export const verifyElement = selector =>
   cy.findByTestId(selector).should('exist');

--- a/src/applications/appeals/onramp/tests/cypress/helpers.js
+++ b/src/applications/appeals/onramp/tests/cypress/helpers.js
@@ -18,7 +18,7 @@ export const verifyUrl = link => {
   if (link === ' ') {
     // For introduction with space, just verify we're at the root path
     // The space doesn't actually appear in the URL for the root route
-    cy.url().should('contain', `${ROOT}/`);
+    cy.url().should('contain', ROOT);
   } else {
     // Handle normal routes
     cy.url().should('contain', `${ROOT}/${link}`);

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-1.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_2);
       h.checkOverviewPanel([c.TITLE_BOARD_DIRECT]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-2.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_2);
       h.checkOverviewPanel([c.TITLE_BOARD_DIRECT]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-3.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_2);
       h.checkOverviewPanel([c.TITLE_BOARD_DIRECT]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-cfi.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-direct/path-cfi.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_2B);
       h.checkOverviewPanel([c.TITLE_BOARD_DIRECT], true);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-1.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2A_1);
       h.checkOverviewPanel([c.TITLE_SC, c.TITLE_BOARD_EVIDENCE]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-2.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2A_1);
       h.checkOverviewPanel([c.TITLE_BOARD_EVIDENCE]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-3.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2A_1);
       h.checkOverviewPanel([c.TITLE_SC, c.TITLE_BOARD_EVIDENCE]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-cfi.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-evidence/path-cfi.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2A_2);
       h.checkOverviewPanel([c.TITLE_SC, c.TITLE_BOARD_EVIDENCE], true);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-1.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_1);
       h.checkOverviewPanel([c.TITLE_BOARD_HEARING]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-2.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_1);
       h.checkOverviewPanel([c.TITLE_BOARD_HEARING]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-3.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_1);
       h.checkOverviewPanel([c.TITLE_BOARD_HEARING]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-cfi.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-board-hearing/path-cfi.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_H_2B_1A);
       h.checkOverviewPanel([c.TITLE_BOARD_HEARING], true);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-1.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_IS_1C);
       h.checkOverviewPanel([
         c.TITLE_HLR,

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-2.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_IS_1C);
       h.checkOverviewPanel([
         c.TITLE_HLR,

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-3.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_IS_1C);
       h.checkOverviewPanel([
         c.TITLE_HLR,

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-cfi-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-cfi-1.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_IS_1D);
       h.checkOverviewPanel(
         [c.TITLE_HLR, c.TITLE_BOARD_DIRECT, c.TITLE_BOARD_HEARING],

--- a/src/applications/appeals/onramp/tests/cypress/results-hlr/path-cfi-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-hlr/path-cfi-2.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_IS_1D);
       h.checkOverviewPanel(
         [c.TITLE_HLR, c.TITLE_BOARD_DIRECT, c.TITLE_BOARD_HEARING],

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/2-IS3/results-2-IS3-path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/2-IS3/results-2-IS3-path-1.cypress.spec.js
@@ -27,7 +27,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_2_IS_3);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/2-IS3/results-2-IS3-path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/2-IS3/results-2-IS3-path-2.cypress.spec.js
@@ -29,7 +29,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_2_IS_3);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-1-1B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-1-1B.cypress.spec.js
@@ -21,7 +21,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_1_1B);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-1-1C.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-1-1C.cypress.spec.js
@@ -18,7 +18,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_1_1C);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-1-3B.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-1-3B.cypress.spec.js
@@ -25,7 +25,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_1_3B);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-3-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-3-1.cypress.spec.js
@@ -35,7 +35,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_2_S_3_1);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-3.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_2_S_3);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-4-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-4-1.cypress.spec.js
@@ -35,7 +35,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_2_S_4_1);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-4.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-non-dr/results-2-S-4.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_NON_DR);
       h.verifyNonDrResultsHeader(RESULTS_2_S_4);
       cy.go('back');
 

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-1.cypress.spec.js
@@ -26,7 +26,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-2.cypress.spec.js
@@ -28,7 +28,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-3.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-4.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-5.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([
         c.TITLE_SC,

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-6.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-7.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-7.cypress.spec.js
@@ -32,7 +32,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([
         c.TITLE_SC,

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-8.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-8.cypress.spec.js
@@ -30,7 +30,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1A);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-1.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-1.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1B);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-2.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-2.cypress.spec.js
@@ -36,7 +36,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1B);
       h.checkOverviewPanel([
         c.TITLE_SC,

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-3.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-3.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1B);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-4.cypress.spec.js
+++ b/src/applications/appeals/onramp/tests/cypress/results-sc/path-cfi-4.cypress.spec.js
@@ -28,7 +28,7 @@ describe('Decision Reviews Onramp', () => {
       h.navigateToResults(path);
 
       // RESULTS
-      h.verifyUrl(ROUTES.RESULTS);
+      h.verifyUrl(ROUTES.RESULTS_DR);
       h.verifyDrResultsHeader(RESULTS_2_S_1B);
       h.checkOverviewPanel([c.TITLE_SC]);
       h.checkGoodFitCards([

--- a/src/applications/appeals/onramp/tests/utilities/page-navigation.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/utilities/page-navigation.unit.spec.jsx
@@ -254,7 +254,8 @@ describe('page navigation utilities', () => {
             updateResultsPageSpy,
           );
 
-          expect(router.push.firstCall.calledWith(ROUTES.RESULTS)).to.be.true;
+          expect(router.push.firstCall.calledWith(ROUTES.RESULTS_DR)).to.be
+            .true;
           expect(updateResultsPageSpy.firstCall.args[0]).to.equal(
             RESULTS_2_H_2B_1,
           );

--- a/src/applications/appeals/onramp/utilities/page-navigation.js
+++ b/src/applications/appeals/onramp/utilities/page-navigation.js
@@ -2,6 +2,7 @@ import { DISPLAY_CONDITIONS } from '../constants/display-conditions';
 import { displayConditionsMet } from './display-conditions';
 import { ROUTES } from '../constants';
 import { printErrorMessage } from '.';
+import { isNonDR } from '../constants/results-data-map';
 
 /** ================================================================
  * Move to given route or error if route not found
@@ -28,7 +29,12 @@ const determineResultsPage = (
 
     if (displayConditionsMet(formResponses, displayConditionsForResultPage)) {
       updateResultsPage(resultPage);
-      pushToRoute('RESULTS', router);
+
+      if (isNonDR.includes(resultPage)) {
+        pushToRoute('RESULTS_NON_DR', router);
+      } else {
+        pushToRoute('RESULTS_DR', router);
+      }
       return;
     }
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed breadcrumb/URL/h1 consistency issues:

1. Introduction page - Aligned all elements (breadcrumb, URL, and h1 heading) to consistently use "Explore disability claim decision review options"

2. Results page - Updated the URL structure to use either "/your-available-options" or "/your-decision-review-options" to match the breadcrumb and heading elements

3. Fix Cypress tests

## Related issue(s)

[Content Issue ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/120001)

## Screenshot/Videos
[DR results page breadcrumbs and URL video](
https://www.loom.com/share/b5b1c562fda940e2bfb8b6d6871dee60?sid=ff1a72a6-703f-45ed-9167-56e9e3f5ce6a)


[NON-DR results page breadcrumbs and URL video](https://www.loom.com/share/fa2087c7b65d4968a480c2b14fd01161?sid=8dd6de8d-59ff-4c81-8420-0fcc94198e91)