### PR TITLE
Fix yarn new:app

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
     "@cypress/code-coverage": "^3.13.9",
     "@department-of-veterans-affairs/eslint-plugin": "^1.20.0",
-    "@department-of-veterans-affairs/generator-vets-website": "^3.17.0",
+    "@department-of-veterans-affairs/generator-vets-website": "^3.17.1",
     "@octokit/rest": "^18.11.0",
     "@sentry/browser": "^6.13.2",
     "@statoscope/webpack-plugin": "^5.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2887,10 +2887,10 @@
     has-proto "^1.2.0"
     jsx-ast-utils "^3.3.3"
 
-"@department-of-veterans-affairs/generator-vets-website@^3.17.0":
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.17.0.tgz#0661c48ec847510c73c68f45ca107fceb64d495a"
-  integrity sha512-JLGFpC4Sjhg+mNDVbX3TK2n7+2zI9tbajrhlYnStdvNOx+rizTxZZOOig+Oy5q5hzd+IsZqypR+g1/SssqFMlw==
+"@department-of-veterans-affairs/generator-vets-website@^3.17.1":
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.17.1.tgz#23d142192b7f91ac68df570888727f42553f0e0a"
+  integrity sha512-B8Ywh7N3BwMaDv4PCp1ZGsY0wSk2F0jvoThEckukAf9Mls5RAlqRCFTFBYFqNnSluqCMzPPlQD7hs+Xyl6XUtA==
   dependencies:
     chalk "^4.1.2"
     yeoman-generator "^5.6.1"


### PR DESCRIPTION
## Summary

- Fix `yarn new:app` by bumping generator-vets-website

## Related issue(s)

- https://github.com/department-of-veterans-affairs/generator-vets-website/pull/436
