### PR TITLE
117082 MHV SM: update start a new message flow - exclude OH pools from contact list

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/EditContactList.jsx
+++ b/src/applications/mhv-secure-messaging/containers/EditContactList.jsx
@@ -45,13 +45,18 @@ const EditContactList = () => {
   );
 
   const recipients = useSelector(state => state.sm.recipients);
-  const { allFacilities, blockedFacilities, allRecipients, error } = recipients;
+  const {
+    vistaFacilities,
+    blockedFacilities,
+    vistaRecipients,
+    error,
+  } = recipients;
 
   const ehrDataByVhaId = useSelector(selectEhrDataByVhaId);
 
   const isContactListChanged = useMemo(
-    () => !_.isEqual(allRecipients, allTriageTeams),
-    [allRecipients, allTriageTeams],
+    () => !_.isEqual(vistaRecipients, allTriageTeams),
+    [vistaRecipients, allTriageTeams],
   );
 
   const isMinimumSelected = useMemo(
@@ -119,9 +124,9 @@ const EditContactList = () => {
 
   useEffect(
     () => {
-      setAllTriageTeams(allRecipients);
+      setAllTriageTeams(vistaRecipients);
     },
-    [allRecipients],
+    [vistaRecipients],
   );
 
   useEffect(() => {
@@ -157,25 +162,13 @@ const EditContactList = () => {
       setIsNavigationBlocked(false);
     }
     return (
-      <button
-        type="button"
-        className={`
-          ${allTriageTeams?.length ? 'usa-button-secondary' : ''}
-          vads-u-display--flex
-          vads-u-flex-direction--row
-          vads-u-justify-content--center
-          vads-u-align-items--center
-          vads-u-margin-y--0
-        `}
+      <va-button
+        back
+        onClick={handleCancel}
+        text="Go back"
         data-testid="contact-list-go-back"
         data-dd-action-name="Go back button"
-        onClick={handleCancel}
-      >
-        <div className="vads-u-margin-right--0p5">
-          <va-icon icon="navigate_far_before" aria-hidden="true" />
-        </div>
-        <span>Go back</span>
-      </button>
+      />
     );
   };
 
@@ -193,7 +186,8 @@ const EditContactList = () => {
       <AlertBackgroundBox closeable focus />
 
       <div
-        className={`${allFacilities?.length > 1 && 'vads-u-margin-bottom--2'}`}
+        className={`${vistaFacilities?.length > 1 &&
+          'vads-u-margin-bottom--2'}`}
       >
         <BlockedTriageGroupAlert
           alertStyle={BlockedTriageAlertStyles.ALERT}
@@ -204,7 +198,9 @@ const EditContactList = () => {
       <p className="vads-u-margin-bottom--3">
         Select the teams you want to show in your contact list. You must select
         at least one team
-        {allFacilities?.length > 1 ? ' from one of your facilities.' : '.'}{' '}
+        {vistaFacilities?.length > 1
+          ? ' from one of your facilities.'
+          : '.'}{' '}
       </p>
 
       {error && (
@@ -236,7 +232,7 @@ const EditContactList = () => {
       {allTriageTeams?.length > 0 && (
         <>
           <form className="contactListForm">
-            {allFacilities.map(stationNumber => {
+            {vistaFacilities.map(stationNumber => {
               if (!blockedFacilities.includes(stationNumber)) {
                 const facilityName = getVamcSystemNameFromVhaId(
                   ehrDataByVhaId,
@@ -248,7 +244,7 @@ const EditContactList = () => {
                     key={stationNumber}
                     errorMessage={checkboxError}
                     facilityName={facilityName}
-                    multipleFacilities={allFacilities?.length > 1}
+                    multipleFacilities={vistaFacilities?.length > 1}
                     updatePreferredTeam={updatePreferredTeam}
                     triageTeams={allTriageTeams
                       .filter(

--- a/src/applications/mhv-secure-messaging/reducers/recipients.js
+++ b/src/applications/mhv-secure-messaging/reducers/recipients.js
@@ -8,6 +8,7 @@ const initialState = {
    */
   allRecipients: [],
   allowedRecipients: [],
+  vistaRecipients: [],
   recentRecipients: undefined,
   blockedRecipients: [],
   blockedFacilities: [],
@@ -50,16 +51,19 @@ export const recipientsReducer = (state = initialState, action) => {
 
         allRecipients: recipients,
 
-        allowedRecipients: recipients
-          .filter(
-            recipient =>
-              recipient.blockedStatus === false &&
-              recipient.preferredTeam === true &&
-              (state.activeCareSystem?.vhaId === undefined ||
-                state.activeCareSystem?.vhaId === recipient.stationNumber),
-          )
+        allowedRecipients: recipients.filter(
+          recipient =>
+            recipient.blockedStatus === false &&
+            recipient.preferredTeam === true &&
+            (state.activeCareSystem?.vhaId === undefined ||
+              state.activeCareSystem?.vhaId === recipient.stationNumber),
+        ),
+
+        vistaRecipients: recipients
+          .filter(recipient => recipient.ohTriageGroup !== true)
           .map(recipient => formatRecipient(recipient)),
 
+        activeCareSystem: action.response.meta.activeCareSystem || null,
         blockedRecipients: recipients
           .filter(recipient => recipient.blockedStatus === true)
           .map(recipient => formatRecipient(recipient)),
@@ -67,6 +71,7 @@ export const recipientsReducer = (state = initialState, action) => {
         blockedFacilities: facilities.fullyBlockedFacilities,
 
         allFacilities: facilities.allFacilities,
+        vistaFacilities: facilities.vistaFacilities,
 
         noAssociations,
 

--- a/src/applications/mhv-secure-messaging/reducers/recipients.js
+++ b/src/applications/mhv-secure-messaging/reducers/recipients.js
@@ -1,5 +1,9 @@
 import { Actions } from '../util/actionTypes';
-import { findBlockedFacilities, formatRecipient } from '../util/helpers';
+import {
+  findAllowedFacilities,
+  findBlockedFacilities,
+  formatRecipient,
+} from '../util/helpers';
 
 const initialState = {
   /**
@@ -13,7 +17,7 @@ const initialState = {
   blockedRecipients: [],
   blockedFacilities: [],
   allFacilities: [],
-  allowedVistaFacilities: [],
+  vistaFacilities: [],
   allowedOhFacilities: [],
   activeCareSystem: null,
   activeCareTeam: null,
@@ -59,6 +63,9 @@ export const recipientsReducer = (state = initialState, action) => {
               state.activeCareSystem?.vhaId === recipient.stationNumber),
         ),
 
+        vistaFacilities: findAllowedFacilities(recipients)
+          .allowedVistaFacilities,
+
         vistaRecipients: recipients
           .filter(recipient => recipient.ohTriageGroup !== true)
           .map(recipient => formatRecipient(recipient)),
@@ -71,7 +78,6 @@ export const recipientsReducer = (state = initialState, action) => {
         blockedFacilities: facilities.fullyBlockedFacilities,
 
         allFacilities: facilities.allFacilities,
-        vistaFacilities: facilities.vistaFacilities,
 
         noAssociations,
 

--- a/src/applications/mhv-secure-messaging/tests/containers/EditContactList.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/EditContactList.unit.spec.jsx
@@ -482,7 +482,7 @@ describe('Edit Contact List container', async () => {
             noAssociationsAtAll.associatedBlockedTriageGroupsQty,
           noAssociations: noAssociationsAtAll.noAssociations,
           allTriageGroupsBlocked: noAssociationsAtAll.allTriageGroupsBlocked,
-          allFacilities: [...noAssociationsAtAll.mockVistaFacilities],
+          vistaFacilities: [...noAssociationsAtAll.mockVistaFacilities],
           blockedFacilities: [...noAssociationsAtAll.mockBlockedFacilities],
           allRecipients: [...noAssociationsAtAll.mockAllRecipients],
           error: true,

--- a/src/applications/mhv-secure-messaging/tests/containers/EditContactList.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/EditContactList.unit.spec.jsx
@@ -16,6 +16,9 @@ import { ErrorMessages, Paths } from '../../util/constants';
 import { checkVaCheckbox, getProps } from '../../util/testUtils';
 
 describe('Edit Contact List container', async () => {
+  const initialVistaRecipients = noBlockedRecipients.mockAllRecipients.filter(
+    r => r.ohTriageGroup === false,
+  );
   const initialState = {
     drupalStaticData,
     sm: {
@@ -28,9 +31,10 @@ describe('Edit Contact List container', async () => {
           noBlockedRecipients.associatedBlockedTriageGroupsQty,
         noAssociations: noBlockedRecipients.noAssociations,
         allTriageGroupsBlocked: noBlockedRecipients.allTriageGroupsBlocked,
-        allFacilities: [...noBlockedRecipients.mockAllFacilities],
+        vistaFacilities: [...noBlockedRecipients.mockVistaFacilities],
         blockedFacilities: [...noBlockedRecipients.mockBlockedFacilities],
         allRecipients: [...noBlockedRecipients.mockAllRecipients],
+        vistaRecipients: initialVistaRecipients,
       },
     },
   };
@@ -67,9 +71,14 @@ describe('Edit Contact List container', async () => {
             oneAssociatedFacility.associatedBlockedTriageGroupsQty,
           noAssociations: oneAssociatedFacility.noAssociations,
           allTriageGroupsBlocked: oneAssociatedFacility.allTriageGroupsBlocked,
-          allFacilities: [...oneAssociatedFacility.mockAllFacilities],
+          vistaFacilities: [...oneAssociatedFacility.mockVistaFacilities],
           blockedFacilities: [...oneAssociatedFacility.mockBlockedFacilities],
           allRecipients: [...oneAssociatedFacility.mockAllRecipients],
+          vistaRecipients: [
+            ...oneAssociatedFacility.mockAllRecipients.filter(
+              r => !r.ohTriageGroup,
+            ),
+          ],
         },
       },
     };
@@ -112,17 +121,17 @@ describe('Edit Contact List container', async () => {
       const selectAllTeams = screen.getAllByTestId(/select-all-/);
       expect(selectAllTeams[0]).to.have.attribute(
         'label',
-        'Select all 6 teams',
+        'Select all 4 teams',
       );
       expect(selectAllTeams[1]).to.have.attribute(
         'label',
-        'Select all 3 teams',
+        'Select all 2 teams',
       );
 
       const allTriageTeams = screen.getAllByTestId(/contact-list-select-team-/);
-      expect(allTriageTeams.length).to.equal(
-        noBlockedRecipients.associatedTriageGroupsQty,
-      );
+      const vistaRecipientsCount =
+        initialState.sm.recipients.vistaRecipients.length;
+      expect(allTriageTeams.length).to.equal(vistaRecipientsCount);
       allTriageTeams.forEach(team =>
         expect(team).to.have.attribute('checked', 'true'),
       );
@@ -144,7 +153,7 @@ describe('Edit Contact List container', async () => {
             oneBlockedRecipient.associatedBlockedTriageGroupsQty,
           noAssociations: oneBlockedRecipient.noAssociations,
           allTriageGroupsBlocked: oneBlockedRecipient.allTriageGroupsBlocked,
-          allFacilities: [...oneBlockedRecipient.mockAllFacilities],
+          vistaFacilities: [...oneBlockedRecipient.mockVistaFacilities],
           blockedFacilities: [...oneBlockedRecipient.mockBlockedFacilities],
           allRecipients: [...oneBlockedRecipient.mockAllRecipients],
         },
@@ -177,9 +186,14 @@ describe('Edit Contact List container', async () => {
             oneBlockedFacility.associatedBlockedTriageGroupsQty,
           noAssociations: oneBlockedFacility.noAssociations,
           allTriageGroupsBlocked: oneBlockedFacility.allTriageGroupsBlocked,
-          allFacilities: [...oneBlockedFacility.mockAllFacilities],
+          vistaFacilities: [...oneBlockedFacility.mockVistaFacilities],
           blockedFacilities: [...oneBlockedFacility.mockBlockedFacilities],
           allRecipients: [...oneBlockedFacility.mockAllRecipients],
+          vistaRecipients: [
+            ...oneBlockedFacility.mockAllRecipients.filter(
+              r => !r.ohTriageGroup,
+            ),
+          ],
         },
       },
     };
@@ -197,6 +211,56 @@ describe('Edit Contact List container', async () => {
       );
     });
     screen.unmount();
+  });
+
+  it('oracle health teams do not appear in list of contacts', async () => {
+    const oracleHealthTeams = noBlockedRecipients.mockAllRecipients.filter(
+      r => r.ohTriageGroup,
+    );
+
+    const customState = {
+      ...initialState,
+      sm: {
+        ...initialState.sm,
+        recipients: {
+          allowedRecipients: [...noBlockedRecipients.mockAllowedRecipients],
+          blockedRecipients: [...noBlockedRecipients.mockBlockedRecipients],
+          associatedTriageGroupsQty:
+            noBlockedRecipients.associatedTriageGroupsQty,
+          associatedBlockedTriageGroupsQty:
+            noBlockedRecipients.associatedBlockedTriageGroupsQty,
+          noAssociations: noBlockedRecipients.noAssociations,
+          allTriageGroupsBlocked: noBlockedRecipients.allTriageGroupsBlocked,
+          vistaFacilities: [...noBlockedRecipients.mockVistaFacilities],
+          blockedFacilities: [...noBlockedRecipients.mockBlockedFacilities],
+          allRecipients: [...noBlockedRecipients.mockAllRecipients],
+          vistaRecipients: [...initialVistaRecipients],
+        },
+      },
+    };
+    const { getAllByTestId, queryByTestId, container, unmount } = setup(
+      customState,
+    );
+    const vistaRecipientsCount =
+      customState.sm.recipients.vistaRecipients.length;
+    await waitFor(() => {
+      const allTriageTeams = getAllByTestId(/contact-list-select-team-/);
+      expect(allTriageTeams.length).to.equal(vistaRecipientsCount);
+      allTriageTeams.forEach(team =>
+        expect(team).to.have.attribute('checked', 'true'),
+      );
+    });
+    const oracleHealthTeam = oracleHealthTeams[0];
+    const oracleHealthTeamCheckbox = queryByTestId(
+      `contact-list-select-team-${oracleHealthTeam.id}`,
+    );
+    expect(oracleHealthTeamCheckbox).to.be.null;
+    expect(
+      container.querySelectorAll(
+        `va-checkbox[label="${oracleHealthTeam.name}"]`,
+      ),
+    ).to.not.exist;
+    unmount();
   });
 
   it('modifies all teams in one facility when "select all" is checked', async () => {
@@ -418,7 +482,7 @@ describe('Edit Contact List container', async () => {
             noAssociationsAtAll.associatedBlockedTriageGroupsQty,
           noAssociations: noAssociationsAtAll.noAssociations,
           allTriageGroupsBlocked: noAssociationsAtAll.allTriageGroupsBlocked,
-          allFacilities: [...noAssociationsAtAll.mockAllFacilities],
+          allFacilities: [...noAssociationsAtAll.mockVistaFacilities],
           blockedFacilities: [...noAssociationsAtAll.mockBlockedFacilities],
           allRecipients: [...noAssociationsAtAll.mockAllRecipients],
           error: true,

--- a/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/SelectCareTeam.unit.spec.jsx
@@ -124,9 +124,11 @@ describe('SelectCareTeam', () => {
     });
     expect(screen.getByTestId('care-system-636')).to.exist; // VA Boston
     expect(screen.getByTestId('care-system-662')).to.exist; // VA Seattle
+    expect(screen.getByTestId('care-system-757')).to.exist; // VA Seattle
+
     // Check the number of radio options
     const radioOptions = screen.container.querySelectorAll('va-radio-option');
-    expect(radioOptions.length).to.equal(2);
+    expect(radioOptions.length).to.equal(3);
   });
 
   it('displays health care system facilities as select dropdown when 6 or more', async () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-api-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-api-errors.cypress.spec.js
@@ -26,7 +26,7 @@ describe('SM CONTACT LIST API ERRORS', () => {
       body: {},
     }).as('saveRecipientsFail');
 
-    ContactListPage.selectCheckBox('100');
+    ContactListPage.selectCheckBox('***TG 100_SLC4%');
     ContactListPage.clickSaveContactListButton();
     cy.wait('@saveRecipientsFail');
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility.cypress.spec.js
@@ -44,7 +44,7 @@ describe('SM MULTI FACILITY CONTACT LIST', () => {
   });
 
   it(`user won't see the alert after saving changes`, () => {
-    const selectedTeam = [`100`, `ABC`];
+    const selectedTeam = [`***TG 100_SLC4%`, `TG-7410`];
     const updatedRecipientsList = ContactListPage.setPreferredTeams(
       mockMixRecipients,
       selectedTeam,
@@ -61,7 +61,7 @@ describe('SM MULTI FACILITY CONTACT LIST', () => {
   });
 
   it('verify single contact selected', () => {
-    const selectedTeam = [`100`];
+    const selectedTeam = [`***TG 100_SLC4%`];
     const updatedRecipientsList = ContactListPage.setPreferredTeams(
       mockMixRecipients,
       selectedTeam,
@@ -82,7 +82,7 @@ describe('SM MULTI FACILITY CONTACT LIST', () => {
       .its('request.body')
       .then(req => {
         const selected = req.updatedTriageTeams.filter(el =>
-          el.name.includes(`100`),
+          el.name.includes(selectedTeam[0]),
         );
 
         cy.wrap(selected).each(el => {
@@ -94,7 +94,11 @@ describe('SM MULTI FACILITY CONTACT LIST', () => {
   });
 
   it(`verify few contacts selected`, () => {
-    const selectedTeamList = [`200`, `Cardio`, `TG-7410`];
+    const selectedTeamList = [
+      `***TG 200_APPT_SLC4%`,
+      `Jeasmitha-Cardio-Clinic`,
+      `TG-7410`,
+    ];
     const updatedRecipientsList = ContactListPage.setPreferredTeams(
       mockMixRecipients,
       selectedTeamList,
@@ -130,5 +134,11 @@ describe('SM MULTI FACILITY CONTACT LIST', () => {
 
         cy.injectAxeThenAxeCheck(AXE_CONTEXT);
       });
+  });
+  it('excludes OH care teams from contact list', () => {
+    ContactListPage.validateCheckBoxDoesNotExist('OH TG GROUP 002');
+    cy.get('[label*="White City VA Medical Center"]').should('not.exist');
+    cy.get('[label*="VA Indiana health care"]').should('exist');
+    cy.injectAxeThenAxeCheck(AXE_CONTEXT);
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility.cypress.spec.js
@@ -33,7 +33,7 @@ describe('SM MULTI FACILITY CONTACT LIST NAVIGATE AWAY', () => {
   });
 
   it(`user won't see the alert after saving changes`, () => {
-    const selectedTeam = [`ABC`];
+    const selectedTeam = [`###ABC_XYZ_TRIAGE_TEAM###`];
     const updatedRecipientsList = ContactListPage.setPreferredTeams(
       mockRecipients,
       selectedTeam,
@@ -49,7 +49,7 @@ describe('SM MULTI FACILITY CONTACT LIST NAVIGATE AWAY', () => {
   });
 
   it('verify single contact selected', () => {
-    const selectedTeam = [`100`];
+    const selectedTeam = [`***TG 100_SLC4%`];
     const updatedRecipientsList = ContactListPage.setPreferredTeams(
       mockRecipients,
       selectedTeam,
@@ -81,7 +81,11 @@ describe('SM MULTI FACILITY CONTACT LIST NAVIGATE AWAY', () => {
   });
 
   it(`verify few contacts selected`, () => {
-    const selectedTeamList = [`200`, `Cardio`, `TG-7410`];
+    const selectedTeamList = [
+      `***TG 200_APPT_SLC4%`,
+      `Jeasmitha-Cardio-Clinic`,
+      `TG-7410`,
+    ];
     const updatedRecipientsList = ContactListPage.setPreferredTeams(
       mockRecipients,
       selectedTeamList,
@@ -104,11 +108,8 @@ describe('SM MULTI FACILITY CONTACT LIST NAVIGATE AWAY', () => {
     cy.wait('@savedList')
       .its('request.body')
       .then(req => {
-        const selected = req.updatedTriageTeams.filter(
-          el =>
-            el.name.includes(`200`) ||
-            el.name.includes(`Cardio`) ||
-            el.name.includes(`TG-7410`),
+        const selected = req.updatedTriageTeams.filter(el =>
+          selectedTeamList.some(team => el.name.includes(team)),
         );
 
         cy.wrap(selected).each(el => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-back-to-facility-selection.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/curated-list-tests/secure-messaging-curated-list-back-to-facility-selection.cypress.spec.js
@@ -1,5 +1,5 @@
 import SecureMessagingSite from '../sm_site/SecureMessagingSite';
-import { AXE_CONTEXT, Paths } from '../utils/constants';
+import { AXE_CONTEXT, Locators, Paths } from '../utils/constants';
 import GeneralFunctionsPage from '../pages/GeneralFunctionsPage';
 import PilotEnvPage from '../pages/PilotEnvPage';
 import PatientMessageDraftsPage from '../pages/PatientMessageDraftsPage';
@@ -229,7 +229,6 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
     cy.injectAxeThenAxeCheck(AXE_CONTEXT);
     cy.findByText(/Select a different care team/i).click();
     cy.findByTestId(`compose-recipient-combobox`).click();
-
     PatientComposePage.selectComboBoxRecipient('###ABC_XYZ_TRIAGE_TEAM###');
 
     cy.findByText(/Update your contact list/i).click();
@@ -240,7 +239,7 @@ describe('SM CURATED LIST BACK TO SELECTION', () => {
       .find(`va-button[text="Save changes"]`)
       .click();
 
-    cy.findByText(/Go back/i).click();
+    cy.findByTestId(Locators.BUTTONS.CL_GO_BACK).click();
 
     PatientComposePage.getComboBox().should(
       'have.value',

--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/multi-facilities-recipients-response.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/multi-facilities-recipients-response.json
@@ -9,7 +9,8 @@
         "stationNumber": "531",
         "blockedStatus": false,
         "relationType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -21,7 +22,8 @@
         "stationNumber": "531",
         "blockedStatus": false,
         "relationType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -33,7 +35,8 @@
         "stationNumber": "531",
         "blockedStatus": false,
         "relationType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -45,7 +48,8 @@
         "blockedStatus": false,
         "name": "***TG 100_SLC4%",
         "relationType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -57,7 +61,8 @@
         "blockedStatus": false,
         "name": "***TG 200_APPT_SLC4%",
         "relationType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -69,7 +74,8 @@
         "stationNumber": "583",
         "blockedStatus": false,
         "relationType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -81,7 +87,8 @@
         "blockedStatus": false,
         "name": "SLC4 PCMM",
         "relationType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -93,7 +100,8 @@
         "stationNumber": "531",
         "blockedStatus": false,
         "preferredTeam": true,
-        "relationshipType": "PATIENT"
+        "relationshipType": "PATIENT",
+        "ohTriageGroup": false
       }
     },
     {
@@ -105,7 +113,8 @@
         "stationNumber": "531",
         "blockedStatus": false,
         "preferredTeam": true,
-        "relationshipType": "PATIENT"
+        "relationshipType": "PATIENT",
+        "ohTriageGroup": true
       }
     }
   ],

--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/recipientsResponse/recipients-response.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/recipientsResponse/recipients-response.json
@@ -137,7 +137,7 @@
       "type": "all_triage_teams",
       "attributes": {
         "triageTeamId": 56219,
-        "stationNumber": "613GF",
+        "stationNumber": "589",
         "blockedStatus": false,
         "name": "SLC4 PCMM",
         "relationType": "PATIENT",
@@ -182,7 +182,7 @@
       "attributes": {
         "triageTeamId": 3658299,
         "name": "OH TG GROUP 002",
-        "stationNumber": "663",
+        "stationNumber": "668",
         "blockedStatus": false,
         "preferredTeam": true,
         "relationshipType": "PATIENT",

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/ContactListPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/ContactListPage.js
@@ -13,17 +13,22 @@ class ContactListPage {
   };
 
   verifyHeaders = () => {
-    cy.get(`h1`)
-      .should(`be.visible`)
-      .and(`have.text`, `Messages: Contact list`);
+    cy.findByText('Messages: Contact list', { selector: 'h1' }).should(
+      'be.visible',
+    );
 
-    cy.get(`.contactListForm`)
-      .find(`h2`)
-      .should(`have.text`, `Need help?`);
+    cy.findByText(`Need help?`, { selector: 'h2' }).should('be.visible');
+  };
+
+  checkBoxByName = name => {
+    return cy
+      .get(`[label*="${name}"]`)
+      .shadow()
+      .find(`input`);
   };
 
   verifySingleCheckBox = (team, value) => {
-    cy.get(`[label*=${team}]`).should('have.prop', `checked`, value);
+    cy.get(`[label*="${team}"]`).should('have.prop', `checked`, value);
   };
 
   verifyAllCheckboxes = value => {
@@ -49,10 +54,11 @@ class ContactListPage {
   };
 
   selectCheckBox = name => {
-    cy.get(`[label*=${name}]`)
-      .shadow()
-      .find(`input`)
-      .click({ force: true });
+    this.checkBoxByName(name).click({ force: true });
+  };
+
+  validateCheckBoxDoesNotExist = name => {
+    cy.get(`[label*="${name}"]`).should('not.exist');
   };
 
   verifyButtons = () => {
@@ -62,13 +68,13 @@ class ContactListPage {
       .should(`be.visible`)
       .and(`include.text`, Data.BUTTONS.SAVE_AND_EXIT);
 
-    cy.get(Locators.BUTTONS.CL_GO_BACK)
+    cy.findByTestId(Locators.BUTTONS.CL_GO_BACK)
       .should(`be.visible`)
-      .and(`include.text`, Data.BUTTONS.GO_BACK);
+      .and(`have.prop`, `text`, Data.BUTTONS.GO_BACK);
   };
 
   clickGoBackButton = () => {
-    cy.get(Locators.BUTTONS.CL_GO_BACK).click({ force: true });
+    cy.findByTestId(Locators.BUTTONS.CL_GO_BACK).click({ force: true });
   };
 
   verifySaveAlert = () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/ContactListPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/ContactListPage.js
@@ -22,13 +22,13 @@ class ContactListPage {
 
   checkBoxByName = name => {
     return cy
-      .get(`[label*="${name}"]`)
+      .get(`[label="${name}"]`)
       .shadow()
       .find(`input`);
   };
 
   verifySingleCheckBox = (team, value) => {
-    cy.get(`[label*="${team}"]`).should('have.prop', `checked`, value);
+    cy.get(`[label="${team}"]`).should('have.prop', `checked`, value);
   };
 
   verifyAllCheckboxes = value => {
@@ -58,7 +58,7 @@ class ContactListPage {
   };
 
   validateCheckBoxDoesNotExist = name => {
-    cy.get(`[label*="${name}"]`).should('not.exist');
+    cy.get(`[label="${name}"]`).should('not.exist');
   };
 
   verifyButtons = () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
@@ -102,7 +102,8 @@ class PatientComposePage {
   selectComboBoxRecipient = text => {
     const comboBox = this.getComboBox();
     comboBox.clear();
-    comboBox.type(text, { waitForAnimations: true }).type('{enter}');
+    comboBox.type(text, { waitForAnimations: true });
+    comboBox.type('{enter}');
   };
 
   selectCategory = (category = 'OTHER') => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
@@ -102,7 +102,7 @@ class PatientComposePage {
   selectComboBoxRecipient = text => {
     const comboBox = this.getComboBox();
     comboBox.clear();
-    comboBox.type(text, { waitForAnimations: true });
+    comboBox.type(text, { waitForAnimations: true }).type('{enter}');
   };
 
   selectCategory = (category = 'OTHER') => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDetailsPage.js
@@ -50,7 +50,15 @@ class PatientMessageDetailsPage {
     cy.findByTestId(Locators.ALERTS.THREAD_EXPAND)
       .should('be.visible')
       .shadow()
-      .find('button')
+      .findByText('Expand all')
+      .click({ force: true });
+  };
+
+  collapseAllThreadMessages = () => {
+    cy.findByTestId(Locators.ALERTS.THREAD_EXPAND)
+      .should('be.visible')
+      .shadow()
+      .findByText('Collapse all')
       .click({ force: true });
   };
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
@@ -18,7 +18,7 @@ describe('SM EXPAND ALL ACCORDIONS', () => {
 
     PatientMessageDetailsPage.verifyExpandedThreadBody(threadResponse);
 
-    PatientMessageDetailsPage.expandAllThreadMessages();
+    PatientMessageDetailsPage.collapseAllThreadMessages();
 
     PatientMessageDetailsPage.verifyAccordionStatus(false);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-recipients-grouping-compose.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-recipients-grouping-compose.cypress.spec.js
@@ -45,7 +45,7 @@ describe('SM RECIPIENTS GROUPING ON COMPOSE', () => {
   });
 
   it('verify particular group', () => {
-    PatientComposePage.verifyRecipientsQuantityInGroup(0, 3);
+    PatientComposePage.verifyRecipientsQuantityInGroup(0, 4);
     PatientComposePage.verifyRecipientsQuantityInGroup(1, 3);
     PatientComposePage.verifyRecipientsQuantityInGroup(2, 1);
     PatientComposePage.verifyRecipientsQuantityInGroup(3, 1);
@@ -59,12 +59,11 @@ describe('SM RECIPIENTS GROUPING ON COMPOSE', () => {
 
     PatientComposePage.verifyRecipientsGroupName(
       2,
-      'VA Martinsburg health care',
+      'VA Northern Arizona health care',
     );
-
     PatientComposePage.verifyRecipientsGroupName(
       3,
-      'VA Northern Arizona health care',
+      'VA Puget Sound health care',
     );
 
     cy.injectAxeThenAxeCheck(AXE_CONTEXT);
@@ -78,12 +77,12 @@ describe('SM RECIPIENTS GROUPING ON COMPOSE', () => {
 
     PatientComposePage.verifyFacilityNameByRecipientName(
       `SLC4 PCMM`,
-      'VA Martinsburg health care',
+      'VA Kansas City health care',
     );
 
     PatientComposePage.verifyFacilityNameByRecipientName(
       `OH TG GROUP 002`,
-      'VA Puget Sound health care',
+      'VA Spokane health care',
     );
 
     cy.injectAxeThenAxeCheck(AXE_CONTEXT);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-recipients-grouping-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-recipients-grouping-draft.cypress.spec.js
@@ -44,7 +44,7 @@ describe('SM RECIPIENTS GROUPING ON DRAFT', () => {
   });
 
   it('verify particular group', () => {
-    PatientComposePage.verifyRecipientsQuantityInGroup(0, 3);
+    PatientComposePage.verifyRecipientsQuantityInGroup(0, 4);
     PatientComposePage.verifyRecipientsQuantityInGroup(1, 3);
     PatientComposePage.verifyRecipientsQuantityInGroup(2, 1);
     PatientComposePage.verifyRecipientsQuantityInGroup(3, 1);
@@ -56,11 +56,11 @@ describe('SM RECIPIENTS GROUPING ON DRAFT', () => {
     PatientComposePage.verifyRecipientsGroupName(1, 'VA Madison health care');
     PatientComposePage.verifyRecipientsGroupName(
       2,
-      'VA Martinsburg health care',
+      'VA Northern Arizona health care',
     );
     PatientComposePage.verifyRecipientsGroupName(
       3,
-      'VA Northern Arizona health care',
+      'VA Puget Sound health care',
     );
 
     cy.injectAxe();

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -165,7 +165,7 @@ export const Locators = {
     EDIT_DRAFT: `[data-testid="edit-draft-button-body"]`,
     EDIT_DRAFTS: '[data-testid="edit-draft-button-body-text"]',
     CL_SAVE: `[data-testid="contact-list-save"]`,
-    CL_GO_BACK: '[data-testid="contact-list-go-back"]',
+    CL_GO_BACK: 'contact-list-go-back',
     ALERT_CLOSE: `.first-focusable-child`,
   },
   LINKS: {

--- a/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/drupal-data-mock.json
+++ b/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/drupal-data-mock.json
@@ -16,6 +16,11 @@
           "facilityId": "583",
           "vamcSystemName": "Test Facility 3",
           "isCerner": false
+        },
+        "757": {
+          "facilityId": "757",
+          "vamcSystemName": "Test Facility 4",
+          "isCerner": true
         }
       }
     }

--- a/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-facility-blocked-mock.json
+++ b/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-facility-blocked-mock.json
@@ -5,6 +5,7 @@
   "allTriageGroupsBlocked": false,
   "mockBlockedFacilities": ["583"],
   "mockAllFacilities": ["583", "636"],
+  "mockVistaFacilities": ["583", "636"],
 
   "mockAllRecipients": [
     {
@@ -112,5 +113,4 @@
       "type": "Care Team"
     }
   ]
-
 }

--- a/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-mock.json
+++ b/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-mock.json
@@ -4,7 +4,8 @@
   "noAssociations": false,
   "allTriageGroupsBlocked": false,
   "mockBlockedFacilities": [],
-  "mockAllFacilities": ["636", "662"],
+  "mockAllFacilities": ["636", "662", "757"],
+  "mockVistaFacilities": ["636", "662"],
 
   "mockAllRecipients": [
     {

--- a/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-no-associations-at-all-mock.json
+++ b/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-no-associations-at-all-mock.json
@@ -9,5 +9,6 @@
   "mockBlockedRecipients": [],
   "mockBlokedFacilities": [],
   "mockAllFacilities": [],
+  "mockVistaFacilities": [],
   "mockBlockedFacilities": []
 }

--- a/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-one-blocked-mock.json
+++ b/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-one-blocked-mock.json
@@ -5,6 +5,7 @@
   "allTriageGroupsBlocked": false,
   "mockBlockedFacilities": [],
   "mockAllFacilities": ["636", "662"],
+  "mockVistaFacilities": ["636", "662"],
 
   "mockAllRecipients": [
     {

--- a/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-one-facility-mock.json
+++ b/src/applications/mhv-secure-messaging/tests/fixtures/json-triage-mocks/triage-teams-one-facility-mock.json
@@ -5,6 +5,7 @@
   "allTriageGroupsBlocked": false,
   "mockBlockedFacilities": [],
   "mockAllFacilities": ["662"],
+  "mockVistaFacilities": ["662"],
 
   "mockAllRecipients": [
     {

--- a/src/applications/mhv-secure-messaging/tests/fixtures/mock-api-responses/all-triage-teams-response.json
+++ b/src/applications/mhv-secure-messaging/tests/fixtures/mock-api-responses/all-triage-teams-response.json
@@ -9,7 +9,8 @@
         "stationNumber": "649",
         "blockedStatus": true,
         "relationshipType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -21,7 +22,8 @@
         "stationNumber": "649",
         "blockedStatus": false,
         "relationshipType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -33,7 +35,8 @@
         "stationNumber": "649",
         "blockedStatus": false,
         "relationshipType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -45,7 +48,8 @@
         "stationNumber": "649",
         "blockedStatus": false,
         "relationshipType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -57,7 +61,8 @@
         "stationNumber": "649",
         "blockedStatus": false,
         "relationshipType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -69,7 +74,8 @@
         "stationNumber": "649",
         "blockedStatus": false,
         "relationshipType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     },
     {
@@ -81,11 +87,15 @@
         "stationNumber": "649",
         "blockedStatus": false,
         "relationshipType": "PATIENT",
-        "preferredTeam": true
+        "preferredTeam": true,
+        "ohTriageGroup": false
       }
     }
   ],
   "meta": {
+    "associatedTriageGroups": 7,
+    "friendlyTriageTeamPilotFacilities": "",
+    "associatedBlockedTriageGroups": 1,
     "sort": {
       "name": "ASC"
     }

--- a/src/applications/mhv-secure-messaging/tests/reducers/allRecipients.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/reducers/allRecipients.unit.spec.jsx
@@ -28,6 +28,7 @@ describe('allRecipients reducers', () => {
           relationshipType: recipient.attributes.relationshipType,
           signatureRequired: false,
           healthCareSystemName: undefined,
+          ohTriageGroup: recipient.attributes.ohTriageGroup,
           type: 'Care Team',
           status: recipient.attributes.blockedStatus
             ? RecipientStatus.BLOCKED

--- a/src/applications/mhv-secure-messaging/tests/reducers/allRecipients.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/reducers/allRecipients.unit.spec.jsx
@@ -36,6 +36,7 @@ describe('allRecipients reducers', () => {
         };
       }),
     );
+    expect(store.getState().vistaFacilities).to.deep.equal(['649']);
   });
   it('should dispatch action on getAllTriageTeamRecipients error', async () => {
     const store = mockStore();
@@ -55,5 +56,86 @@ describe('allRecipients reducers', () => {
     expect(store.getState().allRecipients[0].name).to.equal(
       recipient.attributes.name,
     );
+  });
+
+  it('should correctly set vistaFacilities with multiple facilities', async () => {
+    const store = mockStore();
+    const customRecipients = [
+      {
+        id: '1',
+        type: 'al_triage_teams',
+        attributes: {
+          triageTeamId: 1,
+          name: 'Team 1',
+          stationNumber: '123',
+          blockedStatus: false,
+          relationshipType: 'PATIENT',
+          preferredTeam: true,
+          ohTriageGroup: false,
+        },
+      },
+      {
+        id: '2',
+        type: 'al_triage_teams',
+        attributes: {
+          triageTeamId: 2,
+          name: 'Team 2',
+          stationNumber: '456',
+          blockedStatus: false,
+          relationshipType: 'PATIENT',
+          preferredTeam: true,
+          ohTriageGroup: false,
+        },
+      },
+      {
+        id: '3',
+        type: 'al_triage_teams',
+        attributes: {
+          triageTeamId: 3,
+          name: 'Team 3',
+          stationNumber: '123',
+          blockedStatus: false,
+          relationshipType: 'PATIENT',
+          preferredTeam: true,
+          ohTriageGroup: false,
+        },
+      },
+      {
+        id: '4',
+        type: 'al_triage_teams',
+        attributes: {
+          triageTeamId: 4,
+          name: 'Team 4',
+          stationNumber: '789',
+          blockedStatus: true, // Blocked, should not be in vistaFacilities
+          relationshipType: 'PATIENT',
+          preferredTeam: true,
+          ohTriageGroup: false,
+        },
+      },
+      {
+        id: '4',
+        type: 'al_triage_teams',
+        attributes: {
+          triageTeamId: 4,
+          name: 'Team 4',
+          stationNumber: '567',
+          blockedStatus: false,
+          relationshipType: 'PATIENT',
+          preferredTeam: true,
+          ohTriageGroup: true, // OH, should not be in vistaFacilities
+        },
+      },
+    ];
+    const customMockResponse = {
+      data: customRecipients,
+      meta: {
+        associatedTriageGroups: 4,
+        associatedBlockedTriageGroups: 1,
+      },
+    };
+    mockApiRequest(customMockResponse);
+    await store.dispatch(getAllTriageTeamRecipients());
+    expect(store.getState().vistaFacilities).to.deep.equal(['123', '456']);
   });
 });

--- a/src/applications/mhv-secure-messaging/util/helpers.js
+++ b/src/applications/mhv-secure-messaging/util/helpers.js
@@ -410,6 +410,28 @@ export const findBlockedFacilities = recipients => {
   return { fullyBlockedFacilities, allFacilities };
 };
 
+export const findAllowedFacilities = recipients => {
+  const allowedVistaFacilities = new Set();
+  const allowedOracleFacilities = new Set();
+
+  recipients.forEach(recipient => {
+    const { stationNumber, blockedStatus, ohTriageGroup } = recipient;
+
+    if (blockedStatus === false) {
+      if (ohTriageGroup === true) {
+        allowedOracleFacilities.add(stationNumber);
+      } else {
+        allowedVistaFacilities.add(stationNumber);
+      }
+    }
+  });
+
+  return {
+    allowedVistaFacilities: [...allowedVistaFacilities],
+    allowedOracleFacilities: [...allowedOracleFacilities],
+  };
+};
+
 export const getStationNumberFromRecipientId = (recipientId, recipients) => {
   const recipient = recipients.find(item => item.triageTeamId === recipientId);
   return recipient?.stationNumber || null;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This pull request refactors the contact list feature in Secure Messaging to distinguish between VistA and Oracle Health (OH) care teams, ensuring that only VistA teams are shown and selectable in the contact list UI. It updates Redux state, selectors, and the component logic to use new `vistaFacilities` and `vistaRecipients` fields, and adds comprehensive test coverage (unit and E2E) to confirm that OH teams are excluded from the contact list. The changes also update UI elements for improved accessibility and consistency.

**Contact List Filtering and State Management:**

- Introduced new `vistaFacilities` and `vistaRecipients` fields in the Redux state and updated the reducer to populate these fields by filtering out Oracle Health (OH) care teams; the UI now only displays VistA care teams in the contact list. [[1]](diffhunk://#diff-c0c3d50a3dcfabaf647cedf7cec8af4d5951e9cd366630530669fcbff1c82e87R15-R20) [[2]](diffhunk://#diff-c0c3d50a3dcfabaf647cedf7cec8af4d5951e9cd366630530669fcbff1c82e87L53-R73)
- Updated all selectors and logic in `EditContactList.jsx` to use `vistaFacilities` and `vistaRecipients` instead of the old `allFacilities` and `allRecipients` fields, ensuring consistent filtering throughout the component. [[1]](diffhunk://#diff-91d4a6dbf959f395713141a8086f50df4d8329a25390ef516ea8e6beb7358a56L48-R59) [[2]](diffhunk://#diff-91d4a6dbf959f395713141a8086f50df4d8329a25390ef516ea8e6beb7358a56L122-R129) [[3]](diffhunk://#diff-91d4a6dbf959f395713141a8086f50df4d8329a25390ef516ea8e6beb7358a56L196-R190) [[4]](diffhunk://#diff-91d4a6dbf959f395713141a8086f50df4d8329a25390ef516ea8e6beb7358a56L207-R203) [[5]](diffhunk://#diff-91d4a6dbf959f395713141a8086f50df4d8329a25390ef516ea8e6beb7358a56L239-R235) [[6]](diffhunk://#diff-91d4a6dbf959f395713141a8086f50df4d8329a25390ef516ea8e6beb7358a56L251-R247)

**UI and Accessibility Improvements:**

- Replaced the custom "Go back" button with a standardized `<va-button back>` component for improved accessibility and code clarity.

**Testing Enhancements:**

- Updated and expanded unit tests to verify that only VistA teams appear in the contact list, and added a new test to confirm that OH care teams are excluded from the UI. [[1]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471R19-R21) [[2]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471L31-R37) [[3]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471L70-R81) [[4]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471L115-R134) [[5]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471L147-R156) [[6]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471L180-R196) [[7]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471R216-R265) [[8]](diffhunk://#diff-855386c4fca18b90b7803b0f5c7cfef965284d96f0923ecb57ebc71805754471L421-R485)
- Updated e2e tests to use new VistA team identifiers, verify the exclusion of OH care teams, and add an explicit test for OH team exclusion from the contact list. [[1]](diffhunk://#diff-bee912bd8c9706f3d18e8fbc9fd8acc30ca0c0658d44e7a6e1f01848b6387895L47-R47) [[2]](diffhunk://#diff-bee912bd8c9706f3d18e8fbc9fd8acc30ca0c0658d44e7a6e1f01848b6387895L64-R64) [[3]](diffhunk://#diff-bee912bd8c9706f3d18e8fbc9fd8acc30ca0c0658d44e7a6e1f01848b6387895L85-R85) [[4]](diffhunk://#diff-bee912bd8c9706f3d18e8fbc9fd8acc30ca0c0658d44e7a6e1f01848b6387895L97-R101) [[5]](diffhunk://#diff-bee912bd8c9706f3d18e8fbc9fd8acc30ca0c0658d44e7a6e1f01848b6387895R138-R143)

**Minor Test/Code Cleanups:**

- Adjusted test expectations and selectors to match the new data structure and filtered team lists. [[1]](diffhunk://#diff-331142c9738f9057415638552d907d357263b94008b07cd08454904df9001083R127-R131) [[2]](diffhunk://#diff-b0a04233fc9e13a3140cb5d6a0f73e61274267d44a3a6ff1327abd620a7858b1L2-R2) [[3]](diffhunk://#diff-b0a04233fc9e13a3140cb5d6a0f73e61274267d44a3a6ff1327abd620a7858b1L232)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117082

## Testing done

- unit test coverage
- e2e test coverage

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
