### PR TITLE
DR Onramp: fix print button width

### DIFF
--- a/src/applications/appeals/onramp/constants/results-content/common.jsx
+++ b/src/applications/appeals/onramp/constants/results-content/common.jsx
@@ -16,7 +16,7 @@ export const PRINT_RESULTS = (
       that may apply to you.
     </p>
     <va-button
-      class="vads-u-width--full"
+      class="print-button"
       onClick={window.print}
       text="Print this page"
     />

--- a/src/applications/appeals/onramp/sass/onramp.scss
+++ b/src/applications/appeals/onramp/sass/onramp.scss
@@ -26,4 +26,10 @@
       list-style-type: disc;
     }
   }
+
+  @media screen and (max-width: 479px) {
+    .print-button {
+      width: 100%;
+    }
+  }
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Fix print button clickable width (on results page). Issue reported [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/119989#issuecomment-3339062657).

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/119989

## Testing done

Tested at 320, 479, and 480. 480 is the breakpoint that we want the button **not** to be full width anymore. Note that while the Design System does have classes that typically work to target styles at different breakpoints (e.g. `small-screen:vads-u-margin-top--0`), width doesn't seem to be supported for those and it wasn't working, so I had to add a regular CSS style instead.

https://github.com/user-attachments/assets/f8585c56-a54c-41b1-aa33-68538475e68a