### PR TITLE
Fixes appointments OH getSlots params

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -676,6 +676,7 @@ export function getAppointmentSlots(start, end, forceFetch = false) {
           startDate: startDateString,
           endDate: endDateString,
           typeOfCare: data.typeOfCareId,
+          provider: data.selectedProvider,
         });
         const tomorrow = startOfDay(
           addDays(new Date(new Date().toISOString()), 1),

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -675,6 +675,7 @@ export function getAppointmentSlots(start, end, forceFetch = false) {
           clinicId: data.clinicId,
           startDate: startDateString,
           endDate: endDateString,
+          typeOfCare: data.typeOfCareId,
         });
         const tomorrow = startOfDay(
           addDays(new Date(new Date().toISOString()), 1),

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -627,6 +627,7 @@ export function getAppointmentSlots(start, end, forceFetch = false) {
     const state = getState();
     const siteId = getSiteIdFromFacilityId(getFormData(state).vaFacility);
     const newAppointment = getNewAppointment(state);
+    const typeOfCare = getTypeOfCare(getFormData(state))?.idV2;
     const { data } = newAppointment;
 
     let startDate = start;
@@ -675,7 +676,7 @@ export function getAppointmentSlots(start, end, forceFetch = false) {
           clinicId: data.clinicId,
           startDate: startDateString,
           endDate: endDateString,
-          typeOfCare: data.typeOfCareId,
+          typeOfCare,
           provider: data.selectedProvider,
         });
         const tomorrow = startOfDay(

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -369,6 +369,17 @@ const responses = {
       data: slots,
     });
   },
