### PR TITLE
Update 0969 Confirmation Page

### DIFF
--- a/src/applications/income-and-asset-statement/components/NextStepsSection.jsx
+++ b/src/applications/income-and-asset-statement/components/NextStepsSection.jsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { apiRequest } from 'platform/utilities/api';
+import { getFormLink, inProgressApi } from 'platform/forms/helpers';
+
+const NextStepsSection = ({ loggedIn }) => {
+  const [loading, setLoading] = useState(false);
+  const [hasInProgress, setHasInProgress] = useState(false);
+
+  const pensionLink = getFormLink('21P-527EZ');
+
+  const NextSteps = () => (
+    <>
+      <p>
+        You don’t need to reapply for Veterans Pension or DIC if you’re already
+        receiving these benefits.
+      </p>
+
+      <h3>If you’re applying for Veterans Pension benefits</h3>
+      <p>
+        If you submitted this form as part of your Veterans Pension application,
+        you can return to the online form to complete your application.
+      </p>
+      <va-link
+        href={pensionLink}
+        text="Continue your Veterans Pension application"
+      />
+
+      <h3>If you’re applying for DIC benefits</h3>
+      <p>
+        If you submitted this form as part of your DIC application, you can
+        submit your completed DIC application by mail or in person.
+      </p>
+      <va-link href="" text="Apply for DIC compensation" />
+    </>
+  );
+
+  useEffect(
+    () => {
+      let isMounted = true;
+
+      const checkInProgress = async () => {
+        if (!loggedIn) return;
+        setLoading(true);
+        try {
+          await apiRequest(inProgressApi('21P-527EZ'));
+          if (isMounted) {
+            setHasInProgress(true);
+          }
+        } catch (e) {
+          // Any failure → log and gracefully fall back to NextSteps content
+          /* eslint-disable no-console */
+          console.warn('Failed to check in-progress 21P-527EZ:', e);
+          /* eslint-enable no-console */
+          if (isMounted) {
+            setHasInProgress(false);
+          }
+        } finally {
+          if (isMounted) setLoading(false);
+        }
+      };
+
+      checkInProgress();
+      return () => {
+        isMounted = false;
+      };
+    },
+    [loggedIn],
+  );
+
+  return (
+    <section>
+      <h2>What to do next</h2>
+
+      {!loggedIn && <NextSteps />}
+
+      {loggedIn && (
+        <>
+          {loading && (
+            <va-loading-indicator message="Checking your in-progress applications…" />
+          )}
+
+          {!loading && (
+            <>
+              {hasInProgress ? (
+                <>
+                  <p>
+                    You have an in-progress Pension benefits application. You
+                    can return to the online form to complete your application.
+                  </p>
+                  <va-link-action
+                    href={pensionLink}
+                    text="Continue Veterans Pension application"
+                  />
+                </>
+              ) : (
+                <NextSteps />
+              )}
+            </>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+NextStepsSection.propTypes = {
+  loggedIn: PropTypes.bool.isRequired,
+};
+
+export default NextStepsSection;

--- a/src/applications/income-and-asset-statement/containers/ConfirmationPage.jsx
+++ b/src/applications/income-and-asset-statement/containers/ConfirmationPage.jsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { isLoggedIn } from 'platform/user/selectors';
 import environment from 'platform/utilities/environment';
 import { ConfirmationView } from 'platform/forms-system/src/js/components/ConfirmationView';
+import NextStepsSection from '../components/NextStepsSection';
 
 let mockData;
 if (!environment.isProduction() && !environment.isStaging()) {
@@ -51,6 +52,7 @@ export const ConfirmationPage = props => {
       <h2>Save a copy of your form</h2>
       <ConfirmationView.ChapterSectionCollection />
       <ConfirmationView.PrintThisPage />
+      <NextStepsSection loggedIn={loggedIn} />
       <ConfirmationView.WhatsNextProcessList
         item1Content={
           loggedIn ? (


### PR DESCRIPTION
## Summary

This PR updates the **Confirmation** page for the **Income and Asset Statement form (VA Form 21P-0969)** by adding a **“What to do next”** section. The section queries for an **in-progress Pension Benefits (21P-527EZ)** application and **dynamically renders next steps** based on the response:

- If an in-progress Pension application **exists**: display an action link to continue the saved application
- If **no** in-progress Pension application exists or **cannot be determined**: display next steps to start a new Pension Benefits application with helpful context.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/116522

## Related issue(s)
N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Start at the 0969 base route:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  

## How to verify

1. **In-progress app found**  
   - Authenticate and start a Pension Benefits form 21P-527EZ
   - Submit 0969 → On **Confirmation**, verify the “What to do next” section shows:  
     - Contextual copy acknowledging a saved Pension application  
     - Action link to **continue** the saved Pension Benefits application  
     - No console errors

2. **No in-progress app** or **Error/unknown state** 
   - 'Finish application later' and then 'Start a new application' to remove the in progress Pension Benefits form 
   - Submit 0969 → Verify the section displays:  
     - Guidance to **start** a new Pension Benefits application  
     - Correct links to the Pension form intro and DIC compensation
     - Console warning logged
     - UI fails gracefully

3. **Not authenticated**  
   - Do not authenticate and submit 0969 → Verify:  
     - Guidance to **start** a new Pension Benefits application  
     - Correct links to the Pension form intro and DIC compensation
     - No console errors

4. **Accessibility & layout**  
   - Confirm heading order on the Confirmation page remains valid 
   - Check keyboard focus order and screen reader reading for the new section

## What areas of the site does it impact?

- Income and Asset Statement (VA Form 21P-0969)  
- **Confirmation page** “What to do next” section with dynamic content

## Screenshots

| No In Progress Form Found                    | Authenticated and In Progress Form Found                                       |
|--------------------------|----------------------------------------------------------|
|<img width="1560" height="2464" alt="localhost_3001_supporting-forms-for-claims_submit-income-and-asset-statement-form-21p-0969_confirmation (1)" src="https://github.com/user-attachments/assets/8372222a-f383-47b1-b16c-fa27a3608033" />|<img width="1560" height="2190" alt="localhost_3001_supporting-forms-for-claims_submit-income-and-asset-statement-form-21p-0969_confirmation" src="https://github.com/user-attachments/assets/b81332e7-4e6e-4f12-b0d9-18fecb5c5f5e" />



### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone

0969 Post-MVP enhancements

## Requested Feedback
