### PR TITLE
MHV SM: Update recent recipient handling in messaging components - validate null values

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ComposeForm/RecipientsSelect.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/RecipientsSelect.jsx
@@ -180,6 +180,7 @@ const RecipientsSelect = ({
     e => {
       const { value } = e.detail;
       if (!+value) {
+        onValueChange(null);
         return;
       }
 

--- a/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
+++ b/src/applications/mhv-secure-messaging/containers/RecentCareTeams.jsx
@@ -110,7 +110,7 @@ const RecentCareTeams = () => {
       );
       dispatch(
         updateDraftInProgress({
-          recipientId: value,
+          recipientId: recipient?.triageTeamId,
           careSystemName: recipient?.healthCareSystemName,
           recipientName: recipient?.name,
           careSystemVhaId: recipient?.stationNumber,

--- a/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
+++ b/src/applications/mhv-secure-messaging/containers/SelectCareTeam.jsx
@@ -76,7 +76,7 @@ const SelectCareTeam = () => {
       if (String(selectedCareTeamId) !== String(newId)) {
         setSelectedCareTeamId(newId);
 
-        if (recipient.id && recipient.id !== '0') {
+        if (newId && newId !== '0') {
           setCareTeamError('');
           dispatch(
             updateDraftInProgress({
@@ -103,7 +103,7 @@ const SelectCareTeam = () => {
               }),
             );
           }
-        } else if (!recipient.id) {
+        } else if (!newId || newId === '0') {
           dispatch(
             updateDraftInProgress({
               recipientId: null,
@@ -270,7 +270,7 @@ const SelectCareTeam = () => {
 
       const selectedRecipientStationNumber = allowedRecipients.find(
         recipient => recipient.id === +selectedCareTeamId,
-      ).stationNumber;
+      )?.stationNumber;
 
       if (
         !draftInProgress.careSystemVhaId ||

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/RecipientsSelect.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/RecipientsSelect.unit.spec.jsx
@@ -132,6 +132,28 @@ describe('RecipientsSelect', () => {
     });
   });
 
+  it('calls the onValueChange callback when a recipient is null', async () => {
+    // NOTE: Component derives alert text from selected recipient (effectiveSignatureRequired),
+    // not just the isSignatureRequired prop. Selecting a signature-required recipient
+    // should immediately show the REQUIRED alert text.
+    const onValueChange = sinon.spy();
+    const setCheckboxMarked = sinon.spy();
+    const setElectronicSignature = sinon.spy();
+    const customProps = {
+      onValueChange,
+      setCheckboxMarked,
+      setElectronicSignature,
+      defaultValue: '1', // Simulate selecting the placeholder (null) option
+    };
+    const screen = setup({ props: customProps });
+    selectVaSelect(screen.container, null);
+
+    await waitFor(() => {
+      expect(onValueChange.calledOnce).to.be.true;
+      expect(onValueChange.calledWith(null)).to.be.true;
+    });
+  });
+
   it('displays the signature alert when a recipient with signatureRequired is selected', async () => {
     const setAlertDisplayed = sinon.spy();
     const customProps = {

--- a/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/RecentCareTeams.unit.spec.jsx
@@ -214,14 +214,14 @@ describe('RecentCareTeams component', () => {
           recipients: {
             recentRecipients: [
               {
-                triageTeamId: 636,
+                triageTeamId: 123,
                 name: 'VA Boston',
                 healthCareSystemName: 'Test Facility 1',
                 stationNumber: '636',
                 ohTriageGroup: true,
               },
               {
-                triageTeamId: 662,
+                triageTeamId: 456,
                 name: 'VA Seattle',
                 healthCareSystemName: 'Test Facility 2',
                 stationNumber: '662',
@@ -237,12 +237,11 @@ describe('RecentCareTeams component', () => {
       );
       const screen = renderComponent(customState);
       expect(screen.getByText('Recent care teams')).to.exist;
-
-      selectVaRadio(screen.container, '636');
+      selectVaRadio(screen.container, 123);
       await waitFor(() => {
         const callArgs = updateDraftInProgressStub.lastCall.args[0];
         expect(callArgs).to.include({
-          recipientId: '636',
+          recipientId: 123,
           recipientName: 'VA Boston',
           careSystemVhaId: '636',
           careSystemName: 'Test Facility 1',
@@ -250,7 +249,7 @@ describe('RecentCareTeams component', () => {
         });
       });
 
-      selectVaRadio(screen.container, '662');
+      selectVaRadio(screen.container, 456);
       await waitFor(() => {
         const callArgs = updateDraftInProgressStub.lastCall.args[0];
 
@@ -258,7 +257,7 @@ describe('RecentCareTeams component', () => {
           careSystemName: 'Test Facility 2',
           careSystemVhaId: '662',
           ohTriageGroup: false,
-          recipientId: '662',
+          recipientId: 456,
           recipientName: 'VA Seattle',
         });
       });

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -50,8 +50,15 @@ class PatientMessageDetailsPage {
     cy.findByTestId(Locators.ALERTS.THREAD_EXPAND)
       .should('be.visible')
       .shadow()
-      .find('button')
-      .first()
+      .findByText('Expand all')
+      .click({ force: true });
+  };
+
+  collapseAllThreadMessages = () => {
+    cy.findByTestId(Locators.ALERTS.THREAD_EXPAND)
+      .should('be.visible')
+      .shadow()
+      .findByText('Collapse all')
       .click({ force: true });
   };
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -51,6 +51,7 @@ class PatientMessageDetailsPage {
       .should('be.visible')
       .shadow()
       .find('button')
+      .first()
       .click({ force: true });
   };
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
@@ -18,7 +18,7 @@ describe('SM EXPAND ALL ACCORDIONS', () => {
 
     PatientMessageDetailsPage.verifyExpandedThreadBody(threadResponse);
 
-    PatientMessageDetailsPage.expandAllThreadMessages();
+    PatientMessageDetailsPage.collapseAllThreadMessages();
 
     PatientMessageDetailsPage.verifyAccordionStatus(false);
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request updates the recipient selection logic and related tests in the secure messaging application to ensure consistent handling of recipient IDs as numbers rather than strings, and improves how null or placeholder selections are processed. The changes also address edge cases and update tests to match the new logic.

**Recipient selection logic improvements:**

* Updated `RecipientsSelect` to call `onValueChange(null)` when the user selects the placeholder option, ensuring null values are handled correctly.

**Care team and recipient ID consistency:**

* Updated `RecentCareTeams` to use `recipient?.triageTeamId` instead of `value`, ensuring recipient IDs are consistently treated as numbers.

**Test updates for new logic:**

* Added and updated unit tests to verify that `onValueChange(null)` is called when a null recipient is selected, and ensured that recipient IDs in tests are numbers, not strings. [[1]](diffhunk://#diff-6fc4c2f2e09f132a482f1350756efe0d0cfd90181699a699ccf047ca7fe5193bR135-R156) [[2]](diffhunk://#diff-d9ffae9a0895b66c46e05bf9fd405f8902c07dc3010522dca577bbf4ec7b043dL217-R224) [[3]](diffhunk://#diff-d9ffae9a0895b66c46e05bf9fd405f8902c07dc3010522dca577bbf4ec7b043dL240-R260)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/120889

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