+  'GET /vaos/v2/locations/:facility_id/slots': (req, res) => {
+    const start = new Date(req.query.start);
+    const end = new Date(req.query.end);
+    const slots = appointmentSlotsV2.data.filter(slot => {
+      const slotStartDate = new Date(slot.attributes.start);
+      return isWithinInterval(slotStartDate, { start, end });
+    });
+    return res.json({
+      data: slots,
+    });
+  },
   'GET /vaos/v2/patients': (req, res) => {
     return res.json({
       data: {

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -166,15 +166,25 @@ export function getAvailableV2Slots({
   startDate,
   endDate,
 }) {
-  const queryParams = [];
   const start = startDate.toISOString();
   const end = endDate.toISOString();
 
-  if (typeOfCare) queryParams.push(`&clinical_service=${typeOfCare}`);
-  if (provider) queryParams.push(`&provider=${encodeURIComponent(provider)}`);
+  const includeServiceParams = !clinicId;
+  const queryParams = [];
+  if (includeServiceParams && typeOfCare) {
+    queryParams.push(`&clinical_service=${typeOfCare}`);
+  }
+  if (includeServiceParams && provider) {
+    queryParams.push(`&provider=${encodeURIComponent(provider)}`);
+  }
 
   let baseUrl = `/vaos/v2/locations/${facilityId}`;
-  if (clinicId) baseUrl = `${baseUrl}/clinics/${clinicId.split('_')[1]}`;
+  if (clinicId) {
+    const selectedClinicId = clinicId.includes('_')
+      ? clinicId.split('_')[1]
+      : clinicId;
+    baseUrl = `${baseUrl}/clinics/${selectedClinicId}`;
+  }
 
   baseUrl = `${baseUrl}/slots?start=${encodeURIComponent(
     start,

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 import { getTestFacilityId } from '../../utils/appointment';
 import { DATE_FORMATS } from '../../utils/constants';
+import { removeEmpty } from '../../utils/object';
 import {
   apiRequestWithUrl,
   parseApiList,
@@ -166,19 +167,23 @@ export function getAvailableV2Slots({
   startDate,
   endDate,
 }) {
-  const start = startDate.toISOString();
-  const end = endDate.toISOString();
+  const paramsObj = {
+    // eslint-disable-next-line camelcase
+    clinical_service: clinicId ? null : typeOfCare,
+    provider,
+    start: startDate.toISOString(),
+    end: endDate.toISOString(),
+  };
 
-  const includeServiceParams = !clinicId;
-  const queryParams = [];
-  if (includeServiceParams && typeOfCare) {
-    queryParams.push(`&clinical_service=${typeOfCare}`);
-  }
-  if (includeServiceParams && provider) {
-    queryParams.push(`&provider=${encodeURIComponent(provider)}`);
-  }
+  // Construct the parameter string and remove all keys that have values of null
+  // or undefined
+  const searchParams = new URLSearchParams(removeEmpty(paramsObj)).toString();
 
+  // For both OH and VistA searches the base URL looks like this
   let baseUrl = `/vaos/v2/locations/${facilityId}`;
+
+  // If a clinicId is passed, we are querying a VistA location and need to
+  // add the clinicId to the baseUrl
   if (clinicId) {
     const selectedClinicId = clinicId.includes('_')
       ? clinicId.split('_')[1]
@@ -186,9 +191,8 @@ export function getAvailableV2Slots({
     baseUrl = `${baseUrl}/clinics/${selectedClinicId}`;
   }
 
-  baseUrl = `${baseUrl}/slots?start=${encodeURIComponent(
-    start,
-  )}&end=${encodeURIComponent(end)}${queryParams.join('')}`;
+  // Adds the parameters to the baseUrl
+  baseUrl = `${baseUrl}/slots?${searchParams}`;
 
   return apiRequestWithUrl(baseUrl).then(parseApiList);
 }

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -171,7 +171,7 @@ export function getAvailableV2Slots({
   const end = endDate.toISOString();
 
   if (typeOfCare) queryParams.push(`&clinical_service=${typeOfCare}`);
-  if (provider) queryParams.push(`&provider=${provider}`);
+  if (provider) queryParams.push(`&provider=${encodeURIComponent(provider)}`);
 
   let baseUrl = `/vaos/v2/locations/${facilityId}`;
   if (clinicId) baseUrl = `${baseUrl}/clinics/${clinicId.split('_')[1]}`;

--- a/src/applications/vaos/services/vaos/index.js
+++ b/src/applications/vaos/services/vaos/index.js
@@ -170,15 +170,15 @@ export function getAvailableV2Slots({
   const start = startDate.toISOString();
   const end = endDate.toISOString();
 
-  if (typeOfCare) queryParams.push(`clinical_service=${typeOfCare}`);
-  if (provider) queryParams.push(`provider=${provider}`);
+  if (typeOfCare) queryParams.push(`&clinical_service=${typeOfCare}`);
+  if (provider) queryParams.push(`&provider=${provider}`);
 
   let baseUrl = `/vaos/v2/locations/${facilityId}`;
   if (clinicId) baseUrl = `${baseUrl}/clinics/${clinicId.split('_')[1]}`;
 
   baseUrl = `${baseUrl}/slots?start=${encodeURIComponent(
     start,
-  )}&end=${encodeURIComponent(end)}${queryParams.join('&')}`;
+  )}&end=${encodeURIComponent(end)}${queryParams.join('')}`;
 
   return apiRequestWithUrl(baseUrl).then(parseApiList);
 }

--- a/src/applications/vaos/tests/mocks/mockApis.js
+++ b/src/applications/vaos/tests/mocks/mockApis.js
@@ -508,29 +508,55 @@ export function mockAppointmentSlotApi({
   facilityId,
   preferredDate,
   startDate,
+  typeOfCare,
+  provider,
   response: data = [],
   responseCode = 200,
 } = {}) {
   const start = startDate || startOfMonth(preferredDate);
   const end = endDate || lastDayOfMonth(addMonths(preferredDate, 1));
-  const baseUrl =
-    `${
-      environment.API_URL
-    }/vaos/v2/locations/${facilityId}/clinics/${clinicId}/slots?` +
-    `start=${encodeURIComponent(start.toISOString())}` +
-    `&end=${encodeURIComponent(end.toISOString())}`;
 
-  if (responseCode === 200) {
-    setFetchJSONResponse(global.fetch.withArgs(baseUrl), {
-      data,
-    });
-  } else {
-    setFetchJSONFailure(global.fetch.withArgs(baseUrl), {
-      errors: [],
-    });
+  let clinicSegment = '';
+  let selectedClinicId;
+  if (clinicId) {
+    selectedClinicId = clinicId.includes('_')
+      ? clinicId.split('_')[1]
+      : clinicId;
+    clinicSegment = `/clinics/${selectedClinicId}`;
   }
 
-  return decodeURIComponent(baseUrl);
+  const extraParams = [];
+  if (typeOfCare) extraParams.push(`&clinical_service=${typeOfCare}`);
+  if (provider) extraParams.push(`&provider=${encodeURIComponent(provider)}`);
+
+  const providerSlotUrl = `${
+    environment.API_URL
+  }/vaos/v2/locations/${facilityId}${clinicSegment}/slots?start=${encodeURIComponent(
+    start.toISOString(),
+  )}&end=${encodeURIComponent(end.toISOString())}${extraParams.join('')}`;
+
+  let primaryUrl = null;
+  if (clinicId && clinicId.includes('_')) {
+    primaryUrl = `${
+      environment.API_URL
+    }/vaos/v2/locations/${facilityId}/clinics/${clinicId}/slots?start=${encodeURIComponent(
+      start.toISOString(),
+    )}&end=${encodeURIComponent(end.toISOString())}${extraParams.join('')}`;
+  }
+
+  if (responseCode === 200) {
+    setFetchJSONResponse(global.fetch.withArgs(providerSlotUrl), { data });
+    if (primaryUrl) {
+      setFetchJSONResponse(global.fetch.withArgs(primaryUrl), { data });
+    }
+  } else {
+    setFetchJSONFailure(global.fetch.withArgs(providerSlotUrl), { errors: [] });
+    if (primaryUrl) {
+      setFetchJSONFailure(global.fetch.withArgs(primaryUrl), { errors: [] });
+    }
+  }
+
+  return providerSlotUrl;
 }
 
 /**

--- a/src/applications/vaos/utils/object.js
+++ b/src/applications/vaos/utils/object.js
@@ -1,0 +1,13 @@
+/**
+ * Removes object properties with values of null or undefined and
+ * returns new object
+ *
+ * @export
+ * @param {Object} obj
+ * @returns {Object} An object with keys that have either null or undefined values
+ */
+export function removeEmpty(obj) {
+  return Object.entries(obj)
+    .filter(([_, v]) => v != null)
+    .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {});
+}

--- a/src/applications/vaos/utils/object.js
+++ b/src/applications/vaos/utils/object.js
@@ -4,7 +4,7 @@
  *
  * @export
  * @param {Object} obj
- * @returns {Object} An object with keys that have either null or undefined values
+ * @returns {Object} An object with keys that do not have either null or undefined values
  */
 export function removeEmpty(obj) {
   return Object.entries(obj)


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR fixes an issue with the OH `getSlots` function that was no longer correctly sending the required parameters for OH slot searches. The original work was done in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/37273).


## Related issue(s)

This PR resolves the following issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/117211

## Testing done
- Manual local testing with mocks

## Screenshots
The request is now including the correct params for OH slot queries:

<img width="820" height="510" alt="CleanShot 2025-10-01 at 06 10 53@2x" src="https://github.com/user-attachments/assets/3ebb97c0-e63a-4c14-a7ad-b2f83b95287d" />



## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/prepare-for-an-accessibility-staging-review) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

