### PR TITLE
arp/find_a_representative_use_accredited_models_toggle_over_env

### DIFF
--- a/src/applications/representative-appoint/api/fetchRepStatus.js
+++ b/src/applications/representative-appoint/api/fetchRepStatus.js
@@ -1,13 +1,9 @@
 import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { REPRESENTATIVE_STATUS_API } from '../constants/api';
+import { getBaseUrl } from '../config/form';
 
 export const fetchRepStatus = async () => {
-  const requestUrl = `${
-    environment.BASE_URL === 'http://localhost:3001'
-      ? `https://staging-api.va.gov`
-      : `${environment.API_URL}`
-  }${REPRESENTATIVE_STATUS_API}`;
+  const requestUrl = `${getBaseUrl()}${REPRESENTATIVE_STATUS_API}`;
   const apiSettings = {
     'Content-Type': 'application/json',
     mode: 'cors',

--- a/src/applications/representative-appoint/api/fetchRepresentatives.js
+++ b/src/applications/representative-appoint/api/fetchRepresentatives.js
@@ -1,7 +1,7 @@
-import environment from 'platform/utilities/environment';
 import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
 import { REPRESENTATIVES_API } from '../constants/api';
 import manifest from '../manifest.json';
+import { getBaseUrl } from '../config/form';
 
 export const fetchRepresentatives = async ({ query }) => {
   const apiSettings = {
@@ -17,13 +17,8 @@ export const fetchRepresentatives = async ({ query }) => {
 
   const startTime = new Date().getTime();
 
-  const apiUrl =
-    environment.BASE_URL === 'http://localhost:3001'
-      ? `https://staging-api.va.gov`
-      : `${environment.API_URL}`;
-
   return new Promise((resolve, reject) => {
-    fetch(`${apiUrl}${REPRESENTATIVES_API}?query=${query}`, apiSettings)
+    fetch(`${getBaseUrl()}${REPRESENTATIVES_API}?query=${query}`, apiSettings)
       .then(res => {
         if (!res.ok) {
           throw Error(res.statusText);

--- a/src/applications/representative-appoint/api/sendNextStepsEmail.js
+++ b/src/applications/representative-appoint/api/sendNextStepsEmail.js
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/browser';
 
-import environment from 'platform/utilities/environment';
 import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
 import { NEXT_STEPS_EMAIL_API } from '../constants/api';
 import manifest from '../manifest.json';
+import { getBaseUrl } from '../config/form';
 
 export default async function sendNextStepsEmail(body) {
   const apiSettings = {
@@ -20,21 +20,16 @@ export default async function sendNextStepsEmail(body) {
     body: JSON.stringify(body),
   };
 
-  const apiUrl =
-    environment.BASE_URL === 'http://localhost:3001'
-      ? `https://staging-api.va.gov`
-      : `${environment.API_URL}`;
-
   try {
     const response = await fetch(
-      `${apiUrl}${NEXT_STEPS_EMAIL_API}`,
+      `${getBaseUrl()}${NEXT_STEPS_EMAIL_API}`,
       apiSettings,
     );
 
     if (!response.ok) {
       const errorBody = await response.json();
 
-      const errorMessage = `Error on API request to ${apiUrl}${NEXT_STEPS_EMAIL_API}: ${
+      const errorMessage = `Error on API request to ${getBaseUrl()}${NEXT_STEPS_EMAIL_API}: ${
         response.statusText
       }. ${errorBody.error || 'Unknown error'}`;
       throw new Error(errorMessage);

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -1,5 +1,6 @@
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import FormFooter from 'platform/forms/components/FormFooter';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import GetFormHelp from '../components/GetFormHelp';
 import configService from '../utilities/configService';
@@ -49,6 +50,14 @@ import SubmissionError from '../components/SubmissionError';
 // const mockData = initialData;
 
 const { fullName, ssn, date, dateRange, usaPhone } = commonDefinitions;
+
+let baseUrl = 'https://staging-api.va.gov';
+
+export const getBaseUrl = () => baseUrl;
+
+export const setFindRepBaseUrlFromFlag = enabled => {
+  baseUrl = enabled ? environment.API_URL : 'https://staging-api.va.gov';
+};
 
 const formConfigFromService = configService.getFormConfig();
 

--- a/src/applications/representative-appoint/containers/App.jsx
+++ b/src/applications/representative-appoint/containers/App.jsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { isLoggedIn } from 'platform/user/selectors';
 import { scrollTo } from 'platform/utilities/scroll';
 import { setData } from 'platform/forms-system/src/js/actions';
-
-import formConfig from '../config/form';
+import formConfig, { setFindRepBaseUrlFromFlag } from '../config/form';
 
 import { wrapWithBreadcrumb } from '../components/Breadcrumbs';
 
@@ -20,6 +20,12 @@ import { selectAuthStatus } from '../utilities/selectors/authStatus';
 import { selectFeatureToggles } from '../utilities/selectors/featureToggles';
 
 function App({ location, children, formData }) {
+  const {
+    useToggleValue,
+    useToggleLoadingValue,
+    TOGGLE_NAMES,
+  } = useFeatureToggle();
+
   const subTitle = getFormSubtitle(formData);
   const { isLoadingFeatureFlags } = useSelector(selectFeatureToggles);
   const { isLoadingProfile } = useSelector(selectAuthStatus);
@@ -30,6 +36,21 @@ function App({ location, children, formData }) {
 
   // Set default view fields within the form data
   useDefaultFormData();
+
+  const useLocalBaseURL = useToggleValue(
+    TOGGLE_NAMES.findARepresentativeUseAccreditedModels,
+  );
+
+  const togglesLoading = useToggleLoadingValue();
+
+  useEffect(
+    () => {
+      if (!togglesLoading) {
+        setFindRepBaseUrlFromFlag(Boolean(useLocalBaseURL));
+      }
+    },
+    [togglesLoading, useLocalBaseURL],
+  );
 
   const { pathname } = location || {};
   const [updatedFormConfig, setUpdatedFormConfig] = useState({ ...formConfig });

--- a/src/applications/representative-appoint/tests/api/fetchRepStatus.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/api/fetchRepStatus.unit.spec.jsx
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import * as platformApi from '@department-of-veterans-affairs/platform-utilities/api';
 import fetchRepStatus from '../../api/fetchRepStatus';
+import { setFindRepBaseUrlFromFlag } from '../../config/form';
+import { REPRESENTATIVE_STATUS_API } from '../../constants/api';
 
 describe('fetchRepStatus', () => {
   let sandbox;
@@ -9,26 +12,25 @@ describe('fetchRepStatus', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    global.fetch = sandbox.stub(global, 'fetch');
+    fetchStub = sandbox.stub(platformApi, 'fetchAndUpdateSessionExpiration');
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('should return representative status successfully', async () => {
+  it('uses API_URL when the flag is ON', async () => {
+    setFindRepBaseUrlFromFlag(true);
     const mockResponse = {
       ok: true,
       statusText: 'OK',
       json: () => Promise.resolve({ data: 'Mocked Data' }),
     };
-    fetchStub = fetch.resolves(mockResponse);
+    fetchStub.resolves(mockResponse);
 
     const result = await fetchRepStatus();
 
-    const expectedUrl = `${
-      environment.API_URL
-    }/representation_management/v0/power_of_attorney`;
+    const expectedUrl = `${environment.API_URL}${REPRESENTATIVE_STATUS_API}`;
     sinon.assert.calledWith(fetchStub, expectedUrl, {
       'Content-Type': 'application/json',
       mode: 'cors',
@@ -41,27 +43,46 @@ describe('fetchRepStatus', () => {
     expect(result).to.have.nested.property('data', 'Mocked Data');
   });
 
-  it('should throw an error if the response is not ok', async () => {
+  it('uses staging base when the flag is OFF', async () => {
+    setFindRepBaseUrlFromFlag(false);
+    const mockResponse = {
+      ok: true,
+      statusText: 'OK',
+      json: () => Promise.resolve({ data: 'Mocked Data' }),
+    };
+    fetchStub.resolves(mockResponse);
+
+    await fetchRepStatus();
+
+    const expectedUrl = `https://staging-api.va.gov${REPRESENTATIVE_STATUS_API}`;
+    sinon.assert.calledWith(fetchStub, expectedUrl, sinon.match.object);
+  });
+
+  it('throws when response is not ok', async () => {
+    setFindRepBaseUrlFromFlag(true);
     const mockErrorResponse = {
       ok: false,
       statusText: 'Internal Server Error',
       json: () => Promise.resolve({ error: 'Some error' }),
     };
-    fetchStub = fetch.resolves(mockErrorResponse);
+    fetchStub.resolves(mockErrorResponse);
 
     try {
       await fetchRepStatus();
+      expect.fail('Expected error to be thrown');
     } catch (error) {
       expect(error.message).to.equal('Internal Server Error');
     }
   });
 
-  it('should handle errors', async () => {
+  it('bubbles network errors', async () => {
+    setFindRepBaseUrlFromFlag(true);
     const mockError = new Error('Network error');
-    fetchStub = fetch.rejects(mockError);
+    fetchStub.rejects(mockError);
 
     try {
       await fetchRepStatus();
+      expect.fail('Expected error to be thrown');
     } catch (error) {
       expect(error).to.equal(mockError);
     }

--- a/src/applications/representative-appoint/tests/api/fetchRepresentatives.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/api/fetchRepresentatives.unit.spec.jsx
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import * as platformApi from '@department-of-veterans-affairs/platform-utilities/api';
 import { fetchRepresentatives } from '../../api/fetchRepresentatives';
+import { setFindRepBaseUrlFromFlag } from '../../config/form';
+import { REPRESENTATIVES_API } from '../../constants/api';
 import repResults from '../fixtures/data/representative-results.json';
 
 describe('fetchRepresentatives', () => {
@@ -11,64 +14,88 @@ describe('fetchRepresentatives', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    global.fetch = sandbox.stub(global, 'fetch');
+    fetchStub = sandbox.stub(platformApi, 'fetchAndUpdateSessionExpiration');
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('should call the api with the query param', async () => {
+  it('calls API_URL when flag is ON, with query param', async () => {
+    setFindRepBaseUrlFromFlag(true);
+
     const mockResponse = {
       ok: true,
       statusText: 'OK',
       json: () => Promise.resolve({ repResults }),
     };
-    fetchStub = fetch.resolves(mockResponse);
+    fetchStub.resolves(mockResponse);
 
     await fetchRepresentatives({ query });
 
     const expectedUrl = `${
       environment.API_URL
-    }/representation_management/v0/original_entities?query=${query}`;
-
-    sinon.assert.calledWith(fetchStub, expectedUrl);
+    }${REPRESENTATIVES_API}?query=${query}`;
+    sinon.assert.calledWith(fetchStub, expectedUrl, sinon.match.object);
   });
 
-  it('returns a list of representatives', async () => {
+  it('calls staging base when flag is OFF, with query param', async () => {
+    setFindRepBaseUrlFromFlag(false);
+
     const mockResponse = {
       ok: true,
       statusText: 'OK',
       json: () => Promise.resolve({ repResults }),
     };
-    fetchStub = fetch.resolves(mockResponse);
+    fetchStub.resolves(mockResponse);
+
+    await fetchRepresentatives({ query });
+
+    const expectedUrl = `https://staging-api.va.gov${REPRESENTATIVES_API}?query=${query}`;
+    sinon.assert.calledWith(fetchStub, expectedUrl, sinon.match.object);
+  });
+
+  it('returns a list of representatives', async () => {
+    setFindRepBaseUrlFromFlag(true);
+    const mockResponse = {
+      ok: true,
+      statusText: 'OK',
+      json: () => Promise.resolve({ repResults }),
+    };
+    fetchStub.resolves(mockResponse);
 
     const result = await fetchRepresentatives({ query });
 
     expect(result.repResults).to.deep.equal(repResults);
   });
 
-  it('should throw an error if the response is not ok', async () => {
+  it('throws when response is not ok', async () => {
+    setFindRepBaseUrlFromFlag(true);
+
     const mockErrorResponse = {
       ok: false,
       statusText: 'Internal Server Error',
       json: () => Promise.resolve({ error: 'Some error' }),
     };
-    fetchStub = fetch.resolves(mockErrorResponse);
+    fetchStub.resolves(mockErrorResponse);
 
     try {
       await fetchRepresentatives({ query });
+      expect.fail('Expected error to be thrown');
     } catch (error) {
       expect(error.message).to.equal('Internal Server Error');
     }
   });
 
-  it('should handle errors', async () => {
+  it('bubbles network errors', async () => {
+    setFindRepBaseUrlFromFlag(true);
+
     const mockError = new Error('Network error');
-    fetchStub = fetch.rejects(mockError);
+    fetchStub.rejects(mockError);
 
     try {
       await fetchRepresentatives({ query });
+      expect.fail('Expected error to be thrown');
     } catch (error) {
       expect(error).to.equal(mockError);
     }

--- a/src/applications/representative-appoint/tests/api/sendNextStepsEmail.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/api/sendNextStepsEmail.unit.spec.jsx
@@ -1,11 +1,18 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import * as platformApi from '@department-of-veterans-affairs/platform-utilities/api';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import * as Sentry from '@sentry/browser';
 import sendNextStepsEmail from '../../api/sendNextStepsEmail';
+import { setFindRepBaseUrlFromFlag } from '../../config/form';
+import { NEXT_STEPS_EMAIL_API } from '../../constants/api';
+import manifest from '../../manifest.json';
 
 describe('sendNextStepsEmail', () => {
   let sandbox;
   let fetchStub;
+  let sentryStub;
+
   const body = {
     formNumber: '21-22',
     formName:
@@ -18,80 +25,110 @@ describe('sendNextStepsEmail', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    global.fetch = sandbox.stub(global, 'fetch');
+    fetchStub = sandbox.stub(platformApi, 'fetchAndUpdateSessionExpiration');
+    sentryStub = sandbox.stub(Sentry, 'captureException');
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('should call the api with the provided body', async () => {
+  it('calls API_URL when flag is ON, with provided body', async () => {
+    setFindRepBaseUrlFromFlag(true); // ON → environment.API_URL
+
     const mockResponse = {
       ok: true,
       statusText: 'OK',
       json: () => Promise.resolve({ message: 'email enqueued' }),
     };
-    fetchStub = fetch.resolves(mockResponse);
+    fetchStub.resolves(mockResponse);
 
     await sendNextStepsEmail(body);
 
-    const expectedUrl = `${
-      environment.API_URL
-    }/representation_management/v0/next_steps_email`;
-
-    sinon.assert.calledWith(fetchStub, expectedUrl, {
-      body: JSON.stringify(body),
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'Sec-Fetch-Mode': 'cors',
-        'Source-App-Name': 'appoint-a-representative',
-        'X-CSRF-Token': null,
-        'X-Key-Inflection': 'camel',
-      },
-      method: 'POST',
-      mode: 'cors',
-    });
+    const expectedUrl = `${environment.API_URL}${NEXT_STEPS_EMAIL_API}`;
+    sinon.assert.calledWith(
+      fetchStub,
+      expectedUrl,
+      sinon.match({
+        method: 'POST',
+        mode: 'cors',
+        credentials: 'include',
+        headers: sinon.match({
+          'X-Key-Inflection': 'camel',
+          'Sec-Fetch-Mode': 'cors',
+          'Content-Type': 'application/json',
+          'Source-App-Name': manifest.entryName,
+        }),
+        body: JSON.stringify(body),
+      }),
+    );
   });
 
-  it('returns the api response as json', async () => {
+  it('calls staging base when flag is OFF', async () => {
+    setFindRepBaseUrlFromFlag(false); // OFF → staging
+
     const mockResponse = {
       ok: true,
       statusText: 'OK',
       json: () => Promise.resolve({ message: 'email enqueued' }),
     };
-    fetchStub = fetch.resolves(mockResponse);
+    fetchStub.resolves(mockResponse);
+
+    await sendNextStepsEmail(body);
+
+    const expectedUrl = `https://staging-api.va.gov${NEXT_STEPS_EMAIL_API}`;
+    sinon.assert.calledWith(fetchStub, expectedUrl, sinon.match.object);
+  });
+
+  it('returns the API response as JSON', async () => {
+    setFindRepBaseUrlFromFlag(true);
+
+    const mockResponse = {
+      ok: true,
+      statusText: 'OK',
+      json: () => Promise.resolve({ message: 'email enqueued' }),
+    };
+    fetchStub.resolves(mockResponse);
 
     const result = await sendNextStepsEmail(body);
 
     expect(result).to.eql({ message: 'email enqueued' });
   });
 
-  it('should throw an error if the response is not ok', async () => {
+  it('throws a detailed error when response is not ok', async () => {
+    setFindRepBaseUrlFromFlag(true);
+
     const mockErrorResponse = {
       ok: false,
       statusText: 'Internal Server Error',
       json: () => Promise.resolve({ error: 'Some error' }),
     };
-    fetchStub = fetch.resolves(mockErrorResponse);
-    const expectedError =
-      'Error on API request to https://dev-api.va.gov/representation_management/v0/next_steps_email: Internal Server Error. Some error';
+    fetchStub.resolves(mockErrorResponse);
 
     try {
       await sendNextStepsEmail(body);
+      expect.fail('Expected error to be thrown');
     } catch (error) {
-      expect(error.message).to.equal(expectedError);
+      const expectedUrl = `${environment.API_URL}${NEXT_STEPS_EMAIL_API}`;
+      expect(error.message).to.equal(
+        `Error on API request to ${expectedUrl}: Internal Server Error. Some error`,
+      );
+      sinon.assert.calledOnce(sentryStub);
     }
   });
 
-  it('should handle errors', async () => {
+  it('bubbles network errors and reports to Sentry', async () => {
+    setFindRepBaseUrlFromFlag(true);
+
     const mockError = new Error('Network error');
-    fetchStub = fetch.rejects(mockError);
+    fetchStub.rejects(mockError);
 
     try {
       await sendNextStepsEmail(body);
+      expect.fail('Expected error to be thrown');
     } catch (error) {
       expect(error).to.equal(mockError);
+      sinon.assert.calledOnce(sentryStub);
     }
   });
 });

--- a/src/applications/representative-appoint/tests/config/formConfig.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/config/formConfig.unit.spec.jsx
@@ -1,7 +1,23 @@
 import { expect } from 'chai';
-import formConfig from '../../config/form';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import formConfig, {
+  getBaseUrl,
+  setFindRepBaseUrlFromFlag,
+} from '../../config/form';
 import mockFormData2122a from '../fixtures/data/21-22a/form-data.json';
 import mockFormData2122 from '../fixtures/data/form-data.json';
+
+describe('form getBaseUrl setter', () => {
+  it('uses environment.API_URL when flag is ON', () => {
+    setFindRepBaseUrlFromFlag(true);
+    expect(getBaseUrl()).to.equal(environment.API_URL);
+  });
+
+  it('uses staging URL when flag is OFF', () => {
+    setFindRepBaseUrlFromFlag(false);
+    expect(getBaseUrl()).to.equal('https://staging-api.va.gov');
+  });
+});
 
 describe('FormConfig depends function', () => {
   const { chapters } = formConfig;

--- a/src/applications/representative-search/config.js
+++ b/src/applications/representative-search/config.js
@@ -32,12 +32,12 @@ export const endpointOptions = {
 /*
  * Toggle true for local development
  */
-export const useStagingDataLocally = true;
 
-const baseUrl =
-  useStagingDataLocally && environment.BASE_URL === 'http://localhost:3001'
-    ? `https://staging-api.va.gov`
-    : `${environment.API_URL}`;
+let baseUrl = `https://staging-api.va.gov`;
+
+export const setFindRepBaseUrlFromFlag = enabled => {
+  baseUrl = enabled ? environment.API_URL : 'https://staging-api.va.gov';
+};
 
 export const formatReportBody = newReport => {
   const reportRequestBody = {

--- a/src/applications/representative-search/containers/App.jsx
+++ b/src/applications/representative-search/containers/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -6,6 +6,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 import { VaLoadingIndicator } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
+import { setFindRepBaseUrlFromFlag } from '../config';
 import { useBrowserMonitoring } from '../hooks/useBrowserMonitoring';
 
 function App({ children }) {
@@ -22,7 +23,20 @@ function App({ children }) {
     TOGGLE_NAMES.findARepresentativeEnableFrontend,
   );
 
+  const useLocalBaseURL = useToggleValue(
+    TOGGLE_NAMES.findARepresentativeUseAccreditedModels,
+  );
+
   const togglesLoading = useToggleLoadingValue();
+
+  useEffect(
+    () => {
+      if (!togglesLoading) {
+        setFindRepBaseUrlFromFlag(Boolean(useLocalBaseURL));
+      }
+    },
+    [togglesLoading, useLocalBaseURL],
+  );
 
   if (togglesLoading) {
     return (

--- a/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.jsx
+++ b/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.jsx
@@ -5,6 +5,7 @@ import {
   getApi,
   endpointOptions,
   formatReportBody,
+  setFindRepBaseUrlFromFlag,
 } from '../config';
 
 describe('Locator url and parameters builder', () => {
@@ -14,6 +15,10 @@ describe('Locator url and parameters builder', () => {
   const name = 'test';
   const sort = 'distance_asc';
   const distance = '100';
+
+  beforeEach(() => {
+    setFindRepBaseUrlFromFlag(true);
+  });
 
   it('should build VA request with type=veteran_service_officer', () => {
     const type = 'veteran_service_officer';
@@ -36,7 +41,9 @@ describe('Locator url and parameters builder', () => {
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/services/veteran/v0/vso_accredited_representatives?address=43210&lat=40.17887&long=-99.27246&name=test&page=1&per_page=10&sort=distance_asc&type=veteran_service_officer&distance=100`,
+      }/services/veteran/v0/vso_accredited_representatives` +
+        `?address=43210&lat=40.17887&long=-99.27246&name=test&page=1&per_page=10` +
+        `&sort=distance_asc&type=veteran_service_officer&distance=100`,
     );
   });
 
@@ -61,11 +68,13 @@ describe('Locator url and parameters builder', () => {
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/services/veteran/v0/other_accredited_representatives?address=43210&lat=40.17887&long=-99.27246&name=test&page=1&per_page=10&sort=distance_asc&type=claim_agents&distance=100`,
+      }/services/veteran/v0/other_accredited_representatives` +
+        `?address=43210&lat=40.17887&long=-99.27246&name=test&page=1&per_page=10` +
+        `&sort=distance_asc&type=claim_agents&distance=100`,
     );
   });
 
-  it('should build VA request with type=attorney and page = 2 and perPage = 7', () => {
+  it('should build VA request with type=attorney and page=2, perPage=7', () => {
     const type = 'attorney';
     const { requestUrl } = getApi(endpointOptions.fetchOtherReps);
 
@@ -85,7 +94,9 @@ describe('Locator url and parameters builder', () => {
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/services/veteran/v0/other_accredited_representatives?address=43210&lat=40.17887&long=-99.27246&name=test&page=2&per_page=7&sort=distance_asc&type=attorney&distance=100`,
+      }/services/veteran/v0/other_accredited_representatives` +
+        `?address=43210&lat=40.17887&long=-99.27246&name=test&page=2&per_page=7` +
+        `&sort=distance_asc&type=attorney&distance=100`,
     );
   });
 
@@ -109,7 +120,11 @@ describe('Locator url and parameters builder', () => {
     const formattedReportBody = JSON.stringify(formatReportBody(reportObject));
 
     expect(formattedReportBody).to.eql(
-      '{"representative_id":123,"flags":[{"flag_type":"phone_number","flagged_value":"644-465-8493"},{"flag_type":"email","flagged_value":"example@rep.com"},{"flag_type":"address","flagged_value":"123 Any Street"},{"flag_type":"other","flagged_value":"other comment"}]}',
+      '{"representative_id":123,"flags":[' +
+        '{"flag_type":"phone_number","flagged_value":"644-465-8493"},' +
+        '{"flag_type":"email","flagged_value":"example@rep.com"},' +
+        '{"flag_type":"address","flagged_value":"123 Any Street"},' +
+        '{"flag_type":"other","flagged_value":"other comment"}]}',
     );
   });
 
@@ -131,7 +146,16 @@ describe('Locator url and parameters builder', () => {
     expect(test).to.eql(
       `${
         environment.API_URL
-      }/services/veteran/v0/other_accredited_representatives?page=2&per_page=7&sort=distance_asc&type=veteran_service_officer&distance=100`,
+      }/services/veteran/v0/other_accredited_representatives` +
+        `?page=2&per_page=7&sort=distance_asc&type=veteran_service_officer&distance=100`,
+    );
+  });
+
+  it('uses staging base when feature flag is OFF', () => {
+    setFindRepBaseUrlFromFlag(false); // flip to staging
+    const { requestUrl } = getApi(endpointOptions.fetchVSOReps);
+    expect(requestUrl).to.eql(
+      `https://staging-api.va.gov${endpointOptions.fetchVSOReps}`,
     );
   });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -95,6 +95,7 @@
   "financialStatusReportReviewPageNavigation": "financial_status_report_review_page_navigation",
   "findARepresentativeEnableFrontend": "find_a_representative_enable_frontend",
   "findARepresentativeFlagResultsEnabled": "find_a_representative_flag_results_enabled",
+  "findARepresentativeUseAccreditedModels": "find_a_representative_use_accredited_models",
   "form1010dBrowserMonitoringEnabled": "form1010d_browser_monitoring_enabled",
   "form107959cBrowserMonitoringEnabled": "form107959c_browser_monitoring_enabled",
   "form107959f1BrowserMonitoringEnabled": "form107959f1_browser_monitoring_enabled",


### PR DESCRIPTION
## Summary

- Changed Rep Search and Appoint to use a feature flag instead of doing an env check first

## Related issue(s)

- https://github.com/orgs/department-of-veterans-affairs/projects/1809/views/8?pane=issue&itemId=129052377&issue=department-of-veterans-affairs%7Cva.gov-team%7C117164

## Testing done

- Added unit testing for each instance of the change

## Screenshots

N/a

## What areas of the site does it impact?

ARP

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed and added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [ ] Browser console contains no warnings or errors.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user