### PR TITLE
DR 119754: Onramp: fix persisted error

### DIFF
--- a/src/applications/appeals/onramp/components/RadioQuestion.jsx
+++ b/src/applications/appeals/onramp/components/RadioQuestion.jsx
@@ -48,6 +48,10 @@ const RadioQuestion = ({
   const radioRef = useRef(null);
   const formResponse = formResponses?.[shortName];
 
+  if (formResponse && formError) {
+    setFormError(false);
+  }
+
   const onContinueClick = () => {
     if (!formResponse) {
       setFormError(true);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

We had a defect identified as part of the bug bash as described below:

>Fill out a few screens normally, then trigger an error by pressing the Continue button without selecting a radio button. If you If you press the Back button and return to previous screens that have already been successfully completed, the error persists.
> Ideally when you go back to the previous screens, you will not see the error for the future screen. I get if there's some weirdness with the form system then so be it, but seems like a bug.
> https://www.loom.com/share/99a0555c4ddd459c826402bf535ff2da

This ticket addresses the defect by clearing the error if a form response is present in the Redux store.

https://github.com/user-attachments/assets/8a1d20fe-5352-4fd3-8e07-6ec7d0ccf9eb

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119754