### PR TITLE
DMT | Add child duplicate checks

### DIFF
--- a/src/applications/dependents/686c-674/config/chapters/report-add-child/config.js
+++ b/src/applications/dependents/686c-674/config/chapters/report-add-child/config.js
@@ -1,4 +1,5 @@
-import { getFullName } from '../../../../shared/utils';
+import React from 'react';
+import { getFullName, getFormatedDate } from '../../../../shared/utils';
 
 function isFieldMissing(value) {
   return value === undefined || value === null || value === '';
@@ -120,5 +121,78 @@ export const arrayBuilderOptions = {
   maxItems: 20,
   text: {
     getItemName: item => getFullName(item.fullName),
+    cardDescription: item => (
+      <div>
+        Date of birth:
+        <strong> {getFormatedDate(item?.birthDate)}</strong>
+      </div>
+    ),
+    duplicateSummaryCardLabel: () => 'DUPLICATE CHILD',
+    duplicateSummaryCardWarningOrErrorAlert: () => (
+      <>
+        <p className="vads-u-margin-top--0">
+          You’ve entered this dependent name and date of birth more than once.
+        </p>
+        <p>Review your entries, edit or delete any duplicates.</p>
+      </>
+    ),
+    duplicateSummaryCardInfoAlert: () =>
+      'This child shares a date of birth with someone already on your benefits.',
+  },
+  duplicateChecks: {
+    comparisonType: 'internal',
+    comparisons: ['fullName.first', 'fullName.last', 'birthDate'],
+
+    itemPathModalChecks: {
+      // change comparison for '686-report-add-child/:index/information' page
+      information: {
+        comparisonType: 'external',
+        comparisons: ['birthDate'],
+        externalComparisonData: ({ formData }) => {
+          const dependents = formData?.dependents || {};
+          if (
+            !formData.vaDependentsDuplicateModals ||
+            !dependents?.hasDependents
+          ) {
+            return [];
+          }
+          return dependents.awarded
+            ?.filter(
+              dependent =>
+                dependent.relationshipToVeteran.toLowerCase() === 'child',
+            )
+            .map(child => [child.dateOfBirth || '']);
+        },
+
+        // NOTE: Text settings here get props in a different shape from the
+        // options text object
+        duplicateModalTitle: () =>
+          'You already have a dependent with this date of birth',
+        // Not using itemData here because name chanages
+        duplicateModalDescription: props => {
+          const { itemData, fullData } = props;
+          const { birthDate } = itemData || '';
+          // get Full name of duplicate dependent loaded in by prefill
+          const dependentToShow =
+            fullData?.dependents?.awarded?.find(
+              dep => dep.dateOfBirth === birthDate,
+            ) || itemData;
+          return (
+            <>
+              Our records show a dependent with the date of birth{' '}
+              <strong>{getFormatedDate(birthDate)}</strong>, already listed on
+              your benefits as{' '}
+              <strong>{getFullName(dependentToShow.fullName)}</strong>.
+              <p>
+                If you need to add another dependent with the same date of
+                birth, you can continue adding this dependent.
+              </p>
+            </>
+          );
+        },
+        duplicateModalPrimaryButtonText: () => 'Cancel',
+        duplicateModalSecondaryButtonText: () => 'Continue adding',
+      },
+    },
   },
 };

--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-ancillary.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-ancillary.cypress.spec.js
@@ -208,7 +208,7 @@ const testConfig = createTestConfig(
         });
       },
     },
-    skip: Cypress.env('CI'),
+    // skip: Cypress.env('CI'),
   },
 
   manifest,

