### PR TITLE
Updated TOU to not be Reliant on Flipper

### DIFF
--- a/src/applications/terms-of-use/components/TermsAcceptanceAction.jsx
+++ b/src/applications/terms-of-use/components/TermsAcceptanceAction.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
-import { termsOfUseEnabled } from '@department-of-veterans-affairs/platform-user/exports';
 
 export default function TermsAcceptance({
   error,
@@ -12,47 +10,45 @@ export default function TermsAcceptance({
   isUnauthenticated,
   isDisabled = false,
 }) {
-  const termsOfUseAuthorized = useSelector(termsOfUseEnabled);
   const className = isUnauthenticated ? 'hidden' : '';
   const acceptBtnText =
     isFullyAuthenticated && !isMiddleAuth ? 'Continue to accept' : 'Accept';
   return (
     <>
-      {(isMiddleAuth || isFullyAuthenticated) &&
-        termsOfUseAuthorized && (
-          <>
-            <h2 id="do-you-accept-of-terms-of-use" className={className}>
-              Do you accept these terms of use?
-            </h2>
-            {error.isError && (
-              <va-alert
-                status="error"
-                slim
-                visible
-                uswds
-                data-testid="error-non-modal"
-                class="vads-u-margin-y--1p5"
-              >
-                {error.message}
-              </va-alert>
-            )}
-            <va-button
-              disabled={isDisabled}
-              data-testid="accept"
-              text={acceptBtnText}
-              onClick={() => handleTouClick('accept')}
-              ariaLabel="Accept the VA online services terms of use"
-            />
-            <va-button
-              disabled={isDisabled}
-              data-testid="decline"
-              text="Decline"
-              secondary
-              ariaLabel="Decline the VA online services terms of use"
-              onClick={() => setShowDeclineModal(true)}
-            />
-          </>
-        )}
+      {(isMiddleAuth || isFullyAuthenticated) && (
+        <>
+          <h2 id="do-you-accept-of-terms-of-use" className={className}>
+            Do you accept these terms of use?
+          </h2>
+          {error.isError && (
+            <va-alert
+              status="error"
+              slim
+              visible
+              uswds
+              data-testid="error-non-modal"
+              class="vads-u-margin-y--1p5"
+            >
+              {error.message}
+            </va-alert>
+          )}
+          <va-button
+            disabled={isDisabled}
+            data-testid="accept"
+            text={acceptBtnText}
+            onClick={() => handleTouClick('accept')}
+            ariaLabel="Accept the VA online services terms of use"
+          />
+          <va-button
+            disabled={isDisabled}
+            data-testid="decline"
+            text="Decline"
+            secondary
+            ariaLabel="Decline the VA online services terms of use"
+            onClick={() => setShowDeclineModal(true)}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
+++ b/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
@@ -10,15 +10,8 @@ import {
 } from 'platform/testing/unit/msw-adapter';
 import TermsOfUse from '../containers/TermsOfUse';
 
-const store = ({
-  termsOfUseEnabled = true,
-  authenticatedWithSiS = false,
-} = {}) => ({
+const store = ({ authenticatedWithSiS = false } = {}) => ({
   getState: () => ({
-    featureToggles: {
-      // eslint-disable-next-line camelcase
-      terms_of_use: termsOfUseEnabled,
-    },
     user: {
       profile: {
         session: {
@@ -123,17 +116,6 @@ describe('TermsOfUse', () => {
         2,
       ); // modal
     });
-  });
-
-  it('should NOT display Accept or Decline buttons termsOfUse Flipper is disabled', () => {
-    const mockStore = store({ termsOfUseEnabled: false });
-    const { container } = render(
-      <Provider store={mockStore}>
-        <TermsOfUse />
-      </Provider>,
-    );
-
-    expect(container.querySelectorAll('va-button', container).length).to.eql(2); // modal
   });
 
   it('should display the declined modal if the decline button is clicked', async () => {

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -72,11 +72,3 @@ export const ssoeTransactionId = state =>
  */
 export const signInServiceEnabled = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.signInServiceEnabled];
-
-/**
- * Checks if the Terms of Use feature flag is enabled.
- * @param {Object} state - The application state.
- * @returns {boolean} - True if the feature is enabled.
- */
-export const termsOfUseEnabled = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.termsOfUse];

--- a/src/platform/user/exportsFile.js
+++ b/src/platform/user/exportsFile.js
@@ -120,7 +120,6 @@ export {
   isAuthenticatedWithSSOe,
   isAuthenticatedWithOAuth,
   ssoeTransactionId,
-  termsOfUseEnabled,
 } from './authentication/selectors';
 export { externalApplicationsConfig } from './authentication/usip-config';
 export { OAuthEnabledApplications } from './authentication/config/constants';

--- a/src/platform/user/tests/authentication/selectors.unit.spec.jsx
+++ b/src/platform/user/tests/authentication/selectors.unit.spec.jsx
@@ -184,23 +184,4 @@ describe('authentication selectors', () => {
       expect(selectors.signInServiceEnabled(state)).to.be.undefined;
     });
   });
-
-  describe('termsOfUseEnabled', () => {
-    it('pulls out featureToggles.termsOfUse', () => {
-      const state = {
-        featureToggles: {
-          [FEATURE_FLAG_NAMES.termsOfUse]: true,
-        },
-      };
-
-      expect(selectors.termsOfUseEnabled(state)).to.be.true;
-    });
-    it('returns undefined when termsOfUse is not present', () => {
-      const state = {
-        featureToggles: {},
-      };
-
-      expect(selectors.termsOfUseEnabled(state)).to.be.undefined;
-    });
-  });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -297,7 +297,6 @@
   "stemSCOEmail": "stem_sco_email",
   "subform89404192": "subform_8940_4192",
   "supplyReorderingSleepApneaEnabled": "supply_reordering_sleep_apnea_enabled",
-  "termsOfUse": "terms_of_use",
   "toeLightHouseDgiDirectDeposit": "toe_light_house_dgi_direct_deposit",
   "toggleVyeAddressDirectDepositForms": "toggle_vye_address_direct_deposit_forms",
   "toggleVyeAddressDirectDepositFormsInProfile": "toggle_vye_address_direct_deposit_forms_in_profile",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removed `termsOfUse` flipper and related code from Terms of Use.

## Related issue(s)
[Github Projects Ticket](https://github.com/department-of-veterans-affairs/identity-documentation/issues/668)

## Testing done
- Updated `TermsOfUse.unit.spec.jsx` and `selectors.unit.spec.jsx`. Ran tests locally to ensure no breaking changes.
- Can be replicated by running `yarn test:unit --app-folder terms-of-use` and `yarn test:unit src/platform/user/tests/authentication/selectors.unit.spec.jsx`.

## What areas of the site does it impact?
This impacts feature flags, authentication selectors, user exports, terms of use, and related tests.

## Acceptance criteria
- [x] Remove frontend feature flag for Terms of Use.