### PR TITLE
fix: heading for screen reader

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/form0781/manualUploadPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/form0781/manualUploadPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const manualUploadPageTitle = 'Upload VA Form 21 -0781';
+export const manualUploadPageTitle = 'Upload VA Form 21-0781';
 
 export const manualUploadPageDescription = (
   <>


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixing the heading for manual page as the screen reader reads the "-" as a minus due to the space between "21" and "-0781". Removed the space.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/107718

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/107718

## Testing done
- ran test associated to page.
- used native macOS screen reader in chrome.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| manual Page Upload  |<img width="671" height="942" alt="Screenshot 2025-10-06 at 3 03 16 PM" src="https://github.com/user-attachments/assets/e3bc33d4-b537-4b03-ac48-af8f8b69876f" />|<img width="671" height="942" alt="image" src="https://github.com/user-attachments/assets/af83292b-12a1-4f5f-9979-12d407187b9f" />|

## What areas of the site does it impact?

`manualPageUpload page`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