--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-duplicate-checker.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-duplicate-checker.cypress.spec.js
@@ -1,0 +1,69 @@
+import path from 'path';
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+
+import formConfig from '../../config/form';
+import manifest from '../../manifest.json';
+import { setupCypress } from './cypress.helpers';
+
+Cypress.config('waitForAnimations', true);
+
+const testConfig = createTestConfig(
+  {
+    dataPrefix: 'data',
+    dataSets: ['duplicate-children'],
+    fixtures: { data: path.join(__dirname, 'fixtures') },
+    setupPerTest: () => {
+      // Pass form start page path
+      setupCypress('/686-report-add-child/summary');
+    },
+
+    stopTestAfterPath: '/review-and-submit',
+    pageHooks: {
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.wait('@mockVaFileNumber');
+          cy.get('va-button[data-testid="continue-your-application"]').click();
+        });
+      },
+
+      '686-report-add-child/summary': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('va-card').should('have.length', 3);
+          cy.get('va-alert[status="warning"]')
+            .should('have.length', 2)
+            .first()
+            .should('contain', 'more than once');
+
+          cy.get(`va-link[label="Edit Penny Foster"]`)
+            .first()
+            .click();
+
+          cy.fillVaTextInput('root_fullName_first', 'Mary');
+          cy.get('va-button[continue]').click();
+
+          cy.get('va-modal[status="warning"]')
+            .shadow()
+            .find('.va-modal-alert-body')
+            .should('contain', 'already have a dependent with this date');
+
+          cy.get('va-modal[status="warning"]')
+            .shadow()
+            .find('.va-modal-alert-body va-button')
+            .first() // cancel button
+            .click();
+
+          cy.selectVaRadioOption('root_view:completedAddChild', 'N');
+
+          cy.clickFormContinue();
+        });
+      },
+    },
+    // skip: Cypress.env('CI'),
+  },
+
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);

--- a/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674-maximal.cypress.spec.js
@@ -247,7 +247,7 @@ const testConfig = createTestConfig(
         });
       },
     },
-    skip: Cypress.env('CI'),
+    // skip: Cypress.env('CI'),
   },
 
   manifest,

--- a/src/applications/dependents/686c-674/tests/e2e/686C-674.cypress.spec.js
+++ b/src/applications/dependents/686c-674/tests/e2e/686C-674.cypress.spec.js
@@ -248,7 +248,7 @@ const testConfig = createTestConfig(
         });
       },
     },
-    skip: Cypress.env('CI'),
+    // skip: Cypress.env('CI'),
   },
 
   manifest,

