### PR TITLE
Update average time

### DIFF
--- a/src/applications/appeals/onramp/constants/results-content/dr-screens/card-content.js
+++ b/src/applications/appeals/onramp/constants/results-content/dr-screens/card-content.js
@@ -113,7 +113,7 @@ export const START_BOARD = {
 };
 
 export const DECISION_TIMELINES = {
-  SC: '79.3 days',
+  SC: '79.3 days (roughly 3 months)',
   HLR: '125 days (4 to 5 months)',
   BOARD_DIRECT: '365 days (1 year)',
   BOARD_EVIDENCE: '550 days (1.5 years)',

--- a/src/applications/appeals/onramp/tests/utilities/dr-results-content-utils.unit.spec.jsx
+++ b/src/applications/appeals/onramp/tests/utilities/dr-results-content-utils.unit.spec.jsx
@@ -163,7 +163,9 @@ describe('card utilities', () => {
 
   describe('getDecisionTimeline', () => {
     it('returns timeline string for SC', () => {
-      expect(getDecisionTimeline('CARD_SC')).to.equal('79.3 days');
+      expect(getDecisionTimeline('CARD_SC')).to.equal(
+        '79.3 days (roughly 3 months)',
+      );
     });
 
     it('returns empty string for unknown', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

I'm updating the content at the average time, as Cindy requested in the [wireframes](https://www.figma.com/design/5vAWK3wpBkJgG7ngLXYmht/Onramping-Tool?node-id=2718-73525&p=f&t=PdV512ctpSShQI7k-0). 


## Related issue(s)

[Content Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/120001)

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="380" height="469" alt="Screenshot 2025-09-25 at 12 43 29 PM" src="https://github.com/user-attachments/assets/c63735ec-f4c6-41f4-9488-bf630eed64d5" /> | <img width="385" height="458" alt="Screenshot 2025-09-25 at 12 40 15 PM" src="https://github.com/user-attachments/assets/0390cda2-ecbe-41f1-94f5-6206bbee5c20" />   | 
| Desktop | <img width="550" height="428" alt="Screenshot 2025-09-25 at 12 43 13 PM" src="https://github.com/user-attachments/assets/26032aed-7e11-48b1-bd9d-9eff7cfc0fd7" /> | <img width="623" height="543" alt="Screenshot 2025-09-25 at 12 31 27 PM" src="https://github.com/user-attachments/assets/b29cd017-2635-4011-942c-1efad4417642" />    |
