### PR TITLE
Fix a typo in the immediate care alert message

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -256,7 +256,7 @@ export default function DateTimeSelectPage() {
         !loadingSlots &&
         appointmentSlotsStatus !== FETCH_STATUS.failed
       ) {
-        scrollAndFocus('h2');
+        scrollAndFocus('h1');
       } else if (
         (!loadingSlots && isInitialLoad) ||
         appointmentSlotsStatus === FETCH_STATUS.failed

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -93,8 +93,7 @@ function getAlertMessage({
             at {formatInTimeZone(earliestDate, timezone, 'h:mm aaaa')}{' '}
             {getFormattedTimezoneAbbr(earliestDate, timezone)}
           </span>
-          . If this date date doesn’t work, you can pick a new one from the
-          calendar.
+          . If this date doesn’t work, you can pick a new one from the calendar.
         </div>
         <div className="vads-u-margin-bottom--2">
           If the date you want isn’t available, you can call your local VA

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -700,7 +700,7 @@ describe('VAOS Page: DateTimeSelectPage', () => {
     // And the info about later slots is displayed
     expect(
       await screen.findByText(
-        /If this date date doesn’t work, you can pick a new one from the calendar./i,
+        /If this date doesn’t work, you can pick a new one from the calendar./i,
       ),
     ).to.exist;
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Fixing a small typo in the immediate care alert message
- United Appointments Experience
- This is not behind a flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119633

## Testing done

- Tested locally

## What areas of the site does it impact?

Appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