--- a/src/applications/dependents/686c-674/tests/e2e/cypress.helpers.js
+++ b/src/applications/dependents/686c-674/tests/e2e/cypress.helpers.js
@@ -1,0 +1,109 @@
+import { getUnixTime, add } from 'date-fns';
+
+import mockVaFileNumber from './fixtures/va-file-number.json';
+import mockUser from './user.json';
+
+export const setupCypress = (returnUrl = '') => {
+  const submission = {
+    formSubmissionId: '123fake-submission-id-567',
+    timestamp: '2020-11-12',
+    attributes: {
+      guid: '123fake-submission-id-567',
+    },
+  };
+
+  const twoMonthsAgo = getUnixTime(add(new Date(), { months: -2 }));
+
+  const sipData = {
+    form: '686C-674-V2',
+    metadata: {
+      version: 1,
+      returnUrl,
+      savedAt: new Date().getTime(),
+      submission: {
+        status: false,
+        errorMessage: false,
+        id: false,
+        timestamp: false,
+        hasAttemptedSubmit: false,
+      },
+      createdAt: twoMonthsAgo,
+      expiresAt: getUnixTime(add(new Date(), { years: 1 })),
+      lastUpdated: twoMonthsAgo,
+      inProgressFormId: 1234,
+    },
+    lastUpdated: twoMonthsAgo,
+  };
+
+  const userData = returnUrl
+    ? {
+        data: {
+          ...mockUser.data,
+          attributes: {
+            ...mockUser.data.attributes,
+            inProgressForms: [sipData],
+          },
+        },
+      }
+    : mockUser;
+
+  cy.intercept('GET', '/v0/user', userData);
+  cy.intercept('GET', '/v0/feature_toggles?*', {
+    data: {
+      type: 'feature_toggles',
+      features: [
+        { name: 'vaDependentsV2', value: true },
+        { name: 'va_dependents_v2', value: true },
+        { name: 'vaDependentsNetWorthAndPension', value: true },
+        { name: 'va_dependents_net_worth_and_pension', value: true },
+        { name: 'vaDependentsDuplicateModals', value: true },
+        { name: 'va_dependents_duplicate_modals', value: true },
+      ],
+    },
+  });
+  cy.intercept('GET', '/v0/maintenance_windows*', 'OK');
+  cy.intercept('GET', '/v0/maintenance_windows', { data: [] });
+  cy.intercept('POST', '/v0/claim_attachments', {
+    data: { attributes: { confirmationCode: '5' } },
+  });
+  cy.intercept('GET', '/v0/profile/valid_va_file_number', mockVaFileNumber).as(
+    'mockVaFileNumber',
+  );
+  cy.get('@testData').then(testData => {
+    const mockSipGet = {
+      formData: testData,
+      metadata: {
+        version: 0,
+        prefill: true,
+        returnUrl,
+      },
+    };
+
+    const mockSipPut = {
+      data: {
+        id: '1234',
+        type: 'in_progress_forms',
+        attributes: {
+          formId: '686C-674-V2',
+          createdAt: '2021-06-03T00:00:00.000Z',
+          updatedAt: '2021-06-03T00:00:00.000Z',
+          metadata: {
+            version: 1,
+            returnUrl,
+            savedAt: 1593500000000,
+            lastUpdated: 1593500000000,
+            expiresAt: 99999999999,
+          },
+        },
+      },
+    };
+
+    cy.intercept('GET', '/v0/in_progress_forms/686C-674-V2', mockSipGet);
+    cy.intercept('PUT', '/v0/in_progress_forms/686C-674-V2', mockSipPut);
+    cy.intercept('POST', '/v0/dependents_applications', submission).as(
+      'submitApplication',
+    );
+
+    cy.login(userData);
+  });
+};

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/duplicate-children.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/duplicate-children.json
@@ -1,0 +1,275 @@
+{
+  "view:childrenToAddMissingInformation": {},
+  "veteranContactInformation": {
+    "phoneNumber": "2023336688",
+    "emailAddress": "vets.gov.user80@gmail.com",
+    "electronicCorrespondence": true,
+    "veteranAddress": {
+      "view:militaryBaseDescription": {},
+      "country": "USA",
+      "street": "1700 Clairmont Rd",
+      "city": "Decatur",
+      "state": "GA",
+      "postalCode": "30033"
+    }
+  },
+  "dependents": {
+    "hasDependents": true,
+    "awarded": [
+      {
+        "fullName": {
+          "first": "SPOUSY",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "1970-07-07",
+        "ssn": "702023332",
+        "relationshipToVeteran": "Spouse",
+        "awardIndicator": "Y"
+      },
+      {
+        "fullName": {
+          "first": "PENNY",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "2014-08-08",
+        "ssn": "793473479",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "Y"
+      }
+    ],
+    "notAwarded": [
+      {
+        "fullName": {
+          "first": "SARAH",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "2005-09-08",
+        "ssn": "793477434",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "MARSHA",
+          "middle": "P",
+          "last": "FOSTER"
+        },
+        "ssn": "783054787",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "JOCELYN",
+          "last": "PAULINE"
+        },
+        "ssn": "793368394",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "LAUREN",
+          "last": "PARKER"
+        },
+        "dateOfBirth": "2002-02-02",
+        "ssn": "779349323",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "TINKER",
+          "last": "BELL"
+        },
+        "dateOfBirth": "2001-01-01",
+        "ssn": "746342034",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "ZACK",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "1995-05-05",
+        "ssn": "765353222",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "VICTORIA",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "1994-02-02",
+        "ssn": "793432332",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "SIERRA",
+          "last": "KLEIN"
+        },
+        "dateOfBirth": "2005-05-05",
+        "ssn": "780934232",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "STACY",
+          "last": "FOSTER"
+        },
+        "ssn": "798703232",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "PETER",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "2021-03-01",
+        "ssn": "997010104",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "LIAM",
+          "last": "FOSTER"
+        },
+        "ssn": "997010045",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "CARL",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "2020-02-07",
+        "ssn": "997010046",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      },
+      {
+        "fullName": {
+          "first": "DAVID",
+          "last": "FOSTER"
+        },
+        "dateOfBirth": "2021-11-02",
+        "ssn": "997010049",
+        "relationshipToVeteran": "Child",
+        "awardIndicator": "N"
+      }
+    ]
+  },
+  "view:addDependentOptions": {
+    "addChild": true
+  },
+  "view:addDependentOptionsDescription": {},
+  "view:addOrRemoveDependents": {
+    "add": true
+  },
+  "useV2": true,
+  "view:removeDependentOptions": {},
+  "spouseInformation": {
+    "fullName": {}
+  },
+  "view:certificateNotice": {},
+  "view:cancelAddSpouse": {},
+  "doesLiveWithSpouse": {
+    "address": {
+      "view:militaryBaseDescription": {}
+    }
+  },
+  "currentMarriageInformation": {
+    "location": {},
+    "view:marriageTypeInformation": {}
+  },
+  "childrenToAdd": [
+    {
+      "ssn": "793473479",
+      "fullName": {
+        "first": "Penny",
+        "last": "Foster"
+      },
+      "birthDate": "2014-08-08",
+      "doesChildLiveWithYou": true,
+      "hasChildEverBeenMarried": false,
+      "doesChildHaveDisability": false,
+      "isBiologicalChild": true,
+      "birthLocation": {
+        "location": {
+          "city": "Test",
+          "state": "AL",
+          "postalCode": "12345"
+        }
+      }
+    },
+    {
+      "ssn": "987654321",
+      "fullName": {
+        "first": "Mike",
+        "last": "Foster"
+      },
+      "birthDate": "2023-01-01",
+      "doesChildLiveWithYou": true,
+      "hasChildEverBeenMarried": false,
+      "doesChildHaveDisability": false,
+      "isBiologicalChild": true,
+      "birthLocation": {
+        "location": {
+          "city": "Test",
+          "state": "AL",
+          "postalCode": "12345"
+        }
+      }
+    },
+    {
+      "doesChildLiveWithYou": true,
+      "hasChildEverBeenMarried": false,
+      "doesChildHaveDisability": false,
+      "isBiologicalChild": true,
+      "birthLocation": {
+        "location": {
+          "city": "Test",
+          "state": "AL",
+          "postalCode": "12345"
+        }
+      },
+      "ssn": "987654321",
+      "fullName": {
+        "first": "Mike",
+        "last": "Foster"
+      },
+      "birthDate": "2023-01-01"
+    }
+  ],
+  "reportDivorce": {
+    "fullName": {},
+    "view:cancelDivorce": {},
+    "divorceLocation": {
+      "location": {}
+    }
+  },
+  "view:additionalEvidenceDescription": {},
+  "view:selectable686Options": {
+    "addChild": true
+  },
+  "veteranInformation": {
+    "fullName": {
+      "first": "Pauline",
+      "middle": "E",
+      "last": "Foster"
+    },
+    "ssn": "796330625",
+    "birthDate": "1976-06-09",
+    "ssnLastFour": "0625",
+    "vaFileLastFour": "0625"
+  },
+  "daysTillExpires": 365
+}

