### PR TITLE
[4875] Form Upload - write front end tests for new supporting evidence pages

### DIFF
--- a/src/applications/simple-forms/form-upload/tests/unit/components/CustomReviewTopContent.unit.spec.jsx
+++ b/src/applications/simple-forms/form-upload/tests/unit/components/CustomReviewTopContent.unit.spec.jsx
@@ -38,6 +38,16 @@ const mockStore = withPhoneNumber => ({
         address: { postalCode: '55555' },
         fullName: { first: 'John', last: 'Veteran' },
         phoneNumber: withPhoneNumber ? '1234567890' : null,
+        supportingDocuments: [
+          {
+            confirmationCode: '12345',
+            name: 'placeholder',
+            size: 1024,
+            warnings: [],
+            additionalData: {},
+            type: 'image/png',
+          },
+        ],
       },
     },
     scheduledDowntime: {
@@ -79,6 +89,14 @@ describe('CustomReviewTopContent', () => {
 
       expect(fileInput).to.exist;
       expect(fileInput).to.have.attr('read-only', 'true');
+    });
+
+    it('renders the supporting documents input component', () => {
+      const { container } = subject();
+      const fileInputMultiple = $('va-file-input-multiple', container);
+
+      expect(fileInputMultiple).to.exist;
+      expect(fileInputMultiple).to.have.attr('read-only', 'true');
     });
   });
 


### PR DESCRIPTION
## Summary

This PR raises unit test coverage of the Supporting Documents feature of Form Upload to acceptable percentages.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/4875

## Testing done

Unit tests
