### PR TITLE
CC: timezone in date, add params for ccEps appointments

### DIFF
--- a/src/applications/vaos/components/AppointmentDate.jsx
+++ b/src/applications/vaos/components/AppointmentDate.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 
 /**
  * Component for displaying appointment date in a consistent format
  */
-export default function AppointmentDate({ date }) {
-  const formattedDate = format(new Date(date), 'EEEE, MMMM do, yyyy');
+export default function AppointmentDate({ date, timezone }) {
+  const formattedDate = formatInTimeZone(
+    new Date(date),
+    timezone,
+    'EEEE, MMMM do, yyyy',
+  );
 
   return (
     <span data-dd-privacy="mask" data-testid="appointment-date">
@@ -17,4 +21,5 @@ export default function AppointmentDate({ date }) {
 
 AppointmentDate.propTypes = {
   date: PropTypes.string.isRequired,
+  timezone: PropTypes.string.isRequired,
 };

--- a/src/applications/vaos/components/AppointmentDate.unit.spec.jsx
+++ b/src/applications/vaos/components/AppointmentDate.unit.spec.jsx
@@ -5,9 +5,12 @@ import AppointmentDate from './AppointmentDate';
 
 describe('AppointmentDate', () => {
   const sampleDate = '2024-11-18T18:30:00Z';
+  const sampleTimezone = 'America/New_York';
 
   it('should render date with default format', () => {
-    const { getByTestId } = render(<AppointmentDate date={sampleDate} />);
+    const { getByTestId } = render(
+      <AppointmentDate date={sampleDate} timezone={sampleTimezone} />,
+    );
 
     const dateElement = getByTestId('appointment-date');
     expect(dateElement).to.exist;
@@ -15,7 +18,9 @@ describe('AppointmentDate', () => {
   });
 
   it('should have data-dd-privacy mask attribute', () => {
-    const { getByTestId } = render(<AppointmentDate date={sampleDate} />);
+    const { getByTestId } = render(
+      <AppointmentDate date={sampleDate} timezone={sampleTimezone} />,
+    );
 
     const dateElement = getByTestId('appointment-date');
     expect(dateElement).to.exist;

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
@@ -93,7 +93,10 @@ export default function EpsAppointmentDetailsPage() {
           <span data-dd-privacy="mask">Community Care Appointment</span>
         </h1>
         <Section heading="When">
-          <AppointmentDate date={appointment.start} />
+          <AppointmentDate
+            date={appointment.start}
+            timezone={appointment.provider.location.timezone}
+          />
           <br />
           <AppointmentTime
             date={appointment.start}

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.jsx
@@ -66,6 +66,19 @@ export default function EpsAppointmentDetailsPage() {
   }
 
   const { attributes: appointment } = referralAppointmentInfo;
+  const isPastAppointment = appointment.past;
+
+  const backLink = isPastAppointment
+    ? '/my-health/appointments/past'
+    : '/my-health/appointments';
+
+  const backLinkText = isPastAppointment
+    ? 'Back to past appointments'
+    : 'Back to appointments';
+
+  const pageTitle = isPastAppointment
+    ? 'Past community care appointment'
+    : 'Community care appointment';
 
   return (
     <PageLayout>
@@ -75,11 +88,11 @@ export default function EpsAppointmentDetailsPage() {
             back
             aria-label="Back link"
             data-testid="back-link"
-            text="Back to appointments"
-            href="/my-health/appointments"
+            text={backLinkText}
+            href={backLink}
             onClick={e => {
               e.preventDefault();
-              history.push('/');
+              history.push(isPastAppointment ? '/past' : '/');
             }}
           />
         </nav>
@@ -90,7 +103,7 @@ export default function EpsAppointmentDetailsPage() {
         icon-name="calendar_today"
       >
         <h1 className="vaos__dynamic-font-size--h2">
-          <span data-dd-privacy="mask">Community Care Appointment</span>
+          <span data-dd-privacy="mask">{pageTitle}</span>
         </h1>
         <Section heading="When">
           <AppointmentDate

--- a/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/referral-appointments/EpsAppointmentDetailsPage.unit.spec.jsx
@@ -149,7 +149,14 @@ describe('EpsAppointmentDetailsPage', () => {
   });
 
   it('should render appointment details when appointment is loaded', async () => {
-    requestStub.resolves({ data: referralAppointmentInfo });
+    const referralAppointmentFuture = {
+      ...referralAppointmentInfo,
+      attributes: {
+        ...referralAppointmentInfo.attributes,
+        past: false,
+      },
+    };
+    requestStub.resolves({ data: referralAppointmentFuture });
     const { container, getByText, getByTestId } = renderWithStoreAndRouter(
       <EpsAppointmentDetailsPage />,
       {
@@ -170,7 +177,7 @@ describe('EpsAppointmentDetailsPage', () => {
     );
 
     // Check heading
-    expect(getByText('Community Care Appointment')).to.exist;
+    expect(getByText('Community care appointment')).to.exist;
 
     // Check sections exist
     expect(getByText('When')).to.exist;

--- a/src/applications/vaos/referral-appointments/utils/appointment.js
+++ b/src/applications/vaos/referral-appointments/utils/appointment.js
@@ -7,7 +7,8 @@ const appointmentData = {
     start: '2024-11-18T13:30:00Z',
     isLatest: false,
     lastRetrieved: '2025-01-29T16:30:25Z',
-    modality: 'OV',
+    modality: 'communityCareEps',
+    past: true,
     provider: {
       id: 'DBKQ-123',
       location: {

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -708,8 +708,11 @@ export function groupAppointmentByDay(appointments) {
 
 export function getLink({ appointment }) {
   const { isPastAppointment } = appointment.vaos;
+  const ccEps = appointment.modality === 'communityCareEps';
 
-  return `${isPastAppointment ? 'past' : ''}/${appointment.id}`;
+  return `${isPastAppointment ? 'past' : ''}/${appointment.id}${
+    ccEps ? '?eps=true' : ''
+  }`;
 }
 
 export function getPractitionerName(appointment) {

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -710,7 +710,7 @@ export function getLink({ appointment }) {
   const { isPastAppointment } = appointment.vaos;
   const ccEps = appointment.modality === 'communityCareEps';
 
-  return `${isPastAppointment ? 'past' : ''}/${appointment.id}${
+  return `${isPastAppointment && !ccEps ? 'past' : ''}/${appointment.id}${
     ccEps ? '?eps=true' : ''
   }`;
 }

--- a/src/applications/vaos/services/appointment/index.unit.spec.jsx
+++ b/src/applications/vaos/services/appointment/index.unit.spec.jsx
@@ -12,6 +12,7 @@ import {
   getLongTermAppointmentHistoryV2,
   getVAAppointmentLocationId,
   isValidPastAppointment,
+  getLink,
 } from '.';
 import MockAppointmentResponse from '../../tests/fixtures/MockAppointmentResponse';
 import {
@@ -444,6 +445,51 @@ describe('VAOS Services: Appointment ', () => {
       const filtered = appointments.filter(isValidPastAppointment);
 
       expect(filtered.length).to.equal(3);
+    });
+  });
+
+  describe('getLink', () => {
+    it('should return the correct link for a past appointment', () => {
+      const appointment = {
+        vaos: {
+          isPastAppointment: true,
+        },
+        id: '123',
+        modality: 'vaInPerson',
+      };
+      expect(getLink({ appointment })).to.equal('past/123');
+    });
+
+    it('should return the correct link for a CC appointment', () => {
+      const appointment = {
+        id: '123',
+        vaos: {
+          isPastAppointment: true,
+        },
+        modality: 'communityCareEps',
+      };
+      expect(getLink({ appointment })).to.equal('/123?eps=true');
+      const futureAppointment = {
+        id: '1234',
+        vaos: {
+          isPastAppointment: false,
+        },
+        modality: 'communityCareEps',
+      };
+      expect(getLink({ appointment: futureAppointment })).to.equal(
+        '/1234?eps=true',
+      );
+    });
+
+    it('should return the correct link for a future appointment', () => {
+      const appointment = {
+        id: '123',
+        vaos: {
+          isPastAppointment: false,
+        },
+        modality: 'vaInPerson',
+      };
+      expect(getLink({ appointment })).to.equal('/123');
     });
   });
 });

--- a/src/applications/vaos/services/mocks/utils/confirmedAppointments.js
+++ b/src/applications/vaos/services/mocks/utils/confirmedAppointments.js
@@ -369,6 +369,7 @@ const appointmentTemplates = {
           id: appointmentId,
           status: 'booked',
           patientIcn: null,
+          modality: 'communityCareEps',
           created: formatAppointmentDate(new Date()),
           locationId: 'sandbox-network-5vuTac8v',
           clinic: '9L5WE4aN',

--- a/src/applications/vaos/tests/e2e/referrals/page-objects/EpsAppointmentDetails.js
+++ b/src/applications/vaos/tests/e2e/referrals/page-objects/EpsAppointmentDetails.js
@@ -6,7 +6,7 @@ class AppointmentDetails {
    * Validates that the user is on the appointment details page
    */
   validate() {
-    cy.findByText('Community Care Appointment').should('exist');
+    cy.findByText('Community care appointment').should('exist');
     cy.findByTestId('appointment-card').should('exist');
     return this;
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Check for an appointments modality. If modality indicates it is an EPS + CC appointment, then add appropriate params to render EpsCC component.
- Add timezone to date formatting for edge case where the difference of UTC and Local may print a different date.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/120998

## Testing done

- Tests running
- Update local mock data to include accurate modality, confirm components.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

VAOS Appointments and Community Care

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
