### PR TITLE
0969 | Update royalties relationship to veteran pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-unassociated-incomes/unassociatedIncomePages.js
@@ -278,6 +278,9 @@ const veteranIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'unassociatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',
@@ -312,6 +315,9 @@ const spouseIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'unassociatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',
@@ -342,6 +348,9 @@ const custodianIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'unassociatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',
@@ -372,6 +381,9 @@ const parentIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'unassociatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',
@@ -398,6 +410,9 @@ const nonVeteranIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'unassociatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/03-associated-incomes/associatedIncomePages.js
@@ -279,6 +279,9 @@ const veteranIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'associatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',
@@ -313,6 +316,9 @@ const spouseIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'associatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',
@@ -342,6 +348,9 @@ const custodianIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'associatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',
@@ -369,6 +378,9 @@ const parentIncomeRecipientPage = {
     otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
       'associatedIncomes',
     ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/04-owned-assets/ownedAssetPages.js
@@ -327,7 +327,7 @@ const parentSummaryPage = {
 };
 
 /** @returns {PageSchema} */
-const incomeRecipientPage = {
+const nonVeteranIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Property and business relationship',
@@ -723,12 +723,12 @@ export const ownedAssetPages = arrayBuilderPages(options, pageBuilder => ({
     schema: parentIncomeRecipientPage.schema,
   }),
   // Page 1 MVP
-  ownedAssetIncomeRecipientPage: pageBuilder.itemPage({
+  ownedAssetNonVeteranRecipientPage: pageBuilder.itemPage({
     title: incomeRecipientPageTitle,
     path: 'property-and-business/:index/income-recipient',
     depends: () => !showUpdatedContent(),
-    uiSchema: incomeRecipientPage.uiSchema,
-    schema: incomeRecipientPage.schema,
+    uiSchema: nonVeteranIncomeRecipientPage.uiSchema,
+    schema: nonVeteranIncomeRecipientPage.schema,
   }),
   // When claimantType is 'CHILD' we skip showing the recipient page entirely
   // To preserve required data, we auto-set recipientRelationship to 'CHILD'

--- a/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { lowercase } from 'lodash';
 
 import {
   arrayBuilderItemFirstPageTitleUI,
@@ -19,6 +20,7 @@ import {
 import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
 import { RoyaltiesSummaryDescription } from '../../../components/SummaryDescriptions';
+import { DependentDescription } from '../../../components/DependentDescription';
 import {
   formatCurrency,
   formatPossessiveString,
@@ -26,14 +28,22 @@ import {
   isDefined,
   isRecipientInfoIncomplete,
   otherGeneratedIncomeTypeExplanationRequired,
-  otherRecipientRelationshipExplanationRequired,
+  otherRecipientRelationshipTypeUI,
   recipientNameRequired,
   requireExpandedArrayField,
   resolveRecipientFullName,
+  sharedRecipientRelationshipBase,
   showUpdatedContent,
   sharedYesNoOptionsBase,
 } from '../../../helpers';
-import { relationshipLabels, generatedIncomeTypeLabels } from '../../../labels';
+import {
+  custodianRelationshipLabels,
+  generatedIncomeTypeLabels,
+  parentRelationshipLabels,
+  relationshipLabelDescriptions,
+  relationshipLabels,
+  spouseRelationshipLabels,
+} from '../../../labels';
 
 /** @type {ArrayBuilderOptions} */
 export const options = {
@@ -61,7 +71,9 @@ export const options = {
       }
       const fullName = resolveRecipientFullName(item, formData);
       const possessiveName = formatPossessiveString(fullName);
-      return `${possessiveName} income`;
+      return `${possessiveName} income from ${lowercase(
+        generatedIncomeTypeLabels[item.incomeGenerationMethod],
+      )}`;
     },
     cardDescription: item =>
       isDefined(item?.grossMonthlyIncome) &&
@@ -116,6 +128,7 @@ const updatedTitleWithItems =
   'Do you have more income from royalties or other assets to report?';
 const summaryPageTitle =
   'Income and net worth from royalties and other properties';
+const incomeRecipientPageTitle = 'Royalty relationship';
 const yesNoOptionLabels = {
   Y: 'Yes, I have income from an owned asset to report',
   N: 'No, I don’t have income from an owned asset to report',
@@ -250,7 +263,143 @@ const custodianSummaryPage = {
 };
 
 /** @returns {PageSchema} */
-const royaltyRecipientPage = {
+const veteranIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Royalty relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: Object.fromEntries(
+        Object.entries(relationshipLabels).filter(
+          ([key]) => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      descriptions: relationshipLabelDescriptions,
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'royaltiesAndOtherProperties',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(relationshipLabels).filter(
+          key => key !== 'PARENT' && key !== 'CUSTODIAN',
+        ),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const spouseIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Royalty relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: spouseRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key === 'CHILD',
+        ),
+      ),
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'royaltiesAndOtherProperties',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(Object.keys(spouseRelationshipLabels)),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const custodianIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Royalty relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: custodianRelationshipLabels,
+      descriptions: Object.fromEntries(
+        Object.entries(relationshipLabelDescriptions).filter(
+          ([key]) => key !== 'CHILD',
+        ),
+      ),
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'royaltiesAndOtherProperties',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(
+        Object.keys(custodianRelationshipLabels),
+      ),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const parentIncomeRecipientPage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Royalty relationship',
+      nounSingular: options.nounSingular,
+    }),
+    recipientRelationship: radioUI({
+      ...sharedRecipientRelationshipBase,
+      labels: parentRelationshipLabels,
+      descriptions: {
+        SPOUSE: 'The Veteran’s other parent should file a separate claim',
+      },
+    }),
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'royaltiesAndOtherProperties',
+    ),
+    'ui:options': {
+      ...requireExpandedArrayField('otherRecipientRelationshipType'),
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      recipientRelationship: radioSchema(Object.keys(parentRelationshipLabels)),
+      otherRecipientRelationshipType: { type: 'string' },
+    },
+    required: ['recipientRelationship'],
+  },
+};
+
+/** @returns {PageSchema} */
+const nonVeteranIncomeRecipientPage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Royalty relationship',
@@ -258,23 +407,12 @@ const royaltyRecipientPage = {
     }),
     recipientRelationship: radioUI({
       title: 'Who receives the income?',
+      ...sharedYesNoOptionsBase,
       labels: relationshipLabels,
     }),
-    otherRecipientRelationshipType: {
-      'ui:title': 'Describe their relationship to the Veteran',
-      'ui:webComponentField': VaTextInputField,
-      'ui:options': {
-        expandUnder: 'recipientRelationship',
-        expandUnderCondition: 'OTHER',
-        expandedContentFocus: true,
-      },
-      'ui:required': (formData, index) =>
-        otherRecipientRelationshipExplanationRequired(
-          formData,
-          index,
-          'royaltiesAndOtherProperties',
-        ),
-    },
+    otherRecipientRelationshipType: otherRecipientRelationshipTypeUI(
+      'royaltiesAndOtherProperties',
+    ),
     'ui:options': {
       ...requireExpandedArrayField('otherRecipientRelationshipType'),
     },
@@ -409,16 +547,86 @@ export const royaltiesAndOtherPropertyPages = arrayBuilderPages(
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
-    royaltyRecipientPage: pageBuilder.itemPage({
+    royaltyVeteranRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="VETERAN" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'royalties/:index/veteran-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'VETERAN',
+      uiSchema: veteranIncomeRecipientPage.uiSchema,
+      schema: veteranIncomeRecipientPage.schema,
+    }),
+    royaltySpouseRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="SPOUSE" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'royalties/:index/spouse-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'SPOUSE',
+      uiSchema: spouseIncomeRecipientPage.uiSchema,
+      schema: spouseIncomeRecipientPage.schema,
+    }),
+    royaltyCustodianRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="CUSTODIAN" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'royalties/:index/custodian-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CUSTODIAN',
+      uiSchema: custodianIncomeRecipientPage.uiSchema,
+      schema: custodianIncomeRecipientPage.schema,
+    }),
+    royaltyParentRecipientPage: pageBuilder.itemPage({
+      ContentBeforeButtons: showUpdatedContent() ? (
+        <DependentDescription claimantType="PARENT" />
+      ) : null,
+      title: incomeRecipientPageTitle,
+      path: 'royalties/:index/parent-income-recipient',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'PARENT',
+      uiSchema: parentIncomeRecipientPage.uiSchema,
+      schema: parentIncomeRecipientPage.schema,
+    }),
+    royaltyNonVeteranRecipientPage: pageBuilder.itemPage({
       title: 'Royalty recipient',
       path: 'royalties/:index/income-recipient',
-      uiSchema: royaltyRecipientPage.uiSchema,
-      schema: royaltyRecipientPage.schema,
+      depends: () => !showUpdatedContent(),
+      uiSchema: nonVeteranIncomeRecipientPage.uiSchema,
+      schema: nonVeteranIncomeRecipientPage.schema,
+    }),
+    // When claimantType is 'CHILD' we skip showing the recipient page entirely
+    // To preserve required data, we auto-set recipientRelationship to 'CHILD'
+    royaltyChildRecipientNamePage: pageBuilder.itemPage({
+      title: incomeRecipientPageTitle,
+      path: 'royalties/:index/recipient-name-updated',
+      depends: formData =>
+        showUpdatedContent() && formData.claimantType === 'CHILD',
+      uiSchema: {
+        ...recipientNamePage.uiSchema,
+        'ui:options': {
+          updateSchema: (formData, formSchema, _uiSchema, index) => {
+            const arrayData = formData?.royaltiesAndOtherProperties || [];
+            const item = arrayData[index];
+            if (formData.claimantType === 'CHILD' && item) {
+              item.recipientRelationship = 'CHILD';
+            }
+            return {
+              ...formSchema,
+            };
+          },
+        },
+      },
+      schema: recipientNamePage.schema,
     }),
     royaltyRecipientNamePage: pageBuilder.itemPage({
       title: 'Royalty recipient',
       path: 'royalties/:index/recipient-name',
       depends: (formData, index) =>
+        (!showUpdatedContent() || formData.claimantType !== 'CHILD') &&
         recipientNameRequired(formData, index, 'royaltiesAndOtherProperties'),
       uiSchema: recipientNamePage.uiSchema,
       schema: recipientNamePage.schema,

--- a/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
@@ -24,6 +24,7 @@ import { DependentDescription } from '../../../components/DependentDescription';
 import {
   formatCurrency,
   formatPossessiveString,
+  fullNameUIHelper,
   generateDeleteDescription,
   isDefined,
   isRecipientInfoIncomplete,
@@ -79,12 +80,6 @@ export const options = {
       isDefined(item?.grossMonthlyIncome) &&
       isDefined(item?.fairMarketValue) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
-          <li>
-            Income generation method:{' '}
-            <span className="vads-u-font-weight--bold">
-              {generatedIncomeTypeLabels[item.incomeGenerationMethod]}
-            </span>
-          </li>
           <li>
             Gross monthly income:{' '}
             <span className="vads-u-font-weight--bold">
@@ -430,8 +425,14 @@ const nonVeteranIncomeRecipientPage = {
 /** @returns {PageSchema} */
 const recipientNamePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Royalty recipient'),
-    recipientName: fullNameNoSuffixUI(title => `Income recipient’s ${title}`),
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Financial account recipient',
+    ),
+    recipientName: showUpdatedContent()
+      ? fullNameUIHelper()
+      : fullNameNoSuffixUI(title => `Income recipient’s ${title}`),
   },
   schema: {
     type: 'object',
@@ -446,11 +447,11 @@ const generatedIncomeTypePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Royalty income information'),
     incomeGenerationMethod: radioUI({
-      title: 'How is the income generated from this asset?',
+      title: 'How is income generated from this asset?',
       labels: generatedIncomeTypeLabels,
     }),
     otherIncomeType: {
-      'ui:title': 'Tell us how the income is generated',
+      'ui:title': 'Describe how income is generated',
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'incomeGenerationMethod',
@@ -459,14 +460,26 @@ const generatedIncomeTypePage = {
       },
       'ui:required': otherGeneratedIncomeTypeExplanationRequired,
     },
-    grossMonthlyIncome: currencyUI('Gross monthly income'),
-    fairMarketValue: currencyUI('Fair market value of this asset'),
+    grossMonthlyIncome: currencyUI({
+      title: 'What’s the gross monthly income from this asset?',
+      hint: 'Gross income is income before taxes and any other deductions.',
+    }),
+    fairMarketValue: currencyUI({
+      title: 'What’s the fair market value of this asset?',
+      hint:
+        'The market value is the dollar amount that an asset may be sold at.',
+    }),
     canBeSold: yesNoUI({
       title: 'Can the asset be sold?',
     }),
-    mitigatingCircumstances: textareaUI(
-      'Explain any mitigating circumstances that prevent the sale of this asset',
-    ),
+    mitigatingCircumstances: {
+      ...textareaUI('Explain why this asset can’t be sold'),
+      'ui:options': {
+        expandUnder: 'canBeSold',
+        expandUnderCondition: false,
+        expandedContentFocus: true,
+      },
+    },
     'ui:options': {
       ...requireExpandedArrayField('otherIncomeType'),
     },

--- a/src/applications/income-and-asset-statement/labels.jsx
+++ b/src/applications/income-and-asset-statement/labels.jsx
@@ -1,5 +1,3 @@
-import { showUpdatedContent } from './helpers';
-
 // Always name keys with uppercase snake_casing
 // Always use keys for data storage
 export const relationshipLabels = {
@@ -93,7 +91,7 @@ export const updatedIncomeTypeLabels = {
 export const incomeTypeEarnedLabels = {
   INTEREST: 'Interest',
   DIVIDENDS: 'Dividends',
-  OTHER: showUpdatedContent() ? 'Other financial asset income' : 'Other',
+  OTHER: 'Other financial asset income',
 };
 
 export const ownedAssetTypeLabels = {
@@ -103,10 +101,10 @@ export const ownedAssetTypeLabels = {
 };
 
 export const generatedIncomeTypeLabels = {
-  INTELLECTUAL_PROPERTY: 'Benefits from intellectual property',
-  MINERALS_LUMBER: 'Extraction of minerals/lumber',
-  USE_OF_LAND: 'Use of land',
-  OTHER: 'Other',
+  INTELLECTUAL_PROPERTY: 'Intellectual property rights',
+  MINERALS_LUMBER: 'Mineral or lumber extraction',
+  USE_OF_LAND: 'Land usage fees',
+  OTHER: 'Another way',
 };
 
 export const trustTypeLabels = {

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/05-owned-assets/ownedAssetPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/05-owned-assets/ownedAssetPages.unit.spec.jsx
@@ -570,10 +570,10 @@ describe('owned asset list and loop pages', () => {
       });
 
       const schema =
-        ownedAssetPages.ownedAssetIncomeRecipientPage.schema.properties
+        ownedAssetPages.ownedAssetNonVeteranRecipientPage.schema.properties
           .ownedAssets.items;
       const uiSchema =
-        ownedAssetPages.ownedAssetIncomeRecipientPage.uiSchema.ownedAssets
+        ownedAssetPages.ownedAssetNonVeteranRecipientPage.uiSchema.ownedAssets
           .items;
 
       testNumberOfFieldsByType(
@@ -617,10 +617,10 @@ describe('owned asset list and loop pages', () => {
 
       describe('default updated recipient page', () => {
         const schema =
-          ownedAssetPages.ownedAssetIncomeRecipientPage.schema.properties
+          ownedAssetPages.ownedAssetNonVeteranRecipientPage.schema.properties
             .ownedAssets.items;
         const uiSchema =
-          ownedAssetPages.ownedAssetIncomeRecipientPage.uiSchema.ownedAssets
+          ownedAssetPages.ownedAssetNonVeteranRecipientPage.uiSchema.ownedAssets
             .items;
         const formData = {
           ...testData.data.ownedAssets[0],

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
@@ -47,21 +47,23 @@ describe('royalties list and loop pages', () => {
     it('should return "John Doe’s income" if recipient is Veteran', () => {
       const item = {
         recipientRelationship: 'VETERAN',
+        incomeGenerationMethod: 'INTELLECTUAL_PROPERTY',
       };
       expect(options.text.getItemName(item, 0, mockFormData)).to.equal(
-        'John Doe’s income',
+        'John Doe’s income from benefits from intellectual property',
       );
     });
     it('should return "Alex Smith’s income" if recipient is Veteran and not logged in', () => {
       const item = {
         recipientRelationship: 'VETERAN',
+        incomeGenerationMethod: 'USE_OF_LAND',
       };
       expect(
         options.text.getItemName(item, 0, {
           ...mockFormData,
           isLoggedIn: false,
         }),
-      ).to.equal('Alex Smith’s income');
+      ).to.equal('Alex Smith’s income from use of land');
     });
     it('should return "Jane Doe’s income', () => {
       const recipientName = { first: 'Jane', middle: 'A', last: 'Doe' };
@@ -145,10 +147,10 @@ describe('royalties list and loop pages', () => {
 
   describe('recipient page', () => {
     const schema =
-      royaltiesAndOtherPropertyPages.royaltyRecipientPage.schema.properties
-        .royaltiesAndOtherProperties.items;
+      royaltiesAndOtherPropertyPages.royaltyNonVeteranRecipientPage.schema
+        .properties.royaltiesAndOtherProperties.items;
     const uiSchema =
-      royaltiesAndOtherPropertyPages.royaltyRecipientPage.uiSchema
+      royaltiesAndOtherPropertyPages.royaltyNonVeteranRecipientPage.uiSchema
         .royaltiesAndOtherProperties.items;
 
     testNumberOfFieldsByType(

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
@@ -72,7 +72,7 @@ describe('royalties list and loop pages', () => {
         incomeGenerationMethod: 'INTELLECTUAL_PROPERTY',
       };
       expect(options.text.getItemName(item, 0, mockFormData)).to.equal(
-        'John Doe’s income from benefits from intellectual property',
+        'John Doe’s income from intellectual property rights',
       );
     });
     it('should return "Alex Smith’s income" if recipient is Veteran and not logged in', () => {
@@ -85,7 +85,7 @@ describe('royalties list and loop pages', () => {
           ...mockFormData,
           isLoggedIn: false,
         }),
-      ).to.equal('Alex Smith’s income from use of land');
+      ).to.equal('Alex Smith’s income from land usage fees');
     });
     it('should return "Jane Doe’s income', () => {
       const recipientName = { first: 'Jane', middle: 'A', last: 'Doe' };
@@ -112,6 +112,7 @@ describe('royalties list and loop pages', () => {
     const {
       recipientRelationship,
       recipientName,
+      incomeGenerationMethod,
       canBeSold,
       ...baseItem
     } = testData.data.royaltiesAndOtherProperties[0];
@@ -128,6 +129,7 @@ describe('royalties list and loop pages', () => {
     const {
       recipientRelationship,
       recipientName,
+      incomeGenerationMethod,
       canBeSold,
       ...baseItem
     } = testDataZeroes.data.royaltiesAndOtherProperties[0];
@@ -369,7 +371,7 @@ describe('royalties list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      { 'va-radio': 2, 'va-text-input': 2, 'va-textarea': 1 },
+      { 'va-radio': 2, 'va-text-input': 2 },
       'income type',
     );
     testComponentFieldsMarkedAsRequired(
@@ -377,9 +379,9 @@ describe('royalties list and loop pages', () => {
       schema,
       uiSchema,
       [
-        'va-radio[label="How is the income generated from this asset?"]',
-        'va-text-input[label="Gross monthly income"]',
-        'va-text-input[label="Fair market value of this asset"]',
+        'va-radio[label="How is income generated from this asset?"]',
+        'va-text-input[label="What’s the gross monthly income from this asset?"]',
+        'va-text-input[label="What’s the fair market value of this asset?"]',
         'va-radio[label="Can the asset be sold?"]',
       ],
       'income type',


### PR DESCRIPTION
## Summary

This PR updates the **Relationship to Veteran** page in the **Royalties and other assets** chapter of the **Income and Asset Statement form (VA Form 21P-0969)** as part of Post-MVP improvements.  
The updates refine labels, hint text, and page structure to align with Design QA feedback and ensure consistency with other claimant-type relationship pages across the form.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111693

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111691  
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111699  

## Associated Pull Request(s)

- N/A

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the form:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  
5. Go to the **Royalties and other assets** chapter → Relationship to Veteran page  

## How to verify

1. For each `claimantType` (Veteran, Spouse, Parent, Custodian), confirm:  
   - The Relationship to Veteran page displays updated content per Post-MVP requirements  
   - Labels and hint text align with plain language standards  
   - Field ordering and grouping match updated patterns from other chapters (e.g., Recurring Income, Financial Accounts)  
2. Validate Review & Submit correctly reflects relationship data captured on this page  
3. Test with no input, valid input, and invalid input to confirm validation works as expected  
4. Confirm accessibility compliance (heading levels, labels, focus order)  
5. Ensure no console errors or regressions  

## What areas of the site does it impact?

- Income and Asset Statement (VA Form 21P-0969)  
- **Royalties and other assets** → Relationship to Veteran page  

## Screenshots

| Before | After |
|--------|-------|
| Outdated labels and hint text | Updated labels, hint text, and structure per Post-MVP |

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone

- Post-MVP enhancements for 0969  
- **Behind** `income_and_assets_content_updates` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm the updated Relationship to Veteran page for Royalties aligns with Post-MVP design patterns and is consistent with relationship pages in other chapters.