--- a/src/applications/dependents/686c-674/tests/e2e/fixtures/duplicate-children.json
+++ b/src/applications/dependents/686c-674/tests/e2e/fixtures/duplicate-children.json
@@ -13,6 +13,7 @@
       "postalCode": "30033"
     }
   },
+  "vaDependentsDuplicateModals": true,
   "dependents": {
     "hasDependents": true,
     "awarded": [


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Add child duplicate checks to 686c:
  > - Comparing first, last and date of birth on the summary page
  > - Comparing only date of birth after initial add child page
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/117072

## To test locally

- Pull down this branch locally
- Start frontend server
- Open `src/applications/dependents/686c-674/tests/mock-api-full-data.js` in an editor and make the following changes:
  ```diff
  - const mockMaxData = require('./e2e/fixtures/maximal.json');
  + const mockMaxData = require('./e2e/fixtures/duplicate-children.json');

  - const returnUrl = 'review-and-submit';
  + const returnUrl = '/686-report-add-child/summary';
  ```
- Start mock server in the terminal using
  ```bash
  yarn mock-api --responses ./src/applications/dependents/686c-674/tests/mock-api-full-data.js
  ```
- Open the browser console, and enter 
  ```
  localStorage.setItem('hasSession', true)
   ```
- In the browser, go to http://localhost:3001/manage-dependents/add-remove-form-21-686c-674/
- Click the button to continue the form
- Verify that the 2 of the 3 dependents cards have a duplicate warning
- Edit "Penny Foster"
- On the name & DoB page, continue past the page
- Note that the duplicate modal pops up

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > E2E tests added
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         |  | 
| ------- | ----- |
| Array builder summary page showing warning alerts in matching cards with duplicate children from comparing internal array data only | <img width="700" alt="array builder summary page showing warning alerts in matching cards with duplicate children entered" src="https://github.com/user-attachments/assets/0aa7f4c4-73ba-4328-b710-56f8581fc247" /> | 
| Add child name & DoB page modal warning shown when a duplicate date of birth is found in API loaded data | <img width="700" alt="possible duplicate warning modal shown when a duplicate date of birth is found in API loaded data" src="https://github.com/user-attachments/assets/885414ed-7293-4cce-b021-881e4d8b8d5d" /> |

## What areas of the site does it impact?

Form 686c-674

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
