### PR TITLE
refactor: replace Date mocking with sinon fake timers in unit tests

### DIFF
--- a/src/applications/ask-va/tests/components/Announcements.unit.spec.jsx
+++ b/src/applications/ask-va/tests/components/Announcements.unit.spec.jsx
@@ -40,19 +40,12 @@ const generateStore = (initialState = {}) => {
 
 describe('<Announcements />', () => {
   const mockDate = new Date('2024-03-20T12:00:00Z');
-  let originalDate;
+  let clock;
   let apiRequestStub;
   let constantsStub;
 
   beforeEach(() => {
-    // Mock the Date constructor to return a consistent date
-    originalDate = global.Date;
-    global.Date = class extends Date {
-      constructor(...args) {
-        super(...args);
-        return args.length === 0 ? mockDate : this;
-      }
-    };
+    clock = sinon.useFakeTimers({ now: mockDate.getTime(), toFake: ['Date'] });
 
     // Mock the API request
     apiRequestStub = sinon
@@ -64,8 +57,8 @@ describe('<Announcements />', () => {
   });
 
   afterEach(() => {
-    // Restore the original Date constructor and stubs
-    global.Date = originalDate;
+    // Restore the clock and stubs
+    clock.restore();
     apiRequestStub.restore();
     constantsStub.restore();
   });

--- a/src/platform/user/profile/vap-svc/tests/components/ContactInfoFormAppConfigContext.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/ContactInfoFormAppConfigContext.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
+import sinon from 'sinon';
 import {
   createPutHandler,
   jsonResponse,
@@ -97,20 +98,15 @@ TestComponent.propTypes = {
 };
 
 describe('ContactInfoFormAppConfigProvider - Error Handling', () => {
-  let originalDate;
+  let clock;
   const mockDate = new Date('2025-04-08T18:01:25.548Z');
 
-  before(() => {
-    originalDate = global.Date;
-    global.Date = class extends Date {
-      constructor() {
-        return mockDate;
-      }
-    };
+  beforeEach(() => {
+    clock = sinon.useFakeTimers({ now: mockDate.getTime(), toFake: ['Date'] });
   });
 
-  after(() => {
-    global.Date = originalDate;
+  afterEach(() => {
+    clock.restore();
   });
 
   it('shows error alert when profile update fails and form save succeeds with the correct updated data', async () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

##  Summary

Refactors unit tests to use Sinon's useFakeTimers() instead of manually mocking the Date constructor. This better matches other tests and avoids polluting the Date global.

###   Changes

* Replaced custom Date mocking: Removed manual Date constructor overrides in favor of sinon.useFakeTimers()
* Improved test isolation: Updated from before/after to beforeEach/afterEach hooks to ensure each test gets a fresh clock instance
* Simplified cleanup: Streamlined teardown logic using clock.restore()

###   Files Modified

* `src/applications/ask-va/tests/components/Announcements.unit.spec.jsx`
* `src/platform/user/profile/vap-svc/tests/components/ContactInfoFormAppConfigContext.unit.spec.jsx`

###   Benefits

* More reliable - Sinon's fake timers properly handle all time-related functionality
* Cleaner code - Removes complex manual mocking logic
* Better test isolation - Each test gets a fresh clock instance
* Standard practice - Uses established testing library features instead of custom solutions
