### PR TITLE
Income and asset 111695 111697 royalty pages

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
+++ b/src/applications/income-and-asset-statement/config/chapters/05-royalties-and-other-properties/royaltiesAndOtherPropertyPages.js
@@ -24,6 +24,7 @@ import { DependentDescription } from '../../../components/DependentDescription';
 import {
   formatCurrency,
   formatPossessiveString,
+  fullNameUIHelper,
   generateDeleteDescription,
   isDefined,
   isRecipientInfoIncomplete,
@@ -79,12 +80,6 @@ export const options = {
       isDefined(item?.grossMonthlyIncome) &&
       isDefined(item?.fairMarketValue) && (
         <ul className="u-list-no-bullets vads-u-padding-left--0 vads-u-font-weight--normal">
-          <li>
-            Income generation method:{' '}
-            <span className="vads-u-font-weight--bold">
-              {generatedIncomeTypeLabels[item.incomeGenerationMethod]}
-            </span>
-          </li>
           <li>
             Gross monthly income:{' '}
             <span className="vads-u-font-weight--bold">
@@ -430,8 +425,14 @@ const nonVeteranIncomeRecipientPage = {
 /** @returns {PageSchema} */
 const recipientNamePage = {
   uiSchema: {
-    ...arrayBuilderItemSubsequentPageTitleUI('Royalty recipient'),
-    recipientName: fullNameNoSuffixUI(title => `Income recipient’s ${title}`),
+    ...arrayBuilderItemSubsequentPageTitleUI(
+      showUpdatedContent()
+        ? 'Person who receives this income'
+        : 'Financial account recipient',
+    ),
+    recipientName: showUpdatedContent()
+      ? fullNameUIHelper()
+      : fullNameNoSuffixUI(title => `Income recipient’s ${title}`),
   },
   schema: {
     type: 'object',
@@ -446,11 +447,11 @@ const generatedIncomeTypePage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI('Royalty income information'),
     incomeGenerationMethod: radioUI({
-      title: 'How is the income generated from this asset?',
+      title: 'How is income generated from this asset?',
       labels: generatedIncomeTypeLabels,
     }),
     otherIncomeType: {
-      'ui:title': 'Tell us how the income is generated',
+      'ui:title': 'Describe how income is generated',
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'incomeGenerationMethod',
@@ -459,14 +460,26 @@ const generatedIncomeTypePage = {
       },
       'ui:required': otherGeneratedIncomeTypeExplanationRequired,
     },
-    grossMonthlyIncome: currencyUI('Gross monthly income'),
-    fairMarketValue: currencyUI('Fair market value of this asset'),
+    grossMonthlyIncome: currencyUI({
+      title: 'What’s the gross monthly income from this asset?',
+      hint: 'Gross income is income before taxes and any other deductions.',
+    }),
+    fairMarketValue: currencyUI({
+      title: 'What’s the fair market value of this asset?',
+      hint:
+        'The market value is the dollar amount that an asset may be sold at.',
+    }),
     canBeSold: yesNoUI({
       title: 'Can the asset be sold?',
     }),
-    mitigatingCircumstances: textareaUI(
-      'Explain any mitigating circumstances that prevent the sale of this asset',
-    ),
+    mitigatingCircumstances: {
+      ...textareaUI('Explain why this asset can’t be sold'),
+      'ui:options': {
+        expandUnder: 'canBeSold',
+        expandUnderCondition: false,
+        expandedContentFocus: true,
+      },
+    },
     'ui:options': {
       ...requireExpandedArrayField('otherIncomeType'),
     },

--- a/src/applications/income-and-asset-statement/labels.jsx
+++ b/src/applications/income-and-asset-statement/labels.jsx
@@ -1,5 +1,3 @@
-import { showUpdatedContent } from './helpers';
-
 // Always name keys with uppercase snake_casing
 // Always use keys for data storage
 export const relationshipLabels = {
@@ -93,7 +91,7 @@ export const updatedIncomeTypeLabels = {
 export const incomeTypeEarnedLabels = {
   INTEREST: 'Interest',
   DIVIDENDS: 'Dividends',
-  OTHER: showUpdatedContent() ? 'Other financial asset income' : 'Other',
+  OTHER: 'Other financial asset income',
 };
 
 export const ownedAssetTypeLabels = {
@@ -103,10 +101,10 @@ export const ownedAssetTypeLabels = {
 };
 
 export const generatedIncomeTypeLabels = {
-  INTELLECTUAL_PROPERTY: 'Benefits from intellectual property',
-  MINERALS_LUMBER: 'Extraction of minerals/lumber',
-  USE_OF_LAND: 'Use of land',
-  OTHER: 'Other',
+  INTELLECTUAL_PROPERTY: 'Intellectual property rights',
+  MINERALS_LUMBER: 'Mineral or lumber extraction',
+  USE_OF_LAND: 'Land usage fees',
+  OTHER: 'Another way',
 };
 
 export const trustTypeLabels = {

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/06-royalties-and-other-properties/royaltiesAndOtherPropertyPages.unit.spec.jsx
@@ -72,7 +72,7 @@ describe('royalties list and loop pages', () => {
         incomeGenerationMethod: 'INTELLECTUAL_PROPERTY',
       };
       expect(options.text.getItemName(item, 0, mockFormData)).to.equal(
-        'John Doe’s income from benefits from intellectual property',
+        'John Doe’s income from intellectual property rights',
       );
     });
     it('should return "Alex Smith’s income" if recipient is Veteran and not logged in', () => {
@@ -85,7 +85,7 @@ describe('royalties list and loop pages', () => {
           ...mockFormData,
           isLoggedIn: false,
         }),
-      ).to.equal('Alex Smith’s income from use of land');
+      ).to.equal('Alex Smith’s income from land usage fees');
     });
     it('should return "Jane Doe’s income', () => {
       const recipientName = { first: 'Jane', middle: 'A', last: 'Doe' };
@@ -112,6 +112,7 @@ describe('royalties list and loop pages', () => {
     const {
       recipientRelationship,
       recipientName,
+      incomeGenerationMethod,
       canBeSold,
       ...baseItem
     } = testData.data.royaltiesAndOtherProperties[0];
@@ -128,6 +129,7 @@ describe('royalties list and loop pages', () => {
     const {
       recipientRelationship,
       recipientName,
+      incomeGenerationMethod,
       canBeSold,
       ...baseItem
     } = testDataZeroes.data.royaltiesAndOtherProperties[0];
@@ -369,7 +371,7 @@ describe('royalties list and loop pages', () => {
       formConfig,
       schema,
       uiSchema,
-      { 'va-radio': 2, 'va-text-input': 2, 'va-textarea': 1 },
+      { 'va-radio': 2, 'va-text-input': 2 },
       'income type',
     );
     testComponentFieldsMarkedAsRequired(
@@ -377,9 +379,9 @@ describe('royalties list and loop pages', () => {
       schema,
       uiSchema,
       [
-        'va-radio[label="How is the income generated from this asset?"]',
-        'va-text-input[label="Gross monthly income"]',
-        'va-text-input[label="Fair market value of this asset"]',
+        'va-radio[label="How is income generated from this asset?"]',
+        'va-text-input[label="What’s the gross monthly income from this asset?"]',
+        'va-text-input[label="What’s the fair market value of this asset?"]',
         'va-radio[label="Can the asset be sold?"]',
       ],
       'income type',


### PR DESCRIPTION
## Summary

This PR updates the **Royalties and other assets** chapter in the **Income and Asset Statement form (VA Form 21P-0969)** to include Post-MVP enhancements for the **Recipient name** and **Royalty income information** pages.  
These updates refine the page structure, titles, and field content for consistency across claimant types and align with Design QA and Post-MVP content standards.

## Issues

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111695  
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111697  

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111691  
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111693  
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/111699  

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/income_and_assets_content_updates`  
4. Navigate to the form:  
   `http://localhost:3001/supporting-forms-for-claims/submit-income-and-asset-statement-form-21p-0969/`  
5. Go to the **Royalties and other assets** chapter  

## How to verify

1. Navigate through the **Recipient name** and **Royalty income information** pages:  
   - Confirm both pages are displayed correctly for all claimant types (Veteran, Spouse, Parent, Custodian)  
   - Verify page titles, labels, and hint text reflect the Post-MVP content updates  
   - Ensure help text and form controls match the latest Design QA and accessibility guidance  

2. Add, edit, and remove items in the Royalties list-and-loop to confirm:  
   - The pages render in the correct sequence  
   - Data is properly saved and displayed on the summary page  
   - Validation messages appear and function as expected  

3. Accessibility:  
   - Confirm heading levels and label associations are correct  
   - Validate keyboard navigation and focus order  

4. Review & Submit:  
   - Verify royalty recipient and income details display accurately  

## What areas of the site does it impact?

- Income and Asset Statement (VA Form 21P-0969)  
- **Royalties and other assets** → Recipient name and Royalty income information pages  

## Screenshots

| Before | After |
|--------|-------|
| Generic or missing royalty pages | Updated pages per Post-MVP content and design alignment |

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user  

## Milestone

- Post-MVP updates for 0969  
- **Behind** `income_and_assets_content_updates` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm the updated **Recipient name** and **Royalty income information** pages follow the correct Post-MVP patterns and align with content/design QA expectations across all claimant types.
