### PR TITLE
10-7959a | Fix VaRadio screenreader issue on address change page

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
@@ -63,25 +63,22 @@ export const applicantMemberNumberSchema = {
       ),
     ),
     applicantMemberNumber: textUI({
-      updateUiSchema: formData => {
-        return {
-          'ui:title': 'CHAMPVA member number',
-          'ui:errorMessages': {
-            required: 'Please enter your CHAMPVA member number',
-            pattern: 'Must be numbers only',
-          },
-          'ui:options': {
-            classNames: ['dd-privacy-hidden'],
-            uswds: true,
-            hint: `This number is usually the same as ${nameWording(
-              formData,
-              true,
-              false,
-              true,
-            )} Social Security number.`,
-          },
-        };
+      title: 'CHAMPVA member number',
+      errorMessages: {
+        required: 'Please enter your CHAMPVA member number',
+        pattern: 'Must be numbers only',
       },
+      classNames: ['dd-privacy-hidden'],
+      updateUiSchema: formData => ({
+        'ui:options': {
+          hint: `This number is usually the same as ${nameWording(
+            formData,
+            true,
+            false,
+            true,
+          )} Social Security number.`,
+        },
+      }),
     }),
     'ui:options': {
       itemAriaLabel: () => 'identification information',
@@ -119,30 +116,23 @@ export const applicantAddressSchema = {
     }),
     applicantNewAddress: {
       ...radioUI({
-        type: 'radio',
-        updateUiSchema: formData => {
-          const labels = {
-            yes: 'Yes',
-            no: 'No',
-            unknown: 'I’m not sure',
-          };
-
-          return {
-            'ui:title': `Has ${nameWording(
-              formData,
-              true,
-              false,
-              true,
-            )} mailing address changed since ${
-              formData.certifierRole === 'applicant' ? 'your' : 'their'
-            } last CHAMPVA claim or benefits application submission?`,
-            'ui:options': {
-              classNames: ['dd-privacy-hidden'],
-              labels,
-              hint: `If the mailing address changed, we'll update our records with the new address.`,
-            },
-          };
+        labels: {
+          yes: 'Yes',
+          no: 'No',
+          unknown: 'I’m not sure',
         },
+        classNames: ['dd-privacy-hidden'],
+        hint: `If the mailing address changed, we'll update our records with the new address.`,
+        updateUiSchema: formData => ({
+          'ui:title': `Has ${nameWording(
+            formData,
+            true,
+            false,
+            true,
+          )} mailing address changed since ${
+            formData.certifierRole === 'applicant' ? 'your' : 'their'
+          } last CHAMPVA claim or benefits application submission?`,
+        }),
       }),
     },
     'ui:options': {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates two fields for correct use of `updateUiSchema` from the forms system. The fix ensures that radio options are being correctly read by screenreaders and giving the user an accurate indication of which option is selected.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#118986

## Screenshots

| Before | After |
| ------ | ----- |
| | |

## Acceptance criteria

- Screenreaders correctly read radio options

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
