### PR TITLE
DR 119899 Onramp: update headings for NGF cards

### DIFF
--- a/src/applications/appeals/onramp/components/dr-results-screens/NotGoodFitCard.jsx
+++ b/src/applications/appeals/onramp/components/dr-results-screens/NotGoodFitCard.jsx
@@ -7,7 +7,7 @@ import {
 } from '../../utilities/dr-results-content-utils';
 
 const NotGoodFitCard = ({ card, formResponses }) => {
-  const H3 = getCardTitle(card);
+  const H4 = getCardTitle(card);
   const content = getCardContent(card, formResponses, false);
   const learnMoreLink = getLearnMoreLink(card);
 
@@ -17,7 +17,7 @@ const NotGoodFitCard = ({ card, formResponses }) => {
       class="not-good-fit-card"
       data-testid={`not-good-fit-${card}`}
     >
-      <h3 className="vads-u-margin-top--0">{H3}</h3>
+      <h4 className="vads-u-margin-top--0">{H4}</h4>
       <p>This may not be an option because:</p>
       {content}
       {learnMoreLink}

--- a/src/applications/appeals/onramp/tests/components/dr-results-screens/NotGoodFitCard.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/components/dr-results-screens/NotGoodFitCard.unit.spec.jsx
@@ -32,7 +32,7 @@ describe('NotGoodFitCard', () => {
       <NotGoodFitCard card={card} formResponses={formResponses} />,
     );
 
-    expect(screen.getByRole('heading', { level: 3 })).to.have.text(
+    expect(screen.getByRole('heading', { level: 4 })).to.have.text(
       'Higher-Level Review',
     );
   });

--- a/src/applications/appeals/onramp/tests/utilities/dr-results-card-display-utils.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/utilities/dr-results-card-display-utils.unit.spec.jsx
@@ -51,7 +51,7 @@ describe('getDisplayCards', () => {
       );
 
       expect(container.innerHTML).to.contain(
-        '<h3 class="vads-u-margin-top--0">Higher-Level Review</h3>',
+        '<h4 class="vads-u-margin-top--0">Higher-Level Review</h4>',
       );
       expect(container.innerHTML).to.contain(
         `<p data-testid="ngf-content-0">${c.CARD_NGF_YES_LAW_POLICY}`,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update Not Good Fit cards' headers to h4 per guidance from Tracy and Cindy.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119899

## Testing done & screenshots
<img width="1826" height="1102" alt="Screenshot 2025-09-25 at 9 15 58 AM" src="https://github.com/user-attachments/assets/f8733a01-1697-4cb9-a579-da71cd7e0431" />

<img width="1827" height="1117" alt="Screenshot 2025-09-25 at 9 15 51 AM" src="https://github.com/user-attachments/assets/230a72cc-a82d-4704-b5b5-797b8e612093" />
