### PR TITLE
VEBT-3503

### DIFF
--- a/src/applications/gi/components/content/modals/AccreditationModalContent.jsx
+++ b/src/applications/gi/components/content/modals/AccreditationModalContent.jsx
@@ -4,35 +4,32 @@ export default function AccreditationModalContent() {
   return (
     <>
       <p>
-        The goal of accreditation is to ensure the education provided by
-        institutions of higher learning meets acceptable levels of quality.
+        The goal of accreditation is to ensure that the education provided by
+        the institutions of higher education meets acceptable levels of quality.
+        Accreditation may not be necessary for every program you wish to pursue.
+      </p>
+      <p>
         Accreditation matters if you plan to start school at one institution and
         transfer to another to complete your degree. Be sure to ask any
-        potential school about their credit transfer policy.
+        potential school you may want to transfer to about its credit transfer
+        policy.
       </p>
       <p>
-        Schools are accredited regionally or nationally by private educational
-        associations. While the Department of Education (ED) doesn't say whether
-        regional or national accreditation is better, a recent ED study revealed
-        that, “Nearly 90 percent of all student credit transfer opportunities
-        occurred between institutions that were regionally, rather than
-        nationally, accredited.”{' '}
-        <a href="http://nces.ed.gov/pubs2014/2014163.pdf" id="anch_386">
-          Read the ED report on credit transferability
-        </a>
-        .
+        CAUTION: Not every program approved for GI Bill benefits is accredited.
+        Prior to enrolling, it’s important to determine whether or not your
+        field of study requires accreditation for employment and/or licensing.
       </p>
       <p>
-        To learn more about the accreditation process and types of
-        accreditation, visit the{' '}
+        To learn more about accreditation, visit the{' '}
         <a
           href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type"
           target="_blank"
           rel="noopener noreferrer"
         >
-          About this tool
+          {' '}
+          about this tool
         </a>{' '}
-        page.
+        page.{' '}
       </p>
     </>
   );

--- a/src/applications/gi/components/profile/Academics.jsx
+++ b/src/applications/gi/components/profile/Academics.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ariaLabels } from '../../constants';
-import { upperCaseFirstLetterOnly } from '../../utils/helpers';
 import LearnMoreLabel from '../LearnMoreLabel';
 
 export default function Academics({ institution, onShowModal }) {
@@ -24,7 +23,7 @@ export default function Academics({ institution, onShowModal }) {
                 buttonId="accreditation-button"
                 buttonClassName="small-screen-font"
               />
-              :
+              : Yes
             </strong>
           ) : (
             <>
@@ -36,7 +35,8 @@ export default function Academics({ institution, onShowModal }) {
       )}
       {accredited && (
         <>
-          {accreditationType && upperCaseFirstLetterOnly(accreditationType)} (
+          {' '}
+          (
           <a
             href={`http://nces.ed.gov/collegenavigator/?id=${
               institution.cross

--- a/src/applications/gi/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi/containers/ProfilePageHeader.jsx
@@ -224,7 +224,7 @@ const ProfilePageHeader = ({
                 <span>Accreditation: Yes</span>
               ) : (
                 <LearnMoreLabel
-                  text={`${_.capitalize(accreditationType)} Accreditation`}
+                  text="Accredited"
                   onClick={() => dispatchShowModal('typeAccredited')}
                   ariaLabel={ariaLabels.learnMore.accreditation}
                   buttonId="typeAccredited-button"

--- a/src/applications/gi/containers/search/LearnMoreAccreditedContent.jsx
+++ b/src/applications/gi/containers/search/LearnMoreAccreditedContent.jsx
@@ -13,8 +13,7 @@ const LearnMoreAccreditedContent = ({ onCloseEvent, visible }) => {
       <p>
         The goal of accreditation is to ensure that the education provided by
         the institutions of higher education meets acceptable levels of quality.
-        Accreditation types are either regional or national. Accreditation may
-        not be necessary for every program you wish to pursue.
+        Accreditation may not be necessary for every program you wish to pursue.
       </p>
       <p>
         Accreditation matters if you plan to start school at one institution and
@@ -23,13 +22,12 @@ const LearnMoreAccreditedContent = ({ onCloseEvent, visible }) => {
         policy.
       </p>
       <p>
-        CAUTION: Not every program approved for GI Bill benefits is accredited
-        by the regional or national accreditor. Prior to enrolling, it’s
-        important to determine whether or not your field of study requires
-        accreditation for employment and/or licensing.
+        CAUTION: Not every program approved for GI Bill benefits is accredited.
+        Prior to enrolling, it’s important to determine whether or not your
+        field of study requires accreditation for employment and/or licensing.
       </p>
       <p>
-        To learn more about accreditation types, visit the{' '}
+        To learn more about accreditation, visit the{' '}
         <a
           href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type"
           target="_blank"

--- a/src/applications/gi/containers/search/ResultCard.jsx
+++ b/src/applications/gi/containers/search/ResultCard.jsx
@@ -43,7 +43,6 @@ export function ResultCard({
     city,
     state,
     studentCount,
-    accreditationType,
     cautionFlags,
     facilityCode,
     vetTecProvider,
@@ -281,15 +280,7 @@ export function ResultCard({
         </p>
         <p className="vads-u-margin-top--1 vads-u-margin-bottom--2p5">
           {/* eslint-disable-next-line no-nested-ternary */}
-          {accredited ? (
-            accreditationType ? (
-              <span className="capitalize-value">{accreditationType}</span>
-            ) : (
-              'Yes'
-            )
-          ) : (
-            'N/A'
-          )}
+          {accredited ? 'Yes' : 'N/A'}
         </p>
       </div>
       <div className="vads-u-flex--1">

--- a/src/applications/gi/tests/containers/Modals.unit.spec.jsx
+++ b/src/applications/gi/tests/containers/Modals.unit.spec.jsx
@@ -445,7 +445,7 @@ describe('<Modals>', () => {
     it('should render', () => {
       const wrapper = shallow(<Modals {...props} />);
       expect(wrapper.html()).to.contain(
-        'The goal of accreditation is to ensure the education provided',
+        'The goal of accreditation is to ensure that the education',
       );
       wrapper.unmount();
     });

--- a/src/applications/gi/tests/containers/ProfilePageHeader.unit.spec.jsx
+++ b/src/applications/gi/tests/containers/ProfilePageHeader.unit.spec.jsx
@@ -568,7 +568,7 @@ describe('<ProfilePageHeader>', () => {
       expect(accYes).to.exist;
     });
   });
-  it('should render "<Type> Accreditation" when accreditationType is set', async () => {
+  it('should render "Accredited" when accreditationType is set', async () => {
     const inst = {
       ...TEST_INSTITUTION,
       accredited: true,
@@ -583,7 +583,7 @@ describe('<ProfilePageHeader>', () => {
       },
     );
     await waitFor(() => {
-      expect(screen.getByText(/Hybrid Accreditation/i)).to.exist;
+      expect(screen.getByText(/Accredited/i)).to.exist;
     });
   });
 
@@ -761,18 +761,6 @@ describe('<ProfilePageHeader>', () => {
       await waitFor(() => {
         expect(document.body.textContent).to.match(/Flight Institution/);
       });
-    });
-  });
-
-  it('renders Hybrid Accreditation LearnMoreLabel when accreditationType is set', async () => {
-    const inst = { ...TEST_INSTITUTION, accreditationType: 'Hybrid' };
-    renderWithStoreAndRouter(<ProfilePageHeader institution={inst} />, {
-      initialState: {
-        constants: mockConstants(),
-      },
-    });
-    await waitFor(() => {
-      expect(document.body.textContent).to.match(/Hybrid Accreditation/);
     });
   });
   it('renders preferred provider LearnMoreLabel when preferredProvider is true', async () => {

--- a/src/applications/gi/tests/containers/search/ResultCard.unit.spec.jsx
+++ b/src/applications/gi/tests/containers/search/ResultCard.unit.spec.jsx
@@ -196,7 +196,7 @@ describe('<ResultCard>', () => {
     );
     expect(screen.getByText('10 - 100 hours')).to.exist;
   });
-  it('shows the accreditationType when accredited AND accreditationType is present', () => {
+  it('shows "Yes" when accredited AND accreditationType is present', () => {
     const inst = {
       ...INSTITUTION,
       accredited: true,
@@ -208,7 +208,7 @@ describe('<ResultCard>', () => {
       <ResultCard institution={inst} version={null} />,
       { initialState: { constants: mockConstants() } },
     );
-    expect(getByText(/regional/)).to.exist;
+    expect(getByText(/^Yes$/)).to.exist;
   });
 
   it('shows "Yes" when accredited is true but accreditationType is null', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Updating displays for accreditation to not include accreditation types and updating related learn more modals per business request, as follows:

**Modals (both to be updated as follows):**

<img width="492" height="257" alt="image" src="https://github.com/user-attachments/assets/9ba5b7f4-5414-48e8-98c4-9c2d166d5a1c" />


**Inst profile Header**
- `Accreditation: Yes` if accredited: true but accreditation type not provided, regardless of accreditation type
- `Accredited learn more` if accredited: true and accreditation type provided
- Not showing anything if not accredited
 
**Inst profile Academics section**
- `Accreditation learn more: Yes (See accreditors)` if accredited and accreditation type returned - regardless of accreditation type 
- `Accreditation: Yes (see accreditors)` if accredited but no accreditation type returned
- `Accreditation: None` if not accredited
 
**Inst result cards**
- `Accreditation: Yes` regardless of accreditation type, if accredited
- `Accreditation: N/A` if not accredited

## Related issue(s)

- [VEBT-3503](https://jira.devops.va.gov/browse/VEBT-3503)

## Testing done

Updated tests

<img width="768" height="137" alt="Screenshot 2025-09-26 at 2 09 13 PM" src="https://github.com/user-attachments/assets/44725d93-9a60-4e06-837b-ba85d0ebe2f3" />

## Screenshots

**Modals:**

<img width="1050" height="769" alt="Screenshot 2025-09-26 at 1 38 53 PM" src="https://github.com/user-attachments/assets/f5dc2bd6-1000-41e1-b9b4-6aee9781cd2c" />
<img width="1057" height="741" alt="Screenshot 2025-09-26 at 1 41 06 PM" src="https://github.com/user-attachments/assets/294923b3-f639-4719-bee8-3c1e8c0125e9" />

**Profile Header:**

<img width="758" height="594" alt="Screenshot 2025-09-26 at 1 40 49 PM" src="https://github.com/user-attachments/assets/c6cc51c8-8033-43e5-8e11-88d3ef205899" />
<img width="754" height="501" alt="Screenshot 2025-09-26 at 1 42 26 PM" src="https://github.com/user-attachments/assets/6162a135-c5c9-4fbc-86aa-f1162d3b28cf" />
<img width="758" height="515" alt="Screenshot 2025-09-26 at 1 43 17 PM" src="https://github.com/user-attachments/assets/5cc1310c-6f76-41be-9940-be5c1fbef9d6" />

**Academics section:**

<img width="1014" height="336" alt="Screenshot 2025-09-26 at 1 42 14 PM" src="https://github.com/user-attachments/assets/c2ec653d-a183-44da-855d-19d20d89045d" />
<img width="1012" height="404" alt="Screenshot 2025-09-26 at 1 42 35 PM" src="https://github.com/user-attachments/assets/cc55cb7a-3d1e-499f-8a04-aea5f85a2c7c" />

<img width="1012" height="405" alt="Screenshot 2025-09-26 at 1 43 23 PM" src="https://github.com/user-attachments/assets/5d68c05c-9866-424a-9d6f-f326762415f6" />

**Search Results:**

<img width="1020" height="636" alt="Screenshot 2025-09-26 at 1 43 40 PM" src="https://github.com/user-attachments/assets/472bd7e0-01fd-449a-ad5b-f922bc255919" />


## What areas of the site does it impact?

GI Comparison Tool - Schools & Employers search results and institution profile page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
