### PR TITLE
Vebt 3453 #comment Added focus to first h3 in training provider summary 22-10297 form

### DIFF
--- a/src/applications/edu-benefits/10297/config/form.js
+++ b/src/applications/edu-benefits/10297/config/form.js
@@ -31,7 +31,7 @@ import {
   atLeast3Years,
 } from '../pages';
 
-import { trainingProviderArrayOptions } from '../helpers';
+import { trainingProviderArrayOptions, focusOnH3 } from '../helpers';
 
 import dateReleasedFromActiveDuty from '../pages/dateReleasedFromActiveDuty';
 import activeDutyStatus from '../pages/activeDutyStatus';
@@ -152,6 +152,7 @@ const formConfig = {
             path: 'training-provider',
             uiSchema: trainingProviderSummary.uiSchema,
             schema: trainingProviderSummary.schema,
+            scrollAndFocusTarget: focusOnH3,
           }),
           trainingProviderDetails: pageBuilder.itemPage({
             title: 'Training provider name and mailing address',

--- a/src/applications/edu-benefits/10297/helpers.js
+++ b/src/applications/edu-benefits/10297/helpers.js
@@ -3,6 +3,8 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
+import { focusElement } from '~/platform/utilities/ui';
+
 export const ConfirmationSubmissionAlert = ({ confirmationNumber }) => (
   <>
     <p>Your submission is in progress.</p>
@@ -156,4 +158,8 @@ export const maskBankInformation = (string, unmaskedLength) => {
   const maskedPart = '●'.repeat(repeatCount);
   const unmaskedPart = string.slice(-unmaskedLength);
   return `${maskedPart}${unmaskedPart}`;
+};
+
+export const focusOnH3 = () => {
+  focusElement('#main h3');
 };

--- a/src/applications/edu-benefits/8794/components/NeedHelp.jsx
+++ b/src/applications/edu-benefits/8794/components/NeedHelp.jsx
@@ -13,6 +13,7 @@ const NeedHelp = () => {
             <va-link
               text="contact your Education Liaison Representative."
               href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/elr.asp"
+              external
             />
           </p>
         </div>

--- a/src/applications/edu-benefits/8794/components/NeedHelp.jsx
+++ b/src/applications/edu-benefits/8794/components/NeedHelp.jsx
@@ -13,7 +13,6 @@ const NeedHelp = () => {
             <va-link
               text="contact your Education Liaison Representative."
               href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/elr.asp"
-              external
             />
           </p>
         </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

### - _(Summarize the changes that have been made to the platform)_
- Added focus to first h3 in training provider summary 22-10297 form
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

Jira -> https://jira.devops.va.gov/browse/VEBT-3453

Issue Type: Bug
Reporter: Zina Al Waidh

Labels: (choose one)

[ ]Potential_Defect
[ ]Chrome_Only
[(/) ]Internal_Bug
[ ]Platform_Issue
Priority: (choose one)

[ ]High – Critical issue or blocking
[(/) ]Medium – Important but not blocking
[ ]Low – Cosmetic or minor issue
Summary

while testing form 10297 using screen readers, Step 2 "Tell us about your training Provider" does not have focus first thing as H3 - it is instead on "Do you have a training provider to add?"

Environment
Browser: Chrome, edge
Environment: (select one)

[(/) ] Staging
[ ] Dev
[ ] Prod
Bug Description

while testing form 10297 using screen readers, Step 2 "Tell us about your training Provider" does not have focus first thing as H3

Acceptance Criteria Reference

Summarize or paste acceptance criteria from the related user story.
Example:

AC1: Step 2: "Tell us about your training provider" H3 focus should be first when screen reader user goes to that part/step 
AC2: focus is removed from "Do you have a training provider to add?" when user transitions to that step 
Steps to Reproduce

Navigate to Step 2 of form 10297 with a screen reader
Focus is on "Do you have a training provider to add?" not "Tell us about your training provider"

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots


https://github.com/user-attachments/assets/20294dc9-84c1-4fb3-a6e1-af229844b339


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
