### PR TITLE
Update legacy care expenses page for pdf form alignment

### DIFF
--- a/src/applications/pensions/config/chapters/05-financial-information/careExpenses.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/careExpenses.js
@@ -20,12 +20,16 @@ import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 import ListItemView from '../../../components/ListItemView';
 import {
   careTypeLabels,
+  careTypeLabelsOld,
   careFrequencyLabels,
   recipientTypeLabels,
 } from '../../../labels';
 import { doesHaveCareExpenses } from './helpers';
 import ArrayDescription from '../../../components/ArrayDescription';
-import { showMultiplePageResponse } from '../../../helpers';
+import {
+  showMultiplePageResponse,
+  showPdfFormAlignment,
+} from '../../../helpers';
 
 const {
   childName,
@@ -95,6 +99,19 @@ export default {
         careType: radioUI({
           title: 'Choose the type of care:',
           labels: careTypeLabels,
+          updateSchema: () => ({
+            type: 'string',
+            enum: Object.keys(
+              showPdfFormAlignment() ? careTypeLabels : careTypeLabelsOld,
+            ),
+          }),
+          updateUiSchema: () => ({
+            'ui:options': {
+              labels: showPdfFormAlignment()
+                ? careTypeLabels
+                : careTypeLabelsOld,
+            },
+          }),
         }),
         ratePerHour: currencyUI(
           'If this is an in-home provider, what is the rate per hour?',
@@ -141,7 +158,7 @@ export default {
             recipients: radioSchema(Object.keys(recipientTypeLabels)),
             childName,
             provider,
-            careType: radioSchema(Object.keys(careTypeLabels)),
+            careType: radioSchema(Object.keys(careTypeLabelsOld)),
             ratePerHour: currencySchema,
             hoursPerWeek: numberSchema,
             careDateRange: {

--- a/src/applications/pensions/tests/unit/chapters/05-financial-information/careExpenses.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/05-financial-information/careExpenses.unit.spec.jsx
@@ -73,7 +73,7 @@ describe('Unreimbursed care expenses pension page', () => {
       'va-memorable-date': 2,
       'va-checkbox': 1,
       'va-radio': 3,
-      'va-radio-option': 9, // includes 4 care type options
+      'va-radio-option': 7,
     },
     pageTitle,
   );


### PR DESCRIPTION
## Summary

This PR updates the **Legacy care expenses** page in the **Pension Benefits form (VA Form 21P-527EZ)** that use the single page list and loop that is currently in production.
The **“Choose the type of care”** radio button values now dynamically reflect the version of the form in use based on the **`showPdfFormAlignment`** feature toggle.  

- **With toggle OFF (current logic):** legacy values are displayed  
- **With toggle ON (PDF form alignment enabled):** updated PDF-aligned values are displayed  

This ensures the digital form matches the PDF form structure for care expenses.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118104

## Related issue(s)

- Ongoing PDF form alignment work for the Pension Benefits form  

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Enable/disable the toggle at:  
   `http://localhost:3000/flipper/features/show_pdf_form_alignment`  
4. Navigate to the Pension Benefits form:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
5. Progress to the **Single page list-and-loop care expenses** → `/financial/care-expenses` → `/financial/care-expenses/add`


## How to verify

1. **With `showPdfFormAlignment` disabled:**  
   - Verify the existing (legacy) radio values appear 
   - Confirm behavior is unchanged from prior implementation  

2. **With `showPdfFormAlignment` enabled:**  
   - Verify the radio values update to reflect the aligned PDF values  
   - Confirm form validation and navigation logic still function as expected  

3. Validate that Review & Submit includes the selected care expense type correctly in both toggle states.  
4. Ensure no console errors or regressions.

## What areas of the site does it impact?

- Pension Benefits (21P-527EZ)  
- Legacy care expenses → “Choose the type of care” page  
- Conditional rendering of radio values based on `showPdfFormAlignment`  

## Screenshots

| Toggle OFF (legacy values) | Toggle ON (PDF-aligned values) |
|----------------------------|--------------------------------|
| _Legacy options displayed_ | _Updated options displayed_    |

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) Please confirm the **Legacy care expenses** page correctly switches between legacy and PDF-aligned radio values depending on the `showPdfFormAlignment` toggle state, and that no regressions occur in validation or Review & Submit.