### PR TITLE
Pension | Update array builder text

### DIFF
--- a/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
@@ -22,7 +22,14 @@ const options = {
       item?.previousFullName
         ? formatFullName(item.previousFullName)
         : undefined,
-    summaryTitleWithoutItems: 'Other Service names',
+    summaryTitleWithoutItems: 'Other service names',
+    cancelAddYes: 'Yes, cancel adding this previous name',
+    cancelAddNo: 'No',
+    cancelEditYes: 'Yes, cancel editing this previous name',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
+    deleteTitle: 'Delete this previous name',
+    deleteNo: 'No',
   },
 };
 
@@ -70,7 +77,7 @@ const otherNamePage = {
       nounSingular: options.nounSingular,
       hasMultipleItemPages: false,
     }),
-    previousFullName: fullNameUI(title => `Previous ${title}`),
+    previousFullName: fullNameUI(),
   },
   schema: {
     type: 'object',

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistoryPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistoryPages.js
@@ -26,6 +26,13 @@ const options = {
   text: {
     getItemName: item => item?.jobType,
     summaryTitleWithoutItems: 'Current employment',
+    cancelAddYes: 'Yes, cancel adding this current job',
+    cancelAddNo: 'No',
+    cancelEditYes: 'Yes, cancel editing this current job',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
+    deleteTitle: 'Delete this current job',
+    deleteNo: 'No',
   },
 };
 
@@ -38,6 +45,7 @@ const summaryPage = {
   uiSchema: {
     'view:isAddingCurrentEmployment': arrayBuilderYesNoUI(options, {
       title: 'Are you currently employed?',
+      hint: null,
       labelHeaderLevel: ' ',
     }),
   },

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/federalMedicalCentersPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/federalMedicalCentersPages.js
@@ -20,7 +20,10 @@ const options = {
     getItemName: item => item?.medicalCenter,
     summaryTitleWithoutItems: 'Treatment from federal medical facilities',
     cancelEditTitle: 'Cancel editing this federal medical facility',
+    cancelAddNo: 'No',
+    cancelNo: 'No',
     deleteTitle: 'Delete federal medical facility',
+    deleteNo: 'No',
   },
 };
 

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistoryPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistoryPages.js
@@ -32,6 +32,13 @@ const options = {
   text: {
     getItemName: item => item?.jobType,
     summaryTitleWithoutItems: 'Previous employment',
+    cancelAddYes: 'Yes, cancel adding this previous job',
+    cancelAddNo: 'No',
+    cancelEditYes: 'Yes, cancel editing this previous job',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
+    deleteTitle: 'Delete this previous job',
+    deleteNo: 'No',
   },
 };
 

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/vaMedicalCentersPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/vaMedicalCentersPages.js
@@ -19,8 +19,13 @@ const options = {
   text: {
     getItemName: item => item?.medicalCenter,
     summaryTitleWithoutItems: 'Treatment from VA medical facilities',
-    cancelEditTitle: 'Cancel editing this VA medical facility',
+    cancelAddYes: 'Yes, cancel adding this VA medical facility',
+    cancelAddNo: 'No',
+    cancelEditYes: 'Yes, cancel editing this VA medical facility',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
     deleteTitle: 'Delete VA medical facility',
+    deleteNo: 'No',
   },
 };
 

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
@@ -35,6 +35,7 @@ import { isBetween18And23 } from './helpers';
 import {
   DependentSeriouslyDisabledDescription,
   formatFullName,
+  formatPossessiveString,
   showMultiplePageResponse,
 } from '../../../helpers';
 
@@ -98,7 +99,7 @@ const summaryPage = {
 const fullNamePage = {
   uiSchema: {
     ...arrayBuilderItemFirstPageTitleUI({
-      title: 'Add a dependent child',
+      title: 'Dependent child',
       nounSingular: options.nounSingular,
     }),
     fullName: fullNameUI(title => `Child’s ${title}`),
@@ -117,7 +118,9 @@ const birthInformationPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} birth information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} birth information`,
       undefined,
       false,
     ),
@@ -144,7 +147,9 @@ const socialSecurityNumberPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} Social Security information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} Social Security information`,
       undefined,
       false,
     ),
@@ -175,7 +180,9 @@ const relationshipPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} relationship information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} relationship information`,
       undefined,
       false,
     ),
@@ -198,7 +205,9 @@ const attendingSchoolPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} school information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} school information`,
       undefined,
       false,
     ),
@@ -232,7 +241,9 @@ const disabledPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} disabled information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} disability information`,
       undefined,
       false,
     ),
@@ -265,7 +276,9 @@ const previouslyMarriedPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} marriage information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} marriage information`,
       undefined,
       false,
     ),
