### PR TITLE
1010d | Add temporary redirect based on feature toggle status

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/App.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/App.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { fromUnixTime, endOfDay, isPast, isValid } from 'date-fns';
 import { getAppUrl } from 'platform/utilities/registry-helpers';
 import {
   DowntimeNotification,
@@ -11,7 +10,7 @@ import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 import { useBrowserMonitoring } from '../helpers/useBrowserMonitoring';
-import { addStyleToShadowDomOnPages } from '../../shared/utilities';
+import { addStyleToShadowDomOnPages, isExpired } from '../../shared/utilities';
 
 const breadcrumbList = [
   { href: '/', label: 'Home' },
@@ -32,12 +31,6 @@ const breadcrumbList = [
     label: `Apply for CHAMPVA benefits`,
   },
 ];
-
-// util to check if an in-progress form is expired
-export const isExpired = expiresAt => {
-  const ex = fromUnixTime(Number(expiresAt));
-  return !isValid(ex) || isPast(endOfDay(ex));
-};
 
 export default function App({ location, children }) {
   const {

--- a/src/applications/ivc-champva/10-10d-extended/containers/App.jsx
+++ b/src/applications/ivc-champva/10-10d-extended/containers/App.jsx
@@ -1,45 +1,61 @@
-import React from 'react';
-
+import React, { useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import {
   DowntimeNotification,
   externalServices,
-} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
-import { Toggler } from 'platform/utilities/feature-toggles';
-import PropTypes from 'prop-types';
+} from 'platform/monitoring/DowntimeNotification';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import WIP from '../../shared/components/WIP';
-
+import { getAppUrl } from 'platform/utilities/registry-helpers';
 import formConfig from '../config/form';
 
-export default function App({ location, children }) {
-  return (
-    <Toggler toggleName={Toggler.TOGGLE_NAMES.form1010dExtended}>
-      <Toggler.Enabled>
-        <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-          <DowntimeNotification
-            appTitle={`CHAMPVA Form ${formConfig.formId}`}
-            dependencies={[externalServices.pega]}
-          >
-            {children}
-          </DowntimeNotification>
-        </RoutedSavableApp>
-      </Toggler.Enabled>
-      <Toggler.Disabled>
-        <br />
-        <WIP
-          content={{
-            description:
-              'We’re rolling out the CHAMPVA Application (VA Form 10-10d) in stages. It’s not quite ready yet. Please check back again soon.',
-            redirectLink: '/',
-            redirectText: 'Return to VA home page',
-          }}
-        />
-      </Toggler.Disabled>
-    </Toggler>
+const App = ({ location, children }) => {
+  const {
+    isLoadingFeatureFlags,
+    isLoadingProfile,
+    isMergedFormEnabled,
+  } = useSelector(state => ({
+    isLoadingFeatureFlags: state?.featureToggles?.loading,
+    isMergedFormEnabled: state.featureToggles.form1010dExtended,
+    isLoadingProfile: state.user?.profile?.loading,
+  }));
+  const isAppLoading = useMemo(
+    () => isLoadingFeatureFlags || isLoadingProfile,
+    [isLoadingFeatureFlags, isLoadingProfile],
   );
-}
+
+  // redirect to standalone form if feature is disabled
+  useEffect(
+    () => {
+      if (isAppLoading) return;
+      if (!isMergedFormEnabled) {
+        window.location(getAppUrl('10-10D'));
+      }
+    },
+    [isAppLoading, isMergedFormEnabled],
+  );
+
+  return isAppLoading ? (
+    <va-loading-indicator
+      message="Loading application..."
+      class="vads-u-margin-y--4"
+      set-focus
+    />
+  ) : (
+    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      <DowntimeNotification
+        appTitle={`CHAMPVA Form ${formConfig.formId}`}
+        dependencies={[externalServices.pega]}
+      >
+        {children}
+      </DowntimeNotification>
+    </RoutedSavableApp>
+  );
+};
 
 App.propTypes = {
   children: PropTypes.node,
   location: PropTypes.object,
 };
+
+export default App;

--- a/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/ivc-champva/10-10d-extended/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -1,6 +1,6 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [{ "name": "form1010d_extended", "value": true }]
+    "features": [{ "name": "form1010dExtended", "value": true }]
   }
 }

--- a/src/applications/ivc-champva/shared/utilities.js
+++ b/src/applications/ivc-champva/shared/utilities.js
@@ -1,7 +1,14 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { fromUnixTime, endOfDay, isPast, isValid } from 'date-fns';
 import { waitForShadowRoot } from 'platform/utilities/ui/webComponents';
+
+// util to check if an in-progress form is expired
+export const isExpired = expiresAt => {
+  const ex = fromUnixTime(Number(expiresAt));
+  return !isValid(ex) || isPast(endOfDay(ex));
+};
 
 /**
  * Returns either a form of 'you', or the applicant's full name based


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the 10-10D standalone and 10-10d/10-7959c merged forms to implement a redirect based on the feature toggle status for the merged form. This update prepares the team for a phased launch where if the toggle is active and the user does not have an in-progress standalone form, they will be directed to the merged form. If the toggle is disabled and they attempt to access the merged form, they will be directed to the standalone form for completion.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#120486

## Testing done

- Attempt to access the merged form with the feature disabled. You should be directed to the standalone form
- Attempt to access the standalone unauthenticated with the feature enabled. You should be directed to the merged form.
- Attempt to access the standalone authenticated with a form in progress. You should not be redirect to the merged form.

## Acceptance criteria

- Redirects handle identified conditionals with correct behavior

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user