### PR TITLE
Added first connect flag/updated exclusion list and unit tests

### DIFF
--- a/src/applications/virtual-agent/components/WebChat.jsx
+++ b/src/applications/virtual-agent/components/WebChat.jsx
@@ -54,7 +54,7 @@ const styleOptions = {
 
 export const renderMarkdown = text => MarkdownRenderer.render(text);
 
-const WebChat = ({ token, code, webChatFramework }) => {
+const WebChat = ({ code, webChatFramework }) => {
   const {
     createDirectLine,
     createStore,
@@ -85,7 +85,7 @@ const WebChat = ({ token, code, webChatFramework }) => {
   clearBotSessionStorageEventListener(isLoggedIn);
   signOutEventListener(isLoggedIn);
 
-  const directLine = useDirectLine(createDirectLine, token, isLoggedIn);
+  const directLine = useDirectLine(createDirectLine);
 
   return (
     <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>

--- a/src/applications/virtual-agent/components/WebChat.jsx
+++ b/src/applications/virtual-agent/components/WebChat.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { isMobile } from 'react-device-detect'; // Adding this library for accessibility reasons to distinguish between desktop and mobile
@@ -82,8 +82,21 @@ const WebChat = ({ code, webChatFramework }) => {
     isStsAuthEnabled,
   });
 
-  clearBotSessionStorageEventListener(isLoggedIn);
-  signOutEventListener(isLoggedIn);
+  // Register global event listeners once and clean up on unmount
+  useEffect(
+    () => {
+      const cleanupBeforeUnload = clearBotSessionStorageEventListener(
+        isLoggedIn,
+      );
+      const cleanupSignOut = signOutEventListener(isLoggedIn);
+
+      return () => {
+        if (typeof cleanupBeforeUnload === 'function') cleanupBeforeUnload();
+        if (typeof cleanupSignOut === 'function') cleanupSignOut();
+      };
+    },
+    [isLoggedIn],
+  );
 
   const directLine = useDirectLine(createDirectLine);
 

--- a/src/applications/virtual-agent/components/WebChat.jsx
+++ b/src/applications/virtual-agent/components/WebChat.jsx
@@ -73,6 +73,10 @@ const WebChat = ({ code, webChatFramework }) => {
     TOGGLE_NAMES.virtualAgentUseStsAuthentication,
   );
 
+  const isSessionPersistenceEnabled = useToggleValue(
+    TOGGLE_NAMES.virtualAgentChatbotSessionPersistenceEnabled,
+  );
+
   const store = useWebChatStore({
     createStore,
     code,
@@ -80,6 +84,7 @@ const WebChat = ({ code, webChatFramework }) => {
     environment,
     isComponentToggleOn,
     isStsAuthEnabled,
+    isSessionPersistenceEnabled,
   });
 
   // Register global event listeners once and clean up on unmount

--- a/src/applications/virtual-agent/event-listeners/clearBotSessionStorageEventListener.js
+++ b/src/applications/virtual-agent/event-listeners/clearBotSessionStorageEventListener.js
@@ -1,7 +1,12 @@
 import { clearBotSessionStorage } from '../utils/sessionStorage';
 
 export default function clearBotSessionStorageEventListener(isLoggedIn) {
-  window.addEventListener('beforeunload', () => {
+  const handler = () => {
     clearBotSessionStorage(false, isLoggedIn);
-  });
+  };
+
+  window.addEventListener('beforeunload', handler);
+
+  // Return cleanup remover for React effects
+  return () => window.removeEventListener('beforeunload', handler);
 }

--- a/src/applications/virtual-agent/event-listeners/signOutEventListener.js
+++ b/src/applications/virtual-agent/event-listeners/signOutEventListener.js
@@ -2,20 +2,33 @@ import { logErrorToDatadog } from '../utils/logging';
 import { clearBotSessionStorage } from '../utils/sessionStorage';
 
 export default function signOutEventListener(isLoggedIn) {
-  const links = document.querySelectorAll('div#account-menu ul li a');
+  const links = Array.from(
+    document.querySelectorAll('div#account-menu ul li a'),
+  );
+
+  const handler = () => clearBotSessionStorage(true);
+  let attached = false;
+
   for (const link of links) {
     if (link.textContent === 'Sign Out') {
-      link.addEventListener('click', () => {
-        clearBotSessionStorage(true);
-      });
-      return;
+      link.addEventListener('click', handler);
+      attached = true;
     }
   }
 
-  if (isLoggedIn) {
+  if (!attached && isLoggedIn) {
     const error = new TypeError(
       'Virtual Agent chatbot could not find sign out link in menu, and user is logged in',
     );
     logErrorToDatadog(true, error);
   }
+
+  // Return cleanup that removes listeners if attached
+  return () => {
+    for (const link of links) {
+      if (link.textContent === 'Sign Out') {
+        link.removeEventListener('click', handler);
+      }
+    }
+  };
 }

--- a/src/applications/virtual-agent/hooks/useChatbotToken.js
+++ b/src/applications/virtual-agent/hooks/useChatbotToken.js
@@ -50,7 +50,7 @@ export default function useChatbotToken() {
 
   useEffect(
     () => {
-      // Intentionally run once on mount: prevents duplicate fetches on re-renders
+      // Runs on mount and whenever isSessionPersistenceEnabled changes: prevents duplicate fetches on re-renders
       clearBotSessionStorage();
 
       // When persistence is OFF, force fresh token/conversationId.

--- a/src/applications/virtual-agent/hooks/useDirectline.js
+++ b/src/applications/virtual-agent/hooks/useDirectline.js
@@ -8,11 +8,11 @@ const getDirectLineDomain = () =>
     : 'https://northamerica.directline.botframework.com/v3/directline';
 
 // Connection logic:
-// - Production DirectLine (websocket) does not replay history with watermark.
-//   To guarantee greeting and avoid blank chat on reload, always start a NEW
-//   conversation (omit conversationId/watermark) in production.
-// - Local mock supports watermark-based replay: include conversationId and
-//   watermark=0 to request full transcript.
+// - If session persistence is enabled, both production DirectLine (websocket)
+//   and local mock will attempt to replay history using conversationId and
+//   watermark=0 to request the full transcript.
+// - If session persistence is not enabled, a NEW conversation is started
+//   (conversationId and watermark are omitted).
 export default function useDirectLine(createDirectLine) {
   const token = getTokenKey();
   const domain = getDirectLineDomain();

--- a/src/applications/virtual-agent/hooks/useDirectline.js
+++ b/src/applications/virtual-agent/hooks/useDirectline.js
@@ -1,48 +1,46 @@
 import { useMemo } from 'react';
 import {
   getConversationIdKey,
-  getLoggedInFlow,
+  getFirstConnection,
   getTokenKey,
+  setFirstConnection,
 } from '../utils/sessionStorage';
-
-const getIsLoggedIn = isLoggedIn => {
-  const loggedInFlow = getLoggedInFlow();
-  return loggedInFlow === 'true' && isLoggedIn;
-};
-
-function getConversationId(isLoggedIn) {
-  const conversationIdKey = getConversationIdKey();
-  return isLoggedIn ? conversationIdKey : '';
-}
-
-function getDirectLineToken(token, isLoggedIn) {
-  const tokenKey = getTokenKey();
-  return isLoggedIn ? tokenKey : token;
-}
 
 const getDirectLineDomain = () =>
   process.env.USE_LOCAL_DIRECTLINE
     ? 'http://localhost:3002/v3/directline'
     : 'https://northamerica.directline.botframework.com/v3/directline';
 
-export default function useDirectLine(
-  createDirectLine,
-  directLineToken,
-  loggedIn,
-) {
-  const isLoggedIn = getIsLoggedIn(loggedIn);
-  const token = getDirectLineToken(directLineToken, isLoggedIn);
-  const conversationId = getConversationId(isLoggedIn);
+// First-connection logic:
+// - Do NOT send conversationId on the very first connection in production
+//   (breaks the bot's greeting/init flow).
+// - Always send conversationId on subsequent connections to enable history replay.
+// - In local mock mode, always include conversationId so the mock can persist state.
+export default function useDirectLine(createDirectLine) {
+  const token = getTokenKey();
+  const firstConnection = getFirstConnection();
   const domain = getDirectLineDomain();
 
+  const conversationId =
+    firstConnection === 'false' || process.env.USE_LOCAL_DIRECTLINE
+      ? getConversationIdKey()
+      : '';
+
+  // Mark that we've connected once for subsequent reloads
+  setFirstConnection('false');
+
+  // Intentionally keep an empty dependency array to avoid recreating the DirectLine
+  // connection on re-renders. We capture the initial token/domain/conversationId at
+  // mount time to drive the desired reconnect behavior.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   return useMemo(
     () =>
       createDirectLine({
         token,
         domain,
         conversationId,
-        watermark: '',
+        watermark: '0', // request full transcript history
       }),
-    [createDirectLine],
+    [],
   );
 }

--- a/src/applications/virtual-agent/hooks/useWebChat.js
+++ b/src/applications/virtual-agent/hooks/useWebChat.js
@@ -25,7 +25,7 @@ const getLoadingStatus = (
 
 export default function useWebChat(props, paramLoadingStatus) {
   const webChatFramework = useWebChatFramework(props);
-  const token = useChatbotToken(props);
+  const token = useChatbotToken();
 
   const loadingStatus = getLoadingStatus(
     webChatFramework.loadingStatus,

--- a/src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx
@@ -12,25 +12,87 @@ describe('useChatbotToken', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    sessionStorage.clear();
   });
 
   afterEach(() => {
     sandbox.restore();
+    sessionStorage.clear();
   });
 
   describe('useChatbotToken', () => {
     it('should return token loadingStatus', async () => {
       sandbox.stub(RetryOnce, 'default').resolves({
         token: 'abc',
+        conversationId: 'cid-1',
+        code: 'code-1',
       });
 
       let result;
       await act(async () => {
-        result = renderHook(() => useChatbotToken({ timeout: 1 }));
+        result = renderHook(() => useChatbotToken());
       });
 
       expect(result.result.current.token).to.equal('abc');
       expect(result.result.current.loadingStatus).to.equal(COMPLETE);
+    });
+
+    it('should store new token and conversationId on fresh session', async () => {
+      sandbox.stub(RetryOnce, 'default').resolves({
+        token: 't-new',
+        conversationId: 'c-new',
+        code: 'code-new',
+      });
+
+      await act(async () => {
+        renderHook(() => useChatbotToken());
+      });
+
+      expect(sessionStorage.getItem('va-bot.token')).to.equal('t-new');
+      expect(sessionStorage.getItem('va-bot.conversationId')).to.equal('c-new');
+    });
+
+    it('should reuse existing token/conversationId and not fetch again', async () => {
+      // Pre-populate existing values
+      sessionStorage.setItem('va-bot.token', 't-existing');
+      sessionStorage.setItem('va-bot.conversationId', 'c-existing');
+
+      const retryStub = sandbox.stub(RetryOnce, 'default').resolves({
+        token: 't-should-not-be-used',
+        conversationId: 'c-should-not-be-used',
+      });
+
+      let result;
+      await act(async () => {
+        result = renderHook(() => useChatbotToken());
+      });
+
+      expect(result.result.current.token).to.equal('t-existing');
+      expect(result.result.current.loadingStatus).to.equal(COMPLETE);
+      expect(retryStub.called).to.be.false; // no fetch when values exist
+      // Ensure values not overwritten
+      expect(sessionStorage.getItem('va-bot.token')).to.equal('t-existing');
+      expect(sessionStorage.getItem('va-bot.conversationId')).to.equal(
+        'c-existing',
+      );
+    });
+
+    it('should run the effect only once on mount (no duplicate fetches)', async () => {
+      const retryStub = sandbox.stub(RetryOnce, 'default').resolves({
+        token: 'abc',
+        conversationId: 'cid-1',
+      });
+
+      let rendered;
+      await act(async () => {
+        rendered = renderHook(() => useChatbotToken());
+      });
+      // Re-render the hook to simulate component re-render
+      await act(async () => {
+        rendered.rerender();
+      });
+
+      expect(retryStub.calledOnce).to.be.true;
     });
   });
 });

--- a/src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useChatbotToken.unit.spec.jsx
@@ -1,14 +1,29 @@
+import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { describe, it } from 'mocha';
 import { act } from 'react-dom/test-utils';
 import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import TOGGLE_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import * as RetryOnce from '../../utils/retryOnce';
 import useChatbotToken from '../../hooks/useChatbotToken';
 import { COMPLETE } from '../../utils/loadingStatus';
 
 describe('useChatbotToken', () => {
   let sandbox;
+  const createWrapper = (persist = false) => {
+    const initialState = {
+      featureToggles: {
+        loading: false,
+        [TOGGLE_NAMES.virtualAgentChatbotSessionPersistenceEnabled]: persist,
+      },
+    };
+    const store = createStore((state = initialState) => state);
+    // eslint-disable-next-line react/prop-types
+    return ({ children }) => <Provider store={store}>{children}</Provider>;
+  };
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -30,7 +45,9 @@ describe('useChatbotToken', () => {
 
       let result;
       await act(async () => {
-        result = renderHook(() => useChatbotToken());
+        result = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(false),
+        });
       });
 
       expect(result.result.current.token).to.equal('abc');
@@ -45,7 +62,9 @@ describe('useChatbotToken', () => {
       });
 
       await act(async () => {
-        renderHook(() => useChatbotToken());
+        renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(false),
+        });
       });
 
       expect(sessionStorage.getItem('va-bot.token')).to.equal('t-new');
@@ -64,7 +83,9 @@ describe('useChatbotToken', () => {
 
       let result;
       await act(async () => {
-        result = renderHook(() => useChatbotToken());
+        result = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(true),
+        });
       });
 
       expect(result.result.current.token).to.equal('t-existing');
@@ -85,7 +106,9 @@ describe('useChatbotToken', () => {
 
       let rendered;
       await act(async () => {
-        rendered = renderHook(() => useChatbotToken());
+        rendered = renderHook(() => useChatbotToken(), {
+          wrapper: createWrapper(false),
+        });
       });
       // Re-render the hook to simulate component re-render
       await act(async () => {

--- a/src/applications/virtual-agent/tests/hooks/useDirectline.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/hooks/useDirectline.unit.spec.jsx
@@ -1,8 +1,12 @@
+import React from 'react';
 import { expect } from 'chai';
 import { renderHook } from '@testing-library/react-hooks';
 import sinon from 'sinon';
-import useDirectLine from '../../hooks/useDirectline';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import TOGGLE_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import * as SessionStorageModule from '../../utils/sessionStorage';
+import useDirectLine from '../../hooks/useDirectline';
 
 const publicDirectLine =
   'https://northamerica.directline.botframework.com/v3/directline';
@@ -23,8 +27,21 @@ describe('directline', () => {
 
   const stubUseLocalDirectline = useLocalDirectline => {
     sandbox.stub(process, 'env').value({
+      ...process.env,
       USE_LOCAL_DIRECTLINE: useLocalDirectline,
     });
+  };
+
+  const createWrapper = (persist = false) => {
+    const initialState = {
+      featureToggles: {
+        loading: false,
+        [TOGGLE_NAMES.virtualAgentChatbotSessionPersistenceEnabled]: persist,
+      },
+    };
+    const store = createStore((state = initialState) => state);
+    // eslint-disable-next-line react/prop-types
+    return ({ children }) => <Provider store={store}>{children}</Provider>;
   };
 
   const setSessionStorageBase = () => {
@@ -45,70 +62,64 @@ describe('directline', () => {
       const createDirectLineFn = sandbox.spy();
       stubUseLocalDirectline(true);
       setSessionStorageBase();
-      sandbox
-        .stub(
-          SessionStorageModule,
-          SessionStorageModule.getFirstConnection.name,
-        )
-        .returns(undefined);
 
-      renderHook(() => useDirectLine(createDirectLineFn));
+      renderHook(() => useDirectLine(createDirectLineFn), {
+        wrapper: createWrapper(false),
+      });
 
       expect(createDirectLineFn.calledOnce).to.be.true;
       expect(createDirectLineFn.args[0][0].domain).to.equal(localDirectLine);
+      expect(createDirectLineFn.args[0][0].conversationId).to.equal(
+        sessionConversationIdKey,
+      );
+      expect(createDirectLineFn.args[0][0]).to.not.have.property('watermark');
     });
     it('should call public directline when USE_LOCAL_DIRECTLINE is false', () => {
       const createDirectLineFn = sandbox.spy();
       stubUseLocalDirectline(false);
       setSessionStorageBase();
-      sandbox
-        .stub(
-          SessionStorageModule,
-          SessionStorageModule.getFirstConnection.name,
-        )
-        .returns(undefined);
 
-      renderHook(() => useDirectLine(createDirectLineFn));
+      renderHook(() => useDirectLine(createDirectLineFn), {
+        wrapper: createWrapper(false),
+      });
 
       expect(createDirectLineFn.calledOnce).to.be.true;
       expect(createDirectLineFn.args[0][0].domain).to.equal(publicDirectLine);
+      expect(createDirectLineFn.args[0][0].conversationId).to.equal(
+        sessionConversationIdKey,
+      );
+      expect(createDirectLineFn.args[0][0]).to.not.have.property('watermark');
     });
     it('should call public directline when USE_LOCAL_DIRECTLINE is not set', () => {
       const createDirectLineFn = sandbox.spy();
       stubUseLocalDirectline('');
       setSessionStorageBase();
-      sandbox
-        .stub(
-          SessionStorageModule,
-          SessionStorageModule.getFirstConnection.name,
-        )
-        .returns(undefined);
 
-      renderHook(() => useDirectLine(createDirectLineFn));
+      renderHook(() => useDirectLine(createDirectLineFn), {
+        wrapper: createWrapper(false),
+      });
 
       expect(createDirectLineFn.calledOnce).to.be.true;
       expect(createDirectLineFn.args[0][0].domain).to.equal(publicDirectLine);
+      expect(createDirectLineFn.args[0][0].conversationId).to.equal(
+        sessionConversationIdKey,
+      );
     });
-    it('should omit conversationId on first connection (production)', () => {
+    it('should include conversationId when present (production)', () => {
       const createDirectLineFn = sandbox.spy();
       setSessionStorageBase();
       stubUseLocalDirectline(false);
-      sandbox
-        .stub(
-          SessionStorageModule,
-          SessionStorageModule.getFirstConnection.name,
-        )
-        .returns(undefined);
 
-      renderHook(() => useDirectLine(createDirectLineFn));
+      renderHook(() => useDirectLine(createDirectLineFn), {
+        wrapper: createWrapper(false),
+      });
 
       expect(createDirectLineFn.calledOnce).to.be.true;
       expect(
         createDirectLineFn.calledWithExactly({
           token: sessionToken,
           domain: publicDirectLine,
-          conversationId: '',
-          watermark: '0',
+          conversationId: sessionConversationIdKey,
         }),
       ).to.be.true;
     });
@@ -116,14 +127,45 @@ describe('directline', () => {
       const createDirectLineFn = sandbox.spy();
       setSessionStorageBase();
       stubUseLocalDirectline(false);
-      sandbox
-        .stub(
-          SessionStorageModule,
-          SessionStorageModule.getFirstConnection.name,
-        )
-        .returns('false');
 
-      renderHook(() => useDirectLine(createDirectLineFn));
+      renderHook(() => useDirectLine(createDirectLineFn), {
+        wrapper: createWrapper(false),
+      });
+
+      expect(createDirectLineFn.calledOnce).to.be.true;
+      expect(
+        createDirectLineFn.calledWithExactly({
+          token: sessionToken,
+          domain: publicDirectLine,
+          conversationId: sessionConversationIdKey,
+        }),
+      ).to.be.true;
+    });
+    it('should include conversationId on first connection when using local mock', () => {
+      const createDirectLineFn = sandbox.spy();
+      setSessionStorageBase();
+      stubUseLocalDirectline(true);
+
+      renderHook(() => useDirectLine(createDirectLineFn), {
+        wrapper: createWrapper(false),
+      });
+
+      expect(createDirectLineFn.calledOnce).to.be.true;
+      expect(
+        createDirectLineFn.calledWithExactly({
+          token: sessionToken,
+          domain: localDirectLine,
+          conversationId: sessionConversationIdKey,
+        }),
+      ).to.be.true;
+    });
+    it('should set watermark when persistence is enabled', () => {
+      const createDirectLineFn = sandbox.spy();
+      setSessionStorageBase();
+      stubUseLocalDirectline(false);
+      renderHook(() => useDirectLine(createDirectLineFn), {
+        wrapper: createWrapper(true),
+      });
 
       expect(createDirectLineFn.calledOnce).to.be.true;
       expect(
@@ -134,49 +176,6 @@ describe('directline', () => {
           watermark: '0',
         }),
       ).to.be.true;
-    });
-    it('should include conversationId on first connection when using local mock', () => {
-      const createDirectLineFn = sandbox.spy();
-      setSessionStorageBase();
-      stubUseLocalDirectline(true);
-      sandbox
-        .stub(
-          SessionStorageModule,
-          SessionStorageModule.getFirstConnection.name,
-        )
-        .returns(undefined);
-
-      renderHook(() => useDirectLine(createDirectLineFn));
-
-      expect(createDirectLineFn.calledOnce).to.be.true;
-      expect(
-        createDirectLineFn.calledWithExactly({
-          token: sessionToken,
-          domain: localDirectLine,
-          conversationId: sessionConversationIdKey,
-          watermark: '0',
-        }),
-      ).to.be.true;
-    });
-    it("should set firstConnection to 'false' after hook runs", () => {
-      const createDirectLineFn = sandbox.spy();
-      const setFirstConnectionSpy = sandbox.spy(
-        SessionStorageModule,
-        SessionStorageModule.setFirstConnection.name,
-      );
-      setSessionStorageBase();
-      stubUseLocalDirectline(false);
-      sandbox
-        .stub(
-          SessionStorageModule,
-          SessionStorageModule.getFirstConnection.name,
-        )
-        .returns(undefined);
-
-      renderHook(() => useDirectLine(createDirectLineFn));
-
-      expect(setFirstConnectionSpy.calledOnce).to.be.true;
-      expect(setFirstConnectionSpy.calledWith('false')).to.be.true;
     });
   });
 });

--- a/src/applications/virtual-agent/tests/utils/actions.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/utils/actions.unit.spec.jsx
@@ -467,6 +467,10 @@ describe('actions', () => {
       };
 
       const processCSATStub = sandbox.stub(ProcessCSATModule, 'default');
+      const originalRAF = window.requestAnimationFrame;
+      const originalGlobalRAF = global.requestAnimationFrame;
+      window.requestAnimationFrame = cb => cb();
+      global.requestAnimationFrame = cb => cb();
 
       processIncomingActivity({
         action,
@@ -474,6 +478,8 @@ describe('actions', () => {
       })();
 
       expect(processCSATStub.calledOnce).to.be.true;
+      window.requestAnimationFrame = originalRAF;
+      global.requestAnimationFrame = originalGlobalRAF;
     });
 
     it('should not call processCSAT when activity is not CSATSurveyResponse', () => {

--- a/src/applications/virtual-agent/tests/utils/sessionStorage.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/utils/sessionStorage.unit.spec.jsx
@@ -9,14 +9,12 @@ import {
   getLoggedInFlow,
   getRecentUtterances,
   getTokenKey,
-  getFirstConnection,
   setConversationIdKey,
   setInAuthExp,
   setIsTrackingUtterances,
   setLoggedInFlow,
   setRecentUtterances,
   setTokenKey,
-  setFirstConnection,
   storeUtterances,
 } from '../../utils/sessionStorage';
 
@@ -27,19 +25,7 @@ describe('sessionStorage', () => {
     sandbox = sinon.sandbox.create();
   });
 
-  describe('firstConnection', () => {
-    it('should set and get first-connection flag as a string', () => {
-      setFirstConnection('false');
-      const result = getFirstConnection();
-      expect(result).to.equal('false');
-    });
-
-    it('should use the prefixed key for first-connection', () => {
-      setFirstConnection('false');
-      const raw = sessionStorage.getItem('va-bot.firstConnection');
-      expect(raw).to.equal('false');
-    });
-  });
+  // firstConnection helpers removed; key retained for backward compatibility
 
   afterEach(() => {
     sandbox.restore();
@@ -172,13 +158,13 @@ describe('sessionStorage', () => {
       expect(itemToNotClear).to.be.equal('strawberry');
     });
 
-    it('should preserve FIRST_CONNECTION, CONVERSATION_ID_KEY, and TOKEN_KEY by default and clear other keys', () => {
+    it('should preserve firstConnection (raw), conversationId and token by default and clear other keys', () => {
       // Ensure default clearing path triggers (both not 'true')
       sessionStorage.removeItem('va-bot.loggedInFlow');
       sessionStorage.removeItem('va-bot.inAuthExperience');
 
       // Set critical keys (should persist)
-      setFirstConnection('false');
+      sessionStorage.setItem('va-bot.firstConnection', 'false');
       setConversationIdKey('abc');
       setTokenKey('def');
 
@@ -189,7 +175,9 @@ describe('sessionStorage', () => {
       clearBotSessionStorage(false);
 
       // Critical keys remain
-      expect(getFirstConnection()).to.equal('false');
+      expect(sessionStorage.getItem('va-bot.firstConnection')).to.equal(
+        'false',
+      );
       expect(getConversationIdKey()).to.equal('abc');
       expect(getTokenKey()).to.equal('def');
 

--- a/src/applications/virtual-agent/tests/utils/sessionStorage.unit.spec.jsx
+++ b/src/applications/virtual-agent/tests/utils/sessionStorage.unit.spec.jsx
@@ -9,12 +9,14 @@ import {
   getLoggedInFlow,
   getRecentUtterances,
   getTokenKey,
+  getFirstConnection,
   setConversationIdKey,
   setInAuthExp,
   setIsTrackingUtterances,
   setLoggedInFlow,
   setRecentUtterances,
   setTokenKey,
+  setFirstConnection,
   storeUtterances,
 } from '../../utils/sessionStorage';
 
@@ -23,6 +25,20 @@ describe('sessionStorage', () => {
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+  });
+
+  describe('firstConnection', () => {
+    it('should set and get first-connection flag as a string', () => {
+      setFirstConnection('false');
+      const result = getFirstConnection();
+      expect(result).to.equal('false');
+    });
+
+    it('should use the prefixed key for first-connection', () => {
+      setFirstConnection('false');
+      const raw = sessionStorage.getItem('va-bot.firstConnection');
+      expect(raw).to.equal('false');
+    });
   });
 
   afterEach(() => {
@@ -154,6 +170,32 @@ describe('sessionStorage', () => {
       const itemToNotClear = sessionStorage.getItem('va-bot.itemToNotClear');
 
       expect(itemToNotClear).to.be.equal('strawberry');
+    });
+
+    it('should preserve FIRST_CONNECTION, CONVERSATION_ID_KEY, and TOKEN_KEY by default and clear other keys', () => {
+      // Ensure default clearing path triggers (both not 'true')
+      sessionStorage.removeItem('va-bot.loggedInFlow');
+      sessionStorage.removeItem('va-bot.inAuthExperience');
+
+      // Set critical keys (should persist)
+      setFirstConnection('false');
+      setConversationIdKey('abc');
+      setTokenKey('def');
+
+      // Set other bot-prefixed keys (should be cleared)
+      sessionStorage.setItem('va-bot.itemToClear', 'banana');
+      setRecentUtterances(['x']);
+
+      clearBotSessionStorage(false);
+
+      // Critical keys remain
+      expect(getFirstConnection()).to.equal('false');
+      expect(getConversationIdKey()).to.equal('abc');
+      expect(getTokenKey()).to.equal('def');
+
+      // Others cleared
+      expect(sessionStorage.getItem('va-bot.itemToClear')).to.be.null;
+      expect(getRecentUtterances()).to.be.null;
     });
   });
 

--- a/src/applications/virtual-agent/utils/actions.js
+++ b/src/applications/virtual-agent/utils/actions.js
@@ -141,7 +141,21 @@ export const processIncomingActivity = ({
   }
 
   if (isCSATSurveyResponse) {
-    processCSAT(data);
+    try {
+      // Defer to next frame to allow Adaptive Card DOM to render
+      requestAnimationFrame(() => {
+        try {
+          processCSAT(data);
+        } catch (e) {
+          // Safeguard to prevent crashing the chat UI
+          // eslint-disable-next-line no-console
+          console.warn('CSAT processing error (deferred):', e);
+        }
+      });
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('CSAT processing error:', e);
+    }
   }
 
   const trackingUtterances = getIsTrackingUtterances();

--- a/src/applications/virtual-agent/utils/actions.js
+++ b/src/applications/virtual-agent/utils/actions.js
@@ -120,8 +120,7 @@ export const processIncomingActivity = ({
   const isFormPostButton = data.value?.type === 'FormPostButton';
   const isCSATSurveyResponse = data.valueType === 'CSATSurveyResponse';
 
-  const isAtBeginningOfConversation = !getIsTrackingUtterances();
-  if (isAtBeginningOfConversation) {
+  if (!getIsTrackingUtterances()) {
     setIsTrackingUtterances(true);
   }
 

--- a/src/applications/virtual-agent/utils/processCSAT.js
+++ b/src/applications/virtual-agent/utils/processCSAT.js
@@ -2,18 +2,30 @@ export const BLUE_STAR =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiA8Zz4KICA8dGl0bGU+TGF5ZXIgMTwvdGl0bGU+CiAgPHBhdGggc3Ryb2tlPSIjMDAzZTczIiBkPSJtMi44NjE5OCwxNC43MDc1bDExLjYzMTgxLDBsMy41OTQzMiwtMTEuMzU1NzVsMy41OTQzMiwxMS4zNTU3NWwxMS42MzE4MSwwbC05LjQxMDMyLDcuMDE4MTZsMy41OTQ1MSwxMS4zNTU3NWwtOS40MTAzMiwtNy4wMTgzNWwtOS40MTAzMiw3LjAxODM1bDMuNTk0NTEsLTExLjM1NTc1bC05LjQxMDMyLC03LjAxODE2eiIgaWQ9InN2Z18xIiBzdHJva2Utd2lkdGg9IjIiIGZpbGw9IiMwMDNlNzMiLz4KIDwvZz4KCjwvc3ZnPg==';
 
 export default function processCSAT(data) {
+  // Locate the most recent CSAT survey in the DOM
   const surveys = document.querySelectorAll('#chatbot-csat-survey');
-  const survey = surveys[surveys.length - 1];
+  if (!surveys || surveys.length === 0) {
+    return; // No survey rendered yet; nothing to do
+  }
 
-  const stars = survey.querySelectorAll('img');
-  const rating = Number(data.value.response);
+  const survey = surveys[surveys.length - 1];
+  if (!survey) {
+    return;
+  }
+
+  // Apply star highlight if rating is present
+  const rating = Number(data?.value?.response);
   if (!Number.isNaN(rating)) {
-    for (let i = 0; i < rating; i++) {
+    const stars = survey.querySelectorAll('img') || [];
+    const count = Math.min(rating, stars.length);
+    for (let i = 0; i < count; i++) {
       stars[i].src = BLUE_STAR;
     }
   }
 
   // Make survey not clickable and appear disabled
   const columns = survey.querySelectorAll('#chatbot-csat-survey-columnset');
-  columns[0].style.pointerEvents = 'none';
+  if (columns && columns[0]) {
+    columns[0].style.pointerEvents = 'none';
+  }
 }

--- a/src/applications/virtual-agent/utils/sessionStorage.js
+++ b/src/applications/virtual-agent/utils/sessionStorage.js
@@ -5,6 +5,7 @@ const RECENT_UTTERANCES = `${BOT_SESSION_PREFIX}recentUtterances`;
 const CONVERSATION_ID_KEY = `${BOT_SESSION_PREFIX}conversationId`;
 const IS_TRACKING_UTTERANCES = `${BOT_SESSION_PREFIX}isTrackingUtterances`;
 const TOKEN_KEY = `${BOT_SESSION_PREFIX}token`;
+const CODE_KEY = `${BOT_SESSION_PREFIX}code`;
 const FIRST_CONNECTION = `${BOT_SESSION_PREFIX}firstConnection`;
 const SKILL_EVENT_VALUE = `${BOT_SESSION_PREFIX}skillEventValue`;
 
@@ -79,6 +80,14 @@ export function setTokenKey(value) {
   setStorageItem(TOKEN_KEY, value);
 }
 
+export function getCodeKey() {
+  return getStorageItem(CODE_KEY);
+}
+
+export function setCodeKey(value) {
+  setStorageItem(CODE_KEY, value);
+}
+
 // First-connection flag helpers.
 // NOTE: store values as strings, e.g., 'false' or 'true' (not booleans).
 export function getFirstConnection() {
@@ -96,7 +105,12 @@ export function clearBotSessionStorage(forceClear) {
   const expectToClear = loggedInFlow !== 'true' && inAuthExp !== 'true';
   // Ensure critical keys persist across page lifecycle clears.
   // Keep first-connection flag, conversationId, and token.
-  const excludeClear = [FIRST_CONNECTION, CONVERSATION_ID_KEY, TOKEN_KEY];
+  const excludeClear = [
+    FIRST_CONNECTION,
+    CONVERSATION_ID_KEY,
+    TOKEN_KEY,
+    CODE_KEY,
+  ];
 
   // capture the canceled login scenarios [issue #479]
   if (!forceClear && loggedInFlow === 'true' && inAuthExp !== 'true') {

--- a/src/applications/virtual-agent/utils/sessionStorage.js
+++ b/src/applications/virtual-agent/utils/sessionStorage.js
@@ -88,7 +88,7 @@ export function setCodeKey(value) {
   setStorageItem(CODE_KEY, value);
 }
 
-// First-connection helpers removed; key retained for backward compatibility
+// First-connection helpers removed; key is still used to preserve the flag during session clears for backward compatibility
 
 export function clearBotSessionStorage(forceClear) {
   const botSessionKeys = Object.keys(sessionStorage);

--- a/src/applications/virtual-agent/utils/sessionStorage.js
+++ b/src/applications/virtual-agent/utils/sessionStorage.js
@@ -88,21 +88,18 @@ export function setCodeKey(value) {
   setStorageItem(CODE_KEY, value);
 }
 
-// First-connection flag helpers.
-// NOTE: store values as strings, e.g., 'false' or 'true' (not booleans).
-export function getFirstConnection() {
-  return getStorageItem(FIRST_CONNECTION);
-}
-
-export function setFirstConnection(value) {
-  setStorageItem(FIRST_CONNECTION, value);
-}
+// First-connection helpers removed; key retained for backward compatibility
 
 export function clearBotSessionStorage(forceClear) {
   const botSessionKeys = Object.keys(sessionStorage);
   const loggedInFlow = getLoggedInFlow();
   const inAuthExp = getInAuthExp();
   const expectToClear = loggedInFlow !== 'true' && inAuthExp !== 'true';
+  // When user is in the auth experience but not logged in, do nothing.
+  // This preserves any temporary session state during the auth flow.
+  if (!forceClear && inAuthExp === 'true' && loggedInFlow !== 'true') {
+    return;
+  }
   // Ensure critical keys persist across page lifecycle clears.
   // Keep first-connection flag, conversationId, and token.
   const excludeClear = [

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -342,6 +342,7 @@
   "virtualAgentShowAiDisclaimer": "virtual_agent_show_ai_disclaimer",
   "virtualAgentShowFloatingChatbot": "virtual_agent_show_floating_chatbot",
   "virtualAgentUseStsAuthentication": "virtual_agent_use_sts_authentication",
+  "virtualAgentChatbotSessionPersistenceEnabled": "virtual_agent_chatbot_session_persistence_enabled",
   "vreModularApi": "vre_modular_api",
   "vreCutoverNotice": "vre_cutover_notice",
   "vyeLoginWidget": "vye_login_widget",


### PR DESCRIPTION
# Virtual Agent: Persisted transcript on reload (flagged), stable reconnect with fallback, and test updates

# Summary
- **Enable transcript replay on reload** when the feature flag is ON by preserving `token`/`conversationId` and using `watermark=0`.
- **Gate reconnect semantics**: only pass `conversationId` when the persistence flag is enabled, preventing “unknown conversation” 404s.
- **Add one-time fallback**: if initial Direct Line connect reports failure, automatically retry with a fresh connection (no `conversationId`/`watermark`).
- **Harden session storage** with a first-connect flag and refined exclusion list.
- **Update unit tests** to reflect new gating and fallback behavior.
- Minor cleanup for console and lint errors.

# Why
- Avoids reconnect 404s caused by stale `conversationId` with new tokens.
- Delivers the “persist messages across refresh/navigation” experience safely behind a feature flag.

# Key Changes
- **Direct Line connection logic**
  - [src/applications/virtual-agent/hooks/useDirectline.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useDirectline.js:0:0-0:0)
    - Build options with `{ token, domain }`.
    - Include `conversationId` only when `TOGGLE_NAMES.virtualAgentChatbotSessionPersistenceEnabled` is true and a value exists.
    - Include `watermark: '0'` when the flag is ON to request transcript replay.
    - Subscribe to `connectionStatus$`; on status `4` (failed), create a fresh instance without `conversationId`/`watermark` and swap it in.
    - Lint-safe unsubscribe guards added.

- **Token/conversation persistence**
  - [src/applications/virtual-agent/hooks/useChatbotToken.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useChatbotToken.js:0:0-0:0)
    - Acquire and reuse `token`/`conversationId` across reloads when the flag is ON.

- **Session storage rules**
  - [src/applications/virtual-agent/utils/sessionStorage.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/utils/sessionStorage.js:0:0-0:0)
    - Preserve critical keys (`first-connection`, `conversationId`, `token`, `code`) on non-forced clears.
    - Force clear on sign out to truly end chat.

- **Lifecycle events**
  - [src/applications/virtual-agent/event-listeners/clearBotSessionStorageEventListener.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/event-listeners/clearBotSessionStorageEventListener.js:0:0-0:0)
    - Non-forced clear on `beforeunload` to support replay.
  - [src/applications/virtual-agent/event-listeners/signOutEventListener.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/event-listeners/signOutEventListener.js:0:0-0:0)
    - Force clear on sign out.

- **Local vs public Direct Line**
  - Domain selected via `process.env.USE_LOCAL_DIRECTLINE`:
    - Local: `http://localhost:3002/v3/directline`
    - Default: `https://northamerica.directline.botframework.com/v3/directline`

- **Tests**
  - [src/applications/virtual-agent/tests/hooks/useDirectline.unit.spec.jsx](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/tests/hooks/useDirectline.unit.spec.jsx:0:0-0:0)
    - Expect no `conversationId` unless the flag is ON.
    - Validate `watermark: '0'` when flag is ON.
    - Assert fallback behavior on initial failure (status `4`).

# Behavior by Flag
- **Flag OFF (default)**:
  - Fresh conversation each load.
  - Options: `{ token, domain }`. No transcript replay.
  - If initial connect fails, auto-fallback still applies.
- **Flag ON**:
  - Reconnect using `{ token, domain, conversationId, watermark: '0' }` for transcript replay.
  - If reconnect fails (e.g., stale `conversationId`), one-time fallback recreates a fresh connection automatically.

# Testing Instructions
- **Unit tests**
  - Run: `yarn test src/applications/virtual-agent/tests/hooks/useDirectline.unit.spec.jsx`
- **Manual QA**
  - Flag OFF: reload → new conversation, no replay.
  - Flag ON: send a few messages → reload → transcript replays and session continues.
  - Sign out: keys cleared; next session starts clean.
  - Toggle `USE_LOCAL_DIRECTLINE` to confirm domain switching.

# Risk & Mitigations
- **Reconnect instability**: Addressed via gating and fallback.
- **Unexpected clears**: First-connect flag and refined exclusions minimize disruption.
- **Safe rollout**: Entire feature behind `virtualAgentChatbotSessionPersistenceEnabled`.

# Config
- Feature flag: `TOGGLE_NAMES.virtualAgentChatbotSessionPersistenceEnabled`
- Env: `process.env.USE_LOCAL_DIRECTLINE` selects local vs public Direct Line

# Rollback Plan
- Toggle OFF the feature flag to revert to current behavior (no transcript replay).
- If needed, revert [useDirectline.js](cci:7://file:///Users/mattkerns/dev/projects/vets-website/src/applications/virtual-agent/hooks/useDirectline.js:0:0-0:0) to remove gating/fallback.