@@ -294,7 +307,9 @@ const inHouseholdPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} household information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} household information`,
       undefined,
       false,
     ),
@@ -316,7 +331,9 @@ const addressPage = {
   uiSchema: {
     ...arrayBuilderItemSubsequentPageTitleUI(
       ({ formData }) =>
-        `${formatFullName(formData.fullName)} address information`,
+        `${formatPossessiveString(
+          formatFullName(formData.fullName),
+        )} address information`,
       undefined,
       false,
     ),

--- a/src/applications/pensions/config/chapters/05-financial-information/careExpensesPages.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/careExpensesPages.js
@@ -76,6 +76,13 @@ const options = {
           </li>
         </ul>
       ),
+    cancelAddYes: 'Yes, cancel adding this care expense',
+    cancelAddNo: 'No',
+    cancelEditYes: 'Yes, cancel editing this care expense',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
+    deleteTitle: 'Delete this care expense',
+    deleteNo: 'No',
   },
 };
 

--- a/src/applications/pensions/config/chapters/05-financial-information/incomeSourcesPages.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/incomeSourcesPages.js
@@ -23,8 +23,8 @@ import { formatCurrency, showMultiplePageResponse } from '../../../helpers';
 /** @type {ArrayBuilderOptions} */
 const options = {
   arrayPath: 'incomeSources',
-  nounSingular: 'Income source',
-  nounPlural: 'Income sources',
+  nounSingular: 'income source',
+  nounPlural: 'income sources',
   required: false,
   isItemIncomplete: item =>
     !item?.typeOfIncome ||
@@ -57,6 +57,13 @@ const options = {
           </li>
         </ul>
       ),
+    cancelAddYes: 'Yes, cancel adding this income source',
+    cancelAddNo: 'No',
+    cancelEditYes: 'Yes, cancel editing this income source',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
+    deleteTitle: 'Delete this income source',
+    deleteNo: 'No',
   },
 };
 

--- a/src/applications/pensions/config/chapters/05-financial-information/medicalExpensesPages.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/medicalExpensesPages.js
@@ -21,8 +21,8 @@ import { formatCurrency, showMultiplePageResponse } from '../../../helpers';
 /** @type {ArrayBuilderOptions} */
 const options = {
   arrayPath: 'medicalExpenses',
-  nounSingular: 'Medical expense',
-  nounPlural: 'Medical expenses',
+  nounSingular: 'medical expense',
+  nounPlural: 'medical expenses',
   required: false,
   isItemIncomplete: item =>
     !item?.recipients ||
@@ -62,6 +62,13 @@ const options = {
           </li>
         </ul>
       ),
+    cancelAddYes: 'Yes, cancel adding this medical expense',
+    cancelAddNo: 'No',
+    cancelEditYes: 'Yes, cancel editing this medical expense',
+    cancelEditNo: 'No',
+    cancelNo: 'No',
+    deleteTitle: 'Delete this medical expense',
+    deleteNo: 'No',
   },
 };
 

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -94,6 +94,21 @@ export const formatFullName = ({
     .join(' ');
 };
 
+/**
+ * Converts any string (e.g., a person's name or noun) to its possessive form.
+ * - "Johnson" -> "Johnson’s"
+ * - "Williams" -> "Williams’"
+ * - "Business" -> "Business’"
+ * - "Emma Lee" -> "Emma Lee’s"
+ *
+ * @param {string} str - The string to convert (e.g., full name or label)
+ * @returns {string} - Possessive form of the string
+ */
+export const formatPossessiveString = str => {
+  if (!str || typeof str !== 'string') return '';
+  return str.endsWith('s') ? `${str}’` : `${str}’s`;
+};
+
 export function isHomeAcreageMoreThanTwo(formData) {
   return (
     formData.homeOwnership === true && formData.homeAcreageMoreThanTwo === true


### PR DESCRIPTION
## Summary

This PR updates **text content** across the **multiple page list-and-loop patterns** used in the **Pension Benefits form (VA Form 21P-527EZ)**.  
The updates refine page titles, hint text, and modal text and button labels to improve clarity, align with VA Design System guidance, and provide a more consistent user experience.  

These changes are gated behind the **`pension_multiple_page_response`** feature toggle and only affect the new multi-page list-and-loop implementations.

## Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/118520

## Related issue(s)

- Ongoing refinements for multiple page list-and-loop usability and content clarity

## Associated Pull Request(s)

- N/A  

## How to run in local environment

1. Check out this branch locally  
2. Run `vets-website` and `vets-api`  
3. Enable the feature toggle:  
   `http://localhost:3000/flipper/features/pension_multiple_page_response`  
4. Navigate to the Pension Benefits form:  
   `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/`  
5. Proceed through any list-and-loop chapter that supports multiple pages (e.g., income, dependents, or medical expenses)

## How to verify

1. With **`pension_multiple_page_response`** enabled:  
   - Confirm page titles, labels, and hint text reflect the updated, simplified language.  
   - Verify “Add another” and “Yes/No” prompts use consistent text across all affected list-and-loop pages.  
   - Ensure summary pages correctly reflect updated copy and button labels.  
2. With **`pension_multiple_page_response`** disabled:  
   - Confirm legacy list-and-loop pages and text remain unchanged.  
3. Validate accessibility (heading levels, focus states, and screen reader output).  
4. Confirm no console errors and successful navigation through multi-page sections.  

## What areas of the site does it impact?

- Pension Benefits (21P-527EZ)  
- List-and-loop patterns across income, dependent, and medical expense sections  
- Conditional UI text and summary page content behind the `pension_multiple_page_response` toggle  

## Screenshots

| Before | After |
|--------|-------|
| Inconsistent text across list-and-loop pages | Updated text for clarity, consistency, and alignment with VADS |

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Milestone

- Post-MVP text and content improvements for multiple page list-and-loop flows  
- **Behind** `pension_multiple_page_response` feature toggle  

## Requested Feedback

(OPTIONAL) Please confirm the updated list-and-loop text is aligned with the Design QA recommendations and provides consistent phrasing across all multi-page list-and-loop flows.
