### PR TITLE
fix: focus delete button after uploading file

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -281,10 +281,8 @@ export const ancillaryFormUploadUi = (
 ) => {
   const findAndFocusLastSelect = () => {
     const uploadList = document.getElementsByClassName('schemaform-file-list');
-    const deleteButton = uploadList[0].lastChild.querySelector('va-button');
-    if (deleteButton) {
-      focusElement(deleteButton);
-    }
+    const deleteButton = uploadList[0]?.lastChild?.querySelector('va-button');
+    if (deleteButton) focusElement(deleteButton);
   };
 
   return fileUploadUI(label, {

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -280,9 +280,10 @@ export const ancillaryFormUploadUi = (
   } = {},
 ) => {
   const findAndFocusLastSelect = () => {
-    const lastSelect = [...document.querySelectorAll('select')].slice(-1);
-    if (lastSelect.length) {
-      focusElement(lastSelect[0]);
+    const uploadList = document.getElementsByClassName('schemaform-file-list');
+    const deleteButton = uploadList[0].lastChild.querySelector('va-button');
+    if (deleteButton) {
+      focusElement(deleteButton);
     }
   };
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixing a accessibility issue where focus after uploading a file was inconsistent. Requested fix was to focus on "Delete File" `va-button` after uploading a file.
closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/107717
## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107717
## Testing done
Ran axe devtools to ensure changes complied with accessibility with changes
Ran unit test for page


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| `mental-health-form-0781/upload` |[before](https://us02web.zoom.us/clips/share/s3OEmjEdRCi2JlLAHlgNAA)| [after](https://github.com/user-attachments/assets/da79ac9a-b79f-4a2a-9305-792389e3ea9e)|

## What areas of the site does it impact?
any pages that use `ancillaryFormUploadUi`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
