### PR TITLE
119880 Safely format birth date for PDF generation

### DIFF
--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -66,7 +66,7 @@ const ChemHemDetails = props => {
     // Test to see if formatDateLong and formatBirthDate return the same value for the user's
     // date of birth. If not, throw an error that will get picked up by Datadog that indicates
     // which date is earlier.
-    asyncErrorForUnequalBirthDates('1980-09-01');
+    asyncErrorForUnequalBirthDates(user.dob);
 
     setDownloadStarted(true);
     const { title, subject, subtitles } = generateLabsIntro(record);

--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -55,18 +55,6 @@ const ChemHemDetails = props => {
     [record.date, record.name],
   );
 
-  useEffect(
-    /**
-     * Test to see if formatDateLong and formatBirthDate return the same value for the user's
-     * date of birth. If not, throw an error that will get picked up by Datadog that indicates
-     * which date is earlier.
-     */
-    () => {
-      asyncErrorForUnequalBirthDates(user.dob);
-    },
-    [user.dob],
-  );
-
   usePrintTitle(
     pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE,
     user.userFullName,
@@ -75,6 +63,11 @@ const ChemHemDetails = props => {
   );
 
   const generateChemHemPdf = async () => {
+    // Test to see if formatDateLong and formatBirthDate return the same value for the user's
+    // date of birth. If not, throw an error that will get picked up by Datadog that indicates
+    // which date is earlier.
+    asyncErrorForUnequalBirthDates('1980-09-01');
+
     setDownloadStarted(true);
     const { title, subject, subtitles } = generateLabsIntro(record);
     const scaffold = generatePdfScaffold(user, title, subject);

--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -62,7 +62,7 @@ const ChemHemDetails = props => {
      * which date is earlier.
      */
     () => {
-      asyncErrorForUnequalBirthDates('1980-09-01');
+      asyncErrorForUnequalBirthDates(user.dob);
     },
     [user.dob],
   );

--- a/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -22,7 +22,11 @@ import ChemHemResults from './ChemHemResults';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
 import InfoAlert from '../shared/InfoAlert';
-import { processList, generateTextFile } from '../../util/helpers';
+import {
+  processList,
+  generateTextFile,
+  asyncErrorForUnequalBirthDates,
+} from '../../util/helpers';
 import { pageTitles } from '../../util/constants';
 import DateSubheading from '../shared/DateSubheading';
 import {
@@ -49,6 +53,18 @@ const ChemHemDetails = props => {
       focusElement(document.querySelector('h1'));
     },
     [record.date, record.name],
+  );
+
+  useEffect(
+    /**
+     * Test to see if formatDateLong and formatBirthDate return the same value for the user's
+     * date of birth. If not, throw an error that will get picked up by Datadog that indicates
+     * which date is earlier.
+     */
+    () => {
+      asyncErrorForUnequalBirthDates('1980-09-01');
+    },
+    [user.dob],
   );
 
   usePrintTitle(

--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.jsx
@@ -13,6 +13,7 @@ import {
   dateFormat,
   dateFormatWithoutTimezone,
   dispatchDetails,
+  errorForUnequalBirthDates,
   extractContainedByRecourceType,
   extractContainedResource,
   formatDate,
@@ -1049,5 +1050,64 @@ describe('formatDateTime', () => {
 
     expect(formattedDate).to.equal('January 5, 2025');
     expect(formattedTime).to.equal('12:00 AM');
+  });
+});
+
+describe('errorForUnequalBirthDates (no sinon)', () => {
+  it('does not throw when using default functions', () => {
+    expect(() => errorForUnequalBirthDates('2000-09-01')).to.not.throw();
+  });
+
+  it('does not throw when dates are equal', () => {
+    const deps = {
+      formatDateLong: () => 'September 1, 2000',
+      formatBirthDate: () => 'September 1, 2000',
+    };
+
+    expect(() => errorForUnequalBirthDates('anything', deps)).to.not.throw();
+  });
+
+  it('throws when formatDateLong is earlier than formatBirthDate', () => {
+    const deps = {
+      formatDateLong: () => 'September 1, 2000',
+      formatBirthDate: () => 'September 2, 2000',
+    };
+
+    expect(() => errorForUnequalBirthDates('anything', deps)).to.throw(
+      /formatDateLong is earlier than formatBirthDate/,
+    );
+  });
+
+  it('throws when formatBirthDate is earlier than formatDateLong', () => {
+    const deps = {
+      formatDateLong: () => 'September 2, 2000',
+      formatBirthDate: () => 'September 1, 2000',
+    };
+
+    expect(() => errorForUnequalBirthDates('anything', deps)).to.throw(
+      /formatBirthDate is earlier than formatDateLong/,
+    );
+  });
+
+  it('throws when formatDateLong returns an invalid date string', () => {
+    const deps = {
+      formatDateLong: () => 'not a date',
+      formatBirthDate: () => 'September 1, 2000',
+    };
+
+    expect(() => errorForUnequalBirthDates('anything', deps)).to.throw(
+      /Invalid birth date via formatDateLong/,
+    );
+  });
+
+  it('throws when formatBirthDate returns an invalid date string', () => {
+    const deps = {
+      formatDateLong: () => 'September 1, 2000',
+      formatBirthDate: () => 'not a date',
+    };
+
+    expect(() => errorForUnequalBirthDates('anything', deps)).to.throw(
+      /Invalid birth date via formatBirthDate/,
+    );
   });
 });

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -2,6 +2,8 @@ import moment from 'moment-timezone';
 import { datadogRum } from '@datadog/browser-rum';
 import { snakeCase } from 'lodash';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
+import { formatBirthDate } from '@department-of-veterans-affairs/mhv/exports';
+
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 import {
@@ -858,4 +860,33 @@ export const getFailedDomainList = (failed, displayMap) => {
     modFailed.push('medications');
   }
   return modFailed.map(domain => displayMap[domain]);
+};
+
+/**
+ * Compares the dob formatted by two different methods and, if they are unequal, throws an error
+ * indicating which date is earlier.
+ * @param {string} userDob - The user's date of birth from the redux store
+ */
+export const errorForUnequalBirthDates = (
+  userDob,
+  deps = { formatDateLong, formatBirthDate },
+) => {
+  const d1 = new Date(deps.formatDateLong(userDob));
+  const d2 = new Date(deps.formatBirthDate(userDob));
+
+  if (Number.isNaN(d1.getTime()))
+    throw new Error('Invalid birth date via formatDateLong');
+  if (Number.isNaN(d2.getTime()))
+    throw new Error('Invalid birth date via formatBirthDate');
+
+  if (d1.getTime() < d2.getTime()) {
+    throw new Error(`formatDateLong is earlier than formatBirthDate`);
+  }
+  if (d1.getTime() > d2.getTime()) {
+    throw new Error(`formatBirthDate is earlier than formatDateLong`);
+  }
+};
+
+export const asyncErrorForUnequalBirthDates = async userDob => {
+  errorForUnequalBirthDates(userDob);
 };

--- a/src/platform/mhv/exportsFile.js
+++ b/src/platform/mhv/exportsFile.js
@@ -21,6 +21,7 @@ export {
 export { default as usePrintTitle } from './hooks/usePrintTitle';
 export {
   formatName,
+  formatBirthDate,
   generatePdfScaffold,
   updatePageTitle,
   openCrisisModal,

--- a/src/platform/mhv/tests/util-helpers.unit.spec.jsx
+++ b/src/platform/mhv/tests/util-helpers.unit.spec.jsx
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import {
   formatName,
   formatNameFirstLast,
   generatePdfScaffold,
+  formatBirthDate,
 } from '../util/helpers';
 
 describe('formatName', () => {
@@ -86,6 +88,59 @@ describe('generatePdfScaffold', () => {
     expect(scaffold.preface).to.eq(
       'If you have any questions about these results, send a secure message to your care team.',
     );
+  });
+});
+
+describe('formatBirthDate', () => {
+  it('falls back for an unexpected format', () => {
+    const fb = sinon.spy();
+    formatBirthDate('2020-12-5', fb);
+    expect(fb.calledOnce).to.be.true;
+    expect(fb.calledWith('2020-12-5')).to.be.true;
+  });
+
+  it('formats YYYY-MM-DD (with leading zero in day)', () => {
+    const fb = sinon.spy();
+    const result = formatBirthDate('2020-12-05', fb);
+    expect(result).to.eq('December 5, 2020');
+    expect(fb.notCalled).to.be.true;
+  });
+
+  it('formats YYYY-MM-DD (01-01)', () => {
+    const fb = sinon.spy();
+    const result = formatBirthDate('1999-01-01', fb);
+    expect(result).to.eq('January 1, 1999');
+    expect(fb.notCalled).to.be.true;
+  });
+
+  it('formats YYYY-MM-DD (double-digit day)', () => {
+    const fb = sinon.spy();
+    const result = formatBirthDate('2001-11-23', fb);
+    expect(result).to.eq('November 23, 2001');
+    expect(fb.notCalled).to.be.true;
+  });
+
+  it('formats YYYY-MM-DD (double-digit month)', () => {
+    const fb = sinon.spy();
+    const result = formatBirthDate('2010-10-09', fb);
+    expect(result).to.eq('October 9, 2010');
+    expect(fb.notCalled).to.be.true;
+  });
+
+  it('throws for invalid month 00', () => {
+    expect(() => formatBirthDate('2020-00-05')).to.throw('Invalid month');
+  });
+
+  it('throws for invalid month 13', () => {
+    expect(() => formatBirthDate('2020-13-05')).to.throw('Invalid month');
+  });
+
+  it('throws for invalid day 00', () => {
+    expect(() => formatBirthDate('2020-12-00')).to.throw('Invalid day');
+  });
+
+  it('throws for invalid day 32', () => {
+    expect(() => formatBirthDate('2020-12-32')).to.throw('Invalid day');
   });
 });
 

--- a/src/platform/mhv/util/helpers.js
+++ b/src/platform/mhv/util/helpers.js
@@ -22,6 +22,51 @@ export const formatName = ({ first, middle, last, suffix }) => {
 };
 
 /**
+ * Formats a birth date string. We always expect to get this date in YYYY-MM-DD format. If the
+ * string is in a different format, fall back to the original formatDateLong function.
+ * @param {string} dateStr - The date string to format
+ * @param {function} fallback - The fallback function to call if the format is invalid
+ * @returns {string} The formatted date string
+ */
+export const formatBirthDate = (dateStr, fallback = formatDateLong) => {
+  // Regex check for YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    return fallback(dateStr); // Fall back to a date-handling function
+  }
+
+  const [year, month, day] = dateStr.split('-');
+
+  // Validate month range
+  if (month < '01' || month > '12') {
+    throw new Error('Invalid month in date string');
+  }
+
+  // Validate day range (01–31 only, no per-month/day-of-month checks)
+  if (day < '01' || day > '31') {
+    throw new Error('Invalid day in date string');
+  }
+  const months = {
+    '01': 'January',
+    '02': 'February',
+    '03': 'March',
+    '04': 'April',
+    '05': 'May',
+    '06': 'June',
+    '07': 'July',
+    '08': 'August',
+    '09': 'September',
+    '10': 'October',
+    '11': 'November',
+    '12': 'December',
+  };
+
+  // Strip leading zero from day (e.g. "01" -> "1")
+  const dayNum = day.startsWith('0') ? day.slice(1) : day;
+
+  return `${months[month]} ${dayNum}, ${year}`;
+};
+
+/**
  * @param {Object} user user profile object from redux store (state.user.profile)
  * @param {Object} title title of the doc (displayed at the top of the doc)
  * @param {Object} subject subject of the doc (metadata)
@@ -30,7 +75,7 @@ export const formatName = ({ first, middle, last, suffix }) => {
  */
 export const generatePdfScaffold = (user, title, subject, preface) => {
   const name = formatName(user.userFullName);
-  const dob = formatDateLong(user.dob);
+  const dob = formatBirthDate(user.dob);
   const scaffold = {
     headerLeft: name,
     headerRight: `Date of birth: ${dob}`,
@@ -158,7 +203,7 @@ export const formatNameFirstLast = ({ first, middle, last, suffix }) => {
  * @returns {string} A formatted date string or "Not found" if the DOB is missing.
  */
 export const formatUserDob = userProfile => {
-  return userProfile?.dob ? formatDateLong(userProfile.dob) : 'Not found';
+  return userProfile?.dob ? formatBirthDate(userProfile.dob) : 'Not found';
 };
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- A user is experiencing an off-by-one error in their birth date on MR PDFs. To ensure valid date-conversion, I switched to a very simple method that does not use JS `Date` at all. If it encounters a date with an unexpected format, it will fall back to the older function.
- Added logging to compare the old method with the new method and log if they are different.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119880

## Testing done

- Tested in an app and added full unit tests.

## Screenshots

N/A

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
