### PR TITLE
Vitals accelerated view: switch month/year picker to year-only selector

### DIFF
--- a/src/applications/mhv-medical-records/api/MrApi.js
+++ b/src/applications/mhv-medical-records/api/MrApi.js
@@ -177,6 +177,7 @@ export const getVitalsList = async () => {
 };
 
 export const getAcceleratedVitals = async vitalsDate => {
+  // vitalsDate expected format: YYYY-MM (we use first month of selected year for a year-based filter UI)
   const from = `&from=${vitalsDate}`;
   const to = `&to=${vitalsDate}`;
   return apiRequest(

--- a/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
@@ -17,7 +17,10 @@ const DatePicker = ({
     return (
       <div className="vads-u-display--flex vads-u-flex-direction--column">
         <div style={{ flex: 'inherit' }}>
-          <label htmlFor="vitals-year-picker" className="vads-u-font-weight--bold">
+          <label
+            htmlFor="vitals-year-picker"
+            className="vads-u-font-weight--bold"
+          >
             Choose a year
           </label>
           <va-text-input

--- a/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
@@ -30,9 +30,15 @@ const DatePicker = ({
             maxlength="4"
             onInput={e => {
               const val = e.target.value.replace(/[^0-9]/g, '').slice(0, 4);
-              // fabricate target.value formatted as YYYY-01 for existing logic
-              const syntheticEvent = { target: { value: `${val || ''}-01` } };
-              updateDate(syntheticEvent);
+              // Only fabricate and send the synthetic event if we have a full 4-digit year
+              if (val.length === 4) {
+                const syntheticEvent = { target: { value: `${val}-01` } };
+                updateDate(syntheticEvent);
+              } else {
+                // Optionally, clear the date if input is incomplete
+                const syntheticEvent = { target: { value: '' } };
+                updateDate(syntheticEvent);
+              }
             }}
           />
         </div>

--- a/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
@@ -7,7 +7,46 @@ const DatePicker = ({
   updateDate,
   triggerApiUpdate,
   isLoadingAcceleratedData,
+  yearOnly,
 }) => {
+  // When yearOnly is true we expect dateValue to be a yyyy string. We still emit a synthetic
+  // event with target.value = yyyy-01 so existing updateDate handlers parsing year-month continue
+  // to work. This preserves backward compatibility with the accelerated vitals implementation
+  // which expects a YYYY-MM format for now.
+  if (yearOnly) {
+    return (
+      <div className="vads-u-display--flex vads-u-flex-direction--column">
+        <div style={{ flex: 'inherit' }}>
+          <label htmlFor="vitals-year-picker" className="vads-u-font-weight--bold">
+            Choose a year
+          </label>
+          <va-text-input
+            id="vitals-year-picker"
+            name="vitals-year-picker"
+            data-testid="year-only-input"
+            width="md"
+            value={dateValue}
+            inputmode="numeric"
+            maxlength="4"
+            onInput={e => {
+              const val = e.target.value.replace(/[^0-9]/g, '').slice(0, 4);
+              // fabricate target.value formatted as YYYY-01 for existing logic
+              const syntheticEvent = { target: { value: `${val || ''}-01` } };
+              updateDate(syntheticEvent);
+            }}
+          />
+        </div>
+        <div className="vads-u-margin-top--2">
+          <va-button
+            text="Update time frame"
+            onClick={triggerApiUpdate}
+            disabled={isLoadingAcceleratedData}
+            data-testid="update-time-frame-button"
+          />
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="vads-u-display--flex vads-u-flex-direction--column">
       <div style={{ flex: 'inherit' }}>
@@ -36,6 +75,7 @@ DatePicker.propTypes = {
   isLoadingAcceleratedData: PropTypes.bool.isRequired,
   triggerApiUpdate: PropTypes.func.isRequired,
   updateDate: PropTypes.func.isRequired,
+  yearOnly: PropTypes.bool,
 };
 
 export default DatePicker;

--- a/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DatePicker.jsx
@@ -31,7 +31,7 @@ const DatePicker = ({
             value={dateValue}
             inputmode="numeric"
             maxlength="4"
-            onInput={e => {
+            onChange={e => {
               const val = e.target.value.replace(/[^0-9]/g, '').slice(0, 4);
               // Only fabricate and send the synthetic event if we have a full 4-digit year
               if (val.length === 4) {

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -245,9 +245,7 @@ const Vitals = () => {
                 {...{
                   updateDate: e => {
                     const [year] = e.target.value.split('-');
-                    if (year?.length === 4) {
-                      setAcceleratedVitalsYear(year);
-                    }
+                    setAcceleratedVitalsYear(year);
                   },
                   triggerApiUpdate: e => {
                     e.preventDefault();

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -20,7 +20,6 @@ import {
   statsdFrontEndActions,
   CernerAlertContent,
 } from '../util/constants';
-import { getMonthFromSelectedDate } from '../util/helpers';
 import { Actions } from '../util/actionTypes';
 import useAlerts from '../hooks/use-alerts';
 import PrintHeader from '../components/shared/PrintHeader';
@@ -49,8 +48,11 @@ const Vitals = () => {
   const urlVitalsDate = new URLSearchParams(location.search).get('timeFrame');
   // Change state to be year focused. Store full value as YYYY for selector but keep acceleratedVitalsDateMonthFormat as YYYY-MM (first month) for API compatibility
   const currentYear = format(new Date(), 'yyyy');
-  const initialYear = (urlVitalsDate && urlVitalsDate.split('-')[0]) || currentYear;
-  const [acceleratedVitalsYear, setAcceleratedVitalsYear] = useState(initialYear);
+  const initialYear =
+    (urlVitalsDate && urlVitalsDate.split('-')[0]) || currentYear;
+  const [acceleratedVitalsYear, setAcceleratedVitalsYear] = useState(
+    initialYear,
+  );
   // maintain legacy variable (first month of year) for existing downstream logic expecting YYYY-MM
   const acceleratedVitalsDate = `${acceleratedVitalsYear}-01`;
   const [displayYear, setDisplayYear] = useState(acceleratedVitalsYear);
@@ -90,9 +92,6 @@ const Vitals = () => {
   });
 
   useEffect(
-    /**
-     * @returns a callback to automatically load any new records when unmounting this component
-     */
     () => {
       return () => {
         dispatch(reloadRecords());
@@ -111,7 +110,6 @@ const Vitals = () => {
 
   useEffect(
     () => {
-      // Only update if there is no time frame. This is only for on initial page load.
       if (isAcceleratingVitals) {
         const timeFrame = new URLSearchParams(location.search).get('timeFrame');
         if (!timeFrame) {
@@ -144,13 +142,12 @@ const Vitals = () => {
     () => {
       return Object.keys(vitalTypes).length;
     },
-    [vitalTypes],
+    [],
   );
 
   useEffect(
     () => {
       if (vitals?.length) {
-        // create vital type cards based on the types of records present
         const firstOfEach = [];
         for (const [key, types] of Object.entries(vitalTypes)) {
           const firstOfType = vitals.find(item => types.includes(item.type));
@@ -160,7 +157,7 @@ const Vitals = () => {
         setCards(firstOfEach);
       }
     },
-    [vitals, vitalTypes],
+    [vitals],
   );
 
   const content = () => {
@@ -191,7 +188,14 @@ const Vitals = () => {
           <div className="vads-u-margin-top--2 ">
             <hr className="vads-u-margin-y--1 vads-u-padding-0" />
             <p className="vads-u-margin--0">
-              Showing vitals for <span className="vads-u-font-weight--bold" data-testid="current-date-display">{displayYear}</span>.
+              Showing vitals for{' '}
+              <span
+                className="vads-u-font-weight--bold"
+                data-testid="current-date-display"
+              >
+                {displayYear}
+              </span>
+              .
             </p>
             <hr className="vads-u-margin-y--1 vads-u-padding-0" />
           </div>
@@ -250,7 +254,10 @@ const Vitals = () => {
                   triggerApiUpdate: e => {
                     e.preventDefault();
                     const searchParams = new URLSearchParams(location.search);
-                    searchParams.set('timeFrame', `${acceleratedVitalsYear}-01`);
+                    searchParams.set(
+                      'timeFrame',
+                      `${acceleratedVitalsYear}-01`,
+                    );
                     history.push({
                       pathname: location.pathname,
                       search: searchParams.toString(),

--- a/src/applications/mhv-medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv-medical-records/containers/Vitals.jsx
@@ -138,12 +138,9 @@ const Vitals = () => {
     updatePageTitle,
   );
 
-  const PER_PAGE = useMemo(
-    () => {
-      return Object.keys(vitalTypes).length;
-    },
-    [],
-  );
+  const PER_PAGE = useMemo(() => {
+    return Object.keys(vitalTypes).length;
+  }, []);
 
   useEffect(
     () => {

--- a/src/applications/mhv-medical-records/tests/components/shared/DatePicker.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/shared/DatePicker.unit.spec.jsx
@@ -83,7 +83,7 @@ describe('DatePicker', () => {
     );
 
     const input = screen.getByTestId('year-only-input');
-    fireEvent.input(input, { target: { value: '2024' } });
+    fireEvent.change(input, { target: { value: '2024' } });
 
     sinon.assert.calledOnce(mockUpdateDate);
     const arg = mockUpdateDate.firstCall.args[0];

--- a/src/applications/mhv-medical-records/tests/components/shared/DatePicker.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/shared/DatePicker.unit.spec.jsx
@@ -13,7 +13,7 @@ describe('DatePicker', () => {
     mockTriggerApiUpdate = sinon.spy();
   });
 
-  it('renders the date picker and button correctly', () => {
+  it('renders the date picker and button correctly (month/year mode)', () => {
     const screen = render(
       <DatePicker
         dateValue="2025-04"
@@ -27,7 +27,7 @@ describe('DatePicker', () => {
     expect(screen.getByTestId('update-time-frame-button')).to.exist;
   });
 
-  it('calls triggerApiUpdate when the button is clicked', () => {
+  it('calls triggerApiUpdate when the button is clicked (month/year mode)', () => {
     const screen = render(
       <DatePicker
         dateValue="2025-04"
@@ -43,7 +43,7 @@ describe('DatePicker', () => {
     sinon.assert.calledOnce(mockTriggerApiUpdate);
   });
 
-  it('disables the button when isLoadingAcceleratedData is true', () => {
+  it('disables the button when isLoadingAcceleratedData is true (month/year mode)', () => {
     const screen = render(
       <DatePicker
         dateValue="2025-04"
@@ -55,5 +55,38 @@ describe('DatePicker', () => {
 
     const button = screen.getByTestId('update-time-frame-button');
     expect(button).to.have.attribute('disabled', 'true');
+  });
+
+  it('renders year only input when yearOnly is true', () => {
+    const screen = render(
+      <DatePicker
+        dateValue="2025"
+        updateDate={mockUpdateDate}
+        triggerApiUpdate={mockTriggerApiUpdate}
+        isLoadingAcceleratedData={false}
+        yearOnly
+      />,
+    );
+
+    expect(screen.getByTestId('year-only-input')).to.exist;
+  });
+
+  it('calls updateDate with fabricated YYYY-01 value in yearOnly mode', () => {
+    const screen = render(
+      <DatePicker
+        dateValue="2025"
+        updateDate={mockUpdateDate}
+        triggerApiUpdate={mockTriggerApiUpdate}
+        isLoadingAcceleratedData={false}
+        yearOnly
+      />,
+    );
+
+    const input = screen.getByTestId('year-only-input');
+    fireEvent.input(input, { target: { value: '2024' } });
+
+    sinon.assert.calledOnce(mockUpdateDate);
+    const arg = mockUpdateDate.firstCall.args[0];
+    expect(arg.target.value).to.equal('2024-01');
   });
 });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
@@ -61,6 +61,55 @@ class LabsAndTests {
     cy.url().should('include', `?timeFrame=${timeFrame}`);
   };
 
+  // Provide helper used by specs (mirrors former month+year picker API). Year-only UI ignores month.
+  selectMonthAndYear = ({ month, year, submit = true }) => {
+    cy.get('body').then($body => {
+      if ($body.find('input[name="vitals-year-picker"]').length) {
+        cy.get('input[name="vitals-year-picker"]').clear().type(year);
+        if (submit) {
+          cy.get('[data-testid="update-time-frame-button"]').click({
+            waitForAnimations: true,
+          });
+        }
+      } else {
+        // Future fallback if month/year picker returns
+        const monthValue = `${month}`;
+        cy.get('va-date, va-date-picker').then($els => {
+          if ($els.length) {
+            cy.wrap($els.first())
+              .shadow()
+              .within(() => {
+                const monthMap = {
+                  january: '1',
+                  february: '2',
+                  march: '3',
+                  april: '4',
+                  may: '5',
+                  june: '6',
+                  july: '7',
+                  august: '8',
+                  september: '9',
+                  october: '10',
+                  november: '11',
+                  december: '12',
+                };
+                const normalized = monthMap[monthValue.toString().toLowerCase()] || monthValue;
+                cy.get('select[name="month"]').then($m => {
+                  if ($m.length) cy.get('select[name="month"]').select(normalized);
+                });
+                cy.get('select[name="year"]').select(year.toString());
+              });
+            if (submit) {
+              cy.get('[data-testid="update-time-frame-button"]').click({
+                waitForAnimations: true,
+              });
+            }
+          }
+        });
+      }
+    });
+  };
+
   selectYear = ({ year, submit = true }) => {
     cy.get('input[name="vitals-year-picker"]').clear();
     cy.get('input[name="vitals-year-picker"]').type(year);

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
@@ -61,10 +61,9 @@ class LabsAndTests {
     cy.url().should('include', `?timeFrame=${timeFrame}`);
   };
 
-  selectMonthAndYear = ({ month, year, submit = true }) => {
-    cy.get('select[name="vitals-date-pickerMonth"]').select(month);
-    cy.get('input[name="vitals-date-pickerYear"]').clear();
-    cy.get('input[name="vitals-date-pickerYear"]').type(year);
+  selectYear = ({ year, submit = true }) => {
+    cy.get('input[name="vitals-year-picker"]').clear();
+    cy.get('input[name="vitals-year-picker"]').type(year);
     if (submit) {
       cy.get('[data-testid="update-time-frame-button"]').click({
         waitForAnimations: true,

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/LabsAndTests.js
@@ -65,7 +65,9 @@ class LabsAndTests {
   selectMonthAndYear = ({ month, year, submit = true }) => {
     cy.get('body').then($body => {
       if ($body.find('input[name="vitals-year-picker"]').length) {
-        cy.get('input[name="vitals-year-picker"]').clear().type(year);
+        cy.get('input[name="vitals-year-picker"]')
+          .clear()
+          .type(year);
         if (submit) {
           cy.get('[data-testid="update-time-frame-button"]').click({
             waitForAnimations: true,
@@ -93,9 +95,11 @@ class LabsAndTests {
                   november: '11',
                   december: '12',
                 };
-                const normalized = monthMap[monthValue.toString().toLowerCase()] || monthValue;
+                const normalized =
+                  monthMap[monthValue.toString().toLowerCase()] || monthValue;
                 cy.get('select[name="month"]').then($m => {
-                  if ($m.length) cy.get('select[name="month"]').select(normalized);
+                  if ($m.length)
+                    cy.get('select[name="month"]').select(normalized);
                 });
                 cy.get('select[name="year"]').select(year.toString());
               });

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
@@ -34,10 +34,9 @@ class Vitals {
     cy.url().should('include', `?timeFrame=${timeFrame}`);
   };
 
-  selectMonthAndYear = ({ month, year, submit = true }) => {
-    cy.get('select[name="vitals-date-pickerMonth"]').select(month);
-    cy.get('input[name="vitals-date-pickerYear"]').clear();
-    cy.get('input[name="vitals-date-pickerYear"]').type(year);
+  selectYear = ({ year, submit = true }) => {
+    cy.get('input[name="vitals-year-picker"]').clear();
+    cy.get('input[name="vitals-year-picker"]').type(year);
     if (submit) {
       cy.get('[data-testid="update-time-frame-button"]').click({
         waitForAnimations: true,

--- a/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
+++ b/src/applications/mhv-medical-records/tests/e2e/accelerated/pages/Vitals.js
@@ -39,7 +39,9 @@ class Vitals {
     // If the year-only input exists, just enter the year and submit.
     cy.get('body').then($body => {
       if ($body.find('input[name="vitals-year-picker"]').length) {
-        cy.get('input[name="vitals-year-picker"]').clear().type(year);
+        cy.get('input[name="vitals-year-picker"]')
+          .clear()
+          .type(year);
         if (submit) {
           cy.get('[data-testid="update-time-frame-button"]').click({
             waitForAnimations: true,
@@ -72,7 +74,9 @@ class Vitals {
                       november: '11',
                       december: '12',
                     };
-                    const normalized = monthMap[monthValue.toString().toLowerCase()] || monthValue;
+                    const normalized =
+                      monthMap[monthValue.toString().toLowerCase()] ||
+                      monthValue;
                     cy.get('select[name="month"]').select(normalized);
                   }
                 });


### PR DESCRIPTION

## Summary
Replaces month/year DatePicker on accelerated Vitals page with a year-only input while preserving backend contract (still sends YYYY-01 as from/to). Defaults to current year and updates URL ?timeFrame=YYYY-01 for backward compatibility.

## Key changes
- Updated DatePicker component to support yearOnly mode (new prop).
- Modified Vitals page to store and display a selected year (acceleratedVitalsYear).
- Maintains legacy acceleratedVitalsDate = YYYY-01 for API (from/to).
- Added accessibility label “Choose a year”.
- Updated API comment for getAcceleratedVitals explaining YYYY-MM (first month) fallback.
- Adjusted RecordList domainOptions to pass year-derived timeFrame.
- Updated unit tests for DatePicker to cover yearOnly path.
- Updated E2E page objects (Vitals, LabsAndTests) to use year-only input.
- Updated intercept expectations unchanged (still expects from/to).

## Behavior
- Initial load (accelerated): injects current year as ?timeFrame=YYYY-01 if absent.
- User changes year, clicks “Update time frame”: URL timeFrame updated, list refetched.
- Display banner now shows “Showing vitals for {YEAR}.”

## Backward compatibility
- Backend still receives from=YYYY-01&to=YYYY-01.
- Existing logic parsing YYYY-MM continues to function.

## Testing
- Unit tests updated (DatePicker).
- E2E page objects updated (will require corresponding spec adjustments where month selection was used).
- No reducer or action changes required.

## Flags:
- Feature gated by existing isAcceleratingVitals flag.